### PR TITLE
iOS: allow access to the scrollEnabled property for a textArea

### DIFF
--- a/apidoc/Titanium/UI/TextArea.yml
+++ b/apidoc/Titanium/UI/TextArea.yml
@@ -116,6 +116,9 @@ properties:
   - name: value
     description: value of the field
     type: String
+  - name: scrollable
+    description: true (default) if textarea can be scrolled
+    type: Boolean
 notes: |
     Both Text Areas and Text Fields can control the buttons displayed in a button bar above the keyboard when it's visible.
     

--- a/iphone/Classes/TiUITextArea.m
+++ b/iphone/Classes/TiUITextArea.m
@@ -44,6 +44,11 @@
 	[(UITextView *)[self textWidgetView] setEditable:[TiUtils boolValue:value]];
 }
 
+-(void)setScrollable_:(id)value
+{
+	[(UITextView *)[self textWidgetView] setScrollEnabled:[TiUtils boolValue:value]];
+}
+
 -(void)setEditable_:(id)editable
 {
 	[(UITextView *)[self textWidgetView] setEditable:[TiUtils boolValue:editable]];


### PR DESCRIPTION
This is to allow the text areas to have the scrollable property turned on or off

Jira ticket:

http://jira.appcelerator.org/browse/TIMOB-4595
