### PR TITLE
[TIMOB-4468] Directories in documentation folder will now be ignored; pre

### DIFF
--- a/support/module/builder.py
+++ b/support/module/builder.py
@@ -157,7 +157,7 @@ def docgen(module_dir, dest_dir):
 		return
 
 	for file in os.listdir(doc_dir):
-		if file in ignoreFiles:
+		if file in ignoreFiles or os.path.isdir(os.path.join(doc_dir, file)):
 			continue
 		md = open(os.path.join(doc_dir, file), 'r').read()
 		html = markdown.markdown(md)


### PR DESCRIPTION
[TIMOB-4468] Directories in documentation folder will now be ignored; previously, they would crash the build.

http://jira.appcelerator.org/browse/TIMOB-4468
