### PR TITLE
TIMOB-6415 (1.8.X) APIDOC: Re-introduce alternative (non-jsca) JSON documentation at …

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -72,7 +72,6 @@ if clean and os.path.exists('iphone/iphone/build'):
 build_type = 'full'
 build_dirs = ['iphone', 'android', 'mobileweb']
 force_iphone = False
-
 if ARGUMENTS.get('iphone',0):
 	build_type='iphone'
 	build_dirs=['iphone']
@@ -160,11 +159,13 @@ def package_sdk(target, source, env):
 	mobileweb = build_type in ['full', 'mobileweb']
 	package_all = ARGUMENTS.get('package_all', 0)
 	version_tag = ARGUMENTS.get('version_tag', version)
+	build_jsca = int(ARGUMENTS.get('build_jsca', 1))
 	print "Packaging MobileSDK (%s)..." % version_tag
+	packager = package.Packager(build_jsca=build_jsca)
 	if package_all:
-		package.Packager().build_all_platforms(os.path.abspath('dist'), version, module_apiversion, android, iphone, ipad, mobileweb, version_tag)
+		packager.build_all_platforms(os.path.abspath('dist'), version, module_apiversion, android, iphone, ipad, mobileweb, version_tag)
 	else:
-		package.Packager().build(os.path.abspath('dist'), version, module_apiversion, android, iphone, ipad, mobileweb, version_tag)
+		packager.build(os.path.abspath('dist'), version, module_apiversion, android, iphone, ipad, mobileweb, version_tag)
 	if install and not clean:
 		install_mobilesdk(version_tag)
 

--- a/apidoc/docgen.py
+++ b/apidoc/docgen.py
@@ -6,7 +6,6 @@
 # parse out Titanium API documentation templates into a 
 # format that can be used by other documentation generators
 # such as PDF, etc.
-
 import os, sys, traceback
 import re, optparse
 import generators
@@ -30,7 +29,7 @@ from mako.template import Template
 
 # TiLogger is also in support/android
 from tilogger import *
-log = None
+log = TiLogger(None)
 
 # We package the python markdown module already in /support/module/support/markdown.
 module_support_dir = os.path.abspath(os.path.join(this_dir, "..", "support", "module", "support"))

--- a/apidoc/generators/jsca_generator.py
+++ b/apidoc/generators/jsca_generator.py
@@ -219,11 +219,22 @@ def generate(raw_apis, annotated_apis, options):
 
 	if options.stdout:
 		json.dump(result, sys.stdout, sort_keys=False, indent=4)
-	if options.output is not None and len(options.output) > 0:
-		if not os.path.exists(options.output):
-			os.makedirs(options.output)
-		out_path = os.path.join(options.output, "api.jsca")
-		f = open(out_path, "w")
-		json.dump(result, f, sort_keys=False, indent=4)
-		f.close()
-
+	else:
+		output_folder = None
+		if options.output:
+			output_folder = options.output
+		else:
+			dist_dir = os.path.abspath(os.path.join(this_dir, "..", "..", "dist"))
+			if os.path.exists(dist_dir):
+				output_folder = os.path.join(dist_dir, "apidoc")
+				if not os.path.exists(output_folder):
+					os.mkdir(output_folder)
+		if not output_folder:
+			log.warn("No output folder specified and dist path does not exist.  Forcing output to stdout.")
+			json.dump(result, sys.stdout, sort_keys=False, indent=4)
+		else:
+			output_file = os.path.join(output_folder, "api.jsca")
+			f = open(output_file, "w")
+			json.dump(result, f, sort_keys=False, indent=4)
+			f.close()
+			log.info("%s written" % output_file)

--- a/apidoc/generators/json_generator.py
+++ b/apidoc/generators/json_generator.py
@@ -3,8 +3,206 @@
 # Copyright (c) 2011 Appcelerator, Inc. All Rights Reserved.
 # Licensed under the Apache Public License (version 2)
 
