### PR TITLE
[TIMOB-5935] Ensure that proxies are cleared on cell reuse.

### DIFF
--- a/iphone/Classes/TiUITableView.m
+++ b/iphone/Classes/TiUITableView.m
@@ -78,6 +78,9 @@
 
 -(void)prepareForReuse
 {
+    // If we're reusing a cell, it obviously isn't attached to a proxy.
+    proxy = nil;
+    
 	[super prepareForReuse];
 	
 	// TODO: HACK: In the case of abnormally large table view cells, we have to reset the size.


### PR DESCRIPTION
No reason to have a proxy hanging around once a cell goes into the reuse phase; leaving a stale reference there may lead to crashes or unpredictable behavior.
