### PR TITLE
[TIMOB-6769] Support % values of height on table rows

### DIFF
--- a/iphone/Classes/TiUITableViewRowProxy.m
+++ b/iphone/Classes/TiUITableViewRowProxy.m
@@ -350,6 +350,9 @@ TiProxy * DeepScanForProxyOfViewContainingPoint(UIView * targetView, CGPoint poi
 	{
 		result = [self autoHeightForWidth:width];
 	}
+    if (TiDimensionIsPercent(height)) {
+        result = TiDimensionCalculateValue(height, [self table].bounds.size.height);
+    }
 	return (result == 0) ? [table tableRowHeight:0] : result;
 }
 

--- a/iphone/Classes/TiUITableViewRowProxy.m
+++ b/iphone/Classes/TiUITableViewRowProxy.m
@@ -350,7 +350,7 @@ TiProxy * DeepScanForProxyOfViewContainingPoint(UIView * targetView, CGPoint poi
 	{
 		result = [self autoHeightForWidth:width];
 	}
-    if (TiDimensionIsPercent(height)) {
+    if (TiDimensionIsPercent(height) && [self table] != nil) {
         result = TiDimensionCalculateValue(height, [self table].bounds.size.height);
     }
 	return (result == 0) ? [table tableRowHeight:0] : result;


### PR DESCRIPTION
This sizes rows relative to the total height of the table, useful for partitioning a table so that an exact number of rows is visible (i.e. the number of visible rows is always 100/rowHeight when using %).
