### PR TITLE
[TIMOB-6368]Ensure the section count is synced on the main thread

### DIFF
--- a/iphone/Classes/TiUITableViewProxy.m
+++ b/iphone/Classes/TiUITableViewProxy.m
@@ -624,7 +624,9 @@ NSArray * tableKeySequence;
         TiUITableViewSectionProxy* section = [sections lastObject];
         if (header != nil) {
             section = [self sectionWithHeader:header table:table];		
-            TiThreadPerformOnMainThread(^{section.section = [sections count];}, YES);
+            TiThreadPerformOnMainThread(^{
+                section.section = [sections count];
+            }, YES);
             actionType = TiUITableViewActionAppendRowWithSection;
         }
         row.section = section;

--- a/iphone/Classes/TiUITableViewProxy.m
+++ b/iphone/Classes/TiUITableViewProxy.m
@@ -623,9 +623,8 @@ NSArray * tableKeySequence;
         TiUITableViewActionType actionType = TiUITableViewActionAppendRow;
         TiUITableViewSectionProxy* section = [sections lastObject];
         if (header != nil) {
-            section = [self sectionWithHeader:header table:table];			
-            section.section = [sections count];
-            
+            section = [self sectionWithHeader:header table:table];		
+            TiThreadPerformOnMainThread(^{section.section = [sections count];}, YES);
             actionType = TiUITableViewActionAppendRowWithSection;
         }
         row.section = section;


### PR DESCRIPTION
When adding sections with append row make sure that the section count is accurate since the dispatchAction happens on main thread while append row is called on the background thread
