### PR TITLE
TIMOB 2906 Stop fullscreen translucent theme for modal activities.

### DIFF
--- a/android/modules/ui/src/ti/modules/titanium/ui/TiUIWindow.java
+++ b/android/modules/ui/src/ti/modules/titanium/ui/TiUIWindow.java
@@ -536,8 +536,11 @@ public class TiUIWindow extends TiUIView
 		}
 		props = resolver.findProperty(TiC.PROPERTY_MODAL);
 		if (props != null && props.containsKey(TiC.PROPERTY_MODAL)) {
-			intent.setClass(activity, TiModalActivity.class);
-			intent.putExtra(TiC.PROPERTY_MODAL, TiConvert.toBoolean(props, TiC.PROPERTY_MODAL));
+			boolean modal = TiConvert.toBoolean(props, TiC.PROPERTY_MODAL);
+			intent.putExtra(TiC.PROPERTY_MODAL, modal);
+			if (modal) {
+				intent.setClass(activity, TiModalActivity.class);
+			}
 		}
 		props = resolver.findProperty(TiC.PROPERTY_URL);
 		if (props != null && props.containsKey(TiC.PROPERTY_URL)) {

--- a/android/titanium/src/org/appcelerator/titanium/TiBaseActivity.java
+++ b/android/titanium/src/org/appcelerator/titanium/TiBaseActivity.java
@@ -239,12 +239,11 @@ public abstract class TiBaseActivity extends Activity
 		int softInputMode = getIntentInt(TiC.PROPERTY_WINDOW_SOFT_INPUT_MODE, -1);
 		boolean hasSoftInputMode = softInputMode != -1;
 		
-		if (!modal) {
-			setFullscreen(fullscreen);
-			setNavBarHidden(navBarHidden);
-		} else {
-			int flags = WindowManager.LayoutParams.FLAG_BLUR_BEHIND;
-			getWindow().setFlags(flags, flags);
+		setFullscreen(fullscreen);
+		setNavBarHidden(navBarHidden);
+		if (modal) {
+			getWindow().setFlags(WindowManager.LayoutParams.FLAG_BLUR_BEHIND,
+					WindowManager.LayoutParams.FLAG_BLUR_BEHIND);
 		}
 
 		if (hasSoftInputMode) {

--- a/apidoc/Titanium/UI/Window.yml
+++ b/apidoc/Titanium/UI/Window.yml
@@ -183,7 +183,12 @@ properties:
     platforms: [iphone, ipad]
     type: Object
   - name: modal
-    description: boolean to indicate if the window should be opened modal in front of other windows
+    description: |
+        boolean to indicate if the window should be opened modal in front of other windows.  Android note: the
+        combination of `fullscreen:true` and `modal:true` will not work as expected.  Android modal windows are translucent,
+        and, in Android, the contents of a translucent window cannot appear above the status bar.  I.e., even though
+        you say `fullscreen:true`, the status bar will still be visible *if* it was visible in the previous window.  `navBarHidden` and
+        `modal` do work fine together, however.
     type: Boolean
     default: false
   - name: navBarHidden

--- a/support/android/templates/AndroidManifest.xml
+++ b/support/android/templates/AndroidManifest.xml
@@ -34,7 +34,7 @@
       	/>
 		<activity android:name="org.appcelerator.titanium.TiModalActivity"
 			android:configChanges="keyboardHidden|orientation"
-			android:theme="@android:style/Theme.Translucent.NoTitleBar.Fullscreen"
+			android:theme="@android:style/Theme.Translucent"
 		/>
 		<activity android:name="ti.modules.titanium.ui.TiTabActivity"
 			android:configChanges="keyboardHidden|orientation"


### PR DESCRIPTION
Stop fullscreen translucent theme for modal activities. Respect other flags (fullscreen, navBarHidden) when modal flag also used.  Update docs to indicate that modal:true and fullscreen:true won't work together in Android. TIMOB-2906
