### PR TITLE
Fixed TIMOB-4207: Media.createVideoPlayer requires CAMERA_PERMISSION

### DIFF
--- a/support/android/builder.py
+++ b/support/android/builder.py
@@ -650,7 +650,6 @@ class Builder(object):
 			
 			# MEDIA
 			'Media.vibrate' : VIBRATE_PERMISSION,
-			'Media.createVideoPlayer' : CAMERA_PERMISSION,
 			'Media.showCamera' : CAMERA_PERMISSION,
 			
 			# CONTACTS


### PR DESCRIPTION
I removed the permission association between Media.createVideoPlayer and CAMERA_PERMISSION. Tested an app that uses the video player on my device before and after the change with a clean build. Worked in both cases. The only difference was the AndroidManifest.xml did and then did not include the camera permissions. Should be ok to merge in!

Not precisely a complicated change, either...