-import sys
+import sys, json, os
+
+this_dir = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(os.path.abspath(os.path.join(this_dir, "..")))
+from common import dict_has_non_empty_member
+
+# Contains TiLogger:
+android_support_dir = os.path.abspath(os.path.join(this_dir, "..", "..", "support", "android"))
+sys.path.append(android_support_dir)
+from tilogger import *
+
+
+# We piggy-back on some of the functionality from the html generator, because
+# this json format includes a property named "filename" which is corresponds to
+# the filename generated for the html format.
+import html_generator
+from html_generator import markdown_to_html
+
+all_annotated_apis = None
+log = None
+
+def copy_key_val(source, target, key):
+	if key in source:
+		target[key] = source[key]
+
+def create_dict_for_json(api):
+	result = {
+			"name": api.name,
+			"summary": api.summary_html,
+			"description": None if not api.description_html else api.description_html,
+			}
+
+	if hasattr(api, "filename_html"):
+		result["filename"] = api.filename_html
+
+	if api.typestr in ["method", "module", "proxy"]:
+		result["examples"] = to_json_examples(api)
+
+	if api.typestr == "property" and api.parent and api.parent.typestr != "event":
+		result["examples"] = to_json_examples(api)
+
+	if api.typestr in ["method", "module", "proxy", "event"]:
+		result["platforms"] = api.platforms
+
+	if api.typestr == "property" and api.parent and api.parent.typestr != "event":
+		result["platforms"] = api.platforms
+
+	if hasattr(api, "deprecated"):
+		result["deprecated"] = api.deprecated
+
+	copy_key_val(api.api_obj, result, "optional")
+	copy_key_val(api.api_obj, result, "type")
+
+	return result
+
+def to_json_example(example):
+	return {
+			"description": example["title"],
+			"code": markdown_to_html(example["example"])
+			}
+
+def to_json_examples(api):
+	if dict_has_non_empty_member(api.api_obj, "examples"):
+		return [to_json_example(e) for e in api.api_obj["examples"]]
+	else:
+		return []
+
+def to_json_event_property(p):
+	return create_dict_for_json(p)
+
+def to_json_event_properties(properties):
+	if not properties:
+		return []
+	else:
+		return [to_json_event_property(p) for p in properties]
+
+def to_json_event(event):
+	result = create_dict_for_json(event)
+	result["properties"] = to_json_event_properties(event.properties)
+	return result
+
+def to_json_events(api):
+	if not api.events:
+		return []
+	return [to_json_event(event) for event in api.events]
+
+def to_json_parameter(parameter):
+	result = create_dict_for_json(parameter)
+	result["optional"] = True if parameter.optional else False
+	return result
+
+def to_json_parameters(parameters):
+	if not parameters:
+		return []
+	else:
+		return [to_json_parameter(parameter) for parameter in parameters]
+
+def to_json_method(m):
+	result = create_dict_for_json(m)
+	result["parameters"] = to_json_parameters(m.parameters)
+	result["returns"] = m.api_obj["returns"] if "returns" in m.api_obj else {"type": "void"}
+	return result
+
+def to_json_methods(api):
+	if not api.methods:
+		return []
+	return [to_json_method(m) for m in api.methods]
+
+def to_json_property(p):
+	result = create_dict_for_json(p)
+	copy_key_val(p.api_obj, result, "permission")
+	copy_key_val(p.api_obj, result, "value")
+	copy_key_val(p.api_obj, result, "availability")
+	copy_key_val(p.api_obj, result, "default")
+	return result
+
+def to_json_properties(api):
+	if not api.properties:
+		return []
+	return [to_json_property(p) for p in api.properties]
+
+def find_proxy_names_in_module(module):
+	return [proxy.name for proxy in all_annotated_apis.values() if proxy.typestr == "proxy" and proxy.parent is module]
+
+def is_view_proxy(api):
+	if api.typestr != "proxy":
+		return
+	if api.name == "Titanium.UI.View":
+		return True
+	else:
+		parent = api.parent
+		while parent is not None:
+			if parent.name == "Titanium.UI.View":
+				return True
+			parent = parent.parent
+	return False
+
+def transform_one_api(api):
+	transformed = create_dict_for_json(api)
+	transformed["methods"] = to_json_methods(api)
+	transformed["events"] = to_json_events(api)
+	transformed["properties"] = to_json_properties(api)
+
+	if api.typestr == "module":
+		transformed["objects"] = find_proxy_names_in_module(api)
+		transformed["type"] = "module"
+		transformed["subtype"] = None
+	elif api.typestr == "proxy":
+		transformed["type"] = "object"
+		if is_view_proxy(api):
+			transformed["subtype"] = "view"
+		else:
+			transformed["subtype"] = "proxy"
+	else:
+		transformed["type"] = "object"
+		transformed["subtype"] = None
+	return transformed
 
 def generate(raw_apis, annotated_apis, options):
-	print >> sys.stderr, "JSON Not yet suppported"
-	sys.exit(1)
+	global all_annotated_apis, log
+	all_annotated_apis = annotated_apis
+	log_level = TiLogger.INFO
+	if options and options.verbose:
+		log_level = TiLogger.TRACE
+	log = TiLogger(None, level=log_level, output_stream=sys.stderr)
+	log.info("Generating JSON")
+
+	# Apply HTML annotations because we make use of some of them here.
+	html_generator.generate(raw_apis, annotated_apis, None)
+	all_annotated_apis = html_generator.all_annotated_apis
+	tree = {};
+	keys = annotated_apis.keys()
+	keys.sort()
+	for key in keys:
+		one_api = annotated_apis[key]
+		log.trace("Transforming %s to JSON" % key)
+		tree[key] = transform_one_api(one_api)
+	if options.stdout:
+		json.dump(tree, sys.stdout, sort_keys=False, indent=4)
+	else:
+		# Output to a file named api.json either in the folder
+		# specified by options.output or, if that's None, our
+		# standard dist/apidoc location where we also dump
+		# html output
+		output_folder = None
+		if options is not None and options.output:
+			output_folder = options.output
+		if not output_folder:
+			dist_path = os.path.abspath(os.path.join(this_dir, "..", "..", "dist"))
+			if os.path.exists(dist_path):
+				output_folder = os.path.join(dist_path, "apidoc")
+				if not os.path.exists(output_folder):
+					os.mkdir(output_folder)
+
+		if not output_folder:
+			log.warn("No output folder specified and dist path does not exist.  Forcing output to stdout.")
+			json.dump(tree, sys.stdout, sort_keys=False, indent=4)
+		else:
+			output_file = os.path.join(output_folder, "api.json")
+			f = open(output_file, "w")
+			json.dump(tree, f, sort_keys=False, indent=4)
+			f.close()
+			log.info("%s written" % output_file)

