### PR TITLE
[TIMOB-6286][1_7_X] Support for preventing backups

### DIFF
--- a/apidoc/Titanium/Filesystem/File.tdoc
+++ b/apidoc/Titanium/Filesystem/File.tdoc
@@ -22,6 +22,10 @@ The File object which support various filesystem based operations.
 
 android, iphone, ipad
 
+- properties
+
+remoteBackup[boolean]: Indicates whether or not to perform backup to iCloud or iTunes of a file. Default is true; only affects iOS devices of version 5.0.1. or later.
+
 - methods
 
 nativePath: returns the fully resolved native path

--- a/iphone/Classes/TiFilesystemFileProxy.h
+++ b/iphone/Classes/TiFilesystemFileProxy.h
@@ -31,6 +31,7 @@
 @property(nonatomic,readonly) id executable;
 @property(nonatomic,readonly) id hidden;
 
+@property(nonatomic,readwrite,assign) NSNumber* remoteBackup;
 
 
 @end


### PR DESCRIPTION
Adds the Ti.Filesystem.File.remoteBackup property to 1.7.x. There is a doc change; please review before accepting.
## Full commit

Merge pull request #785 from sptramer/timob-6286
[TIMOB-6286] Support for preventing iCloud backups
- Includes an update to the File.tdoc for the property
  Conflicts:
  
  apidoc/Titanium/Filesystem/File.yml
