### PR TITLE
add click event to TabGroup to inform if user hit one of tabs

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TabGroupProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TabGroupProxy.java
@@ -339,6 +339,15 @@ public class TabGroupProxy extends TiWindowProxy
 		opened = false;
 	}
 
+	public KrollDict buildClickEvent(int tabIndex)
+    {
+        KrollDict e = new KrollDict();
+
+        e.put(TiC.EVENT_PROPERTY_INDEX, tabIndex);
+
+        return e;
+    }
+
 	public KrollDict buildFocusEvent(String to, String from)
 	{
 		int toIndex = indexForId(to);

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUITabGroup.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUITabGroup.java
@@ -80,6 +80,18 @@ public class TiUITabGroup extends TiUIView
 				tabHost.setVisibility(View.INVISIBLE);
 			}
 		}
+
+        for (int i=0;i<tabHost.getTabWidget().getTabCount();i++) {
+            final int myTabIndex = i;
+            tabHost.getTabWidget().getChildAt(i).setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(android.view.View v) {
+                    getTabHost().setCurrentTab(myTabIndex);
+                    proxy.fireEvent(TiC.EVENT_CLICK, ((TabGroupProxy) proxy).buildClickEvent(myTabIndex));
+                }
+            });
+        }
+
 	}
 
 	public void setActiveTab(int index)
@@ -164,6 +176,10 @@ public class TiUITabGroup extends TiUIView
 			return -1;
 		}
 	}
+
+	public TabHost getTabHost() {
+        return tabHost;
+    }
 
 	@Override
 	public void propertyChanged(String key, Object oldValue, Object newValue, KrollProxy proxy)


### PR DESCRIPTION
For phone applications, if we using TabGroup, it's good to realize if user selects a tab (which might be already selected). Currently this event is ignored by Titanium code. I added a click event which fires when user click on tabs.

This contribution done by PHXX LLC. Company. 
