### PR TITLE
TIMOB-4079 TImer not running after startup of tabbed app

### DIFF
--- a/android/titanium/src/ti/modules/titanium/TitaniumModule.java
+++ b/android/titanium/src/ti/modules/titanium/TitaniumModule.java
@@ -469,14 +469,6 @@ public class TitaniumModule extends KrollModule implements TiContext.OnLifecycle
 	}
 
 	@Override
-	public void onStop(Activity activity) {
-		if (activity instanceof TiBaseActivity) {
-			cancelTimers((TiBaseActivity) activity);
-		}
-		super.onStop(activity);
-	}
-
-	@Override
 	public void onDestroy(Service service)
 	{
 	}


### PR DESCRIPTION
Remove onStop which only cleared timers, because we don't want to force clearing them until onDestroy. TIMOB-4079
