### PR TITLE
TIMOB-4360 Android drillbit packaging error fix

### DIFF
--- a/drillbit/modules/drillbit/0.1.0/android.js
+++ b/drillbit/modules/drillbit/0.1.0/android.js
@@ -243,7 +243,7 @@ var harnessBuildTriggers = [
 	ti.path.join('build', 'android', 'AndroidManifest.custom.xml'),
 	
 	// Directory triggers (any file under these dirs)
-	'modules',
+	'modules', 'Resources',
 	ti.path.join('build', 'android', 'src'),
 	ti.path.join('build', 'android', 'res')
 ];


### PR DESCRIPTION
http://jira.appcelerator.org/browse/TIMOB-4360

Drillbit: App packaging problem causes "includes" test suite and others to fail

Fixed by simply adding "Resources" to the list of dirs drillbit cares about when doing a full rebuild
