### PR TITLE
[TIMOB-4733] Ti.Buffer now tracks byte ordering information.

### DIFF
--- a/drillbit/drillbit.py
+++ b/drillbit/drillbit.py
@@ -85,19 +85,25 @@ def build_and_run(args=None):
 	# first we need to find the desktop SDK for tibuild.py
 	if platform.system() == 'Darwin':
 		base_sdk = '/Library/Application Support/Titanium/sdk/osx'
+		alternate_sdk = os.path.expanduser("~/Library/Application Support/Titanium/sdk/osx")
 		platform_name = 'osx'
 	elif platform.system() == 'Windows':
 		if platform.release() == 'XP':
 			base_sdk = 'C:\\Documents and Settings\\All Users\\Application Data\\Titanium\\sdk\\win32'
 		else:
 			base_sdk = 'C:\\ProgramData\\Titanium\\sdk\\win32'
+		alternate_sdk = None
 		platform_name = 'win32'
 	elif platform.system() == 'Linux':
 		base_sdk = os.path.expanduser("~/.titanium/sdk/linux")
+		alternate_sdk = None
 		platform_name = 'linux'
 	
 	if not os.path.exists(base_sdk):
-		error_no_desktop_sdk()
+		if os.path.exists(alternate_sdk):
+			base_sdk = alternate_sdk
+		else:
+			error_no_desktop_sdk()
 	
 	versions = [dir for dir in os.listdir(base_sdk) if not dir.startswith(".")]
 	if len(versions) == 0:

--- a/drillbit/drillbit.py
+++ b/drillbit/drillbit.py
@@ -85,25 +85,19 @@ def build_and_run(args=None):
 	# first we need to find the desktop SDK for tibuild.py
 	if platform.system() == 'Darwin':
 		base_sdk = '/Library/Application Support/Titanium/sdk/osx'
-		alternate_sdk = os.path.expanduser("~/Library/Application Support/Titanium/sdk/osx")
 		platform_name = 'osx'
 	elif platform.system() == 'Windows':
 		if platform.release() == 'XP':
 			base_sdk = 'C:\\Documents and Settings\\All Users\\Application Data\\Titanium\\sdk\\win32'
 		else:
 			base_sdk = 'C:\\ProgramData\\Titanium\\sdk\\win32'
-		alternate_sdk = None
 		platform_name = 'win32'
 	elif platform.system() == 'Linux':
 		base_sdk = os.path.expanduser("~/.titanium/sdk/linux")
-		alternate_sdk = None
 		platform_name = 'linux'
 	
 	if not os.path.exists(base_sdk):
-		if os.path.exists(alternate_sdk):
-			base_sdk = alternate_sdk
-		else:
-			error_no_desktop_sdk()
+		error_no_desktop_sdk()
 	
 	versions = [dir for dir in os.listdir(base_sdk) if not dir.startswith(".")]
 	if len(versions) == 0:

