### PR TITLE
Corrected log messages generated in builder.py, log all messages to build log file

### DIFF
--- a/support/android/builder.py
+++ b/support/android/builder.py
@@ -246,8 +246,7 @@ class Builder(object):
 		return True
 	
 	def wait_for_device(self, type):
-		print "[DEBUG] Waiting for device to be ready ..."
-		sys.stdout.flush()
+		debug("Waiting for device to be ready ...")
 		t = time.time()
 		max_wait = 30
 		max_zero = 6
@@ -502,7 +501,6 @@ class Builder(object):
 
 	def copy_project_resources(self):
 		info("Copying project resources..")
-		sys.stdout.flush()
 		
 		resources_dir = os.path.join(self.top_dir, 'Resources')
 		android_resources_dir = os.path.join(resources_dir, 'android')
@@ -1249,8 +1247,7 @@ class Builder(object):
 			local_compiler_dir = os.path.abspath(os.path.join(self.top_dir,'plugins'))
 			tp_compiler_dir = os.path.abspath(os.path.join(titanium_dir,'plugins'))
 			if not os.path.exists(tp_compiler_dir) and not os.path.exists(local_compiler_dir):
-				print "[ERROR] Build Failed (Missing plugins directory)"
-				sys.stdout.flush()
+				error("Build Failed (Missing plugins directory)")
 				sys.exit(1)
 			compiler_config = {
 				'platform':'android',
@@ -1269,12 +1266,11 @@ class Builder(object):
 			for plugin in self.tiappxml.properties['plugins']:
 				local_plugin_file = os.path.join(local_compiler_dir,plugin['name'],'plugin.py')
 				plugin_file = os.path.join(tp_compiler_dir,plugin['name'],plugin['version'],'plugin.py')
-				print "[INFO] plugin=%s" % plugin_file
+				info("plugin=%s" % plugin_file)
 				if not os.path.exists(local_plugin_file) and not os.path.exists(plugin_file):
-					print "[ERROR] Build Failed (Missing plugin for %s)" % plugin['name']
-					sys.stdout.flush()
+					error("Build Failed (Missing plugin for %s)" % plugin['name'])
 					sys.exit(1)
-				print "[INFO] Detected compiler plugin: %s/%s" % (plugin['name'],plugin['version'])
+				info("Detected compiler plugin: %s/%s" % (plugin['name'],plugin['version']))
 				code_path = plugin_file
 				if os.path.exists(local_plugin_file):	
 					code_path = local_plugin_file
@@ -1488,7 +1484,6 @@ class Builder(object):
 						dex_args.append(os.path.join(self.support_dir, 'modules', 'titanium-network.jar'))
 	
 				info("Compiling Android Resources... This could take some time")
-				sys.stdout.flush()
 				# TODO - Document Exit message
 				run_result = run.run(dex_args, warning_regex=r'warning: ')
 				if (run_result == None):
@@ -1497,6 +1492,7 @@ class Builder(object):
 					sys.exit(1)
 				else:
 					dex_built = True
+					debug("Android classes.dex built")
 			
 			if self.sdcard_copy and not build_only and \
 				(not self.resources_installed or not self.app_installed) and \

--- a/support/android/builder.py
+++ b/support/android/builder.py
@@ -1258,7 +1258,9 @@ class Builder(object):
 				'build_dir':s.project_dir,
 				'app_name':self.name,
 				'android_builder':self,
-				'deploy_type':deploy_type
+				'deploy_type':deploy_type,
+				'dist_dir':dist_dir,
+				'logger':log
 			}
 			for plugin in self.tiappxml.properties['plugins']:
 				local_plugin_file = os.path.join(local_compiler_dir,plugin['name'],'plugin.py')

--- a/support/android/builder.py
+++ b/support/android/builder.py
@@ -11,6 +11,7 @@ from compiler import Compiler
 from os.path import join, splitext, split, exists
 from shutil import copyfile
 from xml.dom.minidom import parseString
+from tilogger import *
 
 template_dir = os.path.abspath(os.path.dirname(sys._getframe(0).f_code.co_filename))
 top_support_dir = os.path.dirname(template_dir) 
@@ -30,6 +31,7 @@ ignoreFiles = ['.gitignore', '.cvsignore', '.DS_Store'];
 ignoreDirs = ['.git','.svn','_svn', 'CVS'];
 android_avd_hw = {'hw.camera': 'yes', 'hw.gps':'yes'}
 res_skips = ['style']
