### PR TITLE
TIMOB-4612: Reading and writing large files cause ANR / Exceptions in Fastdev

### DIFF
--- a/android/modules/filesystem/src/ti/modules/titanium/filesystem/FileProxy.java
+++ b/android/modules/filesystem/src/ti/modules/titanium/filesystem/FileProxy.java
@@ -1,6 +1,6 @@
 /**
  * Appcelerator Titanium Mobile
- * Copyright (c) 2009-2010 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2009-2011 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
@@ -28,28 +28,17 @@ import android.net.Uri;
 public class FileProxy extends TiFileProxy
 {
 	private static final String LCAT = "FileProxy";
-	String path;
-	TiBaseFile tbf; // The base file object.
 
-	public static <T>
-	String join(final Collection<T> objs, final String delimiter) {
-	    if (objs == null || objs.isEmpty())
-	        return "";
-	    Iterator<T> iter = objs.iterator();
-	    // remove the following two lines, if you expect the Collection will behave well
-	    if (!iter.hasNext())
-	        return "";
-	    StringBuffer buffer = new StringBuffer(String.valueOf(iter.next()));
-	    while (iter.hasNext())
-	        buffer.append(delimiter).append(String.valueOf(iter.next()));
-	    return buffer.toString();
-	}
+	protected String path;
+	protected TiBaseFile tbf; // The base file object.
 
-	public FileProxy(TiContext tiContext, String[] parts) {
+	public FileProxy(TiContext tiContext, String[] parts)
+	{
 		this(tiContext, parts, true);
 	}
 	
-	public FileProxy(TiContext tiContext, String[] parts, boolean resolve) {
+	public FileProxy(TiContext tiContext, String[] parts, boolean resolve)
+	{
 		super(tiContext);
 
 		//String path = getTiContext().resolveUrl(join(Arrays.asList(parts), "/"));
@@ -82,42 +71,72 @@ public class FileProxy extends TiFileProxy
 		tbf = TiFileFactory.createTitaniumFile(tiContext, new String[] { path }, false);
 	}
 
-	private FileProxy(TiContext tiContext, TiBaseFile tbf) {
+	private FileProxy(TiContext tiContext, TiBaseFile tbf)
+	{
 		super(tiContext);
 		this.tbf = tbf;
 	}
 
-	public TiBaseFile getBaseFile() {
+	public static <T>
+	String join(final Collection<T> objs, final String delimiter)
+	{
+		if (objs == null || objs.isEmpty()) {
+			return "";
+		}
+
+		Iterator<T> iter = objs.iterator();
+		// remove the following two lines, if you expect the Collection will behave well
+		if (!iter.hasNext()) {
+			return "";
+		}
+
+		StringBuffer buffer = new StringBuffer(String.valueOf(iter.next()));
+		while (iter.hasNext()) {
+			buffer.append(delimiter).append(String.valueOf(iter.next()));
+		}
+
+		return buffer.toString();
+	}
+
+	public TiBaseFile getBaseFile()
+	{
 		return tbf;
 	}
 
 	@Kroll.method
-	public boolean isFile() {
+	public boolean isFile()
+	{
 		return tbf.isFile();
 	}
 
 	@Kroll.method
-	public boolean isDirectory() {
+	public boolean isDirectory()
+	{
 		return tbf.isDirectory();
 	}
 
 	@Kroll.getProperty @Kroll.method
-	public boolean getReadonly() {
+	public boolean getReadonly()
+	{
 		return tbf.isReadonly();
 	}
 
 	@Kroll.getProperty @Kroll.method
-	public boolean getWritable() {
+	public boolean getWritable()
+	{
 		return tbf.isWriteable();
 	}
 
 	@Kroll.method
-	public boolean copy (String destination) throws IOException {
+	public boolean copy (String destination)
+		throws IOException
+	{
 		return tbf.copy(destination);
 	}
 
 	@Kroll.method
-	public boolean createDirectory(@Kroll.argument(optional=true) Object arg) {
+	public boolean createDirectory(@Kroll.argument(optional=true) Object arg)
+	{
 		boolean recursive = true;
 
 		if (arg != null) {
@@ -127,7 +146,8 @@ public class FileProxy extends TiFileProxy
 	}
 
 	@Kroll.method
-	public boolean deleteDirectory(@Kroll.argument(optional=true) Object arg) {
+	public boolean deleteDirectory(@Kroll.argument(optional=true) Object arg)
+	{
 		boolean recursive = false;
 
 		if (arg != null) {
@@ -137,32 +157,38 @@ public class FileProxy extends TiFileProxy
 	}
 
 	@Kroll.method
-	public boolean deleteFile() {
+	public boolean deleteFile()
+	{
 		return tbf.deleteFile();
 	}
 
 	@Kroll.method
-	public boolean exists() {
+	public boolean exists()
+	{
 		return tbf.exists();
 	}
 
 	@Kroll.method
-	public String extension() {
+	public String extension()
+	{
 		return tbf.extension();
 	}
 
 	@Kroll.getProperty @Kroll.method
-	public boolean getSymbolicLink() {
+	public boolean getSymbolicLink()
+	{
 		return tbf.isSymbolicLink();
 	}
 
 	@Kroll.getProperty @Kroll.method
-	public boolean getExecutable() {
+	public boolean getExecutable()
+	{
 		return tbf.isExecutable();
 	}
 
 	@Kroll.getProperty @Kroll.method
-	public boolean getHidden() {
+	public boolean getHidden()
+	{
 		return tbf.isHidden();
 	}
 
@@ -188,12 +214,14 @@ public class FileProxy extends TiFileProxy
 	}
 
 	@Kroll.getProperty @Kroll.method
-	public String getName() {
+	public String getName()
+	{
 		return tbf.name();
 	}
 
 	@Kroll.getProperty @Kroll.method
-	public String getNativePath() {
+	public String getNativePath()
+	{
 		return tbf.nativePath();
 	}
 
@@ -218,17 +246,20 @@ public class FileProxy extends TiFileProxy
 	}
 
 	@Kroll.method
-	public TiBaseFile resolve() {
+	public TiBaseFile resolve()
+	{
 		return tbf.resolve();
 	}
 
 	@Kroll.getProperty @Kroll.method
-	public double getSize() {
+	public double getSize()
+	{
 		return tbf.size();
 	}
 
 	@Kroll.method
-	public double spaceAvailable() {
+	public double spaceAvailable()
+	{
 		return tbf.spaceAvailable();
 	}
 

--- a/android/titanium/src/org/appcelerator/titanium/TiBlob.java
+++ b/android/titanium/src/org/appcelerator/titanium/TiBlob.java
@@ -20,6 +20,7 @@ import org.appcelerator.titanium.io.TiBaseFile;
 import org.appcelerator.titanium.util.Log;
 import org.appcelerator.titanium.util.TiConfig;
 import org.appcelerator.titanium.util.TiMimeTypeHelper;
+import org.appcelerator.titanium.util.TiStreamHelper;
 
 import android.graphics.Bitmap;
 import android.graphics.Bitmap.CompressFormat;
@@ -68,7 +69,8 @@ public class TiBlob extends KrollProxy
 		return new TiBlob(tiContext, TYPE_FILE, file, mimeType);
 	}
 
-	public static TiBlob blobFromImage(TiContext tiContext, Bitmap image) {
+	public static TiBlob blobFromImage(TiContext tiContext, Bitmap image)
+	{
 		ByteArrayOutputStream bos = new ByteArrayOutputStream();
 		byte data[] = new byte[0];
 		if (image.compress(CompressFormat.PNG, 100, bos)) {
@@ -81,18 +83,21 @@ public class TiBlob extends KrollProxy
 		return blob;
 	}
 
-	public static TiBlob blobFromData(TiContext tiContext, byte[] data) {
+	public static TiBlob blobFromData(TiContext tiContext, byte[] data)
+	{
 		return blobFromData(tiContext, data, "application/octet-stream");
 	}
 
-	public static TiBlob blobFromData(TiContext tiContext, byte[] data, String mimetype) {
+	public static TiBlob blobFromData(TiContext tiContext, byte[] data, String mimetype)
+	{
 		if (mimetype == null || mimetype.length() == 0) {
 			return new TiBlob(tiContext, TYPE_DATA, data, "application/octet-stream");
 		}
 		return new TiBlob(tiContext, TYPE_DATA, data, mimetype);
 	}
 
-	public byte[] getBytes() {
+	public byte[] getBytes()
+	{
 		byte[] bytes = null;
 
 		switch(type) {
@@ -112,10 +117,7 @@ public class TiBlob extends KrollProxy
 				InputStream stream = getInputStream();
 				if (stream != null) {
 					try {
-						bytes = new byte[getLength()];
-						stream.read(bytes);
-					} catch(IOException e) {
-						Log.w(LCAT, e.getMessage(), e);
+						bytes = TiStreamHelper.toByteArray(stream, getLength());
 					} finally {
 						try {
 							stream.close();
@@ -133,10 +135,11 @@ public class TiBlob extends KrollProxy
 	}
 
 	@Kroll.getProperty @Kroll.method
-	public int getLength() {
+	public int getLength()
+	{
 		switch (type) {
 			case TYPE_FILE:
-				return (int) ((TiBaseFile)data).getNativeFile().length();
+				return (int) ((TiBaseFile)data).size();
 			case TYPE_DATA:
 			case TYPE_IMAGE:
 				return ((byte[])data).length;
@@ -162,7 +165,8 @@ public class TiBlob extends KrollProxy
 	}
 
 	@Kroll.method
-	public void append(TiBlob blob) {
+	public void append(TiBlob blob)
+	{
 		switch(type) {
 			case TYPE_STRING :
 				try {
@@ -191,7 +195,8 @@ public class TiBlob extends KrollProxy
 	}
 
 	@Kroll.getProperty @Kroll.method
-	public String getText() {
+	public String getText()
+	{
 		String result = null;
 
 		// Only support String and Data. Same as iPhone
@@ -219,26 +224,31 @@ public class TiBlob extends KrollProxy
 	}
 
 	@Kroll.getProperty @Kroll.method
-	public String getMimeType() {
+	public String getMimeType()
+	{
 		return mimetype;
 	}
 
-	public Object getData() {
+	public Object getData()
+	{
 		return data;
 	}
 	
 	@Kroll.getProperty @Kroll.method
-	public int getType() {
+	public int getType()
+	{
 		return type;
 	}
 
 	@Kroll.getProperty @Kroll.method
-	public int getWidth() {
+	public int getWidth()
+	{
 		return width;
 	}
 
 	@Kroll.getProperty @Kroll.method
-	public int getHeight() {
+	public int getHeight()
+	{
 		return height;
 	}
 
@@ -247,8 +257,7 @@ public class TiBlob extends KrollProxy
 		// blob should return the text value on toString 
 		// if it's not null
 		String text = getText();
-		if (text!=null)
-		{
+		if (text != null) {
 			return text;
 		}
 		return "[object TiBlob]";

--- a/android/titanium/src/org/appcelerator/titanium/TiFastDev.java
+++ b/android/titanium/src/org/appcelerator/titanium/TiFastDev.java
@@ -44,6 +44,7 @@ public class TiFastDev
 	private static final String TEMP_FILE_PREFIX = "tifastdev";
 	private static final String TEMP_FILE_SUFFIX = "tmp";
 
+	public static final String COMMAND_LENGTH = "length";
 	public static final String COMMAND_GET = "get";
 	public static final String COMMAND_HANDSHAKE = "handshake";
 	public static final String COMMAND_KILL = "kill";
@@ -150,6 +151,15 @@ public class TiFastDev
 	public String toURL(String relativePath)
 	{
 		return urlPrefix + "/" + relativePath;
+	}
+
+	public int getLength(String relativePath)
+	{
+		byte result[][] = session.sendMessage(COMMAND_LENGTH);
+		if (result != null && result.length > 0) {
+			return session.toInt(result[0]);
+		}
+		return -1;
 	}
 
 	public InputStream openInputStream(String relativePath)

--- a/android/titanium/src/org/appcelerator/titanium/TiFastDev.java
+++ b/android/titanium/src/org/appcelerator/titanium/TiFastDev.java
@@ -6,7 +6,10 @@
  */
 package org.appcelerator.titanium;
 
