### PR TITLE
[TIMOB-5976] Update event propagation test

### DIFF
--- a/demos/KitchenSink/Resources/examples/view_event_propagation.js
+++ b/demos/KitchenSink/Resources/examples/view_event_propagation.js
@@ -60,24 +60,28 @@ win.addEventListener('click',function(ev)
 a.addEventListener('click',function(ev)
 {
 	l.text = "view: You clicked on " +ev.source.name;
+	Ti.API.info('Clicked: '+ev.source.name);
 	clear(l);
 });
 
 b.addEventListener('click',function(ev)
 {
 	l.text = "view: You clicked on " +ev.source.name;
+	Ti.API.info('Clicked: '+ev.source.name);	
 	clear(l);
 });
 
 c.addEventListener('click',function(ev)
 {
 	l.text = "view: You clicked on " +ev.source.name;
+	Ti.API.info('Clicked: '+ev.source.name);	
 	clear(l);
 });
 
 d.addEventListener('click',function(ev)
 {
 	l.text = "view: You clicked on " +ev.source.name;
+	Ti.API.info('Clicked: '+ev.source.name);	
 	clear(l);
 });
 


### PR DESCRIPTION
This bug is invalid, but it's easy to see why it was reported. Events involving view touches are now not just displayed on a label, but also logged.
