### PR TITLE
TIMOB1653 regression: window_events was broken by test example

### DIFF
--- a/demos/KitchenSink/Resources/examples/window_events.js
+++ b/demos/KitchenSink/Resources/examples/window_events.js
@@ -223,9 +223,9 @@ if (Ti.Platform.osname === 'android') {
 		height:'auto',
 		font:{fontSize:13,fontFamily:'Helvetica Neue'}
 	});
-}
 
-win.add(l11);
+	win.add(l11);
+}
 
 function pad (x)
 {


### PR DESCRIPTION
TIMOB1653 regression: Change to sample code tried to insert a NULL into iPhone's view heirarchy.
