### PR TITLE
Android MapView Annotation rightView fix

### DIFF
--- a/android/modules/map/src/ti/modules/titanium/map/TiOverlayItemView.java
+++ b/android/modules/map/src/ti/modules/titanium/map/TiOverlayItemView.java
@@ -183,7 +183,8 @@ public class TiOverlayItemView extends FrameLayout
 
 				}
 			} else if (rightView != null) {
-				rightPane.addView(rightView.peekView().getNativeView());
+				//rightPane.addView(rightView.peekView().getNativeView());
+				rightPane.addView(rightView.getView(rightView.getTiContext().getActivity()).getNativeView());
 			}
 			rightPane.setVisibility(VISIBLE);
 


### PR DESCRIPTION
Fixed a bug in the Android branch that was causing the right view on a map annotation to not show.  Made it work just like the left view which was working fine.
