### PR TITLE
[TIMOB-3600] Prevent visual errors in cell redraw

### DIFF
--- a/iphone/Classes/TiUITableView.h
+++ b/iphone/Classes/TiUITableView.h
@@ -35,6 +35,7 @@
 -(void) setSelectedBackgroundGradient_:(TiGradient *)newGradient;
 
 -(void) updateGradientLayer:(BOOL)useSelected;
+-(CGSize)computeCellSize;
 
 @end
 
@@ -83,7 +84,7 @@
 -(IBAction)hideSearchScreen:(id)sender;
 -(UITableView*)searchTableView;
 -(UITableView*)tableView;
-
+-(CGFloat)tableRowHeight:(CGFloat)height;
 
 @end
 

--- a/iphone/Classes/TiUITableView.m
+++ b/iphone/Classes/TiUITableView.m
@@ -43,6 +43,21 @@
 	[super dealloc];
 }
 
+-(CGSize)computeCellSize
+{
+    CGFloat width = [proxy sizeWidthForDecorations:[[proxy table] tableView].bounds.size.width forceResizing:YES];
+	CGFloat height = [proxy rowHeight:width];
+	height = [[proxy table] tableRowHeight:height];
+    
+    // If there is a separator, then it's included as part of the row height as the system, so remove the pixel for it
+    // from our cell size
+    if ([[[proxy table] tableView] separatorStyle] == UITableViewCellSeparatorStyleSingleLine) {
+        height -= 1;
+    }
+    
+    return CGSizeMake(width, height);
+}
+
 -(void)prepareForReuse
 {
 	[super prepareForReuse];
@@ -52,9 +67,10 @@
 	// and if its frame is too big... the view system allocates way too much memory/pixels and doesn't appear to let
 	// them go.
 
-	// Until we can properly revisit this... just size the cell to 320x44.  The standard size.
 	CGRect oldFrame = [[self contentView] frame];
-	[[self contentView] setFrame:CGRectMake(oldFrame.origin.x, oldFrame.origin.y, 320, 44)];
+    CGSize cellSize = [self computeCellSize];
+    
+	[[self contentView] setFrame:CGRectMake(oldFrame.origin.x, oldFrame.origin.y, cellSize.width, cellSize.height)];
 }
 
 - (UIView *)hitTest:(CGPoint) point withEvent:(UIEvent *)event 
@@ -1493,7 +1509,9 @@ if(ourTableView != tableview)	\
 	if (cell == nil)
 	{
 		cell = [[[TiUITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:row.tableClass row:row] autorelease];
-		[cell setBounds:CGRectMake(0, 0, [tableview bounds].size.width,44)];
+        CGSize cellSize = [(TiUITableViewCell*)cell computeCellSize];
+		[cell setBounds:CGRectMake(0, 0, cellSize.width,cellSize.height)];
+        [[cell contentView] setBounds:[cell bounds]];
 	}
 	else
 	{
@@ -1501,7 +1519,11 @@ if(ourTableView != tableview)	\
 		// So what we're going to do with this cell is clear its contents out, then redraw it as if it were a new cell.
 		// Keeps the cell pool small and reusable.
 		[TiUITableViewRowProxy clearTableRowCell:cell];
-		
+        
+        // Have to reset the proxy on the cell, and the row's callback cell, as it may have been cleared in reuse operations (or reassigned)
+        [(TiUITableViewCell*)cell setProxy:row];
+        [row setCallbackCell:(TiUITableViewCell*)cell];
+        
 		/*
 		 * Old-school style:
 		// in the case of a reuse, we need to tell the row proxy to update the data

--- a/iphone/Classes/TiUITableViewRowProxy.m
+++ b/iphone/Classes/TiUITableViewRowProxy.m
@@ -617,10 +617,7 @@ TiProxy * DeepScanForProxyOfViewContainingPoint(UIView * targetView, CGPoint poi
 	NSArray* cellSubviews = [[cell contentView] subviews];
 	// Clear out the old cell view
 	for (UIView* view in cellSubviews) {
-		if ([view isKindOfClass:[TiUITableViewRowContainer class]]) {
-			[view removeFromSuperview];
-			break;
-		}
+		[view removeFromSuperview];
 	}
 }
 
@@ -634,15 +631,20 @@ TiProxy * DeepScanForProxyOfViewContainingPoint(UIView * targetView, CGPoint poi
 	{
 		UIView *contentView = cell.contentView;
 		CGRect rect = [contentView frame];
-		CGFloat rowWidth = [self sizeWidthForDecorations:rect.size.width forceResizing:NO];
-		CGFloat rowHeight = [self rowHeight:rowWidth];
-		rowHeight = [table tableRowHeight:rowHeight];
+        CGSize cellSize = [(TiUITableViewCell*)cell computeCellSize];
+		CGFloat rowWidth = cellSize.width;
+		CGFloat rowHeight = cellSize.height;
+
 		if (rowHeight < rect.size.height || rowWidth < rect.size.width)
 		{
 			rect.size.height = rowHeight;
 			rect.size.width = rowWidth;
 			contentView.frame = rect;
 		}
+        else if (CGSizeEqualToSize(rect.size, CGSizeZero)) {
+            rect.size = CGSizeMake(rowWidth, rowHeight);
+            [contentView setFrame:rect];
+        }
 		rect.origin = CGPointZero;
 		[rowContainerView release];
 		rowContainerView = [[TiUITableViewRowContainer alloc] initWithFrame:rect];


### PR DESCRIPTION
[TIMOB-3600] Size cells appropriately to their expected size when dequeuing, and make sure callback cell/proxy information on them is accurate.

Functional testing to confirm that all KS tableview tests were unaffected by this change was performed.
