### PR TITLE
[TIMOB 5249] Kitchensink: XML properties, responseText and responseXML should return null

### DIFF
--- a/iphone/Classes/TiNetworkHTTPClientProxy.m
+++ b/iphone/Classes/TiNetworkHTTPClientProxy.m
@@ -188,7 +188,7 @@ extern NSString * const TI_APPLICATION_DEPLOYTYPE;
 	if (request!=nil)
 	{
 		NSData *data = [request responseData];
-		if ((![data isEqual: (id)[NSNull null]]) || [data length]==0) 
+		if (data==nil || [data length]==0) 
 		{
 			return (id)[NSNull null];
 		}
@@ -200,12 +200,12 @@ extern NSString * const TI_APPLICATION_DEPLOYTYPE;
 			// with in a _special_ way
 			NSStringEncoding encoding = ExtractEncodingFromData(data);
 			result = [[[NSString alloc] initWithBytes:[data bytes] length:[data length] encoding:encoding] autorelease];
-			if (result!=nil)
-			{
-				return result;
-			}
+			
 		}
-		return result;
+		if (result!=nil)
+		{
+			return result;
+		}
 	}
 	return (id)[NSNull null];
 }

--- a/iphone/Classes/TiNetworkHTTPClientProxy.m
+++ b/iphone/Classes/TiNetworkHTTPClientProxy.m
@@ -188,9 +188,9 @@ extern NSString * const TI_APPLICATION_DEPLOYTYPE;
 	if (request!=nil)
 	{
 		NSData *data = [request responseData];
-		if (data==nil || [data length]==0) 
+		if ((![data isEqual: (id)[NSNull null]]) || [data length]==0) 
 		{
-			return nil;
+			return (id)[NSNull null];
 		}
 		[[data retain] autorelease];
 		NSString * result = [[[NSString alloc] initWithBytes:[data bytes] length:[data length] encoding:[request responseEncoding]] autorelease];
@@ -207,19 +207,19 @@ extern NSString * const TI_APPLICATION_DEPLOYTYPE;
 		}
 		return result;
 	}
-	return nil;
+	return (id)[NSNull null];
 }
 
 -(TiProxy*)responseXML
 {
 	NSString *responseText = [self responseText];
-	if (responseText!=nil)
+	if (responseText != nil && (![responseText isEqual:(id)[NSNull null]]))
 	{
 		TiDOMDocumentProxy *dom = [[[TiDOMDocumentProxy alloc] _initWithPageContext:[self executionContext]] autorelease];
 		[dom parseString:responseText];
 		return dom;
 	}
-	return nil;
+	return (id)[NSNull null];
 }
 
 -(TiBlob*)responseData
@@ -229,7 +229,7 @@ extern NSString * const TI_APPLICATION_DEPLOYTYPE;
 		NSString *contentType = [[request responseHeaders] objectForKey:@"Content-Type"];
 		return [[[TiBlob alloc] initWithData:[request responseData] mimetype:contentType] autorelease];
 	}
-	return nil;
+	return (id)[NSNull null];
 }
 
 -(NSString*)connectionType
@@ -534,7 +534,7 @@ extern NSString * const TI_APPLICATION_DEPLOYTYPE;
 	
 	// should it automatically redirect
 	[request setShouldRedirect:[autoRedirect boolValue]];
-
+	
 	// allow self-signed certs (NO) or required valid SSL (YES)    
 	[request setValidatesSecureCertificate:[validatesSecureCertificate boolValue]];
 	

--- a/iphone/Classes/TiNetworkHTTPClientResultProxy.m
+++ b/iphone/Classes/TiNetworkHTTPClientResultProxy.m
@@ -106,13 +106,13 @@
 -(TiDOMDocumentProxy*)responseXML
 {
 	NSString* responseText = [self valueForKey:@"responseText"];
-	if (responseText!=nil)
+	if (![responseText isEqual:(id)[NSNull null]])
 	{
 		TiDOMDocumentProxy *dom = [[[TiDOMDocumentProxy alloc] _initWithPageContext:[self executionContext]] autorelease];
 		[dom parseString:responseText];
 		return dom;
 	}
-	return nil;
+	return (id)[NSNull null];
 }
 
 -(id)getResponseHeader:(id)args


### PR DESCRIPTION
Fairly straight forward fix, caused due to changes that where made to how we differentiated the code base to show null and undefined .

Jira Ticket includes the test case .
