### PR TITLE
[TIMOB-4258] tiapp.xml support for supplying supported file types

### DIFF
--- a/iphone/Classes/TiApp.mm
+++ b/iphone/Classes/TiApp.mm
@@ -399,6 +399,7 @@ void MyUncaughtExceptionHandler(NSException *exception)
 {
 	[launchOptions removeObjectForKey:UIApplicationLaunchOptionsURLKey];	
 	[launchOptions setObject:[url absoluteString] forKey:@"url"];
+    return YES;
 }
 
 - (void)applicationWillTerminate:(UIApplication *)application


### PR DESCRIPTION
## DOCUMENTATION

tiapp.xml now has support for specifying which file types your app can open. In-app, these are passed through as the `url` property of `Titanium.App.getArguments()` or as the `url` property of the `resumed` event (if your app is running when the request is made). The URL is always a `file://` URL identifier.

The relevant XML tags are:

`fileTypes` : The toplevel tag which contains `type` tags.
`type` : The tag which contains child tags describing information about the supported type.
`name` : The name of the type.
`icon` : The icon to use to represent the type. Note that this is not the icon that appears in the list of apps to open a file; that is your app's icon.
`uti` : A comma-separated list of [UTIs](http://developer.apple.com/library/mac/#documentation/Miscellaneous/Reference/UTIRef/Articles/System-DeclaredUniformTypeIdentifiers.html). These are the types that will be associated with your app.
`owner` : A boolean value indicating whether or not your app should be considered the default for opening this type of file.

These tags appear in the iphone section of the tiapp.xml, as this is an iphone-specific feature (for the time being).
## EXAMPLE

```
<iphone>
 ....
        <fileTypes>
            <type>
                <name>PDF</name>
                <icon>pdf_type_icon.png</icon>
                <uti>com.adobe.pdf</uti>
                <owner>false</owner>
            </type>
        </fileTypes>
    </iphone>
```
