### PR TITLE
[TIMOB-6610] Fix background services implementation

### DIFF
--- a/iphone/Classes/TiApp.mm
+++ b/iphone/Classes/TiApp.mm
@@ -673,7 +673,11 @@ TI_INLINE void waitForMemoryPanicCleared();   //WARNING: This must never be run 
 	{
 		backgroundServices = [[NSMutableArray alloc] initWithCapacity:1];
 	}
-	[backgroundServices addObject:proxy];
+	
+	//Only add if it isn't already added
+	if (![backgroundServices containsObject:proxy]) {
+		[backgroundServices addObject:proxy];
+	}
 }
 
 -(void)checkBackgroundServices
@@ -695,13 +699,13 @@ TI_INLINE void waitForMemoryPanicCleared();   //WARNING: This must never be run 
 -(void)unregisterBackgroundService:(TiProxy*)proxy
 {
 	[backgroundServices removeObject:proxy];
+	[runningServices removeObject:proxy];
 	[self checkBackgroundServices];
 }
 
 -(void)stopBackgroundService:(TiProxy *)proxy
 {
 	[runningServices removeObject:proxy];
-	[backgroundServices removeObject:proxy];
 	[self checkBackgroundServices];
 }
 

--- a/iphone/Classes/TiApp.mm
+++ b/iphone/Classes/TiApp.mm
@@ -651,7 +651,8 @@ TI_INLINE void waitForMemoryPanicCleared();   //WARNING: This must never be run 
 		[proxy performSelector:@selector(endBackground)];
 		[runningServices removeObject:proxy];
 	}
-	
+
+	[self checkBackgroundServices];
 	RELEASE_TO_NIL(runningServices);
 }
 

--- a/iphone/Classes/TiAppiOSProxy.h
+++ b/iphone/Classes/TiAppiOSProxy.h
@@ -12,6 +12,7 @@
 
 @interface TiAppiOSProxy : TiProxy {
 @private
+	NSMutableDictionary *backgroundServices;
 }
 
 @end

--- a/iphone/Classes/TiAppiOSProxy.m
+++ b/iphone/Classes/TiAppiOSProxy.m
@@ -20,6 +20,7 @@
 -(void)dealloc
 {
 	[[NSNotificationCenter defaultCenter] removeObserver:self];
+	RELEASE_TO_NIL(backgroundServices);
 	[super dealloc];
 }
 
@@ -59,7 +60,26 @@
 
 -(id)registerBackgroundService:(id)args
 {
-	TiAppiOSBackgroundServiceProxy *proxy = [[TiAppiOSBackgroundServiceProxy alloc] _initWithPageContext:[self executionContext] args:args];
+	NSDictionary* a;
+	ENSURE_ARG_AT_INDEX(a, args, 0, NSDictionary)
+	
+	NSString* urlString = [a objectForKey:@"url"];
+	
+	if ([urlString length] == 0) {
+		return;
+	}
+	
+	if (backgroundServices == nil) {
+		backgroundServices = [[NSMutableDictionary alloc]init];
+	}
+	
+	TiAppiOSBackgroundServiceProxy *proxy = [backgroundServices objectForKey:urlString];
+	
+	if (proxy == nil) {
+		proxy = [[TiAppiOSBackgroundServiceProxy alloc] _initWithPageContext:[self executionContext] args:args];
+		[backgroundServices setValue:proxy forKey:urlString];
+	}
+	
 	[[TiApp app] registerBackgroundService:proxy];
 	return [proxy autorelease];
 }

--- a/iphone/Classes/TiAppiOSProxy.m
+++ b/iphone/Classes/TiAppiOSProxy.m
@@ -76,12 +76,12 @@
 	TiAppiOSBackgroundServiceProxy *proxy = [backgroundServices objectForKey:urlString];
 	
 	if (proxy == nil) {
-		proxy = [[TiAppiOSBackgroundServiceProxy alloc] _initWithPageContext:[self executionContext] args:args];
+		proxy = [[[TiAppiOSBackgroundServiceProxy alloc] _initWithPageContext:[self executionContext] args:args] autorelease];
 		[backgroundServices setValue:proxy forKey:urlString];
 	}
 	
 	[[TiApp app] registerBackgroundService:proxy];
-	return [proxy autorelease];
+	return proxy;
 }
 
 -(id)scheduleLocalNotification:(id)args

--- a/iphone/Classes/TiAppiOSProxy.m
+++ b/iphone/Classes/TiAppiOSProxy.m
@@ -63,7 +63,7 @@
 	NSDictionary* a;
 	ENSURE_ARG_AT_INDEX(a, args, 0, NSDictionary)
 	
-	NSString* urlString = [a objectForKey:@"url"];
+	NSString* urlString = [[TiUtils toURL:[a objectForKey:@"url"] proxy:self]absoluteString];
 	
 	if ([urlString length] == 0) {
 		return;


### PR DESCRIPTION
Fixes these 3 issues
1. Calling stop actually unregisters the service
2. Calling unregister while app is in background does not remove the service from running services so the background task is not killed.
3. Calling register multiple times with the same url result in multiple instance of the same service being run in BG.(It should be a NO-OP ideally if the service is already registered)
