### PR TITLE
[TIMOB-6838] Ensure all delegates are set to nil before calling cancel

### DIFF
--- a/iphone/Classes/TiNetworkHTTPClientProxy.m
+++ b/iphone/Classes/TiNetworkHTTPClientProxy.m
@@ -142,7 +142,7 @@ extern NSString * const TI_APPLICATION_DEPLOYTYPE;
 {
 	if (request!=nil && connected)
 	{
-		[request cancel];
+		[request clearDelegatesAndCancel];
 	}
 	RELEASE_TO_NIL(url);
 	RELEASE_TO_NIL(request);
@@ -333,7 +333,7 @@ extern NSString * const TI_APPLICATION_DEPLOYTYPE;
 	{
 		connected = NO;
 		[[TiApp app] stopNetwork];
-		[request cancel];
+		[request clearDelegatesAndCancel];
 		[self forgetSelf];
 	}
 }


### PR DESCRIPTION
Crash was due to bad access. The Proxy was probably garbage collected before failure was reported (Failure is always reported on main thread). Abort now clears the delegates before cancel is called. So we should not see any errors reported on abort. 

Test is in JIRA
