### PR TITLE
[TIMOB-3561] Enable exceptions in drillbit

### DIFF
--- a/drillbit/modules/drillbit/0.1.0/drillbitTest.js
+++ b/drillbit/modules/drillbit/0.1.0/drillbitTest.js
@@ -474,18 +474,6 @@ DrillbitTest.Subject.prototype.shouldBeLessThanEqual = function(expected, lineNu
 
 DrillbitTest.Subject.prototype.shouldThrowException = function(expected,lineNumber)
 {
-	if (Titanium.Platform.name == 'iPhone OS' || Titanium.Platform.name == 'iOS')
-	{
-		// iOS 4.0+ Simulator doesn't correctly propagate exceptions, so we ignore
-		// for iOS and issue a warning. Ticket:
-		// http://jira.appcelerator.org/browse/TIMOB-3561
-		Ti.API.warn("Not running test: ignoring shouldThrowException on line " + lineNumber + " in iOS, see http://jira.appcelerator.org/browse/TIMOB-3561");
-		
-		this.lineNumber = lineNumber;
-		DrillbitTest.assertion(this);
-		return;
-	}
-
 	this.lineNumber = lineNumber;
 	DrillbitTest.assertion(this);
 	if (typeof(this.target) == 'function')


### PR DESCRIPTION
Apparently this has been fixed for some time (thanks Blain!) and we should be re-enabling exceptions in drillbit for iOS now that we can properly catch and process them.

Testing this bug simply requires a drillbit run of the buffer test, which should PASS without this pull request (no exceptions checked) and FAIL without it (we don't throw exceptions where we should).
