### PR TITLE
(Android) TIMOB-4485 Fixes NPE when window is a tab window

### DIFF
--- a/android/modules/ui/src/ti/modules/titanium/ui/TiUIWindow.java
+++ b/android/modules/ui/src/ti/modules/titanium/ui/TiUIWindow.java
@@ -118,6 +118,7 @@ public class TiUIWindow extends TiUIView
 	public TiUIWindow(TiWindowProxy proxy, Activity activity)
 	{
 		super(proxy);
+		resolver = new TiPropertyResolver(proxy.getProperties());
 		if (idGenerator == null) {
 			idGenerator = new AtomicInteger(0);
 		}


### PR DESCRIPTION
http://jira.appcelerator.org/browse/TIMOB-4485

the class-level "resolver" is used in several places, so we should instantiate it no matter which way the window gets instantiated (win.open versus tab.window -> tabgroup.open).  Fixes NPE introduced by very recent commit which was relying on resolver being instantiated. TIMOB-4485
