### PR TITLE
Patch 1

### DIFF
--- a/support/titanium.py
+++ b/support/titanium.py
@@ -202,7 +202,7 @@ def build(args):
 	pass
 	
 def run_project_args(args,script,project_dir,platform):
-	return [script,"run",project_dir]
+	return [script,"run",project_dir,platform]
 	
 def run_module_args(args,script,project_dir,platform):
 	return [script,"run",platform,project_dir]


### PR DESCRIPTION
When running "titanium run" in Windows, i was getting an error from builder.py that indicated that the 'platform' argument was missing even though i had it on the command-line, e.g.:

C:\Documents and Settings\mshafi>titanium run --dir=<project_dir> --platform=android
Usage: C:\Documents and Settings\All Users\Application Data\Titanium\mobilesdk\win32\1.6.2\android\builder.py run <project_dir> <android_sdk>

i traced it down to the run_project_args method in titanium.py that seemed to be missing the 'platform' value.  Adding that made the above command run properly.
