### PR TITLE
Bugfix for #2178 - Black does not work in a background gradient

### DIFF
--- a/iphone/Classes/TiGradient.m
+++ b/iphone/Classes/TiGradient.m
@@ -184,8 +184,28 @@
 			thisEntry = [thisEntry objectForKey:@"color"];
 		}
 
-		UIColor * thisColor = [[TiUtils colorValue:thisEntry] _color];
-		if (thisColor == nil)
+ 	    UIColor * thisColor = [[TiUtils colorValue:thisEntry] _color];
+	   
+	    //Bugfix for bug #2178 - Jacob Relkin
+	   	    
+	    CGColorSpaceRef colorspace = CGColorGetColorSpace([thisColor CGColor]);
+	    if(CGColorSpaceGetModel(colorspace) == kCGColorSpaceModelMonochrome) 
+		{
+			/*
+			 Transform colorspace to RGB.
+			 Monochrome colorspaces won't work in CAGradientLayer
+             so we have to use UIColor's colorWithRed:green:blue:alpha: method
+			 to transform it to the RGB colorspace.
+		    */
+ 		    NSLog(@"colorspace is monochrome - transforming colorspace...");
+		    CGFloat *components = CGColorGetComponents([thisColor CGColor]);
+		    thisColor = [UIColor colorWithRed:components[0]
+										green:components[0] 
+										 blue:components[0]
+										alpha:components[1]];
+		}
+
+  	    if (thisColor == nil)
 		{
 			[self throwException:TiExceptionInvalidType subreason:
 					@"Colors must be an array of colors or objects with a color property" location:CODELOCATION];
@@ -196,9 +216,9 @@
 		{
 			offsetsDefined ++;
 		}
-
+        
 		CFArrayAppendValue(colorValues, [thisColor CGColor]);
-		currentIndex ++;
+	    currentIndex ++;
 	}
 	[self clearCache];
 }


### PR DESCRIPTION
Am I supposed to write something here? Okay, here goes:

`CAGradientLayer` for some odd reason does not support colors in the `CGColorSpaceModelMonochrome` color space model.

The fix for this is to check if the color space model is `kCGColorSpaceModelMonochrome`, and if it is, re-assign the gradient's color to the RGB representation of the color by using `UIColor`'s `colorWithRed:green:blue:alpha:` method.

Here's a screenshot of it in action: http://cl.ly/3u282l072k3g1O1F1x01
