### PR TITLE
API docs for Ti.XML.serializeToString

### DIFF
--- a/apidoc/Titanium/XML/XML.tdoc
+++ b/apidoc/Titanium/XML/XML.tdoc
@@ -21,8 +21,13 @@ android, iphone, ipad
 - methods
 
 parseString: parse an XML string into a DOMDocument
+serializeToString: serialize a DOMDocument or DOMNode and its descendants into an XML string
 
 - method : parseString, object
 
 xml[string]: the XML content as a string
+
+- method : serializeToString, string
+
+node[DOMNode]: the XML DOMNode or DOMDocument to serialize
 


### PR DESCRIPTION
Patch adds serializeToString method to API docs for Ti.XML. The implementation seems to be all merged to upstream master already, but didn't get added to docs:

https://appcelerator.lighthouseapp.com/projects/32238/tickets/1452-need-way-to-serialize-dom-trees-back-to-xml-on-mobile-save-xml-output
