### PR TITLE
[TIMOB-6741] Titanium.Filesystem.File.size support

### DIFF
--- a/drillbit/tests/filesystem/filesystem.js
+++ b/drillbit/tests/filesystem/filesystem.js
@@ -401,5 +401,21 @@ describe("Ti.Filesystem tests", {
 		valueOf(blob.length).shouldBe(0);
 		valueOf(blob.text).shouldBe("");
 		valueOf(blob.toString()).shouldBe("");
+	},
+	
+	fileSize:function() {
+		
+		// For now, all we can do is make sure the size is not 0
+		// without dumping a file of an exact size
+		
+		// NOTE: Android might be failing this right now; I only
+		// found a getSize() op in their code.
+		
+		var testFile = Ti.Filesystem.getFile(Ti.Filesystem.resourcesDirectory, "file.txt");
+		valueOf(testFile).shouldNotBeNull();
+		valueOf(testFile.size).shouldNotBe(0);
+
+		var blob = testFile.read();
+		valueOf(blob.length).shouldNotBe(0);
 	}
 });

--- a/iphone/Classes/KrollObject.m
+++ b/iphone/Classes/KrollObject.m
@@ -979,6 +979,13 @@ bool KrollHasInstance(TiContextRef ctx, TiObjectRef constructor, TiValueRef poss
 					c = ((cIMP)methodFunction)(target,selector);
 					return [NSNumber numberWithChar:c];
 				}
+                else if ([attributes hasPrefix:@"TQ,"])
+                {
+                    unsigned long long ull;
+                    typedef unsigned long long (*ullIMP)(id, SEL, ...);
+                    ull = ((ullIMP)methodFunction)(target,selector);
+                    return [NSNumber numberWithUnsignedLongLong:ull];
+                }
 				else 
 				{
 					// let it fall through and return undefined

--- a/iphone/Classes/TiFile.h
+++ b/iphone/Classes/TiFile.h
@@ -19,7 +19,7 @@
 }
 
 @property(nonatomic,readonly) NSString *path;
-@property(nonatomic,readonly) NSInteger size;
+@property(nonatomic,readonly) unsigned long long size;
 
 -(id)initWithPath:(NSString*)path;
 -(id)initWithTempFilePath:(NSString*)path;

--- a/iphone/Classes/TiFile.m
+++ b/iphone/Classes/TiFile.m
@@ -44,7 +44,7 @@
 	return path;
 }
 
--(NSInteger)size
+-(unsigned long long)size
 {
 	NSFileManager *fm = [NSFileManager defaultManager];
 	NSError *error = nil; 
@@ -52,14 +52,18 @@
 	id resultType = [resultDict objectForKey:NSFileType];
 	if ([resultType isEqualToString:NSFileTypeSymbolicLink])
 	{
-		resultDict = [fm attributesOfFileSystemForPath:path error:&error];
+        // TODO: We should be translating all symlinks into their actual paths always
+        NSString* realPath = [fm destinationOfSymbolicLinkAtPath:path error:nil];
+        if (realPath != nil) {
+            resultDict = [fm attributesOfItemAtPath:realPath error:&error];
+        }
 	}
-	if (error != NULL)
+	if (error != nil)
 	{
 		return 0;
 	}
 	id result = [resultDict objectForKey:NSFileSize];
-	return [result intValue];
+	return [result unsignedLongLongValue];
 }
 
 -(id)blob


### PR DESCRIPTION
It turns out that our drillbit tests for `Titanium.Filesystem.File.size` were not sufficient (they only checked for empty files having zero size, not for non-empty files having non-zero size). This updates the drillbit test and adds correct size support for iOS.
