### PR TITLE
[TIMOB-4732] Android scons/ant for paths with space

### DIFF
--- a/android/build/common.xml
+++ b/android/build/common.xml
@@ -164,7 +164,7 @@ Common ant tasks and macros for building Android-based Titanium modules and proj
 				compiler.args="@{compiler.args}">
 
 				<javac.args>
-					<compilerarg line="-s @{apt.src.dir} -Akroll.jsonFile=@{kroll.jsonFile} -Akroll.jsonPackage=@{kroll.jsonPackage} -proc:only"/>
+					<compilerarg line="-s &quot;@{apt.src.dir}&quot; -Akroll.jsonFile=@{kroll.jsonFile} -Akroll.jsonPackage=@{kroll.jsonPackage} -proc:only"/>
 					<extra.args/>
 				</javac.args>
 				<javac.classpath>


### PR DESCRIPTION
Found this issue while sconsing up the latest off a path that had a space in the name. Marshall was kind enough to assist with the fix so somebody else should review/functional.

Functional testing is just by building the android project in any directory with a space in the name.
