### PR TITLE
[TIMOB-6417] Check selector availability in point conversion

### DIFF
--- a/iphone/Classes/TiUtils.m
+++ b/iphone/Classes/TiUtils.m
@@ -355,6 +355,15 @@ static void getAddrInternal(char* macAddress, const char* ifName) {
         id xVal = [value objectForKey:@"x"];
         id yVal = [value objectForKey:@"y"];
         if (xVal && yVal) {
+            if (![xVal respondsToSelector:@selector(floatValue)] ||
+                ![yVal respondsToSelector:@selector(floatValue)]) 
+            {
+                if (isValid) {
+                    *isValid = NO;
+                }
+                return CGPointMake(0.0, 0.0);
+            }
+            
             if (isValid) {
                 *isValid = YES;
             }


### PR DESCRIPTION
This problem may occur frequently after the update to use [NSNull null] to distinguish between null/undefined values.

Note that in order for this pull request to pass functional, the UI test in drillbit may still fail, but does _does_ need to complete running without a crash report generated.
