### PR TITLE
[TIMOB-6273] Update where databases are stored

### DIFF
--- a/apidoc/Titanium/Filesystem/File.yml
+++ b/apidoc/Titanium/Filesystem/File.yml
@@ -131,6 +131,9 @@ properties:
         multiple times will not cause problems. For files distributed with your
         app, this will need to be set on boot. This flag will only affect iOS
         versions 5.0.1 and later, but is safe to set on earlier versions.
+        
+        Note that setting this property will also prevent the file from
+        being backed up to iTunes.
     default: true
     type: Boolean
     platforms: [iphone,ipad]

--- a/apidoc/Titanium/Filesystem/File.yml
+++ b/apidoc/Titanium/Filesystem/File.yml
@@ -124,7 +124,7 @@ properties:
     permission: read-only
   - name: remoteBackup
     summary: Value indicating whether or not to back up to a cloud service.
-    description: 
+    description: |
         Some apps may be rejected by Apple for backing up specific files; if this
         is the case, ensure that this value is set to `false` for them. This
         value should only need to be set once by your app, but setting it
@@ -132,8 +132,8 @@ properties:
         app, this will need to be set on boot. This flag will only affect iOS
         versions 5.0.1 and later, but is safe to set on earlier versions.
         
-        Note that setting this property will also prevent the file from
-        being backed up to iTunes.
+        Note that setting this property to `false` will also prevent the
+        file from being backed up to iTunes.
     default: true
     type: Boolean
     platforms: [iphone,ipad]

--- a/iphone/Classes/TiDatabaseProxy.m
+++ b/iphone/Classes/TiDatabaseProxy.m
@@ -61,6 +61,7 @@
     if (exists && !isDirectory) {
         NSLog(@"[WARN] Recreating file %@... should be a directory and isn't.", dbPath);
         [fm removeItemAtPath:dbPath error:nil];
+        exists = NO;
     }
 
 	// create folder, and migrate the old one if necessary    

--- a/iphone/Classes/TiDatabaseProxy.m
+++ b/iphone/Classes/TiDatabaseProxy.m
@@ -51,7 +51,7 @@
     // Apparently following these guidelines is now required for app submission
     
 	NSString *rootDir = [NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES) objectAtIndex:0];
-	NSString *dbPath = [[rootDir stringByAppendingPathComponent:@"Private Documents"] retain];
+	NSString *dbPath = [rootDir stringByAppendingPathComponent:@"Private Documents"];
 	NSFileManager *fm = [NSFileManager defaultManager];
 	
 	BOOL isDirectory;
@@ -70,8 +70,7 @@
     if (oldCopyExists) {
         NSDirectoryEnumerator* contents = [fm enumeratorAtPath:oldPath];
         
-        NSString* oldFile;
-        while (oldFile = [contents nextObject]) {
+        for (NSString* oldFile in contents) {
             [fm moveItemAtPath:oldFile toPath:[dbPath stringByAppendingPathComponent:[oldFile lastPathComponent]] error:nil];
         }
         
@@ -79,7 +78,7 @@
         [fm removeItemAtPath:oldPath error:nil];
     }
 	
-	return [dbPath autorelease];
+	return dbPath;
 }
 
 -(NSString*)dbPath:(NSString*)name_

--- a/iphone/Classes/TiDatabaseProxy.m
+++ b/iphone/Classes/TiDatabaseProxy.m
@@ -57,7 +57,13 @@
 	BOOL isDirectory;
 	BOOL exists = [fm fileExistsAtPath:dbPath isDirectory:&isDirectory];
 	
-	// create folder, and migrate the old one if necessary
+    // Because of sandboxing, this should never happen, but we still need to handle it.
+    if (exists && !isDirectory) {
+        NSLog(@"[WARN] Recreating file %@... should be a directory and isn't.", dbPath);
+        [fm removeItemAtPath:dbPath error:nil];
+    }
+
+	// create folder, and migrate the old one if necessary    
 	if (!exists) 
 	{
         [fm createDirectoryAtPath:dbPath withIntermediateDirectories:YES attributes:nil error:nil];
@@ -67,7 +73,7 @@
     NSString* oldRoot = [NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, YES) objectAtIndex:0];
     NSString* oldPath = [oldRoot stringByAppendingString:@"database"];
     BOOL oldCopyExists = [fm fileExistsAtPath:oldPath isDirectory:&isDirectory];
-    if (oldCopyExists) {
+    if (oldCopyExists && isDirectory) {
         NSDirectoryEnumerator* contents = [fm enumeratorAtPath:oldPath];
         
         for (NSString* oldFile in contents) {


### PR DESCRIPTION
Required to conform to Apple's iOS 5 storage guidelines: https://developer.apple.com/library/ios/#qa/qa1719/_index.html

Note that we're assuming that this is all "offline data". Developers are still required to manually set the do-not-backup flag on DB files.
