### PR TITLE
TIMOB-4885 Android webview: deadlock when evalJS includes some UI such as alert()

### DIFF
--- a/android/modules/ui/src/ti/modules/titanium/ui/WebViewProxy.java
+++ b/android/modules/ui/src/ti/modules/titanium/ui/WebViewProxy.java
@@ -9,7 +9,6 @@ package ti.modules.titanium.ui;
 import org.appcelerator.kroll.annotations.Kroll;
 import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.TiContext;
-import org.appcelerator.titanium.util.AsyncResult;
 import org.appcelerator.titanium.util.TiConvert;
 import org.appcelerator.titanium.view.TiUIView;
 
@@ -31,12 +30,11 @@ public class WebViewProxy extends ViewProxy
 
 	private static final int MSG_FIRST_ID = ViewProxy.MSG_LAST_ID + 1;
 
-	private static final int MSG_EVAL_JS = MSG_FIRST_ID + 100;
 	private static final int MSG_GO_BACK = MSG_FIRST_ID + 101;
 	private static final int MSG_GO_FORWARD = MSG_FIRST_ID + 102;
 	private static final int MSG_RELOAD = MSG_FIRST_ID + 103;
 	private static final int MSG_STOP_LOADING = MSG_FIRST_ID + 104;
-	
+
 	protected static final int MSG_LAST_ID = MSG_FIRST_ID + 999;
 
 	public WebViewProxy(TiContext context) {
@@ -44,33 +42,28 @@ public class WebViewProxy extends ViewProxy
 	}
 
 	@Override
-	public TiUIView createView(Activity activity) {
+	public TiUIView createView(Activity activity)
+	{
 		TiUIWebView webView = new TiUIWebView(this);
 		webView.focus();
 		return webView;
 	}
 
-	public TiUIWebView getWebView() {
+	public TiUIWebView getWebView()
+	{
 		return (TiUIWebView)getView(getTiContext().getActivity());
 	}
 
 	@Kroll.method
-	public Object evalJS(String code) {
-		if (getTiContext().isUIThread()) {
-			return getWebView().getJSValue(code);
-		} else {
-			return sendBlockingUiMessage(MSG_EVAL_JS, code);
-		}
+	public Object evalJS(String code)
+	{
+		return getWebView().getJSValue(code);
 	}
 
 	@Override
-	public boolean handleMessage(Message msg) {
+	public boolean handleMessage(Message msg)
+	{
 		switch (msg.what) {
-			case MSG_EVAL_JS:
-				AsyncResult result = (AsyncResult)msg.obj;
-				String value = getWebView().getJSValue((String)result.getArg());
-				result.setResult(value);
-				return true;
 			case MSG_GO_BACK:
 				getWebView().goBack();
 				return true;
@@ -86,59 +79,63 @@ public class WebViewProxy extends ViewProxy
 		}
 		return super.handleMessage(msg);
 	}
-	
+
 	@Kroll.method
 	public void setBasicAuthentication(String username, String password)
 	{
 		getWebView().setBasicAuthentication(username, password);
 	}
-	
+
 	@Kroll.method
-	public boolean canGoBack() {
+	public boolean canGoBack()
+	{
 		return getWebView().canGoBack();
 	}
-	
+
 	@Kroll.method
-	public boolean canGoForward() {
+	public boolean canGoForward()
+	{
 		return getWebView().canGoForward();
 	}
 	
 	@Kroll.method
-	public void goBack() {
+	public void goBack()
+	{
 		getUIHandler().sendEmptyMessage(MSG_GO_BACK);
 	}
-	
-	
+
 	@Kroll.method
-	public void goForward() {
+	public void goForward()
+	{
 		getUIHandler().sendEmptyMessage(MSG_GO_FORWARD);
 	}
-	
+
 	@Kroll.method
-	public void reload() {
+	public void reload()
+	{
 		getUIHandler().sendEmptyMessage(MSG_RELOAD);
 	}
-	
-	@Kroll.method
-	public void stopLoading() {
-		getUIHandler().sendEmptyMessage(MSG_STOP_LOADING);
 
+	@Kroll.method
+	public void stopLoading()
+	{
+		getUIHandler().sendEmptyMessage(MSG_STOP_LOADING);
 	}
-	
+
 	@Kroll.method @Kroll.getProperty
 	public int getPluginState()
 	{
 		int pluginState = TiUIWebView.PLUGIN_STATE_OFF;
-		
+
 		if (hasProperty(TiC.PROPERTY_PLUGIN_STATE)) {
 			pluginState = TiConvert.toInt(getProperty(TiC.PROPERTY_PLUGIN_STATE));
 		}
-		
+
 		return pluginState;
 	}
-	
+
 	@Kroll.method @Kroll.setProperty
-	public void setPluginState(int pluginState) 
+	public void setPluginState(int pluginState)
 	{
 		switch(pluginState) {
 			case TiUIWebView.PLUGIN_STATE_OFF :
@@ -150,36 +147,36 @@ public class WebViewProxy extends ViewProxy
 				setProperty(TiC.PROPERTY_PLUGIN_STATE, TiUIWebView.PLUGIN_STATE_OFF, true);
 		}
 	}
-	
+
 	@Kroll.method
 	public void pause() 
 	{
 		getWebView().pauseWebView();
 	}
-	
+
 	@Kroll.method
 	public void resume()
 	{
 		getWebView().resumeWebView();
 	}
-	
+
 	@Kroll.method(runOnUiThread=true) @Kroll.setProperty(runOnUiThread=true)
 	public void setEnableZoomControls(boolean enabled)
 	{
 		setProperty(TiC.PROPERTY_ENABLE_ZOOM_CONTROLS, enabled, true);
 	}
-	
+
 	@Kroll.method @Kroll.getProperty
 	public boolean getEnableZoomControls()
 	{
 		boolean enabled = true;
-		
+
 		if(hasProperty(TiC.PROPERTY_ENABLE_ZOOM_CONTROLS)) {
 			enabled = TiConvert.toBoolean(getProperty(TiC.PROPERTY_ENABLE_ZOOM_CONTROLS));
 		}
 		return enabled;
 	}
-	
+
 	@Override
 	public void releaseViews()
 	{
@@ -189,6 +186,5 @@ public class WebViewProxy extends ViewProxy
 		// if it's not there.
 		// So we're just overriding and not calling super.
 	}
-
 
 }


### PR DESCRIPTION
http://jira.appcelerator.org/browse/TIMOB-4885

Takes `evalJS` off of the main thread.

See [testing notes](http://jira.appcelerator.org/browse/TIMOB-4885?focusedCommentId=165920&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-165920).
