### PR TITLE
[TIMOB-6575] Replacing the way we included icons for the app

### DIFF
--- a/support/iphone/Info.plist
+++ b/support/iphone/Info.plist
@@ -10,15 +10,6 @@
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIconFile</key>
 	<string>__APPICON__.png</string>
-	<key>CFBundleIconFiles</key>
-	<array>
-		<string>__APPICON__.png</string>
-		<string>__APPICON__@2x.png</string>
-		<string>__APPICON__-72.png</string>
-		<string>__APPICON__-Small-50.png</string>
-		<string>__APPICON__-Small.png</string>
-		<string>__APPICON__-Small@2x.png</string>
-	</array>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/support/tiapp.py
+++ b/support/tiapp.py
@@ -439,7 +439,6 @@ class TiAppXML(object):
 		tempiconslist += sorted(os.listdir(iconsdir2))
 		iconslist = list(set(sorted(tempiconslist)))
 		iconorder = list([iconname+".png",iconname+"@2x.png",iconname+"-72.png",iconname+"-Small-50.png",iconname+"-Small.png",iconname+"-Small@2x.png"])
-		ordered_list =[]
 		for type in iconorder:
 			for icon in iconslist:
 				if type == icon:

--- a/support/tiapp.py
+++ b/support/tiapp.py
@@ -433,8 +433,12 @@ class TiAppXML(object):
 		#Creating proper CFBundleIconFiles rather than hard coding the values in there
 		propertyName = 'CFBundleIconFiles'
 		propertyValue = '<array>\n'
-		iconsdir  = os.path.join(project_dir,'Resources','iphone')
-		for iconfile in os.listdir(iconsdir):
+		iconsdir1 = os.path.join(project_dir,'Resources','iphone')
+		iconsdir2 = os.path.join(project_dir,'Resources')
+		tempiconslist = sorted(os.listdir(iconsdir1))
+		tempiconslist += (sorted(os.listdir(iconsdir2)))
+		iconslist = list(set(sorted(tempiconslist)))
+		for iconfile in iconslist:
 			if fnmatch.fnmatch(iconfile, iconname+'.png'):
 				propertyValue += "\t<string>%s</string>\n" %(iconname+'.png')
 			elif fnmatch.fnmatch(iconfile, iconname+'@2x.png'):

--- a/support/tiapp.py
+++ b/support/tiapp.py
@@ -3,7 +3,7 @@
 #
 # tiapp parser
 # 
-import os, types, uuid
+import os, types, uuid , fnmatch
 import codecs, time, sys
 from xml.dom.minidom import parseString
 from StringIO import StringIO
@@ -364,7 +364,7 @@ class TiAppXML(object):
 	
 		# we want the icon without the extension for the plist
 		iconname = os.path.splitext(icon)[0]
-			
+		
 		self.infoplist_properties = {}	
 		for p in self.properties:
 			value = self.properties[p]
@@ -426,9 +426,29 @@ class TiAppXML(object):
 				propertyValue += '</array>'
 				
 				self.infoplist_properties[propertyName]=propertyValue
-		
+
 		plist = codecs.open(file,'r','utf-8','replace').read()
 		plist = plist.replace('__APPICON__',iconname)
+
+		#Creating proper CFBundleIconFiles rather than hard coding the values in there
+		propertyName = 'CFBundleIconFiles'
+		propertyValue = '<array>\n'
+		iconsdir  = os.path.join(project_dir,'Resources','iphone')
+		for iconfile in os.listdir(iconsdir):
+			if fnmatch.fnmatch(iconfile, iconname+'.png'):
+				propertyValue += "\t<string>%s</string>\n" %(iconname+'.png')
+			elif fnmatch.fnmatch(iconfile, iconname+'@2x.png'):
+				propertyValue += "\t<string>%s</string>\n" %(iconname+'@2x.png')
+			elif fnmatch.fnmatch(iconfile, iconname+'-72.png'):
+				propertyValue += "\t<string>%s</string>\n" %(iconname+'-72.png')
+			elif fnmatch.fnmatch(iconfile, iconname+'-Small-50.png'):
+				propertyValue += "\t<string>%s</string>\n" %(iconname+'-Small-50.png')
+			elif fnmatch.fnmatch(iconfile, iconname+'-Small.png'):
+				propertyValue += "\t<string>%s</string>\n" %(iconname+'-Small.png')
+			elif fnmatch.fnmatch(iconfile, iconname+'-Small@2x.png'):
+				propertyValue += "\t<string>%s</string>\n" %(iconname+'-Small@2x.png')
+		propertyValue += '</array>\n'
+		self.infoplist_properties[propertyName]=propertyValue
 
 		# replace the bundle id with the app id 
 		# in case it's changed

