### PR TITLE
[TIMOB-5006] iOS: iAd rotation bug

### DIFF
--- a/iphone/Classes/TiUITabGroup.m
+++ b/iphone/Classes/TiUITabGroup.m
@@ -61,6 +61,7 @@ DEFINE_EXCEPTIONS
 {
 	[super layoutSubviews];
 	UIView *view = [self tabController].view;
+	[view setTransform:CGAffineTransformIdentity];
 	[view setFrame:[self bounds]];
 }
 


### PR DESCRIPTION
Looks an edge case where transform values are being passed to views in 4.3 and causing an unwanted rotation.

Testing instructions...
- look for the last code placed on the jira bug by Karol ... --- make sure to test it against iOS 4.3 and 5.0
