### PR TITLE
Bug Fix - extra spaces in builder.py can cause iphone device installs to fail

### DIFF
--- a/support/iphone/builder.py
+++ b/support/iphone/builder.py
@@ -987,7 +987,7 @@ def main(args):
 					f=open(os.path.join(iphone_resources_dir,'Entitlements.plist'),'w+')
 					f.write(entitlements_contents)
 					f.close()
-					args+=["CODE_SIGN_ENTITLEMENTS = Resources/Entitlements.plist"]
+					args+=["CODE_SIGN_ENTITLEMENTS=Resources/Entitlements.plist"]
 
 				# only build if force rebuild (different version) or 
 				# the app hasn't yet been built initially


### PR DESCRIPTION
The extra spaces end up in the file path for Entitlements.plist triggering a CodeSign error.
See http://bit.ly/ffdPpn and similar forums posts.
