### PR TITLE
[TIMOB-5056] FileSystem Blob empty file size

### DIFF
--- a/iphone/Classes/TiFile.m
+++ b/iphone/Classes/TiFile.m
@@ -50,7 +50,7 @@
 	NSError *error = nil; 
 	NSDictionary * resultDict = [fm attributesOfItemAtPath:path error:&error];
 	id resultType = [resultDict objectForKey:NSFileType];
-	if (resultType == NSFileTypeSymbolicLink)
+	if ([resultType isEqualToString:NSFileTypeSymbolicLink])
 	{
 		resultDict = [fm attributesOfFileSystemForPath:path error:&error];
 	}

--- a/iphone/Classes/TiFile.m
+++ b/iphone/Classes/TiFile.m
@@ -49,11 +49,16 @@
 	NSFileManager *fm = [NSFileManager defaultManager];
 	NSError *error = nil; 
 	NSDictionary * resultDict = [fm attributesOfItemAtPath:path error:&error];
-	id result = [resultDict objectForKey:NSFileSize];
-	if (error!=NULL)
+	id resultType = [resultDict objectForKey:NSFileType];
+	if (resultType == NSFileTypeSymbolicLink)
+	{
+		resultDict = [fm attributesOfFileSystemForPath:path error:&error];
+	}
+	if (error != NULL)
 	{
 		return 0;
 	}
+	id result = [resultDict objectForKey:NSFileSize];
 	return [result intValue];
 }
 


### PR DESCRIPTION
[TIMOB-5056] FileSystem Blob empty file size was detecting the symlink size instead of the actual file size.

Testing 

<b>\* Drillbit -> filesystem....</b> 
