### PR TITLE
[TIMOB-4666] Fix for unreleased event handler crash

### DIFF
--- a/demos/KitchenSink/Resources/examples/platform.js
+++ b/demos/KitchenSink/Resources/examples/platform.js
@@ -11,6 +11,7 @@ win.addEventListener('close',function()
 {
 	// turn it off, no need to waste the battery
 	Titanium.Platform.batteryMonitoring = false;
+	Titanium.Platform.removeEventListener('battery');
 });
 
 function batteryStateToString(state)


### PR DESCRIPTION
We need to be making sure that any event which is added to a module via addEventListener() is cleaned up when the window is closed, as the module may persist, and so will the event listener - but functions which the event listeners call may be cleaned up.

Tested iPad 2/4.3.3 and iPod 4GT/4.3.3.
