### PR TITLE
Re-fix to allow debugging w/modules on iOS

### DIFF
--- a/support/iphone/compiler.py
+++ b/support/iphone/compiler.py
@@ -278,7 +278,7 @@ class Compiler(object):
 		
 		if deploytype!='development' or has_modules:
 
-			if os.path.exists(app_dir):
+			if os.path.exists(app_dir) and deploytype != 'development':
 				self.copy_resources([resources_dir],app_dir)
 				
 			if deploytype == 'production':


### PR DESCRIPTION
Initial fix was bad. This fix has been tested to confirm that:
- The original problem is solved
- Install to device/packaging is not affected

When testing, _PLEASE_ test all build processes. This should be standard for any build script change which could affect multiple build types (either across iOS and Android, or across sim/install/package). This change will affect:

iOS
- Simulator build
- Install build
- Package build
