### PR TITLE
[TIMOB-4901] Handle empty <guid/> tag

### DIFF
--- a/support/module/builder.py
+++ b/support/module/builder.py
@@ -115,7 +115,7 @@ def stage(platform, project_dir, manifest, callback):
 		tiapp = os.path.join(gen_project_dir, 'tiapp.xml')
 		xml = open(tiapp).read()
 		tiappf = open(tiapp,'w')
-		idx = xml.find('</guid>')
+		xml = xml.replace('<guid/>','<guid></guid>')
 		xml = xml.replace('</guid>','</guid>\n<modules>\n<module version="%s">%s</module>\n</modules>\n' % (version,moduleid))
 		# generate a guid since this is currently done by developer
 		guid = str(uuid.uuid4())

--- a/support/titanium.py
+++ b/support/titanium.py
@@ -198,6 +198,7 @@ def create(args):
 		guid = str(uuid.uuid4())
 		if os.path.exists(tiapp):
 			xml = open(tiapp).read()
+			xml = xml.replace('<guid/>','<guid></guid>')
 			xml = xml.replace('<guid></guid>','<guid>%s</guid>' % guid)
 			fout = open(tiapp,'w')
 			fout.write(xml)


### PR DESCRIPTION
 Replace the empty <guid/> tag with <guid></guid> where necessary.
## TESTING

In order to test this:
- scons the distribution
- Install your distribution
- Modify the installed tiapp.xml to change "&lt;guid&gt;&lt;/guid&gt;" into "&lt;guid/&gt;"
- Create a new project using the titanium.py script from the installation:
  
  titanium.py create --platform=iphone --type=project --name=test --id=com.appcelerator.test
- Check the new project's tiapp.xml for a GUID

PASS:
- There is a GUID in the tiapp,.xml

FAIL:
- There is an empty "&lt;guid/&gt;" tag in the tiapp.xml, or no GUID information at all.

NOTE:
- Do not create the new project through tistudio; this is a test for the SDK build scripts ONLY.
