### PR TITLE
[TIMOB-5055] Filesystem blob returns false during exists() call in drillbit

### DIFF
--- a/iphone/Classes/TiBlob.m
+++ b/iphone/Classes/TiBlob.m
@@ -224,7 +224,7 @@
 	 */
 #ifdef USE_TI_FILESYSTEM
 	if (path != nil) {
-		return [[[TiFilesystemFileProxy alloc] initWithPath:path] autorelease];	
+		return [[[TiFilesystemFileProxy alloc] initWithFile:path] autorelease];	
 	}
 #else
 	NSLog(@"[FATAL] Blob.file property requested but the Filesystem module was never requested.")


### PR DESCRIPTION
[TIMOB-5055] Filesystem blob returns false during exists() call in drillbit
<b>
*same as [TIMOB-4915]</b>

TESTING :DRILLBIT  filesystem

drillbit will no longer fail on Filesystem on this error 
<b>    blobFile false   63  should be true, was: false </b>
