### PR TITLE
[TIMOB-5326] Better "holding onto views" during detach

### DIFF
--- a/iphone/Classes/TiViewProxy.m
+++ b/iphone/Classes/TiViewProxy.m
@@ -1019,8 +1019,10 @@ LAYOUTPROPERTIES_SETTER(setMinHeight,minimumHeight,TiFixedValueRuleFromObject,[s
 	if (view!=nil)
 	{
 		[self viewWillDetach];
-		// hold the view during detachment
-		[[view retain] autorelease];
+		// hold the view during detachment -- but we can't release it immediately.
+        // What if it (or a subview, such as a tableview) is in the middle of an animation?
+        // We probably need to be even MORE careful here.
+		[[view retain] performSelector:@selector(autorelease) withObject:nil afterDelay:0.5];
 		view.proxy = nil;
 		if (self.modelDelegate!=nil && [self.modelDelegate respondsToSelector:@selector(detachProxy)])
 		{


### PR DESCRIPTION
We need to be holding onto a view for a little longer than we might like during the detach step, just in case it's in the middle of an animation (or other operation) currently queued on the main runloop.
