### PR TITLE
TIMOB-1423 : Do not fire focus during the middle of the window opening.

### DIFF
--- a/iphone/Classes/TiUIWindowProxy.m
+++ b/iphone/Classes/TiUIWindowProxy.m
@@ -787,7 +787,10 @@ else{\
 		// we can't fire focus here since we 
 		// haven't yet wired up the JS context at this point
 		// and listeners wouldn't be ready
-		[self fireFocus:YES];
+		if(![self opening])
+		{
+			[self fireFocus:YES];
+		}
 		[self setupWindowDecorations];
 	}
 	[super _tabFocus];

--- a/iphone/Classes/TiWindowProxy.h
+++ b/iphone/Classes/TiWindowProxy.h
@@ -77,6 +77,8 @@ TiOrientationFlags TiOrientationFlagsFromObject(id args);
 
 -(void)fireFocus:(BOOL)newFocused;
 
+@property(nonatomic,readonly)	BOOL opening;
+
 #pragma mark Public APIs
 
 @property(nonatomic,readonly)	NSNumber *opened;

--- a/iphone/Classes/TiWindowProxy.m
+++ b/iphone/Classes/TiWindowProxy.m
@@ -56,6 +56,7 @@ TiOrientationFlags TiOrientationFlagsFromObject(id args)
 
 @implementation TiWindowProxy
 @synthesize navController, controller;
+@synthesize opening;
 
 - (void)willAnimateRotationToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation duration:(NSTimeInterval)duration
 {


### PR DESCRIPTION
Turns out other situations added as comments to 1423 are separate issues, and thus, this first commit is sufficient in solving this ticket.
