### PR TITLE
TIMOB-5767 Remove invalid platform specifier from contact Person.yml and add a check for it in validator.py

### DIFF
--- a/apidoc/Titanium/Contacts/Person.yml
+++ b/apidoc/Titanium/Contacts/Person.yml
@@ -8,7 +8,7 @@ properties:
     description: |
         URLs of webpages associated with the person.  Multi-value, valid labels are: `home`, `work`, `other`, `homepage`.  Values are strings.
     type: Object
-    platforms: [iphone, ipad, ipod]
+    platforms: [iphone, ipad]
   - name: address
     description: |
         The addresses for the person.  Multi-value, valid labels are: `home`, `work`, `other`.  Values are dictionaries.

--- a/apidoc/validate.py
+++ b/apidoc/validate.py
@@ -26,6 +26,7 @@ except:
 	sys.exit(1)
 
 
+VALID_PLATFORMS = ["android", "iphone", "ipad"]
 types = {}
 errorTrackers = {}
 options = None
@@ -81,6 +82,9 @@ def validateRequired(tracker, map, required):
 def validatePlatforms(tracker, platforms):
 	if type(platforms) != list:
 		tracker.trackError('"platforms" specified, but isn\'t a list: %s' % platforms)
+	for p in platforms:
+		if p not in VALID_PLATFORMS:
+			tracker.trackError('platform specifier "%s" is not valid. Valid platforms are: %s.' % (p, VALID_PLATFORMS))
 
 def validateSince(tracker, since):
 	if type(since) not in [str, dict]:


### PR DESCRIPTION
http://jira.appcelerator.org/browse/TIMOB-5767

Test is to run python docgen.py like described in the ticket and make sure it doesn't error out (no stacktrace should result).

You can also test the validator by opening one of our documentation .yml files and find a "platforms: [xxx, xx, xx]" section then add an invalid platform to the list.  Then run python validate.py.  Valid platforms are: iphone, ipad, android.
