### PR TITLE
[TIMOB-5441][TIMOB-6134] Improve the rendering of tableview cells.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ xcuserdata
 *.swp
 *.orig
 *.rej
+*.BACKUP.*
+*.BASE.*
+*.LOCAL.*
+*.REMOTE.*

--- a/iphone/Classes/TiLayoutQueue.h
+++ b/iphone/Classes/TiLayoutQueue.h
@@ -13,5 +13,6 @@
 }
 
 +(void)addViewProxy:(TiViewProxy*)newViewProxy;
++(void)layoutProxy:(TiViewProxy*)thisProxy;
 
 @end

--- a/iphone/Classes/TiLayoutQueue.m
+++ b/iphone/Classes/TiLayoutQueue.m
@@ -40,12 +40,7 @@ void performLayoutRefresh(CFRunLoopTimerRef timer, void *info)
 	
 	for (TiViewProxy *thisProxy in localLayoutArray)
 	{
-		if ([thisProxy viewAttached]) {
-			[thisProxy layoutChildrenIfNeeded];
-		}
-		else {
-			[thisProxy refreshView:nil];
-		}
+        [TiLayoutQueue layoutProxy:thisProxy];
 	}
 		
 	RELEASE_TO_NIL(localLayoutArray);
@@ -57,6 +52,16 @@ void performLayoutRefresh(CFRunLoopTimerRef timer, void *info)
 +(void)initialize
 {
 	pthread_mutex_init(&layoutMutex, NULL);
+}
+
++(void)layoutProxy:(TiViewProxy*)thisProxy
+{
+    if ([thisProxy viewAttached]) {
+        [thisProxy layoutChildrenIfNeeded];
+    }
+    else {
+        [thisProxy refreshView:nil];
+    }
 }
 
 +(void)addViewProxy:(TiViewProxy*)newViewProxy

--- a/iphone/Classes/TiUITableView.h
+++ b/iphone/Classes/TiUITableView.h
@@ -25,7 +25,7 @@
 	CGPoint hitPoint;
 }
 @property (nonatomic,readonly) CGPoint hitPoint;
-@property (nonatomic,readwrite,assign) TiUITableViewRowProxy* proxy;
+@property (nonatomic,readwrite,retain) TiUITableViewRowProxy* proxy;
 
 -(id)initWithStyle:(UITableViewCellStyle)style_ reuseIdentifier:(NSString *)reuseIdentifier_ row:(TiUITableViewRowProxy*)row_;
 

--- a/iphone/Classes/TiUITableView.m
+++ b/iphone/Classes/TiUITableView.m
@@ -82,8 +82,7 @@
 -(void)prepareForReuse
 {
     // If we're reusing a cell, it obviously isn't attached to a proxy.
-    [proxy setCallbackCell:nil];
-    proxy = nil;
+    [self setProxy:nil];
     
 	[super prepareForReuse];
 	

--- a/iphone/Classes/TiUITableView.m
+++ b/iphone/Classes/TiUITableView.m
@@ -28,7 +28,7 @@
 -(id)initWithStyle:(UITableViewCellStyle)style_ reuseIdentifier:(NSString *)reuseIdentifier_ row:(TiUITableViewRowProxy *)row_
 {
 	if (self = [super initWithStyle:style_ reuseIdentifier:reuseIdentifier_]) {
-		proxy = row_;
+		proxy = [row_ retain];
 		[proxy setCallbackCell:self];
 		self.exclusiveTouch = YES;
 	}
@@ -40,6 +40,7 @@
 {
     [proxy setCallbackCell:nil];
     
+    RELEASE_TO_NIL(proxy);
 	RELEASE_TO_NIL(gradientLayer);
 	RELEASE_TO_NIL(backgroundGradient);
 	RELEASE_TO_NIL(selectedBackgroundGradient);
@@ -55,7 +56,7 @@
     if ([proxy callbackCell] == self) {
         [proxy setCallbackCell:nil];
     }
-    proxy = proxy_;
+    proxy = [proxy_ retain];
 }
 
 -(CGSize)computeCellSize
@@ -363,19 +364,6 @@
 {
 	UITableView *table = [self tableView];
 	
-	if ((animation == UITableViewRowAnimationNone) && ![tableview isEditing])
-	{
-		if([NSThread isMainThread])
-		{
-			[tableview reloadData];
-		}
-		else
-		{
-			[tableview performSelectorOnMainThread:@selector(reloadData) withObject:nil waitUntilDone:NO];
-		}
-		return;
-	}
-
 	//Table views hate having 0 sections, so we have to act like it has at least 1.
 	oldCount = MAX(1,oldCount);
 	newCount = MAX(1,newCount);
@@ -697,7 +685,7 @@
 	if ([searchController searchResultsTableView] != nil) {
 		[self updateSearchResultIndexes];
 		[[searchController searchResultsTableView] reloadSections:[NSIndexSet indexSetWithIndex:0]
-					   withRowAnimation:UITableViewRowAnimationFade];		
+                                                  withRowAnimation:UITableViewRowAnimationFade];
 	}
 }
 
@@ -2040,14 +2028,6 @@ if(ourTableView != tableview)	\
 
 #pragma mark Search Display Controller Delegates
 
-- (void) searchDisplayController:(UISearchDisplayController *)controller willShowSearchResultsTableView:(UITableView *)tableView
-{
-    // Carry over (relevant) display properties from our table to the search table, for consistency.  Note that
-    // we MAY NOT be able to get the correct row height min/max.
-    [tableView setBackgroundColor:[[self tableView] backgroundColor]];
-    [tableView setSeparatorStyle:[[self tableView] separatorStyle]];
-    [tableView setSeparatorColor:[[self tableView] separatorColor]];
-}
 
 - (void) searchDisplayControllerDidEndSearch:(UISearchDisplayController *)controller
 {

--- a/iphone/Classes/TiUITableViewRowProxy.m
+++ b/iphone/Classes/TiUITableViewRowProxy.m
@@ -663,7 +663,6 @@ TiProxy * DeepScanForProxyOfViewContainingPoint(UIView * targetView, CGPoint poi
 			[rowContainerView addSubview:uiview];
 			[proxy setReproxying:NO];
 		}
-		[self willEnqueue];
 		[contentView addSubview:rowContainerView];
 	}
 	configuredChildren = YES;


### PR DESCRIPTION
Tableview cells now render more efficiently and at more opportune times (when the cell is laid out). There is also no longer a disconnect between rendering of search results tables and the tableview itself (-[UITableView reloadData] queues on the runloop, whereas -[UITableView reloadSections:] is immediate).

These changes were regression-tested against the KitchenSink Base UI->Views->TableViews tests to determine if there were any rendering or loading changes. All those discovered were fixed. Reviewers should conduct a regression test against KS as well.
