### PR TITLE
TIMOB-5097 Line added. SeparatorStyle is iOS only in docs now.

### DIFF
--- a/apidoc/Titanium/UI/TableView.yml
+++ b/apidoc/Titanium/UI/TableView.yml
@@ -265,6 +265,7 @@ properties:
     type: String
   - name: separatorStyle
     description: the separator style constant. For iPhone, Titanium.UI.iPhone.TableViewSeparatorStyle
+    platforms: [iphone, ipad]
     type: Number
   - name: showVerticalScrollIndicator
     description: whether tableview displays vertical scroll indicator (iOS Only)


### PR DESCRIPTION
No code to test, only docs.
