### PR TITLE
[TIMOB-5807] Compensate for HTTP response header case-correction

### DIFF
--- a/iphone/Classes/TiNetworkHTTPClientProxy.m
+++ b/iphone/Classes/TiNetworkHTTPClientProxy.m
@@ -550,13 +550,24 @@ extern NSString * const TI_APPLICATION_DEPLOYTYPE;
 	}
 }
 
+// Checked with Apache project to see if this is a known bug for them; it's
+// not, so this must be a client-side issue with Apple.
+//
+// Turns out Apple has a bug where they seem to case-correct headers;
+// this turns WWW-Authenticate into Www-Authenticate. We don't have complete
+// information on how response headers are mangled, but assume that
+// they are all case-corrected like this.
+//
+// TODO: Investigate the case-correction of HTTP headers and file a bug w/Apple.
+
 -(id)getResponseHeader:(id)args
 {
+    ENSURE_SINGLE_ARG(args, NSString);
+    
 	if (request!=nil)
 	{
-		id key = [args objectAtIndex:0];
-		ENSURE_TYPE(key,NSString);
-		return [[request responseHeaders] objectForKey:key];
+        NSString* header = [TiUtils caseCorrect:args];
+		return [[request responseHeaders] objectForKey:header];
 	}
 	return nil;
 }

--- a/iphone/Classes/TiNetworkHTTPClientResultProxy.m
+++ b/iphone/Classes/TiNetworkHTTPClientResultProxy.m
@@ -117,11 +117,12 @@
 
 -(id)getResponseHeader:(id)args
 {
+    ENSURE_SINGLE_ARG(args, NSString);
+    
 	id result = [delegate getResponseHeader:args];
 	if (result == nil) {
-		id key = [args objectAtIndex:0];
-		ENSURE_TYPE(key,NSString);
-		result = [responseHeaders objectForKey:key];
+        NSString* header = [TiUtils caseCorrect:args];
+		result = [responseHeaders objectForKey:header];
 	}
 	return result;
 }

--- a/iphone/Classes/TiUtils.h
+++ b/iphone/Classes/TiUtils.h
@@ -220,4 +220,6 @@ typedef enum {
 +(NSString*)convertToHex:(unsigned char*)result length:(size_t)length;
 
 +(NSString*)uniqueIdentifier;
+
++(NSString*)caseCorrect:(NSString*)str;
 @end

--- a/iphone/Classes/TiUtils.m
+++ b/iphone/Classes/TiUtils.m
@@ -1635,4 +1635,22 @@ if ([str isEqualToString:@#orientation]) return (UIDeviceOrientation)orientation
     NSString* uid = [TiUtils oldUUID];
     return uid;
 }
+
+// Used for HTTP response header case-correction, as performed by Apple
++(NSString*)caseCorrect:(NSString *)str
+{
+    if ([str rangeOfString:@"-"].location != NSNotFound) {
+        NSArray* substrings = [str componentsSeparatedByString:@"-"];
+        NSMutableString* header = [NSMutableString stringWithString:[[substrings objectAtIndex:0] capitalizedString]];
+        for (int i=1; i < [substrings count]; i++) {
+            NSString* substr = [substrings objectAtIndex:i];
+            [(NSMutableString*)header appendFormat:@"-%@",[substr capitalizedString]];
+        }
+        
+        return header;
+    }
+    
+    return str;
+}
+
 @end


### PR DESCRIPTION
It appears that Apple has a bug where HTTP headers are case corrected (split on separator tokens and then 'capitalized' correctly). This affects `WWW-Authenticate` in particular, but may also be screwing with other headers.

We have not yet filed a bug with Apple, since this requires more investigation and reproduction outside of Titanium.
