### PR TITLE
[timob-5301]  In 'scrollViewDidEndDragging', perform 'handleNewKeyboardSt

### DIFF
--- a/iphone/Classes/TiUITableView.m
+++ b/iphone/Classes/TiUITableView.m
@@ -14,6 +14,7 @@
 #import "TiProxy.h"
 #import "TiViewProxy.h"
 #import "TiUITableViewProxy.h"
+#import "TiApp.h"
 
 #define DEFAULT_SECTION_HEADERFOOTER_HEIGHT 20.0
 

--- a/iphone/Classes/TiUITableView.m
+++ b/iphone/Classes/TiUITableView.m
@@ -2037,6 +2037,8 @@ if(ourTableView != tableview)	\
 		[event setObject:[TiUtils sizeToDictionary:tableview.bounds.size] forKey:@"size"];
 		[self.proxy fireEvent:@"scrollEnd" withObject:event];
 	}
+    // Update keyboard status to insure that any fields actively being edited remain in view
+    [[[TiApp app] controller] performSelector:@selector(handleNewKeyboardStatus) withObject:nil afterDelay:0.0];
 }
 
 - (void)scrollViewDidEndDecelerating:(UIScrollView *)scrollView 


### PR DESCRIPTION
[timob-5301]  In 'scrollViewDidEndDragging', perform 'handleNewKeyboardStatus' to insure actively edited fields are scrolled back into view.
