### PR TITLE
TIMOB-2853 fixes NPE when setting opacity value of 1

### DIFF
--- a/android/titanium/src/org/appcelerator/titanium/view/TiUIView.java
+++ b/android/titanium/src/org/appcelerator/titanium/view/TiUIView.java
@@ -846,7 +846,10 @@ public abstract class TiUIView
 
 	public void clearOpacity(View view)
 	{
-		view.getBackground().clearColorFilter();
+		Drawable d = view.getBackground();
+		if (d != null) {
+			d.clearColorFilter();
+		}
 	}
 
 	protected void registerForKeyClick(View clickable) 

--- a/drillbit/tests/ui/ui.js
+++ b/drillbit/tests/ui/ui.js
@@ -97,5 +97,29 @@ describe("Ti.UI tests", {
 				callback.passed();
 			}, 1000);
 		},1000);
+	},
+	// http://jira.appcelerator.org/browse/TIMOB-2853
+	opacityCrash_as_async: function(callback) {
+		var failureTimeout = null;
+		var w = Ti.UI.createWindow();
+		var btn = Ti.UI.createImageView({
+			opacity: 1,
+			image: 'KS_nav_ui.png',
+			top: 1, width: 50, left: 1, height: 40
+		});
+		w.add( btn );
+		w.addEventListener('open', function() {
+			setTimeout(function(){
+				if (failureTimeout !== null) {
+					clearTimeout(failureTimeout);
+				}
+				callback.passed();
+			}, 1000);
+		});
+		failureTimeout = setTimeout(function(){
+			callback.failed("Test may have crashed app.  Was never able to read back tableview dimensions.");
+		},3000);
+		w.open();
+
 	}
 });


### PR DESCRIPTION
checks for no background drawable before trying to clear color filter on it.

Recommend also testing with the sample app I put in a comment in the item:

http://jira.appcelerator.org/browse/TIMOB-2853

There's also a drillbit test.
