### PR TITLE
[TIMOB-3876] Manually adjust app frame when exiting video player fullscreen

### DIFF
--- a/iphone/Classes/TiMediaVideoPlayerProxy.h
+++ b/iphone/Classes/TiMediaVideoPlayerProxy.h
@@ -37,6 +37,10 @@
 	// On rotate in fullscreen mode on iPad, we need to check if the orientation changed so we can redraw.
 	BOOL hasRotated;
     
+    // Need to preserve status bar frame information when entering/exiting fullscreen to properly re-render
+    // views when exiting it.
+    BOOL statusBarWasHidden;
+    
     // Have to track loading in the proxy in addition to the view, in case we load before the view should be rendered
     BOOL loaded;
 }

--- a/iphone/Classes/TiMediaVideoPlayerProxy.m
+++ b/iphone/Classes/TiMediaVideoPlayerProxy.m
@@ -888,6 +888,7 @@ NSArray* moviePlayerKeys = nil;
 		[self fireEvent:@"fullscreen" withObject:event];
 	}	
 	hasRotated = NO;
+    statusBarWasHidden = [[UIApplication sharedApplication] isStatusBarHidden];
 }
 
 -(void)handleFullscreenExitNotification:(NSNotification*)note
@@ -901,7 +902,20 @@ NSArray* moviePlayerKeys = nil;
 		[self fireEvent:@"fullscreen" withObject:event];
 	}	
 	if (hasRotated) {
-		[[[TiApp app] controller] resizeView];
+        // Because of the way that status bar visibility could be toggled by going in/out of fullscreen mode in video player,
+        // (and depends on whether or not DONE is clicked as well) we have to manually calculate and set the root controller's
+        // frame based on whether or not the status bar was visible when we entered fullscreen mode.
+        CGRect appFrame = [[UIScreen mainScreen] applicationFrame];
+        if (statusBarWasHidden != [[UIApplication sharedApplication] isStatusBarHidden]) {
+            // Modify the app frame before setting it manually
+            if ([[UIApplication sharedApplication] isStatusBarHidden]) { // Bar was previously visible
+                appFrame.size.width -= TI_STATUSBAR_HEIGHT;
+            }
+            else { // Bar was previously invisible
+                appFrame.size.width += TI_STATUSBAR_HEIGHT;
+            }
+        }
+        [[[[TiApp app] controller] view] setFrame:appFrame];
 		[[[TiApp app] controller] repositionSubviews];
 	}
 	hasRotated = NO;

--- a/iphone/Classes/TiMediaVideoPlayerProxy.m
+++ b/iphone/Classes/TiMediaVideoPlayerProxy.m
@@ -892,17 +892,7 @@ NSArray* moviePlayerKeys = nil;
         // Because of the way that status bar visibility could be toggled by going in/out of fullscreen mode in video player,
         // (and depends on whether or not DONE is clicked as well) we have to manually calculate and set the root controller's
         // frame based on whether or not the status bar was visible when we entered fullscreen mode.
-        CGRect appFrame = [[UIScreen mainScreen] applicationFrame];
-        if (statusBarWasHidden != [[UIApplication sharedApplication] isStatusBarHidden]) {
-            // Modify the app frame before setting it manually
-            if ([[UIApplication sharedApplication] isStatusBarHidden]) { // Bar was previously visible
-                appFrame.size.width -= TI_STATUSBAR_HEIGHT;
-            }
-            else { // Bar was previously invisible
-                appFrame.size.width += TI_STATUSBAR_HEIGHT;
-            }
-        }
-        [[[[TiApp app] controller] view] setFrame:appFrame];
+        [[[TiApp app] controller] resizeViewForStatusBarHidden:statusBarWasHidden];
 		[[[TiApp app] controller] repositionSubviews];
 	}
 	hasRotated = NO;

--- a/iphone/Classes/TiRootViewController.h
+++ b/iphone/Classes/TiRootViewController.h
@@ -67,6 +67,7 @@
 -(void)windowClosed:(UIViewController *)closedViewController;
 
 -(CGRect)resizeView;
+-(CGRect)resizeViewForStatusBarHidden:(BOOL)statusBarHidden;
 -(void)repositionSubviews;
 
 -(void)refreshOrientationWithDuration:(NSTimeInterval) duration;

--- a/iphone/Classes/TiRootViewController.m
+++ b/iphone/Classes/TiRootViewController.m
@@ -541,6 +541,25 @@
 	return [[self view] bounds];
 }
 
+// Some controllers (like MPVideoPlayerController) manually hide/show the bar
+// based on whether or not they enter a "fullscreen" mode, and upon exiting,
+// the root view size needs to be adjusted based on any status bar differences.
+-(CGRect)resizeViewForStatusBarHidden:(BOOL)statusBarHidden
+{
+    CGRect appFrame = [[UIScreen mainScreen] applicationFrame];
+    BOOL currentlyHiding = [[UIApplication sharedApplication] isStatusBarHidden];
+    if (statusBarHidden != currentlyHiding) {
+        // Modify the app frame before setting it manually
+        if (currentlyHiding) { // Bar was previously visible
+            appFrame.size.width -= TI_STATUSBAR_HEIGHT;
+        }
+        else { // Bar was previously invisible
+            appFrame.size.width += TI_STATUSBAR_HEIGHT;
+        }
+    }
+    [[self view] setFrame:appFrame];    
+    return [[self view] bounds];
+}
 
 -(void)repositionSubviews
 {


### PR DESCRIPTION
Turns out that when the video player exit fullscreen callback is invoked, the status bar is still hidden/shown according to the video player display settings, and NOT the settings of the rest of the app. This means if the status bar visibility is different from when we went fullscreen, manual adjustments have to happen.
