### PR TITLE
[TIMOB-5967] Packaged apps failing verification

### DIFF
--- a/support/iphone/Info.plist
+++ b/support/iphone/Info.plist
@@ -15,7 +15,6 @@
 		<string>__APPICON__.png</string>
 		<string>__APPICON__@2x.png</string>
 		<string>__APPICON__-72.png</string>
-		<string>iTunesArtwork</string>
 		<string>__APPICON__-Small-50.png</string>
 		<string>__APPICON__-Small.png</string>
 		<string>__APPICON__-Small@2x.png</string>


### PR DESCRIPTION
'iTunesArtwork"  icon is only ment for Adhoc distribution, leading to the failure in validation

Testing 
*Package an app having all the icons (icon.png,icon@2x.png,icon-72.png,icon-Small-50.png,icon-Small.png, icon-Small@2x.png) and try doing a validation .

For details about the dimensions about the different icons , refer http://developer.apple.com/library/ios/#qa/qa1686/_index.html
