### PR TITLE
Fire the 'error' event if the webView receives an error. 

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiWebViewClient.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiWebViewClient.java
@@ -66,6 +66,17 @@ public class TiWebViewClient extends WebViewClient
 		//TODO report this to the user
 		String text = "Javascript Error("+errorCode+"): " + description;
 		Log.e(LCAT, "Received on error" + text);
+		
+		// Kosso : Dec 10, 2011
+		// fire the error event!!!
+		KrollDict data = new KrollDict();
+		data.put("url", failingUrl);
+		data.put("description", description);
+		data.put("errorCode", errorCode);
+		data.put("message", description);
+		data.put("type", errorCode);
+		webView.getProxy().fireEvent("error", data);
+		
 	}
 
 	@Override


### PR DESCRIPTION
This has been missing for some time. 

There are many times when we need to fire the error event back to an app. (Specifically useful when dealing with OAuth authorization, since user can define a bogus callback in Twitter (for example) then parse the access tokens from the failed URL returned. This is a 'safer' approach to trying to trying to parse a 'PIN' from a web DOM, since the provider could break those implementation by simply changing the design of their pages (as has happened before).

This has been tested and does fire the error event back to an app, but does not avoid momentarily seeing the Android broswer 'not found' error page. 
