### PR TITLE
[timob-4738]  Remove scaling from ScrollableView for parity

### DIFF
--- a/apidoc/Titanium/UI/ScrollableView.yml
+++ b/apidoc/Titanium/UI/ScrollableView.yml
@@ -47,14 +47,6 @@ properties:
     description: disable view bouncing.  iOS only.
     platforms: [iphone, ipad]
     type: Boolean
-  - name: maxZoomScale
-    description: the maximum zoom scale for the view
-    type: Number
-    platforms: [iphone, ipad]
-  - name: minZoomScale
-    description: the minimum zoom scale for the view
-    type: Number
-    platforms: [iphone, ipad]
   - name: pagingControlColor
     description: the color of the paging control. defaults to black.
     type: String

--- a/iphone/Classes/TiUIScrollableView.h
+++ b/iphone/Classes/TiUIScrollableView.h
@@ -16,8 +16,6 @@
 	BOOL showPageControl;
 	CGFloat pageControlHeight;
 	BOOL handlingPageControlEvent;
-	CGFloat maxScale;
-	CGFloat minScale;
         
     // Have to correct for an apple goof; rotation stops scrolling, AND doesn't move to the next page.
     BOOL rotatedWhileScrolling;

--- a/iphone/Classes/TiUIScrollableView.m
+++ b/iphone/Classes/TiUIScrollableView.m
@@ -15,31 +15,6 @@
 @property(nonatomic,readonly)	TiUIScrollableViewProxy * proxy;
 @end
 
-
-
-@interface InnerScrollView : UIScrollView<UIScrollViewDelegate>
-{
-}
-@end
-
-@implementation InnerScrollView
-
-- (UIView *)viewForZoomingInScrollView:(UIScrollView *)scrollView
-{
-	if ([[self subviews] count] > 0) {
-		return [[self subviews] objectAtIndex:0];
-	}
-	return nil;
-}
-
-- (void)scrollViewDidEndZooming:(UIScrollView *)scrollView_ withView:(UIView *)view atScale:(float)scale 
-{
-}
-
-@end
-
-
-
 @implementation TiUIScrollableView
 
 #pragma mark Internal 
@@ -61,8 +36,6 @@
 
 -(void)initializerState
 {
-	maxScale = 1.0;
-	minScale = 1.0;
 }
 
 -(CGRect)pageControlRect
@@ -252,17 +225,7 @@
 		
 		if (readd)
 		{
-			//TODO: optimize for non-scaled?
-			InnerScrollView *view = [[InnerScrollView alloc] initWithFrame:viewBounds];
-			[view setMaximumZoomScale:maxScale];
-			[view setMinimumZoomScale:minScale];
-			[view setShowsVerticalScrollIndicator:NO];
-			[view setShowsHorizontalScrollIndicator:NO];
-			[view setDelegate:view];
-//			[view setAutoresizingMask:UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight];
-			[view setPagingEnabled:NO];
-			[view setBackgroundColor:[UIColor clearColor]];
-			[view setDelaysContentTouches:NO];
+			UIView *view = [[UIView alloc] initWithFrame:viewBounds];
 			[sv addSubview:view];
 			[view release];
 		}
@@ -443,16 +406,6 @@
         
 		[self.proxy replaceValue:NUMINT(newPage) forKey:@"currentPage" notification:NO];
 	}
-}
-
--(void)setMaxZoomScale_:(id)scale
-{
-	maxScale = [TiUtils floatValue:scale];
-}
-
--(void)setMinZoomScale_:(id)scale
-{
-	minScale = [TiUtils floatValue:scale];
 }
 
 -(void)setDisableBounce_:(id)value

--- a/iphone/Classes/TiUIScrollableViewProxy.m
+++ b/iphone/Classes/TiUIScrollableViewProxy.m
@@ -16,8 +16,6 @@
 {
 	pthread_rwlock_init(&viewsLock, NULL);
 	[self replaceValue:NUMINT(0) forKey:@"currentPage" notification:NO];
-	[self replaceValue:NUMFLOAT(1) forKey:@"minZoomScale" notification:NO];
-	[self replaceValue:NUMFLOAT(1) forKey:@"maxZoomScale" notification:NO];
 	[super _initWithProperties:properties];
 }
 


### PR DESCRIPTION
This ticket was removing a "feature" that was not supposed to be supported, therefore the test is KS->Base UI->Views->Scroll Views->Scrollable View to insure that it's still operational with no regressions.
