### PR TITLE
[TIMOB-6490][1_7_X] Remove 'dead' keyboard toolbars from superview

### DIFF
--- a/iphone/Classes/TiRootViewController.m
+++ b/iphone/Classes/TiRootViewController.m
@@ -1193,6 +1193,7 @@ What this does mean is that any
 	if(leavingAccessoryView != nil)
 	{
 		NSLog(@"[WARN] Trying to blur out %@, but %@ is already leaving focus.",accessoryView,leavingAccessoryView);
+        [leavingAccessoryView removeFromSuperview];
 		RELEASE_TO_NIL_AUTORELEASE(leavingAccessoryView);
 	}
 


### PR DESCRIPTION
If a keyboard toolbar is animated offscreen while we're blurring another one, it should be removed from the superview before proceeding.

Duplicate of pull #878 for 1.7.6 inclusion. This one is safe to push the green button on.
