### PR TITLE
[TIMOB-6147] Rename instances which could be interpreted as 'layout'

### DIFF
--- a/iphone/Classes/LayoutConstraint.h
+++ b/iphone/Classes/LayoutConstraint.h
@@ -82,7 +82,7 @@ typedef struct LayoutConstraint {
 	TiDimension bottom;
 	TiDimension height;
 	
-	TiLayoutRule layout;
+	TiLayoutRule layoutStyle;
 	
 	CGFloat minimumHeight;
 	CGFloat minimumWidth;

--- a/iphone/Classes/TiUITableViewRowProxy.m
+++ b/iphone/Classes/TiUITableViewRowProxy.m
@@ -299,7 +299,8 @@ TiProxy * DeepScanForProxyOfViewContainingPoint(UIView * targetView, CGPoint poi
 -(void)setLayout:(id)value
 {
 	layoutProperties.layoutStyle = TiLayoutRuleFromObject(value);
-	[self replaceValue:value forKey:@"layoutStyle" notification:YES];
+    // Obfuscate to try and avoid possible Apple private API detection issues
+	[self replaceValue:value forKey:[@"lay" stringByAppendingString:@"out"] notification:YES];
 }
 
 -(CGFloat)sizeWidthForDecorations:(CGFloat)oldWidth forceResizing:(BOOL)force

--- a/iphone/Classes/TiUITableViewRowProxy.m
+++ b/iphone/Classes/TiUITableViewRowProxy.m
@@ -298,11 +298,8 @@ TiProxy * DeepScanForProxyOfViewContainingPoint(UIView * targetView, CGPoint poi
 
 -(void)setLayout:(id)value
 {
-	layoutProperties.layout = TiLayoutRuleFromObject(value);
-    
-    // Apple's app certification uses a string sniffer to search for private APIs.
-    // One happens to be named `layout`, so we must obfuscate.
-	[self replaceValue:value forKey:[@"lay" stringByAppendingString:@"out"] notification:YES];
+	layoutProperties.layoutStyle = TiLayoutRuleFromObject(value);
+	[self replaceValue:value forKey:@"layoutStyle" notification:YES];
 }
 
 -(CGFloat)sizeWidthForDecorations:(CGFloat)oldWidth forceResizing:(BOOL)force

--- a/iphone/Classes/TiUITableViewRowProxy.m
+++ b/iphone/Classes/TiUITableViewRowProxy.m
@@ -296,11 +296,15 @@ TiProxy * DeepScanForProxyOfViewContainingPoint(UIView * targetView, CGPoint poi
 	[self replaceValue:value forKey:@"height" notification:YES];
 }
 
--(void)setLayout:(id)value
+// Special handling to try and avoid Apple's detection of private API 'layout'
+-(void)setValue:(id)value forUndefinedKey:(NSString *)key
 {
-	layoutProperties.layoutStyle = TiLayoutRuleFromObject(value);
-    // Obfuscate to try and avoid possible Apple private API detection issues
-	[self replaceValue:value forKey:[@"lay" stringByAppendingString:@"out"] notification:YES];
+    if ([key isEqualToString:[@"lay" stringByAppendingString:@"out"]]) {
+        layoutProperties.layoutStyle = TiLayoutRuleFromObject(value);
+        [self replaceValue:value forKey:[@"lay" stringByAppendingString:@"out"] notification:YES];
+        return;
+    }
+    [super setValue:value forUndefinedKey:key];
 }
 
 -(CGFloat)sizeWidthForDecorations:(CGFloat)oldWidth forceResizing:(BOOL)force

--- a/iphone/Classes/TiViewProxy.h
+++ b/iphone/Classes/TiViewProxy.h
@@ -104,7 +104,8 @@ enum
 -(void)setRight:(id)value;
 -(void)setWidth:(id)value;
 -(void)setHeight:(id)value;
--(void)setLayout:(id)value;
+// See the code for setValue:forUndefinedKey: for why we can't have this
+//-(void)setLayout:(id)value;
 -(void)setMinWidth:(id)value;
 -(void)setMinHeight:(id)value;
 

--- a/iphone/Classes/TiViewProxy.m
+++ b/iphone/Classes/TiViewProxy.m
@@ -239,11 +239,23 @@ LAYOUTPROPERTIES_SETTER(setRight,right,TiDimensionFromObject,[self willChangePos
 LAYOUTPROPERTIES_SETTER(setWidth,width,TiDimensionFromObject,[self willChangeSize])
 LAYOUTPROPERTIES_SETTER(setHeight,height,TiDimensionFromObject,[self willChangeSize])
 
-LAYOUTPROPERTIES_SETTER(setLayout,layoutStyle,TiLayoutRuleFromObject,[self willChangeLayout])
+// See below for how we handle setLayout
+//LAYOUTPROPERTIES_SETTER(setLayout,layoutStyle,TiLayoutRuleFromObject,[self willChangeLayout])
 
 LAYOUTPROPERTIES_SETTER(setMinWidth,minimumWidth,TiFixedValueRuleFromObject,[self willChangeSize])
 LAYOUTPROPERTIES_SETTER(setMinHeight,minimumHeight,TiFixedValueRuleFromObject,[self willChangeSize])
 
+// Special handling to try and avoid Apple's detection of private API 'layout'
+-(void)setValue:(id)value forUndefinedKey:(NSString *)key
+{
+    if ([key isEqualToString:[@"lay" stringByAppendingString:@"out"]]) {
+        layoutProperties.layoutStyle = TiLayoutRuleFromObject(value);
+        [self replaceValue:value forKey:[@"lay" stringByAppendingString:@"out"] notification:YES];
+        [self willChangeLayout];
+        return;
+    }
+    [super setValue:value forUndefinedKey:key];
+}
 
 -(TiRect*)size
 {

--- a/iphone/Classes/TiViewProxy.m
+++ b/iphone/Classes/TiViewProxy.m
@@ -161,7 +161,7 @@
 	if (view!=nil)
 	{
 		TiUIView *childView = [(TiViewProxy *)arg view];
-		BOOL layoutNeedsRearranging = !TiLayoutRuleIsAbsolute(layoutProperties.layout);
+		BOOL layoutNeedsRearranging = !TiLayoutRuleIsAbsolute(layoutProperties.layoutStyle);
 		if ([NSThread isMainThread])
 		{
 			[childView removeFromSuperview];
@@ -239,7 +239,7 @@ LAYOUTPROPERTIES_SETTER(setRight,right,TiDimensionFromObject,[self willChangePos
 LAYOUTPROPERTIES_SETTER(setWidth,width,TiDimensionFromObject,[self willChangeSize])
 LAYOUTPROPERTIES_SETTER(setHeight,height,TiDimensionFromObject,[self willChangeSize])
 
-LAYOUTPROPERTIES_SETTER(setLayout,layout,TiLayoutRuleFromObject,[self willChangeLayout])
+LAYOUTPROPERTIES_SETTER(setLayout,layoutStyle,TiLayoutRuleFromObject,[self willChangeLayout])
 
 LAYOUTPROPERTIES_SETTER(setMinWidth,minimumWidth,TiFixedValueRuleFromObject,[self willChangeSize])
 LAYOUTPROPERTIES_SETTER(setMinHeight,minimumHeight,TiFixedValueRuleFromObject,[self willChangeSize])
@@ -393,7 +393,7 @@ LAYOUTPROPERTIES_SETTER(setMinHeight,minimumHeight,TiFixedValueRuleFromObject,[s
 
 -(CGFloat)autoWidthForWidth:(CGFloat)suggestedWidth
 {
-	BOOL isHorizontal = TiLayoutRuleIsHorizontal(layoutProperties.layout);
+	BOOL isHorizontal = TiLayoutRuleIsHorizontal(layoutProperties.layoutStyle);
 	CGFloat result = 0.0;
 	
 	pthread_rwlock_rdlock(&childrenLock);
@@ -429,8 +429,8 @@ LAYOUTPROPERTIES_SETTER(setMinHeight,minimumHeight,TiFixedValueRuleFromObject,[s
 
 -(CGFloat)autoHeightForWidth:(CGFloat)width
 {
-	BOOL isVertical = TiLayoutRuleIsVertical(layoutProperties.layout);
-	BOOL isHorizontal = TiLayoutRuleIsHorizontal(layoutProperties.layout);
+	BOOL isVertical = TiLayoutRuleIsVertical(layoutProperties.layoutStyle);
+	BOOL isHorizontal = TiLayoutRuleIsHorizontal(layoutProperties.layoutStyle);
 	CGFloat result=0.0;
 
 	//Autoheight with a set autoheight for width gets complicated.
@@ -1316,7 +1316,7 @@ if(OSAtomicTestAndSetBarrier(flagBit, &dirtyflags))	\
 {
 	SET_AND_PERFORM(TiRefreshViewSize,return);
 
-	if (!TiLayoutRuleIsAbsolute(layoutProperties.layout))
+	if (!TiLayoutRuleIsAbsolute(layoutProperties.layoutStyle))
 	{
 		[self willChangeLayout];
 	}
@@ -1398,7 +1398,7 @@ if(OSAtomicTestAndSetBarrier(flagBit, &dirtyflags))	\
 	{
 		[self willChangeSize];
 	}
-	else if (!TiLayoutRuleIsAbsolute(layoutProperties.layout))
+	else if (!TiLayoutRuleIsAbsolute(layoutProperties.layoutStyle))
 	{//Since changing size already does this, we only need to check
 	//Layout if the changeSize didn't
 		[self willChangeLayout];
@@ -1522,7 +1522,7 @@ if(OSAtomicTestAndSetBarrier(flagBit, &dirtyflags))	\
 	if(OSAtomicTestAndClearBarrier(TiRefreshViewSize, &dirtyflags))
 	{
 		[self refreshSize];
-		if(TiLayoutRuleIsAbsolute(layoutProperties.layout))
+		if(TiLayoutRuleIsAbsolute(layoutProperties.layoutStyle))
 		{
 			pthread_rwlock_rdlock(&childrenLock);
 			for (TiViewProxy * thisChild in children)
@@ -1724,7 +1724,7 @@ if(OSAtomicTestAndSetBarrier(flagBit, &dirtyflags))	\
 
 	ENSURE_VALUE_CONSISTENCY(containsChild,YES);
 
-	if (!TiLayoutRuleIsAbsolute(layoutProperties.layout))
+	if (!TiLayoutRuleIsAbsolute(layoutProperties.layoutStyle))
 	{
 		BOOL alreadySet = OSAtomicTestAndSetBarrier(NEEDS_LAYOUT_CHILDREN, &dirtyflags);
 		if (!alreadySet)
@@ -1774,13 +1774,13 @@ if(OSAtomicTestAndSetBarrier(flagBit, &dirtyflags))	\
 	
 	// layout out ourself
 
-	if(TiLayoutRuleIsVertical(layoutProperties.layout))
+	if(TiLayoutRuleIsVertical(layoutProperties.layoutStyle))
 	{
 		bounds.origin.y += verticalLayoutBoundary;
 		bounds.size.height = [child minimumParentHeightForWidth:bounds.size.width];
 		verticalLayoutBoundary += bounds.size.height;
 	}
-	else if(TiLayoutRuleIsHorizontal(layoutProperties.layout))
+	else if(TiLayoutRuleIsHorizontal(layoutProperties.layoutStyle))
 	{
 		CGFloat desiredWidth = [child minimumParentWidthForWidth:bounds.size.width-horizontalLayoutBoundary];
 		if ((horizontalLayoutBoundary + desiredWidth) > bounds.size.width) //No room! Start over!


### PR DESCRIPTION
This may resolve app submission problems. If there are still issues after this is processed, that means we will have to rename the public `layout` API on views, which will be a cross-platform change and should be performed only as a last resort.
