### PR TITLE
Fix for ticket# 2436: exception for addView() on empty scrollableView

### DIFF
--- a/android/modules/ui/src/ti/modules/titanium/ui/widget/TiScrollableView.java
+++ b/android/modules/ui/src/ti/modules/titanium/ui/widget/TiScrollableView.java
@@ -93,7 +93,8 @@ public class TiScrollableView extends TiCompositeLayout
 		this.handler = handler;
 		me = this;
 		showPagingControl = true;
-
+		views = new ArrayList<TiViewProxy>();
+		
 		//below this was in "doOpen"
 		//setLayoutParams(new FrameLayout.LayoutParams(LayoutParams.FILL_PARENT, LayoutParams.FILL_PARENT));
 		setFocusable(true);

--- a/drillbit/tests/android/android.ui.js
+++ b/drillbit/tests/android/android.ui.js
@@ -134,6 +134,15 @@ describe("Ti.UI.Android tests", {
 	removeMethodsAddRemoveView: function() {
 		valueOf (Ti.UI.addView).shouldBeUndefined();
 		valueOf (Ti.UI.removeView).shouldBeUndefined();
+	},
+	
+	// https://appcelerator.lighthouseapp.com/projects/32238/tickets/2436
+	addViewToEmptyScrollableView: function() {
+		var scrollableView = Ti.UI.createScrollableView ();
+		var view = Ti.UI.createView();
+		
+		scrollableView.addView (view);
 	}
 
 })
+


### PR DESCRIPTION
Fixes exception when calling addView() on scrollableView object that has an uninitialized views ArrayList by adding initialization to the constructor for scrollableView.  Drillbit test included in android.ui.js.
