### PR TITLE
[timob-3630]  in md5HexDigest, if parm is not convertable to a string but

### DIFF
--- a/iphone/Classes/UtilsModule.m
+++ b/iphone/Classes/UtilsModule.m
@@ -93,9 +93,15 @@
 {
 	ENSURE_SINGLE_ARG(args,NSObject);
 	
+	NSData* data = nil;
 	NSString *nstr = [self convertToString:args];
-    const char* data = [nstr UTF8String];
-    return [TiUtils md5:[NSData dataWithBytes:data length:strlen(data)]];
+	if (nstr) {
+		const char* s = [nstr UTF8String];
+		data = [NSData dataWithBytes:s length:strlen(s)];
+	} else if ([args respondsToSelector:@selector(data)]) {
+		data = [args data];
+	}
+	return [TiUtils md5:data];
 }
 
 -(id)sha1:(id)args


### PR DESCRIPTION
[timob-3630]  in md5HexDigest, if parm is not convertable to a string but is convertable to NSData, convert it to NSData and digest that.
