### PR TITLE
[TIOMB-6293] Removing timestamp from being appended on app version for distribuition build

### DIFF
--- a/support/iphone/builder.py
+++ b/support/iphone/builder.py
@@ -343,11 +343,15 @@ def distribute_xc4(name, icon, log):
 	project_info_plist = plistlib.readPlist(os.path.join(archive_bundle,'Info.xml.plist'))
 	appbundle = "Applications/%s.app" % name
 	# NOTE: We chop off the end '.' of 'CFBundleVersion' to provide the 'short' version
+	version = project_info_plist['CFBundleVersion']
+	app_version_ = version.split('.')
+	if(len(app_version_) > 3):
+		version = app_version_[0]+app_version_[1]+app_version_[2]	
 	archive_info = {
 		'ApplicationProperties' : {
 			'ApplicationPath' : appbundle,
 			'CFBundleIdentifier' : project_info_plist['CFBundleIdentifier'],
-			'CFBundleShortVersionString' : project_info_plist['CFBundleVersion'].rsplit('.',1)[0],
+			'CFBundleShortVersionString' : version,
 			'IconPaths' : [os.path.join(appbundle,icon), os.path.join(appbundle,icon)]
 		},
 		'ArchiveVersion' : float(1),

--- a/support/iphone/builder.py
+++ b/support/iphone/builder.py
@@ -346,7 +346,7 @@ def distribute_xc4(name, icon, log):
 	version = project_info_plist['CFBundleVersion']
 	app_version_ = version.split('.')
 	if(len(app_version_) > 3):
-		version = app_version_[0]+app_version_[1]+app_version_[2]	
+		version = app_version_[0]+','+app_version_[1]+'.'+app_version_[2]	
 	archive_info = {
 		'ApplicationProperties' : {
 			'ApplicationPath' : appbundle,

--- a/support/iphone/builder.py
+++ b/support/iphone/builder.py
@@ -346,7 +346,7 @@ def distribute_xc4(name, icon, log):
 	version = project_info_plist['CFBundleVersion']
 	app_version_ = version.split('.')
 	if(len(app_version_) > 3):
-		version = app_version_[0]+','+app_version_[1]+'.'+app_version_[2]	
+		version = app_version_[0]+'.'+app_version_[1]+'.'+app_version_[2]	
 	archive_info = {
 		'ApplicationProperties' : {
 			'ApplicationPath' : appbundle,

--- a/support/iphone/builder.py
+++ b/support/iphone/builder.py
@@ -859,7 +859,8 @@ def main(args):
 				version = ti.properties['version']
 				# we want to make sure in debug mode the version always changes
 				version = "%s.%d" % (version,time.time())
-				ti.properties['version']=version
+				if (deploytype != 'production'):
+					ti.properties['version']=version
 				pp = os.path.expanduser("~/Library/MobileDevice/Provisioning Profiles/%s.mobileprovision" % appuuid)
 				provisioning_profile = read_provisioning_profile(pp,o)
 	

--- a/support/iphone/compiler.py
+++ b/support/iphone/compiler.py
@@ -208,12 +208,6 @@ class Compiler(object):
 				main_file.write(main_template)
 				main_file.close()
 		
-		if deploytype == 'production':
-			version = ti.properties['version']
-			# we want to make sure in debug mode the version always changes
-			version = "%s.%d" % (version,time.time())
-			ti.properties['version']=version
-
 		resources_dir = os.path.join(project_dir,'Resources')
 		iphone_resources_dir = os.path.join(resources_dir,'iphone')
 		iphone_platform_dir = os.path.join(project_dir,'platform','iphone')


### PR DESCRIPTION
it turns out that we need to append a timestamp for normal simulator and device build, otherwise the apps would be reinstalled on device during rebuilds. So just removing timestamp from being appended on to the appversion string only for distribution build.

Testing Instructions in Jira
