### PR TITLE
[TIMOB-4797] Allow breakpoints in require() JS modules

### DIFF
--- a/iphone/Classes/KrollBridge.mm
+++ b/iphone/Classes/KrollBridge.mm
@@ -795,7 +795,19 @@ CFMutableSetRef	krollBridgeRegistry = nil;
 	// we found data, now create the common js module proxy
 	if (data!=nil)
 	{
+        NSString* urlPath = (filepath != nil) ? filepath : path;
+		NSURL *url_ = [TiHost resourceBasedURL:urlPath baseURL:NULL];
+       	const char *urlCString = [[url_ absoluteString] UTF8String];
+        if ([[self host] debugMode]) {
+            TiDebuggerBeginScript([self krollContext],urlCString);
+        }
+        
 		module = [self loadCommonJSModule:[[[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding] autorelease] withPath:path];
+        
+        if ([[self host] debugMode]) {
+            TiDebuggerEndScript([self krollContext]);
+        }
+        
 		if (filepath!=nil && module!=nil)
 		{
 			// uri is optional but we point it to where we loaded it


### PR DESCRIPTION
This is purely a timobile-land fix. There are no related debugger components that needed to be updated.

The TiStudio ticket (linked from the TIMOB ticket) contains a sample that can be used to validate the fix. The debugger test plan will also be updated to include a require() check.
