### PR TITLE
TIMOB-4622: NavigationGroup's willShow + TiWindowProxy's didAppear = focus for navGroup roots

### DIFF
--- a/iphone/Classes/TiUIWindowProxy.m
+++ b/iphone/Classes/TiUIWindowProxy.m
@@ -710,23 +710,27 @@ else{\
 - (void)viewWillAppear:(BOOL)animated;    // Called when the view is about to made visible. Default does nothing
 {
 	animating = YES;
+	[super viewWillAppear:animated];
 }
 
 - (void)viewDidAppear:(BOOL)animated;     // Called when the view has been fully transitioned onto the screen. Default does nothing
 {
 	animating = NO;
 	[self updateTitleView];
+	[super viewDidAppear:animated];
 }
 
 - (void)viewWillDisappear:(BOOL)animated; // Called when the view is dismissed, covered or otherwise hidden. Default does nothing
 {
 	animating = YES;
+	[super viewWillDisappear:animated];
 }
 
 - (void)viewDidDisappear:(BOOL)animated;  // Called after the view was dismissed, covered or otherwise hidden. Default does nothing
 {
 	animating = NO;
 	[self updateTitleView];
+	[super viewDidDisappear:animated];
 }
 
 -(void)setupWindowDecorations

--- a/iphone/Classes/TiUIiPadPopoverProxy.h
+++ b/iphone/Classes/TiUIiPadPopoverProxy.h
@@ -1,6 +1,6 @@
 /**
  * Appcelerator Titanium Mobile
- * Copyright (c) 2010 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2010-2011 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */

--- a/iphone/Classes/TiUIiPadPopoverProxy.m
+++ b/iphone/Classes/TiUIiPadPopoverProxy.m
@@ -1,6 +1,6 @@
 /**
  * Appcelerator Titanium Mobile
- * Copyright (c) 2010 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2010-2011 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
@@ -291,16 +291,37 @@
 	[self performSelector:@selector(release) withObject:nil afterDelay:0.5];
 }
 
-- (UIViewController *)childViewController;
-{
-	return nil;
-}
-
 -(BOOL)suppressesRelayout
 {
 	return YES;
 }
 
+- (UIViewController *)childViewController;
+{
+	return nil;
+}
+
+/*	
+ *	The viewWill/DidAppear/Disappear functions are here to conform to the
+ *	TIUIViewController protocol, but currently do nothing. In the future they
+ *	may pass the events onto the children. But whether that's needed or not
+ *	requires research. TODO: Research popover actions for view transitions
+ */
+- (void)viewWillAppear:(BOOL)animated
+{
+}
+
+- (void)viewDidAppear:(BOOL)animated
+{
+}
+
+- (void)viewWillDisappear:(BOOL)animated
+{
+}
+
+- (void)viewDidDisappear:(BOOL)animated
+{
+}
 
 @end
 #endif

--- a/iphone/Classes/TiUIiPhoneNavigationGroup.m
+++ b/iphone/Classes/TiUIiPhoneNavigationGroup.m
@@ -56,7 +56,7 @@
 		[windowProxy prepareForNavView:controller];
 		
 		root = windowProxy;
-		[self setVisibleProxy:windowProxy];
+//		[self setVisibleProxy:windowProxy];
 	}
 	return controller;
 }

--- a/iphone/Classes/TiUIiPhoneNavigationGroupProxy.m
+++ b/iphone/Classes/TiUIiPhoneNavigationGroupProxy.m
@@ -116,6 +116,31 @@
 	[super windowDidClose];
 }
 
+/*
+ *	NavigationGroup was not made as a subclass of TiWindowProxy, which is our
+ *	analog/delegate/wrapper to native UIViewControllers (See TabGroup, etc).
+ *	A refactor along these lines should be done in the far future, as it will
+ *	help with window orientation, blur/focus, etc. However, it also would/should
+ *	depricate adding a navGroup to a window, preferring to open the navGroup
+ *	directly.
+ *
+ *	navGroup's willShow is the first step of this transition, to restore the
+ *	UIViewControllers' viewWill/DidAppear/Disappear event chain so that the root
+ *	view controller (And thus the root TiWindow) gets the proper focus event.
+ *	TODO: Make NavigationGroupProxy a full-fledged TiWindowProxy.
+ */
+
+-(void)willShow
+{
+	TiUIiPhoneNavigationGroup * ourView = (id)[self view];
+	UINavigationController * ourNC = [ourView controller];
+	UIViewController * ourVC = [ourNC topViewController];
+	
+	[ourView navigationController:ourNC willShowViewController:ourVC animated:NO];
+	[super willShow];
+	[ourView navigationController:ourNC didShowViewController:ourVC animated:NO];
+}
+
 @end
 
 #endif

