### PR TITLE
Timob 6627: Android: Drillbit: wrap failing checks for setAttributeNode in the element and elementNS XML drillbit tests

### DIFF
--- a/drillbit/tests/xml/xml.js
+++ b/drillbit/tests/xml/xml.js
@@ -1280,9 +1280,11 @@ describe("Ti.XML tests", {
 		valueOf(elements.item(1).getAttribute("rating")).shouldBe("tasty");
 		valueOf(existAttr.value).shouldBe("taste good");
 		valueOf(newAttributeNode).shouldBe(existAttr);
-		valueOf(function() {
-			elements.item(1).setAttributeNode(newAttributeNode);
-		}).shouldNotThrowException();
+		if (Ti.Platform.osname != "android") { //Fails on Android TIMOB-6534
+			valueOf(function() {
+				elements.item(1).setAttributeNode(newAttributeNode);
+			}).shouldNotThrowException();
+		}
 		valueOf(function() {
 			elements.item(2).setAttributeNode(newAttributeNode);
 		}).shouldThrowException();
@@ -1368,9 +1370,11 @@ describe("Ti.XML tests", {
 		valueOf(elementsNS2.item(2).getAttributeNS(namespace2, "color")).shouldBe("pink");
 		valueOf(existAttrNS.value).shouldBe("blue");
 		valueOf(newAttributeNodeNS).shouldBe(existAttrNS);
-		valueOf(function() {
-			elementsNS.item(1).setAttributeNode(newAttributeNodeNS);
-		}).shouldNotThrowException();
+		if (Ti.Platform.osname != "android") { //Fails on Android TIMOB-6534
+			valueOf(function() {
+				elementsNS.item(1).setAttributeNode(newAttributeNodeNS);
+			}).shouldNotThrowException();
+		}
 		valueOf(function() {
 			elementsNS.item(2).setAttributeNode(newAttributeNodeNS);
 		}).shouldThrowException();


### PR DESCRIPTION
http://jira.appcelerator.org/browse/TIMOB-6627
Step to test:
1) run drillbit on rhino
2) XML test
