### PR TITLE
[TIMOB-1542] Document potential interrupts of the 'pause' event.

### DIFF
--- a/apidoc/Titanium/App/App.yml
+++ b/apidoc/Titanium/App/App.yml
@@ -29,10 +29,15 @@ events:
         the exact behavior that triggers this event.
     platforms: [iphone, ipad]
   - name: pause
-    summary: fired when an iOS application will stop being the focus. This does include not
-        only the user leaving the application, but pauses due to notifications or calls. See
-        [applicationWillResignActive](http://developer.apple.com/library/ios/documentation/UIKit/Reference/UIApplicationDelegate_Protocol/Reference/Reference.html#//apple_ref/doc/uid/TP40006786-CH3-SW10) for
-        the exact behavior that triggers this event.
+    summary: fired when an iOS application will stop being the focus. 
+    description: |
+    	This does include not include only the user leaving the application, 
+    	but pauses due to notifications or calls. See [applicationWillResignActive](http://developer.apple.com/library/ios/documentation/UIKit/Reference/UIApplicationDelegate_Protocol/Reference/Reference.html#//apple_ref/doc/uid/TP40006786-CH3-SW10) 
+    	for the exact behavior that triggers this event.
+    	Note that making calls to functions which modify the UI during this
+    	event may cause execution UP TO the blocking call before the suspension,
+    	but then execute the REMAINDER of the callback after the application is
+    	resumed (but before the resume event is triggered).
     platforms: [iphone, ipad]
 properties:
   - name: copyright

--- a/apidoc/Titanium/App/App.yml
+++ b/apidoc/Titanium/App/App.yml
@@ -31,14 +31,14 @@ events:
   - name: pause
     summary: fired when an iOS application will stop being the focus. 
     description: |
-    	This does include not include only the user leaving the application, 
-    	but pauses due to notifications or calls. See [applicationWillResignActive](http://developer.apple.com/library/ios/documentation/UIKit/Reference/UIApplicationDelegate_Protocol/Reference/Reference.html#//apple_ref/doc/uid/TP40006786-CH3-SW10) 
-    	for the exact behavior that triggers this event.
-    	
-    	Note that making calls to functions which modify the UI during this
-    	event may cause execution UP TO the UI call before the suspension,
-    	but then execute the REMAINDER of the callback after the application is
-    	resumed (but before the resume event is triggered).
+        This includes not only the user leaving the application, 
+        but also pauses due to notifications or calls. See [applicationWillResignActive](http://developer.apple.com/library/ios/documentation/UIKit/Reference/UIApplicationDelegate_Protocol/Reference/Reference.html#//apple_ref/doc/uid/TP40006786-CH3-SW10) 
+        for the exact behavior that triggers this event.
+        
+        Note that making calls to functions which modify the UI during this
+        event may cause execution UP TO the UI call before the suspension,
+        but then execute the REMAINDER of the callback after the application is
+        resumed (but before the resume event is triggered).
     platforms: [iphone, ipad]
 properties:
   - name: copyright

--- a/apidoc/Titanium/App/App.yml
+++ b/apidoc/Titanium/App/App.yml
@@ -34,8 +34,9 @@ events:
     	This does include not include only the user leaving the application, 
     	but pauses due to notifications or calls. See [applicationWillResignActive](http://developer.apple.com/library/ios/documentation/UIKit/Reference/UIApplicationDelegate_Protocol/Reference/Reference.html#//apple_ref/doc/uid/TP40006786-CH3-SW10) 
     	for the exact behavior that triggers this event.
+    	
     	Note that making calls to functions which modify the UI during this
-    	event may cause execution UP TO the blocking call before the suspension,
+    	event may cause execution UP TO the UI call before the suspension,
     	but then execute the REMAINDER of the callback after the application is
     	resumed (but before the resume event is triggered).
     platforms: [iphone, ipad]


### PR DESCRIPTION
Because of how we schedule threading, events which are intended to occur on the main thread (i.e. UI updates) cannot be called during the "pause" event. This documents this behavior, but the bug remains to be resolved.
