### PR TITLE
[TIMOB-5380] ENSURE_UI_THREAD() should run in common modes

### DIFF
--- a/iphone/Classes/TiThreading.h
+++ b/iphone/Classes/TiThreading.h
@@ -25,7 +25,7 @@ return; \
 
 #define ENSURE_UI_THREAD(x,y) \
 if (![NSThread isMainThread]) { \
-[self performSelectorOnMainThread:@selector(x:) withObject:y waitUntilDone:WAIT_UNTIL_DONE_ON_UI_THREAD]; \
+[self performSelectorOnMainThread:@selector(x:) withObject:y waitUntilDone:WAIT_UNTIL_DONE_ON_UI_THREAD modes:[NSArray arrayWithObject:NSRunLoopCommonModes]]; \
 return; \
 } \
 


### PR DESCRIPTION
Doing so prevents autorelease starvation. Apparently the runloop system doesn't like it when you have a bunch of stuff queued for default mode, and a bunch of stuff queued for other modes, and alternates between the two until it's satisfied (or gets a memory panic).
