### PR TITLE
[TIMOB-5062][TIMOB-5279] Table memory usage improvements

### DIFF
--- a/iphone/Classes/ImageLoader.m
+++ b/iphone/Classes/ImageLoader.m
@@ -452,7 +452,7 @@ DEFINE_EXCEPTIONS
 				}
 			}
 #endif
-		    result = [self setImage:resultImage forKey:url cache:NO];
+		    result = [self setImage:resultImage forKey:url cache:YES];
 			[result setIsLocalImage:YES];
 		}
 	}

--- a/iphone/Classes/ImageLoader.m
+++ b/iphone/Classes/ImageLoader.m
@@ -452,7 +452,7 @@ DEFINE_EXCEPTIONS
 				}
 			}
 #endif
-		    result = [self setImage:resultImage forKey:url cache:YES];
+		    result = [self setImage:resultImage forKey:url cache:NO];
 			[result setIsLocalImage:YES];
 		}
 	}

--- a/iphone/Classes/TiUITableView.h
+++ b/iphone/Classes/TiUITableView.h
@@ -25,7 +25,7 @@
 	CGPoint hitPoint;
 }
 @property (nonatomic,readonly) CGPoint hitPoint;
-@property (nonatomic,readwrite) TiUITableViewRowProxy* proxy;
+@property (nonatomic,readwrite,assign) TiUITableViewRowProxy* proxy;
 
 -(id)initWithStyle:(UITableViewCellStyle)style_ reuseIdentifier:(NSString *)reuseIdentifier_ row:(TiUITableViewRowProxy*)row_;
 

--- a/iphone/Classes/TiUITableViewRowProxy.m
+++ b/iphone/Classes/TiUITableViewRowProxy.m
@@ -621,10 +621,18 @@ TiProxy * DeepScanForProxyOfViewContainingPoint(UIView * targetView, CGPoint poi
 +(void)clearTableRowCell:(UITableViewCell *)cell
 {
 	NSArray* cellSubviews = [[cell contentView] subviews];
+    
 	// Clear out the old cell view
 	for (UIView* view in cellSubviews) {
 		[view removeFromSuperview];
 	}
+    
+    // ... But that's not enough. We need to detatch the views
+    // for all children of the row, to clean up memory.
+    NSArray* children = [[(TiUITableViewCell*)cell proxy] children];
+    for (TiViewProxy* child in children) {
+        [child detachView];
+    }
 }
 
 -(void)configureChildren:(UITableViewCell*)cell

--- a/iphone/Classes/TiUITableViewRowProxy.m
+++ b/iphone/Classes/TiUITableViewRowProxy.m
@@ -273,6 +273,7 @@ TiProxy * DeepScanForProxyOfViewContainingPoint(UIView * targetView, CGPoint poi
 -(void)_destroy
 {
 	RELEASE_TO_NIL(tableClass);
+    [rowContainerView performSelectorOnMainThread:@selector(removeFromSuperview) withObject:nil waitUntilDone:NO];
 	[rowContainerView performSelectorOnMainThread:@selector(release) withObject:nil waitUntilDone:NO];
 	rowContainerView = nil;
 	[callbackCell setProxy:nil];
@@ -651,6 +652,7 @@ TiProxy * DeepScanForProxyOfViewContainingPoint(UIView * targetView, CGPoint poi
             [contentView setFrame:rect];
         }
 		rect.origin = CGPointZero;
+        [rowContainerView removeFromSuperview];
 		[rowContainerView release];
 		rowContainerView = [[TiUITableViewRowContainer alloc] initWithFrame:rect];
 		[rowContainerView setBackgroundColor:[UIColor clearColor]];
@@ -762,7 +764,6 @@ TiProxy * DeepScanForProxyOfViewContainingPoint(UIView * targetView, CGPoint poi
 				return;
 			}
 			
-			UIView* oldContainerView = [rowContainerView retain];
 			if (rowContainerView != aview) {
 				[rowContainerView release];
 				rowContainerView = [aview retain];


### PR DESCRIPTION
Fixes for table scrolling memory usage. Incurs a (very small) performance hit because views must now be re-created on the fly instead of having them available pre-created, but this is necessary for very large table views which use custom rows.
