### PR TITLE
#3077 compass true heading is sometimes returned as greater than 360 degrees on Android

### DIFF
--- a/android/modules/geolocation/src/ti/modules/titanium/geolocation/TiCompass.java
+++ b/android/modules/geolocation/src/ti/modules/titanium/geolocation/TiCompass.java
@@ -126,7 +126,7 @@ public class TiCompass
 		if (geomagneticField != null) {
 			float trueHeading = x - geomagneticField.getDeclination();
 			if (trueHeading < 0) {
-				trueHeading = 360 - trueHeading;
+				trueHeading = (360 - trueHeading) % 360;
 			}
 
 			heading.put(TiC.PROPERTY_TRUE_HEADING, trueHeading);


### PR DESCRIPTION
Ti.Geolocation sometimes produces true headings that are greater than 360 degrees. I'm assuming that titanium_mobile/android/modules/geolocation/src/ti/modules/titanium/geolocation/TiCompass.java on line 129 just needs a bit of modular arithmetic (% 360).
