### PR TITLE
TIMOB-4712 TIMOB-4713 Allow XML parsing exceptions to be re-thrown

### DIFF
--- a/android/modules/xml/src/ti/modules/titanium/xml/XMLModule.java
+++ b/android/modules/xml/src/ti/modules/titanium/xml/XMLModule.java
@@ -46,7 +46,8 @@ public class XMLModule extends KrollModule {
 	}
 	
 	@Kroll.method
-	public DocumentProxy parseString(String xml) throws SAXException, IOException
+	public DocumentProxy parseString(String xml)
+		throws SAXException, IOException
 	{
 		return parse(getTiContext(), xml);
 	}

--- a/android/modules/xml/src/ti/modules/titanium/xml/XMLModule.java
+++ b/android/modules/xml/src/ti/modules/titanium/xml/XMLModule.java
@@ -46,25 +46,29 @@ public class XMLModule extends KrollModule {
 	}
 	
 	@Kroll.method
-	public DocumentProxy parseString(String xml)
+	public DocumentProxy parseString(String xml) throws SAXException, IOException
 	{
 		return parse(getTiContext(), xml);
 	}
 	
 	public static DocumentProxy parse(TiContext context, String xml)
+		throws SAXException, IOException
 	{
 		return parse(context, xml, System.getProperty("file.encoding", "UTF-8"));
 	}
 	
 	public static DocumentProxy parse(TiContext context, String xml, String encoding)
+		throws SAXException, IOException
 	{
 		if (builder != null) {
 			try {
 				return new DocumentProxy(context, builder.parse(new ByteArrayInputStream(xml.getBytes(encoding))));
 			} catch (SAXException e) {
 				Log.e(LCAT, "Error parsing XML", e);
+				throw e;
 			} catch (IOException e) {
 				Log.e(LCAT, "Error reading XML", e);
+				throw e;
 			}
 		}
 		return null;


### PR DESCRIPTION
http://jira.appcelerator.org/browse/TIMOB-4712
http://jira.appcelerator.org/browse/TIMOB-4713

Here's a quick test app:

http://jira.appcelerator.org/browse/TIMOB-4712?focusedCommentId=160675&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-160675

But also be sure the "documentParsing" test in drillbit's xml.js passes.
