### PR TITLE
[TIMOB-6550] Do not check native module from require.

### DIFF
--- a/android/runtime/common/src/js/module.js
+++ b/android/runtime/common/src/js/module.js
@@ -186,14 +186,6 @@ Module.prototype.loadExternalModule = function(id, externalBinding, context) {
 Module.prototype.require = function (request, context, useCache) {
 	useCache = useCache === undefined ? true : useCache;
 
-	// Delegate native module requests.
-	if (NativeModule.exists(request)) {
-		if (kroll.DBG) {
-			kroll.log(TAG, 'Found native module: "' + request + '"');
-		}
-		return NativeModule.require(request);
-	}
-
 	// get external binding (for external / 3rd party modules)
 	var externalBinding = kroll.externalBinding(request);
 


### PR DESCRIPTION
We do not make these internal native modules public, so to avoid
name clashes do not attempt to load natives from the version of
require we expose to application code.

See JIRA ticket for testing details.
