### PR TITLE
Here is a simple text chance pull request to update createFile API doc. 

### DIFF
--- a/apidoc/Titanium/Filesystem/File.yml
+++ b/apidoc/Titanium/Filesystem/File.yml
@@ -9,7 +9,7 @@ methods:
     returns:
         type: Boolean
   - name: createFile
-    description: create a file path at the path for the file object
+    description: create a file path at the path for the file object. (only implemented on iOS, the workaround on Android for the time being is to use write() which creates a file if it does not exsist already). 
     returns:
         type: Boolean
   - name: createTimestamp


### PR DESCRIPTION
I ran into this api not existing on Android on 1.8.x. I want to make sure no one else waist their time researching this.

Here is the android file that implements the File object. You can see that it does not have createFile
https://github.com/appcelerator/titanium_mobile/blob/master/android/modules/filesystem/src/ti/modules/titanium/filesystem/FilesystemModule.java

This is a post on Q/A forum. It is actually wrong. The getFile API does not create the file:
http://developer.appcelerator.com/question/117609/createfile-failing-on-android-21
