### PR TITLE
(iOS) changed split view master popover button behaviour from 'show' to 'toggle' like stock split view 

### DIFF
--- a/iphone/Classes/MGSplitView/MGSplitViewController.h
+++ b/iphone/Classes/MGSplitView/MGSplitViewController.h
@@ -61,6 +61,7 @@ typedef enum _MGSplitViewDividerStyle {
 - (IBAction)showMasterPopover:(id)sender; // shows the master view in a popover spawned from the provided barButtonItem, if it's currently hidden.
 - (IBAction)hideMasterPopover:(id)sender;
 - (void)notePopoverDismissed; // should rarely be needed, because you should not change the popover's delegate. If you must, then call this when it's dismissed.
+- (void) toggleMasterPopover:(id)sender;
 
 // Conveniences for you, because I care.
 - (BOOL)isShowingMaster;

--- a/iphone/Classes/MGSplitView/MGSplitViewController.m
+++ b/iphone/Classes/MGSplitView/MGSplitViewController.m
@@ -570,7 +570,7 @@
 		_barButtonItem = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Master", nil) 
 														  style:UIBarButtonItemStyleBordered 
 														 target:self 
-														 action:@selector(showMasterPopover:)];
+														 action:@selector(toggleMasterPopover:)];
 		
 		// Inform delegate of this state of affairs.
 		if (_delegate && [_delegate respondsToSelector:@selector(splitViewController:willHideViewController:withBarButtonItem:forPopoverController:)]) {
@@ -710,6 +710,16 @@
 	[UIView commitAnimations];
 }
 
+- (void) toggleMasterPopover:(id)sender {
+    if ( _hiddenPopoverController ) {
+        if ( _hiddenPopoverController.popoverVisible ) {
+            [self showMasterPopover:sender];
+        }
+        else {
+            [self showMasterPopover:sender];
+        }
+    }
+}
 
 - (IBAction)showMasterPopover:(id)sender
 {

--- a/iphone/Classes/MGSplitView/MGSplitViewController.m
+++ b/iphone/Classes/MGSplitView/MGSplitViewController.m
@@ -713,7 +713,7 @@
 - (void) toggleMasterPopover:(id)sender {
     if ( _hiddenPopoverController ) {
         if ( _hiddenPopoverController.popoverVisible ) {
-            [self showMasterPopover:sender];
+            [self hideMasterPopover:sender];
         }
         else {
             [self showMasterPopover:sender];

--- a/iphone/Classes/TiUIiPadSplitWindowProxy.m
+++ b/iphone/Classes/TiUIiPadSplitWindowProxy.m
@@ -62,6 +62,20 @@
 	return [detailView orientationFlags];
 }
 
+-(BOOL)_handleClose:(id)args
+{
+    // Ensure popup isn't visible so it can be dealloced
+    [self hidePopover:nil];
+
+    return [super _handleClose:args];
+}
+
+-(void)hidePopover:(id)args
+{
+    ENSURE_UI_THREAD_0_ARGS;
+    [[self view] setMasterPopupVisible_:NO];
+}
+
 @end
 
 #endif


### PR DESCRIPTION
hello

our app requires the split view master popover button to show/hide the pop-over, like UISplitViewController, so this change enables that

many regards

paul@boxuk.com
