### PR TITLE
[TIMOB-4989] Only compile in resources when going into production mode.

### DIFF
--- a/support/iphone/compiler.py
+++ b/support/iphone/compiler.py
@@ -278,7 +278,7 @@ class Compiler(object):
 		
 		if deploytype!='development' or has_modules:
 
-			if os.path.exists(app_dir):
+			if os.path.exists(app_dir) and deploytype=='production':
 				self.copy_resources([resources_dir],app_dir)
 				
 			if deploytype == 'production':


### PR DESCRIPTION
Self-explanatory. Solves issue of not being able to debug apps which incorporate external modules.
