### PR TITLE
1441 scrollview memory bugfix

### DIFF
--- a/iphone/Classes/TiViewProxy.m
+++ b/iphone/Classes/TiViewProxy.m
@@ -729,6 +729,13 @@ LAYOUTPROPERTIES_SETTER(setMinHeight,minimumHeight,TiFixedValueRuleFromObject,[s
 -(void)viewWillDetach
 {
 	// for subclasses
+	pthread_rwlock_rdlock(&childrenLock);
+	if (children != nil) {
+		for (TiViewProxy* child in children) {
+			[child detachView];
+		}
+	}
+	pthread_rwlock_unlock(&childrenLock);
 }
 
 -(void)viewDidDetach


### PR DESCRIPTION
If a view is detached check if there are children and detach them as well. This fixes some memory problems here in my project, but this was just done by trial and error, so please feel free to use a better fix..
