### PR TITLE
(iOS) Fix build error related to missing Default.png

### DIFF
--- a/support/iphone/builder.py
+++ b/support/iphone/builder.py
@@ -42,6 +42,17 @@ def version_sort(a,b):
 		return 1
 	return 0
 
+# Find the SDK file path
+def find_sdk_path(version):
+	sdk_path = os.path.join(os.path.expanduser("~/Library/Application Support/Titanium"),"mobilesdk","osx",version)
+	if os.path.exists(sdk_path):
+		return sdk_path
+	sdk_path = os.path.join("/Library","Application Support","Titanium","mobilesdk","osx",version)
+	if os.path.exists(sdk_path):
+		return sdk_path
+	print "Is Titanium installed? I can't find it"
+	sys.exit(1)
+
 # this will return the version of the iOS SDK that we have installed
 def check_iphone_sdk(s):
 	found = []
@@ -999,6 +1010,7 @@ def main(args):
 
 				# copy Default.png and appicon each time so if they're 
 				# changed they'll stick get picked up	
+				# If Default.png is not found in the project, copy it from the SDK's default path
 				app_icon_path = os.path.join(project_dir,'Resources','iphone',applogo)
 				if not os.path.exists(app_icon_path):
 					app_icon_path = os.path.join(project_dir,'Resources',applogo)
@@ -1007,8 +1019,10 @@ def main(args):
 				defaultpng_path = os.path.join(project_dir,'Resources','iphone','Default.png')
 				if not os.path.exists(defaultpng_path):
 					defaultpng_path = os.path.join(project_dir,'Resources','Default.png')
+				if not os.path.exists(defaultpng_path):
+					defaultpng_path = os.path.join(find_sdk_path(sdk_version),'iphone','resources','Default.png')
 				if os.path.exists(defaultpng_path):
-					shutil.copy(defaultpng_path,app_dir)
+					shutil.copy(defaultpng_path,iphone_resources_dir)
 
 				extra_args = None
 


### PR DESCRIPTION
Default.png was no longer being pulled in from the SDK when it didnt exist in the project. This will pull it in. It will also put it in the build/iphone/Resources folder instead of the project.app bundle. 

This issue is addressed: http://developer.appcelerator.com/question/121018/titanium-sdk-17-fails-to-work-for-me and a few other threads there as well.
