### PR TITLE
TiFile.spaceAvailable() implementation for Android using android.os.StatFs

### DIFF
--- a/android/titanium/src/org/appcelerator/titanium/io/TiFile.java
+++ b/android/titanium/src/org/appcelerator/titanium/io/TiFile.java
@@ -29,6 +29,7 @@ import org.appcelerator.titanium.util.Log;
 import org.appcelerator.titanium.util.TiConfig;
 
 import android.net.Uri;
+import android.os.StatFs;
 
 public class TiFile extends TiBaseFile
 {
@@ -192,8 +193,8 @@ public class TiFile extends TiBaseFile
 	@Override
 	public double spaceAvailable()
 	{
-		// only implemented in Java 6.0 :(
-		return 0;
+		StatFs stat = new StatFs(file.getPath());
+		return (double)stat.getAvailableBlocks() * (double)stat.getBlockSize();
 	}
 
 	@Override


### PR DESCRIPTION
[#1842] Android implementation of TiFile.spaceAvailable using android.os.StatFs, as java.io.File.getFreeSpace isn't available in current Android.
