### PR TITLE
[TIMOB-5380] Back out dangerous changes, fix synchronization

### DIFF
--- a/iphone/Classes/KrollContext.mm
+++ b/iphone/Classes/KrollContext.mm
@@ -1123,9 +1123,9 @@ static TiValueRef StringFormatDecimalCallback (TiContextRef jsContext, TiObjectR
 		loopCount++;
 		
 		// if we're suspended, we simply wait for resume
+        [condition lock];
 		if (suspended)
 		{
-			[condition lock];
 			//TODO: Suspended currently only is set on app pause/resume. We should have it happen whenever a JS thread
 			//should be paused. Paused being no timers waiting, no events being triggered, no code to execute.
 			if (suspended && ([queue count] == 0))
@@ -1134,15 +1134,18 @@ static TiValueRef StringFormatDecimalCallback (TiContextRef jsContext, TiObjectR
 				[condition wait];
 				VerboseLog(@"Resumed! %@",self)
 			} 
-			[condition unlock];
 		}
+        [condition unlock];
 		
 		// we're stopped, we need to check to see if we have stuff that needs to
 		// be executed before we can exit.  if we have stuff in the queue, we 
 		// process just those events and then we immediately exit and clean up
 		// otherwise, we can just exit immediately from here
+
+        [condition lock];
 		if (stopped)
 		{
+            [condition unlock];
 			exit_after_flush = YES;
 			int queue_count = 0;
 			
@@ -1161,6 +1164,10 @@ static TiValueRef StringFormatDecimalCallback (TiContextRef jsContext, TiObjectR
 				break;
 			}
 		}
+        // If this is the case, then we were not halted, and must unlock the condition.
+        if (!exit_after_flush) {
+            [condition unlock];
+        }
 
 		BOOL stuff_in_queue = YES;
 		int internalLoopCount = 0;
@@ -1224,7 +1231,7 @@ static TiValueRef StringFormatDecimalCallback (TiContextRef jsContext, TiObjectR
 					entry = nil;
 				}				
 			}
-            [pool_ drain];
+            [pool_ release];
 		}
 
 		// TODO: experiment, attempt to collect more often than usual given our environment

--- a/iphone/Classes/TiUITableView.m
+++ b/iphone/Classes/TiUITableView.m
@@ -44,6 +44,18 @@
 	[super dealloc];
 }
 
