### PR TITLE
TIMOB-6588 add module_apiversion property to version.txt in SDK

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -17,6 +17,7 @@ sys.path.append(path.join(cwd,"support","android"))
 import titanium_version, ant
 from androidsdk import AndroidSDK
 version = titanium_version.version
+module_apiversion = titanium_version.module_apiversion
 
 # allow it to be overriden on command line or in env
 if os.environ.has_key('PRODUCT_VERSION'):
@@ -161,9 +162,9 @@ def package_sdk(target, source, env):
 	version_tag = ARGUMENTS.get('version_tag', version)
 	print "Packaging MobileSDK (%s)..." % version_tag
 	if package_all:
-		package.Packager().build_all_platforms(os.path.abspath('dist'), version, android, iphone, ipad, mobileweb, version_tag)
+		package.Packager().build_all_platforms(os.path.abspath('dist'), version, module_apiversion, android, iphone, ipad, mobileweb, version_tag)
 	else:
-		package.Packager().build(os.path.abspath('dist'), version, android, iphone, ipad, mobileweb, version_tag)
+		package.Packager().build(os.path.abspath('dist'), version, module_apiversion, android, iphone, ipad, mobileweb, version_tag)
 	if install and not clean:
 		install_mobilesdk(version_tag)
 

--- a/build/titanium_version.py
+++ b/build/titanium_version.py
@@ -1,1 +1,3 @@
 version = '1.9.0'
+module_apiversion = '2'
+

--- a/site_scons/package.py
+++ b/site_scons/package.py
@@ -271,13 +271,14 @@ def create_platform_zip(platform,dist_dir,osname,version,version_tag):
 	zf = zipfile.ZipFile(sdkzip, 'w', zipfile.ZIP_DEFLATED)
 	return (zf,basepath)
 
-def zip_mobilesdk(dist_dir,osname,version,android,iphone,ipad,mobileweb,version_tag):
+def zip_mobilesdk(dist_dir,osname,version,module_apiversion,android,iphone,ipad,mobileweb,version_tag):
 	zf, basepath = create_platform_zip('mobilesdk',dist_dir,osname,version,version_tag)
 
 	version_txt = """version=%s
+module_apiversion=%s
 timestamp=%s
 githash=%s
-""" % (version,ts,githash)
+""" % (version,module_apiversion,ts,githash)
 
 	zf.writestr('%s/version.txt' % basepath,version_txt)
 	jsca = generate_jsca()
@@ -293,23 +294,23 @@ githash=%s
 	
 	zf.close()
 				
-def zip_it(dist_dir,osname,version,android,iphone,ipad,mobileweb,version_tag):
-	zip_mobilesdk(dist_dir,osname,version,android,iphone,ipad,mobileweb,version_tag)
+def zip_it(dist_dir,osname,version,module_apiversion,android,iphone,ipad,mobileweb,version_tag):
+	zip_mobilesdk(dist_dir,osname,version,module_apiversion,android,iphone,ipad,mobileweb,version_tag)
 
 class Packager(object):
 	def __init__(self):
 		self.os_names = { "Windows":"win32", "Linux":"linux", "Darwin":"osx" }
 	 
-	def build(self,dist_dir,version,android=True,iphone=True,ipad=True,mobileweb=True,version_tag=None):
+	def build(self,dist_dir,version,module_apiversion,android=True,iphone=True,ipad=True,mobileweb=True,version_tag=None):
 		if version_tag == None:
 			version_tag = version
-		zip_it(dist_dir,self.os_names[platform.system()],version,android,iphone,ipad,mobileweb,version_tag)
+		zip_it(dist_dir,self.os_names[platform.system()],version,module_apiversion,android,iphone,ipad,mobileweb,version_tag)
 
-	def build_all_platforms(self,dist_dir,version,android=True,iphone=True,ipad=True,mobileweb=True,version_tag=None):
+	def build_all_platforms(self,dist_dir,version,module_apiversion,android=True,iphone=True,ipad=True,mobileweb=True,version_tag=None):
 		if version_tag == None:
 			version_tag = version
 		for os in self.os_names.values():
-			zip_it(dist_dir,os,version,android,iphone,ipad,mobileweb,version_tag)
+			zip_it(dist_dir,os,version,module_apiversion,android,iphone,ipad,mobileweb,version_tag)
 		
 if __name__ == '__main__':
 	Packager().build(os.path.abspath('../dist'), "1.1.0")


### PR DESCRIPTION
http://jira.appcelerator.org/browse/TIMOB-6588

Testing steps:  build SDK via scons and verify that the version.txt inside the generated zip has the new "module_apiversion=2"
