### PR TITLE
WebView zoom control fix for issue: TIMOB-4844

### DIFF
--- a/android/modules/ui/src/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
+++ b/android/modules/ui/src/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
@@ -84,16 +84,15 @@ public class TiUIWebView extends TiUIView {
 		settings.setJavaScriptEnabled(true);
 		settings.setSupportMultipleWindows(true);
 		settings.setJavaScriptCanOpenWindowsAutomatically(true);
-		settings.setSupportZoom(true);
 		settings.setLoadsImagesAutomatically(true);
 		settings.setLightTouchEnabled(true);
 		
+		boolean enableZoom = true;  // enable zoom controls by default
 		if(proxy.hasProperty(TiC.PROPERTY_ENABLE_ZOOM_CONTROLS)) {
-			settings.setBuiltInZoomControls(TiConvert.toBoolean(proxy.getProperty(TiC.PROPERTY_ENABLE_ZOOM_CONTROLS)));
-		} else {
-			// enable zoom controls by default
-			settings.setBuiltInZoomControls(true);
+			enableZoom = TiConvert.toBoolean(proxy.getProperty(TiC.PROPERTY_ENABLE_ZOOM_CONTROLS));
 		}
+		settings.setBuiltInZoomControls(enableZoom);
+		settings.setSupportZoom(enableZoom);
 		
 		// We can only support webview settings for plugin/flash in API 8 and higher.
 		if (Build.VERSION.SDK_INT > Build.VERSION_CODES.ECLAIR_MR1) {


### PR DESCRIPTION
Set supportsZoom on WebView to same value as setBuiltInZoomControls to ensure WebView zoom controls enabled/disaled for all devices.
See: http://jira.appcelerator.org/browse/TIMOB-4844