+-(void)setProxy:(TiUITableViewRowProxy *)proxy_
+{
+    if (proxy == proxy_) {
+        return;
+    }
+    
+    if ([proxy callbackCell] == self) {
+        [proxy setCallbackCell:nil];
+    }
+    proxy = proxy_;
+}
+
 -(CGSize)computeCellSize
 {
     CGFloat width = 0;

--- a/iphone/Classes/TiUITableView.m
+++ b/iphone/Classes/TiUITableView.m
@@ -38,6 +38,8 @@
 
 -(void)dealloc
 {
+    [proxy setCallbackCell:nil];
+    
 	RELEASE_TO_NIL(gradientLayer);
 	RELEASE_TO_NIL(backgroundGradient);
 	RELEASE_TO_NIL(selectedBackgroundGradient);

--- a/iphone/Classes/TiUITableView.m
+++ b/iphone/Classes/TiUITableView.m
@@ -399,27 +399,6 @@
 	{
 		if ([section parent] == ourProxy)
 		{
-            // Due to the "traditional" way of aligning data in the stack in Titanium apps
-            // (creating rows, then passing an array of them into setData()) it would take
-            // TWO garbage collection passes to collect rows when a section is removed
-            // (one pass to remove the section, and then an additional pass to remove the
-            // newly freed rows that appear earlier on the stack).
-            // We want to avoid that, and should forget the rows on a section before it's
-            // deallocated, to take advantage of aggressive GC and better handle memory warnings.
-            // For apps with lots of rows, this makes a HUGE difference and can determine
-            // whether jetsam kills with an L2 or the app is blessed to continue.
-            // 
-            // This isn't an issue if row r_1 is used in both section_a and section_b, where
-            // tableView.setData(section_b) replaces tableView.data == section_a. This is
-            // because section_b remembers the row proxies before section_a forgets them,
-            // keeping memory consistent where required.
-            
-            for (TiUITableViewRowProxy* row in [section rows]) {
-                [row setTable:nil];
-                [row setSection:nil];
-                [section forgetProxy:row];
-            }
-            
 			[section setTable:nil];
 			[section setParent:nil];
 			[self.proxy forgetProxy:section];

--- a/iphone/Classes/TiUITableViewRowProxy.h
+++ b/iphone/Classes/TiUITableViewRowProxy.h
@@ -47,7 +47,7 @@ typedef enum
 @property(nonatomic,readwrite,assign) TiUITableView *table;
 @property(nonatomic,readwrite,assign) TiUITableViewSectionProxy *section;
 @property(nonatomic,readwrite,assign) NSInteger row;
-@property(nonatomic,readwrite,retain) TiUITableViewCell* callbackCell;
+@property(nonatomic,readwrite,assign) TiUITableViewCell* callbackCell;
 
 +(void)clearTableRowCell:(UITableViewCell*)cell;
 -(void)initializeTableViewCell:(UITableViewCell*)cell;

--- a/iphone/Classes/TiUITableViewRowProxy.m
+++ b/iphone/Classes/TiUITableViewRowProxy.m
@@ -258,16 +258,17 @@ TiProxy * DeepScanForProxyOfViewContainingPoint(UIView * targetView, CGPoint poi
 
 -(void)setCallbackCell:(TiUITableViewCell *)newValue
 {
+    // Don't want to set our callback's proxy to nil accidentally
 	if (newValue == callbackCell)
 	{
 		return;
 	}
+    
 	if ([callbackCell proxy] == self)
 	{
 		[callbackCell setProxy:nil];
 	}
-	[callbackCell release];
-	callbackCell = [newValue retain];
+    callbackCell = newValue;
 }
 
 -(void)_destroy
@@ -277,7 +278,6 @@ TiProxy * DeepScanForProxyOfViewContainingPoint(UIView * targetView, CGPoint poi
 	[rowContainerView performSelectorOnMainThread:@selector(release) withObject:nil waitUntilDone:NO];
 	rowContainerView = nil;
 	[callbackCell setProxy:nil];
-	[callbackCell performSelectorOnMainThread:@selector(release) withObject:nil waitUntilDone:NO];
 	callbackCell = nil;
 	[super _destroy];
 }

--- a/iphone/Classes/TiUITableViewRowProxy.m
+++ b/iphone/Classes/TiUITableViewRowProxy.m
@@ -256,21 +256,6 @@ TiProxy * DeepScanForProxyOfViewContainingPoint(UIView * targetView, CGPoint poi
 
 @synthesize tableClass, table, section, row, callbackCell;
 
--(void)setCallbackCell:(TiUITableViewCell *)newValue
-{
-    // Don't want to set our callback's proxy to nil accidentally
-	if (newValue == callbackCell)
-	{
-		return;
-	}
-    
-	if ([callbackCell proxy] == self)
-	{
-		[callbackCell setProxy:nil];
-	}
-    callbackCell = newValue;
-}
-
 -(void)_destroy
 {
 	RELEASE_TO_NIL(tableClass);

--- a/iphone/Classes/TiUITableViewSectionProxy.m
+++ b/iphone/Classes/TiUITableViewSectionProxy.m
@@ -27,7 +27,6 @@
 		{
 			[thisRow setParent:nil];
             [thisRow setSection:nil];
-            [self forgetProxy:thisRow];
 		}
 	}
 	RELEASE_TO_NIL(rows);


### PR DESCRIPTION
Backs out the forgetProxy: of rows in section deallocation (turns out this is dangerous, and even generates a [FATAL] warning). Also, fixes a very serious issue where suspend/resume was not synchronized correctly in Kroll due to improper use of the condition lock. This was leading to inaccurate GC and possibly even dropping (or simply not running) events after resuming.

As a bonus, also resolves holding onto table view cells for an indefinite period.
