### PR TITLE
[TIMOB-5250] Kitchensink: Platform>XHR>File download, unexpected console output, file download progress: "infinity"

### DIFF
--- a/iphone/Classes/TiNetworkHTTPClientProxy.m
+++ b/iphone/Classes/TiNetworkHTTPClientProxy.m
@@ -622,6 +622,7 @@ extern NSString * const TI_APPLICATION_DEPLOYTYPE;
 	if (hasOndatastream)
 	{
 		CGFloat progress = (CGFloat)((CGFloat)downloadProgress/(CGFloat)downloadLength);
+		progress = progress == INFINITY ? 1.0 : progress;
 		TiNetworkHTTPClientResultProxy *thisPointer = [[TiNetworkHTTPClientResultProxy alloc] initWithDelegate:self];
 		NSDictionary *event = [NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithFloat:progress],@"progress",@"datastream",@"type",nil];
 		[self fireCallback:@"ondatastream" withArg:event withSource:thisPointer];


### PR DESCRIPTION
Caused due to a divide by zero condition caused by caching which lead to progress value becoming  infinity.

Test in KitchenSink for details see jira ticket.
