### PR TITLE
TIMOB-4709 Make our XML parser namespace aware

### DIFF
--- a/android/modules/xml/src/ti/modules/titanium/xml/XMLModule.java
+++ b/android/modules/xml/src/ti/modules/titanium/xml/XMLModule.java
@@ -35,7 +35,9 @@ public class XMLModule extends KrollModule {
 	
 	static {
 		try {
-			builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+			DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+			factory.setNamespaceAware(true);
+			builder = factory.newDocumentBuilder();
 		} catch (ParserConfigurationException e) {
 			Log.e(LCAT, "Error finding DOM implementation", e);
 		}

--- a/drillbit/tests/xml/xml.js
+++ b/drillbit/tests/xml/xml.js
@@ -491,7 +491,7 @@ describe("Ti.XML tests", {
 		var elements = doc.getElementsByTagNameNS("http://example.com", "cake");
 		valueOf(elements).shouldNotBeNull();
 		valueOf(elements).shouldBeObject();
-		valueOf(elements.length).shouldBeGreaterThan(0); // Fails in Android. TIMOB-4709
+		valueOf(elements.length).shouldBeGreaterThan(0);
 		for (var i = 0; i < elements.length; i++) {
 			var checkelem = elements.item(i);
 			valueOf(checkelem.localName).shouldBe("cake");


### PR DESCRIPTION
http://jira.appcelerator.org/browse/TIMOB-4709

Test: drillbit xml "apiXmlDocumentGetElementsByTagNameNS" test should now succeed.
