### PR TITLE
[TIMOB-3360] Forward authorization

### DIFF
--- a/iphone/Classes/ASI/ASIHTTPRequest.m
+++ b/iphone/Classes/ASI/ASIHTTPRequest.m
@@ -1819,11 +1819,17 @@ static BOOL isiPhoneOS2;
 
 				// Perhaps there are other headers we should be preserving, but it's hard to know what we need to keep and what to throw away.
 				NSString *userAgent = [[self requestHeaders] objectForKey:@"User-Agent"];
-				if (userAgent) {
-					[self setRequestHeaders:[NSMutableDictionary dictionaryWithObject:userAgent forKey:@"User-Agent"]];
-				} else {
-					[self setRequestHeaders:nil];
-				}
+                NSString* authorization = [[self requestHeaders] objectForKey:@"Authorization"];
+                
+                NSMutableDictionary* newHeaders = [NSMutableDictionary dictionary];
+                if (userAgent != nil) {
+                    [newHeaders setValue:userAgent forKey:@"User-Agent"];
+                }
+                if (authorization != nil) {
+                    [newHeaders setValue:authorization forKey:@"Authorization"];
+                }
+                
+                [self setRequestHeaders:newHeaders];
 				[self setHaveBuiltRequestHeaders:NO];
 			} else {
 			


### PR DESCRIPTION
Forward authorization headers in a redirect.  Note that we're still dropping a lot of headers, but as the documentation in ASI says, it's hard to determine what can be safely preserved and jettisoned. We'll have to come up with a more full-fledged solution in the HTTPClient API redesign.

The test associated with this ticket should be considered fragile and can break at any time (the 302 redirect is controlled by the ticket submitter).
