### PR TITLE
Timob 6319 Animation - NullPointerException is thrown when exiting Animation example in KitchenSink

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIImageView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIImageView.java
@@ -359,12 +359,15 @@ public class TiUIImageView extends TiUIView implements OnLifecycleEvent, Handler
 					if (!animating.get()) {
 						break topLoop;
 					}
-					Bitmap b = imageSources.get(j).getBitmap();
 					try {
+						Bitmap b = imageSources.get(j).getBitmap();
 						bitmapQueue.offer(new BitmapWithIndex(b, j), (int) getDuration() * imageSources.size(),
-							TimeUnit.MILLISECONDS);
+								TimeUnit.MILLISECONDS);
 					} catch (InterruptedException e) {
 						e.printStackTrace();
+					}
+					catch (NullPointerException n) {
+						Log.w(LCAT,  "NullPointerException");
 					}
 					repeatIndex++;
 				}

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIImageView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIImageView.java
@@ -365,8 +365,7 @@ public class TiUIImageView extends TiUIView implements OnLifecycleEvent, Handler
 							if (imageSources != null) {
 								Bitmap b = imageSources.get(j).getBitmap();
 								bitmapQueue.offer(new BitmapWithIndex(b, j), (int) getDuration() * imageSources.size(), TimeUnit.MILLISECONDS);
-							}
-							else {
+							} else {
 								break;
 							}
 						}

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIImageView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIImageView.java
@@ -361,10 +361,10 @@ public class TiUIImageView extends TiUIView implements OnLifecycleEvent, Handler
 						break topLoop;
 					}
 					try {
-						synchronized(lock) {
+						synchronized(releasedLock) {
 							if (imageSources != null) {
-							Bitmap b = imageSources.get(j).getBitmap();
-							bitmapQueue.offer(new BitmapWithIndex(b, j), (int) getDuration() * imageSources.size(), TimeUnit.MILLISECONDS);
+								Bitmap b = imageSources.get(j).getBitmap();
+								bitmapQueue.offer(new BitmapWithIndex(b, j), (int) getDuration() * imageSources.size(), TimeUnit.MILLISECONDS);
 							}
 							else {
 								break;
@@ -908,7 +908,7 @@ public class TiUIImageView extends TiUIView implements OnLifecycleEvent, Handler
 		if (imageSources != null) {
 			imageSources.clear();
 		}
-		synchronized(lock) {
+		synchronized(releasedLock) {
 			imageSources = null;
 		}
 		defaultImageSource = null;

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIImageView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIImageView.java
@@ -364,10 +364,11 @@ public class TiUIImageView extends TiUIView implements OnLifecycleEvent, Handler
 						bitmapQueue.offer(new BitmapWithIndex(b, j), (int) getDuration() * imageSources.size(),
 								TimeUnit.MILLISECONDS);
 					} catch (InterruptedException e) {
-						e.printStackTrace();
+						Log.w(LCAT, "Interrupted while adding Bitmap into bitmapQueue");
 					}
 					catch (NullPointerException n) {
 						Log.w(LCAT, "NullPointerException");
+						break;
 					}
 					repeatIndex++;
 				}

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIImageView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIImageView.java
@@ -367,7 +367,7 @@ public class TiUIImageView extends TiUIView implements OnLifecycleEvent, Handler
 						e.printStackTrace();
 					}
 					catch (NullPointerException n) {
-						Log.w(LCAT,  "NullPointerException");
+						Log.w(LCAT, "NullPointerException");
 					}
 					repeatIndex++;
 				}

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIImageView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIImageView.java
@@ -366,7 +366,7 @@ public class TiUIImageView extends TiUIView implements OnLifecycleEvent, Handler
 								Bitmap b = imageSources.get(j).getBitmap();
 								bitmapQueue.offer(new BitmapWithIndex(b, j), (int) getDuration() * imageSources.size(), TimeUnit.MILLISECONDS);
 							} else {
-								break;
+								break topLoop;
 							}
 						}
 					} catch (InterruptedException e) {


### PR DESCRIPTION
Testing steps in Jira ticket.

Jira Ticket:
http://jira.appcelerator.org/browse/TIMOB-6319
