### PR TITLE
[TIMOB-4166] Scroll while decelerating

### DIFF
--- a/iphone/Classes/TiUITableView.m
+++ b/iphone/Classes/TiUITableView.m
@@ -1993,7 +1993,7 @@ if(ourTableView != tableview)	\
 
 - (void)scrollViewDidScroll:(UIScrollView *)scrollView
 {	
-	if (scrollView.isDragging) 
+	if (scrollView.isDragging || scrollView.isDecelerating) 
 	{
 		if ([self.proxy _hasListeners:@"scroll"])
 		{


### PR DESCRIPTION
Turns out Android has ALWAYS sent 'scroll' events while the view is decelerating. This is actually a parity issue, and solves the problem of tables prematurely no longer sending this event. This is a behavior change which could result in significant 'event spam' for users, but is required without question.

TiUIScrollView does not appear to require similar modifications.
