### PR TITLE
[TIMOB-6200][TIMOB-6165][TIMOB-5441] Reload table w/no animation

### DIFF
--- a/iphone/Classes/TiUITableView.m
+++ b/iphone/Classes/TiUITableView.m
@@ -714,6 +714,9 @@
 	if ([searchController searchResultsTableView] != nil) {
         [self updateSearchResultIndexes];
         
+        // Because -[UITableView reloadData] queues on the main runloop, we need to sync the search
+        // table reload to the same method. The only time we reloadData, though, is when setting the
+        // data, so toggle a flag to indicate what the search should do.
         if (reloadSearch) {
             [[searchController searchResultsTableView] reloadData];
         }

--- a/iphone/Classes/TiUITableView.m
+++ b/iphone/Classes/TiUITableView.m
@@ -546,6 +546,7 @@
 	ENSURE_UI_THREAD(dispatchAction,action);
 	
 	NSMutableArray * sections = [(TiUITableViewProxy *)[self proxy] sections];
+    BOOL reloadSearch = NO;
 	switch (action.type)
 	{
 		case TiUITableViewActionRowReload:
@@ -689,6 +690,7 @@
 		case TiUITableViewActionSetData:
 		{
 			[self replaceData:action.obj animation:action.animation];
+            reloadSearch = YES;
 			break;
 		}
 		case TiUITableViewActionAppendRow:
@@ -710,11 +712,9 @@
 	}
 
 	if ([searchController searchResultsTableView] != nil) {
-		[self updateSearchResultIndexes];
-        // -[UITableView reloadData] helpfully queues on the main runloop, and does NOT
-        // execute immediately. This means that however we update the search results table
-        // must match with how we update the tableview data, or else there could be a mismatch.
-        if (action.animation == UITableViewRowAnimationNone) {
+        [self updateSearchResultIndexes];
+        
+        if (reloadSearch) {
             [[searchController searchResultsTableView] reloadData];
         }
         else {


### PR DESCRIPTION
This is a bug that's been present in Apple's code since 2.0; when you reload, insert, or remove sections/rows, even with the row animation as 'none', the table animates the rows in. However, -[UITableView reloadData] does NOT animate changes in (ever) making it the only suitable replacement for these actions.

See comments in the code for further details. All three bugs listed on this ticket should be tested before acceptance.
