### PR TITLE
TIMOB-4270 If jsca is the only output generated, make sure the output folder exists

### DIFF
--- a/apidoc/generators/jsca_generator.py
+++ b/apidoc/generators/jsca_generator.py
@@ -12,8 +12,11 @@ except:
 
 def generate(raw_apis, annotated_apis, options):
 	print >> sys.stderr, "[WARN] JSCA is not yet supported. A skeleton api.jsca will be created."
+	if not os.path.exists(options.output):
+		os.makedirs(options.output)
 	out_path = os.path.join(options.output, "api.jsca")
 	api = {"types": [], "aliases": [{"type": "Titanium", "name": "Ti"}]}
+
 	f = open(out_path, "w")
 	json.dump(api, f, indent=4)
 	print json.dumps(api, indent=4)


### PR DESCRIPTION
I'm adding this to 4270 (which just got merged) because it should have been in there and it's still fresh.

The merge of 4270 broke the scons build for anyone who didn't have dist/apidoc folder already.  You can recreate the failcase by (before pulling this branch) deleting dist/apidoc if it exists then running scons.  

http://jira.appcelerator.org/browse/TIMOB-4270
