### PR TITLE
TIMOB-5173 modify TiBaseActivity to keep track of lightweight window crea

### DIFF
--- a/android/modules/ui/src/ti/modules/titanium/ui/TiUIWindow.java
+++ b/android/modules/ui/src/ti/modules/titanium/ui/TiUIWindow.java
@@ -189,9 +189,9 @@ public class TiUIWindow extends TiUIView
 
 			// set this so that if the LW window is created on top of the root activity 
 			// it can still be accessed via the activity
-			if(lightWeight)
+			if (lightWeight)
 			{
-				if(proxyActivity instanceof TiBaseActivity)
+				if (proxyActivity instanceof TiBaseActivity)
 				{
 					((TiBaseActivity)proxyActivity).lwWindow = (TiWindowProxy)proxy;
 				}
@@ -339,6 +339,14 @@ public class TiUIWindow extends TiUIView
 				}
 				lightWindow.removeAllViews();
 				lightWindow = null;
+			}
+
+			// set the lightweight window reference on the activity to null when the window closes
+			TiContext proxyContext = proxy.getTiContext();
+			Activity proxyActivity = proxyContext.getActivity();
+			if (proxyActivity instanceof TiBaseActivity)
+			{
+				((TiBaseActivity)proxyActivity).lwWindow = null;
 			}
 		}
 	}

--- a/android/modules/ui/src/ti/modules/titanium/ui/TiUIWindow.java
+++ b/android/modules/ui/src/ti/modules/titanium/ui/TiUIWindow.java
@@ -184,7 +184,18 @@ public class TiUIWindow extends TiUIView
 				bindProxies();
 			}
 		} else {
-			bindWindowActivity(proxyContext, proxyContext.getActivity());
+			Activity proxyActivity = proxyContext.getActivity();
+			bindWindowActivity(proxyContext, proxyActivity);
+
+			// set this so that if the LW window is created on top of the root activity 
+			// it can still be accessed via the activity
+			if(lightWeight)
+			{
+				if(proxyActivity instanceof TiBaseActivity)
+				{
+					((TiBaseActivity)proxyActivity).lwWindow = (TiWindowProxy)proxy;
+				}
+			}
 		}
 		if (!newActivity && !lightWeight) {
 			proxy.switchContext(windowContext);

--- a/android/modules/ui/src/ti/modules/titanium/ui/UIModule.java
+++ b/android/modules/ui/src/ti/modules/titanium/ui/UIModule.java
@@ -12,6 +12,7 @@ import org.appcelerator.kroll.annotations.Kroll;
 import org.appcelerator.titanium.TiApplication;
 import org.appcelerator.titanium.TiBaseActivity;
 import org.appcelerator.titanium.TiContext;
+import org.appcelerator.titanium.proxy.TiWindowProxy;
 import org.appcelerator.titanium.util.Log;
 import org.appcelerator.titanium.util.TiConvert;
 import org.appcelerator.titanium.util.TiOrientationHelper;
@@ -155,7 +156,12 @@ public class UIModule extends KrollModule
 			{
 				orientationModes = new int[] {tiOrientationMode};
 			}
-			((TiBaseActivity) activity).getWindowProxy().setOrientationModes (orientationModes);
+
+			// this should only be entered if a LW window is created on top of the root activity
+			if(((TiBaseActivity) activity).getWindowProxy() == null)
+			{
+				((TiBaseActivity) activity).lwWindow.setOrientationModes(orientationModes);
+			}
 		}
 	}
 }

--- a/android/modules/ui/src/ti/modules/titanium/ui/UIModule.java
+++ b/android/modules/ui/src/ti/modules/titanium/ui/UIModule.java
@@ -158,9 +158,17 @@ public class UIModule extends KrollModule
 			}
 
 			// this should only be entered if a LW window is created on top of the root activity
-			if(((TiBaseActivity) activity).getWindowProxy() == null)
+			if (((TiBaseActivity) activity).getWindowProxy() == null)
 			{
-				((TiBaseActivity) activity).lwWindow.setOrientationModes(orientationModes);
+				TiWindowProxy lwWindow = ((TiBaseActivity) activity).lwWindow;
+				if (lwWindow != null)
+				{
+					lwWindow.setOrientationModes(orientationModes);
+				}
+				else
+				{
+					Log.e(LCAT, "no window has been associated with activity, unable to set orientation");
+				}
 			}
 		}
 	}

--- a/android/modules/ui/src/ti/modules/titanium/ui/UIModule.java
+++ b/android/modules/ui/src/ti/modules/titanium/ui/UIModule.java
@@ -158,12 +158,12 @@ public class UIModule extends KrollModule
 			}
 
 			// this should only be entered if a LW window is created on top of the root activity
-			if (((TiBaseActivity) activity).getWindowProxy() == null)
+			TiBaseActivity tiBaseActivity = (TiBaseActivity)activity;
+			if (tiBaseActivity.getWindowProxy() == null)
 			{
-				TiWindowProxy lwWindow = ((TiBaseActivity) activity).lwWindow;
-				if (lwWindow != null)
+				if (tiBaseActivity.lwWindow != null)
 				{
-					lwWindow.setOrientationModes(orientationModes);
+					tiBaseActivity.lwWindow.setOrientationModes(orientationModes);
 				}
 				else
 				{

--- a/android/titanium/src/org/appcelerator/titanium/TiBaseActivity.java
+++ b/android/titanium/src/org/appcelerator/titanium/TiBaseActivity.java
@@ -64,6 +64,8 @@ public abstract class TiBaseActivity extends Activity
 	protected int msgActivityCreatedId = -1;
 	protected int msgId = -1;
 
+	public TiWindowProxy lwWindow;
+
 
 	// could use a normal ConfigurationChangedListener but since only orientation changes are
 	// forwarded, create a separate interface in order to limit scope and maintain clarity 


### PR DESCRIPTION
TIMOB-5173 modify TiBaseActivity to keep track of lightweight window created on top of it.  Addressed reported issue with setting Ti.UI.orientation when only a lightweight window is created on top of the root activity
