### PR TITLE
fix for google_apis_dir never being set in androidsdk.py script when the 

### DIFF
--- a/android/build/common.xml
+++ b/android/build/common.xml
@@ -100,7 +100,7 @@ Common ant tasks and macros for building Android-based Titanium modules and proj
 					<if>
 						<not><isset property="google.apis"/></not>
 						<then>
-							<property name="google.apis" location="${android.sdk}/add-ons/addon_google_apis_google_inc_8"/>
+							<property name="google.apis" location="${android.sdk}/add-ons/addon-google_apis-google_inc_-8"/>
 						</then>
 					</if>
 				</else>

--- a/support/android/androidsdk.py
+++ b/support/android/androidsdk.py
@@ -92,7 +92,8 @@ class AndroidSDK:
 
 	def find_google_apis_dir(self):
 		if 'GOOGLE_APIS' in os.environ:
-			return os.environ['GOOGLE_APIS']
+			self.google_apis_dir = os.environ['GOOGLE_APIS']
+			return self.google_apis_dir
 		self.google_apis_dir = self.find_dir(self.api_level, os.path.join('add-ons', 'google_apis-'))
 		if self.google_apis_dir is None:
 			self.google_apis_dir = self.find_dir(self.api_level, os.path.join('add-ons', 'addon_google_apis_google_inc_'))


### PR DESCRIPTION
fix for google_apis_dir never being set in androidsdk.py script when the GOOGLE_APIS environment variable is set

http://jira.appcelerator.org/browse/TIMOB-6141
