### PR TITLE
TIMOB-6828 Reinstate the clear on null feature, and add drillbit test to ensure no exceptions thrown. 

### DIFF
--- a/drillbit/tests/network.httpclient.js
+++ b/drillbit/tests/network.httpclient.js
@@ -88,6 +88,30 @@ describe("Ti.Network.HTTPClient tests", {
 		timeoutError: "Timed out waiting for HTTP onload"
 	}),
 
+	requestHeaderMethods: asyncTest({
+		start: function() {
+			var xhr = Ti.Network.createHTTPClient();
+			xhr.setTimeout(30000);
+			xhr.onload = this.async(function(e) {
+					//TODO: set up a server that parrots back the request headers so
+					//that we can verfiy what we actually send.
+				valueOf(1).shouldBe(1);
+			});
+			xhr.onerror = this.async(function(e) {
+				throw e.error;
+			});
+			xhr.open('GET','http://www.appcelerator.com');
+			xhr.setRequestHeader('adhocHeader','notcleared');
+			xhr.setRequestHeader('clearedHeader','notcleared');
+			valueOf(function() {
+				xhr.setRequestHeader('clearedHeader',null);
+			}).shouldNotThrowException();
+			xhr.send();
+		},
+		timeout: 30000,
+		timeoutError: "Timed out waiting for HTTP onload"
+	}),
+
 	// Confirms that only the selected cookie is deleted
 	clearCookiePositiveTest_as_async: function(callback) {
 		var timer = 0;

--- a/iphone/Classes/ASI/ASIHTTPRequest.m
+++ b/iphone/Classes/ASI/ASIHTTPRequest.m
@@ -484,7 +484,14 @@ static NSString* ASI_TLS_VERSION_1_2 = @"kCFStreamSocketSecurityLevelTLSv1_2SSLv
 	if (!requestHeaders) {
 		[self setRequestHeaders:[NSMutableDictionary dictionaryWithCapacity:1]];
 	}
-	[requestHeaders setObject:value forKey:header];
+	if (value == nil)
+	{
+		[requestHeaders removeObjectForKey:header];
+	}
+	else
+	{
+		[requestHeaders setObject:value forKey:header];
+	}
 }
 
 // This function will be called either just before a request starts, or when postLength is needed, whichever comes first


### PR DESCRIPTION
This drillbit does not test the actual setting of the headers, and if such testing is needed, we should have a server that can parrot back the request headers for full coverage.
