### PR TITLE
[timob-4984]  Convert external video player timings to milliseconds

### DIFF
--- a/demos/KitchenSink/Resources/examples/movie_embed.js
+++ b/demos/KitchenSink/Resources/examples/movie_embed.js
@@ -1,5 +1,16 @@
 var win = Titanium.UI.currentWindow;
 
+if (Titanium.Platform.name != 'Android') {
+	var statusLabel = Titanium.UI.createLabel({
+		text:'tap on movie content',
+		width:'auto',
+		top:50,
+		height:25,
+		font:{fontSize:12,fontFamily:'Helvetica Neue'}
+	});
+	win.add(statusLabel);
+}
+
 var activeMovie = Titanium.Media.createVideoPlayer({
 	contentURL:'../movie.mp4',
 	backgroundColor:'#111',
@@ -23,6 +34,20 @@ var movieLabel = Titanium.UI.createLabel({
 
 // add label to view
 activeMovie.add(movieLabel);
+
+// label click
+if (Titanium.Platform.name != 'Android') {
+	activeMovie.addEventListener('click',function()
+	{
+		var newText = "";
+		newText += " i:" + activeMovie.initialPlaybackTime;
+		newText += " p:" + activeMovie.playableDuration;
+		newText += " e:" + activeMovie.endPlaybackTime;
+		newText += " d:" + activeMovie.duration;
+		newText += " c:" + activeMovie.currentPlaybackTime;
+		statusLabel.text = newText;
+	});
+}
 
 // label click
 movieLabel.addEventListener('click',function()

--- a/iphone/Classes/TiMediaVideoPlayerProxy.m
+++ b/iphone/Classes/TiMediaVideoPlayerProxy.m
@@ -262,7 +262,7 @@ NSArray* moviePlayerKeys = nil;
 	if (movie) {
 		double ourTime = [TiUtils doubleValue:time];
 		if (ourTime > 0 || isnan(ourTime)) { 
-            ourTime *= 1000.0f; // convert from milliseconds to seconds
+            ourTime /= 1000.0f; // convert from milliseconds to seconds
 			[[self player] setInitialPlaybackTime:ourTime];
 		}
 	} else {

--- a/iphone/Classes/TiMediaVideoPlayerProxy.m
+++ b/iphone/Classes/TiMediaVideoPlayerProxy.m
@@ -258,14 +258,14 @@ NSArray* moviePlayerKeys = nil;
 
 -(void)setInitialPlaybackTime:(id)time
 {
-	if (movie != nil) {
-		CGFloat ourTime = [TiUtils doubleValue:time];
-		if (ourTime > 0) {
-			ENSURE_UI_THREAD_1_ARG(time);
+    ENSURE_UI_THREAD_1_ARG(time);
+	if (movie) {
+		double ourTime = [TiUtils doubleValue:time];
+		if (ourTime > 0 || isnan(ourTime)) { 
+            ourTime *= 1000.0f; // convert from milliseconds to seconds
 			[[self player] setInitialPlaybackTime:ourTime];
 		}
-	}
-	else {
+	} else {
 		[loadProperties setValue:time forKey:@"initialPlaybackTime"];
 	}
 }
@@ -273,7 +273,11 @@ NSArray* moviePlayerKeys = nil;
 -(NSNumber*)initialPlaybackTime
 {
 	if (movie != nil) {
-		return NUMDOUBLE([[self player] initialPlaybackTime]);
+        NSTimeInterval n = [[self player] initialPlaybackTime];
+        if (n == -1) {
+            n = NAN;
+        }
+		return NUMDOUBLE(1000.0f * n);
 	}
 	else {
 		RETURN_FROM_LOAD_PROPERTIES(@"initialPlaybackTime", NUMINT(0));
@@ -641,7 +645,7 @@ NSArray* moviePlayerKeys = nil;
 	ONLY_IN_3_2_OR_GREATER(playableDuration)
 	
 	if (movie != nil) {
-		return NUMDOUBLE([[self player] playableDuration]);
+		return NUMDOUBLE(1000.0f * [[self player] playableDuration]);
 	}
 	else {
 		return NUMINT(0);
@@ -653,7 +657,7 @@ NSArray* moviePlayerKeys = nil;
 	ONLY_IN_3_2_OR_GREATER(duration)
 	
 	if (movie != nil) {
-		return NUMDOUBLE([[self player] duration]);
+		return NUMDOUBLE(1000.0f * [[self player] duration]);
 	}
 	else {
 		return NUMINT(0);
@@ -665,7 +669,7 @@ NSArray* moviePlayerKeys = nil;
 	ONLY_IN_3_2_OR_GREATER(currentPlaybackTime)
 	
 	if (movie != nil) {
-		return NUMDOUBLE([[self player] currentPlaybackTime]);
+		return NUMDOUBLE(1000.0f * [[self player] currentPlaybackTime]);
 	}
 	else {
 		return NUMINT(0);
@@ -677,9 +681,12 @@ NSArray* moviePlayerKeys = nil;
 	ONLY_IN_3_2_OR_GREATER(endPlaybackTime)
 	
 	if (movie != nil) {
-		return NUMDOUBLE([[self player] endPlaybackTime]);
-	}
-	else {
+        NSTimeInterval n = [[self player] endPlaybackTime];
+        if (n == -1) {
+            n = NAN;
+        }
+		return NUMDOUBLE(1000.0f * n);
+	} else {
 		return NUMINT(0);
 	}
 }


### PR DESCRIPTION
Note: test has been added to KS for non-android systems only as we have a number of parity issues between platforms and the documentation.  The test is in KS->Phone->Play Movie->Embedded Video.
