### PR TITLE
[TIMOB-7955] disableBounce for Ti.UI.WebView and scrollsToTop for Ti.UI.ScrollView and Ti.UI.WebView

### DIFF
--- a/iphone/Classes/TiUIScrollView.m
+++ b/iphone/Classes/TiUIScrollView.m
@@ -155,6 +155,11 @@
 	[[self scrollView] setBounces:![TiUtils boolValue:value]];
 }
 
+-(void)setScrollsToTop_:(id)value
+{
+	[[self scrollView] setScrollsToTop:[TiUtils boolValue:value]];
+}
+
 -(void)setHorizontalBounce_:(id)value
 {
 	[[self scrollView] setAlwaysBounceHorizontal:[TiUtils boolValue:value]];

--- a/iphone/Classes/TiUIWebView.m
+++ b/iphone/Classes/TiUIWebView.m
@@ -243,6 +243,23 @@ NSString * const kTitaniumJavascript = @"Ti.App={};Ti.API={};Ti.App._listeners={
 	}
 }
 
+-(UIScrollView*)scrollview
+{
+	UIWebView* webView = [self webview];
+	if ([webView respondsToSelector:@selector(scrollView)]) {
+		// as of iOS 5.0, we can return the scroll view
+		return [webView scrollView];
+	} else {
+		// in earlier versions, we need to find the scroll view
+		for (id subview in [webView subviews]) {
+			if ([subview isKindOfClass:[UIScrollView class]]) {
+				return (UIScrollView*)subview;
+			}
+		}
+	}
+	return nil;
+}
+
 
 #pragma mark Public APIs
 
@@ -386,6 +403,18 @@ NSString * const kTitaniumJavascript = @"Ti.App={};Ti.API={};Ti.App._listeners={
 	BOOL scaling = [TiUtils boolValue:args];
 	scalingOverride = YES;
 	[[self webview] setScalesPageToFit:scaling];
+}
+
+-(void)setDisableBounce_:(id)value
+{
+	BOOL bounces = ![TiUtils boolValue:value];
+	[[self scrollview] setBounces:bounces];
+}
+
+-(void)setScrollsToTop_:(id)value
+{
+	BOOL scrollsToTop = [TiUtils boolValue:value];
+	[[self scrollview] setScrollsToTop:scrollsToTop];
 }
 
 #ifndef USE_BASE_URL


### PR DESCRIPTION
Hi Guys,

we’ve added the `disableBounce` property known from `Ti.UI.ScrollView` to `Ti.UI.WebView` – useful for cases with non-scrolling webviews that shouldn’t bounce and maybe more …

we’ve also added iPhone-specific `scrollsToTop` to both `Ti.UI.ScrollView` and `Ti.UI.WebView`. Default is true; setting it to false does not scroll the view to top when the user taps the status bar. This is useful when having multiple scrollable views visible to make one view “scroll-to-top-able” by excluding the others.

It would be nice to have these patches upstream as we think they might be useful for others and getting them into Titanium Developer with an official release.

I’ve just signed the CLA and squashed the changes into a single commit.

Cheers,
David
