### PR TITLE
TIMOB-4447: JSS - Android picks up jss file from the iphone folder

### DIFF
--- a/support/common/css/csscompiler.py
+++ b/support/common/css/csscompiler.py
@@ -76,20 +76,39 @@ class CSSCompiler(object):
 		if self.platform == 'universal':
 			return key == 'ios' or key == 'ipad' or key == 'iphone'
 		return self.platform == key
-	
-	def __init__(self,dir,platform,appid):
+
+	def is_platform_ios(self):
+		return self.platform in ["iphone", "ipad", "ios", "universal"]
+
+	def is_platform_dir(self, dir,):
+		platform_dirs = [os.path.join(self.dir, p) for p in ["iphone", "android", "blackberry"]]
+
+		if dir in platform_dirs:
+				basename = os.path.basename(dir)
+				if self.is_platform_ios() and basename == "iphone":
+					return True
+				elif self.platform == basename:
+					return True
+				return False
+		return True
+
+	def __init__(self, dir, platform, appid):
 		self.dir = dir
 		self.platform = platform
 		self.appid = appid
 		self.files = {}
-		
-		for dirname,dirs,files in os.walk(dir):
+
+		for root, dirs, files in os.walk(dir):
+			if not self.is_platform_dir(root):
+				continue
+
 			for name in ignoreDirs:
 				if name in dirs:
 					dirs.remove(name)	# don't visit ignored directories			  
 			for f in files:
 				if f in ignoreFiles: continue
 				if not f.endswith('.jss'): continue
+				path = os.path.join(root, f)
 				tok = f[0:-4].split('.')
 				count = len(tok)
 				if count > 1:
@@ -100,11 +119,11 @@ class CSSCompiler(object):
 				if self.files.has_key(tok[0]):
 					dict = self.files[tok[0]]
 				if count == 1:
-					dict['base'] = os.path.join(dirname,f)
+					dict['base'] = path
 				elif count == 2:
-					dict['platform'] = os.path.join(dirname,f)
+					dict['platform'] = path
 				elif count == 3:
-					dict['density'][tok[2]] = os.path.join(dirname,f)
+					dict['density'][tok[2]] = path
 				
 				self.files[tok[0]] = dict
 		
@@ -145,7 +164,7 @@ class CSSCompiler(object):
 		
 		self.transform_properties()
 		
-		if self.platform == 'iphone' or self.platform == 'ipad' or self.platform == 'ios' or self.platform == 'universal':
+		if self.is_platform_ios():
 			self.code = self.generate_ios_code(self.classes,self.classes_density,self.ids,self.ids_density,self.tags,self.tags_density)
 		elif self.platform == 'android':
 			#merge classes and tags for backward compatibility with current Android implementation

--- a/support/common/css/csscompiler.py
+++ b/support/common/css/csscompiler.py
@@ -84,13 +84,12 @@ class CSSCompiler(object):
 		platform_dirs = [os.path.join(self.dir, p) for p in ["iphone", "android", "blackberry"]]
 
 		if dir in platform_dirs:
-				basename = os.path.basename(dir)
-				if self.is_platform_ios() and basename == "iphone":
-					return True
-				elif self.platform == basename:
-					return True
-				return False
-		return True
+			basename = os.path.basename(dir)
+			if self.is_platform_ios() and basename == "iphone":
+				return True
+			elif self.platform == basename:
+				return True
+		return False
 
 	def __init__(self, dir, platform, appid):
 		self.dir = dir


### PR DESCRIPTION
This is actually bug for both iOS and Android -- it just happens to only manifest in Android because of directory name sorting.

http://jira.appcelerator.org/browse/TIMOB-4447
