### PR TITLE
[TIMOB-5861] Occurs because of synchronization issues where setting the w

### DIFF
--- a/iphone/Classes/TiUIScrollView.m
+++ b/iphone/Classes/TiUIScrollView.m
@@ -52,7 +52,8 @@
 {
 	if (TiDimensionIsAuto(contentWidth) || TiDimensionIsAuto(contentHeight))
 	{
-		[self setNeedsHandleContentSize];
+        [self performSelector:@selector(setNeedsHandleContentSize) withObject:nil afterDelay:.1];
+		//[self setNeedsHandleContentSize];
 	}
 }
 
@@ -129,13 +130,15 @@
 -(void)setContentWidth_:(id)value
 {
 	contentWidth = [TiUtils dimensionValue:value];
-	[self setNeedsHandleContentSize];
+    [self performSelector:@selector(setNeedsHandleContentSize) withObject:nil afterDelay:.1];
+	//[self setNeedsHandleContentSize];
 }
 
 -(void)setContentHeight_:(id)value
 {
 	contentHeight = [TiUtils dimensionValue:value];
-	[self setNeedsHandleContentSize];
+    [self performSelector:@selector(setNeedsHandleContentSize) withObject:nil afterDelay:.1];
+	//[self setNeedsHandleContentSize];
 }
 
 -(void)setShowHorizontalScrollIndicator_:(id)value

--- a/iphone/Classes/TiUIScrollView.m
+++ b/iphone/Classes/TiUIScrollView.m
@@ -52,8 +52,7 @@
 {
 	if (TiDimensionIsAuto(contentWidth) || TiDimensionIsAuto(contentHeight))
 	{
-        [self performSelector:@selector(setNeedsHandleContentSize) withObject:nil afterDelay:.1];
-		//[self setNeedsHandleContentSize];
+		[self performSelector:@selector(setNeedsHandleContentSize) withObject:nil afterDelay:.1];
 	}
 }
 
@@ -130,15 +129,13 @@
 -(void)setContentWidth_:(id)value
 {
 	contentWidth = [TiUtils dimensionValue:value];
-    [self performSelector:@selector(setNeedsHandleContentSize) withObject:nil afterDelay:.1];
-	//[self setNeedsHandleContentSize];
+	[self performSelector:@selector(setNeedsHandleContentSize) withObject:nil afterDelay:.1];
 }
 
 -(void)setContentHeight_:(id)value
 {
 	contentHeight = [TiUtils dimensionValue:value];
-    [self performSelector:@selector(setNeedsHandleContentSize) withObject:nil afterDelay:.1];
-	//[self setNeedsHandleContentSize];
+	[self performSelector:@selector(setNeedsHandleContentSize) withObject:nil afterDelay:.1];
 }
 
 -(void)setShowHorizontalScrollIndicator_:(id)value


### PR DESCRIPTION
[TIMOB-5861] Occurs because of synchronization issues where setting the width,height,contentWidth and contentHeight all call the same function. Introduced small delay in function call to fix sync issues
