### PR TITLE
[TIMOB-4942] Remove 'path property from Blob

### DIFF
--- a/apidoc/Titanium/Blob.yml
+++ b/apidoc/Titanium/Blob.yml
@@ -29,11 +29,6 @@ properties:
     type: String
     description: When this blob represents a <Titanium.File>, this is the file URL that represents it
     permission: read-only
-  - name: path
-    type: String
-    description: When this blob represents a <Titanium.File>, this is the absolute path to the file.
-    platforms: [iphone, ipad]
-    permission: read-only
   - name: size
     type: Number
     description: When this blob represents an image, this is the total number of pixels in the image.


### PR DESCRIPTION
Ti.Blob was exposing  (on iOS only) a 'path' property that was used internally. So the documentation was updated accordingly.
