### PR TITLE
[TIMOB-4531] Table rows must be created with valid context

### DIFF
--- a/iphone/Classes/TiUITableViewProxy.m
+++ b/iphone/Classes/TiUITableViewProxy.m
@@ -190,7 +190,11 @@ NSArray * tableKeySequence;
 
 -(TiUITableViewRowProxy*)makeTableViewRowFromDict:(NSDictionary*)data
 {
-	TiUITableViewRowProxy *proxy = [[[TiUITableViewRowProxy alloc] _initWithPageContext:[self executionContext]] autorelease];
+    id<TiEvaluator> context = [self executionContext];
+    if (context == nil) {
+        context = [self pageContext];
+    }
+	TiUITableViewRowProxy *proxy = [[[TiUITableViewRowProxy alloc] _initWithPageContext:context] autorelease];
 	[proxy _initWithProperties:data];
 	return proxy;
 }

--- a/iphone/Classes/TiUITableViewRowProxy.m
+++ b/iphone/Classes/TiUITableViewRowProxy.m
@@ -1017,7 +1017,7 @@ TiProxy * DeepScanForProxyOfViewContainingPoint(UIView * targetView, CGPoint poi
 					@"title", @"backgroundImage",
 					@"leftImage",@"hasDetail",@"hasCheck",@"hasChild",	
 					@"indentionLevel",@"selectionStyle",@"color",@"selectedColor",
-					@"height",@"width",@"backgroundColor",
+					@"height",@"width",@"backgroundColor",@"rightImage",
 					nil];
 	}
 	


### PR DESCRIPTION
This may affect other portions of code as well, but here it's probably an issue only because we manually allocate proxies rather than letting the default methodology occur. In particular tableviews may not have an active 'execution' context when creating their table data.