--- a/iphone/Classes/TiViewController.h
+++ b/iphone/Classes/TiViewController.h
@@ -1,6 +1,6 @@
 /**
  * Appcelerator Titanium Mobile
- * Copyright (c) 2009-2010 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2009-2011 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
@@ -13,11 +13,12 @@
 
 - (UIViewController *)childViewController;
 
-@optional
 - (void)viewWillAppear:(BOOL)animated;    // Called when the view is about to made visible. Default does nothing
 - (void)viewDidAppear:(BOOL)animated;     // Called when the view has been fully transitioned onto the screen. Default does nothing
 - (void)viewWillDisappear:(BOOL)animated; // Called when the view is dismissed, covered or otherwise hidden. Default does nothing
 - (void)viewDidDisappear:(BOOL)animated;  // Called after the view was dismissed, covered or otherwise hidden. Default does nothing
+
+@optional
 
 - (void)willAnimateRotationToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation duration:(NSTimeInterval)duration;
 @end

--- a/iphone/Classes/TiViewController.m
+++ b/iphone/Classes/TiViewController.m
@@ -1,6 +1,6 @@
 /**
  * Appcelerator Titanium Mobile
- * Copyright (c) 2009-2010 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2009-2011 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
@@ -23,7 +23,6 @@
 
 -(void)dealloc
 {
-//    RELEASE_TO_NIL(proxy);
     [super dealloc];
 }
 
@@ -50,42 +49,49 @@
 	[[proxy childViewController] willAnimateRotationToInterfaceOrientation:toInterfaceOrientation duration:duration];
 }
 
-- (void)viewWillAppear:(BOOL)animated;    // Called when the view is about to made visible. Default does nothing
+/*
+ *	As of this commit, TiUIViewController protocol, of which proxy should honor,
+ *	requires the viewWill/DidAppear/Disappear method. As such, we could possibly
+ *	remove the respondsToSelector check. The checks are being left currently
+ *	in case a proxy is not honoring the protocol, but once it's determined that
+ *	all the classes are behaving properly, this should be streamlined.
+ *	In other words, TODO: Codecleanup
+ */
+
+- (void)viewWillAppear:(BOOL)animated
 {
 	if ([proxy respondsToSelector:@selector(viewWillAppear:)])
 	{
 		[proxy viewWillAppear:animated];
 	}
 	[[proxy childViewController] viewWillAppear:animated];
-	VerboseLog(@"%@:%@%@",self,proxy,CODELOCATION);
 }
-- (void)viewDidAppear:(BOOL)animated;     // Called when the view has been fully transitioned onto the screen. Default does nothing
+
+- (void)viewDidAppear:(BOOL)animated
 {
 	if ([proxy respondsToSelector:@selector(viewDidAppear:)])
 	{
 		[proxy viewDidAppear:animated];
 	}
 	[[proxy childViewController] viewDidAppear:animated];
-	VerboseLog(@"%@:%@%@",self,proxy,CODELOCATION);
 }
-- (void)viewWillDisappear:(BOOL)animated; // Called when the view is dismissed, covered or otherwise hidden. Default does nothing
+
+- (void)viewWillDisappear:(BOOL)animated
 {
 	if ([proxy respondsToSelector:@selector(viewWillDisappear:)])
 	{
 		[proxy viewWillDisappear:animated];
 	}
 	[[proxy childViewController] viewWillDisappear:animated];
-	VerboseLog(@"%@:%@%@",self,proxy,CODELOCATION);
 }
-- (void)viewDidDisappear:(BOOL)animated;  // Called after the view was dismissed, covered or otherwise hidden. Default does nothing
+
+- (void)viewDidDisappear:(BOOL)animated
 {
 	if ([proxy respondsToSelector:@selector(viewDidDisappear:)])
 	{
 		[proxy viewDidDisappear:animated];
 	}
 	[[proxy childViewController] viewDidDisappear:animated];
-
-	VerboseLog(@"%@:%@%@",self,proxy,CODELOCATION);
 }
 
 @end

--- a/iphone/Classes/TiWindowProxy.m
+++ b/iphone/Classes/TiWindowProxy.m
@@ -731,15 +731,55 @@ END_UI_THREAD_PROTECTED_VALUE(opened)
     // For subclasses
 }
 
-#pragma mark Animation Delegates
 
-- (void)viewDidAppear:(BOOL)animated;    // Called when the view is about to made visible. Default does nothing
+#pragma mark TIUIViewController methods
+/*
+ *	Over time, we should move focus and blurs to be triggered by standard
+ *	Cocoa conventions instead of second-guessing iOS. This will be a slow
+ *	transition, and in the meantime, verbose debug statements of focus being
+ *	already set/cleared should not be a need for panic.
+ */
+
+- (void)viewDidAppear:(BOOL)animated
 {
 	[[self parentOrientationController]
 			childOrientationControllerChangedFlags:self];
+
+	if (!focused)
+	{
+		[self fireFocus:YES];
+	}
+#ifdef VERBOSE
+	else
+	{
+		NSLog(@"[DEBUG] Focused was already set while in viewDidAppear.");
+	}
+#endif	
 }
 
+-(void)viewWillDisappear:(BOOL)animated
+{
+	if (focused)
+	{
+		[self fireFocus:NO];
+	}
+#ifdef VERBOSE
+	else
+	{
+		NSLog(@"[DEBUG] Focused was already cleared while in viewWillDisappear.");
+	}
+#endif
+}
 
+-(void)viewWillAppear:(BOOL)animated
+{
+}
+
+- (void)viewDidDisappear:(BOOL)animated
+{
+}
+
+#pragma mark Animation Delegates
 
 -(BOOL)animationShouldTransition:(id)sender
 {


### PR DESCRIPTION
TIMOB-4622: NavigationGroup's willShow restores the viewWill/DidAppear event chain, TiUIViewController protocol now requires viewWill/DidAppear/Disappear, and TiWindowProxy uses viewDidAppear/WillDisappear to fire focus/blur events if they haven't already.
