### PR TITLE
Using 'image' param instead of deprecated 'url' param in createImageView

### DIFF
--- a/demos/KitchenSink/Resources/examples/button.js
+++ b/demos/KitchenSink/Resources/examples/button.js
@@ -111,7 +111,7 @@ var b5Label = Ti.UI.createLabel({
 b5.add(b5Label);
 
 var b5ImageView = Ti.UI.createImageView({
-	url:'../images/camera.png',
+	image:'../images/camera.png',
 	left:10,
 	height:33,
 	width:33

--- a/demos/KitchenSink/Resources/examples/image_view_basic.js
+++ b/demos/KitchenSink/Resources/examples/image_view_basic.js
@@ -3,7 +3,7 @@ var win = Titanium.UI.currentWindow;
 if (Titanium.Platform.name == 'android') {
 	// iphone moved to a single image property - android needs to do the same
 	var imageView = Titanium.UI.createImageView({
-		url:'http://www.appcelerator.com/wp-content/uploads/2009/06/titanium_desk.png',
+		image:'http://www.appcelerator.com/wp-content/uploads/2009/06/titanium_desk.png',
 		width:261,
 		height:178,
 		top:20


### PR DESCRIPTION
Hi guys,

I just removed some deprecation warnings due to the fact that we are still using the deprecated 'url' param in a
couple of places when creating an image view.

Marco
