### PR TITLE
[TIMOB-5337] Prevent messages being sent to deallocated UIControl in UIBarButtonItem

### DIFF
--- a/iphone/Classes/TiUIButtonProxy.m
+++ b/iphone/Classes/TiUIButtonProxy.m
@@ -46,10 +46,12 @@
 	}
 	*/
     
-	if (button==nil)
+	if (button==nil || !isUsingBarButtonItem)
 	{
 		isUsingBarButtonItem = YES;
-		button = [[TiUINavBarButton alloc] initWithProxy:self];
+        if (button == nil) {
+            button = [[TiUINavBarButton alloc] initWithProxy:self];
+        }
 	}
 	return button;
 }

--- a/iphone/Classes/TiUIButtonProxy.m
+++ b/iphone/Classes/TiUIButtonProxy.m
@@ -100,7 +100,11 @@
 
 -(void)removeBarButtonView
 {
-	RELEASE_TO_NIL(button);
+    // If we remove the button here, it could be the case that the system
+    // sends a message to a released UIControl on the interior of the button,
+    // causing a crash. Very timing-dependent.
+    
+    //	RELEASE_TO_NIL(button);
     [super removeBarButtonView];
 }
 

--- a/iphone/Classes/TiUIWindowProxy.m
+++ b/iphone/Classes/TiUIWindowProxy.m
@@ -777,14 +777,12 @@ else{\
         {
             [(TiViewProxy*)[item proxy] removeBarButtonView];
         }
-        controller.navigationItem.rightBarButtonItem = nil;
         
         item = controller.navigationItem.rightBarButtonItem;
         if ([item respondsToSelector:@selector(proxy)]) 
         {
             [(TiViewProxy*)[item proxy] removeBarButtonView];
         }
-        controller.navigationItem.rightBarButtonItem = nil;
     }
 }
 

--- a/iphone/Classes/TiUIWindowProxy.m
+++ b/iphone/Classes/TiUIWindowProxy.m
@@ -777,12 +777,14 @@ else{\
         {
             [(TiViewProxy*)[item proxy] removeBarButtonView];
         }
+        controller.navigationItem.rightBarButtonItem = nil;
         
         item = controller.navigationItem.rightBarButtonItem;
         if ([item respondsToSelector:@selector(proxy)]) 
         {
             [(TiViewProxy*)[item proxy] removeBarButtonView];
         }
+        controller.navigationItem.rightBarButtonItem = nil;
     }
 }
 


### PR DESCRIPTION
We can't ever deallocate a UIBarButtonItem until it is **guaranteed** to be unable to be reached (i.e. absolutely, unquestionably, offscreen AND with no UIEvents queued in the main loop for it while it IS offscreen). Holding onto the button does not impact memory or performance in any significant way.

Also, it doesn't hurt to force the navigation item to dump its reference to the button to prevent this situation as frequently as possible.
