### PR TITLE
TIMOB-4715: Android: Remove get/setMessageid in Ti.UI.AlertDialog

### DIFF
--- a/android/modules/ui/src/ti/modules/titanium/ui/AlertDialogProxy.java
+++ b/android/modules/ui/src/ti/modules/titanium/ui/AlertDialogProxy.java
@@ -22,7 +22,6 @@ import android.app.Activity;
 		"buttonNames",
 		"cancel",
 		"message",
-		"messageid",
 		"title"
 	}
 )


### PR DESCRIPTION
http://jira.appcelerator.org/browse/TIMOB-4715

These shouldn't have been exposed
