### PR TITLE
[TIMOB-6368]Ensure the section count is synced on the main thread

### DIFF
--- a/iphone/Classes/TiUITableViewProxy.m
+++ b/iphone/Classes/TiUITableViewProxy.m
@@ -604,9 +604,8 @@ NSArray * tableKeySequence;
 		TiUITableViewSectionProxy* section = [sections lastObject];
 		if (header != nil) {
 			section = [self sectionWithHeader:header table:table];	
-			//Ensure all table dispatch actions are completed before we get the section count
-			[self performSelectorOnMainThread:@selector(description) withObject:nil waitUntilDone:YES];
-			section.section = [sections count];
+			//Ensure we get the section count on the main thread
+			[self performSelectorOnMainThread:@selector(sectionCount:) withObject:section waitUntilDone:YES];
 			actionType = TiUITableViewActionAppendRowWithSection;
 		}
 		row.section = section;
@@ -622,6 +621,12 @@ NSArray * tableKeySequence;
 			[section add:row];
 		}
 	}	
+}
+
+-(void)sectionCount:(id)args
+{
+	ENSURE_TYPE(args, TiUITableViewSectionProxy);
+	((TiUITableViewSectionProxy*)args).section = [sections count];
 }
 
 -(void)setData:(id)args withObject:(id)properties immediate:(BOOL)immediate

--- a/iphone/Classes/TiUITableViewProxy.m
+++ b/iphone/Classes/TiUITableViewProxy.m
@@ -599,15 +599,16 @@ NSArray * tableKeySequence;
 	}
 	else
 	{
-        id header = [row valueForKey:@"header"];
-        TiUITableViewActionType actionType = TiUITableViewActionAppendRow;
+		id header = [row valueForKey:@"header"];
+		TiUITableViewActionType actionType = TiUITableViewActionAppendRow;
 		TiUITableViewSectionProxy* section = [sections lastObject];
-        if (header != nil) {
-			section = [self sectionWithHeader:header table:table];			
-            section.section = [sections count];
-            
-            actionType = TiUITableViewActionAppendRowWithSection;
-        }
+		if (header != nil) {
+			section = [self sectionWithHeader:header table:table];	
+			//Ensure all table dispatch actions are completed before we get the section count
+			[self performSelectorOnMainThread:@selector(description) withObject:nil waitUntilDone:YES];
+			section.section = [sections count];
+			actionType = TiUITableViewActionAppendRowWithSection;
+		}
 		row.section = section;
 		row.parent = section;
 		


### PR DESCRIPTION
This commit is for the 1_7_X branch. Calling the throwaway function description on main thread before getting section count. Test is attached to JIRA ticket (Use attachment app.js to reproduce crash consistently)
