### PR TITLE
TIMOB-3158 update setting of the current activity to only occur long term

### DIFF
--- a/android/titanium/src/org/appcelerator/titanium/TiBaseActivity.java
+++ b/android/titanium/src/org/appcelerator/titanium/TiBaseActivity.java
@@ -275,7 +275,6 @@ public abstract class TiBaseActivity extends Activity
 	@Override
 	protected void onCreate(Bundle savedInstanceState)
 	{
-		getTiApp().setCurrentActivity(this, this);
 		messageQueue = TiMessageQueue.getMessageQueue();
 		if (DBG) {
 			Log.d(TAG, "Activity " + this + " onCreate");
@@ -301,7 +300,17 @@ public abstract class TiBaseActivity extends Activity
 		windowCreated();
 
 		if (activityProxy != null) {
+			// we only want to set the current activity for good in the resume state but we need it right now.
+			// save off the existing current activity, set ourselves to be the new current activity temporarily 
+			// so we don't run into problems when we give the proxy the event
+			TiApplication tiApp = getTiApp();
+			Activity tempCurrentActivity = tiApp.getCurrentActivity();
+			tiApp.setCurrentActivity(this, this);
+
 			activityProxy.fireSyncEvent(TiC.EVENT_CREATE, null);
+
+			// set the current activity back to what it was originally
+			tiApp.setCurrentActivity(this, tempCurrentActivity);
 		}
 
 		setContentView(layout);
@@ -550,7 +559,17 @@ public abstract class TiBaseActivity extends Activity
 			mustFireInitialFocus = true;
 		}
 		if (activityProxy != null) {
+			// we only want to set the current activity for good in the resume state but we need it right now.
+			// save off the existing current activity, set ourselves to be the new current activity temporarily 
+			// so we don't run into problems when we give the proxy the event
+			TiApplication tiApp = getTiApp();
+			Activity tempCurrentActivity = tiApp.getCurrentActivity();
+			tiApp.setCurrentActivity(this, this);
+
 			activityProxy.fireSyncEvent(TiC.EVENT_START, null);
+
+			// set the current activity back to what it was originally
+			tiApp.setCurrentActivity(this, tempCurrentActivity);
 		}
 	}
 
@@ -577,7 +596,17 @@ public abstract class TiBaseActivity extends Activity
 			Log.d(TAG, "Activity " + this + " onRestart");
 		}
 		if (activityProxy != null) {
+			// we only want to set the current activity for good in the resume state but we need it right now.
+			// save off the existing current activity, set ourselves to be the new current activity temporarily 
+			// so we don't run into problems when we give the proxy the event
+			TiApplication tiApp = getTiApp();
+			Activity tempCurrentActivity = tiApp.getCurrentActivity();
+			tiApp.setCurrentActivity(this, this);
+
 			activityProxy.fireSyncEvent(TiC.EVENT_RESTART, null);
+
+			// set the current activity back to what it was originally
+			tiApp.setCurrentActivity(this, tempCurrentActivity);
 		}
 	}
 

--- a/android/titanium/src/org/appcelerator/titanium/TiLaunchActivity.java
+++ b/android/titanium/src/org/appcelerator/titanium/TiLaunchActivity.java
@@ -18,6 +18,7 @@ import org.appcelerator.titanium.util.TiConfig;
 import org.appcelerator.titanium.util.TiUrl;
 import org.appcelerator.titanium.view.TiCompositeLayout;
 
+import android.app.Activity;
 import android.app.AlarmManager;
 import android.app.AlertDialog;
 import android.app.PendingIntent;
@@ -84,7 +85,6 @@ public abstract class TiLaunchActivity extends TiBaseActivity
 	@Override
 	protected void onCreate(Bundle savedInstanceState)
 	{
-		getTiApp().setCurrentActivity(this, this);
 		Intent intent = getIntent();
 		if (intent != null) {
 			if (checkMissingLauncher(intent, savedInstanceState)) {
@@ -98,7 +98,19 @@ public abstract class TiLaunchActivity extends TiBaseActivity
 		if (activityProxy == null) {
 			setActivityProxy(new ActivityProxy(tiContext, this));
 		}
+
+		// we only want to set the current activity for good in the resume state but we need it right now.
+		// save off the existing current activity, set ourselves to be the new current activity temporarily 
+		// so we don't run into problems when we bind the current activity
+		TiApplication tiApp = getTiApp();
+		Activity tempCurrentActivity = tiApp.getCurrentActivity();
+		tiApp.setCurrentActivity(this, this);
+
 		TiBindingHelper.bindCurrentActivity(tiContext, activityProxy);
+
+		// set the current activity back to what it was originally
+		tiApp.setCurrentActivity(this, tempCurrentActivity);
+
 		contextCreated();
 		super.onCreate(savedInstanceState);
 	}


### PR DESCRIPTION
TIMOB-3158 update setting of the current activity to only occur long term during a resume event
