### PR TITLE
[MOD-148] (iOS) Renamed "encodingMap" to "tiUtilsEncodingMap" to avert collisions

### DIFF
--- a/iphone/Classes/TiUtils.m
+++ b/iphone/Classes/TiUtils.m
@@ -30,9 +30,9 @@
 extern NSString * const TI_APPLICATION_RESOURCE_DIR;
 #endif
 
-NSDictionary* encodingMap = nil;
-NSDictionary* typeMap = nil;
-NSDictionary* sizeMap = nil;
+static NSDictionary* encodingMap = nil;
+static NSDictionary* typeMap = nil;
+static NSDictionary* sizeMap = nil;
 
 @implementation TiUtils
 


### PR DESCRIPTION
The greystripe library was also declaring a "encodingMap" variable, which was causing 1_7_x builds to crash when you tried to use our module. I renamed "encodingMap" to "tiUtilsEncodingMap" to avert this collision.

_Warning_
I know that this fixes the problems I was having with using the module. What I DO NOT know is if this will break stuff in TiUtils usage of encodingMap. I did not find any other references to this variable in our source code, so I believe we can safely rename it. Can someone else verify my thinking here?
