### PR TITLE
Fixes for #2162 - Android - XML RSS crashes on Load

### DIFF
--- a/android/modules/ui/src/ti/modules/titanium/ui/widget/TiUISlider.java
+++ b/android/modules/ui/src/ti/modules/titanium/ui/widget/TiUISlider.java
@@ -132,6 +132,7 @@ public class TiUISlider extends TiUIView
 		 	if (thumb != null) {
 				thumbDrawable = new SoftReference<Drawable>(thumb);
 				seekBar.setThumb(thumb);
+				seekBar.setThumbOffset(0);
 			} else {
 				Log.e(LCAT, "Unable to locate thumb image for progress bar: " + url);
 			}

--- a/android/modules/ui/src/ti/modules/titanium/ui/widget/TiUISlider.java
+++ b/android/modules/ui/src/ti/modules/titanium/ui/widget/TiUISlider.java
@@ -88,6 +88,11 @@ public class TiUISlider extends TiUIView
 		if (d.containsKey("thumbImage")) {
 			updateThumb(seekBar, d);
 		}
+
+		if (d.containsKey("thumbOffset")) {
+			// This could be pulled out into a separate function but I'm not sure it's really warranted.
+			seekBar.setThumbOffset(TiConvert.toInt(d, "thumbOffset"));
+		}
 		
 		if (d.containsKey("leftTrackImage") && d.containsKey("rightTrackImage")) {
 			updateTrackingImages(seekBar, d);

--- a/android/modules/xml/src/ti/modules/titanium/xml/NodeProxy.java
+++ b/android/modules/xml/src/ti/modules/titanium/xml/NodeProxy.java
@@ -240,7 +240,7 @@ public class NodeProxy extends KrollProxy {
 	}
 	
 	@Kroll.method
-	public XPathUtil.XPathNodeListProxy evaluate(String xpath) {
+	public XPathNodeListProxy evaluate(String xpath) {
 		return XPathUtil.evaluate(this, xpath);
 	}
 }

--- a/android/modules/xml/src/ti/modules/titanium/xml/XPathNodeListProxy.java
+++ b/android/modules/xml/src/ti/modules/titanium/xml/XPathNodeListProxy.java
@@ -1,3 +1,9 @@
+/**
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2009-2010 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
 package ti.modules.titanium.xml;
 
 import java.util.ArrayList;

--- a/android/modules/xml/src/ti/modules/titanium/xml/XPathNodeListProxy.java
+++ b/android/modules/xml/src/ti/modules/titanium/xml/XPathNodeListProxy.java
@@ -1,0 +1,31 @@
+package ti.modules.titanium.xml;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.appcelerator.kroll.KrollProxy;
+import org.appcelerator.kroll.annotations.Kroll;
+import org.appcelerator.titanium.TiContext;
+import org.w3c.dom.Node;
+
+@Kroll.proxy
+public class XPathNodeListProxy extends KrollProxy
+{
+	private List nodeList;
+	public XPathNodeListProxy(TiContext context, List nodeList)
+	{
+		super(context);
+		this.nodeList = nodeList;
+	}
+	
+	@Kroll.getProperty @Kroll.method
+	public int getLength() {
+		return nodeList.size();
+	}
+
+	@Kroll.method
+	public NodeProxy item(int index) {
+		Node node = (Node)nodeList.get(index);
+		return NodeProxy.getNodeProxy(getTiContext(), node);
+	}
+}

--- a/android/modules/xml/src/ti/modules/titanium/xml/XPathUtil.java
+++ b/android/modules/xml/src/ti/modules/titanium/xml/XPathUtil.java
@@ -21,27 +21,6 @@ import org.w3c.dom.Node;
 public class XPathUtil {
 
 	private static final String LCAT = "XPath";
-	@Kroll.proxy
-	public static class XPathNodeListProxy extends KrollProxy
-	{
-		private List nodeList;
-		public XPathNodeListProxy(TiContext context, List nodeList)
-		{
-			super(context);
-			this.nodeList = nodeList;
-		}
-		
-		@Kroll.getProperty @Kroll.method
-		public int getLength() {
-			return nodeList.size();
-		}
-
-		@Kroll.method
-		public NodeProxy item(int index) {
-			Node node = (Node)nodeList.get(index);
-			return NodeProxy.getNodeProxy(getTiContext(), node);
-		}
-	}
 	
 	public static XPathNodeListProxy evaluate(NodeProxy start, String xpathExpr)
 	{


### PR DESCRIPTION
I thought this one was going to prove to be tied to the comment for the @Kroll.proxy annotation that said the proxy constructor could only take one parameter (TiContext) and the XPathNodeListProxy had two arguments. However, that proved not to be the case, Marshall guessed that the real problem was that the Proxy was an inner class of XPathUtil and annotation generator wasn't happy with that. As he predicted, pulling it out into its own separate class fixed the problem.

Note: This pull request includes the code change from the previous pull request (for Android: Expose ThumbOffset on Slider) as well. I'm not sure why that is unless the other hasn't been pulled yet. This is my first significant use of github other than monitoring various other projects so it's certainly possible I've made a mistake in not excluding that.
