### PR TITLE
Getter for unimplemented View.center property on Android

### DIFF
--- a/android/titanium/src/org/appcelerator/titanium/proxy/TiViewProxy.java
+++ b/android/titanium/src/org/appcelerator/titanium/proxy/TiViewProxy.java
@@ -47,6 +47,7 @@ public abstract class TiViewProxy extends TiProxy implements Handler.Callback
 	private static final int MSG_ANIMATE = MSG_FIRST_ID + 109;
 	private static final int MSG_TOIMAGE = MSG_FIRST_ID + 110;
 	private static final int MSG_GETSIZE = MSG_FIRST_ID + 111;
+	private static final int MSG_GETCENTER = MSG_FIRST_ID + 112;
 
 	protected static final int MSG_LAST_ID = MSG_FIRST_ID + 999;
 
@@ -159,6 +160,26 @@ public abstract class TiViewProxy extends TiProxy implements Handler.Callback
 				result.setResult(d);
 				return true;
 			}
+			case MSG_GETCENTER : {
+				AsyncResult result = (AsyncResult) msg.obj;
+				TiDict d = null;
+				if (view != null) {
+					View v = view.getNativeView();
+					if (v != null) {
+						d = new TiDict();
+						d.put("x", (double)v.getLeft() + (double)v.getWidth() / 2);
+						d.put("y", (double)v.getTop() + (double)v.getHeight() / 2);
+					}
+				}
+				if (d == null) {
+					d = new TiDict();
+					d.put("x", 0);
+					d.put("y", 0);
+				}
+
+				result.setResult(d);
+				return true;
+			}
 		}
 		return super.handleMessage(msg);
 	}
@@ -181,6 +202,13 @@ public abstract class TiViewProxy extends TiProxy implements Handler.Callback
 	public TiDict getSize() {
 		AsyncResult result = new AsyncResult(getTiContext().getActivity());
 		Message msg = getUIHandler().obtainMessage(MSG_GETSIZE, result);
+		msg.sendToTarget();
+		return (TiDict) result.getResult();
+	}
+
+	public TiDict getCenter() {
+		AsyncResult result = new AsyncResult(getTiContext().getActivity());
+		Message msg = getUIHandler().obtainMessage(MSG_GETCENTER, result);
 		msg.sendToTarget();
 		return (TiDict) result.getResult();
 	}


### PR DESCRIPTION
Patch for: https://appcelerator.lighthouseapp.com/projects/32238-titanium-mobile/tickets/1775-tiuiview-center-property-not-implemented-on-android-no-warning-in-documentation

Adds a getter implementation for the View center property, works for me in my ad-hoc testing. As with the size property, I'm letting it just return (0, 0) if the native view hasn't been created; have not tested how that case behaves on iPhone, and the docs don't say.

Documentation isn't clear on whether it should be possible to set the property as well, but as I don't need that for my use case I haven't attempted to implement it.
