### PR TITLE
TIMOB-4720: Android: Unexpose toBase64 in Titanium.Blob

### DIFF
--- a/android/titanium/src/org/appcelerator/titanium/TiBlob.java
+++ b/android/titanium/src/org/appcelerator/titanium/TiBlob.java
@@ -290,7 +290,6 @@ public class TiBlob extends KrollProxy
 		}
 	}
 
-	@Kroll.method
 	public String toBase64()
 	{
 		return new String(Base64.encodeBase64(getBytes()));


### PR DESCRIPTION
http://jira.appcelerator.org/browse/TIMOB-4720

To test, you can just run the coverage report, and open Titanium.Blob coverage in the browser:

```
$ ./drillbit/coverage/coverage.py
$ open dist/coverage/proxy-Titanium.Blob.html
```

Verify "toBase64" is no longer listed in the APIs
