### PR TITLE
TIMOB-5890:Parity: Android is passing the wrong time to analytics. Need ...

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/analytics/TiAnalyticsEvent.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/analytics/TiAnalyticsEvent.java
@@ -1,12 +1,13 @@
 /**
  * Appcelerator Titanium Mobile
- * Copyright (c) 2009-2010 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2009-2011 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
 package org.appcelerator.titanium.analytics;
 
 import java.text.SimpleDateFormat;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.TimeZone;
 
@@ -32,11 +33,13 @@ public class TiAnalyticsEvent
 {
 	private static final String LCAT = "TitaniumAnalyticsEvent";
 
-	private static TimeZone utc = TimeZone.getTimeZone("utc");
+	private static TimeZone utc = TimeZone.getTimeZone("UTC");
 	private static SimpleDateFormat isoDateFormatter =
 		new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
 	static {
-		isoDateFormatter.setTimeZone(utc);
+		// Workaround for setting the timezone since there is a bug in android 2.2 and earlier
+		// http://code.google.com/p/android/issues/detail?id=8258
+		isoDateFormatter.setCalendar(Calendar.getInstance(utc));
 	}
 
 	private String eventType;


### PR DESCRIPTION
...to decide on local time + offest or UTC time with no offset

http://jira.appcelerator.org/browse/TIMOB-5890

Test case in Jira.  2.2 and 3.0+ device needs to be tested.  The fail case should be with 2.2 and earlier

Format should be in UTC with no offset.
