### PR TITLE
TIMOB-5426 Default behavior for device is to report machine name precisely.

### DIFF
--- a/iphone/Classes/PlatformModule.m
+++ b/iphone/Classes/PlatformModule.m
@@ -92,7 +92,7 @@ NSString* const DATA_IFACE = @"pdp_ip0";
 		}
 		else 
 		{
-			model = [themodel retain];
+			model = [[NSString alloc] initWithUTF8String:u.machine];
 		}
 		architecture = [arch retain];
 


### PR DESCRIPTION
TIMOB-5426 Default behavior for device is to report machine name more precisely.
