### PR TITLE
removed isDragging check and added boolean dragging to event object

### DIFF
--- a/iphone/Classes/TiUITableView.m
+++ b/iphone/Classes/TiUITableView.m
@@ -2037,17 +2037,15 @@ if(ourTableView != tableview)	\
 
 - (void)scrollViewDidScroll:(UIScrollView *)scrollView
 {	
-	if (scrollView.isDragging) 
-	{
-		if ([self.proxy _hasListeners:@"scroll"])
-		{
-			NSMutableDictionary *event = [NSMutableDictionary dictionary];
-			[event setObject:[TiUtils pointToDictionary:scrollView.contentOffset] forKey:@"contentOffset"];
-			[event setObject:[TiUtils sizeToDictionary:scrollView.contentSize] forKey:@"contentSize"];
-			[event setObject:[TiUtils sizeToDictionary:tableview.bounds.size] forKey:@"size"];
-			[self.proxy fireEvent:@"scroll" withObject:event];
-		}
-	}
+    if ([self.proxy _hasListeners:@"scroll"])
+    {
+        NSMutableDictionary *event = [NSMutableDictionary dictionary];
+        [event setObject:NUMBOOL([scrollView isDragging]) forKey:@"dragging"];
+        [event setObject:[TiUtils pointToDictionary:scrollView.contentOffset] forKey:@"contentOffset"];
+        [event setObject:[TiUtils sizeToDictionary:scrollView.contentSize] forKey:@"contentSize"];
+        [event setObject:[TiUtils sizeToDictionary:tableview.bounds.size] forKey:@"size"];
+        [self.proxy fireEvent:@"scroll" withObject:event];
+    }
 }
 
 


### PR DESCRIPTION
Hi there,

I removed the check for scrollView.isDragging on TableView so that it fires like you would expect it too, and added the boolean "dragging" to the event - which is inline with the "scroll" event on a ScrollView.  This allows the "scroll" event to be fired when a TableView is scrolled, not just when being dragged.  It also allows us to fix the "pull to refresh" issues on devices <= iPhone 3G

Thanks,

Brian
