### PR TITLE
Blob image quality

### DIFF
--- a/iphone/Classes/TiBlob.m
+++ b/iphone/Classes/TiBlob.m
@@ -166,7 +166,8 @@
 		}
 		case TiBlobTypeImage:
 		{
-			return UIImageJPEGRepresentation(image,1.0);
+			id quality = [self valueForUndefinedKey:@"imageQuality"];
+			return UIImageJPEGRepresentation(image, quality == nil ? 1.0 : [TiUtils floatValue:quality]);
 		}
 	}
 	return data;


### PR DESCRIPTION
user can specify image quality before saving blob to file

```
var image = e.media;
var f = Ti.Filesystem.getFile(
   Ti.Filesystem.applicationDataDirectory, 'photo.jpg'
);
image.imageQuality = 0.5;
f.write(image);
```
