### PR TITLE
Fix for TIMOB-4445 iOS module license warning always shown

### DIFF
--- a/support/module/iphone/templates/build.py
+++ b/support/module/iphone/templates/build.py
@@ -99,7 +99,7 @@ def warn(msg):
 
 def validate_license():
 	c = open(os.path.join(cwd,'LICENSE')).read()
-	if c.find(module_license_default)!=1:
+	if c.find(module_license_default)!=-1:
 		warn('please update the LICENSE file with your license text before distributing')
 			
 def validate_manifest():


### PR DESCRIPTION
http://jira.appcelerator.org/browse/TIMOB-4445

Quite a simple fix, really. 1 changed to -1.
