### PR TITLE
TIMOB-4526 handle 0ms duration on animated image view

### DIFF
--- a/android/modules/ui/src/ti/modules/titanium/ui/widget/TiUIImageView.java
+++ b/android/modules/ui/src/ti/modules/titanium/ui/widget/TiUIImageView.java
@@ -452,6 +452,11 @@ public class TiUIImageView extends TiUIView
 			}
 
 			int duration = (int) getDuration();
+			if (duration == 0)
+			{
+				duration = 1;
+			}
+
 			fireStart();
 			timer.schedule(animator, duration, duration);
 		} else {


### PR DESCRIPTION
Android doesnt allow the timer to work on a duration of 0ms, if 0ms is set then change to 1ms in order to avoid exception
