### PR TITLE
[TIMOB-4878] shouldBeInteger is not a defined function. 

### DIFF
--- a/drillbit/tests/media/media.js
+++ b/drillbit/tests/media/media.js
@@ -48,7 +48,7 @@ describe("Ti.Media tests", {
 		if (!isAndroid) valueOf(player.state).shouldBeNumber();
 		valueOf(player.paused).shouldBeBoolean();
 		if (!isAndroid) valueOf(player.waiting).shouldBeBoolean();
-		if (!isAndroid) valueOf(player.bufferSize).shouldBeInteger();
+		if (!isAndroid) valueOf(player.bufferSize).shouldBeNumber();
 		
 	},
 	videoPlayerAPIs: function() {


### PR DESCRIPTION
Replaced with shouldBeNumber.
Test:
Drillbit should no longer throw this exception.
