### PR TITLE
[TIMOB-5352] Fix for typo introduced in UtilsModule

### DIFF
--- a/iphone/Classes/UtilsModule.m
+++ b/iphone/Classes/UtilsModule.m
@@ -95,7 +95,7 @@
 	
 	NSString *nstr = [self convertToString:args];
     const char* data = [nstr UTF8String];
-    return [TiUtils md5:[NSData data:data length:strlen(data)]];
+    return [TiUtils md5:[NSData dataWithBytes:data length:strlen(data)]];
 }
 
 -(id)sha1:(id)args


### PR DESCRIPTION
Minor fix; use ticket 5352 for tracking. Includes repo steps for how this bug was uncovered.

The fact that this wasn't noticed as a build-time warning is a good indicator that we need to drastically reduce the amount of generated warnings in our code.
