### PR TITLE
[TIMOB-4532] Scrollable settings when using searcHidden

### DIFF
--- a/iphone/Classes/TiUITableView.m
+++ b/iphone/Classes/TiUITableView.m
@@ -978,7 +978,7 @@
 	[[searchField view] resignFirstResponder];
 	[self makeRootViewFirstResponder];
 	[searchTableView removeFromSuperview];
-	[tableview setScrollEnabled:[self isScrollable]];
+//	[tableview setScrollEnabled:[self isScrollable]];
 	[self.proxy replaceValue:NUMBOOL(YES) forKey:@"searchHidden" notification:NO];
 	[searchController setActive:NO animated:YES];
 	
@@ -1010,7 +1010,7 @@
 		[tableview scrollToRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:0]
 						 atScrollPosition:UITableViewScrollPositionBottom animated:NO];
 	}
-	[tableview setScrollEnabled:NO];
+//	[tableview setScrollEnabled:NO];
 	
 	CGRect screenRect = [TiUtils viewPositionRect:tableview];
 	CGFloat searchHeight = [[tableview tableHeaderView] bounds].size.height;


### PR DESCRIPTION
[TIMOB-4532] Don't unnecessarily change the scrollable settings when setting tableview.searchHidden.

Note that this changes behavior to be "correct" by not locking the table in place when setting searchHidden = false. This is a behavior change; to get previous behavior you will need the following:

```
tableview.searchHidden = false;
tableview.scrollable = false;
```

Android lacks this property so parity is technically not an issue.
