### PR TITLE
TIMOB-2324 When we're still the top of the navcontroller, keep nav image

### DIFF
--- a/iphone/Classes/TiUIWindowProxy.m
+++ b/iphone/Classes/TiUIWindowProxy.m
@@ -798,7 +798,9 @@ else{\
 	if (focused)
 	{
 		[self fireFocus:NO];
-		[barImageView removeFromSuperview];
+		if ([navController topViewController] != controller) {
+			[barImageView removeFromSuperview];
+		}
 	}
 	[super _tabBlur];
 }


### PR DESCRIPTION
TIMOB-2324 When we're still the top of the navcontroller, don't remove the bar image view.
