### PR TITLE
The return type for getParent() should be Titanium.Filesystem.File

### DIFF
--- a/iphone/Classes/TiFilesystemFileProxy.m
+++ b/iphone/Classes/TiFilesystemFileProxy.m
@@ -383,7 +383,7 @@ FILENOOP(setHidden:(id)x);
 
 -(id)getParent:(id)args
 {
-	return [path stringByDeletingLastPathComponent];
+	return [[[TiFilesystemFileProxy alloc] initWithFile:[path stringByDeletingLastPathComponent]] autorelease];
 }
 
 -(id)name


### PR DESCRIPTION
getParent() method of Titanium.Filesystem.File returns a string, fixed it to return a Titanium.Filesystem.File as documented on iOS. On android it's already fine.
