### PR TITLE
solution to ticket 2226: file rename bug

### DIFF
--- a/demos/KitchenSink/Resources/examples/filesystem.js
+++ b/demos/KitchenSink/Resources/examples/filesystem.js
@@ -44,8 +44,11 @@ newFile.write(f.read());
 Ti.API.info('directoryListing for newDir = ' + newDir.getDirectoryListing());
 Ti.API.info("newfile.txt created: " + String(new Date(newFile.createTimestamp())));
 Ti.API.info("newfile.txt modified: " + String(new Date(newFile.modificationTimestamp())));
+Ti.API.info("newfile.txt renamed as b.txt: " + newFile.rename('b.txt'));
 
-Ti.API.info("newfile.txt deleted: " + newFile.deleteFile());
+var renamedFile = Titanium.Filesystem.getFile(newDir.nativePath, 'b.txt');
+Ti.API.info("newfile.txt deleted (expected to fail): " + newFile.deleteFile());
+Ti.API.info("b.txt deleted: " + renamedFile.deleteFile());
 Ti.API.info("mydir deleted: " + newDir.deleteDirectory());
 Ti.API.info('directoryListing for newDir after deleteDirectory = ' + newDir.getDirectoryListing());
 

--- a/iphone/Classes/TiFilesystemFileProxy.m
+++ b/iphone/Classes/TiFilesystemFileProxy.m
@@ -209,13 +209,19 @@ FILENOOP(setHidden:(id)x);
 	return NUMBOOL(result);
 }
 
+-(NSString *)_grabFirstArgumentAsFileName_:(id)args {
+    NSString * arg = [args objectAtIndex:0];
+    NSString * file = FILE_TOSTR(arg);
+    NSString * dest = [file stringByStandardizingPath];
+
+    return dest;
+}
+
 -(id)move:(id)args
 {
 	ENSURE_TYPE(args,NSArray);
 	NSError * error=nil;
-	NSString * arg = [args objectAtIndex:0];
-	NSString * file = FILE_TOSTR(arg);
-	NSString * dest = [file stringByStandardizingPath];
+	NSString * dest = [self _grabFirstArgumentAsFileName_:args];
     
     if (![dest isAbsolutePath]) {
         NSString * subpath = [path stringByDeletingLastPathComponent];
@@ -228,7 +234,19 @@ FILENOOP(setHidden:(id)x);
 
 -(id)rename:(id)args
 {
-	return [self move:args];
+    ENSURE_TYPE(args,NSArray);
+	NSString * dest = [self _grabFirstArgumentAsFileName_:args];
+    NSString * ourSubpath = [path stringByDeletingLastPathComponent];
+    
+    if ([dest isAbsolutePath]) {
+        NSString * destSubpath = [dest stringByDeletingLastPathComponent];
+
+        if (![ourSubpath isEqualToString:destSubpath]) {
+            return NUMBOOL(NO); // rename is not move
+        }
+    }
+    
+    return [self move:args];
 }
 
 -(id)read:(id)args

--- a/iphone/Classes/TiFilesystemFileProxy.m
+++ b/iphone/Classes/TiFilesystemFileProxy.m
@@ -216,6 +216,12 @@ FILENOOP(setHidden:(id)x);
 	NSString * arg = [args objectAtIndex:0];
 	NSString * file = FILE_TOSTR(arg);
 	NSString * dest = [file stringByStandardizingPath];
+    
+    if (![dest isAbsolutePath]) {
+        NSString * subpath = [path stringByDeletingLastPathComponent];
+        dest = [subpath stringByAppendingPathComponent:dest];
+    }
+    
 	BOOL result = [fm moveItemAtPath:path toPath:dest error:&error];
 	return NUMBOOL(result);	
 }


### PR DESCRIPTION
in the bug, rename is given one argument, the new file name. rename was failing when this name is relative. my proposed solution is to check if the new name is relative and if so, create an absolute file path from the path of the file being renamed. i modified the examples/filesystems.js test code to incorporate renaming