--- a/support/tiapp.py
+++ b/support/tiapp.py
@@ -436,24 +436,17 @@ class TiAppXML(object):
 		iconsdir1 = os.path.join(project_dir,'Resources','iphone')
 		iconsdir2 = os.path.join(project_dir,'Resources')
 		tempiconslist = sorted(os.listdir(iconsdir1))
-		tempiconslist += (sorted(os.listdir(iconsdir2)))
+		tempiconslist += sorted(os.listdir(iconsdir2))
 		iconslist = list(set(sorted(tempiconslist)))
-		for iconfile in iconslist:
-			if fnmatch.fnmatch(iconfile, iconname+'.png'):
-				propertyValue += "\t<string>%s</string>\n" %(iconname+'.png')
-			elif fnmatch.fnmatch(iconfile, iconname+'@2x.png'):
-				propertyValue += "\t<string>%s</string>\n" %(iconname+'@2x.png')
-			elif fnmatch.fnmatch(iconfile, iconname+'-72.png'):
-				propertyValue += "\t<string>%s</string>\n" %(iconname+'-72.png')
-			elif fnmatch.fnmatch(iconfile, iconname+'-Small-50.png'):
-				propertyValue += "\t<string>%s</string>\n" %(iconname+'-Small-50.png')
-			elif fnmatch.fnmatch(iconfile, iconname+'-Small.png'):
-				propertyValue += "\t<string>%s</string>\n" %(iconname+'-Small.png')
-			elif fnmatch.fnmatch(iconfile, iconname+'-Small@2x.png'):
-				propertyValue += "\t<string>%s</string>\n" %(iconname+'-Small@2x.png')
+		iconorder = list([iconname+".png",iconname+"@2x.png",iconname+"-72.png",iconname+"-Small-50.png",iconname+"-Small-50.png",iconname+"-Small.png",iconname+"-Small@2x.png"])
+		ordered_list =[]
+		for type in iconorder:
+			for icon in iconslist:
+				if type == icon:
+					propertyValue += "\t<string>%s</string>\n" %type
 		propertyValue += '</array>\n'
 		self.infoplist_properties[propertyName]=propertyValue
-
+		
 		# replace the bundle id with the app id 
 		# in case it's changed
 		i = plist.index('CFBundleIdentifier')

--- a/support/tiapp.py
+++ b/support/tiapp.py
@@ -438,12 +438,12 @@ class TiAppXML(object):
 		tempiconslist = sorted(os.listdir(iconsdir1))
 		tempiconslist += sorted(os.listdir(iconsdir2))
 		iconslist = list(set(sorted(tempiconslist)))
-		iconorder = list([iconname+".png",iconname+"@2x.png",iconname+"-72.png",iconname+"-Small-50.png",iconname+"-Small-50.png",iconname+"-Small.png",iconname+"-Small@2x.png"])
+		iconorder = list([iconname+".png",iconname+"@2x.png",iconname+"-72.png",iconname+"-Small-50.png",iconname+"-Small.png",iconname+"-Small@2x.png"])
 		ordered_list =[]
 		for type in iconorder:
 			for icon in iconslist:
 				if type == icon:
-					propertyValue += "\t<string>%s</string>\n" %type
+					propertyValue += "\t<string>%s</string>\n" %icon
 		propertyValue += '</array>\n'
 		self.infoplist_properties[propertyName]=propertyValue
 		


### PR DESCRIPTION
Testing Instruction.

Try all variation of appicons, i.e including all optional icon , some icon etc etc. and try running for all build i.e. Simulator, Device , Distribution and after each build check to see if the info.plist has the Right number and name of icons included under 'CFBundleIconFiles'

Duplicate of pull #967
