### PR TITLE
[TIMOB-6832] Make response-header detection more accurate for iOS 4

### DIFF
--- a/iphone/Classes/TiNetworkHTTPClientProxy.m
+++ b/iphone/Classes/TiNetworkHTTPClientProxy.m
@@ -569,8 +569,7 @@ extern NSString * const TI_APPLICATION_DEPLOYTYPE;
     
 	if (request!=nil)
 	{
-        NSString* header = [TiUtils caseCorrect:args];
-		return [[request responseHeaders] objectForKey:header];
+        return [TiUtils getResponseHeader:args fromHeaders:[request responseHeaders]];
 	}
 	return nil;
 }

--- a/iphone/Classes/TiNetworkHTTPClientResultProxy.m
+++ b/iphone/Classes/TiNetworkHTTPClientResultProxy.m
@@ -122,8 +122,7 @@
     
 	id result = [delegate getResponseHeader:args];
 	if (result == nil) {
-        NSString* header = [TiUtils caseCorrect:args];
-		result = [responseHeaders objectForKey:header];
+        return [TiUtils getResponseHeader:args fromHeaders:responseHeaders];
 	}
 	return result;
 }

--- a/iphone/Classes/TiUtils.h
+++ b/iphone/Classes/TiUtils.h
@@ -221,7 +221,5 @@ typedef enum {
 
 +(NSString*)uniqueIdentifier;
 
-+(NSString*)caseCorrect:(NSString*)header;
-
 +(NSString*)getResponseHeader:(NSString*)header fromHeaders:(NSDictionary*)responseHeaders;
 @end

--- a/iphone/Classes/TiUtils.h
+++ b/iphone/Classes/TiUtils.h
@@ -221,5 +221,7 @@ typedef enum {
 
 +(NSString*)uniqueIdentifier;
 
-+(NSString*)caseCorrect:(NSString*)str;
++(NSString*)caseCorrect:(NSString*)header;
+
++(NSString*)getResponseHeader:(NSString*)header fromHeaders:(NSDictionary*)responseHeaders;
 @end

--- a/iphone/Classes/TiUtils.m
+++ b/iphone/Classes/TiUtils.m
@@ -1646,70 +1646,31 @@ if ([str isEqualToString:@#orientation]) return (UIDeviceOrientation)orientation
     return uid;
 }
 
-// In pre-iOS 5, it looks like response headers were mangled to be case-correct
+// In pre-iOS 5, it looks like response headers were case-mangled.
 // (i.e. WWW-Authenticate became Www-Authenticate). So we have to take this
 // mangling into mind; headers such as FooBar-XYZ may also have been mangled
 // to be case-correct. We can't be certain.
 //
-// We also need to handle the case where custom headers do NOT follow the standard naming convention of
-// camelcase/Abc-Xyz but are instead 'abc-xyz'.
+// This means we need to follow the RFC2616 implied MUST that headers are case-insensitive.
 
 +(NSString*)getResponseHeader:(NSString *)header fromHeaders:(NSDictionary *)responseHeaders
 {
-    // Note that thanks to Apple's iOS 4 header mangling, if a response lacks a particular header, we must always
-    // go through these steps to ENSURE that it's really missing.
-    
-    if (![TiUtils isIOS5OrGreater]) {
-        // 1. Check for an exact match, which will be the case almost all of the time.
-        NSString* responseHeader = [responseHeaders valueForKey:header];
-        if (responseHeader != nil) {
-            return responseHeader;
-        }
-        
-        // 2. Check for case-correct
-        responseHeader = [responseHeaders valueForKey:[TiUtils caseCorrect:header]];
-        if (responseHeader != nil) {
-            return responseHeader;
-        }   
-        
-        // 3. It's very unlikely that a response header will contain both
-        // 'xyz' and 'Xyz' or a similar variant (or that things are so bad that neither of
-        // the previous tests pass, which means iOS 4 is REALLY screwing things up). 
-        // We do a case-insensitive compare on the keys, and log a warning about the 
-        // ambiguity if there is more than one possible header.
-
-        NSSet* headers = [responseHeaders keysOfEntriesPassingTest:^BOOL(id key, id obj, BOOL* stop) {
-            return ([key localizedCaseInsensitiveCompare:header] == NSOrderedSame);
-        }];
-
-        responseHeader = [headers anyObject];
-        if ([headers count] > 1) {
-            // This should be rare enough that we can log a fairly verbose message.
-            NSLog(@"[WARN] Ambiguious header request %@ for response headers %@; matched %@ and returning value %@",header,responseHeaders,headers,responseHeader);
-        }
-                  
+    // Do a direct comparison first, and then iterate through the headers if we have to.
+    // This makes things faster in almost all scenarios, and ALWAYS so under iOS 5 unless
+    // the developer is also taking advantage of RFC2616's header spec.
+    __block NSString* responseHeader = [responseHeaders valueForKey:header];
+    if (responseHeader != nil) {
         return responseHeader;
     }
     
-    return [responseHeaders valueForKey:header];
-}
-
-+(NSString*)caseCorrect:(NSString *)str
-{
-    if (![TiUtils isIOS5OrGreater]) {
-        if ([str rangeOfString:@"-"].location != NSNotFound) {
-            NSArray* substrings = [str componentsSeparatedByString:@"-"];
-            NSMutableString* header = [NSMutableString stringWithString:[[substrings objectAtIndex:0] capitalizedString]];
-            for (int i=1; i < [substrings count]; i++) {
-                NSString* substr = [substrings objectAtIndex:i];
-                [(NSMutableString*)header appendFormat:@"-%@",[substr capitalizedString]];
-            }
-            
-            return header;
+    [responseHeaders enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL* stop) {
+        if ([key localizedCaseInsensitiveCompare:header] == NSOrderedSame) {
+            *stop = YES;
+            responseHeader = obj;
         }
-    }
+    }];
     
-    return str;
+    return responseHeader;
 }
 
 @end


### PR DESCRIPTION
We now run through a series of steps for response-header checking under iOS 4, to account for possibly-mangled headers by the OS.

This fix must be regression tested against TIMOB-5807.
