### PR TITLE
2858 ui widgets displaying gmt

### DIFF
--- a/android/titanium/src/org/appcelerator/kroll/KrollDate.java
+++ b/android/titanium/src/org/appcelerator/kroll/KrollDate.java
@@ -19,13 +19,8 @@ public class KrollDate extends Date {
 	public KrollDate(Scriptable jsDate) {
 		this.jsDate = jsDate;
 		
-		long timezoneOffset = callLongMethod("getTimezoneOffset");
-		long millis = callLongMethod("getTime");
+		long millis = callLongMethod("getTime");//Already in UTC
 		
-		// Convert to GMT
-		if (timezoneOffset != 0) {
-			millis += timezoneOffset*60*1000;
-		}
 		setTime(millis);
 	}
 	


### PR DESCRIPTION
No need to convert to GMT, getTime returns ms since epoch in utc.  This affects all droid ui widgets where the value can be set by passing in a a Date object. 
