### PR TITLE
TIMOB-6684 move the extend method we currently override on the Object to...

### DIFF
--- a/android/modules/ui/src/js/window.js
+++ b/android/modules/ui/src/js/window.js
@@ -175,8 +175,9 @@ exports.bootstrapWindow = function(Titanium) {
 		
 		if (!options) {
 			options = {};
+
 		} else if (!(options instanceof UI.Animation)) {
-			this._properties.extend(options);
+			kroll.extend(this._properties, options);
 		}
 
 		// Determine if we should create a heavy or light weight window.
@@ -192,7 +193,7 @@ exports.bootstrapWindow = function(Titanium) {
 
 		// Set any cached properties on the properties given to the "true" view
 		if (this.propertyCache) {
-			this._properties.extend(this.propertyCache);
+			kroll.extend(this._properties, this.propertyCache);
 		}
 
 		if (this.cachedActivityProxy) {
@@ -239,7 +240,7 @@ exports.bootstrapWindow = function(Titanium) {
 
 		// Set any cached properties on the properties given to the "true" view
 		if (this.propertyCache) {
-			this._properties.extend(this.propertyCache);
+			kroll.extend(this._properties, this.propertyCache);
 		}
 
 		this.window = existingWindow;

--- a/android/runtime/common/src/js/kroll.js
+++ b/android/runtime/common/src/js/kroll.js
@@ -8,6 +8,22 @@
 	var TAG = "kroll";
 	var global = this;
 
+	kroll.extend = function(thisObject, otherObject)
+	{
+		if (!otherObject) {
+			// extend with what?!  denied!
+			return;
+		}
+
+		for (var name in otherObject) {
+			if (otherObject.hasOwnProperty(name)) {
+				thisObject[name] = otherObject[name];
+			}
+		}
+
+		return thisObject;
+	}
+
 	function startup() {
 		startup.globalVariables();
 		startup.runMain();

--- a/android/runtime/common/src/js/titanium.js
+++ b/android/runtime/common/src/js/titanium.js
@@ -242,21 +242,6 @@ Titanium.bindInvocationAPIs = function(wrapperTi, scopeVars) {
 
 Titanium.Proxy = Proxy;
 
-// Use defineProperty so we can avoid our custom extensions being enumerated
-Object.defineProperty(Object.prototype, "extend", {
-	value: function(other) {
-		if (!other) return;
-	
-		for (var name in other) {
-			if (other.hasOwnProperty(name)) {
-				this[name] = other[name];
-			}
-		}
-		return this;
-	},
-	enumerable: false
-});
-
 Proxy.defineProperties = function(proxyPrototype, names) {
 	var properties = {};
 	var len = names.length;

--- a/android/runtime/v8/tools/bootstrap.js
+++ b/android/runtime/v8/tools/bootstrap.js
@@ -32,7 +32,7 @@ exports.defineProperties = function(namespace, properties) {
 		customProperties[namespace] = {};
 	}
 
-	customProperties[namespace].extend(properties);
+	kroll.extend(customProperties[namespace], properties);
 }
 
 function defineLazyGetter(namespace, name, getter) {


### PR DESCRIPTION
... the kroll namespace so it does not conflict with frameworks that check if extend is udnefined

http://jira.appcelerator.org/browse/TIMOB-6684

Test instructions in ticket.
