### PR TITLE
[TIMOB-5833] Ensure appropriate methods are hit on rotation

### DIFF
--- a/demos/KitchenSink/Resources/examples/navgroup.js
+++ b/demos/KitchenSink/Resources/examples/navgroup.js
@@ -22,7 +22,8 @@ var modalWin = Ti.UI.createWindow({
 });
 
 var nav = Ti.UI.iPhone.createNavigationGroup({
-	window:modalWin
+	window:modalWin,
+	backgroundColor:'blue'
 });
 
 var table = Ti.UI.createTableView({

--- a/iphone/Classes/TiUIWindowProxy.m
+++ b/iphone/Classes/TiUIWindowProxy.m
@@ -107,6 +107,7 @@
 
 -(void)willAnimateRotationToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation duration:(NSTimeInterval)duration
 {
+    [super willAnimateRotationToInterfaceOrientation:toInterfaceOrientation duration:duration];
 	[TiLayoutQueue addViewProxy:self];
 }
 


### PR DESCRIPTION
In the odd situation where a window's proxy actually responds to a rotation message, we need to make sure that it receives it.
