### PR TITLE
[TIMOB-6385] iOS: Text Field: Bezel, and line border is not being displayed

### DIFF
--- a/iphone/Classes/TiUIScrollView.m
+++ b/iphone/Classes/TiUIScrollView.m
@@ -52,7 +52,7 @@
 {
 	if (TiDimensionIsAuto(contentWidth) || TiDimensionIsAuto(contentHeight))
 	{
-		[self performSelector:@selector(setNeedsHandleContentSize) withObject:nil afterDelay:.1];
+		[self setNeedsHandleContentSize];
 	}
 }
 


### PR DESCRIPTION
Test Case KitchenSink (testing instructions in jira ticket)

<b>NOTE : Do regress it against timob-5861</b>
offending commit was : https://github.com/appcelerator/titanium_mobile/commit/2a0f1e91ef385e5d19762d80af916ea3cf95d110
