### PR TITLE
[TIMOB-3291] Better bar button cleanup

### DIFF
--- a/iphone/Classes/TiUIButtonProxy.m
+++ b/iphone/Classes/TiUIButtonProxy.m
@@ -101,6 +101,7 @@
 -(void)removeBarButtonView
 {
 	RELEASE_TO_NIL(button);
+    [super removeBarButtonView];
 }
 
 -(void)setToolbar:(TiToolbar*)toolbar_

--- a/iphone/Classes/TiUINavBarButton.h
+++ b/iphone/Classes/TiUINavBarButton.h
@@ -6,15 +6,16 @@
  */
 #ifdef USE_TI_UIBUTTON
 
-#import "TiProxy.h"
+#import "TiViewProxy.h"
 
 @class TiUIView;
 
 @interface TiUINavBarButton : UIBarButtonItem<TiProxyDelegate> {
 @private
-	TiProxy *proxy;
+	TiViewProxy *proxy;
 	TiUIView *activityDelegate;
 }
+@property(nonatomic,readonly) TiViewProxy* proxy;
 
 -(id)initWithProxy:(TiProxy*)proxy;
 

--- a/iphone/Classes/TiUINavBarButton.m
+++ b/iphone/Classes/TiUINavBarButton.m
@@ -18,6 +18,7 @@
 #define NAVBAR_MEMORY_DEBUG 0
 
 @implementation TiUINavBarButton
+@synthesize proxy;
 
 DEFINE_EXCEPTIONS
 

--- a/iphone/Classes/TiUIWindowProxy.m
+++ b/iphone/Classes/TiUIWindowProxy.m
@@ -354,9 +354,9 @@
 		{
 			// detach existing one
 			UIBarButtonItem *item = controller.navigationItem.rightBarButtonItem;
-			if (item!=nil && [item isKindOfClass:[TiViewProxy class]])
+			if ([item respondsToSelector:@selector(proxy)])
 			{
-				[(TiViewProxy*)item removeBarButtonView];
+				[(TiViewProxy*)[item proxy] removeBarButtonView];
 			}
 			if (proxy!=nil)
 			{
@@ -400,9 +400,9 @@
 		{
 			// detach existing one
 			UIBarButtonItem *item = controller.navigationItem.leftBarButtonItem;
-			if (item!=nil && [item isKindOfClass:[TiViewProxy class]])
+			if ([item respondsToSelector:@selector(proxy)])
 			{
-				[(TiViewProxy*)item removeBarButtonView];
+				[(TiViewProxy*)[item proxy] removeBarButtonView];
 			}
 			controller.navigationItem.leftBarButtonItem = nil;			
 			if (proxy!=nil)
@@ -618,9 +618,9 @@
 		{
 			for (id current in existing)
 			{
-				if ([current isKindOfClass:[TiViewProxy class]])
+				if ([current respondsToSelector:@selector(proxy)])
 				{
-					[(TiViewProxy*)current removeBarButtonView];
+					[(TiViewProxy*)[current proxy] removeBarButtonView];
 				}
 			}
 		}
@@ -769,6 +769,23 @@ else{\
 	}
 }
 
+-(void)cleanupWindowDecorations
+{
+    if (controller != nil) {
+        UIBarButtonItem *item = controller.navigationItem.leftBarButtonItem;
+        if ([item respondsToSelector:@selector(proxy)])
+        {
+            [(TiViewProxy*)[item proxy] removeBarButtonView];
+        }
+        
+        item = controller.navigationItem.rightBarButtonItem;
+        if ([item respondsToSelector:@selector(proxy)]) 
+        {
+            [(TiViewProxy*)[item proxy] removeBarButtonView];
+        }
+    }
+}
+
 -(void)_tabBeforeFocus
 {
 	if (focused==NO)
@@ -780,6 +797,9 @@ else{\
 
 -(void)_tabBeforeBlur
 {
+    if (focused==YES) {
+        [self cleanupWindowDecorations];
+    }
 	[barImageView removeFromSuperview];
 	[super _tabBeforeBlur];
 }


### PR DESCRIPTION
We need to be appropriately cleaning up the bar button items when they're replaced, and on window blur. It turns out that the handling code for removing bar button items was legacy back from when they were (apparently) proxies instead of UI elements.
