### PR TITLE
[TIMOB-1607] Support enabling plugins in webview at API Level 8 or greater

### DIFF
--- a/android/modules/ui/src/ti/modules/titanium/ui/WebViewProxy.java
+++ b/android/modules/ui/src/ti/modules/titanium/ui/WebViewProxy.java
@@ -10,6 +10,7 @@ import org.appcelerator.kroll.annotations.Kroll;
 import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.TiContext;
 import org.appcelerator.titanium.util.AsyncResult;
+import org.appcelerator.titanium.util.TiConvert;
 import org.appcelerator.titanium.view.TiUIView;
 
 import ti.modules.titanium.ui.widget.webview.TiUIWebView;
@@ -122,6 +123,43 @@ public class WebViewProxy extends ViewProxy
 	public void stopLoading() {
 		getUIHandler().sendEmptyMessage(MSG_STOP_LOADING);
 
+	}
+	
+	@Kroll.method @Kroll.getProperty
+	public int getPluginState()
+	{
+		int pluginState = TiUIWebView.PLUGIN_STATE_OFF;
+		
+		if (hasProperty(TiC.PROPERTY_PLUGIN_STATE)) {
+			pluginState = TiConvert.toInt(getProperty(TiC.PROPERTY_PLUGIN_STATE));
+		}
+		
+		return pluginState;
+	}
+	
+	@Kroll.method @Kroll.setProperty
+	public void setPluginState(int pluginState) {
+		switch(pluginState) {
+		case TiUIWebView.PLUGIN_STATE_OFF :
+		case TiUIWebView.PLUGIN_STATE_ON :
+		case TiUIWebView.PLUGIN_STATE_ON_DEMAND :
+			setProperty(TiC.PROPERTY_PLUGIN_STATE, pluginState, true);
+			break;
+		default:
+			setProperty(TiC.PROPERTY_PLUGIN_STATE, TiUIWebView.PLUGIN_STATE_OFF, true);
+		}
+	}
+	
+	@Kroll.method
+	public void pause() 
+	{
+		getWebView().pauseWebView();
+	}
+	
+	@Kroll.method
+	public void resume()
+	{
+		getWebView().resumeWebView();
 	}
 	
 	@Override

--- a/android/modules/ui/src/ti/modules/titanium/ui/WebViewProxy.java
+++ b/android/modules/ui/src/ti/modules/titanium/ui/WebViewProxy.java
@@ -138,7 +138,8 @@ public class WebViewProxy extends ViewProxy
 	}
 	
 	@Kroll.method @Kroll.setProperty
