### PR TITLE
[TIMOB-5311] Fix for currentPage not updating until ended decelerating

### DIFF
--- a/iphone/Classes/TiUIScrollableView.m
+++ b/iphone/Classes/TiUIScrollableView.m
@@ -448,11 +448,12 @@
 {
 	//switch page control at 50% across the center - this visually looks better
     CGFloat pageWidth = scrollview.frame.size.width;
-    int page = [self currentPage];
+    int page = currentPage;
     int nextPage = floor((scrollview.contentOffset.x - pageWidth / 2) / pageWidth) + 1;
 	if (page != nextPage) {
 		[pageControl setCurrentPage:nextPage];
 		currentPage = nextPage;
+		[self.proxy replaceValue:NUMINT(currentPage) forKey:@"currentPage" notification:NO];
         [self manageCache:currentPage];
 	}
 }


### PR DESCRIPTION
[TIMOB-5311] Fix for currentPage not updating until ended decelerating

"scrollViewDidScroll" was grabbing the current page from its accessor, [self currentPage], but that method is not accurate -- the math in it dictates that if the content offset is _ANYWHERE_ on the first page, return the first page. It is more accurate to use the member variable "currentPage", which is updated when we actually go to another page. I also added in a call to update the proxy with the currentPage right at this point, so the dot and the currentPage property are perfectly in sync.
