### PR TITLE
Timob 6307 --merge into 1_8_X

### DIFF
--- a/apidoc/Titanium/UI/TextArea.yml
+++ b/apidoc/Titanium/UI/TextArea.yml
@@ -1,7 +1,11 @@
 ---
 name: Titanium.UI.TextArea
 summary: A multiline text field that supports editing and scrolling. 
-description: Use the <Titanium.UI.createTextArea> method to create a text area. 
+description: |
+    Use the <Titanium.UI.createTextArea> method to create a text area. 
+
+    On iOS, the `color` property is required for the text area to work
+    properly. This is a known issue.
 extends: Titanium.UI.View
 since: "0.8"
 methods:
@@ -38,6 +42,14 @@ events:
       - name: range
         summary: A range of text. The range is an object with the properties `location` and `length`.
 properties:
+  - name: appearance
+    summary: Determines the appearance of the keyboard displayed when this text area is focused.
+    description: |
+        Specify one of the following constants from <Titanium.UI>: 
+        [KEYBOARD_APPEARANCE_ALERT](Titanium.UI.KEYBOARD_APPEARANCE_ALERT), or
+        [KEYBOARD_APPEARANCE_DEFAULT](Titanium.UI.KEYBOARD_APPEARANCE_DEFAULT).
+    type: Number
+    platforms: [iphone, ipad]
   - name: autoLink
     summary: Automatically convert text within this area to clickable links. 
     description: Specify which type of items should be converted using the `AUTODETECT` constants defined in <Titanium.UI>.
@@ -73,6 +85,22 @@ properties:
     summary: Height of the keyboard toolbar.
     type: Number
     platforms: [iphone,ipad]
+  - name: keyboardType
+    summary: Specifies the keyboard type to display when this text area is focused, such as [KEYBOARD_EMAIL](Titanium.UI.KEYBOARD_EMAIL) or [KEYBOARD_NUMBER_PAD](Titanium.UI.KEYBOARD_NUMBER_PAD).
+    description: |
+        Specify one of the `KEYBOARD` constants from <Titanium.UI>.
+        When asking for a specific kind of input, such as a phone number or email 
+        address, you should always specify the appropriate keyboard type.
+    type: Number
+    platforms: [android,iphone,ipad]
+    default: the platform's default keyboard
+  - name: returnKeyType
+    summary: Specifies the text to display on the keyboard **Return** key when this text area is focused.
+    description: |
+        Specify one of the `RETURNKEY` constants from <Titanium.UI>.
+    type: Number
+    platforms: [android,iphone,ipad]
+    default: the platform's default return key
   - name: suppressReturn
     summary: Should the return key be suppressed during entry?
     type: Boolean
@@ -91,42 +119,62 @@ properties:
     default: true
 
 examples:
-  - title: Text Area with Custom Keyboard Toolbar
-    example: |
-  
-        Both Text Areas and Text Fields can control the buttons displayed in a button bar above the keyboard when it's visible.
-    
-        Example using a custom keyboard toolbar:
-    
-            var textfield = Titanium.UI.createTextField({
-                color:'#336699',
-        	    value:'Focus to see keyboard w/ toolbar',
-        	    height:35,
-        	    width:300,
-        	    top:10,
-        	    borderStyle:Titanium.UI.INPUT_BORDERSTYLE_ROUNDED,
-        	    keyboardToolbar:[flexSpace,camera, flexSpace,tf,flexSpace, send,flexSpace],
-        	    keyboardToolbarColor: '#999',	
-        	    keyboardToolbarHeight: 40,
-            });
-
   - title: Basic Text Area with Customizations
     example: |
         This example creates a highly customized text area.
         
             var ta1 = Titanium.UI.createTextArea({
-            	value:'I am a textarea',
-            	height:70,
-            	width:300,
-            	top:60,
-            	font:{fontSize:20,fontFamily:'Marker Felt', fontWeight:'bold'},
-            	color:'#888',
-            	textAlign:'left',
-            	appearance:Titanium.UI.KEYBOARD_APPEARANCE_ALERT,	
-            	keyboardType:Titanium.UI.KEYBOARD_NUMBERS_PUNCTUATION,
-            	returnKeyType:Titanium.UI.RETURNKEY_EMERGENCY_CALL,
-            	borderWidth:2,
-            	borderColor:'#bbb',
-            	borderRadius:5
+            	value : 'I am a textarea',
+            	height : 70,
+            	width : 300,
+            	top : 60,
+            	font : {fontSize:20,fontFamily:'Marker Felt', fontWeight:'bold'},
+            	color : '#888',
+            	textAlign : 'left',
+            	appearance : Titanium.UI.KEYBOARD_APPEARANCE_ALERT,	
+            	keyboardType : Titanium.UI.KEYBOARD_NUMBERS_PUNCTUATION,
+            	returnKeyType : Titanium.UI.RETURNKEY_EMERGENCY_CALL,
+            	borderWidth : 2,
+            	borderColor : '#bbb',
+            	borderRadius : 5
             });
         
+  - title: Text Area with Custom Keyboard Toolbar (iOS)
+    example: |
+        On iOS, a configurable toolbar can be displayed above the virtual keyboard. 
+        Toolbars can be used with both text areas and text fields. See <Titanium.UI.iOS.Toolbar>
+        for more information.
+
+        This code excerpt creates a text area with a toolbar:
+  
+        Example using a custom keyboard toolbar:
+    
+            var send = Titanium.UI.createButton({
+                title : 'Send',
+                style : Titanium.UI.iPhone.SystemButtonStyle.DONE,
+            });
+            
+            var camera = Titanium.UI.createButton({
+                systemButton : Titanium.UI.iPhone.SystemButton.CAMERA,
+            });
+            
+            var cancel = Titanium.UI.createButton({
+                systemButton : Titanium.UI.iPhone.SystemButton.CANCEL
+            });
+            
+            var flexSpace = Titanium.UI.createButton({
+                systemButton : Titanium.UI.iPhone.SystemButton.FLEXIBLE_SPACE
+            });
+            
+            var textarea = Titanium.UI.createTextArea({
+                color : '#000',
+                value : 'Focus to see keyboard with toolbar',
+                height : 120,
+                width : 300,
+                top : 10,
+                borderColor : '#000',
+                keyboardToolbar : [cancel, flexSpace, camera, flexSpace, send],
+                keyboardToolbarColor : '#999',
+                keyboardToolbarHeight : 40,
+            });
+

