### PR TITLE
[TIMOB-6286] Support for preventing iCloud backups

### DIFF
--- a/apidoc/Titanium/Filesystem/File.yml
+++ b/apidoc/Titanium/Filesystem/File.yml
@@ -122,3 +122,15 @@ properties:
     summary: returns the fully resolved native path
     type: String
     permission: read-only
+  - name: remoteBackup
+    summary: Value indicating whether or not to back up to a cloud service.
+    description: 
+        Some apps may be rejected by Apple for backing up specific files; if this
+        is the case, ensure that this value is set to `false` for them. This
+        value should only need to be set once by your app, but setting it
+        multiple times will not cause problems. For files distributed with your
+        app, this will need to be set on boot.
+    default: true
+    type: Boolean
+    platforms: [iphone,ipad]
+    since: "1.8.0"

--- a/apidoc/Titanium/Filesystem/File.yml
+++ b/apidoc/Titanium/Filesystem/File.yml
@@ -129,7 +129,8 @@ properties:
         is the case, ensure that this value is set to `false` for them. This
         value should only need to be set once by your app, but setting it
         multiple times will not cause problems. For files distributed with your
-        app, this will need to be set on boot.
+        app, this will need to be set on boot. This flag will only affect iOS
+        versions 5.0.1 and later, but is safe to set on earlier versions.
     default: true
     type: Boolean
     platforms: [iphone,ipad]

--- a/iphone/Classes/TiFilesystemFileProxy.h
+++ b/iphone/Classes/TiFilesystemFileProxy.h
@@ -31,6 +31,7 @@
 @property(nonatomic,readonly) id executable;
 @property(nonatomic,readonly) id hidden;
 
+@property(nonatomic,readwrite,assign) NSNumber* remoteBackup;
 
 
 @end

--- a/iphone/Classes/TiFilesystemFileProxy.m
+++ b/iphone/Classes/TiFilesystemFileProxy.m
@@ -7,6 +7,8 @@
 
 #ifdef USE_TI_FILESYSTEM
 
+#include <sys/xattr.h>
+
 #import "TiUtils.h"
 #import "TiBlob.h"
 #import "TiFilesystemFileProxy.h"
@@ -14,6 +16,8 @@
 
 #define FILE_TOSTR(x) \
 	([x isKindOfClass:[TiFilesystemFileProxy class]]) ? [(TiFilesystemFileProxy*)x nativePath] : [TiUtils stringValue:x]
+
+static const char* backupAttr = "com.apple.MobileBackup";
 
 @implementation TiFilesystemFileProxy
 
@@ -442,6 +446,38 @@ FILENOOP(setHidden:(id)x);
 	}
 	
 	return [[[TiFilesystemFileProxy alloc] initWithFile:resultPath] autorelease];
+}
+
+-(NSNumber*)remoteBackup
+{
+    u_int8_t value;
+    const char* fullPath = [[self path] UTF8String];
+    
+    int result = getxattr(fullPath, backupAttr, &value, sizeof(value), 0, 0);
+    if (result == -1) {
+        // Doesn't matter what errno is set to; this means that we're backing up.
+        return [NSNumber numberWithBool:YES];
+    }
+
+    // A value of 0 means backup, so:
+    return [NSNumber numberWithBool:!value];
+}
+
+-(void)setRemoteBackup:(NSNumber *)remoteBackup
+{
+    // Value of 1 means nobackup
+    u_int8_t value = ![TiUtils boolValue:remoteBackup def:YES];
+    const char* fullPath = [[self path] UTF8String];
+    
+    int result = setxattr(fullPath, backupAttr, &value, sizeof(value), 0, 0);
+    if (result != 0) {
+        // Throw an exception with the errno
+        char* errmsg = strerror(errno);
+        [self throwException:@"Error setting remote backup flag:" 
+                   subreason:[NSString stringWithUTF8String:errmsg] 
+                    location:CODELOCATION];
+        return;
+    }
 }
 
 @end

--- a/iphone/Classes/TiFilesystemFileProxy.m
+++ b/iphone/Classes/TiFilesystemFileProxy.m
@@ -451,7 +451,7 @@ FILENOOP(setHidden:(id)x);
 -(NSNumber*)remoteBackup
 {
     u_int8_t value;
-    const char* fullPath = [[self path] UTF8String];
+    const char* fullPath = [[self path] fileSystemRepresentation];
     
     int result = getxattr(fullPath, backupAttr, &value, sizeof(value), 0, 0);
     if (result == -1) {
@@ -467,7 +467,7 @@ FILENOOP(setHidden:(id)x);
 {
     // Value of 1 means nobackup
     u_int8_t value = ![TiUtils boolValue:remoteBackup def:YES];
-    const char* fullPath = [[self path] UTF8String];
+    const char* fullPath = [[self path] fileSystemRepresentation];
     
     int result = setxattr(fullPath, backupAttr, &value, sizeof(value), 0, 0);
     if (result != 0) {


### PR DESCRIPTION
This adds a flag to Ti.Filesystem.File which allows the toggling of an attribute that disables/enables iCloud backups. Some apps require certain files distributed with the app (or created for local information only) to not be backed up to get through the approval process.

Test to ensure that the bit is toggled correctly is attached to jira ticket. We cannot test actual iCloud backups without app submission, iCloud support, etc.
