### PR TITLE
[TIOMB-6239] Removing timestamp from being appended on app version for distribution build

### DIFF
--- a/support/iphone/builder.py
+++ b/support/iphone/builder.py
@@ -859,7 +859,8 @@ def main(args):
 				version = ti.properties['version']
 				# we want to make sure in debug mode the version always changes
 				version = "%s.%d" % (version,time.time())
-				ti.properties['version']=version
+				if (deploytype != 'production'):
+					ti.properties['version'] = version
 				pp = os.path.expanduser("~/Library/MobileDevice/Provisioning Profiles/%s.mobileprovision" % appuuid)
 				provisioning_profile = read_provisioning_profile(pp,o)
 	

--- a/support/iphone/compiler.py
+++ b/support/iphone/compiler.py
@@ -208,12 +208,6 @@ class Compiler(object):
 				main_file.write(main_template)
 				main_file.close()
 		
-		if deploytype == 'production':
-			version = ti.properties['version']
-			# we want to make sure in debug mode the version always changes
-			version = "%s.%d" % (version,time.time())
-			ti.properties['version']=version
-
 		resources_dir = os.path.join(project_dir,'Resources')
 		iphone_resources_dir = os.path.join(resources_dir,'iphone')
 		iphone_platform_dir = os.path.join(project_dir,'platform','iphone')


### PR DESCRIPTION
it turns out that we need to append a timestamp for normal simulator and device build, otherwise the apps would be reinstalled on device during rebuilds. So just removing timestamp from being appended on to the appversion string <b>only for distribution build.</b>

Testing Instructions in Jira