+log = None
 
 # Copied from frameworks/base/tools/aapt/Package.cpp
 uncompressed_types = [
@@ -71,25 +73,20 @@ def read_properties(propFile, separator=":= "):
 	return propDict
 
 def info(msg):
-	print "[INFO] "+msg
-	sys.stdout.flush()
+	log.info(msg)
 
 def debug(msg):
-	print "[DEBUG] "+msg
-	sys.stdout.flush()
+	log.debug(msg)
 
 def warn(msg):
-	print "[WARN] "+msg
-	sys.stdout.flush()
+	log.warn(msg)
 
 def trace(msg):
-	print "[TRACE] "+msg
-	sys.stdout.flush()
-
+	log.trace(msg)
+	
 def error(msg):
-	print "[ERROR] "+msg
-	sys.stdout.flush()
-
+	log.error(msg)
+	
 def remove_orphaned_files(source_folder, target_folder):
 	is_res = source_folder.endswith('Resources') or source_folder.endswith('Resources' + os.sep)
 	for root, dirs, files in os.walk(target_folder):
@@ -1565,7 +1562,7 @@ if __name__ == "__main__":
 		usage()
 	
 	command = sys.argv[1]
-	
+	log = TiLogger(os.path.join(os.path.abspath(os.path.expanduser(dequote(sys.argv[4]))), 'build.log'))
 	template_dir = os.path.abspath(os.path.dirname(sys._getframe(0).f_code.co_filename))
 	get_values_from_tiapp = False
 	

--- a/support/android/tilogger.py
+++ b/support/android/tilogger.py
@@ -1,0 +1,74 @@
+from __future__ import with_statement
+import os, sys
+
+class TiLogger:
+	def __init__(self, logfile):
+		global _logfile
+		_logfile = logfile
+		logfolder = os.path.dirname(_logfile)
+		try:
+			if not os.path.exists(logfolder):
+				os.mkdir(logfolder)
+		except:
+			print "[ERROR] error creating log folder %s: %s" % (logfolder, sys.exc_info()[0])
+		try:
+			with open(_logfile, 'w') as f:
+				f.write('Logfile initialized\n')
+		except:
+			print "[ERROR] error initializing (writing to) log file %s: %s" % (_logfile, sys.exc_info()[0])
+		
+		self.info("logfile = " + logfile)
+			
+	def info(self, msg):
+		global _logfile
+		print "[INFO] "+msg
+		sys.stdout.flush()
+		try:
+			with open(_logfile, 'a') as f:
+				f.write('[INFO] %s\n' % msg)
+		except:
+			print "[ERROR] error writing to log %s: %s" % (_logfile, sys.exc_info()[0])
+
+	def debug(self, msg):
+		global _logfile
+		print "[DEBUG] "+msg
+		sys.stdout.flush()
+		try:
+			with open(_logfile, 'a') as f:
+				f.write('[DEBUG] %s\n' % msg)
+		except:
+			print "[ERROR] error writing to log %s: %s" % (_logfile, sys.exc_info()[0])
+
+	def warn(self, msg):
+		global _logfile
+		print "[WARN] "+msg
+		sys.stdout.flush()
+		try:
+			with open(_logfile, 'a') as f:
+				f.write('[WARN] %s\n' % msg)
+		except:
+			print "[ERROR] error writing to log %s: %s" % (_logfile, sys.exc_info()[0])
+
+	def trace(self, msg):
+		global _logfile
+		print "[TRACE] "+msg
+		sys.stdout.flush()
+		try:
+			with open(_logfile, 'a') as f:
+				f.write('[TRACE] %s\n' % msg)
+		except:
+			print "[ERROR] error writing to log %s: %s" % (_logfile, sys.exc_info()[0])
+
+	def error(self, msg):
+		global _logfile
+		print "[ERROR] "+msg
+		sys.stdout.flush()
+		try:
+			with open(_logfile, 'a') as f:
+				f.write('[ERROR] %s\n' % msg)
+		except:
+			print "[ERROR] error writing to log %s: %s" % (_logfile, sys.exc_info()[0])
+
+# if __name__ == "__main__":
+	# _logfile = ''
+	# print "[DEBUG] TiLogger initialized"


### PR DESCRIPTION
There were inconsistencies in how messages were generated in the build process.  Some were print statements, while others were using the helper functions.  Made all use the helper functions.

Updated the helper functions to use an external logger which will both print the messages and log them to a file.  This file is build.log in the project folder.

The logger is also passed into the plugin so that plugins may log to the same build log.

Thank you.
