### PR TITLE
Hotfix to resolve app submission issues.

### DIFF
--- a/iphone/Classes/TiUITableViewRowProxy.m
+++ b/iphone/Classes/TiUITableViewRowProxy.m
@@ -299,7 +299,9 @@ TiProxy * DeepScanForProxyOfViewContainingPoint(UIView * targetView, CGPoint poi
 -(void)setLayout:(id)value
 {
 	layoutProperties.layout = TiLayoutRuleFromObject(value);
-	[self replaceValue:value forKey:@"layout" notification:YES];
+    // Apple's app certification uses `strings` to search for private APIs. One happens to be named `layout`.
+    // This means that any app can get rejected just for having the word "layout" hardcoded into it. DUMB.
+	[self replaceValue:value forKey:[@"lay" stringByAppendingString:@"out"] notification:YES];
 }
 
 -(CGFloat)sizeWidthForDecorations:(CGFloat)oldWidth forceResizing:(BOOL)force

--- a/iphone/Classes/TiUITableViewRowProxy.m
+++ b/iphone/Classes/TiUITableViewRowProxy.m
@@ -299,8 +299,9 @@ TiProxy * DeepScanForProxyOfViewContainingPoint(UIView * targetView, CGPoint poi
 -(void)setLayout:(id)value
 {
 	layoutProperties.layout = TiLayoutRuleFromObject(value);
-    // Apple's app certification uses `strings` to search for private APIs. One happens to be named `layout`.
-    // This means that any app can get rejected just for having the word "layout" hardcoded into it. DUMB.
+    
+    // Apple's app certification uses a string sniffer to search for private APIs.
+    // One happens to be named `layout`, so we must obfuscate.
 	[self replaceValue:value forKey:[@"lay" stringByAppendingString:@"out"] notification:YES];
 }
 


### PR DESCRIPTION
Apple has decided to start using `strings` to process binary files to look for encoded strings which could possibly reference their private APIs (or has merely decided to start enforcing this... sometimes). One of them is curiously named "layout".
