### PR TITLE
TIMOB-4619 Refix: Orienting splitviews

### DIFF
--- a/demos/KitchenSink-iPad/Resources/split_view_plain.js
+++ b/demos/KitchenSink-iPad/Resources/split_view_plain.js
@@ -28,6 +28,13 @@ SplitViewPlain.modalButton.addEventListener('click', function() {
         modal:true
     });
     
+    modal.orientationModes = [
+    	Titanium.UI.PORTRAIT,
+    	Titanium.UI.UPSIDE_PORTRAIT,
+    	Titanium.UI.LANDSCAPE_LEFT,
+    	Titanium.UI.LANDSCAPE_RIGHT
+    ];
+    
     var flexSpace = Titanium.UI.createButton({
         systemButton:Titanium.UI.iPhone.SystemButton.FLEXIBLE_SPACE
     });

--- a/iphone/Classes/MGSplitView/MGSplitView.h
+++ b/iphone/Classes/MGSplitView/MGSplitView.h
@@ -1,0 +1,20 @@
+/**
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2009-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+
+#import <UIKit/UIKit.h>
+#import "MGSplitViewController.h"
+
+@interface MGSplitView : UIView {
+    MGSplitViewController* controller;
+    BOOL layingOut;
+    BOOL singleLayout;
+}
+@property(nonatomic,readwrite,assign) BOOL layingOut;
+
+- (id)initWithFrame:(CGRect)frame controller:(MGSplitViewController*)controller_;
+-(void)setSingleLayout;
+@end

--- a/iphone/Classes/MGSplitView/MGSplitView.h
+++ b/iphone/Classes/MGSplitView/MGSplitView.h
@@ -4,6 +4,7 @@
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
+#ifdef USE_TI_UIIPADSPLITWINDOW
 
 #import <UIKit/UIKit.h>
 #import "MGSplitViewController.h"
@@ -18,3 +19,5 @@
 - (id)initWithFrame:(CGRect)frame controller:(MGSplitViewController*)controller_;
 -(void)setSingleLayout;
 @end
+
+#endif

--- a/iphone/Classes/MGSplitView/MGSplitView.m
+++ b/iphone/Classes/MGSplitView/MGSplitView.m
@@ -1,0 +1,50 @@
+/**
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2009-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+
+#import "MGSplitView.h"
+
+
+@implementation MGSplitView
+@synthesize layingOut;
+
+- (id)initWithFrame:(CGRect)frame controller:(MGSplitViewController*)controller_
+{
+    self = [super initWithFrame:frame];
+    if (self) {
+        controller = [controller_ retain];
+        layingOut = NO;
+        singleLayout = NO;
+    }
+    return self;
+}
+
+- (void)dealloc
+{
+    RELEASE_TO_NIL(controller);
+    [super dealloc];
+}
+
+-(void)setSingleLayout
+{
+    singleLayout = YES;
+}
+
+// Ugly hack to force the controller's layout method to be called whenever an initial
+// layout request is made. We have to rely on the controller's layout method to properly
+// set the 'layingOut' flag, as well... dangerous, and fragile.
+-(void)layoutSubviews
+{
+    if (!layingOut && !singleLayout) {
+        [controller layoutSubviewsForInterfaceOrientation:[[UIApplication sharedApplication] statusBarOrientation] withAnimation:YES];
+    }
+    else {
+        [super layoutSubviews];
+        singleLayout = NO;
+    }
+}
+
+@end

--- a/iphone/Classes/MGSplitView/MGSplitView.m
+++ b/iphone/Classes/MGSplitView/MGSplitView.m
@@ -6,7 +6,7 @@
  */
 
 #import "MGSplitView.h"
-
+#ifdef USE_TI_UIIPADSPLITWINDOW
 
 @implementation MGSplitView
 @synthesize layingOut;
@@ -48,3 +48,5 @@
 }
 
 @end
+
+#endif

