### PR TITLE
TIMOB-5378: In the event that RootViewController's view was unloaded reload

### DIFF
--- a/iphone/Classes/TiRootViewController.m
+++ b/iphone/Classes/TiRootViewController.m
@@ -292,6 +292,13 @@
 		[self rotateDefaultImageViewToOrientation:UIInterfaceOrientationPortrait];
 		[rootView addSubview:defaultImageView];
 	}
+	//In the event that we are reloading the view due to memory panic.
+	for (TiWindowProxy * thisProxy in windowProxies)
+	{
+		UIView * thisView = [thisProxy view];
+		[rootView addSubview:thisView];
+		[thisProxy reposition];
+	}
 	[rootView release];
 }
 


### PR DESCRIPTION
TIMOB-5378: In the event that RootViewController's view was unloaded, we should reinstate windows on load.
