### PR TITLE
[TIMOB-4687] row updating crash fix

### DIFF
--- a/iphone/Classes/TiUITableView.m
+++ b/iphone/Classes/TiUITableView.m
@@ -45,7 +45,10 @@
 
 -(CGSize)computeCellSize
 {
-    CGFloat width = [proxy sizeWidthForDecorations:[[proxy table] tableView].bounds.size.width forceResizing:YES];
+    CGFloat width = 0;
+    if ([proxy table] != nil) {
+        width = [proxy sizeWidthForDecorations:[[proxy table] tableView].bounds.size.width forceResizing:YES];        
+    }
 	CGFloat height = [proxy rowHeight:width];
 	height = [[proxy table] tableRowHeight:height];
     


### PR DESCRIPTION
Looks like we need to comb the code for situations where we may be grabbing non-id properties off nil values, because they could be defined (but bad), as in the case of (CGRect)[nil bounds].
