### PR TITLE
TIMOB-5494 Making app properties not remember properties that where set wa

### DIFF
--- a/iphone/Classes/TiApp.mm
+++ b/iphone/Classes/TiApp.mm
@@ -186,7 +186,6 @@ TI_INLINE void waitForMemoryPanicCleared();   //WARNING: This must never be run 
 //To load application Defaults 
 - (void) loadUserDefaults
 {
-	[[NSUserDefaults standardUserDefaults] setPersistentDomain:[NSDictionary dictionary] forName:[[NSBundle mainBundle] bundleIdentifier]];
 	NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
 	NSDictionary *appDefaults = [[NSDictionary alloc] initWithDictionary:[ApplicationDefaults copyDefaults]];
 	if(appDefaults)


### PR DESCRIPTION
Caused due to timob-4696 ( picking up app properties from tiapp.xml. )

Check jira for testing code.
