### PR TITLE
TIMOB-5033: Tooling: Use the existing python interpreter for docgen.py from SCons

### DIFF
--- a/site_scons/package.py
+++ b/site_scons/package.py
@@ -38,8 +38,12 @@ def ignore(file):
 		if file == f:
 			return True
 	 return False
+
 def generate_jsca():
-	 process_args = ['python', os.path.join(doc_dir, 'docgen.py'), '-f', 'jsca']
+	 process_args = [sys.executable, os.path.join(doc_dir, 'docgen.py'), '-f', 'jsca']
+	 print "Generating JSCA..."
+	 print " ".join(process_args)
+
 	 jsca_temp_file = tempfile.TemporaryFile()
 	 try:
 		 process = subprocess.Popen(process_args, stdout=jsca_temp_file, stderr=subprocess.PIPE)


### PR DESCRIPTION
http://jira.appcelerator.org/browse/TIMOB-5033

This patch has been tested on the Linux CI server and addresses the current breaking problem. Verification steps are also on the ticket itself