--- a/apidoc/Titanium/UI/TextField.yml
+++ b/apidoc/Titanium/UI/TextField.yml
@@ -34,6 +34,14 @@ events:
     summary: Fired when the return key is pressed on the keyboard.
     platforms: [android, iphone, ipad]
 properties:
+  - name: appearance
+    summary: Determines the appearance of the keyboard displayed when this field is focused.
+    description: |
+        Specify one of the following constants from <Titanium.UI>: 
+        [KEYBOARD_APPEARANCE_ALERT](Titanium.UI.KEYBOARD_APPEARANCE_ALERT), or
+        [KEYBOARD_APPEARANCE_DEFAULT](Titanium.UI.KEYBOARD_APPEARANCE_DEFAULT).
+    type: Number
+    platforms: [iphone, ipad]
   - name: autocapitalization
     summary: Determines how text is capitalized during typing. 
     description: |
@@ -83,6 +91,15 @@ properties:
     summary: Height of the keyboard toolbar.
     type: Number
     platforms: [iphone, ipad]
+  - name: keyboardType
+    summary: Specifies the keyboard type to display when this field is focused, such as [KEYBOARD_EMAIL](Titanium.UI.KEYBOARD_EMAIL) or [KEYBOARD_NUMBER_PAD](Titanium.UI.KEYBOARD_NUMBER_PAD).
+    description: |
+        Specify one of the `KEYBOARD` constants from <Titanium.UI>.
+        When asking for a specific kind of input, such as a phone number or email 
+        address, you should always specify the appropriate keyboard type.
+    type: Number
+    platforms: [android,iphone,ipad]
+    default: the platform's default keyboard
   - name: leftButton
     summary: Left button view. Using an object other than a [Button](Titanium.UI.Button) may have unpredictable results.
     type: Object
@@ -117,6 +134,13 @@ properties:
         Note: on iOS, `passwordMask` *must* be specified when the text field is created.
     type: Boolean
     default: false
+  - name: returnKeyType
+    summary: Specifies the text to display on the keyboard **Return** key when this field is focused.
+    description: |
+        Specify one of the `RETURNKEY` constants from <Titanium.UI>.
+    type: Number
+    platforms: [android,iphone,ipad]
+    default: the platform's default return key
   - name: rightButton
     summary: Right button view. 
     description: Using an object other than a [Button](Titanium.UI.Button) may have 
@@ -178,21 +202,39 @@ examples:
             	width:250,
             	borderStyle:Titanium.UI.INPUT_BORDERSTYLE_ROUNDED
             });
-  - title: Text Area with Custom Keyboard Toolbar
+  - title: Custom Keyboard Toolbar (iOS)
     example: |
-        Both Text Areas and Text Fields can control the buttons displayed in a button bar 
-        above the keyboard when it's visible.
+        On iOS, a configurable toolbar can be displayed above the virtual keyboard. 
+        Toolbars can be used with both text areas and text fields. See <Titanium.UI.iOS.Toolbar>
+        for more information.
+
+        This code excerpt creates a text field with a toolbar:
     
-        Example using a custom keyboard toolbar:
-    
-            var textfield = Titanium.UI.createTextField({
-                color:'#336699',
-        	    value:'Focus to see keyboard w/ toolbar',
-        	    height:35,
-        	    width:300,
-        	    top:10,
-        	    borderStyle:Titanium.UI.INPUT_BORDERSTYLE_ROUNDED,
-        	    keyboardToolbar:[flexSpace,camera, flexSpace,tf,flexSpace, send,flexSpace],
-        	    keyboardToolbarColor: '#999',	
-        	    keyboardToolbarHeight: 40,
+            var send = Titanium.UI.createButton({
+                title : 'Send',
+                style : Titanium.UI.iPhone.SystemButtonStyle.DONE,
             });
+
+            var camera = Titanium.UI.createButton({
+                systemButton : Titanium.UI.iPhone.SystemButton.CAMERA,
+            });
+
+            var cancel = Titanium.UI.createButton({
+                systemButton : Titanium.UI.iPhone.SystemButton.CANCEL
+            });
+
+            var flexSpace = Titanium.UI.createButton({
+                systemButton : Titanium.UI.iPhone.SystemButton.FLEXIBLE_SPACE
+            });
+
+            var textfield = Titanium.UI.createTextField({
+                hintText : 'Focus to see keyboard with toolbar',
+                height : 35,
+                width : 300,
+                top : 10,
+                borderStyle : Titanium.UI.INPUT_BORDERSTYLE_BEZEL,
+                keyboardToolbar : [cancel, flexSpace, camera, flexSpace, send],
+                keyboardToolbarColor : '#999',
+                keyboardToolbarHeight : 40,
+            });
+


### PR DESCRIPTION
TIMOB-6307 
…
 Added missing appearance, keyboardType, and returnKeyType properties to TextField and TextArea.

Replaced keyboard toolbar samples with more detailed, tested samples & clarified that these samples are iOS-specific.

Added note on newly-discovered (but not new) TextArea bug, TIMOB-6652.
commit a3c5d9186d
