### PR TITLE
Proposed fix for #1575: huge icons when launching iPhone app on iPad in 2x zoom

### DIFF
--- a/iphone/Classes/TiUtils.m
+++ b/iphone/Classes/TiUtils.m
@@ -41,7 +41,17 @@ extern NSString * const TI_APPLICATION_RESOURCE_DIR;
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_4_0
 		if ([[UIScreen mainScreen] respondsToSelector:@selector(scale)])
 		{
-			scale = [UIScreen mainScreen].scale;
+			if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone &&
+				[[UIDevice currentDevice].model isEqualToString: @"iPad"])
+			{
+				// iPad in iPhone compatibility mode will return a scale factor of 2.0
+				// when in 2x zoom, which leads to false positives and bugs.
+				scale = 1.0;
+			}
+			else
+			{
+				scale = [UIScreen mainScreen].scale;
+			}
 		}
 #endif	
 	}


### PR DESCRIPTION
https://appcelerator.lighthouseapp.com/projects/32238-titanium-mobile/tickets/1575-ipad-restarting-a-iphone-published-app-on-ipad-after-using-2x-mode-app-uses-incorrect-icons#ticket-1575-4

The problem here seems to be that the UIScreen reports a scale factor of 2.0 when running on iPad at 2x mode, so [TiUtils isRetinaDisplay] gives a false positive and [TiUtils checkFor2XImage:] pulls the @2x images.

When checking the scale, this patch double-checks if we're on an iPad but with a UI_USER_INTERFACE_IDIOM() for iPhone mode; if so, then we pretend we're on 1x scale instead of checking the reported value.

In native iPad mode we'll still check the scale, so it should still support automatic use of @2x images on a hypothetical future iPad with a double-density display.
