### PR TITLE
New property "autoRedirect" for Ti.Network.HTTPClient

### DIFF
--- a/android/modules/network/src/ti/modules/titanium/network/HTTPClientProxy.java
+++ b/android/modules/network/src/ti/modules/titanium/network/HTTPClientProxy.java
@@ -124,4 +124,18 @@ public class HTTPClientProxy extends KrollProxy {
 	{
 		client.setAutoEncodeUrl(value);
 	}
+
+	@Kroll.getProperty @Kroll.method
+	public boolean getAutoRedirect()
+	{
+		return client.getAutoRedirect();
+	}
+
+	@Kroll.setProperty @Kroll.method
+	public void setAutoRedirect(boolean value)
+	{
+		client.setAutoRedirect(value);
+	}
+
+	
 }

--- a/android/modules/network/src/ti/modules/titanium/network/TiHTTPClient.java
+++ b/android/modules/network/src/ti/modules/titanium/network/TiHTTPClient.java
@@ -141,6 +141,7 @@ public class TiHTTPClient
 	private boolean aborted;
 	private int timeout = -1;
 	private boolean autoEncodeUrl = true;
+	private boolean autoRedirect = true;
 	
 	class RedirectHandler extends DefaultRedirectHandler {
 		@Override
@@ -165,6 +166,14 @@ public class TiHTTPClient
 			
 			return super.getLocationURI(response, context);
 		}
+		@Override
+    public boolean isRedirectRequested(HttpResponse response, HttpContext context) {
+      if (autoRedirect) {
+         return super.isRedirectRequested(response,context);
+      } else {
+         return false;
+      }
+    }   
 	}
 	
 	class LocalResponseHandler implements ResponseHandler<String>
@@ -1090,5 +1099,15 @@ public class TiHTTPClient
 	protected boolean getAutoEncodeUrl()
 	{
 		return autoEncodeUrl;
+	}
+
+		protected void setAutoRedirect(boolean value)
+	{
+		autoRedirect = value;
+	}
+
+	protected boolean getAutoRedirect()
+	{
+		return autoRedirect;
 	}
 }

--- a/iphone/Classes/TiNetworkHTTPClientProxy.h
+++ b/iphone/Classes/TiNetworkHTTPClientProxy.h
@@ -35,6 +35,7 @@ typedef enum {
 	long long uploadLength;
 	BOOL validatesSecureCertificate;
     NSNumber* timeout;
+    BOOL autoRedirect;
 	
 	// callbacks are now in the JS object
 	BOOL hasOnload;
@@ -64,6 +65,7 @@ typedef enum {
 @property(nonatomic,readonly) NSString* location;
 @property(nonatomic,readwrite) BOOL validatesSecureCertificate;
 @property(nonatomic,retain,readwrite) NSNumber* timeout;
+@property(nonatomic,readwrite) BOOL autoRedirect;
 
 // constants
 @property(nonatomic,readonly) NSInteger UNSENT;

--- a/iphone/Classes/TiNetworkHTTPClientProxy.h
+++ b/iphone/Classes/TiNetworkHTTPClientProxy.h
@@ -35,7 +35,7 @@ typedef enum {
 	long long uploadLength;
 	BOOL validatesSecureCertificate;
     NSNumber* timeout;
-    BOOL autoRedirect;
+    NSNumber* autoRedirect;
 	
 	// callbacks are now in the JS object
 	BOOL hasOnload;
@@ -65,7 +65,7 @@ typedef enum {
 @property(nonatomic,readonly) NSString* location;
 @property(nonatomic,readwrite) BOOL validatesSecureCertificate;
 @property(nonatomic,retain,readwrite) NSNumber* timeout;
-@property(nonatomic,readwrite) BOOL autoRedirect;
+@property(nonatomic,retain,readwrite) NSNumber* autoRedirect;
 
 // constants
 @property(nonatomic,readonly) NSInteger UNSENT;

--- a/iphone/Classes/TiNetworkHTTPClientProxy.m
+++ b/iphone/Classes/TiNetworkHTTPClientProxy.m
@@ -102,7 +102,7 @@ extern NSString * const TI_APPLICATION_DEPLOYTYPE;
 	{
 		readyState = NetworkClientStateUnsent;
 		validatesSecureCertificate = NO;
-		autoRedirect = YES;
+		autoRedirect = [[NSNumber alloc] initWithBool:YES];
 	}
 	return self;
 }
@@ -145,6 +145,7 @@ extern NSString * const TI_APPLICATION_DEPLOYTYPE;
 	}
 	RELEASE_TO_NIL(url);
 	RELEASE_TO_NIL(request);
+	RELEASE_TO_NIL(autoRedirect);
 	[super _destroy];
 }
 
@@ -500,7 +501,7 @@ extern NSString * const TI_APPLICATION_DEPLOYTYPE;
 	[request setValidatesSecureCertificate:validatesSecureCertificate];
 
 	// should it automatically redirect
-	[request setShouldRedirect:autoRedirect];
+	[request setShouldRedirect:[autoRedirect boolValue]];
 	
 	if (async)
 	{

--- a/iphone/Classes/TiNetworkHTTPClientProxy.m
+++ b/iphone/Classes/TiNetworkHTTPClientProxy.m
@@ -94,7 +94,7 @@ extern NSString * const TI_APPLICATION_DEPLOYTYPE;
 
 @implementation TiNetworkHTTPClientProxy
 
-@synthesize timeout, validatesSecureCertificate;
+@synthesize timeout, validatesSecureCertificate, autoRedirect;
 
 -(id)init
 {
@@ -102,6 +102,7 @@ extern NSString * const TI_APPLICATION_DEPLOYTYPE;
 	{
 		readyState = NetworkClientStateUnsent;
 		validatesSecureCertificate = NO;
+		autoRedirect = YES;
 	}
 	return self;
 }
@@ -368,7 +369,8 @@ extern NSString * const TI_APPLICATION_DEPLOYTYPE;
 	[request setShouldUseRFC2616RedirectBehaviour:YES];
 	BOOL keepAlive = [TiUtils boolValue:[self valueForKey:@"enableKeepAlive"] def:YES];
 	[request setShouldAttemptPersistentConnection:keepAlive];
-	[request setShouldRedirect:YES];
+	//handled in send, as now optional
+	//[request setShouldRedirect:YES];
 	[request setShouldPerformCallbacksOnMainThread:NO];
 	[self _fireReadyStateChange:NetworkClientStateOpened failed:NO];
 	[self _fireReadyStateChange:NetworkClientStateHeaders failed:NO];
@@ -496,6 +498,9 @@ extern NSString * const TI_APPLICATION_DEPLOYTYPE;
 	
 	// allow self-signed certs (NO) or required valid SSL (YES)
 	[request setValidatesSecureCertificate:validatesSecureCertificate];
+
+	// should it automatically redirect
+	[request setShouldRedirect:autoRedirect];
 	
 	if (async)
 	{


### PR DESCRIPTION
This commit introduces the new property autoRedirect to Ti.Network.HTTPClient for both android and iphone. By default it is true, aligning with the current behaviour, so that Titanium handles the HTTP redirect.

Since however there are many problems with handling of redirections (for example TIMOB-3360) I prefer handling the redirect behaviour in the Javascript code instead. Therefore if autoRedirect is set to false then the HTTPClient simple returns the 30x response along with all the headers.
