### PR TITLE
Fix for TableView accessory button click while searching

### DIFF
--- a/iphone/Classes/TiUITableView.m
+++ b/iphone/Classes/TiUITableView.m
@@ -1856,7 +1856,16 @@ if(ourTableView != tableview)	\
 
 - (void)tableView:(UITableView *)ourTableView accessoryButtonTappedForRowWithIndexPath:(NSIndexPath *)indexPath
 {
-	[self triggerActionForIndexPath:indexPath fromPath:nil tableView:ourTableView wasAccessory:YES search:NO name:@"click"];
+	BOOL search = NO;
+	if (allowsSelectionSet==NO || [ourTableView allowsSelection]==NO)
+	{
+		[ourTableView deselectRowAtIndexPath:indexPath animated:YES];
+	}
+	if(ourTableView != tableview)
+	{
+		search = YES;
+	}
+	[self triggerActionForIndexPath:indexPath fromPath:nil tableView:ourTableView wasAccessory:YES search:search name:@"click"];
 }
 
 - (NSInteger)tableView:(UITableView *)ourTableView indentationLevelForRowAtIndexPath:(NSIndexPath *)indexPath


### PR DESCRIPTION
When you click accessory buttons when you're running a search on a table view, the wrong row data is passed to the click event. This is because unlike the main click delegate (didSelectRowAtIndexPath) it does not take into account that a search is currently being run.

This has been around since at least 1.4.0 or so, maybe even earlier. I keep changing my local code in ever new version of Titanium that is released. Its a few line fix so would be really good if it was fixed in the Titanium master code.

As per:
http://support.appcelerator.com/tickets/BXF-41874-337 and
http://jira.appcelerator.org/browse/TC-460
