### PR TITLE
[TIMOB-6082] Only remove views we explicitly add to cell content

### DIFF
--- a/iphone/Classes/TiUIActivityIndicatorProxy.m
+++ b/iphone/Classes/TiUIActivityIndicatorProxy.m
@@ -11,12 +11,6 @@
 
 @implementation TiUIActivityIndicatorProxy
 
--(TiUIView*)newView
-{
-	TiUIActivityIndicator * result = [[TiUIActivityIndicator alloc] init];
-	return result;
-}
-
 -(NSMutableDictionary*)langConversionTable
 {
     return [NSMutableDictionary dictionaryWithObject:@"message" forKey:@"messageid"];

--- a/iphone/Classes/TiUITableView.m
+++ b/iphone/Classes/TiUITableView.m
@@ -81,9 +81,6 @@
 
 -(void)prepareForReuse
 {
-    // If we're reusing a cell, it obviously isn't attached to a proxy.
-    [self setProxy:nil];
-    
 	[super prepareForReuse];
 	
 	// TODO: HACK: In the case of abnormally large table view cells, we have to reset the size.
@@ -1556,14 +1553,6 @@ if(ourTableView != tableview)	\
         // Have to reset the proxy on the cell, and the row's callback cell, as it may have been cleared in reuse operations (or reassigned)
         [(TiUITableViewCell*)cell setProxy:row];
         [row setCallbackCell:(TiUITableViewCell*)cell];
-        
-		/*
-		 * Old-school style:
-		// in the case of a reuse, we need to tell the row proxy to update the data
-		// in the re-used cell with this proxy's contents
-		[row renderTableViewCell:cell];
-		 *
-		 */
 	}
 	[row initializeTableViewCell:cell];
 	

--- a/iphone/Classes/TiUITableViewRowProxy.h
+++ b/iphone/Classes/TiUITableViewRowProxy.h
@@ -51,7 +51,6 @@ typedef enum
 
 +(void)clearTableRowCell:(UITableViewCell*)cell;
 -(void)initializeTableViewCell:(UITableViewCell*)cell;
--(void)renderTableViewCell:(UITableViewCell*)cell;
 -(CGFloat)sizeWidthForDecorations:(CGFloat)oldWidth forceResizing:(BOOL)force;
 -(CGFloat)rowHeight:(CGFloat)width;
 -(TiProxy *)touchedViewProxyInCell:(UITableViewCell *)targetCell atPoint:(CGPoint*)point;


### PR DESCRIPTION
Doing otherwise was causing odd redraw behavior, mostly the system placing other views on top of our directly managed content, which should always be displayed atop any existing cell contents (such as the title label).

Also removed a significant amount of dead code in tablerow, and resolved an issue that may have been causing views in tablerows to not be cleaned up correctly.
