### PR TITLE
[TIMOB-5096] Properly handle symlinked directories for simulator builds.

### DIFF
--- a/support/iphone/builder.py
+++ b/support/iphone/builder.py
@@ -838,9 +838,11 @@ def main(args):
 
 				# when in simulator since we point to the resources directory, we need
 				# to explicitly copy over any files
-				ird = os.path.join(project_dir,'Resources','iphone')
-				if os.path.exists(ird): 
-					module_asset_dirs.append([ird,app_dir])
+				
+				# NOTE: Skip this because we symlink in compiler.py now. What a mess.
+				#ird = os.path.join(project_dir,'Resources','iphone')
+				#if os.path.exists(ird): 
+				#	module_asset_dirs.append([ird,app_dir])
 				
 				for ext in ('ttf','otf'):
 					for f in glob.glob('%s/*.%s' % (os.path.join(project_dir,'Resources'),ext)):


### PR DESCRIPTION
This changeset makes it so that the Resources/iphone directory is only touched during the compilation step, and this is where the symlinks for the build process are updated. 

The better solution, of course, would be to rewrite build scripts to make them more coherent.
