### PR TITLE
TIMOB-6585 (1.8.X) Android: use external module apiname in App.java when building the Bootstrap class name

### DIFF
--- a/support/android/android.py
+++ b/support/android/android.py
@@ -210,6 +210,7 @@ class Android(object):
 			if module_bindings is None: continue
 			
 			for module_class in module_bindings['modules'].keys():
+				module_apiName = module_bindings['modules'][module_class]['apiName']
 				module_proxy = module_bindings['proxies'][module_class]
 				module_id = module_proxy['proxyAttrs']['id']
 				module_proxy_class_name = module_proxy['proxyClassName']
@@ -236,6 +237,7 @@ class Android(object):
 					print '[DEBUG] appending module: %s' % module_class
 					self.custom_modules.append({
 						'module_id': module_id,
+						'module_apiName': module_apiName,
 						'proxy_name': module_proxy_class_name,
 						'class_name': module_class,
 						'manifest': module.manifest,

--- a/support/android/templates/App.java
+++ b/support/android/templates/App.java
@@ -53,7 +53,7 @@ public final class ${config['classname']}Application extends TiApplication
 		% for module in custom_modules:
 		<%
 		manifest = module['manifest']
-		className = manifest.name[0:1].upper() + manifest.name[1:]
+		className = module['module_apiName']
 		%>
 		runtime.addExternalModule("${manifest.moduleid}", ${manifest.moduleid}.${className}Bootstrap.class);
 		% endfor


### PR DESCRIPTION
... since that's what's used by the code that generates Bootstrap.

http://jira.appcelerator.org/browse/TIMOB-6585

This is the 1.8.X cherry-pick of a previous PR.  Test is the failcase in the ticket.
