### PR TITLE
[TIMOB-6147] Second pass to comb for layout

### DIFF
--- a/iphone/Classes/TiAnimation.m
+++ b/iphone/Classes/TiAnimation.m
@@ -463,16 +463,16 @@ if (!TiDimensionIsUndefined(autoreverseLayout.a)) {\
 	if ([view_ isKindOfClass:[TiUIView class]])
 	{	//TODO: Shouldn't we be updating the proxy's properties to reflect this?
 		TiUIView *uiview = (TiUIView*)view_;
-		LayoutConstraint *layout = [(TiViewProxy *)[uiview proxy] layoutProperties];
+		LayoutConstraint *layoutProperties = [(TiViewProxy *)[uiview proxy] layoutProperties];
 		
 
 		BOOL doReposition = NO;
 		
 #define CHECK_LAYOUT_CHANGE(a) \
-if (a!=nil && layout!=NULL) \
+if (a!=nil && layoutProperties!=NULL) \
 {\
-		autoreverseLayout.a = layout->a; \
-		layout->a = TiDimensionFromObject(a); \
+		autoreverseLayout.a = layoutProperties->a; \
+		layoutProperties->a = TiDimensionFromObject(a); \
 		doReposition = YES;\
 }\
 else \
@@ -485,12 +485,12 @@ else \
 		CHECK_LAYOUT_CHANGE(height);
 		CHECK_LAYOUT_CHANGE(top);
 		CHECK_LAYOUT_CHANGE(bottom);
-		if (center!=nil && layout != NULL)
+		if (center!=nil && layoutProperties != NULL)
 		{
-			autoreverseLayout.centerX = layout->centerX;
-			autoreverseLayout.centerY = layout->centerY;
-			layout->centerX = [center xDimension];
-			layout->centerY = [center yDimension];
+			autoreverseLayout.centerX = layoutProperties->centerX;
+			autoreverseLayout.centerY = layoutProperties->centerY;
+			layoutProperties->centerX = [center xDimension];
+			layoutProperties->centerY = [center yDimension];
 			doReposition = YES;
 		}
 		else

--- a/iphone/Classes/TiUIButton.m
+++ b/iphone/Classes/TiUIButton.m
@@ -186,19 +186,19 @@ const UIControlEvents unHighlightingTouches = UIControlEventTouchCancel|UIContro
 		// if the layout is undefined or auto, we need to take the size of the image
 		//TODO: Refactor. This will cause problems if there's multiple setImages called,
 		//Since we change the values of the proxy.
-		LayoutConstraint *layout = [(TiViewProxy *)[self proxy] layoutProperties];
+		LayoutConstraint *layoutProperties = [(TiViewProxy *)[self proxy] layoutProperties];
 		BOOL reposition = NO;
 		
-		if (TiDimensionIsUndefined(layout->width) || TiDimensionIsAuto(layout->width))
+		if (TiDimensionIsUndefined(layoutProperties->width) || TiDimensionIsAuto(layoutProperties->width))
 		{
-			layout->width.value = image.size.width;
-			layout->width.type = TiDimensionTypePixels;
+			layoutProperties->width.value = image.size.width;
+			layoutProperties->width.type = TiDimensionTypePixels;
 			reposition = YES;
 		}
-		if (TiDimensionIsUndefined(layout->height) || TiDimensionIsAuto(layout->height))
+		if (TiDimensionIsUndefined(layoutProperties->height) || TiDimensionIsAuto(layoutProperties->height))
 		{
-			layout->height.value = image.size.height;
-			layout->height.type = TiDimensionTypePixels;
+			layoutProperties->height.value = image.size.height;
+			layoutProperties->height.type = TiDimensionTypePixels;
 		}
 		if (reposition)
 		{

--- a/iphone/Classes/TiViewProxy.m
+++ b/iphone/Classes/TiViewProxy.m
@@ -175,7 +175,7 @@
 			[childView performSelectorOnMainThread:@selector(removeFromSuperview) withObject:nil waitUntilDone:NO];
 			if (layoutNeedsRearranging)
 			{
-				[self performSelectorOnMainThread:@selector(layout) withObject:nil waitUntilDone:NO modes:[NSArray arrayWithObject:NSRunLoopCommonModes]];
+				[self performSelectorOnMainThread:@selector(relayout) withObject:nil waitUntilDone:NO modes:[NSArray arrayWithObject:NSRunLoopCommonModes]];
 			}
 		}
 	}


### PR DESCRIPTION
Massive hat tip to Chris Leyton, who informed me of the `@selector(layout)` symbol that we had hiding in the code... which was a typo that was probably causing all of this grief.

Also ran through and changed some other symbols, because why not?
