### PR TITLE
TIMOB-6962 update AudioPlayer to shut down the player and associated buf...

### DIFF
--- a/android/modules/media/src/java/ti/modules/titanium/media/TiSound.java
+++ b/android/modules/media/src/java/ti/modules/titanium/media/TiSound.java
@@ -225,6 +225,12 @@ public class TiSound
 	{
 		try {
 			if (mp != null) {
+				// make sure we actually stop (and thus shutdown any download in the background)
+				// if we are currently in a playing or paused state.  don't call stop directly as
+				// we don't need to update state or firing events back in this case
+				if (mp.isPlaying() || isPaused()) {
+					mp.stop();
+				}
 
 				mp.setOnCompletionListener(null);
 				mp.setOnErrorListener(null);


### PR DESCRIPTION
...fering when the player is destroyed

http://jira.appcelerator.org/browse/TIMOB-6962

Test case in Jira ticket.  Upon hitting destroy, the memory foot print should increase due to release resources.  Variation in the memory footprint over time is expected due to general device processes.
