### PR TITLE
Added runtime detection of iOS 5 or later

### DIFF
--- a/iphone/Classes/TiUtils.h
+++ b/iphone/Classes/TiUtils.h
@@ -203,6 +203,8 @@ typedef enum {
 
 +(BOOL)isIOS4_2OrGreater;
 
++(BOOL)isIOS5OrGreater;
+
 +(BOOL)isIPhone4;
 
 +(BOOL)isRetinaDisplay;

--- a/iphone/Classes/TiUtils.m
+++ b/iphone/Classes/TiUtils.m
@@ -116,6 +116,11 @@ static void getAddrInternal(char* macAddress, const char* ifName) {
 	return [UIView instancesRespondToSelector:@selector(contentScaleFactor)];
 }
 
++(BOOL)isIOS5OrGreater
+{
+  return [UIAlertView instancesRespondToSelector:@selector(alertViewStyle)];
+}
+
 +(BOOL)isiPhoneOS3_2OrGreater
 {
 	// Here's a cheap way to test for 3.2; does it respond to a selector that was introduced with that version?


### PR DESCRIPTION
I couldn't find any runtime detection of iOS5 so I've added a new method on TiUtils, based on a new API introduced on UIAlertview on iOS5
