### PR TITLE
[TIMOB-6748][1_8_X] Building with Ti.Database triggers inclusion of Ti.Filesystem.File

### DIFF
--- a/iphone/Classes/TiFilesystemFileProxy.h
+++ b/iphone/Classes/TiFilesystemFileProxy.h
@@ -6,7 +6,7 @@
  */
 #import "TiBase.h"
 
-#ifdef USE_TI_FILESYSTEM
+#if defined(USE_TI_FILESYSTEM) || defined(USE_TI_DATABASE)
 
 #import "TiFile.h"
 

--- a/iphone/Classes/TiFilesystemFileProxy.m
+++ b/iphone/Classes/TiFilesystemFileProxy.m
@@ -5,7 +5,7 @@
  * Please see the LICENSE included with this distribution for details.
  */
 
-#ifdef USE_TI_FILESYSTEM
+#if defined(USE_TI_FILESYSTEM) || defined(USE_TI_DATABASE)
 
 #include <sys/xattr.h>
 

--- a/iphone/Classes/TiFilesystemFileStreamProxy.h
+++ b/iphone/Classes/TiFilesystemFileStreamProxy.h
@@ -5,7 +5,7 @@
  * Please see the LICENSE included with this distribution for details.
  */
 
-#ifdef USE_TI_FILESYSTEM
+#if defined(USE_TI_FILESYSTEM) || defined(USE_TI_DATABASE)
 
 #import "TiStreamProxy.h"
 

--- a/iphone/Classes/TiFilesystemFileStreamProxy.m
+++ b/iphone/Classes/TiFilesystemFileStreamProxy.m
@@ -5,7 +5,7 @@
  * Please see the LICENSE included with this distribution for details.
  */
 
-#ifdef USE_TI_FILESYSTEM
+#if defined(USE_TI_FILESYSTEM) || defined(USE_TI_DATABASE)
 
 #import "TiStreamProxy.h"
 #import "TiFilesystemFileStreamProxy.h"


### PR DESCRIPTION
Resolves a build issue resulting from the ability to get the file object representing a database.
