### PR TITLE
[TIMOB-5170] ScrollableView.showPagingControl should be false by default.

### DIFF
--- a/android/modules/ui/src/ti/modules/titanium/ui/ScrollableViewProxy.java
+++ b/android/modules/ui/src/ti/modules/titanium/ui/ScrollableViewProxy.java
@@ -15,6 +15,7 @@ import org.appcelerator.kroll.annotations.Kroll;
 import org.appcelerator.titanium.TiContext;
 import org.appcelerator.titanium.proxy.TiViewProxy;
 import org.appcelerator.titanium.util.AsyncResult;
+import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.util.TiEventHelper;
 import org.appcelerator.titanium.view.TiUIView;
 
@@ -51,6 +52,8 @@ public class ScrollableViewProxy extends TiViewProxy
 		super(context);
 		inAnimation = new AtomicBoolean(false);
 		inScroll = new AtomicBoolean(false);
+
+		setProperty(TiC.PROPERTY_SHOW_PAGING_CONTROL, false);
 	}
 
 	@Override

--- a/android/modules/ui/src/ti/modules/titanium/ui/widget/TiScrollableView.java
+++ b/android/modules/ui/src/ti/modules/titanium/ui/widget/TiScrollableView.java
@@ -92,7 +92,7 @@ public class TiScrollableView extends TiCompositeLayout
 		this.proxy = proxy;
 		this.handler = handler;
 		me = this;
-		showPagingControl = true;
+		showPagingControl = false;
 		views = new ArrayList<TiViewProxy>();
 		
 		//below this was in "doOpen"

--- a/android/modules/ui/src/ti/modules/titanium/ui/widget/TiScrollableView.java
+++ b/android/modules/ui/src/ti/modules/titanium/ui/widget/TiScrollableView.java
@@ -92,8 +92,9 @@ public class TiScrollableView extends TiCompositeLayout
 		this.proxy = proxy;
 		this.handler = handler;
 		me = this;
-		showPagingControl = false;
 		views = new ArrayList<TiViewProxy>();
+
+		showPagingControl = proxy.getProperty(TiC.PROPERTY_SHOW_PAGING_CONTROL);
 		
 		//below this was in "doOpen"
 		//setLayoutParams(new FrameLayout.LayoutParams(LayoutParams.FILL_PARENT, LayoutParams.FILL_PARENT));

--- a/android/titanium/src/org/appcelerator/titanium/TiC.java
+++ b/android/titanium/src/org/appcelerator/titanium/TiC.java
@@ -266,6 +266,7 @@ public class TiC
 	public static final String PROPERTY_SELECTED_INDEX = "selectedIndex";
 	public static final String PROPERTY_SELECTION_INDICATOR = "selectionIndicator";
 	public static final String PROPERTY_SEPARATOR_COLOR = "separatorColor";
+	public static final String PROPERTY_SHOW_PAGING_CONTROL = "showPagingControl";
 	public static final String PROPERTY_SIZE = "size";
 	public static final String PROPERTY_SOFT_KEYBOARD_ON_FOCUS = "softKeyboardOnFocus";
 	public static final String PROPERTY_SOUND = "sound";


### PR DESCRIPTION
To achieve parity with iOS, showPagingControl should be false by default and the controls not shown.
Functional test provided on the JIRA ticket.