-	public void setPluginState(int pluginState) {
+	public void setPluginState(int pluginState) 
+	{
 		switch(pluginState) {
 		case TiUIWebView.PLUGIN_STATE_OFF :
 		case TiUIWebView.PLUGIN_STATE_ON :

--- a/android/modules/ui/src/ti/modules/titanium/ui/WebViewProxy.java
+++ b/android/modules/ui/src/ti/modules/titanium/ui/WebViewProxy.java
@@ -141,13 +141,13 @@ public class WebViewProxy extends ViewProxy
 	public void setPluginState(int pluginState) 
 	{
 		switch(pluginState) {
-		case TiUIWebView.PLUGIN_STATE_OFF :
-		case TiUIWebView.PLUGIN_STATE_ON :
-		case TiUIWebView.PLUGIN_STATE_ON_DEMAND :
-			setProperty(TiC.PROPERTY_PLUGIN_STATE, pluginState, true);
-			break;
-		default:
-			setProperty(TiC.PROPERTY_PLUGIN_STATE, TiUIWebView.PLUGIN_STATE_OFF, true);
+			case TiUIWebView.PLUGIN_STATE_OFF :
+			case TiUIWebView.PLUGIN_STATE_ON :
+			case TiUIWebView.PLUGIN_STATE_ON_DEMAND :
+				setProperty(TiC.PROPERTY_PLUGIN_STATE, pluginState, true);
+				break;
+			default:
+				setProperty(TiC.PROPERTY_PLUGIN_STATE, TiUIWebView.PLUGIN_STATE_OFF, true);
 		}
 	}
 	

--- a/android/modules/ui/src/ti/modules/titanium/ui/android/AndroidModule.java
+++ b/android/modules/ui/src/ti/modules/titanium/ui/android/AndroidModule.java
@@ -14,6 +14,7 @@ import org.appcelerator.titanium.util.TiUIHelper;
 import org.appcelerator.titanium.view.TiUIView;
 
 import ti.modules.titanium.ui.UIModule;
+import ti.modules.titanium.ui.widget.webview.TiUIWebView;
 import android.app.Activity;
 import android.content.Intent;
 import android.text.util.Linkify;
@@ -50,6 +51,10 @@ public class AndroidModule extends KrollModule
 	
 	@Kroll.constant public static final int SWITCH_STYLE_CHECKBOX     = 0;
 	@Kroll.constant public static final int SWITCH_STYLE_TOGGLEBUTTON = 1;
+	
+	@Kroll.constant public static final int WEBVIEW_PLUGINS_OFF = TiUIWebView.PLUGIN_STATE_OFF;
+	@Kroll.constant public static final int WEBVIEW_PLUGINS_ON = TiUIWebView.PLUGIN_STATE_ON;
+	@Kroll.constant public static final int WEBVIEW_PLUGINS_ON_DEMAND = TiUIWebView.PLUGIN_STATE_ON_DEMAND;
 	
 	public AndroidModule(TiContext tiContext) 
 	{

--- a/android/modules/ui/src/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
+++ b/android/modules/ui/src/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
@@ -88,7 +88,7 @@ public class TiUIWebView extends TiUIView {
 		settings.setLightTouchEnabled(true);
 		
 		// We can only support webview settings for plugin/flash in API 8 and higher.
-		if (Build.VERSION.SDK_INT > 7) {
+		if (Build.VERSION.SDK_INT > Build.VERSION_CODES.ECLAIR_MR1) {
 			initializePluginAPI(webView);
 		}
 
@@ -109,8 +109,10 @@ public class TiUIWebView extends TiUIView {
 		return (WebView)getNativeView();
 	}
 
-	private void initializePluginAPI(TiWebView webView) {
-		try {
+	private void initializePluginAPI(TiWebView webView) 
+	{
+		try 
+		{
 			Class<?> webSettings = Class.forName("android.webkit.WebSettings");
 			Class<?> pluginState = Class.forName("android.webkit.WebSettings$PluginState");
 			synchronized(this.getClass()) {
@@ -397,7 +399,7 @@ public class TiUIWebView extends TiUIView {
 	
 	public void setPluginState(int pluginState) 
 	{
-		if (Build.VERSION.SDK_INT > 7) {
+		if (Build.VERSION.SDK_INT > Build.VERSION_CODES.ECLAIR_MR1) {
 			TiWebView webView = (TiWebView) getNativeView();
 			WebSettings webSettings = webView.getSettings();
 			if (webView != null) {
@@ -426,7 +428,7 @@ public class TiUIWebView extends TiUIView {
 	
 	public void pauseWebView()
 	{
-		if (Build.VERSION.SDK_INT > 7) {
+		if (Build.VERSION.SDK_INT > Build.VERSION_CODES.ECLAIR_MR1) {
 			View v = getNativeView();
 			if (v != null) {
 				try {
@@ -442,7 +444,7 @@ public class TiUIWebView extends TiUIView {
 	
 	public void resumeWebView()
 	{
-		if (Build.VERSION.SDK_INT > 7) {
+		if (Build.VERSION.SDK_INT > Build.VERSION_CODES.ECLAIR_MR1) {
 			View v = getNativeView();
 			if (v != null) {
 				try {

--- a/android/modules/ui/src/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
+++ b/android/modules/ui/src/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
@@ -10,6 +10,9 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 
 import org.appcelerator.kroll.KrollDict;
 import org.appcelerator.kroll.KrollProxy;
@@ -29,6 +32,8 @@ import org.appcelerator.titanium.view.TiUIView;
 import android.content.Context;
 import android.graphics.Color;
 import android.net.Uri;
+import android.os.Build;
+import android.view.View;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
 
@@ -38,7 +43,18 @@ public class TiUIWebView extends TiUIView {
 	private static final boolean DBG = TiConfig.LOGD;
 	private TiWebViewClient client;
 	private boolean changingUrl = false;
+	
+	private static Enum<?> enumPluginStateOff;
+	private static Enum<?> enumPluginStateOn;
+	private static Enum<?> enumPluginStateOnDemand;
+	private static Method internalSetPluginState;
+	private static Method internalWebViewPause;
+	private static Method internalWebViewResume;
 
+	public static final int PLUGIN_STATE_OFF = 0;
+	public static final int PLUGIN_STATE_ON = 1;
+	public static final int PLUGIN_STATE_ON_DEMAND = 2;
+	
 	private class TiWebView extends WebView {
 		public TiWebViewClient client;
 		public TiWebView(Context context) {
@@ -70,6 +86,11 @@ public class TiUIWebView extends TiUIView {
 		settings.setSupportZoom(true);
 		settings.setLoadsImagesAutomatically(true);
 		settings.setLightTouchEnabled(true);
+		
+		// We can only support webview settings for plugin/flash in API 8 and higher.
+		if (Build.VERSION.SDK_INT > 7) {
+			initializePluginAPI(webView);
+		}
 
 		webView.setWebChromeClient(new TiWebChromeClient(this));
 		client = new TiWebViewClient(this, webView);
@@ -88,6 +109,37 @@ public class TiUIWebView extends TiUIView {
 		return (WebView)getNativeView();
 	}
 
+	private void initializePluginAPI(TiWebView webView) {
+		try {
+			Class<?> webSettings = Class.forName("android.webkit.WebSettings");
+			Class<?> pluginState = Class.forName("android.webkit.WebSettings$PluginState");
+			synchronized(this.getClass()) {
+				// Initialize
+				if (enumPluginStateOff == null) {
+					Field f = pluginState.getDeclaredField("OFF");
+					enumPluginStateOff = (Enum<?>) f.get(null);
+					f = pluginState.getDeclaredField("ON");
+					enumPluginStateOn = (Enum<?>) f.get(null);
+					f = pluginState.getDeclaredField("ON_DEMAND");
+					enumPluginStateOnDemand = (Enum<?>) f.get(null);
+					internalSetPluginState = webSettings.getMethod("setPluginState", pluginState);
+					// Hidden APIs
+					// http://android.git.kernel.org/?p=platform/frameworks/base.git;a=blob;f=core/java/android/webkit/WebView.java;h=bbd8b95c7bea66b7060b5782fae4b3b2c4f04966;hb=4db1f432b853152075923499768639e14403b73a#l2558
+					internalWebViewPause = webView.getClass().getMethod("onPause");
+					internalWebViewResume = webView.getClass().getMethod("onResume");
+				}
+			}
+		} catch (ClassNotFoundException e) {
+			Log.e(LCAT, "ClassNotFound: " + e.getMessage(), e);
+		} catch (NoSuchMethodException e) {
+			Log.e(LCAT, "NoSuchMethod: " + e.getMessage(), e);
+		} catch (NoSuchFieldException e) {
+			Log.e(LCAT, "NoSuchField: " + e.getMessage(), e);			
+		} catch (IllegalAccessException e) {
+			Log.e(LCAT, "IllegalAccess: " + e.getMessage(), e);
+		}			
+	}
+	
 	@Override
 	public void processProperties(KrollDict d) {
 		super.processProperties(d);
@@ -113,6 +165,10 @@ public class TiUIWebView extends TiUIView {
 		// in order to see any of it.
 		if (nativeView != null && nativeView.getBackground() instanceof TiBackgroundDrawable) {
 			nativeView.setBackgroundColor(Color.TRANSPARENT);
+		}
+		
+		if (d.containsKey(TiC.PROPERTY_PLUGIN_STATE)) {
+			setPluginState(TiConvert.toInt(d, TiC.PROPERTY_PLUGIN_STATE));
 		}
 	}
 
@@ -337,6 +393,67 @@ public class TiUIWebView extends TiUIView {
 
 	public void setBasicAuthentication(String username, String password) {
 		client.setBasicAuthentication(username, password);
+	}
+	
+	public void setPluginState(int pluginState) 
+	{
+		if (Build.VERSION.SDK_INT > 7) {
+			TiWebView webView = (TiWebView) getNativeView();
+			WebSettings webSettings = webView.getSettings();
+			if (webView != null) {
+				try {
+					switch(pluginState) {
+					case PLUGIN_STATE_OFF : 
+						internalSetPluginState.invoke(webSettings, enumPluginStateOff);
+						break;
+					case PLUGIN_STATE_ON : 
+						internalSetPluginState.invoke(webSettings, enumPluginStateOn);
+						break;
+					case PLUGIN_STATE_ON_DEMAND : 
+						internalSetPluginState.invoke(webSettings, enumPluginStateOnDemand);
+						break;
+					default :
+						Log.w(LCAT, "Not a valid plugin state. Ignoring setPluginState request");
+					}
+				} catch (InvocationTargetException e) {
+					Log.e(LCAT, "Method not supported", e);
+				} catch (IllegalAccessException e) {
+					Log.e(LCAT, "Illegal Access", e);
+				}
+			}
+		}
+	}
+	
+	public void pauseWebView()
+	{
+		if (Build.VERSION.SDK_INT > 7) {
+			View v = getNativeView();
+			if (v != null) {
+				try {
+					internalWebViewPause.invoke(v);
+				} catch (InvocationTargetException e) {
+					Log.e(LCAT, "Method not supported", e);
+				} catch (IllegalAccessException e) {
+					Log.e(LCAT, "Illegal Access", e);
+				}
+			}
+		}
+	}
+	
+	public void resumeWebView()
+	{
+		if (Build.VERSION.SDK_INT > 7) {
+			View v = getNativeView();
+			if (v != null) {
+				try {
+					internalWebViewResume.invoke(v);
+				} catch (InvocationTargetException e) {
+					Log.e(LCAT, "Method not supported", e);
+				} catch (IllegalAccessException e) {
+					Log.e(LCAT, "Illegal Access", e);
+				}
+			}
+		}
 	}
 
 	public boolean canGoBack() {

--- a/android/modules/ui/src/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
+++ b/android/modules/ui/src/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
@@ -113,11 +113,12 @@ public class TiUIWebView extends TiUIView {
 	{
 		try 
 		{
-			Class<?> webSettings = Class.forName("android.webkit.WebSettings");
-			Class<?> pluginState = Class.forName("android.webkit.WebSettings$PluginState");
 			synchronized(this.getClass()) {
 				// Initialize
 				if (enumPluginStateOff == null) {
+					Class<?> webSettings = Class.forName("android.webkit.WebSettings");
+					Class<?> pluginState = Class.forName("android.webkit.WebSettings$PluginState");
+					
 					Field f = pluginState.getDeclaredField("OFF");
 					enumPluginStateOff = (Enum<?>) f.get(null);
 					f = pluginState.getDeclaredField("ON");
@@ -405,17 +406,17 @@ public class TiUIWebView extends TiUIView {
 			if (webView != null) {
 				try {
 					switch(pluginState) {
-					case PLUGIN_STATE_OFF : 
-						internalSetPluginState.invoke(webSettings, enumPluginStateOff);
-						break;
-					case PLUGIN_STATE_ON : 
-						internalSetPluginState.invoke(webSettings, enumPluginStateOn);
-						break;
-					case PLUGIN_STATE_ON_DEMAND : 
-						internalSetPluginState.invoke(webSettings, enumPluginStateOnDemand);
-						break;
-					default :
-						Log.w(LCAT, "Not a valid plugin state. Ignoring setPluginState request");
+						case PLUGIN_STATE_OFF : 
+							internalSetPluginState.invoke(webSettings, enumPluginStateOff);
+							break;
+						case PLUGIN_STATE_ON : 
+							internalSetPluginState.invoke(webSettings, enumPluginStateOn);
+							break;
+						case PLUGIN_STATE_ON_DEMAND : 
+							internalSetPluginState.invoke(webSettings, enumPluginStateOnDemand);
+							break;
+						default :
+							Log.w(LCAT, "Not a valid plugin state. Ignoring setPluginState request");
 					}
 				} catch (InvocationTargetException e) {
 					Log.e(LCAT, "Method not supported", e);

--- a/android/titanium/src/org/appcelerator/titanium/TiC.java
+++ b/android/titanium/src/org/appcelerator/titanium/TiC.java
@@ -227,6 +227,7 @@ public class TiC
 	public static final String PROPERTY_PINCOLOR = "pincolor";
 	public static final String PROPERTY_PLACES = "places";
 	public static final String PROPERTY_PLAY = "play";
+	public static final String PROPERTY_PLUGIN_STATE = "pluginState";
 	public static final String PROPERTY_POSITION = "position";
 	public static final String PROPERTY_POSTAL_CODE = "postalCode";
 	public static final String PROPERTY_POWER = "power";

--- a/apidoc/Titanium/UI/Android/Android.yml
+++ b/apidoc/Titanium/UI/Android/Android.yml
@@ -64,3 +64,12 @@ properties:
   - name: SWITCH_STYLE_TOGGLEBUTTON
     description: Display Switch as an Android Toggle Button (default)
     type: Number
+  - name: WEBVIEW_PLUGINS_OFF
+    description: Disable plugins in <Titanium.UI.WebView>.
+    type: Number
+  - name: WEBVIEW_PLUGINS_ON
+    description: Enable plugins in <Titanium.UI.WebView>.
+    type: Number
+  - name: WEBVIEW_PLUGINS_OFF
+    description: Display a placeholder and only load plugins when user selects placeholder.
+    type: Number

--- a/apidoc/Titanium/UI/WebView.yml
+++ b/apidoc/Titanium/UI/WebView.yml
@@ -87,6 +87,17 @@ events:
         description: the name of the event fired
       - name: globalPoint
         description: a dictionary with properties x and y describing the point of the event in screen coordinates
+  - name: pause
+    description: Pause native webview plugins. Add a `pause` handler to your <Titanium.UI.Android.Activity> and invoke
+        this method to pause native plugins. This is important with Flash content as it will continue in the background
+        unless this method is invoked.
+    since: "1.8.0"
+    platforms: [android]
+  - name: resume
+    description: Resume native webview plugins. Add a `resume` handler to your <Titanium.UI.Android.Activity> and invoke
+        this method to resume native plugins.
+    since: "1.8.0"
+    platforms: [android]
 properties:
   - name: data
     description: a data blob or file that is used to load the web document
@@ -97,6 +108,14 @@ properties:
   - name: loading
     description: boolean indicating if the webview is loading content
     type: Boolean
+  - name: pluginState
+    description: set how plugins are processed. Accepts one of <Titanium.UI.Android.WEBVIEW_PLUGINS_OFF>, <Titanium.UI.Android.WEBVIEW_PLUGINS_ON>, or <Titanium.UI.Android.WEBVIEW_PLUGINS_ON_DEMAND>.
+        See Android documentation for [WebSettings.PluginState](http://developer.android.com/reference/android/webkit/WebSettings.PluginState.html). Only
+        works on Android devices at API Level 8 or greater.
+    type: Number
+    platforms: [android]
+    since: "1.8.0"
+    default: <Titanium.UI.Android.WEBVIEW_PLUGINS_OFF>
   - name: scalesPageToFit
     description: whether the webview should scale it's contents or not
     type: Boolean

--- a/drillbit/tests/android/android.ui/android.ui.js
+++ b/drillbit/tests/android/android.ui/android.ui.js
@@ -2,6 +2,11 @@
 describe("Ti.UI.Android tests", {
 	androidUIAPIs: function() {
 		valueOf(Ti.UI.Android).shouldNotBeNull();
+		
+		// constants
+		valueOf(Ti.UI.Android.WEBVIEW_PLUGINS_OFF).shouldBeNumber();
+		valueOf(Ti.UI.Android.WEBVIEW_PLUGINS_ON).shouldBeNumber();
+		valueOf(Ti.UI.Android.WEBVIEW_PLUGINS_ON_DEMAND).shouldBeNumber();
 	}, 
 	testModuleNameCollision: function() {
 		// Make sure both Ti.UI.Android and Ti.Android are properly accessible.
@@ -287,6 +292,32 @@ describe("Ti.UI.Android tests", {
 		},10000);
 		w.open();
 
+	},
+	webViewPluginMethods: function() {
+		var wv = Ti.UI.createWebView({
+			
+		});
+		
+		valueOf(wv).shouldNotBeNull();
+		valueOf(wv.getPluginState).shouldBeFunction();
+		valueOf(wv.setPluginState).shouldBeFunction();
+		valueOf(wv.pause).shouldBeFunction();
+		valueOf(wv.resume).shouldBeFunction();
+		
+		valueOf(wv.pluginState).shouldBe(Ti.UI.Android.WEBVIEW_PLUGINS_OFF);
+		wv.pluginState = Ti.UI.Android.WEBVIEW_PLUGINS_ON;
+		valueOf(wv.pluginState).shouldBe(Ti.UI.Android.WEBVIEW_PLUGINS_ON);
+		wv.setPluginState(Ti.UI.Android.WEBVIEW_PLUGINS_ON_DEMAND);
+		valueOf(wv.getPluginState()).shouldBe(Ti.UI.Android.WEBVIEW_PLUGINS_ON_DEMAND);
+		
+		wv = Ti.UI.createWebView({
+			pluginState: Ti.UI.Android.WEBVIEW_PLUGINS_ON
+		});
+		valueOf(wv.pluginState).shouldBe(Ti.UI.Android.WEBVIEW_PLUGINS_ON);
+		
+		// set invalid state, should default to OFF
+		wv.pluginState = 5;
+		valueOf(wv.pluginState).shouldBe(Ti.UI.Android.WEBVIEW_PLUGINS_OFF);
 	}
 })
 

--- a/drillbit/tests/android/android.ui/android.ui.js
+++ b/drillbit/tests/android/android.ui/android.ui.js
@@ -294,9 +294,7 @@ describe("Ti.UI.Android tests", {
 
 	},
 	webViewPluginMethods: function() {
-		var wv = Ti.UI.createWebView({
-			
-		});
+		var wv = Ti.UI.createWebView();
 		
 		valueOf(wv).shouldNotBeNull();
 		valueOf(wv.getPluginState).shouldBeFunction();


### PR DESCRIPTION
[TIMOB-1607] Support enabling plugins in webview at API Level 8 or greater

You will want to test this with drillbit (android.ui)

There is a test app in the comments of the JIRA Issue

This should be tested on 2.1 that nothing crashes

This should be tested on 2.2+ (froyo) and up devices with the flash player installed.
