### PR TITLE
Bugfixes for LH tickets #2178 and #2837

### DIFF
--- a/iphone/Classes/TiGradient.m
+++ b/iphone/Classes/TiGradient.m
@@ -184,8 +184,28 @@
 			thisEntry = [thisEntry objectForKey:@"color"];
 		}
 
-		UIColor * thisColor = [[TiUtils colorValue:thisEntry] _color];
-		if (thisColor == nil)
+ 	    UIColor * thisColor = [[TiUtils colorValue:thisEntry] _color];
+	   
+	    //Bugfix for bug #2178 - Jacob Relkin
+	   	    
+	    CGColorSpaceRef colorspace = CGColorGetColorSpace([thisColor CGColor]);
+	    if(CGColorSpaceGetModel(colorspace) == kCGColorSpaceModelMonochrome) 
+		{
+			/*
+			 Transform colorspace to RGB.
+			 Monochrome colorspaces won't work in CAGradientLayer
+             so we have to use UIColor's colorWithRed:green:blue:alpha: method
+			 to transform it to the RGB colorspace.
+		    */
+ 		    NSLog(@"colorspace is monochrome - transforming colorspace...");
+		    CGFloat *components = CGColorGetComponents([thisColor CGColor]);
+		    thisColor = [UIColor colorWithRed:components[0]
+										green:components[0] 
+										 blue:components[0]
+										alpha:components[1]];
+		}
+
+  	    if (thisColor == nil)
 		{
 			[self throwException:TiExceptionInvalidType subreason:
 					@"Colors must be an array of colors or objects with a color property" location:CODELOCATION];
@@ -196,9 +216,9 @@
 		{
 			offsetsDefined ++;
 		}
-
+        
 		CFArrayAppendValue(colorValues, [thisColor CGColor]);
-		currentIndex ++;
+	    currentIndex ++;
 	}
 	[self clearCache];
 }

--- a/iphone/Classes/TiGradient.m
+++ b/iphone/Classes/TiGradient.m
@@ -186,6 +186,12 @@
 
  	    UIColor * thisColor = [[TiUtils colorValue:thisEntry] _color];
 	   
+	    if (thisColor == nil)
+		{
+		   [self throwException:TiExceptionInvalidType subreason:
+			@"Colors must be an array of colors or objects with a color property" location:CODELOCATION];
+		}	   
+
 	    //Bugfix for bug #2178 - Jacob Relkin
 	   	    
 	    CGColorSpaceRef colorspace = CGColorGetColorSpace([thisColor CGColor]);
@@ -203,12 +209,6 @@
 										green:components[0] 
 										 blue:components[0]
 										alpha:components[1]];
-		}
-
-  	    if (thisColor == nil)
-		{
-			[self throwException:TiExceptionInvalidType subreason:
-					@"Colors must be an array of colors or objects with a color property" location:CODELOCATION];
 		}
 
 		colorOffsets[currentIndex] = thisOffset;

--- a/iphone/Classes/TiUITableView.m
+++ b/iphone/Classes/TiUITableView.m
@@ -1888,10 +1888,7 @@ if(ourTableView != tableview)	\
 		hasTitle = YES;
 		size+=[tableview sectionHeaderHeight];
 	}
-	if ([tableview tableHeaderView]!=nil && searchField == nil)
-	{
-		size+=[tableview tableHeaderView].frame.size.height;
-	}
+	
 	if (hasTitle && size < DEFAULT_SECTION_HEADERFOOTER_HEIGHT)
 	{
 		size += DEFAULT_SECTION_HEADERFOOTER_HEIGHT;


### PR DESCRIPTION
Summary of bug 2178:

`CAGradientLayer` for some odd reason does not support colors in the `CGColorSpaceModelMonochrome` color space model.

The fix for this is to check if the color space model is `kCGColorSpaceModelMonochrome`, and if it is, re-assign the gradient's color to the RGB representation of the color by using `UIColor`'s `colorWithRed:green:blue:alpha:` method.

Here's a screenshot of it in action: http://cl.ly/3u282l072k3g1O1F1x01

Summary of bug 2837:

This was an interesting one - in `tableView:heightForHeaderInSection:`, the height of the `tableView`'s `tableHeaderView` was being added to the local `size` variable for no apparent reason. I simply removed the `if` block and voila! :)
