### PR TITLE
[TIMOB-5397] subtitleid and titleid properties for Ti.Map.Annotation not working properly

### DIFF
--- a/iphone/Classes/TiMapAnnotationProxy.h
+++ b/iphone/Classes/TiMapAnnotationProxy.h
@@ -8,12 +8,12 @@
 
 #ifdef USE_TI_MAP
 
-#import "TiProxy.h"
+#import "TiViewProxy.h"
 #import <MapKit/MapKit.h>
 
 @class TiMapView;
 
-@interface TiMapAnnotationProxy : TiProxy<MKAnnotation> {
+@interface TiMapAnnotationProxy : TiViewProxy<MKAnnotation> {
 @private
 	int tag;
 	TiMapView *delegate;


### PR DESCRIPTION
Ti.Map.Annotation was declared to be a TiProxy and not a TIViewProxy and hence making localization not to work properly.

<b>NOTE</b>
*Even though i checked to see if everything an map annotation works properly , it would be best to check for any regressions.
