### PR TITLE
TIMOB-6553 Android (1.8.X) Make sure module name in KrollGeneratedBindings gets first…

### DIFF
--- a/support/module/android/bootstrap.py
+++ b/support/module/android/bootstrap.py
@@ -324,7 +324,7 @@ class Bootstrap(object):
 		gperfContext = {
 			"headers": self.headers,
 			"bindings": "\n".join(self.initTable),
-			"moduleName": self.moduleName
+			"moduleName": self.moduleName[0].upper() + self.moduleName[1:]
 		}
 
 		open(genBindings, "w").write(gperfTemplate % gperfContext)


### PR DESCRIPTION
...character upper-cased so it matches what's in [Module]Bootstrap.cpp

http://jira.appcelerator.org/browse/TIMOB-6553

This is the 1.8.X cherry-pick of a previously-accepted PR.  It's a one line change and it merged cleanly in the cherry pick.  IMO, no need to functional test.  But be my guest!
