### PR TITLE
[TIMOB-6490] Remove 'dead' keyboard toolbars from superview

### DIFF
--- a/iphone/Classes/TiRootViewController.m
+++ b/iphone/Classes/TiRootViewController.m
@@ -1119,6 +1119,7 @@
 	if(leavingAccessoryView != nil)
 	{
 		NSLog(@"[WARN] Trying to blur out %@, but %@ is already leaving focus.",accessoryView,leavingAccessoryView);
+        [leavingAccessoryView removeFromSuperview];
 		RELEASE_TO_NIL_AUTORELEASE(leavingAccessoryView);
 	}
 


### PR DESCRIPTION
If a keyboard toolbar is already offscreen (or animated offscreen) due to rapid toolbar redraw, we need to ensure that it's removed from the superview at that time.
