### PR TITLE
TIMOB-3378: Android: ScrollView.remove() doesn't really remove on android

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIScrollView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIScrollView.java
@@ -382,5 +382,21 @@ public class TiUIScrollView extends TiUIView {
 			}
 		}
 	}
+	
+	@Override
+	public void remove(TiUIView child)
+	{
+		if (child != null) {
+			View cv = child.getNativeView();
+			if (cv != null) {
+				View nv = getLayout();
+				if (nv instanceof ViewGroup) {
+					((ViewGroup) nv).removeView(cv);
+					children.remove(child);
+					child.setParent(null);
+				}
+			}
+		}
+	}
 
 }


### PR DESCRIPTION
timob-3378: Android: ScrollView.remove() doesn't really remove on android
Several test cases can be found in the Jira ticket http://jira.appcelerator.org/browse/TIMOB-3378 .
