### PR TITLE
[timob-5835]  Eliminate jsmin phase of compiler.py

### DIFF
--- a/support/iphone/compiler.py
+++ b/support/iphone/compiler.py
@@ -429,7 +429,6 @@ class Compiler(object):
 	@classmethod	
 	def make_function_from_file(cls,path,file,instance):
 		file_contents = open(os.path.expanduser(file)).read()
-		file_contents = jspacker.jsmin(file_contents)
 		file_contents = file_contents.replace('Titanium.','Ti.')
 		instance.compile_js(file_contents)
 

--- a/support/iphone/compiler.py
+++ b/support/iphone/compiler.py
@@ -144,6 +144,7 @@ def parse_xcconfig(xcconfig, moduleId, variables):
 class Compiler(object):
 	
 	def __init__(self,project_dir,appid,name,deploytype,xcode,devicefamily,iphone_version,silent=False,sdk=None):
+		self.deploytype = deploytype
 		self.project_dir = project_dir
 		self.project_name = name
 		self.appid = appid
@@ -429,6 +430,8 @@ class Compiler(object):
 	@classmethod	
 	def make_function_from_file(cls,path,file,instance):
 		file_contents = open(os.path.expanduser(file)).read()
+		if instance.deploytype == 'production':
+			file_contents = jspacker.jsmin(file_contents)
 		file_contents = file_contents.replace('Titanium.','Ti.')
 		instance.compile_js(file_contents)
 


### PR DESCRIPTION
This was causing misreporting of line numbers on device for javascript errors and jsmin is no longer necessary. Additionally, this paves the way for being able to do debugging on device.
