### PR TITLE
TIMOB-3648 : Expose Ti.AudioPlayer.bufferSize

### DIFF
--- a/apidoc/Titanium/Media/AudioPlayer.yml
+++ b/apidoc/Titanium/Media/AudioPlayer.yml
@@ -102,3 +102,7 @@ properties:
   - name: waiting
     description: returns boolean indicating if the playback is waiting for audio data from the network
     type: Boolean
+  - name: bufferSize
+    description: the size of the buffer used for streaming, in bytes
+    type: Number
+    platforms: [iphone, ipad]

--- a/demos/KitchenSink/Resources/examples/sound_remote.js
+++ b/demos/KitchenSink/Resources/examples/sound_remote.js
@@ -47,11 +47,38 @@ var stateLabel = Titanium.UI.createLabel({
 	color:'#555'
 });
 
+var streamSize1 = Ti.UI.createButton({
+	title:'Small buffer',
+	top:240,
+	left:10,
+	width:100,
+	height:40
+});
+var streamSize2 = Ti.UI.createButton({
+	title:'Default buffer',
+	top:240,
+	left:110,
+	width:100,
+	height:40
+});
+var streamSize3 = Ti.UI.createButton({
+	title:'Large buffer',
+	top:240,
+	right:10,
+	width:100,
+	height:40	
+});
+
 Ti.UI.currentWindow.add(url);
 Ti.UI.currentWindow.add(streamButton);
 Ti.UI.currentWindow.add(pauseButton);
 Ti.UI.currentWindow.add(progressLabel);
 Ti.UI.currentWindow.add(stateLabel);
