### PR TITLE
2955 json quotes bool values

### DIFF
--- a/android/modules/json/src/ti/modules/titanium/json/JSONModule.java
+++ b/android/modules/json/src/ti/modules/titanium/json/JSONModule.java
@@ -48,7 +48,10 @@ public class JSONModule extends KrollModule {
 			} else {
 				return "" + d;
 			}
-		} else {
+		} else if (data instanceof Boolean) {
+			return TiConvert.toJSONString(data);
+		} 
+		else {
 			return "\"" + TiConvert.toJSONString(data) + "\"";
 		}
 	}


### PR DESCRIPTION
LH#2955 - Android: JSON intake inconsistency compared to iOS.  

Bools where lumped into every other object when being stringified and had quotes wrapped around the value which does not confirm to the JSON standard.  Booleans are defined as their own type and should be represented as: true or false instead of "true" or "false".  
