### PR TITLE
TIMOB-5405 Unregistering background services must check to see to alert.

### DIFF
--- a/iphone/Classes/TiApp.mm
+++ b/iphone/Classes/TiApp.mm
@@ -683,7 +683,6 @@ TI_INLINE void waitForMemoryPanicCleared();   //WARNING: This must never be run 
 		dispatch_async(dispatch_get_main_queue(), ^{
 			if (bgTask != UIBackgroundTaskInvalid)
 			{
-				NSLog(@"Ending background task %X %@",bgTask,CODELOCATION);
 				[[UIApplication sharedApplication] endBackgroundTask:bgTask];
 				bgTask = UIBackgroundTaskInvalid;
 			}


### PR DESCRIPTION
TIMOB-5405 Unregistering background services must check to see to alert iOS that we're done.
