### PR TITLE
[TIMOB-4619] Remove 'ignoreRotation' in favor of querying windows directly

### DIFF
--- a/iphone/Classes/TiRootController.h
+++ b/iphone/Classes/TiRootController.h
@@ -29,4 +29,6 @@
 -(void)didKeyboardFocusOnProxy:(TiViewProxy<TiKeyboardFocusableView> *)visibleProxy;
 -(void)didKeyboardBlurOnProxy:(TiViewProxy<TiKeyboardFocusableView> *)blurredProxy;
 
+-(TiOrientationFlags)allowedOrientations;
+
 @end

--- a/iphone/Classes/TiRootViewController.h
+++ b/iphone/Classes/TiRootViewController.h
@@ -22,7 +22,6 @@
 
 	UIInterfaceOrientation lastOrientation;
 	UIInterfaceOrientation windowOrientation;
-	BOOL ignoreRotations;
 
 	NSMutableArray * viewControllerStack;
 	BOOL isCurrentlyVisible;

--- a/iphone/Classes/TiWindowProxy.h
+++ b/iphone/Classes/TiWindowProxy.h
@@ -95,6 +95,7 @@ TiOrientationFlags TiOrientationFlagsFromObject(id args);
 -(BOOL)_isChildOfTab;
 -(void)_associateTab:(UIViewController*)controller_ navBar:(UINavigationController*)navbar_ tab:(TiProxy<TiTab>*)tab_;
 -(void)prepareForNavView:(UINavigationController*)navController_;
+-(BOOL)allowsOrientation:(UIInterfaceOrientation)orientation;
 
 @property(nonatomic,readwrite,retain)	UIViewController *controller;
 @property(nonatomic,readwrite,retain)	UINavigationController *navController;

--- a/iphone/Classes/TiWindowProxy.m
+++ b/iphone/Classes/TiWindowProxy.m
@@ -118,6 +118,7 @@ TiOrientationFlags TiOrientationFlagsFromObject(id args)
 
 -(void)_configure
 {	
+    orientationFlags = [[[TiApp app] controller] allowedOrientations];
 	[self replaceValue:nil forKey:@"orientationModes" notification:NO];
 	[super _configure];
 }
@@ -718,6 +719,11 @@ END_UI_THREAD_PROTECTED_VALUE(opened)
 
 	[self fireEvent:newFocused?@"focus":@"blur" withObject:nil propagate:NO];
 	focused = newFocused;
+}
+
+-(BOOL)allowsOrientation:(UIInterfaceOrientation)orientation
+{
+    return TI_ORIENTATION_ALLOWED(orientationFlags, orientation);
 }
 
 #pragma mark Animation Delegates


### PR DESCRIPTION
This re-fixes part of the fix for TIMOB-4137, and also resolved TIMOB-4619. When performing functional testing for this request, BOTH of these bugs need to be checked to ensure correct behavior - failure on either of them means that this commit is bad.
