### PR TITLE
[TC-186] Override onGeolocationPermissionsShowPrompt() in TiWebChromeClie

### DIFF
--- a/android/modules/ui/src/ti/modules/titanium/ui/widget/webview/TiWebChromeClient.java
+++ b/android/modules/ui/src/ti/modules/titanium/ui/widget/webview/TiWebChromeClient.java
@@ -89,5 +89,10 @@ public class TiWebChromeClient extends WebChromeClient {
 		
 		return true;
 	}
+
+	public void onGeolocationPermissionsShowPrompt(String origin, android.webkit.GeolocationPermissions.Callback callback) {
+		callback.invoke(origin, true, false);
+	}
+
 }
 


### PR DESCRIPTION
Resolves ticket TC-186: Override onGeolocationPermissionsShowPrompt() in TiWebChromeClient.java to enable W3C geolocation in Android WebView. Also see Android issue 7176 for more info: http://code.google.com/p/android/issues/detail?id=7176
