### PR TITLE
[TIMOB-6293] 1_7_X Removing timestamp from being appended on app version for distribution build

### DIFF
--- a/support/iphone/builder.py
+++ b/support/iphone/builder.py
@@ -356,7 +356,7 @@ def distribute_xc4(name, icon, log):
 	version = project_info_plist['CFBundleVersion']
 	app_version_ = version.split('.')
 	if(len(app_version_) > 3):
-		version = app_version_[0]+','+app_version_[1]+'.'+app_version_[2]	
+		version = app_version_[0]+'.'+app_version_[1]+'.'+app_version_[2]	
 	archive_info = {
 		'ApplicationProperties' : {
 			'ApplicationPath' : appbundle,

--- a/support/iphone/builder.py
+++ b/support/iphone/builder.py
@@ -758,7 +758,8 @@ def main(args):
 				version = ti.properties['version']
 				# we want to make sure in debug mode the version always changes
 				version = "%s.%d" % (version,time.time())
-				ti.properties['version']=version
+				if (deploytype != 'production'):
+					ti.properties['version']=version
 				pp = os.path.expanduser("~/Library/MobileDevice/Provisioning Profiles/%s.mobileprovision" % appuuid)
 				provisioning_profile = read_provisioning_profile(pp,o)
 			

--- a/support/iphone/builder.py
+++ b/support/iphone/builder.py
@@ -356,7 +356,7 @@ def distribute_xc4(name, icon, log):
 	version = project_info_plist['CFBundleVersion']
 	app_version_ = version.split('.')
 	if(len(app_version_) > 3):
-		version = app_version_[0]+app_version_[1]+app_version_[2]	
+		version = app_version_[0]+','+app_version_[1]+'.'+app_version_[2]	
 	archive_info = {
 		'ApplicationProperties' : {
 			'ApplicationPath' : appbundle,

--- a/support/iphone/builder.py
+++ b/support/iphone/builder.py
@@ -353,11 +353,15 @@ def distribute_xc4(name, icon, log):
 	project_info_plist = plistlib.readPlist(os.path.join(archive_bundle,'Info.xml.plist'))
 	appbundle = "Applications/%s.app" % name
 	# NOTE: We chop off the end '.' of 'CFBundleVersion' to provide the 'short' version
+	version = project_info_plist['CFBundleVersion']
+	app_version_ = version.split('.')
+	if(len(app_version_) > 3):
+		version = app_version_[0]+app_version_[1]+app_version_[2]	
 	archive_info = {
 		'ApplicationProperties' : {
 			'ApplicationPath' : appbundle,
 			'CFBundleIdentifier' : project_info_plist['CFBundleIdentifier'],
-			'CFBundleShortVersionString' : project_info_plist['CFBundleVersion'].rsplit('.',1)[0],
+			'CFBundleShortVersionString' : version,
 			'IconPaths' : [os.path.join(appbundle,icon), os.path.join(appbundle,icon)]
 		},
 		'ArchiveVersion' : float(1),

--- a/support/iphone/compiler.py
+++ b/support/iphone/compiler.py
@@ -207,12 +207,6 @@ class Compiler(object):
 			main_file.write(main_template)
 			main_file.close()
 		
-		if deploytype == 'production':
-			version = ti.properties['version']
-			# we want to make sure in debug mode the version always changes
-			version = "%s.%d" % (version,time.time())
-			ti.properties['version']=version
-
 		resources_dir = os.path.join(project_dir,'Resources')
 		iphone_resources_dir = os.path.join(resources_dir,'iphone')
 


### PR DESCRIPTION
Duplicate from pull #889, includes cherry-picked commits from the same. follow the same testing instructions
