### PR TITLE
[TIMOB-6749] Use Markdown2 with Legacy Support

### DIFF
--- a/support/module/iphone/templates/build.py
+++ b/support/module/iphone/templates/build.py
@@ -51,7 +51,10 @@ def generate_doc(config):
 	sdk = config['TITANIUM_SDK']
 	support_dir = os.path.join(sdk,'module','support')
 	sys.path.append(support_dir)
-	import markdown
+	try:
+		import markdown2 as markdown
+	except ImportError:
+		import markdown
 	documentation = []
 	for file in os.listdir(docdir):
 		if file in ignoreFiles or os.path.isdir(os.path.join(docdir, file)):


### PR DESCRIPTION
Gracefully fallback to markdown from markdown2, but prefer markdown2 when it is available.
