### PR TITLE
[TIMOB-5971] permissions and availability exposed on properties

### DIFF
--- a/apidoc/docgen.py
+++ b/apidoc/docgen.py
@@ -227,6 +227,14 @@ class AnnotatedApi(object):
 			self.deprecated = api_obj["deprecated"]
 		else:
 			self.deprecated = None
+		if "permission" in api_obj:
+			self.permission = api_obj["permission"]
+		else:
+			self.permission = None
+		if "availability" in api_obj:
+			self.availability = api_obj["availability"]
+		else:
+			self.availability = None
 
 	@lazyproperty
 	def platforms(self):

--- a/apidoc/templates/html/header.html
+++ b/apidoc/templates/html/header.html
@@ -26,7 +26,9 @@
 % if data.permission:
 	<div class="permission">Permission: ${data.permission}</div>
 % else:
-	<div class="permission">Permission: read-write</div>
+	% if data.typestr == "property":
+		<div class="permission">Permission: read-write</div>
+	% endif
 % endif
 
 <%include file="parent_info.html"/>

--- a/apidoc/templates/html/header.html
+++ b/apidoc/templates/html/header.html
@@ -8,6 +8,10 @@
 
 <h1 class="namespace">${name}</h1>
 
+<%include file="parent_info.html"/>
+
+<%include file="platforms.html"/>
+
 % if data.deprecated:
     <div class="deprecation_warning">Deprecated
         % if "since" in data.deprecated:
@@ -31,12 +35,13 @@
 	% endif
 % endif
 
-<%include file="parent_info.html"/>
-
-<%include file="platforms.html"/>
-
 <h3 id="summary">Summary</h3>
 <div class="summary">${data.summary_html}</div>
+
+% if data.typestr == "property":
+    <h3 id="type">Type</h3>
+    <div class="type">${data.type_html}</div>
+% endif
 
 <%include file="description.html"/>
 

--- a/apidoc/templates/html/header.html
+++ b/apidoc/templates/html/header.html
@@ -19,6 +19,16 @@
     </div>
 % endif
 
+% if data.availability:
+	<div class="availability">Availability: ${data.availability}</div>
+% endif
+
+% if data.permission:
+	<div class="permission">Permission: ${data.permission}</div>
+% else:
+	<div class="permission">Permission: read-write</div>
+% endif
+
 <%include file="parent_info.html"/>
 
 <%include file="platforms.html"/>

--- a/apidoc/templates/html/member_list.html
+++ b/apidoc/templates/html/member_list.html
@@ -33,20 +33,15 @@
 				% if len(item.platforms) < platform_count:
 					<span class="platform_warning">(${platform_names} only.)</span>
 				% endif
-                % if item.deprecated is not None:
-                    <%
-                        deprecation_info = ""
-                        if "since" in item.deprecated:
-                            deprecation_info = " since %s" % item.deprecated["since"]
-                        if "removed" in item.deprecated:
-                            if len(deprecation_info) > 0:
-                                deprecation_info += ", "
-                            else:
-                                deprecation_info += " and "
-                            deprecation_info += ("removed in %s" % item.deprecated["removed"])
-                    %>
-                    <span class="deprecation_warning">(Deprecated${deprecation_info}.)</span>
-                % endif
+				% if item.permission is not None:
+					<span class="permission_warning">${item.permission}</span>
+				% endif
+				% if item.availability is not None:
+					<span class="availability_warning">${item.availability}</span>
+				% endif
+ 				% if item.deprecated is not None:
+					<span class="deprecation_warning">Deprecated</span>
+				% endif
 				% if was_para_close:
 					</p>
 				% endif

--- a/apidoc/templates/html/member_list.html
+++ b/apidoc/templates/html/member_list.html
@@ -29,7 +29,14 @@
 		% if is_property_list:
 			<td class="type${append_cell_class}">${item.type_html}</td>
 		% endif
-			<td class="summary${append_cell_class}">${summary}
+			<td class="summary${append_cell_class}">
+				% if item.deprecated is not None:
+					<%
+						if summary.startswith("<p>"):
+							summary = '%s<span class="deprecation_warning">Deprecated</span>&nbsp;%s' % (summary[:3],summary[3:])
+					%>
+				% endif			
+				${summary}
 				% if len(item.platforms) < platform_count:
 					<span class="platform_warning">(${platform_names} only.)</span>
 				% endif
@@ -38,9 +45,6 @@
 				% endif
 				% if item.availability is not None:
 					<span class="availability_warning">${item.availability}</span>
-				% endif
- 				% if item.deprecated is not None:
-					<span class="deprecation_warning">Deprecated</span>
 				% endif
 				% if was_para_close:
 					</p>


### PR DESCRIPTION
To test lists modify `apidoc/Titanium/Android/Intent.yml`. Append the following properties below `availability` in the `action` property.

```
    permission: read-write
    deprecated:
        since: "1.8.0"
```

You can view the detail from that property to insure that the properties are then correctly reflected. You might also look at Window's properties too.
