### PR TITLE
NSAssert in stopAudioSession of TiMediaAudioSession.m

### DIFF
--- a/iphone/Classes/TiMediaAudioSession.m
+++ b/iphone/Classes/TiMediaAudioSession.m
@@ -300,7 +300,7 @@ void TiAudioSessionInputAvailableCallback(void* inUserData, AudioSessionProperty
 		AudioSessionSetActive(false);
 	}
 #ifdef DEBUG	
-	NSAssert(count >= 0, @"stopAudioSession called too many times");
+	NSAssert(count < 0, @"stopAudioSession called too many times");
 #endif
 	[lock unlock];
 }


### PR DESCRIPTION
The inequality of NSAssert in stopAudioSession should be "less than", shouldn't it?
