### PR TITLE
TIMOB-6428 Android: "R" proxy not working in Rhino

### DIFF
--- a/android/kroll-apt/src/java/org/appcelerator/kroll/annotations/generator/ProxyBindingRhino.java.fm
+++ b/android/kroll-apt/src/java/org/appcelerator/kroll/annotations/generator/ProxyBindingRhino.java.fm
@@ -326,7 +326,7 @@ public class ${className}Prototype extends ${superProxy}
 			}
 		}
 
-		return result;
+		return TypeConverter.javaObjectToJsObject(result, start);
 	}
 	</#if>
 


### PR DESCRIPTION
http://jira.appcelerator.org/browse/TIMOB-6428

Test case is the failcase described in the item.
