### PR TITLE
TIMOB-5049: Destroys may happen on background threads. Be safe with views

### DIFF
--- a/iphone/Classes/TiUITableViewRowProxy.m
+++ b/iphone/Classes/TiUITableViewRowProxy.m
@@ -273,9 +273,11 @@ TiProxy * DeepScanForProxyOfViewContainingPoint(UIView * targetView, CGPoint poi
 -(void)_destroy
 {
 	RELEASE_TO_NIL(tableClass);
-	RELEASE_TO_NIL(rowContainerView);
+	[rowContainerView performSelectorOnMainThread:@selector(release) withObject:nil waitUntilDone:NO];
+	rowContainerView = nil;
 	[callbackCell setProxy:nil];
-	RELEASE_TO_NIL(callbackCell);
+	[callbackCell performSelectorOnMainThread:@selector(release) withObject:nil waitUntilDone:NO];
+	callbackCell = nil;
 	[super _destroy];
 }
 


### PR DESCRIPTION
TIMOB-5049: Destroys may happen on background threads. Talked with Don, test is waived for this due to intermittent behavior and difficulty in recreation, in hopes that QE found this issue again with a test case.
