### PR TITLE
[TIMOB-6895] Have utils properly identify image blobs when loading images

### DIFF
--- a/apidoc/Titanium/Map/Annotation.yml
+++ b/apidoc/Titanium/Map/Annotation.yml
@@ -10,7 +10,7 @@ properties:
     type: Boolean
   - name: image
     summary: image for the pin instead of default image.
-    type: String
+    type: [String, Titanium.Blob]
   - name: leftButton
     summary: the left button image on the annotation. must either be a button type constant or url
     type: [Number,String]

--- a/apidoc/Titanium/Map/Annotation.yml
+++ b/apidoc/Titanium/Map/Annotation.yml
@@ -9,7 +9,8 @@ properties:
     summary: boolean to indicate whether the pin should animate when dropped
     type: Boolean
   - name: image
-    summary: image for the pin instead of default image.
+    summary: The image for the pin instead of the default image.
+    description: Support for using <Titanium.Blob> for this property is only available on iOS.    
     type: [String, Titanium.Blob]
   - name: leftButton
     summary: the left button image on the annotation. must either be a button type constant or url

--- a/apidoc/Titanium/UI/Button.yml
+++ b/apidoc/Titanium/UI/Button.yml
@@ -18,7 +18,7 @@ properties:
     type: Font
   - name: image
     summary: Image to display on the button to the left of the title.
-    type: String
+    type: [String, Titanium.Blob]
   - name: selectedColor
     summary: Button text color used to indicate the selected state.
     type: String

--- a/apidoc/Titanium/UI/Button.yml
+++ b/apidoc/Titanium/UI/Button.yml
@@ -18,6 +18,7 @@ properties:
     type: Font
   - name: image
     summary: Image to display on the button to the left of the title.
+    description: Support for using <Titanium.Blob> for this property is only available on iOS.
     type: [String, Titanium.Blob]
   - name: selectedColor
     summary: Button text color used to indicate the selected state.

--- a/apidoc/Titanium/UI/ButtonBar.yml
+++ b/apidoc/Titanium/UI/ButtonBar.yml
@@ -9,7 +9,12 @@ properties:
     summary: the selected index
     type: Number
   - name: labels
-    summary: the array of labels for the button bar. each object should have the properties `title`, `image`, `width` and `enabled`.
+    summary: The array of labels for the button bar. 
+    detail: |
+        Each object should have the following properties:
+        `title`, `image`, `width` and `enabled`. `image` may
+        either be a path to an image file, or a <Titanium.Blob>
+        representing an image.
     type: Array<Object>
   - name: style
     summary: the style of the button bar

--- a/apidoc/Titanium/UI/DashboardItem.yml
+++ b/apidoc/Titanium/UI/DashboardItem.yml
@@ -32,8 +32,8 @@ properties:
     summary: a boolean to indicate if this item can be deleted when it edit mode
     type: Boolean
   - name: image
-    summary: the URL to the image
-    type: String
+    summary: The image for the item.
+    type: [String, Titanium.Blob]
   - name: selectedImage
-    summary: the URL to the image to display when the item is depressed (clicked)
-    type: String
+    summary: The image to display when the item is depressed (clicked)
+    type: [String, Titanium.Blob]

--- a/apidoc/Titanium/UI/Slider.yml
+++ b/apidoc/Titanium/UI/Slider.yml
@@ -82,6 +82,7 @@ properties:
     type: String
   - name: thumbImage
     summary: The image for the slider thumb.
+    description: Support for using <Titanium.Blob> for this property is only available on iOS.
     type: [String, Titanium.Blob]
   - name: value
     summary: the value of the slider

--- a/apidoc/Titanium/UI/Slider.yml
+++ b/apidoc/Titanium/UI/Slider.yml
@@ -81,8 +81,8 @@ properties:
     summary: the image url of the slider thumb when in the selected state
     type: String
   - name: thumbImage
-    summary: the image url to the slider thumb
-    type: String
+    summary: The image for the slider thumb.
+    type: [String, Titanium.Blob]
   - name: value
     summary: the value of the slider
     type: String

--- a/apidoc/Titanium/UI/Window.yml
+++ b/apidoc/Titanium/UI/Window.yml
@@ -103,10 +103,10 @@ properties:
     type: String
 
   - name: backButtonTitleImage
-    summary: URL to an image to show as the back button.
+    summary: The image to show as the back button.
         This is only valid when the window is a child of a tab.
     platforms: [iphone, ipad]
-    type: String
+    type: [String, Titanium.Blob]
 
   - name: barColor
     summary: Background color for the nav bar, specified as a hex color or color name.

--- a/iphone/Classes/TiUtils.m
+++ b/iphone/Classes/TiUtils.m
@@ -772,7 +772,14 @@ If the new path starts with / and the base url is app://..., we have to massage 
 
 +(UIImage *)image:(id)object proxy:(TiProxy*)proxy
 {
-	return [[ImageLoader sharedLoader] loadImmediateImage:[self toURL:object proxy:proxy]];
+    if ([object isKindOfClass:[TiBlob class]]) {
+        return [(TiBlob*)object image];
+    }
+    else if ([object isKindOfClass:[NSString class]]) {
+        return [[ImageLoader sharedLoader] loadImmediateStretchableImage:[self toURL:object proxy:proxy]];
+    }
+    
+    return nil;
 }
 
 

--- a/iphone/Classes/TiUtils.m
+++ b/iphone/Classes/TiUtils.m
@@ -776,7 +776,7 @@ If the new path starts with / and the base url is app://..., we have to massage 
         return [(TiBlob*)object image];
     }
     else if ([object isKindOfClass:[NSString class]]) {
-        return [[ImageLoader sharedLoader] loadImmediateStretchableImage:[self toURL:object proxy:proxy]];
+        return [[ImageLoader sharedLoader] loadImmediateImage:[self toURL:object proxy:proxy]];
     }
     
     return nil;


### PR DESCRIPTION
`+[TiUtils image:proxy:]` is now blob-enabled, and returns sensible values for expected inputs (blobs, paths, or an object we can't immediately resolve to an image).
