### PR TITLE
set mimeType in setImage likely initWithImage.

### DIFF
--- a/iphone/Classes/TiBlob.m
+++ b/iphone/Classes/TiBlob.m
@@ -206,8 +206,8 @@
 -(void)setData:(NSData*)data_
 {
 	RELEASE_TO_NIL(data);
-	type = TiBlobTypeData;
 	data = [data_ retain];
+	type = TiBlobTypeData;
 }
 
 -(void)setImage:(UIImage *)image_
@@ -215,6 +215,7 @@
 	RELEASE_TO_NIL(image);
 	type = TiBlobTypeImage;
 	image = [image_ retain];
+	mimetype = [@"image/jpeg" retain];
 }
 
 -(NSString*)path


### PR DESCRIPTION
Send incorrect mimetype 'application/octet-stream' when send multipart data,  Titanium.Network.HTTPClient#send with TiBlob that it get from Titanium.UI.View.toImage.