--- a/drillbit/tests/buffer.js
+++ b/drillbit/tests/buffer.js
@@ -291,6 +291,7 @@ describe("Ti.Buffer tests", {
 		}
 		
 		valueOf(buffer.length).shouldBe(length);
+		valueOf(buffer.byteOrder).shouldBe(Ti.Codec.getNativeByteOrder());
 		valueOf(buffer[start+1]).shouldBe(97); // a
 		valueOf(buffer[start+3]).shouldBe(112); // p
 		valueOf(buffer[start+5]).shouldBe(112); // p
@@ -306,6 +307,7 @@ describe("Ti.Buffer tests", {
 
 		// 8 Byte long in Big Endian (most significant byte first)
 		buffer = Ti.createBuffer({ value: 0x12345678, type: Ti.Codec.TYPE_LONG, byteOrder: Ti.Codec.BIG_ENDIAN });
+		valueOf(buffer.byteOrder).shouldBe(Ti.Codec.BIG_ENDIAN);
 		valueOf(buffer.length).shouldBe(8);
 		for (var i = 0; i < 4; i++) {
 			valueOf(buffer[i]).shouldBe(0);
@@ -317,6 +319,7 @@ describe("Ti.Buffer tests", {
 
 		// 4 byte int in Little Endian (least significant byte first)
 		buffer = Ti.createBuffer({ value: 0x12345678, type: Ti.Codec.TYPE_INT, byteOrder: Ti.Codec.LITTLE_ENDIAN });
+		valueOf(buffer.byteOrder).shouldBe(Ti.Codec.LITTLE_ENDIAN);		
 		valueOf(buffer[0]).shouldBe(0x78);
 		valueOf(buffer[1]).shouldBe(0x56);
 		valueOf(buffer[2]).shouldBe(0x34);

--- a/iphone/Classes/TiBuffer.h
+++ b/iphone/Classes/TiBuffer.h
@@ -12,10 +12,11 @@
 // TODO: Support array-style access of bytes
 @interface TiBuffer : TiProxy {
     NSMutableData* data;
-    
+    NSNumber* byteOrder;
 }
 @property(nonatomic, retain) NSMutableData* data;
- 
+-(void)setByteOrder:(CFByteOrder)byteOrder_;
+
 // Public API
 -(NSNumber*)append:(id)args;
 -(NSNumber*)insert:(id)args;
@@ -30,7 +31,7 @@
 -(NSString*)toString:(id)_void;
 
 @property(nonatomic,assign) NSNumber* length;
-
+@property(nonatomic,readonly) NSNumber* byteOrder;
 // SPECIAL NOTES:
 // Ti.Buffer objects have an 'overloaded' Ti.Buffer[x] operation for x==int (making them behave like arrays).
 // See the code for how this works.

--- a/iphone/Classes/TiBuffer.m
+++ b/iphone/Classes/TiBuffer.m
@@ -11,14 +11,28 @@
 NSArray* bufferKeySequence = nil;
 
 @implementation TiBuffer
-@synthesize data;
+@synthesize data, byteOrder;
 
 #pragma mark Internals
+
+-(id)init
+{
+    if (self = [super init]) {
+        byteOrder = [[NSNumber numberWithInt:CFByteOrderGetCurrent()] retain];
+    }
+    return self;
+}
 
 -(void)dealloc
 {
     RELEASE_TO_NIL(data);
+    RELEASE_TO_NIL(byteOrder);
     [super dealloc];
+}
+
+-(void)setByteOrder:(CFByteOrder)byteOrder_
+{
+    byteOrder = [[NSNumber numberWithInt:byteOrder_] retain];
 }
 
 -(NSArray *)keySequence

--- a/iphone/Classes/TopTiModule.m
+++ b/iphone/Classes/TopTiModule.m
@@ -114,7 +114,7 @@
         // Just put the string data directly into the buffer, if we can.
         if (!hasLength){
             NSStringEncoding encoding = [TiUtils charsetToEncoding:charset];
-            [buffer setData:[data dataUsingEncoding:encoding]];
+            [buffer setData:[NSMutableData dataWithData:[data dataUsingEncoding:encoding]]];
         }
         else {
             switch ([TiUtils encodeString:data toBuffer:buffer charset:charset offset:0 sourceOffset:0 length:encodeLength]) {
@@ -145,6 +145,7 @@
         }
         
         byteOrder = (hasByteOrder) ? byteOrder : CFByteOrderGetCurrent();
+        [buffer setByteOrder:byteOrder];
         switch ([TiUtils encodeNumber:data toBuffer:buffer offset:0 type:type endianness:byteOrder]) {
             case BAD_ENDIAN: {
                 [self throwException:[NSString stringWithFormat:@"Invalid endianness: %d", byteOrder]


### PR DESCRIPTION
Just what it says. Test is the 'buffer.js' drillbit test.

Note that Android currently fails, as it does not set the byte order to the native byte order by default, but rather has an 'Undefined' value. A parity bug should be filed.
