### PR TITLE
3331 password mask does not disable autocomplete

### DIFF
--- a/android/modules/ui/src/ti/modules/titanium/ui/widget/TiUIText.java
+++ b/android/modules/ui/src/ti/modules/titanium/ui/widget/TiUIText.java
@@ -382,6 +382,7 @@ public class TiUIText extends TiUIView
 		}
 		if (passwordMask) {
 			tv.setTransformationMethod(PasswordTransformationMethod.getInstance());
+			tv.setInputType(InputType.TYPE_TEXT_VARIATION_PASSWORD);
 		} else {
 			if (tv.getTransformationMethod() instanceof PasswordTransformationMethod) {
 				tv.setTransformationMethod(null);


### PR DESCRIPTION
Fixes ticket #3331. Note that autocomplete does not necessarily turn up in the emulator, but was present on the device I tested with. Explicitly setting the field to password type fixes the problem. 
