### PR TITLE
TIMOB-6553 Make sure module name in KrollGeneratedBindings gets first char upper-cased...

### DIFF
--- a/support/module/android/bootstrap.py
+++ b/support/module/android/bootstrap.py
@@ -324,7 +324,7 @@ class Bootstrap(object):
 		gperfContext = {
 			"headers": self.headers,
 			"bindings": "\n".join(self.initTable),
-			"moduleName": self.moduleName
+			"moduleName": self.moduleName[0].upper() + self.moduleName[1:]
 		}
 
 		open(genBindings, "w").write(gperfTemplate % gperfContext)


### PR DESCRIPTION
so it matches what's in [Module]Bootstrap.cpp.

http://jira.appcelerator.org/browse/TIMOB-6553

Test case is the fail case described in the JIRA ticket, namely building the bump module from jeff's apiversion_2 branch of titanium_mobile_modules.

Will need to cherry-pick in 1.8.0.1 as well, but waiting for this to be accepted first.
