### PR TITLE
[TIMOB-6457][1_8_X] Fix bad errors/crash in require() [and maybe callbacks, too]

### DIFF
--- a/iphone/Classes/KrollContext.mm
+++ b/iphone/Classes/KrollContext.mm
@@ -573,7 +573,8 @@ static TiValueRef StringFormatDecimalCallback (TiContextRef jsContext, TiObjectR
 		NSLog(@"[ERROR] Script Error = %@",[TiUtils exceptionMessage:excm]);
 		fflush(stderr);
 		TiStringRelease(js);
-		throw excm;
+
+		@throw excm;
 	}
 	
 	TiStringRelease(js);

--- a/iphone/Classes/TiUtils.m
+++ b/iphone/Classes/TiUtils.m
@@ -1135,6 +1135,7 @@ If the new path starts with / and the base url is app://..., we have to massage 
 				id lineNumber = [arg objectForKey:@"line"];
 				return [NSString stringWithFormat:@"%@ at %@ (line %@)",message,[source lastPathComponent],lineNumber];
 			}
+            return [NSString stringWithFormat:@"%@ (unknown file)", message];
 		}
 	}
 	return arg;


### PR DESCRIPTION
Turns out that we were not properly converting exception message objects into strings for display when evaluating require()ed modules. This could also be happening during callbacks, but is more unlikely.

This pull request _DOES NOT_ fully resolve the bug; that will require displaying file/line information in addition to the message.
