### PR TITLE
TIMOB-6135 Android: (1_7_X!) Support new Google API locations

### DIFF
--- a/android/build/common.xml
+++ b/android/build/common.xml
@@ -66,8 +66,29 @@ Common ant tasks and macros for building Android-based Titanium modules and proj
 					<property name="android.sdk" location="/opt/android-sdk"/>
 				</else>
 			</if>
-			<property name="android.platform" location="${android.sdk}/platforms/android-7"/>
-			<property name="google.apis" location="${android.sdk}/add-ons/google_apis-7_r01"/>
+			<if>
+				<isset property="env.ANDROID_PLATFORM"/>
+				<then>
+					<property name="android.platform" location="${env.ANDROID_PLATFORM}"/>
+				</then>
+				<else>
+					<property name="android.platform" location="${android.sdk}/platforms/android-7"/>
+				</else>
+			</if>
+			<if>
+				<isset property="env.GOOGLE_APIS"/>
+				<then>
+					<property name="google.apis" location="${env.GOOGLE_APIS}"/>
+				</then>
+				<else>
+					<if>
+						<not><isset property="google.apis"/></not>
+						<then>
+							<property name="google.apis" location="${android.sdk}/add-ons/addon-google_apis-google_inc_-7"/>
+						</then>
+					</if>
+				</else>
+			</if>
 		</else>
 	</if>
 

--- a/support/android/androidsdk.py
+++ b/support/android/androidsdk.py
@@ -91,9 +91,14 @@ class AndroidSDK:
 		self.platform_dir = platform_dir
 
 	def find_google_apis_dir(self):
+		if 'GOOGLE_APIS' in os.environ:
+			self.google_apis_dir = os.environ['GOOGLE_APIS']
+			return self.google_apis_dir
 		self.google_apis_dir = self.find_dir(self.api_level, os.path.join('add-ons', 'google_apis-'))
 		if self.google_apis_dir is None:
 			self.google_apis_dir = self.find_dir(self.api_level, os.path.join('add-ons', 'addon_google_apis_google_inc_'))
+			if self.google_apis_dir is None:
+				self.google_apis_dir = self.find_dir(self.api_level, os.path.join('add-ons', 'addon-google_apis-google_inc_-'))
 
 	def get_maps_jar(self):
 		if self.google_apis_dir is not None:


### PR DESCRIPTION
We've been asked to cherry-pick the fixes for http://jira.appcelerator.org/browse/TIMOB-6135 into 1_7_X, so here we go.  You can use the same old [testing notes](http://jira.appcelerator.org/browse/TIMOB-6135?focusedCommentId=172059&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-172059), except the api version number should be 7 instead of 8.
