### PR TITLE
TIMOB-4471 KS: remove unnecessary if-else block in image_view_basic.js

### DIFF
--- a/demos/KitchenSink/Resources/examples/image_view_basic.js
+++ b/demos/KitchenSink/Resources/examples/image_view_basic.js
@@ -1,25 +1,11 @@
 var win = Titanium.UI.currentWindow;
 
-if (Titanium.Platform.name == 'android') {
-	// iphone moved to a single image property - android needs to do the same
-	var imageView = Titanium.UI.createImageView({
-		image:'http://www.appcelerator.com/wp-content/uploads/2009/06/titanium_desk.png',
-		width:261,
-		height:178,
-		top:20
-	});
-
-}
-else
-{
-	var imageView = Titanium.UI.createImageView({
-		image:'http://www.appcelerator.com/wp-content/uploads/2009/06/titanium_desk.png',
-		width:261,
-		height:178,
-		top:20
-	});
-	
-}
+var imageView = Titanium.UI.createImageView({
+	image:'http://www.appcelerator.com/wp-content/uploads/2009/06/titanium_desk.png',
+	width:261,
+	height:178,
+	top:20
+});
 
 imageView.addEventListener('load', function()
 {


### PR DESCRIPTION
Add to marco's change by removing the now-unnecessary if-else block protecting Android from the image property. TIMOB-4471
