### PR TITLE
[timob-5980] Deprecate Titanium.Platform.id

### DIFF
--- a/apidoc/Titanium/Platform/Platform.yml
+++ b/apidoc/Titanium/Platform/Platform.yml
@@ -83,6 +83,8 @@ properties:
     description: the unique id of the device
     type: String
     permission: read-only
+    deprecated:
+        since: "1.8.0"
   - name: locale
     description: the primary language of the device that the user has enabled
     type: String

--- a/iphone/Classes/PlatformModule.m
+++ b/iphone/Classes/PlatformModule.m
@@ -192,6 +192,7 @@ NSString* const DATA_IFACE = @"pdp_ip0";
 
 -(id)id
 {
+	NSLog(@"[WARN] Ti%@.Platform.id DEPRECATED in 1.8.0", @"tanium");
 	return macaddress;
 }
 


### PR DESCRIPTION
When Titanium.Platform.id is used, a deprecation warning should be logged.
