### PR TITLE
[TIMOB-5969][TIMOB-6016] Disable the reuse of persistent HTTP connections

### DIFF
--- a/iphone/Classes/ASI/ASIHTTPRequest.m
+++ b/iphone/Classes/ASI/ASIHTTPRequest.m
@@ -1337,7 +1337,15 @@ static NSOperationQueue *sharedQueue = nil;
 		}
 		[[self connectionInfo] setObject:[self requestID] forKey:@"request"];		
 		[[self connectionInfo] setObject:[self readStream] forKey:@"stream"];
-		CFReadStreamSetProperty((CFReadStreamRef)[self readStream],  kCFStreamPropertyHTTPAttemptPersistentConnection, kCFBooleanTrue);
+        
+        // SPT: This feature has a behavior change in iOS 5.0 - it turns out that the system likes to clean up these
+        // types of connections at different times now, or simply not persist them "appropriately" in some other fashion.
+        //
+        // Note that this could also be an ASI issue, due to how the persistent connection pool is managed... but because of how
+        // it's cleaned up with the start of each new request (possibly what introduces this problem in the first place), this
+        // "simple" fix should not be introducing any issues until we can replace ASI.
+        
+//		CFReadStreamSetProperty((CFReadStreamRef)[self readStream],  kCFStreamPropertyHTTPAttemptPersistentConnection, kCFBooleanTrue);
 		
 		#if DEBUG_PERSISTENT_CONNECTIONS
 		NSLog(@"[CONNECTION] Request #%@ will use connection #%i",[self requestID],[[[self connectionInfo] objectForKey:@"id"] intValue]);


### PR DESCRIPTION
iOS 5 has a behavior change which is incompatible with the way that ASI "manages" its persistent connection pools (in particular, an existing connection can "expire" at a time while it's being used). As we plan to eventually replace ASI, modifying the library to use different expiration behavior seems like an unsuitable use of time; instead we have turned off the persistent HTTP feature. This may incur minor performance hits in applications which use excessive HTTP operations, but at the benefit of added guarantee that multiple connections (or dropped connections) are less likely to occur.
