### PR TITLE
3298 hide master popover on split window close

### DIFF
--- a/iphone/Classes/TiUIiPadSplitWindowProxy.m
+++ b/iphone/Classes/TiUIiPadSplitWindowProxy.m
@@ -62,6 +62,14 @@
 	return [detailView orientationFlags];
 }
 
+-(BOOL)_handleClose:(id)args
+{
+        // Ensure popup isn't visible so it can be dealloced
+	[[self view] setMasterPopupVisible_:NO];
+
+        return [super _handleClose:args];
+}
+
 @end
 
 #endif


### PR DESCRIPTION
Resolves ticket #3298 - Closing a SplitWindow while the master view popover is visible causes a crash