--- a/iphone/Classes/MGSplitView/MGSplitViewController.h
+++ b/iphone/Classes/MGSplitView/MGSplitViewController.h
@@ -86,6 +86,8 @@ typedef enum _MGSplitViewDividerStyle {
 	2. Change their .cornerRadius
  */
 
+- (void)layoutSubviewsForInterfaceOrientation:(UIInterfaceOrientation)theOrientation withAnimation:(BOOL)animate;
+
 @end
 
 

--- a/iphone/Classes/MGSplitView/MGSplitViewController.h
+++ b/iphone/Classes/MGSplitView/MGSplitViewController.h
@@ -87,6 +87,7 @@ typedef enum _MGSplitViewDividerStyle {
  */
 
 - (void)layoutSubviewsForInterfaceOrientation:(UIInterfaceOrientation)theOrientation withAnimation:(BOOL)animate;
+- (void)layoutSubviews;
 
 @end
 

--- a/iphone/Classes/MGSplitView/MGSplitViewController.m
+++ b/iphone/Classes/MGSplitView/MGSplitViewController.m
@@ -14,6 +14,7 @@
 #import "MGSplitViewController.h"
 #import "MGSplitDividerView.h"
 #import "MGSplitCornersView.h"
+#import "MGSplitView.h"
 
 #define MG_DEFAULT_SPLIT_POSITION		320.0	// default width of master view in UISplitViewController.
 #define MG_DEFAULT_SPLIT_WIDTH			1.0		// default width of split-gutter in UISplitViewController.
@@ -266,6 +267,7 @@
         return;
     }
     
+    [(MGSplitView*)[self view] setLayingOut:YES];
 	if (_reconfigurePopup) {
 		[self reconfigureForMasterInPopover:![self shouldShowMasterForInterfaceOrientation:theOrientation]];
 	}
@@ -331,6 +333,7 @@
 			theView = controller.view;
 			if (theView) {
 				theView.frame = masterRect;
+                theView.bounds = CGRectMake(0, 0, masterRect.size.width, masterRect.size.height);
 				if (!theView.superview) {
 					[controller viewWillAppear:NO];
 					[self.view addSubview:theView];
@@ -352,6 +355,7 @@
 			theView = controller.view;
 			if (theView) {
 				theView.frame = detailRect;
+                theView.bounds = CGRectMake(0, 0, detailRect.size.width, detailRect.size.height);
 				if (!theView.superview) {
 					[self.view insertSubview:theView aboveSubview:self.masterViewController.view];
 				} else {
@@ -493,6 +497,7 @@
 		[self.view bringSubviewToFront:leadingCorners];
 		[self.view bringSubviewToFront:trailingCorners];
 	}
+    [(MGSplitView*)[self view] setLayingOut:NO];
 }
 
 
@@ -554,6 +559,10 @@
 	[self.detailViewController viewDidDisappear:animated];
 }
 
+-(void)loadView
+{
+    [self setView:[[MGSplitView alloc] initWithFrame:CGRectZero controller:self]];
+}
 
 #pragma mark -
 #pragma mark Popover handling
@@ -594,6 +603,7 @@
 		// I know this looks strange, but it fixes a bizarre issue with UIPopoverController leaving masterViewController's views in disarray.
 		if ([[self view] window] != nil)
 		{
+            [(MGSplitView*)[self view] setSingleLayout];
 			[_hiddenPopoverController presentPopoverFromRect:CGRectZero inView:self.view permittedArrowDirections:UIPopoverArrowDirectionAny animated:NO];
 		}
 		
@@ -732,6 +742,7 @@
 		}
 		
 		// Show popover.
+        [(MGSplitView*)[self view] setSingleLayout];
 		[_hiddenPopoverController presentPopoverFromBarButtonItem:_barButtonItem permittedArrowDirections:UIPopoverArrowDirectionAny animated:YES];
 	}
 }
@@ -741,6 +752,7 @@
 	if (!_hiddenPopoverController || (_hiddenPopoverController.popoverVisible)) {
 		// TODO: Does this alert the delegate? More importantly, will this have ramifications in terms of race conditions if someone rotates while this
 		// is hiding? Hope this works.
+        [(MGSplitView*)[self view] setSingleLayout];
 		[_hiddenPopoverController dismissPopoverAnimated:YES];
 	}
 }

