### PR TITLE
Correct path to absolute path for test.db.

### DIFF
--- a/android/modules/database/src/java/ti/modules/titanium/database/DatabaseModule.java
+++ b/android/modules/database/src/java/ti/modules/titanium/database/DatabaseModule.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
+import org.appcelerator.kroll.KrollInvocation;
 import org.appcelerator.kroll.KrollModule;
 import org.appcelerator.kroll.annotations.Kroll;
 import org.appcelerator.kroll.common.Log;
@@ -24,6 +25,7 @@ import org.appcelerator.titanium.TiFileProxy;
 import org.appcelerator.titanium.io.TiBaseFile;
 import org.appcelerator.titanium.io.TiFileFactory;
 import org.appcelerator.titanium.util.TiConvert;
+import org.appcelerator.titanium.util.TiUrl;
 
 import android.content.Context;
 import android.database.SQLException;
@@ -85,7 +87,7 @@ public class DatabaseModule extends KrollModule
 	}
 
 	@Kroll.method
-	public TiDatabaseProxy install(String url, String name) throws IOException
+	public TiDatabaseProxy install(KrollInvocation invocation, String url, String name) throws IOException
 	{
 		try {
 			//TiContext tiContext = invocation.getTiContext();
@@ -105,7 +107,9 @@ public class DatabaseModule extends KrollModule
 				Log.d(LCAT,"db url is = "+url);
 			}
 
-			String path = resolveUrl(null, url);
+			TiUrl tiUrl = TiUrl.createProxyUrl(invocation.getSourceUrl());
+			String path = TiUrl.resolve(tiUrl.baseUrl, url, null);
+			
 			TiBaseFile srcDb = TiFileFactory.createTitaniumFile(path, false);
 
 			if (DBG) {


### PR DESCRIPTION
Android: Database - v8 only, Nook only, selecting pre-packaged Db causes Uncaught Error
