### PR TITLE
Make TableViewRow use font property to style title (iOS)

### DIFF
--- a/iphone/Classes/TiUITableViewRowProxy.m
+++ b/iphone/Classes/TiUITableViewRowProxy.m
@@ -376,6 +376,14 @@ TiProxy * DeepScanForProxyOfViewContainingPoint(UIView * targetView, CGPoint poi
 	{
 		[textLabel setText:title]; //UILabel already checks to see if it hasn't changed.
 		
+		id fontValue = [self valueForKey:@"font"];
+		UIFont *font = nil;
+		if (fontValue!=nil)
+		{
+			font = [[TiUtils fontValue:[self valueForKey:@"font"]] font];
+			textLabel.font = font;
+		}
+		
 		UIColor * textColor = [[TiUtils colorValue:[self valueForKey:@"color"]] _color];
 		[textLabel setTextColor:(textColor==nil)?[UIColor blackColor]:textColor];
 		


### PR DESCRIPTION
TableViewRow api docs state that the `font` property will modify the title styling, but in 1.6.0 that does not work. This patch corrects that for iOS.

Related lighthouse issue:
https://appcelerator.lighthouseapp.com/projects/32238/tickets/3061-apidoc-tableview-and-tableviewrow-font-properties-not-supported

Related Q&A discussion:
http://developer.appcelerator.com/question/33581/bug-table-row-font-doesnt-work-on-iphone
