### PR TITLE
[TIMOB-5050] Need to encode redirect URLs.

### DIFF
--- a/iphone/Classes/ASI/ASIHTTPRequest.m
+++ b/iphone/Classes/ASI/ASIHTTPRequest.m
@@ -2325,7 +2325,15 @@ static NSOperationQueue *sharedQueue = nil;
 	}
 
 	// Force the redirected request to rebuild the request headers (if not a 303, it will re-use old ones, and add any new ones)
-	[self setRedirectURL:[[NSURL URLWithString:[responseHeaders valueForKey:@"Location"] relativeToURL:[self url]] absoluteURL]];
+    // SPT -- Documentation says that +[NSURL URLWithString:relativeToURL:] requires all characters to be %-encoded. So we
+    // "helpfully" have to perform this.
+    NSString* encodedLocation = (NSString*)CFURLCreateStringByAddingPercentEscapes(NULL, 
+                                                                                   (CFStringRef)[responseHeaders valueForKey:@"Location"], 
+                                                                                   NULL,
+                                                                                   NULL, 
+                                                                                   kCFStringEncodingUTF8 );
+    [encodedLocation autorelease];
+	[self setRedirectURL:[[NSURL URLWithString:encodedLocation relativeToURL:[self url]] absoluteURL]];
 	[self setNeedsRedirect:YES];
 
 	// Clear the request cookies


### PR DESCRIPTION
Self-explanatory. This was something that was in the previous local ASI library, but was not carried over when the library was updated.