--- a/iphone/Classes/MGSplitView/MGSplitViewController.m
+++ b/iphone/Classes/MGSplitView/MGSplitViewController.m
@@ -233,6 +233,9 @@
 {
 	UIScreen *screen = [UIScreen mainScreen];
 	CGRect fullScreenRect = screen.bounds; // always implicitly in Portrait orientation.
+    
+    // Because we may 'force' rotation, the status bar isn't oriented yet when this value is retrieved, and it could
+    // very well be wrong. 
 	CGRect appFrame = screen.applicationFrame;
 	
 	// Find status bar height by checking which dimension of the applicationFrame is narrower than screen bounds.
@@ -258,6 +261,11 @@
 
 - (void)layoutSubviewsForInterfaceOrientation:(UIInterfaceOrientation)theOrientation withAnimation:(BOOL)animate
 {
+    // Not ready to begin drawing yet!
+    if (theOrientation == 0) {
+        return;
+    }
+    
 	if (_reconfigurePopup) {
 		[self reconfigureForMasterInPopover:![self shouldShowMasterForInterfaceOrientation:theOrientation]];
 	}

--- a/iphone/Classes/MGSplitView/MGSplitViewController.m
+++ b/iphone/Classes/MGSplitView/MGSplitViewController.m
@@ -603,7 +603,6 @@
 		// I know this looks strange, but it fixes a bizarre issue with UIPopoverController leaving masterViewController's views in disarray.
 		if ([[self view] window] != nil)
 		{
-            [(MGSplitView*)[self view] setSingleLayout];
 			[_hiddenPopoverController presentPopoverFromRect:CGRectZero inView:self.view permittedArrowDirections:UIPopoverArrowDirectionAny animated:NO];
 		}
 		

--- a/iphone/Classes/TiRootController.h
+++ b/iphone/Classes/TiRootController.h
@@ -30,5 +30,6 @@
 -(void)didKeyboardBlurOnProxy:(TiViewProxy<TiKeyboardFocusableView> *)blurredProxy;
 
 -(TiOrientationFlags)allowedOrientations;
+-(BOOL)isTopWindow:(TiWindowProxy*)window;
 
 @end

--- a/iphone/Classes/TiRootViewController.m
+++ b/iphone/Classes/TiRootViewController.m
@@ -280,21 +280,26 @@
             }
             [thisNavCon willAnimateRotationToInterfaceOrientation:newOrientation duration:duration];
         }
+        else {
+            [thisProxy ignoringRotationToOrientation:newOrientation];
+        }
 	}
     
     if (newOrientation != [ourApp statusBarOrientation] && isCurrentlyVisible)
-	{
-		[keyboardFocusedProxy blur:nil];
-		[ourApp setStatusBarOrientation:newOrientation animated:(duration > 0.0)];
-		[keyboardFocusedProxy focus:nil];
-	}
+    {
+        [keyboardFocusedProxy blur:nil];
+        [ourApp setStatusBarOrientation:newOrientation animated:(duration > 0.0)];
+        [keyboardFocusedProxy focus:nil];
+    }
     
-	[[self view] setTransform:transform];
+    [[self view] setTransform:transform];
+    [self resizeView];
+    
+    //Propigate this to everyone else. This has to be done INSIDE the animation.
+    [self repositionSubviews];
+    
 	lastOrientation = newOrientation;
-	[self resizeView];
 
-	//Propigate this to everyone else. This has to be done INSIDE the animation.
-	[self repositionSubviews];
 	
 	if (duration > 0.0)
 	{
@@ -537,6 +542,11 @@ What this does mean is that any
 -(UIViewController *)focusedViewController
 {
 	return [windowViewControllers lastObject];
+}
+
+-(BOOL)isTopWindow:(TiWindowProxy *)window
+{
+    return [[windowProxies lastObject] isEqual:window];
 }
 
 #pragma mark Remote Control Notifications

--- a/iphone/Classes/TiUIiPadSplitWindowProxy.m
+++ b/iphone/Classes/TiUIiPadSplitWindowProxy.m
@@ -59,7 +59,15 @@
 
 -(TiOrientationFlags)orientationFlags
 {
-	return [detailView orientationFlags];
+    // Not even WE follow this convention in the documentation, so we need to make sure
+    // there's a failsafe. Note that because of how orienting works (views pick up their
+    // parent's orientation) we need to query the splitview's orientation FIRST.
+    
+    TiOrientationFlags orientations = [super orientationFlags];
+    if (orientations == TiOrientationNone) {
+        orientations = [detailView orientationFlags];
+    }
+	return orientations;
 }
 
 -(BOOL)_handleClose:(id)args
@@ -68,6 +76,14 @@
 	[(TiUIiPadSplitWindow*)[self view] setMasterPopupVisible_:NO];
     
     return [super _handleClose:args];
+}
+
+// Prevents dumb visual glitches - see 4619
+-(void)ignoringRotationToOrientation:(UIInterfaceOrientation)orientation
+{
+    if (![[[TiApp app] controller] isTopWindow:self]) {
+        [(MGSplitViewController*)[(TiUIiPadSplitWindow*)[self view] controller] layoutSubviewsForInterfaceOrientation:orientation withAnimation:NO];
+    }
 }
 
 @end

