### PR TITLE
TIMOB 5351: Try to eliminate or at least reduce race conditions caused by

### DIFF
--- a/iphone/Classes/TiUITabProxy.h
+++ b/iphone/Classes/TiUITabProxy.h
@@ -24,6 +24,7 @@
 	TiWindowProxy *closingWindow;
 	BOOL opening;
 	BOOL systemTab;
+	BOOL transitionIsAnimating;
 	
 	id<TiOrientationController> parentOrientationController;
 }

--- a/iphone/Classes/TiUITabProxy.m
+++ b/iphone/Classes/TiUITabProxy.m
@@ -152,6 +152,7 @@
 
 - (void)navigationController:(UINavigationController *)navigationController willShowViewController:(UIViewController *)viewController animated:(BOOL)animated
 {
+	transitionIsAnimating = YES;
 	if (current==viewController)
 	{
 		return;
@@ -161,6 +162,7 @@
 
 - (void)navigationController:(UINavigationController *)navigationController didShowViewController:(UIViewController *)viewController animated:(BOOL)animated
 {
+	transitionIsAnimating = NO;
 	[self handleDidShowViewController:viewController];
 }
 
@@ -221,6 +223,11 @@
 
 -(void)openOnUIThread:(NSArray*)args
 {
+	if (transitionIsAnimating)
+	{
+		[self performSelector:_cmd withObject:args afterDelay:0.1];
+		return;
+	}
 	TiWindowProxy *window = [args objectAtIndex:0];
 	BOOL animated = args!=nil && [args count] > 1 ? [TiUtils boolValue:@"animated" properties:[args objectAtIndex:1] def:YES] : YES;
 	TiUITabController *root = [[TiUITabController alloc] initWithProxy:window tab:self];


### PR DESCRIPTION
TIMOB 5351: Try to eliminate or at least reduce race conditions caused by opening one window and closing another at the same time on one tab. Test is in Jira.
