### PR TITLE
[TIMOB-5352] Image caching system rewrite

### DIFF
--- a/iphone/Classes/AnalyticsModule.m
+++ b/iphone/Classes/AnalyticsModule.m
@@ -448,6 +448,7 @@ NSString * const TI_DB_VERSION = @"1";
 -(void)enroll
 {
 	// don't let analytics ever crash the app
+    NSAutoreleasePool* pool = [[NSAutoreleasePool alloc] init];
 	@try 
 	{
 		// if not online (since we need some stuff), re-queue for later
@@ -455,7 +456,7 @@ NSString * const TI_DB_VERSION = @"1";
 		if ([TiUtils boolValue:online]==NO)
 		{
 			NSLog(@"[DEBUG] attempted to enroll, but we're offline. will try again in 10s");
-			[self performSelector:@selector(entroll) withObject:nil afterDelay:10];
+			[self performSelector:@selector(enroll) withObject:nil afterDelay:10];
 			return;
 		}
 		
@@ -479,6 +480,9 @@ NSString * const TI_DB_VERSION = @"1";
 	{
 		NSLog(@"[ERROR] Error sending analytics event. %@",e);
 	}
+    @finally {
+        [pool release];
+    }
 }
 
 -(void)begin

--- a/iphone/Classes/ImageLoader.h
+++ b/iphone/Classes/ImageLoader.h
@@ -53,9 +53,9 @@ typedef enum {
 
 @end
 
-@interface ImageLoader : NSObject {
+@interface ImageLoader : NSObject<NSCacheDelegate> {
 @private
-	NSMutableDictionary *cache;
+	NSCache *cache;
 	ASINetworkQueue* queue;
 	NSMutableArray* timeout;
 	NSRecursiveLock* lock;
@@ -74,8 +74,6 @@ typedef enum {
 -(ImageLoaderRequest*)loadImage:(NSURL*)url 
 					   delegate:(NSObject<ImageLoaderDelegate>*)delegate 
 					   userInfo:(NSDictionary*)userInfo;
-
--(BOOL)purgeEntry:(NSURL*)url;
 
 -(void)suspend;
 -(void)resume;

--- a/iphone/Classes/TiBase.h
+++ b/iphone/Classes/TiBase.h
@@ -446,7 +446,8 @@ return value;\
 #define STRING(x) _QUOTEME(x)
  
 #define TI_VERSION_STR STRING(TI_VERSION)
- 
+
+//#define VERBOSE
 
 #ifdef VERBOSE
 

--- a/iphone/Classes/TiFilesystemFileProxy.m
+++ b/iphone/Classes/TiFilesystemFileProxy.m
@@ -30,6 +30,7 @@
 -(void)dealloc
 {
 	RELEASE_TO_NIL(fm);
+    RELEASE_TO_NIL(path);
 	[super dealloc];
 }
 

--- a/iphone/Classes/TiUIImageViewProxy.m
+++ b/iphone/Classes/TiUIImageViewProxy.m
@@ -106,8 +106,6 @@ static NSArray* imageKeySequence;
 	RELEASE_TO_NIL(urlRequest);
     [self replaceValue:nil forKey:@"image" notification:NO];
     
-    // Purge needs to happen AFTER we've released the ref to 'image', so that the cache knows it can unload the information
-    BOOL released = [[ImageLoader sharedLoader] purgeEntry:imageURL];
     RELEASE_TO_NIL(imageURL);
 	[super dealloc];
 }

--- a/iphone/Classes/TiUtils.h
+++ b/iphone/Classes/TiUtils.h
@@ -217,4 +217,7 @@ typedef enum {
 
 +(int)encodeNumber:(NSNumber*)data toBuffer:(TiBuffer*)dest offset:(int)position type:(NSString*)type endianness:(CFByteOrder)byteOrder;
 
++(NSString*)md5:(NSData*)data;
+
++(NSString*)convertToHex:(unsigned char*)result length:(size_t)length;
 @end

--- a/iphone/Classes/TiUtils.m
+++ b/iphone/Classes/TiUtils.m
@@ -5,6 +5,7 @@
  * Please see the LICENSE included with this distribution for details.
  */
 #import <QuartzCore/QuartzCore.h>
+#import <CommonCrypto/CommonDigest.h>
 
 #import "TiBase.h"
 #import "TiUtils.h"
@@ -1560,6 +1561,24 @@ if ([str isEqualToString:@#orientation]) return orientation;
     }
     
     return (position+size);
+}
+
++(NSString*)convertToHex:(unsigned char*)result length:(size_t)length
+{
+	NSMutableString* encoded = [[NSMutableString alloc] initWithCapacity:length];
+	for (int i=0; i < length; i++) {
+		[encoded appendFormat:@"%02x",result[i]];
+	}
+	NSString* value = [encoded lowercaseString];
+	[encoded release];
+	return value;
+}
+
++(NSString*)md5:(NSData*)data
+{
+	unsigned char result[CC_MD5_DIGEST_LENGTH];
+	CC_MD5([data bytes], [data length], result);
+	return [self convertToHex:(unsigned char*)&result length:CC_MD5_DIGEST_LENGTH];    
 }
 
 @end

--- a/iphone/Classes/UtilsModule.m
+++ b/iphone/Classes/UtilsModule.m
@@ -11,6 +11,7 @@
 #import "Base64Transcoder.h"
 #import "TiBlob.h"
 #import "TiFile.h"
+#import "TiUtils.h"
 #import <CommonCrypto/CommonDigest.h>
 #import <CommonCrypto/CommonHMAC.h>
 
@@ -27,17 +28,6 @@
 		return [(TiBlob*)arg text];
 	}
 	THROW_INVALID_ARG(@"invalid type");
-}
-
--(NSString*)convertToHex:(unsigned char*)result length:(size_t)length
-{
-	NSMutableString* encoded = [[NSMutableString alloc] initWithCapacity:length];
-	for (int i=0; i < length; i++) {
-		[encoded appendFormat:@"%02x",result[i]];
-	}
-	NSString* value = [encoded lowercaseString];
-	[encoded release];
-	return value;
 }
 
 #pragma mark Public API
@@ -104,10 +94,8 @@
 	ENSURE_SINGLE_ARG(args,NSObject);
 	
 	NSString *nstr = [self convertToString:args];
-	const char* str = [nstr UTF8String];
-	unsigned char result[CC_MD5_DIGEST_LENGTH];
-	CC_MD5(str, strlen(str), result);
-	return [self convertToHex:(unsigned char*)&result length:CC_MD5_DIGEST_LENGTH];
+    const char* data = [nstr UTF8String];
+    return [TiUtils md5:[NSData data:data length:strlen(data)]];
 }
 
 -(id)sha1:(id)args
@@ -117,7 +105,7 @@
 	const char *cStr = [nstr UTF8String];
 	unsigned char result[CC_SHA1_DIGEST_LENGTH];
 	CC_SHA1(cStr, [nstr lengthOfBytesUsingEncoding:NSUTF8StringEncoding], result);
-	return [self convertToHex:(unsigned char*)&result length:CC_SHA1_DIGEST_LENGTH];
+	return [TiUtils convertToHex:(unsigned char*)&result length:CC_SHA1_DIGEST_LENGTH];
 }
 
 @end


### PR DESCRIPTION
Rewrite of our image caching system, to use NSCache and properly prefetch cached remote images from storage.

Minor fixes:
- Fixed typo in Analytics, and added a release pool there, just in case...
- Migrated MD5 checksum creation to TiUtils, for use by image loader in addition to utils
- Released instance variables of FileProxy correctly

---

Please test rigorously, using the tests provided on the jira ticket. Review is also crucial; we have now had at least one version of the image cache which did not properly lazy-fetch or prefetch.
