### PR TITLE
[TIMOB-6240] Fix table section header handling

### DIFF
--- a/iphone/Classes/TiUITableView.m
+++ b/iphone/Classes/TiUITableView.m
@@ -1905,7 +1905,6 @@ if(ourTableView != tableview)	\
 	TiUIView *view = [self sectionView:section forLocation:@"headerView" section:&sectionProxy];
 	TiViewProxy *viewProxy = (TiViewProxy *)[view proxy];
 	CGFloat size = 0;
-	BOOL hasTitle = NO;
 	if (viewProxy!=nil)
 	{
 		LayoutConstraint *viewLayout = [viewProxy layoutProperties];
@@ -1923,28 +1922,26 @@ if(ourTableView != tableview)	\
 		}
 	}
     /*
-     * Keeping this code in for historical reasons, because:
-     *
-     * Prior to iOS 5, this method (tableView:heightForHeaderInSection:) had its return value IGNORED
-     * for sections which returned `nil` for tableView:viewForHeaderInSection: -
-     * meaning that it was dead code.
-     *
-     * But in iOS 5, if this method is here, then it is ALWAYS called, even if that return value
-     * is nil; meaning we were previously providing the default spacing (which, contrary to
-     * our HEADERFOOTER_HEIGHT constant, is apparently not 20px and also apparently not 
-     * -[UITableView sectionHeaderHeight]).
-     *
-     * Returning a value of 0 coereces the table into rendering the section of "empty" header height,
-     * which is the behavior consistent with iOS <5.0 behavior.
+     * This behavior is slightly more complex between iOS 4 and iOS 5 than you might believe, and Apple's
+     * documentation is once again misleading. It states that in iOS 4 this value was "ignored if
+     * -[delegate tableView:viewForHeaderInSection:] returned nil" but apparently a non-nil value for
+     * -[delegate tableView:titleForHeaderInSection:] is considered a valid value for height handling as well,
+     * provided it is NOT the empty string.
+     * 
+     * So for parity with iOS 4, iOS 5 must similarly treat the empty string header as a 'nil' value and
+     * return a 0.0 height that is overridden by the system.
+     */
 	else if ([sectionProxy headerTitle]!=nil)
 	{
-		hasTitle = YES;
-		size = [tableview sectionHeaderHeight];
+        if ([TiUtils isIOS5OrGreater] && [[sectionProxy headerTitle] isEqualToString:@""]) {
+            return size;
+        }
+		size+=[tableview sectionHeaderHeight];
+        
         if (size < DEFAULT_SECTION_HEADERFOOTER_HEIGHT) {
-            size = DEFAULT_SECTION_HEADERFOOTER_HEIGHT;
+            size += DEFAULT_SECTION_HEADERFOOTER_HEIGHT;            
         }
 	}
-     */
 	return size;
 }
 


### PR DESCRIPTION
The documentation provided by Apple was misleading as to how table height values are used when getting view/label information for section headers. This fixes the problem introduced by TIMOB-5895 and that bug should be re-tested to confirm that it remains resolved while validating this pull request.
