### PR TITLE
Added missing explanation of use

### DIFF
--- a/demos/KitchenSink/Resources/examples/preferences.js
+++ b/demos/KitchenSink/Resources/examples/preferences.js
@@ -4,6 +4,19 @@
 // Similar files MUST be present at build time or
 // Titanium.UI.Android.openPreferences() will simply
 // do nothing.
+//
+// To access the value of a preference in your program
+// get it from Titanium.App.Properties
+//
+// example:
+//  <EditTextPreference
+//    android:title="Edit Text Preference"
+//    android:summary="You may enter a string"
+//    android:defaultValue=""
+//    android:key="editText" />
+//
+// maps to
+//    Titanium.App.Properties.getString("editText");
 
 var btn = Titanium.UI.createButton({
 	title:	'Click to Open Preferences'


### PR DESCRIPTION
There's no explanation of how to actually use the preference values defined in preferences.xml.
Just added a comment explaining how to get the values in your app as far as I understand it.

Actually including a label in the example window that changes depending on the preference value set would be even nicer but I have no idea what events if any are fired when properties are changed or when the preference view/window is closed.
