### PR TITLE
Timob 6521 - Closing of a nav group should not create a view

### DIFF
--- a/iphone/Classes/TiUIiPhoneNavigationGroupProxy.m
+++ b/iphone/Classes/TiUIiPhoneNavigationGroupProxy.m
@@ -110,7 +110,9 @@
 -(void)windowDidClose
 {
 	WARN_IF_BACKGROUND_THREAD;
-	[[self view] close];
+	if ([self viewAttached]) {
+		[(TiUIiPhoneNavigationGroup*)[self view] close];
+	}
 	[super windowDidClose];
 }
 


### PR DESCRIPTION
This does NOT need merging with 1.8, as the fix was already there. Contact me or Fredrico for the test app
