### PR TITLE
[TIMOB-5465] Maintain local nav controller stack in tabs

### DIFF
--- a/iphone/Classes/TiUITabProxy.h
+++ b/iphone/Classes/TiUITabProxy.h
@@ -21,7 +21,10 @@
 	
 	TiUITabGroupProxy *tabGroup;
 	TiUITabController *current;
-	TiWindowProxy *closingWindow;
+    
+    NSArray* controllerStack;
+    NSMutableArray* closingWindows;
+    
 	BOOL opening;
 	BOOL systemTab;
 	BOOL transitionIsAnimating;


### PR DESCRIPTION
We need to maintain a local nav controller stack in order to appropriately pop/close windows when engaging in certain types of tab behavior, such as popping to the root controller without transitioning through other views (as happens when clicking a tab, opening windows in it, and then clicking the tab again).
