### PR TITLE
TIMOB-6445 -- animate method does not update properties

### DIFF
--- a/apidoc/Titanium/UI/View.yml
+++ b/apidoc/Titanium/UI/View.yml
@@ -32,6 +32,22 @@ methods:
         type: Titanium.UI.View
   - name: animate
     summary: Animates this view.
+    description: |
+        Note that if you use `animate` to move a view, the view's actual *position*
+        is changed, but its layout properties, such as `top`, `left`, `center` and 
+        so on are not changed--these reflect the original values set by the user, not
+        the actual position of the view.
+        
+        In this release, the view's actual position is not available to the application. 
+        This feature will be added to a future release.
+
+        If you need one or more of the layout  properties to be updated after animation,
+        you can update them in the callback after animation is complete. For example:
+
+            var newTop = view1.top - 100;
+            view1.animate({ top: newTop, duration: 500 }, function () {
+                view.top = newTop; 
+            });
     parameters:
       - name: obj
         summary: |
@@ -503,39 +519,40 @@ properties:
         One of: 'absolute', 'vertical', or 'horizontal'.
     description: |
         There are three layout options:
-        *    `absolute`. Default layout. A child view's `top`, `bottom`, `left`, and `right` 
-             properties are interpreted as absolute values in the parent's coordinate space.
 
-             If the child includes a `top` value and **not** a `bottom` value, the child is 
-             positioned `top` units from the top of the parent's bounding box, and its height
-             is set based on its `height` property.
+        *   `absolute`. Default layout. A child view's `top`, `bottom`, `left`, and `right` 
+            properties are interpreted as absolute values in the parent's coordinate space.
 
-             If the child includes a `bottom` value and **not** a `top` value, the child is 
-             positioned `bottom` units from the bottom of the parent's bounding box. Its height
-             is set based on its `height` property.
+            If the child includes a `top` value and **not** a `bottom` value, the child is 
+            positioned `top` units from the top of the parent's bounding box, and its height
+            is set based on its `height` property.
 
-             If the child includes both `top` and `bottom` values, the behavior is 
-             platform-specific.
+            If the child includes a `bottom` value and **not** a `top` value, the child is 
+            positioned `bottom` units from the bottom of the parent's bounding box. Its height
+            is set based on its `height` property.
+
+            If the child includes both `top` and `bottom` values, the behavior is 
+            platform-specific.
              
-             Similar calculations are used for `left` and `right`. 
+            Similar calculations are used for `left` and `right`. 
 
-             You can also position a child by setting its `center` property to a <Point>.
+            You can also position a child by setting its `center` property to a <Point>.
 
-             If no position is set explicitly, children are centered. For example, if a 
-             child specifies a `top` of 20 and does not specify any other position properties,
-             the child is positioned 20 units from the parent's top, and centered horizontally.
+            If no position is set explicitly, children are centered. For example, if a 
+            child specifies a `top` of 20 and does not specify any other position properties,
+            the child is positioned 20 units from the parent's top, and centered horizontally.
 
-         *   `vertical`. Children are laid out vertically from top to bottom. The first child 
-             is laid out `top` units from its parent's bounding box. Each subsequent child is 
-             laid out below the previous child. The space between children is equal to the 
-             upper child's `bottom` value plus the lower child's `top` value.
+         *  `vertical`. Children are laid out vertically from top to bottom. The first child 
+            is laid out `top` units from its parent's bounding box. Each subsequent child is 
+            laid out below the previous child. The space between children is equal to the 
+            upper child's `bottom` value plus the lower child's `top` value.
 
-             Each child is positioned horizontally as for the absolute layout mode.
+            Each child is positioned horizontally as for the absolute layout mode.
 
-         *   `horizontal`. Like vertical layout, except children are laid out horizontally
-             from left to right, using the `left` and `right` values to determine spacing.
+         *  `horizontal`. Like vertical layout, except children are laid out horizontally
+            from left to right, using the `left` and `right` values to determine spacing.
 
-             Each child is positioned vertically as in the absolute layout mode.
+            Each child is positioned vertically as in the absolute layout mode.
     default: absolute layout
   - name: opacity
     summary: Opacity of this view, from 0.0 (transparent) to 1.0 (opaque).
@@ -580,7 +597,7 @@ properties:
   - name: transform
     summary: Transformation matrix to apply to the view.
     platforms: [android, iphone, ipad]
-    type: Object
+    type: [ Titanium.UI.2DMatrix, Titanium.UI.iOS.3DMatrix ]
   - name: visible
     summary: Boolean value indicating whether the view is visible.
     type: Boolean
@@ -593,7 +610,7 @@ properties:
         the view's calculated size as laid out, see the [size](Titanium.UI.View.size) property.
     type: [Number,String]
   - name: zIndex
-    summary: the z index position relative to other sibling views
+    summary: Z index position relative to other sibling views.
     type: Number
   - name: keepScreenOn
     summary: Whether to keep the device screen on.


### PR DESCRIPTION
Added note to animate method about animate not updating layout parameters (top, left, etc.).

Also fixed egregious formatting problem in layout property page that was making most of the
description lay out as a code sample.

Fixed typo (missing cap) on zindex summary.

Changed the type for the transform property from Object to
[ Titanium.UI.2DMatrix, Titanium.UI.iOS.3DMatrix ].
