### PR TITLE
Timob 6520 implement support for apiversion property in module manifest

### DIFF
--- a/support/android/android.py
+++ b/support/android/android.py
@@ -23,7 +23,7 @@ import bindings
 template_dir = os.path.abspath(os.path.dirname(sys._getframe(0).f_code.co_filename))
 module_dir = os.path.join(os.path.dirname(template_dir), 'module')
 sys.path.extend([os.path.dirname(template_dir), module_dir])
-from tiapp import TiAppXML
+from tiapp import TiAppXML, touch_tiapp_xml
 from manifest import Manifest
 from module import ModuleDetector
 import simplejson
@@ -219,6 +219,20 @@ class Android(object):
 
 				print '[DEBUG] module_id = %s' % module_id
 				if module_id == module.manifest.moduleid:
+					# make sure that the module was not built before 1.8.0.1
+					try:
+						module_api_version = int(module.manifest.apiversion)
+						if module_api_version < 2:
+							print "[ERROR] The 'apiversion' in the module manifest is less than version 2.  The module was likely built against a Titanium SDK pre 1.8.0.1.  Please use a version of the module that has 'apiversion' 2 or greater"
+							touch_tiapp_xml(os.path.join(self.project_dir, 'tiapp.xml'))
+							sys.exit(1)
+
+					except(TypeError, ValueError):
+						print "[ERROR] The 'apiversion' in the module manifest is not a valid value.  Please use a version of the module that has an 'apiversion' value of 2 or greater set in it's manifest file"
+						touch_tiapp_xml(os.path.join(self.project_dir, 'tiapp.xml'))
+						sys.exit(1)
+ 
+
 					print '[DEBUG] appending module: %s' % module_class
 					self.custom_modules.append({
 						'module_id': module_id,
@@ -227,6 +241,7 @@ class Android(object):
 						'manifest': module.manifest,
 						'on_app_create': module_onAppCreate
 					})
+
 		
 	def create(self, dir, build_time=False, project_dir=None, include_all_ti_modules=False):
 		template_dir = os.path.dirname(sys._getframe(0).f_code.co_filename)

--- a/support/android/android.py
+++ b/support/android/android.py
@@ -223,12 +223,12 @@ class Android(object):
 					try:
 						module_api_version = int(module.manifest.apiversion)
 						if module_api_version < 2:
-							print "[ERROR] The 'apiversion' in the module manifest is less than version 2.  The module was likely built against a Titanium SDK pre 1.8.0.1.  Please use a version of the module that has 'apiversion' 2 or greater"
+							print "[ERROR] The 'apiversion' for '%s' in the module manifest is less than version 2.  The module was likely built against a Titanium SDK pre 1.8.0.1.  Please use a version of the module that has 'apiversion' 2 or greater" % module_id
 							touch_tiapp_xml(os.path.join(self.project_dir, 'tiapp.xml'))
 							sys.exit(1)
 
 					except(TypeError, ValueError):
-						print "[ERROR] The 'apiversion' in the module manifest is not a valid value.  Please use a version of the module that has an 'apiversion' value of 2 or greater set in it's manifest file"
+						print "[ERROR] The 'apiversion' for '%s' in the module manifest is not a valid value.  Please use a version of the module that has an 'apiversion' value of 2 or greater set in it's manifest file" % module_id
 						touch_tiapp_xml(os.path.join(self.project_dir, 'tiapp.xml'))
 						sys.exit(1)
  

--- a/support/module/all/manifest
+++ b/support/module/all/manifest
@@ -3,7 +3,7 @@
 # during compilation, packaging, distribution, etc.
 #
 version: 0.1
-apiversion: 2.0
+apiversion: 2
 description: My module
 author: Your Name
 license: Specify your license

--- a/support/module/all/manifest
+++ b/support/module/all/manifest
@@ -3,6 +3,7 @@
 # during compilation, packaging, distribution, etc.
 #
 version: 0.1
+apiversion: 2.0
 description: My module
 author: Your Name
 license: Specify your license

--- a/support/tiapp.py
+++ b/support/tiapp.py
@@ -38,6 +38,10 @@ def get_window_properties(node):
 			wp[w.nodeName]=getText(w.childNodes)
 	return wp
 
+def touch_tiapp_xml(tiapp_xml):
+	print "[DEBUG] touching tiapp.xml to force rebuild next time: " + tiapp_xml
+	os.utime(tiapp_xml, None)
+
 			
 class TiAppXML(object):
 	def __init__(self, file, parse_only=False):


### PR DESCRIPTION
http://jira.appcelerator.org/browse/TIMOB-6520

Testing:

Step 1:
Build any project with a module from TiStudio.  In order to generate the failure, do not include "apiversion: <value>" in the module manifest file or provide a value less than 2 or not not an integer.  Including the property along with a value of 2 or higher will result in successful build of the project.

Step 2:
Also updated the module template to generate new modules with a default apieversion property of 2.  Create a new empty project using our titanium.py script, verify the apiversion is set to 2 in the generated manifest and then verify it will build through TiStudio like in step 1.
