### PR TITLE
[TIMOB-4907] Deprecate unnecessary functions in Ti.Network.

### DIFF
--- a/iphone/Classes/NetworkModule.m
+++ b/iphone/Classes/NetworkModule.m
@@ -139,6 +139,7 @@ NSString* const INADDR_ANY_token = @"INADDR_ANY";
 
 -(void)addConnectivityListener:(id)args
 {
+    DEPRECATED_REPLACED(@"addConnectivityListener", @"1.8", @"1.9", @"addEventListener('change',...)");
 	id arg = [args objectAtIndex:0];
 	ENSURE_TYPE(arg,KrollCallback);
 	NSArray *newargs = [NSArray arrayWithObjects:@"change",arg,nil];
@@ -147,6 +148,7 @@ NSString* const INADDR_ANY_token = @"INADDR_ANY";
 
 -(void)removeConnectivityListener:(id)args
 {
+    DEPRECATED_REPLACED(@"removeConnectivityListener", @"1.8", @"1.9", @"removeEventListener('change',...)");    
 	id arg = [args objectAtIndex:0];
 	ENSURE_TYPE(arg,KrollCallback);
 	NSArray *newargs = [NSArray arrayWithObjects:@"change",arg,nil];


### PR DESCRIPTION
Exactly as described. Test code:

```
function f() {}
Ti.Network.addConnectivityListener(f);
Ti.Network.removeConnectivityListener(f);
```

This should print the deprecation warnings for both addConnectivityListener and removeConnectivityListener.
