### PR TITLE
[TIMOB-4946] Window titleControl click events get lost

### DIFF
--- a/iphone/Classes/KrollObject.m
+++ b/iphone/Classes/KrollObject.m
@@ -445,8 +445,9 @@ TiValueRef KrollGetProperty(TiContextRef jsContext, TiObjectRef object, TiString
 		}
 
 		TiValueRef jsResult = ConvertIdTiValue([o context],result);
-		if ([result isKindOfClass:[KrollObject class]] &&
+		if ( ([result isKindOfClass:[KrollObject class]] &&
 				![result isKindOfClass:[KrollCallback class]] && [[result target] isKindOfClass:[TiProxy class]])
+			|| ([result isKindOfClass:[TiProxy class]]) )
 		{
 			[o noteObject:(TiObjectRef)jsResult forTiString:prop context:jsContext];
 		}


### PR DESCRIPTION
Make sure we remember the relationship between context and result when result is of type Proxy.

Test is in JIRA.Please also test [TIMOB-6997] to confirm it is resolved by this fix.