--- a/iphone/Classes/TiViewProxy.h
+++ b/iphone/Classes/TiViewProxy.h
@@ -216,6 +216,7 @@ enum
 
 #pragma mark Layout commands that need refactoring out
 
+-(void)determineSandboxBounds;
 -(void)layoutChildren:(BOOL)optimize;
 -(void)layoutChildrenIfNeeded;
 -(void)layoutChild:(TiViewProxy*)child optimize:(BOOL)optimize;

--- a/iphone/Classes/TiViewProxy.m
+++ b/iphone/Classes/TiViewProxy.m
@@ -1396,6 +1396,21 @@ if(OSAtomicTestAndSetBarrier(flagBit, &dirtyflags))	\
 
 #pragma mark Layout actions
 
+// Need this so we can overload the sandbox bounds on split view detail/master
+-(void)determineSandboxBounds
+{
+    UIView * ourSuperview = [[self view] superview];
+    if(ourSuperview == nil)
+    {
+        //TODO: Should we even be relaying out? I guess so.
+        sandboxBounds = CGRectZero;
+    }
+    else
+    {
+        sandboxBounds = [ourSuperview bounds];
+    }
+}
+
 -(void)refreshView:(TiUIView *)transferView
 {
 	WARN_IF_BACKGROUND_THREAD_OBJ;
@@ -1424,16 +1439,7 @@ if(OSAtomicTestAndSetBarrier(flagBit, &dirtyflags))	\
 		CGRect oldFrame = [[self view] frame];
 		if(![self suppressesRelayout])
 		{
-			UIView * ourSuperview = [[self view] superview];
-			if(ourSuperview == nil)
-			{
-				//TODO: Should we even be relaying out? I guess so.
-				sandboxBounds = CGRectZero;
-			}
-			else
-			{
-				sandboxBounds = [ourSuperview bounds];
-			}
+            [self determineSandboxBounds];
 			[self relayout];
 		}
 		[self layoutChildren:NO];

--- a/iphone/Classes/TiWindowProxy.h
+++ b/iphone/Classes/TiWindowProxy.h
@@ -96,6 +96,7 @@ TiOrientationFlags TiOrientationFlagsFromObject(id args);
 -(void)_associateTab:(UIViewController*)controller_ navBar:(UINavigationController*)navbar_ tab:(TiProxy<TiTab>*)tab_;
 -(void)prepareForNavView:(UINavigationController*)navController_;
 -(BOOL)allowsOrientation:(UIInterfaceOrientation)orientation;
+-(void)ignoringRotationToOrientation:(UIInterfaceOrientation)orientation;
 
 @property(nonatomic,readwrite,retain)	UIViewController *controller;
 @property(nonatomic,readwrite,retain)	UINavigationController *navController;

--- a/iphone/Classes/TiWindowProxy.m
+++ b/iphone/Classes/TiWindowProxy.m
@@ -726,6 +726,11 @@ END_UI_THREAD_PROTECTED_VALUE(opened)
     return TI_ORIENTATION_ALLOWED(orientationFlags, orientation);
 }
 
+-(void)ignoringRotationToOrientation:(UIInterfaceOrientation)orientation
+{
+    // For subclasses
+}
+
 #pragma mark Animation Delegates
 
 - (void)viewDidAppear:(BOOL)animated;    // Called when the view is about to made visible. Default does nothing

--- a/iphone/iphone/Titanium.xcodeproj/project.pbxproj
+++ b/iphone/iphone/Titanium.xcodeproj/project.pbxproj
@@ -869,6 +869,9 @@
 		DAC9D36C138DB65C004917F8 /* debugger.plist in Resources */ = {isa = PBXBuildFile; fileRef = DAC9D36B138DB65C004917F8 /* debugger.plist */; };
 		DAC9D36D138DB678004917F8 /* debugger.plist in Resources */ = {isa = PBXBuildFile; fileRef = DAC9D36B138DB65C004917F8 /* debugger.plist */; };
 		DAC9D36E138DB67F004917F8 /* debugger.plist in Resources */ = {isa = PBXBuildFile; fileRef = DAC9D36B138DB65C004917F8 /* debugger.plist */; };
