### PR TITLE
[TIMOB-6209] Avoid deadlocks when adding views to open windows

### DIFF
--- a/iphone/Classes/TiViewProxy.m
+++ b/iphone/Classes/TiViewProxy.m
@@ -103,13 +103,12 @@
 	else
 	{
 		[self rememberProxy:arg];
-		pthread_rwlock_wrlock(&childrenLock);
 		if (windowOpened)
 		{
-			pthread_rwlock_unlock(&childrenLock);
 			[self performSelectorOnMainThread:@selector(add:) withObject:arg waitUntilDone:NO];
 			return;
 		}
+		pthread_rwlock_wrlock(&childrenLock);
 		if (pendingAdds==nil)
 		{
 			pendingAdds = [[NSMutableArray arrayWithObject:arg] retain];


### PR DESCRIPTION
Don't preemptively lock anything that we don't have to. Probably need a locking evaluation on our code to detect other issues like this that haven't surfaced.
