### PR TITLE
TIMOB-6928 Android: Don't clobber existing modules when loading binding json file...

### DIFF
--- a/android/modules/android/src/java/ti/modules/titanium/android/PendingIntentProxy.java
+++ b/android/modules/android/src/java/ti/modules/titanium/android/PendingIntentProxy.java
@@ -10,6 +10,7 @@ import org.appcelerator.kroll.KrollDict;
 import org.appcelerator.kroll.KrollModule;
 import org.appcelerator.kroll.KrollProxy;
 import org.appcelerator.kroll.annotations.Kroll;
+import org.appcelerator.titanium.TiApplication;
 import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.TiContext;
 import org.appcelerator.titanium.proxy.IntentProxy;
@@ -53,15 +54,13 @@ public class PendingIntentProxy extends KrollProxy
 		super.handleCreationArgs(createdInModule, args);
 
 		pendingIntentContext = getActivity();
-		//pendingIntentContext = this.context.getActivity();
-		/*
-		if (context == null) {
-			pendingIntentContext = this.context.getRootActivity();
+		if (pendingIntentContext == null) {
+			pendingIntentContext = TiApplication.getAppCurrentActivity();
 		}
-		if (context == null) {
-			pendingIntentContext = TiApplication.getInstance().getApplicationContext();
+		if (pendingIntentContext == null) {
+			pendingIntentContext = TiApplication.getInstance();
 		}
-		*/
+
 		if (pendingIntentContext == null || intent == null) {
 			throw new IllegalStateException("Creation arguments must contain intent");
 		}

--- a/drillbit/tests/android/android/android.js
+++ b/drillbit/tests/android/android/android.js
@@ -91,6 +91,37 @@ describe("Ti.Android tests", {
 		intent.setFlags(Ti.Android.FLAG_ACTIVITY_NEW_TASK);
 		valueOf(intent.getFlags()).shouldBe(Ti.Android.FLAG_ACTIVITY_NEW_TASK);
 	},
+
+	// http://jira.appcelerator.org/browse/TIMOB-6928
+	proxyInvocation: function() {
+		var intent, pending, notification;
+		valueOf(function() {
+			intent = Ti.Android.createIntent({
+				className:"org.appcelerator.titanium.TiActivity",
+				flags: Ti.Android.FLAG_ACTIVITY_CLEAR_TOP | Ti.Android.FLAG_ACTIVITY_SINGLE_TOP,
+				packageName:Ti.App.id
+			});
+		}).shouldNotThrowException();
+
+		valueOf(function() {
+			pending = Ti.Android.createPendingIntent({
+				intent: intent,
+				flags:Ti.Android.FLAG_UPDATE_CURRENT
+			});
+		}).shouldNotThrowException();
+
+		valueOf(function() {
+			var notification = Ti.Android.createNotification({
+				contentTitle: "hello",
+				contentText: "hello",
+				when: 0,
+				contentIntent: pending,
+				icon: Ti.Android.R.drawable.progress_indeterminate_horizontal,
+				tickerText: "hello",
+				flags: (Ti.Android.FLAG_ONGOING_EVENT | Ti.Android.FLAG_NO_CLEAR)
+			});
+		}).shouldNotThrowException();
+	},
 	
 	options: {
 		forceBuild: true


### PR DESCRIPTION
...s. The android module appears in two files: android.json and calendar.json.  The latter was 'winning', so the binding layer knew nothing about PendingIntent, Notification,etc.

http://jira.appcelerator.org/browse/TIMOB-6928

The failcase is in the ticket.  When you run it, you should be able to click the button and then see a notification in the notification area.

Please test rhino & v8, as this is stuff at the binding layer for both.  Because the binding layer is touched significantly by this, please run drillbit for both runtimes.