+		DADD76E913CCF4FF00CD03AC /* MGSplitView.m in Sources */ = {isa = PBXBuildFile; fileRef = DADD76E813CCF4FF00CD03AC /* MGSplitView.m */; };
+		DADD76EA13CCF4FF00CD03AC /* MGSplitView.m in Sources */ = {isa = PBXBuildFile; fileRef = DADD76E813CCF4FF00CD03AC /* MGSplitView.m */; };
+		DADD76EB13CCF4FF00CD03AC /* MGSplitView.m in Sources */ = {isa = PBXBuildFile; fileRef = DADD76E813CCF4FF00CD03AC /* MGSplitView.m */; };
 		DAE541E313577BEC00A65123 /* TiDataStream.m in Sources */ = {isa = PBXBuildFile; fileRef = DAE541E213577BEC00A65123 /* TiDataStream.m */; };
 		DAE541E413577BEC00A65123 /* TiDataStream.m in Sources */ = {isa = PBXBuildFile; fileRef = DAE541E213577BEC00A65123 /* TiDataStream.m */; };
 		DAE541E513577BEC00A65123 /* TiDataStream.m in Sources */ = {isa = PBXBuildFile; fileRef = DAE541E213577BEC00A65123 /* TiDataStream.m */; };
@@ -1470,6 +1473,8 @@
 		DABF3EDA134D2E4300836137 /* TiStreamProxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TiStreamProxy.h; sourceTree = "<group>"; };
 		DABF3EDB134D2E4300836137 /* TiStreamProxy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TiStreamProxy.m; sourceTree = "<group>"; };
 		DAC9D36B138DB65C004917F8 /* debugger.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = debugger.plist; path = ../Resources/debugger.plist; sourceTree = "<group>"; };
+		DADD76E713CCF4FF00CD03AC /* MGSplitView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGSplitView.h; sourceTree = "<group>"; };
+		DADD76E813CCF4FF00CD03AC /* MGSplitView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MGSplitView.m; sourceTree = "<group>"; };
 		DAE541E113577BEC00A65123 /* TiDataStream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TiDataStream.h; sourceTree = "<group>"; };
 		DAE541E213577BEC00A65123 /* TiDataStream.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TiDataStream.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -2759,6 +2764,8 @@
 				B440EF7B1209DC400045FEAE /* MGSplitDividerView.m */,
 				B440EF7C1209DC400045FEAE /* MGSplitViewController.h */,
 				B440EF7D1209DC400045FEAE /* MGSplitViewController.m */,
+				DADD76E713CCF4FF00CD03AC /* MGSplitView.h */,
+				DADD76E813CCF4FF00CD03AC /* MGSplitView.m */,
 			);
 			name = MGSplitView;
 			path = ../Classes/MGSplitView;
@@ -3321,6 +3328,7 @@
 				DA2556441353D2FC005D459C /* TiNetworkSocketProxy.m in Sources */,
 				DAE541E313577BEC00A65123 /* TiDataStream.m in Sources */,
 				4D3033A3136239B30034640F /* TiFilesystemFileStreamProxy.m in Sources */,
+				DADD76E913CCF4FF00CD03AC /* MGSplitView.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3589,6 +3597,7 @@
 				DA2556451353D2FC005D459C /* TiNetworkSocketProxy.m in Sources */,
 				DAE541E413577BEC00A65123 /* TiDataStream.m in Sources */,
 				B415067A136745E20084074A /* TiFilesystemFileStreamProxy.m in Sources */,
+				DADD76EA13CCF4FF00CD03AC /* MGSplitView.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3857,6 +3866,7 @@
 				DA2556461353D2FC005D459C /* TiNetworkSocketProxy.m in Sources */,
 				DAE541E513577BEC00A65123 /* TiDataStream.m in Sources */,
 				B415067D136745FE0084074A /* TiFilesystemFileStreamProxy.m in Sources */,
+				DADD76EB13CCF4FF00CD03AC /* MGSplitView.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
Includes a fix for orienting splitviews into orientations they don't support. Note that the Apple HIG specifies that split views must support all orientations.

The fix is performed by selectively laying out subviews either according to the MGSplitViewController's layout methodology, or the standard layout for UIViews, depending on whether or not we're displaying in a popover, or already in a layout for the controller. There are also some other fixes to temporarily rotate split views into unsupported orientations for the purposes of visual consistency (this is not a regression, believe it or not, but is probably undesirable behavior).

Please note that before this can be merged to 1.7.2, the previous (incomplete) fix for 4619, 35cda9a, must be merged.
