### PR TITLE
[TIMOB-6138][1_7_X] Implemented frameSizeChanged for ScrollView

### DIFF
--- a/iphone/Classes/TiUIScrollView.m
+++ b/iphone/Classes/TiUIScrollView.m
@@ -125,8 +125,12 @@
 
 -(void)frameSizeChanged:(CGRect)frame bounds:(CGRect)visibleBounds
 {
-	//Treat this as a size change
-	[(TiViewProxy *)[self proxy] willChangeSize];
+    //Treat this as a size change
+    if (!CGRectIsEmpty(visibleBounds))
+    {
+        [self setNeedsHandleContentSizeIfAutosizing];
+    }
+    [super frameSizeChanged:frame bounds:visibleBounds];
 }
 
 -(void)setContentWidth_:(id)value


### PR DESCRIPTION
Merge of #661 back into 1.7.6. Conflict appears to have been due to to a change where the original 1.7 code was removed in 1.8 as part of a bugfix, and then this method was written back in.
## Original commit

Merge pull request #661 from vishalduggal/timob-6138
[TIMOB-6138] Implemented frameSizeChanged for ScrollView
Conflicts:

```
iphone/Classes/TiUIScrollView.m
```
