### PR TITLE
[TIMOB-6572] Don't inject the alert() function - bind it

### DIFF
--- a/iphone/Classes/KrollBridge.mm
+++ b/iphone/Classes/KrollBridge.mm
@@ -492,17 +492,6 @@ CFMutableSetRef	krollBridgeRegistry = nil;
 	[newEvent release];
 }
 
--(void)injectPatches
-{
-	// called to inject any Titanium patches in JS before a context is loaded... nice for 
-	// setting up backwards compat type APIs
-	
-	NSMutableString *js = [[NSMutableString alloc] init];
-	[js appendString:@"function alert(msg) { Ti.UI.createAlertDialog({title:'Alert',message:msg}).show(); };"];
-	[self evalJSWithoutResult:js];
-	[js release];
-}
-
 -(void)shutdown:(NSCondition*)condition
 {
 #if KROLLBRIDGE_MEMORY_DEBUG==1
@@ -578,14 +567,12 @@ CFMutableSetRef	krollBridgeRegistry = nil;
 				[ti setStaticValue:ko forKey:key purgable:NO];
 			}
 		}
-		[self injectPatches];
 		[self evalFile:[url path] callback:self selector:@selector(booted)];	
 	}
 	else 
 	{
 		// now load the app.js file and get started
 		NSURL *startURL = [host startURL];
-		[self injectPatches];
 		[self evalFile:[startURL absoluteString] callback:self selector:@selector(booted)];
 	}
 }

--- a/iphone/Classes/KrollContext.mm
+++ b/iphone/Classes/KrollContext.mm
@@ -15,6 +15,8 @@
 #include <pthread.h>
 #import "TiDebugger.h"
 
+#import "TiUIAlertDialogProxy.h"
+
 #ifdef KROLL_COVERAGE
 # import "KrollCoverage.h"
 #endif
@@ -245,6 +247,28 @@ static TiValueRef LCallback (TiContextRef jsContext, TiObjectRef jsFunction, TiO
 		return ThrowException(jsContext, [e reason], exception);
 	}
 }	
+
+static TiValueRef AlertCallback (TiContextRef jsContext, TiObjectRef jsFunction, TiObjectRef jsThis, size_t argCount,
+                                 const TiValueRef args[], TiValueRef* exception)
+{
+#ifdef KROLL_COVERAGE
+    [KrollCoverageObject incrementTopLevelFunctionCall:TOP_LEVEL name:@"alert"];
+#endif
+    
+    if (argCount < 1) {
+        return ThrowException(jsContext, @"invalid number of arguments", exception);
+    }
+    
+    KrollContext* ctx = GetKrollContext(jsContext);
+    NSString* message = [KrollObject toID:ctx value:args[0]];
+    
+    TiUIAlertDialogProxy* alert = [[[TiUIAlertDialogProxy alloc] _initWithPageContext:(id<TiEvaluator>)[ctx delegate] args:nil] autorelease];
+    [alert setValue:@"Alert" forKey:@"title"];
+    [alert setValue:message forKey:@"message"];
+    [alert show:nil];
+    
+    return TiValueMakeUndefined(jsContext);
+}
 
 static TiValueRef StringFormatCallback (TiContextRef jsContext, TiObjectRef jsFunction, TiObjectRef jsThis, size_t argCount,
 							 const TiValueRef args[], TiValueRef* exception)
@@ -1007,6 +1031,7 @@ static TiValueRef StringFormatDecimalCallback (TiContextRef jsContext, TiObjectR
 	[self bindCallback:@"clearInterval" callback:&ClearTimerCallback];
 	[self bindCallback:@"require" callback:&CommonJSRequireCallback];
 	[self bindCallback:@"L" callback:&LCallback];
+    [self bindCallback:@"alert" callback:&AlertCallback];
 
 	prop = TiStringCreateWithUTF8CString("String");
 	

--- a/iphone/Classes/TiUIAlertDialogProxy.h
+++ b/iphone/Classes/TiUIAlertDialogProxy.h
@@ -11,4 +11,6 @@
 	UIAlertView *alert;
 }
 
+-(void)show:(id)args;
+
 @end


### PR DESCRIPTION
Evaluating scripts outside of begin/end eval causes issues with the debugger hooks in certain multicontext situations, and we shouldn't be "evaluating" this function anyway; it should be a direct binding into the kroll context.

This pull request will need to be tested both against the bug and a basic `alert()` use case. We may also have been allowing users to overload/redefine `alert` in the past (due to the injection); might want to check for this as well and see if we regressed there. But `alert` is technically reserved by ECMA (again, check).
