### PR TITLE
TIMOB-4705 Use a different document for the no-doctype test

### DIFF
--- a/drillbit/tests/xml/xml.js
+++ b/drillbit/tests/xml/xml.js
@@ -358,11 +358,9 @@ describe("Ti.XML tests", {
 		valueOf(doc.doctype).shouldNotBeUndefined();
 		valueOf(doc.doctype).shouldNotBeNull();
 		valueOf(doc.doctype).shouldBeObject();
-		// File without DTD, to be sure doc.doctype is null as spec says
-		doc = Ti.XML.parseString(this.testSource["nodes.xml"]);
-		valueOf(function() {
-			valueOf(doc.doctype).shouldBeNull(); // Causes NPE for some reason in Android. TIMOB-4705
-		}).shouldNotThrowException();
+		// Document without DTD, to be sure doc.doctype is null as spec says
+		doc = Ti.XML.parseString("<a/>");
+		valueOf(doc.doctype).shouldBeNull();
 	},
 	apiXmlDocumentCreateAttribute: function() {
 		var doc = Ti.XML.parseString("<test/>");


### PR DESCRIPTION
http://jira.appcelerator.org/browse/TIMOB-4705?focusedCommentId=160753&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-160753

TIMOB-4705 Use a different document for the no-doctype test, since a doctype was added to the one I was using.

Test: drillbit xml.js's apiXmlDocumentProperties should pass
