### PR TITLE
TIMOB-4540 TIMOB-4539 TIMOB-4541 the end event wasn't being send in onDes

### DIFF
--- a/android/titanium/src/org/appcelerator/titanium/TiLaunchActivity.java
+++ b/android/titanium/src/org/appcelerator/titanium/TiLaunchActivity.java
@@ -9,6 +9,7 @@ package org.appcelerator.titanium;
 import java.io.IOException;
 import java.util.Set;
 
+import org.appcelerator.titanium.analytics.TiAnalyticsEventFactory;
 import org.appcelerator.titanium.proxy.ActivityProxy;
 import org.appcelerator.titanium.util.Log;
 import org.appcelerator.titanium.util.TiBindingHelper;
@@ -241,6 +242,10 @@ public abstract class TiLaunchActivity extends TiBaseActivity
 	{
 		if (tiContext != null) {
 			tiContext.fireLifecycleEvent(this, TiContext.LIFECYCLE_ON_DESTROY);
+			TiApplication tiApp = tiContext.getTiApp();
+			if (tiApp != null) {
+				tiApp.postAnalyticsEvent(TiAnalyticsEventFactory.createAppEndEvent());
+			}
 		}
 		super.onDestroy();
 	}


### PR DESCRIPTION
TIMOB-4540 TIMOB-4539 TIMOB-4541 the end event wasn't being send in onDestroy. This was causing the apperance of failures for the other tickets.

There is a test app in TIMOB-4541. One of the reviewers may want to run wireshark to watch the bundle going up. Keep in mind that there is a 5 minute lag between when events can be sent if the end event hasn't been fired.
