### PR TITLE
TIMOB-5265 - iOS5 device unique identifier deprecation issue

### DIFF
--- a/iphone/Classes/AnalyticsModule.m
+++ b/iphone/Classes/AnalyticsModule.m
@@ -318,7 +318,7 @@ NSString * const TI_DB_VERSION = @"1";
 	[dict setObject:[TiUtils UTCDate] forKey:@"ts"];
 	[dict setObject:[TiUtils createUUID] forKey:@"id"];
 	[dict setObject:NUMINT(sequence++) forKey:@"seq"];
-	[dict setObject:[[UIDevice currentDevice] uniqueIdentifier] forKey:@"mid"];
+	[dict setObject:[TiUtils uniqueIdentifier] forKey:@"mid"];
 	[dict setObject:TI_APPLICATION_GUID forKey:@"aguid"];
 	[dict setObject:TI_APPLICATION_DEPLOYTYPE forKey:@"deploytype"];
 	[dict setObject:name forKey:@"event"];

--- a/iphone/Classes/GeolocationModule.m
+++ b/iphone/Classes/GeolocationModule.m
@@ -465,7 +465,7 @@ extern BOOL const TI_APPLICATION_ANALYTICS;
 	NSDictionary *params = [NSDictionary dictionaryWithObjectsAndKeys:
 							direction, @"d",
 							aguid,@"aguid",
-							[[UIDevice currentDevice] uniqueIdentifier],@"mid",
+							[TiUtils uniqueIdentifier],@"mid",
 							sid,@"sid",
 							address,@"q",
 							[[NSLocale currentLocale] objectForKey: NSLocaleCountryCode],@"c",

--- a/iphone/Classes/PlatformModule.m
+++ b/iphone/Classes/PlatformModule.m
@@ -49,7 +49,7 @@ NSString* const DATA_IFACE = @"pdp_ip0";
 			[self replaceValue:@"iphone" forKey:@"osname" notification:NO]; 
 		}
 		
-		macaddress = [[[UIDevice currentDevice] uniqueIdentifier] retain];
+		macaddress = [[TiUtils uniqueIdentifier] retain];
 		
 		NSString *themodel = [theDevice model];
 		
@@ -192,7 +192,8 @@ NSString* const DATA_IFACE = @"pdp_ip0";
 
 -(id)id
 {
-	return [[UIDevice currentDevice] uniqueIdentifier];
+// macaddress is the same as uniqueIdentifier
+	return macaddress;
 }
 
 - (NSString *)createUUID:(id)args

--- a/iphone/Classes/TiUtils.h
+++ b/iphone/Classes/TiUtils.h
@@ -217,4 +217,6 @@ typedef enum {
 
 +(int)encodeNumber:(NSNumber*)data toBuffer:(TiBuffer*)dest offset:(int)position type:(NSString*)type endianness:(CFByteOrder)byteOrder;
 
++(id)uniqueIdentifier;
+
 @end

--- a/iphone/Classes/TiUtils.m
+++ b/iphone/Classes/TiUtils.m
@@ -1567,4 +1567,41 @@ if ([str isEqualToString:@#orientation]) return orientation;
     return (position+size);
 }
 
+NSString const *kDeviceUUIDString = @"com.appcelerator.uuid"; // don't obfuscate
+
++(id)uniqueIdentifier
+{
+    // we store in a globally available system pasteboard
+    UIPasteboard *pb = [UIPasteboard pasteboardWithName:@"com.appcelerator" create:YES];
+    pb.persistent = YES; // these is required to make pasteboard persist after application exists and restarts
+    
+    NSData *data = [pb dataForPasteboardType:(NSString*)kDeviceUUIDString];
+    
+    // we attempt to use the unique identifier if we still have one. at some point in the near future (iOS5++) 
+    // this will no longer work and we need to be able to generate a new one
+    NSString *uid = [[UIDevice currentDevice] uniqueIdentifier];
+        
+    if (uid == nil)
+    {
+        if (data == nil)
+        {
+            uid = [TiUtils createUUID];
+        }
+        else
+        {
+            uid = [[[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding] autorelease];
+        }
+    }
+
+    if (data == nil)
+    {
+        // store if not already present - what's nice is that we'll go ahead and migrate (and keep) the old (pre-deprecation)
+        // value and once it goes away on an upgrade, we'll still be using it vs. a randomly generated one
+        [pb setData:[uid dataUsingEncoding:NSUTF8StringEncoding] forPasteboardType:(NSString*)kDeviceUUIDString];
+    }
+    
+    return uid;
+}
+
+
 @end


### PR DESCRIPTION
This is a fix for the iOS5 device unique identifier deprecation issue.  

I have updated the JIRA with instructions on how to test this across applications and also how to test migration from iOS4 to iOS5.
