### PR TITLE
timob-6100: Image view encoding does not work

### DIFF
--- a/demos/KitchenSink/Resources/examples/image_view_encoding.js
+++ b/demos/KitchenSink/Resources/examples/image_view_encoding.js
@@ -4,7 +4,8 @@ var win = Ti.UI.currentWindow;
 // to fetch this image OK
 
 var test_img = Titanium.UI.createImageView({
-	image:'http://www.zoomout.gr/assets/media/PICTURES/ΜΟΥΣΙΚΗ/651_thumb1.jpg'
+		image: 'http://www.zoomout.gr/assets/media/PICTURES/' + encodeURIComponent('ΜΟΥΣΙΚΗ') + '/651_thumb1.jpg'
+
 }); 
 
 win.add(test_img);


### PR DESCRIPTION
Steps to test:
Navigate to base_ui > Views > Image Views > Image View Encoding

Jira Ticket: 
http://jira.appcelerator.org/browse/TIMOB-6100
