### PR TITLE
[TIMOB-5986] Ensure that proxy callback cells are cleared on reuse.

### DIFF
--- a/iphone/Classes/TiUITableView.m
+++ b/iphone/Classes/TiUITableView.m
@@ -79,6 +79,7 @@
 -(void)prepareForReuse
 {
     // If we're reusing a cell, it obviously isn't attached to a proxy.
+    [proxy setCallbackCell:nil];
     proxy = nil;
     
 	[super prepareForReuse];


### PR DESCRIPTION
This prevents crashes when scrolling a window while its context is being cleaned up.
