### PR TITLE
TIMOB-6594 (1_8_X) APIDOC: Allow "Dictionary" (by itself with no type qualifiers) as a datatype

### DIFF
--- a/apidoc/validate.py
+++ b/apidoc/validate.py
@@ -165,7 +165,7 @@ def validateMarkdown(tracker, mdData, name):
 		tracker.trackError('Error parsing markdown block "%s": %s' % (name, e))
 
 def findType(tracker, typeName, name):
-	if typeName in ['Boolean', 'Number', 'String', 'Date', 'Object', 'Callback']: return
+	if typeName in ['Dictionary', 'Boolean', 'Number', 'String', 'Date', 'Object', 'Callback']: return
 
 	containerRegex = r'(Dictionary|Callback|Array)\<([^\>]+)\>'
 	match = re.match(containerRegex, typeName)


### PR DESCRIPTION
This is a 1_8_X cherry-pick of a previous master PR.

http://jira.appcelerator.org/browse/TIMOB-6594

Test case is the fail case in the JIRA item description.
