### PR TITLE
TIMOB-4137 Orientation realignment must happen after modal transitions

### DIFF
--- a/iphone/Classes/TiApp.mm
+++ b/iphone/Classes/TiApp.mm
@@ -220,8 +220,7 @@ void MyUncaughtExceptionHandler(NSException *exception)
 	if (!loaded) {
 		[self attachSplash];
 	}
-	[window addSubview:controller.view];
-
+	[window setRootViewController:controller];
     [window makeKeyAndVisible];
 }
 

--- a/iphone/Classes/TiRootViewController.h
+++ b/iphone/Classes/TiRootViewController.h
@@ -22,6 +22,7 @@
 
 	UIInterfaceOrientation lastOrientation;
 	UIInterfaceOrientation windowOrientation;
+	BOOL ignoreRotations;
 
 	NSMutableArray * viewControllerStack;
 	BOOL isCurrentlyVisible;
@@ -64,5 +65,7 @@
 
 - (void)openWindow:(TiWindowProxy *)window withObject:(id)args;
 - (void)closeWindow:(TiWindowProxy *)window withObject:(id)args;
+
+-(UIInterfaceOrientation)mostRecentlyAllowedOrientation;
 
 @end

--- a/iphone/Classes/TiRootViewController.m
+++ b/iphone/Classes/TiRootViewController.m
@@ -199,7 +199,13 @@
 
 - (void) viewDidAppear:(BOOL)animated
 {
+	ignoreRotations = NO;
 	[self.view becomeFirstResponder];
+	CGFloat duration = 0.0;
+	if (animated) {
+		duration = [[UIApplication sharedApplication] statusBarOrientationAnimationDuration];
+	}
+	[self manuallyRotateToOrientation:[self mostRecentlyAllowedOrientation] duration:duration];
     [super viewDidAppear:animated];
 	VerboseLog(@"%@%@",self,CODELOCATION);
 	[[viewControllerStack lastObject] viewDidAppear:animated];
@@ -207,6 +213,7 @@
 
 - (void) viewDidDisappear:(BOOL)animated
 {
+	ignoreRotations = YES;
 	isCurrentlyVisible = NO;
 	[self.view resignFirstResponder];
     [super viewDidDisappear:animated];
@@ -238,18 +245,16 @@
 
 -(void)manuallyRotateToOrientation:(UIInterfaceOrientation)newOrientation duration:(NSTimeInterval)duration
 {
+	if (ignoreRotations) {
+		return;
+	}
+	
 	UIApplication * ourApp = [UIApplication sharedApplication];
 	if (newOrientation != [ourApp statusBarOrientation])
 	{
 		[keyboardFocusedProxy blur:nil];
 		[ourApp setStatusBarOrientation:newOrientation animated:(duration > 0.0)];
 		[keyboardFocusedProxy focus:nil];
-	}
-	
-	// if already in the orientation, don't do it again
-	if (lastOrientation==newOrientation)
-	{
-		return;
 	}
 
 	CGAffineTransform transform;


### PR DESCRIPTION
TIMOB-4137 We must delay rotating the status bar when returning from a modal until after the modal animation is done. Sample test is in JIRA http://jira.appcelerator.org/browse/TIMOB-4137
