### PR TITLE
32238 loss of precision set double

### DIFF
--- a/android/titanium/src/org/appcelerator/titanium/TiProperties.java
+++ b/android/titanium/src/org/appcelerator/titanium/TiProperties.java
@@ -79,16 +79,24 @@ public class TiProperties
 		if (DBG) {
 			Log.d(LCAT,"getDouble called with key:"+key+", def:"+def);
 		}
-		return (double)preferences.getFloat(key,(float)def);
+		if( !this.hasProperty(key) )
+			return def;
+		
+		String stringValue = preferences.getString(key,"");
+		try {
+			return Double.parseDouble(stringValue);
+		} catch (NumberFormatException e) {
+			return def;
+		}
 	}
 	public void setDouble(String key, double value)
 	{
 		if (DBG) {
 			Log.d(LCAT,"setDouble called with key:"+key+", value:"+value);
 		}
-
+		
 		SharedPreferences.Editor editor = preferences.edit();
-		editor.putFloat(key,(float)value);
+		editor.putString(key,value + "");
 		editor.commit();
 	}
 	public boolean getBool(String key, boolean def)


### PR DESCRIPTION
Casting down to float causes loss of precision, better to store as string and convert to double for the getter.
