### PR TITLE
Add alwaysRetainTaskState="true" in the AndroidManifest.xml template.

### DIFF
--- a/support/android/templates/AndroidManifest.xml
+++ b/support/android/templates/AndroidManifest.xml
@@ -19,6 +19,7 @@
             android:label="${config['appname']}"
 			android:theme="@style/Theme.Titanium"
             android:configChanges="keyboardHidden|orientation"
+            android:alwaysRetainTaskState="true"
         >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
This is based on the solution given in ticket TIMOB-1964. The issue was that android applications would return with blank windows if backgrounded for some period of time.

The solution in the ticket suggested adding the alwaysRetainTaskState in a custom AndroidManifest.xml. I was hoping it could be included in the AndroidManifest.xml template by default.
