### PR TITLE
TIMOB-6566 (1_8_X): Android: V8: Use dynamic linking / loading of stlport_shared to avoid symbol conflicts in modules

### DIFF
--- a/android/build/common.xml
+++ b/android/build/common.xml
@@ -378,7 +378,7 @@ Common ant tasks and macros for building Android-based Titanium modules and proj
 			<arg line="${ndk.build.args}"/>
 		</exec>
 		<copy todir="${dist.dir}">
-			<fileset dir="${kroll.v8.project.dir}" includes="libs/armeabi*/libkroll-v8.so"/>
+			<fileset dir="${kroll.v8.project.dir}" includes="libs/armeabi*/lib*.so"/>
 		</copy>
 	</target>
 

--- a/android/runtime/v8/Application.mk
+++ b/android/runtime/v8/Application.mk
@@ -8,7 +8,7 @@
 
 APP_BUILD_SCRIPT = src/native/Android.mk
 TARGET_PLATFORM = android-8
-APP_STL := stlport_static
+APP_STL := stlport_shared
 APP_ABI := armeabi armeabi-v7a
 
 TARGET_DEVICE := device

--- a/android/runtime/v8/src/java/org/appcelerator/kroll/runtime/v8/V8Runtime.java
+++ b/android/runtime/v8/src/java/org/appcelerator/kroll/runtime/v8/V8Runtime.java
@@ -46,6 +46,7 @@ public final class V8Runtime extends KrollRuntime implements Handler.Callback
 		boolean debuggerEnabled = getKrollApplication().isDebuggerEnabled();
 
 		if (!libLoaded) {
+			System.loadLibrary("stlport_shared");
 			System.loadLibrary("kroll-v8");
 			libLoaded = true;
 		}

--- a/support/android/builder.py
+++ b/support/android/builder.py
@@ -1398,7 +1398,9 @@ class Builder(object):
 		# add sdk runtime native libraries
 		sdk_native_libs = os.path.join(template_dir, 'native', 'libs')
 		apk_zip.write(os.path.join(sdk_native_libs, 'armeabi', 'libkroll-v8.so'), 'lib/armeabi/libkroll-v8.so')
+		apk_zip.write(os.path.join(sdk_native_libs, 'armeabi', 'libstlport_shared.so'), 'lib/armeabi/libstlport_shared.so')
 		apk_zip.write(os.path.join(sdk_native_libs, 'armeabi-v7a', 'libkroll-v8.so'), 'lib/armeabi-v7a/libkroll-v8.so')
+		apk_zip.write(os.path.join(sdk_native_libs, 'armeabi-v7a', 'libstlport_shared.so'), 'lib/armeabi-v7a/libstlport_shared.so')
 		self.apk_updated = True
 
 		apk_zip.close()

--- a/support/module/android/build.xml
+++ b/support/module/android/build.xml
@@ -231,7 +231,10 @@
 		</exec>
 
 		<copy todir="${libs}">
-			<fileset dir="${gen}/libs" includes="**/*"/>
+			<fileset dir="${gen}/libs">
+				<include name="**/*"/>
+				<exclude name="**/libstlport_shared.so"/>
+			</fileset>
 		</copy>
 	</target>
 
@@ -243,7 +246,9 @@
 
 	<target name="zip.libs" depends="libs.check" if="libs.exists">
 		<zip destfile="${dist}/${module.id}-android-${manifest.version}.zip" update="true">
-			<zipfileset dir="${libs}" includes="**/*.so" prefix="${zip.prefix}/libs"/>
+			<zipfileset dir="${libs}" prefix="${zip.prefix}/libs">
+				<include name="**/*.so"/>
+			</zipfileset>
 		</zip>
 	</target>
 

--- a/support/module/android/generated/Application.mk
+++ b/support/module/android/generated/Application.mk
@@ -2,5 +2,5 @@
 
 APP_BUILD_SCRIPT := jni/Android.mk
 TARGET_PLATFORM := android-8
-APP_STL := stlport_static
+APP_STL := stlport_shared
 APP_ABI := armeabi armeabi-v7a


### PR DESCRIPTION
http://jira.appcelerator.org/browse/TIMOB-6566

See [testing notes](http://jira.appcelerator.org/browse/TIMOB-6566?focusedCommentId=175735&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-175735)
