### PR TITLE
Timob 6823:Video - Passing in an HLS manifest URL causes the video player to fail and displays a 'Video View' alert dialog.

### DIFF
--- a/android/modules/media/src/java/android/widget/TiVideoView8.java
+++ b/android/modules/media/src/java/android/widget/TiVideoView8.java
@@ -573,42 +573,6 @@ public class TiVideoView8 extends SurfaceView implements MediaPlayerControl
 				}
 			}
 
-			/*
-			 * Otherwise, pop up an error dialog so the user knows that
-			 * something bad has happened. Only try and pop up the dialog
-			 * if we're attached to a window. When we're going away and no
-			 * longer have a window, don't bother showing the user an error.
-			 */
-			if (getWindowToken() != null) {
-				// Resources r = mContext.getResources();
-				// int messageId;
-				String message;
-
-				if (framework_err == MediaPlayer.MEDIA_ERROR_NOT_VALID_FOR_PROGRESSIVE_PLAYBACK) {
-					// messageId =
-					// com.android.internal.R.string.VideoView_error_text_invalid_progressive_playback;
-					message = "Invalid progressive playback";
-				} else {
-					// messageId =
-					// com.android.internal.R.string.VideoView_error_text_unknown;
-					message = "Unknown error";
-				}
-
-				new AlertDialog.Builder(getContext()).setTitle("Video View").setMessage(message)
-					.setPositiveButton("Error", new DialogInterface.OnClickListener() {
-						public void onClick(DialogInterface dialog, int whichButton)
-						{
-							/*
-							 * If we get here, there is no onError listener,
-							 * so
-							 * at least inform them that the video is over.
-							 */
-							if (mOnCompletionListener != null) {
-								mOnCompletionListener.onCompletion(mMediaPlayer);
-							}
-						}
-					}).setCancelable(false).show();
-			}
 			return true;
 		}
 	};


### PR DESCRIPTION
Jira http://jira.appcelerator.org/browse/TIMOB-6823
