### PR TITLE
[TIMOB-5449] KrollCallback should check to see the context is still valid

### DIFF
--- a/iphone/Classes/KrollCallback.h
+++ b/iphone/Classes/KrollCallback.h
@@ -8,6 +8,7 @@
 #import "TiCore.h"
 #import "KrollContext.h"
 
+@class KrollBridge;
 //
 // KrollCallback is a wrapper around a JS function object which is passed
 // from JS land to native.  This object can be passed around on the native
@@ -20,6 +21,7 @@
 	TiObjectRef thisObj;
 	TiObjectRef function;
 	KrollContext *context;
+	KrollBridge * bridge;
 	NSLock* contextLock;
 	NSString *type;
 }


### PR DESCRIPTION
[TIMOB-5449] KrollCallback should check to see the context is still valid upon release.
