### PR TITLE
Fix to compress apk generated by Titanium 1.5+ (Android)

### DIFF
--- a/support/android/builder.py
+++ b/support/android/builder.py
@@ -1042,7 +1042,7 @@ class Builder(object):
 		debug("creating unsigned apk: " + unsigned_apk)
 		# copy existing resources into the APK
 		resources_zip = zipfile.ZipFile(resources_zip_file)
-		apk_zip = zipfile.ZipFile(unsigned_apk, 'w')
+		apk_zip = zipfile.ZipFile(unsigned_apk, 'w', zipfile.ZIP_DEFLATED)
 
 		def skip_jar_path(path):
 			return path.endswith('/') or \


### PR DESCRIPTION
The apk generated by Titanium 1.5+ (Android) is NOT compressed. This was not the case on 1.4.

AFAICT this is happening because the method of generating the unsigned apk has changed from 1.4 to 1.5 - from using the deprecated command line utility **apkbuilder** to using Python's **zipfile** module. However, by default, the **zipfile** module creates an uncompressed archive. Hence the size of the generated apk is larger than what it used to be on 1.4. This fix ensures that we specifically ask for a compressed archive to be generated.

Relevant Python documentation: http://docs.python.org/library/zipfile.html#zipfile-objects
