### PR TITLE
TIMOB-4686 When we set closingProxy twice, make sure we're not overretaining

### DIFF
--- a/iphone/Classes/TiUIiPhoneNavigationGroup.m
+++ b/iphone/Classes/TiUIiPhoneNavigationGroup.m
@@ -113,6 +113,7 @@
 	NSMutableArray* newControllers = [NSMutableArray arrayWithArray:controller.viewControllers];
 	BOOL animated = [TiUtils boolValue:@"animated" properties:properties def:(windowController == [newControllers lastObject])];
 	[newControllers removeObject:windowController];
+	[closingProxy autorelease];
 	closingProxy = [window retain];
 	[controller setViewControllers:newControllers animated:animated];
 	


### PR DESCRIPTION
TIMOB-4686 When we set closingProxy twice, make sure we're not double-retaining.
