### PR TITLE
Timob 4704 Fix handling of return value of element.setAttributeNode

### DIFF
--- a/android/modules/xml/src/ti/modules/titanium/xml/ElementProxy.java
+++ b/android/modules/xml/src/ti/modules/titanium/xml/ElementProxy.java
@@ -8,6 +8,7 @@ package ti.modules.titanium.xml;
 
 import org.appcelerator.kroll.annotations.Kroll;
 import org.appcelerator.titanium.TiContext;
+import org.w3c.dom.Attr;
 import org.w3c.dom.CDATASection;
 import org.w3c.dom.DOMException;
 import org.w3c.dom.Element;
@@ -154,7 +155,15 @@ public class ElementProxy extends NodeProxy {
 	public AttrProxy setAttributeNode(AttrProxy newAttr)
 		throws DOMException
 	{
-		return getProxy(element.setAttributeNode(newAttr.getAttr()));
+		// Per spec, setAttributeNode returns null if an attribute
+		// with the same name did NOT already exist.  If it did, it
+		// returns the replaced attribute.
+		Attr replacedAttr = element.setAttributeNode(newAttr.getAttr());
+		if (replacedAttr != null) {
+			return getProxy(replacedAttr);
+		} else {
+			return null;
+		}
 	}
 
 	@Kroll.method

--- a/drillbit/tests/xml/xml.js
+++ b/drillbit/tests/xml/xml.js
@@ -408,7 +408,7 @@ describe("Ti.XML tests", {
 		valueOf(attr.name).shouldBeString();
 		valueOf(attr.name).shouldBe("id");
 		valueOf(attr.ownerElement).shouldBeObject();
-//		valueOf(attr.ownerElement).shouldBe(node); // For some reason this doesn't work on android TIMOB-4703
+		valueOf(attr.ownerElement).shouldBe(node); // For some reason this doesn't work on android TIMOB-4703
 		valueOf(attr.specified).shouldBeBoolean();
 		valueOf(attr.specified).shouldBeTrue();
 		valueOf(attr.value).shouldBeString();

--- a/drillbit/tests/xml/xml.js
+++ b/drillbit/tests/xml/xml.js
@@ -326,10 +326,16 @@ describe("Ti.XML tests", {
 		valueOf(attr.name).shouldBeString();
 		valueOf(attr.name).shouldBe("newattr");
 		valueOf(attr.specified).shouldBeBoolean();
-		var addedAttr = node.setAttributeNode(attr); // NPE for some reason in Android. TIMOB-4704
-		valueOf(addedAttr).shouldNotBeNull();
-		valueOf(addedAttr).shouldBeObject();
-		valueOf(addedAttr).shouldBe(attr);
+		// Per spec, when you set an attribute that doesn't exist yet,
+		// null is returned.
+		var addedAttr = node.setAttributeNode(attr);
+		valueOf(addedAttr).shouldBeNull();
+		// Per spec, when you set a new attribute of same name as one that
+		// already exists, it replaces that existing one AND returns that existing one.
+		var secondNewAttr = doc.createAttribute("newattr");
+		var replacedAttr = node.setAttributeNode(secondNewAttr);
+		valueOf(replacedAttr).shouldNotBeNull();
+		valueOf(replacedAttr).shouldBe(attr); // For some reason this doesn't work on android TIMOB-4703
 		valueOf(attr.ownerElement).shouldNotBeNull();
 		valueOf(attr.ownerElement).shouldBe(node); // For some reason this doesn't work on android TIMOB-4703
 		valueOf(attr.specified).shouldBeFalse();


### PR DESCRIPTION
http://jira.appcelerator.org/browse/TIMOB-4704

Per spec `setAttributeNode` returns null if attribute of same name did not exist.  If it did exist, the replaced attribute is returned.
