### PR TITLE
Photopicker popover barbutton

### DIFF
--- a/iphone/Classes/MediaModule.h
+++ b/iphone/Classes/MediaModule.h
@@ -14,11 +14,11 @@
 
 @interface MediaModule : TiModule
 <
-	UINavigationControllerDelegate,
-	UIImagePickerControllerDelegate, 
-	MPMediaPickerControllerDelegate
+UINavigationControllerDelegate,
+UIImagePickerControllerDelegate, 
+MPMediaPickerControllerDelegate
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_4_0
-	,UIVideoEditorControllerDelegate
+,UIVideoEditorControllerDelegate
 #endif
 > {
 @private
@@ -26,7 +26,7 @@
 	UIImagePickerController *picker;
 	BOOL autoHidePicker;
 	BOOL saveToRoll;
-
+    
 	// Music picker
 	MPMediaPickerController* musicPicker;
 	
@@ -39,6 +39,7 @@
 	KrollCallback *pickerSuccessCallback;
 	KrollCallback *pickerErrorCallback;
 	KrollCallback *pickerCancelCallback;
+	KrollCallback *pickerCloseCallback;
 	
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_3_2
 	id popover;
@@ -84,7 +85,7 @@
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_4_0
 @property(nonatomic,readonly) NSNumber* QUALITY_640x480;
 #endif 
- 
+
 @property(nonatomic,readonly) NSArray* availableCameraMediaTypes;
 @property(nonatomic,readonly) NSArray* availablePhotoMediaTypes;
 @property(nonatomic,readonly) NSArray* availablePhotoGalleryMediaTypes;

--- a/iphone/Classes/MediaModule.m
+++ b/iphone/Classes/MediaModule.m
@@ -247,6 +247,10 @@ enum
 		RELEASE_TO_NIL(musicPicker);
 	}
 	
+	if([popoverController contentViewController] == picker) {
+		RELEASE_TO_NIL(picker);
+	}
+    
 	RELEASE_TO_NIL(popover);
 }
 

--- a/iphone/Classes/MediaModule.m
+++ b/iphone/Classes/MediaModule.m
@@ -13,6 +13,7 @@
 #import "TiApp.h"
 #import "Mimetypes.h"
 #import "TiViewProxy.h"
+#import "TiUIButtonProxy.h"
 #import "Ti2DMatrix.h"
 #import "SCListener.h"
 #import "TiMediaAudioSession.h"
@@ -188,11 +189,17 @@ enum
 	{
 		RELEASE_TO_NIL(popover);
 		UIView *poView = [tiApp controller].view;
+        UIBarButtonItem *button = nil; 
 		CGRect poFrame;
 		TiViewProxy* popoverViewProxy = [args objectForKey:@"popoverView"];
+        TiUIButtonProxy* buttonProxy = [args objectForKey:@"barButton"];
 		UIPopoverArrowDirection arrow = [TiUtils intValue:@"arrowDirection" properties:args def:UIPopoverArrowDirectionAny];
 
-		if (popoverViewProxy!=nil)
+        if (buttonProxy!=nil)
+        {
+            button = [buttonProxy barButtonItem];
+        }
+		else if (popoverViewProxy!=nil)
 		{
 			poView = [popoverViewProxy view];
 			poFrame = [poView frame];
@@ -206,7 +213,13 @@ enum
 
 		popover = [[UIPopoverController alloc] initWithContentViewController:picker_];
 		[popover setDelegate:self];
-		[popover presentPopoverFromRect:poFrame inView:poView permittedArrowDirections:arrow animated:animatedPicker];
+        if (button) {
+            [popover presentPopoverFromBarButtonItem:button
+                            permittedArrowDirections:arrow
+                                            animated:animatedPicker];
+        } else {
+            [popover presentPopoverFromRect:poFrame inView:poView permittedArrowDirections:arrow animated:animatedPicker];
+        }
 	}
 #endif
 }


### PR DESCRIPTION
 Committer: Tony Lewis tony.lewis@taknology.net

 On branch photopicker_popover_barbutton

```
modified:   iphone/Classes/MediaModule.m
```

Modified Titanium.Media.openPhotoGallery to accept property barButton.
The barButton property will make the photoPicker open oritented to the
barButton parameter passed. This property will override the popoverView property.
Also modified popover dismiss code to properly release the photo picker control.

Example:

Titanium.Media.openPhotoGallery({

```
success:function(event)
{
},
cancel:function()
{

},
error:function(error)
{
},
allowEditing:false,
barButton:add,
arrowDirection:Ti.UI.iPad.POPOVER_ARROW_DIRECTION_UP,
mediaTypes:[Ti.Media.MEDIA_TYPE_PHOTO]
```

});