--- a/site_scons/package.py
+++ b/site_scons/package.py
@@ -271,8 +271,8 @@ def create_platform_zip(platform,dist_dir,osname,version,version_tag):
 	zf = zipfile.ZipFile(sdkzip, 'w', zipfile.ZIP_DEFLATED)
 	return (zf,basepath)
 
-def zip_mobilesdk(dist_dir,osname,version,module_apiversion,android,iphone,ipad,mobileweb,version_tag):
-	zf, basepath = create_platform_zip('mobilesdk',dist_dir,osname,version,version_tag)
+def zip_mobilesdk(dist_dir, osname, version, module_apiversion, android, iphone, ipad, mobileweb, version_tag, build_jsca):
+	zf, basepath = create_platform_zip('mobilesdk', dist_dir, osname, version, version_tag)
 
 	version_txt = """version=%s
 module_apiversion=%s
@@ -281,8 +281,9 @@ githash=%s
 """ % (version,module_apiversion,ts,githash)
 
 	zf.writestr('%s/version.txt' % basepath,version_txt)
-	jsca = generate_jsca()
-	zf.writestr('%s/api.jsca' % basepath, jsca)
+	if build_jsca:
+		jsca = generate_jsca()
+		zf.writestr('%s/api.jsca' % basepath, jsca)
 	
 	zip_dir(zf,all_dir,basepath)
 	zip_dir(zf,template_dir,basepath)
@@ -294,23 +295,24 @@ githash=%s
 	
 	zf.close()
 				
-def zip_it(dist_dir,osname,version,module_apiversion,android,iphone,ipad,mobileweb,version_tag):
-	zip_mobilesdk(dist_dir,osname,version,module_apiversion,android,iphone,ipad,mobileweb,version_tag)
+def zip_it(dist_dir, osname, version, module_apiversion, android,iphone, ipad, mobileweb, version_tag, build_jsca):
+	zip_mobilesdk(dist_dir, osname, version, module_apiversion, android, iphone, ipad, mobileweb, version_tag, build_jsca)
 
 class Packager(object):
-	def __init__(self):
+	def __init__(self, build_jsca=1):
+		self.build_jsca = build_jsca
 		self.os_names = { "Windows":"win32", "Linux":"linux", "Darwin":"osx" }
 	 
-	def build(self,dist_dir,version,module_apiversion,android=True,iphone=True,ipad=True,mobileweb=True,version_tag=None):
+	def build(self, dist_dir, version, module_apiversion, android=True, iphone=True, ipad=True, mobileweb=True, version_tag=None):
 		if version_tag == None:
 			version_tag = version
-		zip_it(dist_dir,self.os_names[platform.system()],version,module_apiversion,android,iphone,ipad,mobileweb,version_tag)
+		zip_it(dist_dir, self.os_names[platform.system()], version, module_apiversion, android, iphone, ipad, mobileweb, version_tag, self.build_jsca)
 
-	def build_all_platforms(self,dist_dir,version,module_apiversion,android=True,iphone=True,ipad=True,mobileweb=True,version_tag=None):
+	def build_all_platforms(self, dist_dir, version, module_apiversion, android=True, iphone=True, ipad=True, mobileweb=True, version_tag=None):
 		if version_tag == None:
 			version_tag = version
 		for os in self.os_names.values():
-			zip_it(dist_dir,os,version,module_apiversion,android,iphone,ipad,mobileweb,version_tag)
+			zip_it(dist_dir, os, version, module_apiversion, android, iphone, ipad, mobileweb, version_tag, self.build_jsca)
 		
 if __name__ == '__main__':
 	Packager().build(os.path.abspath('../dist'), "1.1.0")


### PR DESCRIPTION
...community's request (with some enhancements). Also make a scons option to not generate JSCA at the end of the build, since it's painful and slow. Still generates it by default, but add build_jsca=0 to your scons command line to suppress.

This is the 1.8.X cherry-pick of a previous PR.

Test notes here:

http://jira.appcelerator.org/browse/TIMOB-6415?focusedCommentId=176372#comment-176372
