### PR TITLE
TIMOB-4888 : Apps must load a splash before the app finishes launching

### DIFF
--- a/iphone/Classes/TiApp.mm
+++ b/iphone/Classes/TiApp.mm
@@ -394,6 +394,7 @@ void MyUncaughtExceptionHandler(NSException *exception)
 		[self generateNotification:notification];
 	}
 	
+	[self loadSplash];
 	[self boot];
 	
 	return YES;


### PR DESCRIPTION
TIMOB-4888 : Apps must load a splash before the app finishes launching in order for the window to get orientation requests during start. Test in Jira, also test against http://jira.appcelerator.org/browse/TIMOB-4782 or other orientation-on-launch issues.
