### PR TITLE
timob-7009: Android: 'model' has the same value as 'os' in ti.start analytics events

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/analytics/TiAnalyticsEventFactory.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/analytics/TiAnalyticsEventFactory.java
@@ -117,7 +117,7 @@ public class TiAnalyticsEventFactory
 			json.put("tz",GregorianCalendar.getInstance().getTimeZone().getRawOffset()/60000);
 			json.put("deploytype", deployType);
 			json.put("platform", TiPlatformHelper.getName());
-			json.put("os", TiPlatformHelper.getModel());
+			json.put("os", TiPlatformHelper.getOS());
 			json.put("osver", TiPlatformHelper.getVersion());
 			json.put("version", application.getTiBuildVersion());
 			json.put("un", TiPlatformHelper.getUsername());

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiPlatformHelper.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiPlatformHelper.java
@@ -161,6 +161,10 @@ public class TiPlatformHelper
 	public static String getName() {
 		return "android";
 	}
+	
+	public static String getOS() {
+		return "Android";
+	}
 
 	public static int getProcessorCount() {
 		return Runtime.getRuntime().availableProcessors();

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiPlatformHelper.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiPlatformHelper.java
@@ -158,10 +158,17 @@ public class TiPlatformHelper
 		return TiApplication.getInstance().getAppInfo();
 	}
 
+	/**
+	 * The name of platform means the SDK family of Ti.mobile ('iphone' vs. 'android').
+	 * The naming has a historical legacy.
+	 */
 	public static String getName() {
 		return "android";
 	}
 	
+	/**
+	 * The name of OS is to indicate (potential future) forks of the OS.
+	 */
 	public static String getOS() {
 		return "Android";
 	}


### PR DESCRIPTION
http://jira.appcelerator.org/browse/TIMOB-7009
Follow the instruction on https://wiki.appcelerator.org/display/tp/Analytics+Test+Plan to test ti.start event.
The expected value for 'os' is 'Android'.
