### PR TITLE
[TIMOB-5335] Manage spinlocks when in a memory panic.

### DIFF
--- a/iphone/Classes/KrollBridge.mm
+++ b/iphone/Classes/KrollBridge.mm
@@ -213,26 +213,55 @@ CFMutableSetRef	krollBridgeRegistry = nil;
 {
 	if (registeredProxies != NULL) {
 		BOOL keepWarning = YES;
-		int proxiesCount = CFDictionaryGetCount(registeredProxies);
+        BOOL holdingLock = NO; // Keep track of whether or not the enumeration loop holds the lock
 		
+        OSSpinLockLock(&proxyLock);
+		int proxiesCount = CFDictionaryGetCount(registeredProxies);
+        OSSpinLockUnlock(&proxyLock);
+        
 		//During a memory panic, we may not get the chance to copy proxies.
 		while (keepWarning)
 		{
 			keepWarning = NO;
+            
 			for (id proxy in (NSDictionary *)registeredProxies)
 			{
+                // Have to put this here, due to how fast enumeration is unrolled... we
+                // absolutely CAN'T allow the possibility that registeredProxies was screwed
+                // with between the end of the loop statement, and the check for mutation.
+                // See http://networkpx.blogspot.com/2009/07/analyzing-objective-cs-for-in-loop-fast.html
+                // for fun details on NSFastEnumeration unrolling in GCC. Could LLVM make this less dumb?
+                
+                if (holdingLock) {
+                    OSSpinLockUnlock(&proxyLock);
+                }
+                
 				[proxy didReceiveMemoryWarning:notification];
 				if (registeredProxies == NULL) {
+                    holdingLock = NO;
 					break;
 				}
+                
+                OSSpinLockLock(&proxyLock);
 				int newCount = CFDictionaryGetCount(registeredProxies);
+                OSSpinLockUnlock(&proxyLock);
+                
 				if (newCount != proxiesCount)
 				{
 					proxiesCount = newCount;
 					keepWarning = YES;
+                    holdingLock = NO;
 					break;
 				}
+                
+                // ... See above for why we have to spinlock here.
+                OSSpinLockLock(&proxyLock);
+                holdingLock = YES;
 			}
+            
+            if (holdingLock) {
+                OSSpinLockUnlock(&proxyLock);
+            }
 		}
 	}
 	


### PR DESCRIPTION
We have to watch the proxy spinlock when in a memory panic, because it turns out that jetsam really does not care how many threads we have running, and the OS will keep scheduling them for us as it sees fit (see the bug report crash for a fun lesson on this, and how the real root cause is that we need to reduce threading).