+if (Ti.Platform.name != 'android') {
+	Ti.UI.currentWindow.add(streamSize1);
+	Ti.UI.currentWindow.add(streamSize2);
+	Ti.UI.currentWindow.add(streamSize3);
+}
 var streamer = Ti.Media.createAudioPlayer();
 
 streamButton.addEventListener('click',function()
@@ -61,6 +88,9 @@ streamButton.addEventListener('click',function()
 		progressLabel.text = 'Stopped';
 		streamer.stop();
 		pauseButton.enabled = false;
+		streamSize1.enabled = true;
+		streamSize2.enabled = true;
+		streamSize3.enabled = true;
 		pauseButton.title = 'Pause Streaming';
 		streamButton.title = "Start Streaming";
 	}
@@ -70,6 +100,10 @@ streamButton.addEventListener('click',function()
 		streamer.url = url.value;
 		streamer.start();
 		pauseButton.enabled = true;
+		streamSize1.enabled = false;
+		streamSize2.enabled = false;
+		streamSize3.enabled = false;
+
 		pauseButton.title = 'Pause Streaming';
 		streamButton.title = "Stop Stream";
 	}
@@ -84,6 +118,22 @@ pauseButton.addEventListener('click', function()
 	else {
 		pauseButton.title = 'Pause Streaming';
 	}
+});
+
+streamSize1.addEventListener('click', function()
+{
+	streamer.bufferSize = 512;
+	Ti.API.log('Set streamer buffer size to ' + streamer.bufferSize);
+});
+streamSize2.addEventListener('click', function()
+{
+	streamer.bufferSize = 2048;
+	Ti.API.log('Set streamer buffer size to ' + streamer.bufferSize);
+});
+streamSize3.addEventListener('click', function()
+{
+	streamer.bufferSize = 4096;
+	Ti.API.log('Set streamer buffer size to ' + streamer.bufferSize);
 });
 
 streamer.addEventListener('progress',function(e)

--- a/drillbit/tests/media/media.js
+++ b/drillbit/tests/media/media.js
@@ -48,6 +48,8 @@ describe("Ti.Media tests", {
 		if (!isAndroid) valueOf(player.state).shouldBeNumber();
 		valueOf(player.paused).shouldBeBoolean();
 		if (!isAndroid) valueOf(player.waiting).shouldBeBoolean();
+		if (!isAndroid) valueOf(player.bufferSize).shouldBeInteger();
+		
 	},
 	videoPlayerAPIs: function() {
 		var isAndroid = (Ti.Platform.osname === 'android');
@@ -88,4 +90,5 @@ describe("Ti.Media tests", {
 		timeout: 5000,
 		timeoutError: "Timed out waiting for sound to play."
 	})
+	// TODO: Need a player streaming test for validating some of those features
 })

--- a/iphone/Classes/AudioStreamer/AudioStreamer.h
+++ b/iphone/Classes/AudioStreamer/AudioStreamer.h
@@ -38,6 +38,16 @@
 								// increase. Min 3, typical 8-24.
 
 #define kAQMaxPacketDescs 512	// Number of packet descriptions in our array
+#define kAQDefaultBufSize 2048	// Number of bytes in each audio queue buffer
+                                // Needs to be big enough to hold a packet of
+                                // audio from the audio file. If number is too
+                                // large, queuing of audio before playback starts
+                                // will take too long.
+                                // Highly compressed files can use smaller
+                                // numbers (512 or less). 2048 should hold all
+                                // but the largest packets. A buffer size error
+                                // will occur if this number is too small.
+
 
 typedef enum
 {
@@ -101,6 +111,7 @@ extern NSString * const ASStatusChangedNotification;
 @property (readonly) double progress;
 @property (readwrite) UInt32 bitRate;
 @property (readwrite,assign) id<AudioStreamerDelegate> delegate;
+@property (nonatomic,readwrite,assign) NSUInteger bufferSize;
 
 - (void)start;
 - (void)stop;

--- a/iphone/Classes/AudioStreamer/AudioStreamer.m
+++ b/iphone/Classes/AudioStreamer/AudioStreamer.m
@@ -162,11 +162,13 @@ NSString * const AS_AUDIO_BUFFER_TOO_SMALL_STRING = @"Audio packets are larger t
 // Properties
 RUN_ON_STREAMER_SET(setErrorCode,TI_AudioStreamerErrorCode)
 RUN_ON_STREAMER_SET(setBitRate,UInt32)
+RUN_ON_STREAMER_SET(setBufferSize, NSUInteger)
 
 RUN_ON_STREAMER_RETURN(errorCode, TI_AudioStreamerErrorCode)
 RUN_ON_STREAMER_RETURN(bitRate, UInt32)
 RUN_ON_STREAMER_RETURN(state, TI_AudioStreamerState)
 RUN_ON_STREAMER_RETURN(progress, double)
+RUN_ON_STREAMER_RETURN(bufferSize, NSUInteger)
 
 // Functions
 RUN_ON_STREAMER_RETURN(isPlaying, BOOL)

--- a/iphone/Classes/AudioStreamer/AudioStreamerBC.h
+++ b/iphone/Classes/AudioStreamer/AudioStreamerBC.h
@@ -22,16 +22,6 @@
 #import "AudioStreamer.h"
 #include <pthread.h>
 #include <AudioToolbox/AudioToolbox.h>
-								
-#define kAQBufSize 2048			// Number of bytes in each audio queue buffer
-								// Needs to be big enough to hold a packet of
-								// audio from the audio file. If number is too
-								// large, queuing of audio before playback starts
-								// will take too long.
-								// Highly compressed files can use smaller
-								// numbers (512 or less). 2048 should hold all
-								// but the largest packets. A buffer size error
-								// will occur if this number is too small.
 
 @interface AudioStreamerBC : NSObject<AudioStreamerProtocol>
 {
@@ -53,6 +43,7 @@
 	size_t packetsFilled;			// how many packets have been filled
 	bool inuse[kNumAQBufs];			// flags to indicate that a buffer is still in use
 	NSInteger buffersUsed;
+    NSUInteger bufferSize;      // Dynamic size of the buffer (buffer is default size of 2k if unspec'd)
 	
 	TI_AudioStreamerState state;
 	TI_AudioStreamerStopReason stopReason;
@@ -79,6 +70,7 @@
 @property (readonly) TI_AudioStreamerState state;
 @property (readonly) double progress;
 @property (readwrite) UInt32 bitRate;
+@property (nonatomic,readwrite,assign) NSUInteger bufferSize;
 
 - (id)initWithURL:(NSURL *)aURL;
 - (void)start;

--- a/iphone/Classes/AudioStreamer/AudioStreamerBC.m
+++ b/iphone/Classes/AudioStreamer/AudioStreamerBC.m
@@ -187,6 +187,12 @@ void ASReadStreamCallBackBC
 @synthesize bitRate;
 @dynamic progress;
 @synthesize delegate;
+@synthesize bufferSize;
+
+-(NSUInteger)bufferSize
+{
+    return (bufferSize) ? bufferSize : kAQDefaultBufSize;
+}
 
 //
 // initWithURL
@@ -199,6 +205,7 @@ void ASReadStreamCallBackBC
 	if (self != nil)
 	{
 		url = [aURL retain];
+        bufferSize = 0;
 	}
 	return self;
 }
@@ -971,7 +978,7 @@ cleanup:
 	}
 	else if (eventType == kCFStreamEventHasBytesAvailable)
 	{
-		UInt8 bytes[kAQBufSize];
+		UInt8 bytes[[self bufferSize]];
 		CFIndex length;
 		@synchronized(self)
 		{
@@ -983,7 +990,7 @@ cleanup:
 			//
 			// Read the bytes from the stream
 			//
-			length = CFReadStreamRead(stream, bytes, kAQBufSize);
+			length = CFReadStreamRead(stream, bytes, [self bufferSize]);
 			
 			if (length == -1)
 			{
@@ -1169,7 +1176,7 @@ cleanup:
 			// allocate audio queue buffers
 			for (unsigned int i = 0; i < kNumAQBufs; ++i)
 			{
-				err = AudioQueueAllocateBuffer(audioQueue, kAQBufSize, &audioQueueBuffer[i]);
+				err = AudioQueueAllocateBuffer(audioQueue, [self bufferSize], &audioQueueBuffer[i]);
 				if (err)
 				{
 					[self failWithErrorCode:AS_AUDIO_QUEUE_BUFFER_ALLOCATION_FAILED];
@@ -1293,12 +1300,12 @@ cleanup:
 					return;
 				}
 				
-				if (packetSize > kAQBufSize)
+				if (packetSize > [self bufferSize])
 				{
 					[self failWithErrorCode:AS_AUDIO_BUFFER_TOO_SMALL];
 				}
 
-				bufSpaceRemaining = kAQBufSize - bytesFilled;
+				bufSpaceRemaining = [self bufferSize] - bytesFilled;
 			}
 
 			// if the space remaining in the buffer is not enough for this packet, then enqueue the buffer.
@@ -1350,7 +1357,7 @@ cleanup:
 		while (inNumberBytes)
 		{
 			// if the space remaining in the buffer is not enough for this packet, then enqueue the buffer.
-			size_t bufSpaceRemaining = kAQBufSize - bytesFilled;
+			size_t bufSpaceRemaining = [self bufferSize] - bytesFilled;
 			if (bufSpaceRemaining < inNumberBytes)
 			{
 				[self enqueueBuffer];
@@ -1376,7 +1383,7 @@ cleanup:
 				
 				// copy data to the audio queue buffer
 				AudioQueueBufferRef fillBuf = audioQueueBuffer[fillBufferIndex];
-				bufSpaceRemaining = kAQBufSize - bytesFilled;
+				bufSpaceRemaining = [self bufferSize] - bytesFilled;
 				size_t copySize;
 				if (bufSpaceRemaining < inNumberBytes)
 				{

--- a/iphone/Classes/AudioStreamer/AudioStreamerCUR.h
+++ b/iphone/Classes/AudioStreamer/AudioStreamerCUR.h
@@ -24,16 +24,6 @@
 #include <pthread.h>
 #include <AudioToolbox/AudioToolbox.h>
 								
-#define kAQDefaultBufSize 2048	// Number of bytes in each audio queue buffer
-								// Needs to be big enough to hold a packet of
-								// audio from the audio file. If number is too
-								// large, queuing of audio before playback starts
-								// will take too long.
-								// Highly compressed files can use smaller
-								// numbers (512 or less). 2048 should hold all
-								// but the largest packets. A buffer size error
-								// will occur if this number is too small.
-
 @interface AudioStreamerCUR : NSObject<AudioStreamerProtocol>
 {
 	NSURL *url;
@@ -79,6 +69,7 @@
 	UInt64 audioDataByteCount;  // Used when the actual number of audio bytes in
 								// the file is known (more accurate than assuming
 								// the whole file is audio)
+    NSUInteger bufferSize;      // Dynamic size of the buffer (buffer is default size of 2k if unspec'd)
 
 	UInt64 processedPacketsCount;		// number of packets accumulated for bitrate estimation
 	UInt64 processedPacketsSizeTotal;	// byte size of accumulated estimation packets
@@ -99,6 +90,7 @@
 @property (readonly) double duration;
 @property (readwrite) UInt32 bitRate;
 @property (readonly) NSDictionary *httpHeaders;
+@property (nonatomic,readwrite,assign) NSUInteger bufferSize;
 
 - (id)initWithURL:(NSURL *)aURL;
 - (void)start;

--- a/iphone/Classes/AudioStreamer/AudioStreamerCUR.m
+++ b/iphone/Classes/AudioStreamer/AudioStreamerCUR.m
@@ -193,6 +193,12 @@ void ASReadStreamCallBackCUR
 @synthesize bitRate;
 @synthesize httpHeaders;
 @synthesize delegate;
+@synthesize bufferSize;
+
+-(NSUInteger)bufferSize
+{
+    return (bufferSize) ? bufferSize : kAQDefaultBufSize;
+}
 
 //
 // initWithURL
@@ -205,6 +211,7 @@ void ASReadStreamCallBackCUR
 	if (self != nil)
 	{
 		url = [aURL retain];
+        bufferSize = 0;
 	}
 	return self;
 }
@@ -1153,7 +1160,7 @@ cleanup:
 			}
 		}
 		
-		UInt8 bytes[kAQDefaultBufSize];
+		UInt8 bytes[[self bufferSize]];
 		CFIndex length;
 		@synchronized(self)
 		{
@@ -1165,7 +1172,7 @@ cleanup:
 			//
 			// Read the bytes from the stream
 			//
-			length = CFReadStreamRead(stream, bytes, kAQDefaultBufSize);
+			length = CFReadStreamRead(stream, bytes, [self bufferSize]);
 			
 			if (length == -1)
 			{
@@ -1335,7 +1342,7 @@ cleanup:
 		if (err || packetBufferSize == 0)
 		{
 			// No packet size available, just use the default
-			packetBufferSize = kAQDefaultBufSize;
+			packetBufferSize = [self bufferSize];
 		}
 	}
 
@@ -1621,7 +1628,7 @@ cleanup:
 		while (inNumberBytes)
 		{
 			// if the space remaining in the buffer is not enough for this packet, then enqueue the buffer.
-			size_t bufSpaceRemaining = kAQDefaultBufSize - bytesFilled;
+			size_t bufSpaceRemaining = [self bufferSize] - bytesFilled;
 			if (bufSpaceRemaining < inNumberBytes)
 			{
 				[self enqueueBuffer];
@@ -1636,7 +1643,7 @@ cleanup:
 					return;
 				}
 				
-				bufSpaceRemaining = kAQDefaultBufSize - bytesFilled;
+				bufSpaceRemaining = [self bufferSize] - bytesFilled;
 				size_t copySize;
 				if (bufSpaceRemaining < inNumberBytes)
 				{

--- a/iphone/Classes/TiMediaAudioPlayerProxy.h
+++ b/iphone/Classes/TiMediaAudioPlayerProxy.h
@@ -13,6 +13,7 @@
 @interface TiMediaAudioPlayerProxy : TiProxy<AudioStreamerDelegate> {
 @private
 	NSURL *url;
+    NSUInteger bufferSize;
 	AudioStreamer *player;
 	BOOL progress;
 	NSTimer *timer;
@@ -27,6 +28,7 @@
 @property (nonatomic,readonly) NSNumber *progress;
 @property (nonatomic,readonly) NSNumber *state;
 @property (nonatomic,readwrite,assign) NSNumber* audioSessionMode;
+@property (nonatomic,readwrite,assign) NSNumber* bufferSize;
 
 @property (nonatomic,readonly) NSNumber *STATE_INITIALIZED;
 @property (nonatomic,readonly) NSNumber *STATE_STARTING;

--- a/iphone/Classes/TiMediaAudioPlayerProxy.m
+++ b/iphone/Classes/TiMediaAudioPlayerProxy.m
@@ -72,6 +72,7 @@
 		}
 		player = [[AudioStreamer alloc] initWithURL:url];
 		[player setDelegate:self];
+        [player setBufferSize:bufferSize];
 		
 		if (progress)
 		{
@@ -164,6 +165,19 @@ PLAYER_PROP_BOOL(paused,isPaused);
 PLAYER_PROP_DOUBLE(bitRate,bitRate);
 PLAYER_PROP_DOUBLE(progress,progress);
 PLAYER_PROP_DOUBLE(state,state);
+
+-(void)setBufferSize:(NSNumber*)bufferSize_
+{
+    bufferSize = [bufferSize_ unsignedIntegerValue];
+    if (player != nil) {
+        [player setBufferSize:bufferSize];
+    }
+}
+
+-(NSNumber*)bufferSize
+{
+    return [NSNumber numberWithUnsignedInteger:((bufferSize) ? bufferSize : kAQDefaultBufSize)];
+}
 
 -(void)setUrl:(id)args
 {


### PR DESCRIPTION
Exposed Ti.AudioPlayer.bufferSize; updated documentation, drillbit (API test) and KS (functional test). New instructions for testing with KS:
- Phone->Sound->Remote Streaming
  - Click 'small buffer'
  - Click 'play'
  - RESULT: One of: 
     alert: "File error: Unable to configure network read stream" (console: Audio packets are larger than kAQBufSize.)
    Fast to initially play; but jerky, lots of interruptions for buffering
- Click 'stop'
- Click 'default buffer'
- Click 'play'
- RESULT:
  Behavior "same as" old KS (low buffering time, consistent playback)
- Click 'stop'
- Click 'Large buffer'
- Click 'play'
- RESULT:
  Long buffering time, should never buffer again (although there's no guarantee on this)
- Click 'stop'
