### PR TITLE
TIMOB-4631: Android: Failure to launch emulator with r12 SDK tools

### DIFF
--- a/support/android/builder.py
+++ b/support/android/builder.py
@@ -399,7 +399,7 @@ class Builder(object):
 			'-sdcard',
 			self.sdcard,
 			'-logcat',
-			"'*:d *'",
+			'*:d,*',
 			'-no-boot-anim',
 			'-partition-size',
 			'128' # in between nexusone and droid


### PR DESCRIPTION
Hot fix for spaces in logcat filters in latest r12 Android SDK . SDK installation still requires a folder without spaces to install.

http://jira.appcelerator.org/browse/TIMOB-4631
