### PR TITLE
[TIMOB-2968] Clear rightImage when reusing cells

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 dist
 .sconsign.dblite
 .DS_Store
+*~

--- a/iphone/Classes/TiUITableViewRowProxy.m
+++ b/iphone/Classes/TiUITableViewRowProxy.m
@@ -436,6 +436,9 @@ TiProxy * DeepScanForProxyOfViewContainingPoint(UIView * targetView, CGPoint poi
 		UIImage *image = [[ImageLoader sharedLoader] loadImmediateImage:url];
 		cell.accessoryView = [[[UIImageView alloc] initWithImage:image] autorelease];
 	}
+    else {
+        cell.accessoryView = nil;
+    }
 }
 
 -(void)configureBackground:(UITableViewCell*)cell


### PR DESCRIPTION
Need to make sure that we're clearing the rightImage on a tableviewrow when we reuse the cell. It looks like everything else was being cleaned up properly - just not this.

Special bonus: Updated the .gitignore to ignore emacs backup files.
