### PR TITLE
[TIMOB-6595] ThumbImage disappears when slider moves

### DIFF
--- a/iphone/Classes/TiUISlider.h
+++ b/iphone/Classes/TiUISlider.h
@@ -14,6 +14,10 @@
 	UISlider *sliderView;
 	NSDate* lastTouchUp;
 	NSTimeInterval lastTimeInterval;
+	
+	NSUInteger thumbImageState;
+	NSUInteger rightTrackImageState;
+	NSUInteger leftTrackImageState;
 }
 
 - (IBAction)sliderChanged:(id)sender;

--- a/iphone/Classes/TiUISlider.h
+++ b/iphone/Classes/TiUISlider.h
@@ -15,9 +15,9 @@
 	NSDate* lastTouchUp;
 	NSTimeInterval lastTimeInterval;
 	
-	NSUInteger thumbImageState;
-	NSUInteger rightTrackImageState;
-	NSUInteger leftTrackImageState;
+	UIControlState thumbImageState;
+	UIControlState rightTrackImageState;
+	UIControlState leftTrackImageState;
 }
 
 - (IBAction)sliderChanged:(id)sender;

--- a/iphone/Classes/TiUISlider.m
+++ b/iphone/Classes/TiUISlider.m
@@ -42,9 +42,9 @@
 		lastTouchUp = [[NSDate alloc] init];
 		lastTimeInterval = 1.0; // Short-circuit so that we don't ignore the first fire
 		
-		thumbImageState = 0;
-		leftTrackImageState = 0;
-		rightTrackImageState = 0;
+		thumbImageState = UIControlStateNormal;
+		leftTrackImageState = UIControlStateNormal;
+		rightTrackImageState = UIControlStateNormal;
 	}
 	return sliderView;
 }

--- a/iphone/Classes/TiUISlider.m
+++ b/iphone/Classes/TiUISlider.m
@@ -73,63 +73,102 @@
 -(void)setThumbImage_:(id)value
 {
 	[self setThumb:value forState:UIControlStateNormal];
+	
+	if ((thumbImageState & UIControlStateSelected)==0) {
+		[self setThumb:value forState:UIControlStateSelected];
+	}
+	if ((thumbImageState & UIControlStateHighlighted)==0) {
+		[self setThumb:value forState:UIControlStateHighlighted];
+	}
+	if ((thumbImageState & UIControlStateDisabled)==0) {
+		[self setThumb:value forState:UIControlStateDisabled];
+	}
 }
 
 -(void)setSelectedThumbImage_:(id)value
 {
 	[self setThumb:value forState:UIControlStateSelected];
+	thumbImageState = thumbImageState | UIControlStateSelected;
 }
 
 -(void)setHighlightedThumbImage_:(id)value
 {
 	[self setThumb:value forState:UIControlStateHighlighted];
+	thumbImageState = thumbImageState | UIControlStateHighlighted;
 }
 
 -(void)setDisabledThumbImage_:(id)value
 {
 	[self setThumb:value forState:UIControlStateDisabled];
+	thumbImageState = thumbImageState | UIControlStateSelected;
 }
 
 
 -(void)setLeftTrackImage_:(id)value
 {
 	[self setLeftTrack:value forState:UIControlStateNormal];
+	
+	if ((leftTrackImageState & UIControlStateSelected)==0) {
+		[self setLeftTrack:value forState:UIControlStateSelected];
+	}
+	if ((leftTrackImageState & UIControlStateHighlighted)==0) {
+		[self setLeftTrack:value forState:UIControlStateHighlighted];
+	}
+	if ((leftTrackImageState & UIControlStateDisabled)==0) {
+		[self setLeftTrack:value forState:UIControlStateDisabled];
+	}
 }
 
 -(void)setSelectedLeftTrackImage_:(id)value
 {
 	[self setLeftTrack:value forState:UIControlStateSelected];
+	leftTrackImageState = leftTrackImageState | UIControlStateSelected;
 }
 
 -(void)setHighlightedLeftTrackImage_:(id)value
 {
 	[self setLeftTrack:value forState:UIControlStateHighlighted];
+	leftTrackImageState = leftTrackImageState | UIControlStateHighlighted;
 }
 
 -(void)setDisabledLeftTrackImage_:(id)value
 {
 	[self setLeftTrack:value forState:UIControlStateDisabled];
+	leftTrackImageState = leftTrackImageState | UIControlStateDisabled;
 }
 
 
 -(void)setRightTrackImage_:(id)value
 {
 	[self setRightTrack:value forState:UIControlStateNormal];
+	
+	if ((rightTrackImageState & UIControlStateSelected)==0) {
+		[self setRightTrack:value forState:UIControlStateSelected];
+	}
+	if ((rightTrackImageState & UIControlStateHighlighted)==0) {
+		[self setRightTrack:value forState:UIControlStateHighlighted];
+	}
+	if ((rightTrackImageState & UIControlStateDisabled)==0) {
+		[self setRightTrack:value forState:UIControlStateDisabled];
+	}
 }
 
 -(void)setSelectedRightTrackImage_:(id)value
 {
 	[self setRightTrack:value forState:UIControlStateSelected];
+	rightTrackImageState = rightTrackImageState | UIControlStateSelected;
 }
 
 -(void)setHighlightedRightTrackImage_:(id)value
 {
 	[self setRightTrack:value forState:UIControlStateHighlighted];
+	rightTrackImageState = rightTrackImageState | UIControlStateHighlighted;
 }
 
 -(void)setDisabledRightTrackImage_:(id)value
 {
 	[self setRightTrack:value forState:UIControlStateDisabled];
+	rightTrackImageState = rightTrackImageState | UIControlStateDisabled;
 }
 
 -(void)setMin_:(id)value

--- a/iphone/Classes/TiUISlider.m
+++ b/iphone/Classes/TiUISlider.m
@@ -41,6 +41,10 @@
 		[self addSubview:sliderView];
 		lastTouchUp = [[NSDate alloc] init];
 		lastTimeInterval = 1.0; // Short-circuit so that we don't ignore the first fire
+		
+		thumbImageState = 0;
+		leftTrackImageState = 0;
+		rightTrackImageState = 0;
 	}
 	return sliderView;
 }


### PR DESCRIPTION
Setting thumbImage, leftTrackImage or rightTrackImage sets the image for all 4 UI states unless overridden specifically by using the corresponding properties

Test is included in JIRA ticket