-import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -15,6 +18,9 @@ import java.net.ServerSocket;
 import java.net.Socket;
 
 import org.appcelerator.titanium.util.Log;
+import org.appcelerator.titanium.util.TiConfig;
+import org.appcelerator.titanium.util.TiStreamHelper;
+import org.appcelerator.titanium.util.TiTempFileHelper;
 
 import android.content.Context;
 import android.content.Intent;
@@ -30,8 +36,13 @@ import android.widget.Toast;
 public class TiFastDev
 {
 	private static final String TAG = "TiFastDev";
+	private static final boolean DBG = TiConfig.LOGD;
+
 	private static TiFastDev _instance;
+	private static final String EMULATOR_HOST = "10.0.2.2";
 	private static final int FASTDEV_PORT = 7999;
+	private static final String TEMP_FILE_PREFIX = "tifastdev";
+	private static final String TEMP_FILE_SUFFIX = "tmp";
 
 	public static final String COMMAND_GET = "get";
 	public static final String COMMAND_HANDSHAKE = "handshake";
@@ -57,10 +68,16 @@ public class TiFastDev
 	protected Socket fastDevSocket;
 	protected Session session;
 	protected boolean restarting = false;
+	protected TiTempFileHelper tempHelper;
 
 	public TiFastDev()
 	{
 		TiApplication app = TiApplication.getInstance();
+		if (app == null) {
+			return;
+		}
+
+		tempHelper = app.getTempFileHelper();
 		if (app.isFastDevMode()) {
 			TiDeployData deployData = app.getDeployData();
 			if (deployData != null) {
@@ -107,7 +124,7 @@ public class TiFastDev
 	protected void connect()
 	{
 		try {
-			fastDevSocket = new Socket("10.0.2.2", port);
+			fastDevSocket = new Socket(EMULATOR_HOST, port);
 		} catch (Exception e) {
 			Log.w(TAG, e.getMessage(), e);
 			enabled = false;
@@ -137,13 +154,37 @@ public class TiFastDev
 
 	public InputStream openInputStream(String relativePath)
 	{
-		byte tokens[][] = session.sendMessage(COMMAND_GET, relativePath);
-		if (tokens == null) {
-			return null;
-		}
+		synchronized (session) {
+			session.checkingForMessage = false;
+			session.sendTokens(COMMAND_GET, relativePath);
 
-		ByteArrayInputStream dataStream = new ByteArrayInputStream(tokens[0]);
-		return dataStream;
+			int tokenCount = session.readTokenCount();
+			if (tokenCount < 1) {
+				return null;
+			}
+	
+			int length = session.readInt();
+			if (length <= 0) {
+				return null;
+			}
+
+			try {
+				// Pull immediately to a temporary file so we avoid tying up
+				// the connection if the app is doing a long-running task with the file.
+				File tempFile = tempHelper.createTempFile(TEMP_FILE_PREFIX, TEMP_FILE_SUFFIX);
+				FileOutputStream tempOut = new FileOutputStream(tempFile);
+				TiStreamHelper.pumpCount(session.getInputStream(), tempOut, length);
+				tempOut.close();
+
+				session.checkingForMessage = true;
+				return new FileInputStream(tempFile);
+			} catch (FileNotFoundException e) {
+				Log.e(TAG, e.getMessage(), e);
+			} catch (IOException e) {
+				Log.e(TAG, e.getMessage(), e);
+			}
+		}
+		return null;
 	}
 
 	public static boolean isFastDevEnabled()
@@ -193,6 +234,11 @@ public class TiFastDev
 			}
 		}
 
+		public InputStream getInputStream()
+		{
+			return in;
+		}
+
 		protected boolean blockRead(byte[] buffer)
 		{
 			try {
@@ -232,11 +278,19 @@ public class TiFastDev
 			return bytes;
 		}
 
+		protected int readInt()
+		{
+			byte buffer[] = new byte[4];
+			if (blockRead(buffer)) {
+				return toInt(buffer);
+			}
+			return -1;
+		}
+
 		protected byte[] readToken()
 		{
-			byte lenBuffer[] = new byte[4];
-			if (blockRead(lenBuffer)) {
-				int length = toInt(lenBuffer);
+			int length = readInt();
+			if (length > 0) {
 				byte tokenData[] = new byte[length];
 				if (blockRead(tokenData)) {
 					return tokenData;
@@ -249,6 +303,9 @@ public class TiFastDev
 		{
 			while (connected) {
 				try {
+					if (DBG) {
+						Log.d(TAG, "checking for message? " + checkingForMessage);
+					}
 					if (checkingForMessage) {
 						if (in.available() > 0) {
 							byte message[][] = readMessage();
@@ -286,13 +343,20 @@ public class TiFastDev
 			}
 		}
 
+		protected int readTokenCount()
+		{
+			int tokenCount = readInt();
+			if (tokenCount > 0) {
+				if (tokenCount > MAX_TOKEN_COUNT) return -1;
+				return tokenCount;
+			}
+			return -1;
+		}
+
 		protected byte[][] readMessage()
 		{
-			byte tokenBuffer[] = new byte[4];
-			if (blockRead(tokenBuffer)) {
-				int tokenCount = toInt(tokenBuffer);
-
-				if (tokenCount > MAX_TOKEN_COUNT) return null;
+			int tokenCount = readTokenCount();
+			if (tokenCount > 0) {
 				byte tokens[][] = new byte[tokenCount][];
 				for (int i = 0; i < tokenCount; i++) {
 					tokens[i] = readToken();
@@ -306,6 +370,9 @@ public class TiFastDev
 		{
 			try {
 				String command = new String(message[0], UTF8_CHARSET);
+				if (DBG) {
+					Log.d(TAG, "Execute command: " + command);
+				}
 				if (COMMAND_KILL.equals(command)) {
 					executeKill();
 				}

--- a/android/titanium/src/org/appcelerator/titanium/io/TiBaseFile.java
+++ b/android/titanium/src/org/appcelerator/titanium/io/TiBaseFile.java
@@ -305,7 +305,7 @@ public abstract class TiBaseFile
 		return false;
 	}
 
-	public double size() {
+	public long size() {
 		logNotSupported("size");
 		return 0;
 	}

--- a/android/titanium/src/org/appcelerator/titanium/io/TiFile.java
+++ b/android/titanium/src/org/appcelerator/titanium/io/TiFile.java
@@ -185,7 +185,7 @@ public class TiFile extends TiBaseFile
 	}
 
 	@Override
-	public double size()
+	public long size()
 	{
 		return file.length();
 	}

--- a/android/titanium/src/org/appcelerator/titanium/io/TiFile.java
+++ b/android/titanium/src/org/appcelerator/titanium/io/TiFile.java
@@ -1,6 +1,6 @@
 /**
  * Appcelerator Titanium Mobile
- * Copyright (c) 2009-2010 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2009-2011 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
@@ -330,7 +330,7 @@ public class TiFile extends TiBaseFile
 			if (!stream) {
 				try {
 					open(append ? MODE_APPEND : MODE_WRITE, true);
-					outstream.write(blob.getBytes());
+					copyStream(blob.getInputStream(), outstream);
 				} finally {
 					close();
 				}
@@ -341,7 +341,7 @@ public class TiFile extends TiBaseFile
 				}
 
 				if (binary) {
-					outstream.write(blob.getBytes());
+					copyStream(blob.getInputStream(), outstream);
 				} else {
 					outwriter.write(new String(blob.getBytes(),"UTF-8"));
 				}

--- a/android/titanium/src/org/appcelerator/titanium/io/TiResourceFile.java
+++ b/android/titanium/src/org/appcelerator/titanium/io/TiResourceFile.java
@@ -188,25 +188,29 @@ public class TiResourceFile extends TiBaseFile
 		return TiC.URL_ANDROID_ASSET_RESOURCES + path;
 	}
 
-	public double size()
+	public long size()
 	{
-		long length = 0;
-		InputStream is = null;
-		try {
-			is = getInputStream();
-			length = is.skip(Long.MAX_VALUE);
-		} catch (IOException e) {
-			Log.w(LCAT, "Error while trying to determine file size: " + e.getMessage());
-		} finally {
-			if (is != null) {
-				try {
-					is.close();
-				} catch (IOException e) {
-					//ignore
+		if (TiFastDev.isFastDevEnabled()) {
+			return TiFastDev.getInstance().getLength(path);
+		} else {
+			long length = 0;
+			InputStream is = null;
+			try {
+				is = getInputStream();
+				length = is.available();
+			} catch (IOException e) {
+				Log.w(LCAT, "Error while trying to determine file size: " + e.getMessage(), e);
+			} finally {
+				if (is != null) {
+					try {
+						is.close();
+					} catch (IOException e) {
+						Log.w(LCAT, e.getMessage(), e);
+					}
 				}
 			}
+			return length;
 		}
-		return length;
 	}
 
 	@Override

--- a/android/titanium/src/org/appcelerator/titanium/io/TiResourceFile.java
+++ b/android/titanium/src/org/appcelerator/titanium/io/TiResourceFile.java
@@ -1,6 +1,6 @@
 /**
  * Appcelerator Titanium Mobile
- * Copyright (c) 2009-2010 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2009-2011 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
@@ -9,9 +9,7 @@ package org.appcelerator.titanium.io;
 
 import java.io.BufferedInputStream;
 import java.io.BufferedReader;
-import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -26,9 +24,7 @@ import org.appcelerator.titanium.TiContext;
 import org.appcelerator.titanium.TiFastDev;
 import org.appcelerator.titanium.util.Log;
 import org.appcelerator.titanium.util.TiConfig;
-import org.appcelerator.titanium.util.TiFileHelper;
 import org.appcelerator.titanium.util.TiFileHelper2;
-import org.appcelerator.titanium.util.TiMimeTypeHelper;
 
 import android.content.Context;
 
@@ -108,32 +104,7 @@ public class TiResourceFile extends TiBaseFile
 	@Override
 	public TiBlob read() throws IOException
 	{
-		ByteArrayOutputStream baos = null;
-		InputStream in = null;
-		try
-		{
-			baos = new ByteArrayOutputStream();
-			in = getInputStream();
-			byte buffer [] = new byte[4096];
-			while(true)
-			{
-				int count = in.read(buffer);
-				if (count < 0)
-				{
-					break;
-				}
-				baos.write(buffer, 0, count);
-			}
-		}
-		finally
-		{
-			if (in!=null)
-			{
-				in.close();
-			}
-		}
-
-		return TiBlob.blobFromData(getTiContext(), baos.toByteArray(), TiMimeTypeHelper.getMimeType(toURL()));
+		return TiBlob.blobFromFile(getTiContext(), this);
 	}
 
 	@Override
@@ -238,7 +209,6 @@ public class TiResourceFile extends TiBaseFile
 		return length;
 	}
 
-
 	@Override
 	public List<String> getDirectoryListing()
 	{
@@ -265,11 +235,4 @@ public class TiResourceFile extends TiBaseFile
 	{
 		return toURL();
 	}
-
-
-	// OUTSIDE OF THE API
-//	String getPath()
-//	{
-//		return path;
-//	}
 }

--- a/android/titanium/src/org/appcelerator/titanium/util/TiStreamHelper.java
+++ b/android/titanium/src/org/appcelerator/titanium/util/TiStreamHelper.java
@@ -98,7 +98,12 @@ public class TiStreamHelper
 
 	public static byte[] toByteArray(InputStream in)
 	{
-		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		return toByteArray(in, 32);
+	}
+
+	public static byte[] toByteArray(InputStream in, int size)
+	{
+		ByteArrayOutputStream out = new ByteArrayOutputStream(size);
 		pump(in, out);
 		return out.toByteArray();
 	}

--- a/android/titanium/src/org/appcelerator/titanium/util/TiStreamHelper.java
+++ b/android/titanium/src/org/appcelerator/titanium/util/TiStreamHelper.java
@@ -50,8 +50,6 @@ public class TiStreamHelper
 		return length;
 	}
 
-	// TODO old stuff begins here - remove everything below this once stream
-	// module if finished
 	public static void pump(InputStream in, OutputStream out)
 	{
 		pump(in, out, DEFAULT_BUFFER_SIZE);
@@ -62,7 +60,33 @@ public class TiStreamHelper
 		byte buffer[] = new byte[bufferSize];
 		int count = 0;
 		try {
-			while((count = in.read(buffer)) != -1) {
+			while ((count = in.read(buffer)) != -1) {
+				if (out != null) {
+					out.write(buffer, 0, count);
+				}
+			}
+		} catch (IOException e) {
+			Log.e(LCAT, "IOException pumping streams", e);
+		}
+	}
+
+	public static void pumpCount(InputStream in, OutputStream out, int byteCount)
+	{
+		pumpCount(in, out, byteCount, DEFAULT_BUFFER_SIZE);
+	}
+
+	public static void pumpCount(InputStream in, OutputStream out, int byteCount, int bufferSize)
+	{
+		byte buffer[] = new byte[bufferSize];
+		int totalCount = 0;
+		try {
+			while (totalCount < byteCount) {
+				int count = in.read(buffer);
+				if (count == -1) {
+					break;
+				}
+
+				totalCount += count;
 				if (out != null) {
 					out.write(buffer, 0, count);
 				}

--- a/support/android/fastdev.py
+++ b/support/android/fastdev.py
@@ -1,6 +1,11 @@
 #
-# A custom server that speeds up development time in Android significantly
+# Appcelerator Titanium Mobile
+# Copyright (c) 2011 by Appcelerator, Inc. All Rights Reserved.
+# Licensed under the terms of the Apache Public License
+# Please see the LICENSE included with this distribution for details.
 #
+# A custom server that speeds up development time in Android significantly
+
 import os, sys, time, optparse, logging
 import urllib, simplejson, threading
 import SocketServer, socket, struct, codecs
@@ -32,7 +37,7 @@ def send_tokens(socket, *tokens):
 	for token in tokens:
 		buffer += pack_int(len(token))
 		buffer += token
-	socket.send(buffer)
+	socket.sendall(buffer)
 
 def read_int(socket):
 	data = socket.recv(4)

--- a/support/android/fastdev.py
+++ b/support/android/fastdev.py
@@ -139,7 +139,10 @@ class FastDevHandler(SocketServer.BaseRequestHandler):
 				if not self.valid_handshake:
 					self.send_tokens("Invalid Handshake")
 					break
-				if command == "get":
+				if command == "length":
+					request_count += 1
+					self.handle_length(tokens[1])
+				elif command == "get":
 					request_count += 1
 					self.handle_get(tokens[1])
 				elif command == "kill-app":
@@ -164,13 +167,29 @@ class FastDevHandler(SocketServer.BaseRequestHandler):
 			logging.warn("handshake: invalid handshake sent, rejecting")
 			self.send_tokens("Invalid Handshake")
 
-	def handle_get(self, relative_path):
+	def get_resource_path(self, relative_path):
 		android_path = os.path.join(self.resources_dir, 'android', relative_path)
 		path = os.path.join(self.resources_dir, relative_path)
 		if os.path.exists(android_path):
-			logging.info("get %s: %s" % (relative_path, android_path))
-			self.send_file(android_path)
+			return android_path
 		elif os.path.exists(path):
+			return path
+		else:
+			return None
+
+	def handle_length(self, relative_path):
+		path = self.get_resource_path(relative_path)
+		if path != None:
+			length = os.path.getsize(path)
+			logging.info("length %s: %d" % (relative_path, length))
+			self.send_tokens(pack_int(length))
+		else:
+			logging.info("length %s: path not found" % relative_path)
+			self.send_tokens(pack_int(-1))
+
+	def handle_get(self, relative_path):
+		path = self.get_resource_path(relative_path)
+		if path != None:
 			logging.info("get %s: %s" % (relative_path, path))
 			self.send_file(path)
 		else:


### PR DESCRIPTION
http://jira.appcelerator.org/browse/TIMOB-4612

This bug actually covers functionality in a lot of places, including TiBaseFile / TiResourceFile / TiFile. The basic problem is that we buffer all of an asset's data in memory before streaming it in several places, making file I/O essentially impossible when using the simplified methods of FileProxy.read / FileProxy.write. We also made this mistake in Fastdev, which added to the issue.
