### PR TITLE
TIMOB-6091 Android: Remove app.getArguments() from KitchenSink-Nook

### DIFF
--- a/apidoc/Titanium/App/App.yml
+++ b/apidoc/Titanium/App/App.yml
@@ -6,7 +6,7 @@ since: "0.1"
 methods:
   - name: getArguments
     description: return the arguments passed to the application on startup as a dictionary
-    platforms: [android, iphone, ipad]
+    platforms: [iphone, ipad]
     returns:
         type: Object
 events:

--- a/demos/KitchenSink-Nook/Resources/examples/app_data.js
+++ b/demos/KitchenSink-Nook/Resources/examples/app_data.js
@@ -11,7 +11,6 @@ data+= 'Description: ' + Titanium.App.getDescription() + '\n';
 data+= 'Copyright: ' + Titanium.App.getCopyright() + '\n';
 data+= 'GUID: ' + Titanium.App.getGUID() + '\n';
 data+= 'Path: ' + Titanium.App.appURLToPath('index.html') + '\n';
-data+= 'Arguments: ' + JSON.stringify(Titanium.App.getArguments()) + '\n';
 data+= 'Build: ' + Titanium.version + '.' + Titanium.buildHash + ' (' + Titanium.buildDate + ')\n';
 
 


### PR DESCRIPTION
(It was already removed in KitchenSink earlier this month.)

http://jira.appcelerator.org/browse/TIMOB-6091

Test case is to run the Platform - Application Data test in KitchenSink-Nook on the NOOK.  It shouldn't fail anymore.
