### PR TITLE
[TIMOB-4939] Debugger handling for 'custom' API.log severity

### DIFF
--- a/iphone/Classes/APIModule.m
+++ b/iphone/Classes/APIModule.m
@@ -33,6 +33,9 @@
         else if ([lcSeverity isEqualToString:@"debug"]) {
             level = LOG_DEBUG;
         }
+        else if (![lcSeverity isEqualToString:@"info"]) { // Custom severity, or just a badly-formed log; either way, debugger treats it as info
+            message = [severity stringByAppendingString:message];
+        }
         TiDebuggerLogMessage(level, message);
     }
     else {


### PR DESCRIPTION
Debugger now translates any custom severity to [INFO] level so that it can be properly handled by the debugger, and concatenates severity w/message. 
