### PR TITLE
TIMOB-6486: Android: Tabs don't fire click events

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TabGroupProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TabGroupProxy.java
@@ -217,7 +217,7 @@ public class TabGroupProxy extends TiWindowProxy
 
 			tspec.setContent(intent);
 
-			tg.addTab(tspec);
+			tg.addTab(tspec, tab);
 		}
 	}
 

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TabProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TabProxy.java
@@ -77,6 +77,7 @@ public class TabProxy extends TiViewProxy
 
 	public void setTabGroup(TabGroupProxy tabGroupProxy) 
 	{
+		setParent(tabGroupProxy);
 		this.tabGroupProxy = tabGroupProxy;
 	}
 

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUITabGroup.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUITabGroup.java
@@ -88,7 +88,7 @@ public class TiUITabGroup extends TiUIView
 				@Override
 				public void onClick(View v)
 				{
-					// We have the set the current tab here to restore the widget's default behavior since
+					// We have to set the current tab here to restore the widget's default behavior since
 					// setOnClickListener seems to overwrite it
 					tabHost.setCurrentTab(tabCount - 1);
 					tabProxy.fireEvent(TiC.EVENT_CLICK, null);

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUITabGroup.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUITabGroup.java
@@ -81,13 +81,16 @@ public class TiUITabGroup extends TiUIView
 				tabHost.setVisibility(View.INVISIBLE);
 			}
 		}
-		int tabCount = tabHost.getTabWidget().getTabCount();
+		final int tabCount = tabHost.getTabWidget().getTabCount();
 		if (tabCount > 0) {
 			tabHost.getTabWidget().getChildTabViewAt(tabCount - 1).setOnClickListener(new OnClickListener()
 			{
 				@Override
 				public void onClick(View v)
 				{
+					// We have the set the current tab here to restore the widget's default behavior since
+					// setOnClickListener seems to overwrite it
+					tabHost.setCurrentTab(tabCount - 1);
 					tabProxy.fireEvent(TiC.EVENT_CLICK, null);
 				}
 			});

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUITabGroup.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUITabGroup.java
@@ -20,6 +20,7 @@ import ti.modules.titanium.ui.TabProxy;
 import ti.modules.titanium.ui.TiTabActivity;
 import android.graphics.drawable.ColorDrawable;
 import android.view.View;
+import android.view.View.OnClickListener;
 import android.widget.TabHost;
 import android.widget.TabHost.OnTabChangeListener;
 import android.widget.TabHost.TabSpec;
@@ -64,7 +65,7 @@ public class TiUITabGroup extends TiUIView
 		return tabHost.newTabSpec(id);
 	}
 
-	public void addTab(TabSpec tab)
+	public void addTab(TabSpec tab, final TabProxy tabProxy)
 	{
 		addingTab = true;
 		tabHost.addTab(tab);
@@ -79,6 +80,17 @@ public class TiUITabGroup extends TiUIView
 			} else {
 				tabHost.setVisibility(View.INVISIBLE);
 			}
+		}
+		int tabCount = tabHost.getTabWidget().getTabCount();
+		if (tabCount > 0) {
+			tabHost.getTabWidget().getChildTabViewAt(tabCount - 1).setOnClickListener(new OnClickListener()
+			{
+				@Override
+				public void onClick(View v)
+				{
+					tabProxy.fireEvent(TiC.EVENT_CLICK, null);
+				}
+			});
 		}
 	}
 


### PR DESCRIPTION
http://jira.appcelerator.org/browse/TIMOB-6486

Test case in ticket.

When clicking on a tab, both the tab, and tabgroup event should be fired.
