### PR TITLE
[TIMOB-5024] iOS: Titanium.XML.Element.hasAttribute is causing drillbit not to run

### DIFF
--- a/iphone/Classes/TiDOMElementProxy.m
+++ b/iphone/Classes/TiDOMElementProxy.m
@@ -161,7 +161,7 @@
 
 -(id)hasAttribute:(id)args
 {
-	return NUMBOOL([self hasAttribute:args]!=nil);
+	return NUMBOOL([self getAttribute:args] != nil);
 }
 
 -(id)hasAttributeNS:(id)args


### PR DESCRIPTION
[TIMOB-5024] hasAttribute was calling itself. Test case is in the JIRA ticket
