### PR TITLE
TIMOB-4174: Database exceptions

### DIFF
--- a/iphone/Classes/TiDatabaseProxy.m
+++ b/iphone/Classes/TiDatabaseProxy.m
@@ -77,7 +77,7 @@
 	database = [[PLSqliteDatabase alloc] initWithPath:path];
 	if (![database open])
 	{
-		[self throwException:@"couldn't open database" subreason:nil location:CODELOCATION];
+		[self throwException:@"couldn't open database" subreason:name_ location:CODELOCATION];
 	}
 }
 

--- a/iphone/Classes/TiUtils.h
+++ b/iphone/Classes/TiUtils.h
@@ -81,6 +81,8 @@ typedef enum {
 
 +(int)intValue:(id)value def:(int)def;
 
++(int)intValue:(id)value def:(int)def valid:(BOOL*)isValid;
+
 +(TiColor*)colorValue:(id)value;
 
 +(TiDimension)dimensionValue:(id)value;

--- a/iphone/Classes/TiUtils.m
+++ b/iphone/Classes/TiUtils.m
@@ -377,6 +377,9 @@ NSDictionary* sizeMap = nil;
 		if(isValid != NULL) *isValid = YES;
 		return [value floatValue];
 	}
+    if (isValid != NULL) {
+        *isValid = NO;
+    }
 	return def;
 }
 
@@ -393,6 +396,9 @@ NSDictionary* sizeMap = nil;
 		}
 		return [value intValue];
 	}
+    if (isValid != NULL) {
+        *isValid = NO;
+    }
 	return def;	
 }
 


### PR DESCRIPTION
We now perform more rigorous typechecking in database to conform to Android's strict guidelines. Note that we should be be performing these checks EVERYWHERE in code that rely on translating string values to numerical values! Otherwise, we get dumb results.

Attached to the ticket is a test that can be used to verify - it's a heavily mangled (but functional) version of the test harness generated by the Drillbit database test. You will need to manually grep output for "passed":false to detect failures. Due to the exception problems on simulator, you must ONLY VERIFY ON DEVICE.

Do not reject this pull request on the grounds that a crash was discovered during testing. Previous functional testing indicated it worked on all devices except 3.1.x, which was a crash due to a UILabel assert.  This has nothing to do with database exception functionality and this submit is clean.  See the ticket for more information, including the JS code which causes the crash, which does NOT include any exception-handling, or database, calls.

Pull request 146 was the previous request. Please do not close internal pull requests prematurely unless it is part of the official rejection process for internal pulls, it forces duplicate pull requests and repeats of information in cases like this, where the rejection reason is invalid and not related to the request at all.
