### PR TITLE
Verizon iPhone 4 model detection fix

### DIFF
--- a/iphone/Classes/PlatformModule.m
+++ b/iphone/Classes/PlatformModule.m
@@ -70,7 +70,7 @@ NSString* const DATA_IFACE = @"pdp_ip0";
 			model = [[NSString stringWithFormat:@"%@ 3GS",themodel] retain];
 		}
 		// detect iPhone 4 model
-		else if (!strcmp(u.machine, "iPhone3,1")) 
+		else if (!strcmp(u.machine, "iPhone3,1") || !strcmp(u.machine, "iPhone3,2") || !strcmp(u.machine, "iPhone3,3")) 
 		{
 			model = [[NSString stringWithFormat:@"%@ 4",themodel] retain];
 		}


### PR DESCRIPTION
We ran into an issue where the new Verizon iPhone 4 is not identified as an iPhone 4 when calling Titanium.Platform.model. This is the patch we're using.
