### PR TITLE
[TIMOB-6451] Work around behavior change to access root activity.

### DIFF
--- a/drillbit/modules/drillbit/0.1.0/templates/app.js
+++ b/drillbit/modules/drillbit/0.1.0/templates/app.js
@@ -46,7 +46,7 @@ w.add(harnessConsole);
 
 // in Android, we run tests through the custom Activity
 if (isAndroid) {
-	w.activity.addEventListener("instrumentationReady", function(e) {
+	Ti.Android.currentActivity.addEventListener("instrumentationReady", function(e) {
 		DrillbitTest.instrumentation = e.instrumentation;
 		runTests();
 	});


### PR DESCRIPTION
Windows may not have an activity proxy set before they are opened.

This should get drillbit running again. Test by trying to run any drillbit test suite.
It should be able to run after this fix is applied.
