### PR TITLE
[TIMOB-4819] Githash and build date now in build console

### DIFF
--- a/support/iphone/builder.py
+++ b/support/iphone/builder.py
@@ -655,8 +655,18 @@ def main(args):
 						module_dir = os.path.join(app_dir, 'modules', module_id)
 						module_asset_dirs.append([module_assets_dir, module_dir])
 
+			full_version = sdk_version
+			if 'version' in versions_txt:
+				full_version = versions_txt['version']
+				if 'timestamp' in versions_txt or 'githash' in versions_txt:
+					full_version += ' ('
+					if 'timestamp' in versions_txt:
+						full_version += '%s' % versions_txt['timestamp']
+					if 'githash' in versions_txt:
+						full_version += ' %s' % versions_txt['githash']
+					full_version += ')'
 
-			print "[INFO] Titanium SDK version: %s" % sdk_version
+			print "[INFO] Titanium SDK version: %s" % full_version
 			print "[INFO] iPhone Device family: %s" % devicefamily
 			print "[INFO] iPhone SDK version: %s" % iphone_version
 			


### PR DESCRIPTION
Added the githash and build date to the console, so that it looks the same as Android's build output as far as versioning goes. Should help a great deal with diagnosing issues (especially the githash).
