### PR TITLE
TIMOB-3465 Fix detection of XML module

### DIFF
--- a/support/android/compiler.py
+++ b/support/android/compiler.py
@@ -90,7 +90,8 @@ class Compiler(object):
 					self.add_required_module(depend)
 
 	def is_module(self, name):
-		if name.isupper(): return False # completely upper case signifies a constant
+		ucase_module_names = ("XML", "API", "JSON", "UI")
+		if name.isupper() and name not in ucase_module_names: return False # completely upper case signifies a constant
 		if not name[0].isupper() and name != "iPhone": return False
 		if 'iPhone.' in name: return False
 		


### PR DESCRIPTION
http://jira.appcelerator.org/browse/TIMOB-3465

XML module was not being included in build because:

a) It has an all upper case name, which means it was being treated as a constant rather than a module.
b) No other module outside of Network had a dependency on it, and only Yahoo has a dependency on Network, so it was easy for XML to be avoided given (a) above.

Fail case is in the item description.
