### PR TITLE
[TIMOB-5014] Functions with return type void where returning null instead

### DIFF
--- a/iphone/Classes/KrollObject.h
+++ b/iphone/Classes/KrollObject.h
@@ -17,12 +17,6 @@ TiValueRef KrollGetProperty(TiContextRef jsContext, TiObjectRef obj, TiStringRef
 bool KrollSetProperty(TiContextRef jsContext, TiObjectRef obj, TiStringRef prop, TiValueRef value, TiValueRef* exception);
 bool KrollDeleteProperty(TiContextRef ctx, TiObjectRef object, TiStringRef propertyName, TiValueRef* exception);
 
-// this is simply a marker interface that we can use 
-// to determine if a object is undefined
-@interface KrollUndefined : NSObject
-+(KrollUndefined*)undefined;
-@end
-
 
 //
 // KrollObject is a generic native wrapper around a native object exposed as a JS object 

--- a/iphone/Classes/KrollObject.m
+++ b/iphone/Classes/KrollObject.m
@@ -25,18 +25,6 @@ TiClassRef JSObjectClassRef = NULL;
 
 id TiValueToId(KrollContext* context, TiValueRef v);
 
-@implementation KrollUndefined
-+(KrollUndefined*)undefined
-{
-	static KrollUndefined *undef;
-	if (undef==nil)
-	{
-		undef = [[KrollUndefined alloc] init];
-	}
-	return undef;
-}
-@end
-
 //
 // function to determine if the object passed is a JS Date
 //
@@ -135,7 +123,10 @@ id TiValueToId(KrollContext *context, TiValueRef v)
 		TiContextRef jsContext = [context context];
 		TiType tt = TiValueGetType(jsContext, v);
 		switch (tt) {
-			case kTITypeUndefined:
+			case kTITypeUndefined:{
+				result = nil;
+				break;
+			}
 			case kTITypeNull: {
 				result = [NSNull null];
 				break;
@@ -205,11 +196,11 @@ id TiValueToId(KrollContext *context, TiValueRef v)
 TiValueRef ConvertIdTiValue(KrollContext *context, id obj)
 {
 	TiContextRef jsContext = [context context];
-	if (obj == nil || [obj isKindOfClass:[NSNull class]])
+	if ([obj isKindOfClass:[NSNull class]])
 	{
 		return TiValueMakeNull(jsContext);
 	}
-	else if ([obj isKindOfClass:[KrollUndefined class]])
+	else if (obj == nil)
 	{
 		return TiValueMakeUndefined(jsContext);
 	}
@@ -1014,7 +1005,7 @@ bool KrollHasInstance(TiContextRef ctx, TiObjectRef constructor, TiValueRef poss
 			}
 		}
 	}
-	return [KrollUndefined undefined];
+	return nil;
 }
 
 -(id)valueForKey:(NSString *)key


### PR DESCRIPTION
 Functions with return type void where returning null instead of undefined as nil was being wrongly considered as a null and returned the same value.

<b>Testing </b>can be done by adding the analytics.js in jira tickets to drillbit and see if it passes or not.
