### PR TITLE
[TIMOB-6719] Titanium.App docs

### DIFF
--- a/apidoc/Titanium/App/App.yml
+++ b/apidoc/Titanium/App/App.yml
@@ -1,87 +1,121 @@
 ---
 name: Titanium.App
-summary: The top level App module.  The App module is mainly used for accessing information about the application at runtime.
+summary: The top level App module. The App module is mainly used for accessing information about the application at runtime.
+description: |
+    The `App` module exposes a number of properties set in the `tiapp.xml` file. 
+    Three of these properties, the application name, ID, and URL, must be specified in the 
+    new project wizard when you create an application. 
+    
+    Most values can be changed by editing the `tiapp.xml` file after creating the project.
+    However, the GUID property is automatically generated and should not be changed.
+
 extends: Titanium.Module
 since: "0.1"
 methods:
   - name: getArguments
-    summary: return the arguments passed to the application on startup as a dictionary
+    summary: Return the arguments passed to the application on startup as a dictionary.
     platforms: [iphone, ipad]
     returns:
-        type: Object
+        type: Dictionary
 events:
   - name: proximity
-    summary: fired when a proximity state changes
+    summary: Fired when the iPhone proximity sensor changes state.
+    description: |
+        The iOS proximity sensor detects whether the device is being held up 
+        to the user's ear, and shuts down the display.
+
+        If [proximityDetection](Titanium.App.proximityDetection) is `true`,
+        events are generated whenever the proximity sensor changes state.
     properties:
       - name: state
-        summary: the proximity state value
-    platforms: [android, iphone, ipad]
+        summary: Proximity state value.
+    platforms: [iphone, ipad]
   - name: resume
-    summary: fired when an iOS application will enter the foreground due to iOS 4's multitasking.
+    summary: Fired when an iOS application will enter the foreground due to iOS 4's multitasking.
+    description: |
         This does not include pauses due to notifications or calls. See
         [applicationWillEnterForeground](http://developer.apple.com/library/ios/#documentation/UIKit/Reference/UIApplication_Class/Reference/Reference.html#//apple_ref/doc/uid/TP40006728-CH3-SW108) for
         the exact behavior that triggers this event.
     platforms: [iphone, ipad]
   - name: resumed
-    summary: fired when an iOS application will return to being the focus. This does include not
-        only the events that trigger resume, but pauses due to notifications or calls. See
+    summary: Fired when an iOS application will return to being the focus. 
+    description: |
+        This includes not
+        only the events that trigger the `resume` event, but also pauses due to notifications 
+        or calls. See
         [applicationDidBecomeActive](http://developer.apple.com/library/ios/documentation/UIKit/Reference/UIApplicationDelegate_Protocol/Reference/Reference.html#//apple_ref/doc/uid/TP40006786-CH3-SW10) for
         the exact behavior that triggers this event.
     platforms: [iphone, ipad]
   - name: pause
-    summary: fired when an iOS application will stop being the focus. 
+    summary: Fired when an iOS application will stop being the focus. 
     description: |
         This includes not only the user leaving the application, 
         but also pauses due to notifications or calls. See [applicationWillResignActive](http://developer.apple.com/library/ios/documentation/UIKit/Reference/UIApplicationDelegate_Protocol/Reference/Reference.html#//apple_ref/doc/uid/TP40006786-CH3-SW10) 
         for the exact behavior that triggers this event.
         
         Note that making calls to functions which modify the UI during this
-        event may cause execution UP TO the UI call before the suspension,
-        but then execute the REMAINDER of the callback after the application is
-        resumed (but before the resume event is triggered).
+        event may cause execution **up to** the UI call before the suspension,
+        but then execute the **remainder** of the callback after the application is
+        resumed (but before the `resume` event is triggered).
     platforms: [iphone, ipad]
 properties:
   - name: copyright
-    summary: the application's copyright
+    summary: Application's copyright statement, from `tiapp.xml`.
     type: String
     permission: read-only
   - name: description
-    summary: the application's description
+    summary: Application's description, from `tiapp.xml`.
     type: String
     permission: read-only
   - name: guid
-    summary: the application's globally unique id (this is system generated and consistent through all versions)
+    summary: Application's globally unique id, from `tiapp.xml`
+    description: This value is system generated and consistent through all versions.
     type: String
     permission: read-only
   - name: id
-    summary: the application's app id as specified in Titanium Developer or Titanium Studio
+    summary: Application's app ID, from `tiapp.xml`. 
+    description: |
+        The application ID is a required property you must specify when creating a new project.
     type: String
     permission: read-only
   - name: idleTimerDisabled
-    summary: property for controlling whether the phone screen will be locked on idle time. Can be set to true to disable the timer
+    summary: Controls whether the phone screen will be locked on idle time. 
+    description: Set to `true` to disable the timer.
     type: Boolean
     platforms: [iphone, ipad]
   - name: name
-    summary: the application's name
+    summary: Application's name, from `tiapp.xml`.
     type: String
     permission: read-only
   - name: proximityDetection
-    summary: a boolean to indicate whether proximity detection is enabled
+    summary: Boolean to indicate whether proximity detection is enabled. 
+    description: |
+        Set to `true` to receive `proximity` events.
+
+        See the [proximity](Titanium.App.proxmity) event for more information.
     type: Boolean
     platforms: [iphone, ipad]
+    default: false
   - name: proximityState
-    summary: the state of the device's proximity detector
-    type: Number
+    summary: State of the device's proximity sensor. 
+    description: |
+        Set to `true` if the proximity sensor is close to the user.
+        
+        If the `proximityDetection` is false, the value of this property is undefined.
+
+        See the [proximity](Titanium.App.proxmity) event for more information.
+    type: Boolean
     platforms: [iphone, ipad]
+    permission: read-only
   - name: publisher
-    summary: the application's publisher
+    summary: Application's publisher, from `tiapp.xml`.
     type: String
     permission: read-only
   - name: url
-    summary: the application url
+    summary: Application URL, from `tiapp.xml`.
     type: String
     permission: read-only
   - name: version
-    summary: the application's version
+    summary: Application version, from `tiapp.xml`.
     type: String
     permission: read-only


### PR DESCRIPTION
TIMOB-6719
Removed outdated reference to Titanium Developer,
clarified where the read-only properties come from.

For kicks, also corrected some information about proximity events,
although it seems likely these are actually iphone-only, not iphone,ipad
as marked.

Edited for style, yadda yadda.
