### PR TITLE
showCamera video support

### DIFF
--- a/android/modules/media/src/ti/modules/titanium/media/MediaModule.java
+++ b/android/modules/media/src/ti/modules/titanium/media/MediaModule.java
@@ -107,7 +107,10 @@ public class MediaModule extends KrollModule
 			errorCallback = (KrollCallback) options.get("error");
 		}
 		if (options.containsKey("mediaTypes")) {
-			type = MEDIA_TYPE_VIDEO;
+			String[] types = options.getStringArray("mediaTypes");
+			if(types.length == 1 && types[0].equals(MEDIA_TYPE_VIDEO)) {
+				type = MEDIA_TYPE_VIDEO;
+			}
 		}
 
 		final KrollCallback fSuccessCallback = successCallback;


### PR DESCRIPTION
Implement showCamera with "mediaTypes:[Ti.Media.MEDIA_TYPE_VIDEO]"

It seems to be a limitation of android itself that you can only have one media type at a time, so "mediaTypes:[Ti.Media.MEDIA_TYPE_VIDEO, Ti.Media.MEDIA_TYPE_PHOTO]" doesn't work
