### PR TITLE
[TIMOB-4643] Custom Theme for JS Activity Crash

### DIFF
--- a/android/titanium/src/org/appcelerator/titanium/TiLaunchActivity.java
+++ b/android/titanium/src/org/appcelerator/titanium/TiLaunchActivity.java
@@ -106,9 +106,6 @@ public abstract class TiLaunchActivity extends TiBaseActivity
 	@Override
 	protected void windowCreated()
 	{
-		ITiAppInfo appInfo = getTiApp().getAppInfo();
-		getIntent().putExtra(TiC.PROPERTY_FULLSCREEN, appInfo.isFullscreen());
-		getIntent().putExtra(TiC.PROPERTY_NAV_BAR_HIDDEN, appInfo.isNavBarHidden());
 		super.windowCreated();
 		loadActivityScript();
 		scriptLoaded();

--- a/android/titanium/src/org/appcelerator/titanium/TiRootActivity.java
+++ b/android/titanium/src/org/appcelerator/titanium/TiRootActivity.java
@@ -12,6 +12,7 @@ import org.appcelerator.titanium.util.TiConfig;
 import org.appcelerator.titanium.util.TiRHelper;
 import org.appcelerator.titanium.view.ITiWindowHandler;
 
+import android.content.Intent;
 import android.content.res.Configuration;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
@@ -36,6 +37,16 @@ public class TiRootActivity extends TiLaunchActivity
 		TiApplication app = getTiApp();
 		app.setRootActivity(this);
 		super.onCreate(savedInstanceState);
+	}
+
+	@Override
+	protected void windowCreated()
+	{
+		// Use settings from tiapp.xml
+		ITiAppInfo appInfo = getTiApp().getAppInfo();
+		getIntent().putExtra(TiC.PROPERTY_FULLSCREEN, appInfo.isFullscreen());
+		getIntent().putExtra(TiC.PROPERTY_NAV_BAR_HIDDEN, appInfo.isNavBarHidden());
+		super.windowCreated();
 	}
 
 	// Lifecyle


### PR DESCRIPTION
[TIMOB-4643] The problem was TiLaunchActivity would blindly overwrite settings for fullscreen and navBarHidden from the values set in tiapp.xml. These values should only be used for TiRootActivity. The crash was because the theme used in the example is Theme.Dialog which does not have some of the window features requested when navBarHidden is false. The usage of custom themes that do not have these window feature should insure that the intent used to launch the activity has navBarHidden set to true so that the window features are not requested.

intent.putExtra('navBarHidden', true);
- You will want to test flags in tiapp.xml.
- Quick run thru of KS
- App attached to the support ticket. See JIRA Issue
