### PR TITLE
Added post-build functionality to plugins

### DIFF
--- a/support/android/builder.py
+++ b/support/android/builder.py
@@ -1511,7 +1511,7 @@ class Builder(object):
 		deploy_type = 'development'
 		self.build_only = build_only
 		self.device_args = device_args
-		self.postbuild_modules = [];
+		self.postbuild_modules = []
 		if install:
 			if self.device_args == None:
 				self.device_args = ['-d']


### PR DESCRIPTION
Added logic to incorporate post-build functionality for plugins. Useful for automated check-out and check-in, pushing completed builds to QA or production, etc.

When the plugins are processed, if the plugin.py contains a postbuild function, the plugin is added to an array for later processing. Once the build completes, the postbuild function is executed for all plugins in the array.
