### PR TITLE
TIMOB-6656 --removing problematic anchors in Window.yml

### DIFF
--- a/apidoc/Titanium/UI/Window.yml
+++ b/apidoc/Titanium/UI/Window.yml
@@ -382,7 +382,6 @@ description: |
 
     Use the <Titanium.UI.createWindow> method to create a window.
 
-    <a id="contexts"/>
     #### Sub-contexts
 
     Windows can be loaded from another JavaScript file by specifying the property `url`,
@@ -402,7 +401,6 @@ description: |
     points to the JavaScript instance by reference in the global context.
 
 
-    <a id="passingdata"/>
     #### Passing Data Between Contexts
 
     By default, sub-context variables cannot access JavaScript references in the global context.


### PR DESCRIPTION
Removed anchors that were causing problems on the web site.

I didn't end up using them, and for some reason they're messing with the website display. See:

http://developer.appcelerator.com/apidoc/mobile/1.8.0.1.RC1/Titanium.UI.Window-object.html
