### PR TITLE
[TIMOB-6660] Rename variable in iteration loop to resolve build problems

### DIFF
--- a/support/tiapp.py
+++ b/support/tiapp.py
@@ -440,9 +440,9 @@ class TiAppXML(object):
 		iconslist = list(set(sorted(tempiconslist)))
 		iconorder = list([iconname+".png",iconname+"@2x.png",iconname+"-72.png",iconname+"-Small-50.png",iconname+"-Small.png",iconname+"-Small@2x.png"])
 		for type in iconorder:
-			for icon in iconslist:
-				if type == icon:
-					propertyValue += "\t<string>%s</string>\n" %icon
+			for nexticon in iconslist:
+				if type == nexticon:
+					propertyValue += "\t<string>%s</string>\n" % nexticon
 		propertyValue += '</array>\n'
 		self.infoplist_properties[propertyName]=propertyValue
 		


### PR DESCRIPTION
Looks like we'd accidentally re-referenced an already declared variable in an iterator loop, which was mangling the value and causing problems further down the build process.
