### PR TITLE
[TIMOB-5053]  Eliminate spurious [WARN]s from logs

### DIFF
--- a/iphone/Classes/TiWindowProxy.m
+++ b/iphone/Classes/TiWindowProxy.m
@@ -361,10 +361,6 @@ END_UI_THREAD_PROTECTED_VALUE(opened)
 -(BOOL)isRootViewAttached
 {
 	BOOL result = ([[[[TiApp app] controller] view] superview]!=nil);
-	if (!result)
-	{
-		NSLog(@"[WARN] We still care about isRootViewAttached!!!!!!!");
-	}
 	return result;
 }
 


### PR DESCRIPTION
This checkin eliminates a warning message from the log that was causing some customer confusion.  There is no test to validate this change.
