### PR TITLE
[TIMOB-5928] send window[Will|Did][Open|Close] messages to camera overlay view

### DIFF
--- a/iphone/Classes/MediaModule.h
+++ b/iphone/Classes/MediaModule.h
@@ -11,6 +11,7 @@
 #import "TiMediaAudioSession.h"
 #import "MediaPlayer/MediaPlayer.h"
 #import "TiMediaMusicPlayer.h"
+#import "TiViewProxy.h"
 
 @interface MediaModule : TiModule
 <
@@ -39,6 +40,7 @@
 	KrollCallback *pickerCancelCallback;
 	
 	id popover;
+    TiViewProxy* cameraView;
 	
 	UIVideoEditorController *editor;
 	KrollCallback *editorSuccessCallback;

--- a/iphone/Classes/MediaModule.m
+++ b/iphone/Classes/MediaModule.m
@@ -98,6 +98,7 @@ static NSDictionary* TI_filterableItemProperties;
 -(void)destroyPicker
 {
 	RELEASE_TO_NIL(popover);
+    RELEASE_TO_NIL(cameraView);
 	RELEASE_TO_NIL(editor);
 	RELEASE_TO_NIL(editorSuccessCallback);
 	RELEASE_TO_NIL(editorErrorCallback);
@@ -416,7 +417,7 @@ static NSDictionary* TI_filterableItemProperties;
 		[picker setShowsCameraControls:[TiUtils boolValue:@"showControls" properties:args def:YES]];
 		
 		// allow an overlay view
-		TiViewProxy *cameraView = [args objectForKey:@"overlay"]; 
+		cameraView = [args objectForKey:@"overlay"]; 
 		if (cameraView!=nil)
 		{
 			ENSURE_TYPE(cameraView,TiViewProxy);
@@ -429,7 +430,9 @@ static NSDictionary* TI_filterableItemProperties;
 			}
 			[TiUtils setView:view positionRect:[picker view].bounds];
 			[cameraView layoutChildren:NO];
+            [cameraView windowWillOpen];
 			[picker setCameraOverlayView:view];
+            [cameraView windowDidOpen];
 			[picker setWantsFullScreenLayout:YES];
 		}
 		
@@ -1089,7 +1092,14 @@ MAKE_SYSTEM_PROP(VIDEO_FINISH_REASON_USER_EXITED,MPMovieFinishReasonUserExited);
 			[[NSNotificationCenter defaultCenter] removeObserver:self name:UIDeviceOrientationDidChangeNotification object:nil];
 		}
 		else {
+            if (cameraView != nil) {
+                [cameraView windowWillClose];
+            }
 			[[TiApp app] hideModalController:picker animated:animatedPicker];
+            if (cameraView != nil) {
+                [cameraView windowDidClose];
+                RELEASE_TO_NIL(cameraView);
+            }
 		}
 		[self destroyPicker];
 	}

--- a/iphone/Classes/MediaModule.m
+++ b/iphone/Classes/MediaModule.m
@@ -291,6 +291,9 @@ static NSDictionary* TI_filterableItemProperties;
 
 -(void)closeModalPicker:(UIViewController*)picker_
 {
+    if (cameraView != nil) {
+        [cameraView windowWillClose];
+    }
 	if (popover)
 	{
 		[(UIPopoverController*)popover dismissPopoverAnimated:animatedPicker];
@@ -300,6 +303,10 @@ static NSDictionary* TI_filterableItemProperties;
 	{
 		[[TiApp app] hideModalController:picker_ animated:animatedPicker];
 	}
+    if (cameraView != nil) {
+        [cameraView windowDidClose];
+        RELEASE_TO_NIL(cameraView);
+    }
 }
 
 - (void)popoverControllerDidDismissPopover:(UIPopoverController *)popoverController
@@ -417,7 +424,7 @@ static NSDictionary* TI_filterableItemProperties;
 		[picker setShowsCameraControls:[TiUtils boolValue:@"showControls" properties:args def:YES]];
 		
 		// allow an overlay view
-		cameraView = [args objectForKey:@"overlay"]; 
+		cameraView = [[args objectForKey:@"overlay"] retain];
 		if (cameraView!=nil)
 		{
 			ENSURE_TYPE(cameraView,TiViewProxy);
@@ -1083,6 +1090,9 @@ MAKE_SYSTEM_PROP(VIDEO_FINISH_REASON_USER_EXITED,MPMovieFinishReasonUserExited);
 	ENSURE_UI_THREAD(hideCamera,args);
 	if (picker!=nil)
 	{
+        if (cameraView != nil) {
+            [cameraView windowWillClose];
+        }
 		if (popover != nil) {
 			[popover dismissPopoverAnimated:animatedPicker];
 			RELEASE_TO_NIL(popover);
@@ -1092,15 +1102,12 @@ MAKE_SYSTEM_PROP(VIDEO_FINISH_REASON_USER_EXITED,MPMovieFinishReasonUserExited);
 			[[NSNotificationCenter defaultCenter] removeObserver:self name:UIDeviceOrientationDidChangeNotification object:nil];
 		}
 		else {
-            if (cameraView != nil) {
-                [cameraView windowWillClose];
-            }
 			[[TiApp app] hideModalController:picker animated:animatedPicker];
-            if (cameraView != nil) {
-                [cameraView windowDidClose];
-                RELEASE_TO_NIL(cameraView);
-            }
 		}
+        if (cameraView != nil) {
+            [cameraView windowDidClose];
+            RELEASE_TO_NIL(cameraView);
+        }
 		[self destroyPicker];
 	}
 }

--- a/iphone/Classes/MediaModule.m
+++ b/iphone/Classes/MediaModule.m
@@ -424,10 +424,11 @@ static NSDictionary* TI_filterableItemProperties;
 		[picker setShowsCameraControls:[TiUtils boolValue:@"showControls" properties:args def:YES]];
 		
 		// allow an overlay view
-		cameraView = [[args objectForKey:@"overlay"] retain];
-		if (cameraView!=nil)
+		TiViewProxy *cameraViewProxy = [args objectForKey:@"overlay"];
+		if (cameraViewProxy!=nil)
 		{
-			ENSURE_TYPE(cameraView,TiViewProxy);
+			ENSURE_TYPE(cameraViewProxy,TiViewProxy);
+            cameraView = [cameraViewProxy retain];
 			UIView *view = [cameraView view];
 			if (editable)
 			{


### PR DESCRIPTION
[TIMOB-5928] iOS: Dynamic positioning of camera overlay objects not working
http://jira.appcelerator.org/browse/TIMOB-5928

[Test case](http://jira.appcelerator.org/browse/TIMOB-5928?focusedCommentId=178788#comment-178788)
