### PR TITLE
Timob 6629 1.8.x Give external module bootstraps a way to call directly into o...

### DIFF
--- a/android/runtime/common/src/js/kroll.js
+++ b/android/runtime/common/src/js/kroll.js
@@ -32,6 +32,7 @@
 	startup.globalVariables = function() {
 		global.kroll = kroll;
 		kroll.ScopeVars = ScopeVars;
+		kroll.NativeModule = NativeModule; // So external module bootstrap.js can call NativeModule.require directly.
 
 		NativeModule.require('events');
 		global.Ti = global.Titanium = NativeModule.require('titanium');

--- a/support/module/android/generated/bootstrap.js
+++ b/support/module/android/generated/bootstrap.js
@@ -6,8 +6,8 @@
  *
  * Warning: This file is GENERATED, and should not be modified
  */
-var bootstrap = require("bootstrap"),
-	invoker = require("invoker"),
+var bootstrap = kroll.NativeModule.require("bootstrap"),
+	invoker = kroll.NativeModule.require("invoker"),
 	Titanium = kroll.binding("Titanium").Titanium;
 
 function moduleBootstrap(moduleBinding) {


### PR DESCRIPTION
...ur NativeModule.require

http://jira.appcelerator.org/browse/TIMOB-6629

See testing notes in JIRA ticket comment.
