### PR TITLE
TIMOB-6313: Extra parens confusing the compiler between void (^)() and void(^)(void).

### DIFF
--- a/iphone/Classes/UIModule.m
+++ b/iphone/Classes/UIModule.m
@@ -235,7 +235,7 @@ MAKE_SYSTEM_PROP_DEPRECATED(AUTODETECT_CALENDAR,UIDataDetectorTypeCalendarEvent,
 -(void)setOrientation:(id)mode
 {
 	UIInterfaceOrientation orientation = (UIInterfaceOrientation)[TiUtils orientationValue:mode def:(UIDeviceOrientation)UIInterfaceOrientationPortrait];
-	TiThreadPerformOnMainThread(^(){
+	TiThreadPerformOnMainThread(^{
 		[[TiApp controller] manuallyRotateToOrientation:orientation duration:[[TiApp controller] suggestedRotationDuration]];
 	}, NO);
 }


### PR DESCRIPTION
Nothing to test functionally, make sure it compiles fine.
