### PR TITLE
TIMOB-4355: Proper blurs means proper navbar cleanups

### DIFF
--- a/iphone/Classes/TiUIWindowProxy.m
+++ b/iphone/Classes/TiUIWindowProxy.m
@@ -225,7 +225,7 @@
 		BOOL animate = args!=nil && [args count]>0 ? [TiUtils boolValue:@"animated" properties:[args objectAtIndex:0] def:YES] : YES;
 		[tab windowClosing:self animated:animate];
 	}
-	else
+	else if(focused)
 	{
 		// if we don't have a tab, we need to fire blur
 		// events ourselves

--- a/iphone/Classes/TiUIiPhoneNavigationGroup.m
+++ b/iphone/Classes/TiUIiPhoneNavigationGroup.m
@@ -19,11 +19,15 @@
 		return;
 	}
     // NOTE: We don't need to blur the currently visible proxy, because it gets closed out by the close: call.
-	[visibleProxy autorelease];
-
+	TiWindowProxy * oldProxy = visibleProxy;
 	visibleProxy = [newVisibleProxy retain];
+	[oldProxy _tabBeforeBlur];
 	[newVisibleProxy _tabBeforeFocus];
+
+	[oldProxy _tabBlur];
 	[newVisibleProxy _tabFocus];
+
+	[oldProxy release];
 }
 
 -(void)dealloc


### PR DESCRIPTION
TIMOB-4355: Must send proper blurs, but to avoid regression, make sure we're don't call it a second time.
