### PR TITLE
[TIMOB-5957] Properly clean up socketThread on connection error

### DIFF
--- a/iphone/Classes/TiNetworkSocketTCPProxy.m
+++ b/iphone/Classes/TiNetworkSocketTCPProxy.m
@@ -94,6 +94,7 @@ static NSString* ARG_KEY = @"arg";
     
     [socket disconnect];
     [socket setDelegate:nil];
+    
     RELEASE_TO_NIL(socket);
 }
 
@@ -158,6 +159,7 @@ static NSString* ARG_KEY = @"arg";
             [self _fireEventToListener:@"error" withObject:event listener:error thisObject:self];
         }
         
+        socketThread = nil;
         [pool release];
         return;
     }


### PR DESCRIPTION
We need to ensure that for errors in the connection process, the socket's thread information is cleared before exiting the thread itself.
