### PR TITLE
[TIMOB-3136] Fixed Camera and Vibrate Inconsistencies in Media Module

### DIFF
--- a/iphone/Classes/MediaModule.m
+++ b/iphone/Classes/MediaModule.m
@@ -469,8 +469,8 @@ MAKE_SYSTEM_PROP(QUALITY_LOW,UIImagePickerControllerQualityTypeLow);
 
 MAKE_SYSTEM_PROP(QUALITY_640x480,UIImagePickerControllerQualityType640x480);
 
-MAKE_SYSTEM_PROP(CAMERA_FRONT,UIImagePickerControllerCameraDeviceRear);
-MAKE_SYSTEM_PROP(CAMERA_REAR,UIImagePickerControllerCameraDeviceFront);
+MAKE_SYSTEM_PROP(CAMERA_FRONT,UIImagePickerControllerCameraDeviceFront);
+MAKE_SYSTEM_PROP(CAMERA_REAR,UIImagePickerControllerCameraDeviceRear);
 
 MAKE_SYSTEM_PROP(CAMERA_FLASH_OFF,UIImagePickerControllerCameraFlashModeOff);
 MAKE_SYSTEM_PROP(CAMERA_FLASH_AUTO,UIImagePickerControllerCameraFlashModeAuto);

--- a/iphone/Classes/MediaModule.m
+++ b/iphone/Classes/MediaModule.m
@@ -946,8 +946,7 @@ MAKE_SYSTEM_PROP(VIDEO_FINISH_REASON_USER_EXITED,MPMovieFinishReasonUserExited);
 
 -(void)vibrate:(id)args
 {
-	ENSURE_UI_THREAD(beep,args);
-	AudioServicesPlayAlertSound(kSystemSoundID_Vibrate);
+	[self beep:args];
 }
 
 -(void)takePicture:(id)args


### PR DESCRIPTION
Two fixes:
- CAMERA_FRONT and CAMERA_REAR were switched.
- vibrate was ensure_ui_threading to the beep method.

Check out the commit messages for more information.
