### PR TITLE
Gallery media types

### DIFF
--- a/android/modules/media/src/ti/modules/titanium/media/MediaModule.java
+++ b/android/modules/media/src/ti/modules/titanium/media/MediaModule.java
@@ -402,7 +402,7 @@ public class MediaModule extends KrollModule
 					mime = "video/*";
 				}
 				if(types[0].equals(MEDIA_TYPE_PHOTO)) {
-					mime = "photo/*";
+					mime = "image/*";
 				}
 				if(types[0].equals(MEDIA_TYPE_ALL)) {
 					mime = "*/*";

--- a/android/modules/media/src/ti/modules/titanium/media/MediaModule.java
+++ b/android/modules/media/src/ti/modules/titanium/media/MediaModule.java
@@ -72,6 +72,7 @@ public class MediaModule extends KrollModule
 	@Kroll.constant public static final String MEDIA_TYPE_PHOTO = "public.image";
 	@Kroll.constant public static final String MEDIA_TYPE_VIDEO = "public.video";
 	@Kroll.constant public static final String MEDIA_TYPE_UNKNOWN = "public.unknown";
+	@Kroll.constant public static final String MEDIA_TYPE_ALL = "public.all";
 	
 	public MediaModule(TiContext tiContext)
 	{
@@ -394,6 +395,21 @@ public class MediaModule extends KrollModule
 		if (options.containsKey("mimeType")) {
 			mime = options.getString("mimeType");
 		}
+		else if(options.containsKey("mediaTypes")) {
+			String[] types = options.getStringArray("mediaTypes");
+			if(types.length == 1) {
+				if(types[0].equals(MEDIA_TYPE_VIDEO)) {
+					mime = "video/*";
+				}
+				if(types[0].equals(MEDIA_TYPE_PHOTO)) {
+					mime = "photo/*";
+				}
+				if(types[0].equals(MEDIA_TYPE_ALL)) {
+					mime = "*/*";
+				}
+			}
+		}
+
 
 		if (DBG) {
 			Log.d(LCAT, "openPhotoGallery called");


### PR DESCRIPTION
Currently titanium's gallery docs claim it supports photos and / or videos. Android itself however only supports photos OR videos. And the implementation only supports photos.

My app requires more media types, so I've altered the titanium API slightly to more closely match android's actual capabilities, to take advantage of the extra features. To be specific, I've deprecated the mediaTypes array on android and added a mimeType parameter where one can specify a mime type of the media to look for -- image/\* opens the gallery looking for images, video/\* opens the gallery looking for video, _/_ prompts the user with a list of apps that they can select from, etc.

This patch doesn't do everything it could (eg, if you select a video it doesn't parse it to find out the width and height, it just returns the blob), but it does add significant useful functionality while not breaking any existing code. The only downside I can see is that it uses a new parameter rather than using the existing mediaTypes, but I can't see a way of making mediaTypes work correctly even in theory, so I think this downside is necessary.
