### PR TITLE
[TIMOB-1242] Support to draggable annotations (Drag & Drop)

### DIFF
--- a/iphone/Classes/TiMapAnnotationProxy.m
+++ b/iphone/Classes/TiMapAnnotationProxy.m
@@ -117,6 +117,13 @@
 	return result;
 }
 
+// Create a method to set the coordinate of annotation
+- (void) setCoordinate:(CLLocationCoordinate2D)coordinate
+{
+	[self setValue:[NSNumber numberWithDouble:coordinate.latitude] forUndefinedKey:@"latitude"];
+	[self setValue:[NSNumber numberWithDouble:coordinate.longitude] forUndefinedKey:@"longitude"];
+}
+
 // Title and subtitle for use by selection UI.
 - (NSString *)title
 {

--- a/iphone/Classes/TiMapView.h
+++ b/iphone/Classes/TiMapView.h
@@ -59,6 +59,13 @@
 -(void)refreshAnnotation:(TiMapAnnotationProxy*)proxy readd:(BOOL)yn;
 -(void)fireClickEvent:(MKAnnotationView *) pinview source:(NSString *)source;
 
+// iOS 4.0+ only
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_4_0
+
+- (void)firePinChangeDragState:(MKAnnotationView *) pinview newState:(MKAnnotationViewDragState)newState fromOldState:(MKAnnotationViewDragState)oldState;
+
+#endif
+
 @end
 
 #endif

--- a/iphone/Classes/TiMapView.m
+++ b/iphone/Classes/TiMapView.m
@@ -588,6 +588,80 @@
 	return nil;
 }
 
+// iOS 4.0+ only
+// Events to draggable annotation
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_4_0
+
+- (void)mapView:(MKMapView *)mapView annotationView:(MKAnnotationView *)annotationView didChangeDragState:(MKAnnotationViewDragState)newState fromOldState:(MKAnnotationViewDragState)oldState
+{
+	[self firePinChangeDragState:annotationView newState:newState fromOldState:oldState];
+}
+
+- (NSString*) annotationViewDragStateToString:(MKAnnotationViewDragState)state
+{
+	switch(state)
+	{
+		case MKAnnotationViewDragStateStarting:
+			return @"starting";
+		case MKAnnotationViewDragStateDragging:
+			return @"dragging";
+		case MKAnnotationViewDragStateCanceling:
+			return @"canceling";
+		case MKAnnotationViewDragStateEnding:
+			return @"ending";
+	}
+	return @"none";
+}
+
+#pragma mark Event generation
+
+- (void)firePinChangeDragState:(MKAnnotationView *) pinview newState:(MKAnnotationViewDragState)newState fromOldState:(MKAnnotationViewDragState)oldState 
+{
+	TiMapAnnotationProxy *viewProxy = [self proxyForAnnotation:pinview];
+	if (viewProxy == nil)
+	{
+		return;
+	}
+
+	TiProxy * ourProxy = [self proxy];
+	BOOL parentWants = [ourProxy _hasListeners:@"pinchangedragstate"];
+	BOOL viewWants = [viewProxy _hasListeners:@"pinchangedragstate"];
+	if(!parentWants && !viewWants)
+	{
+		return;
+	}
+
+	id title = [viewProxy title];
+	if (title == nil)
+	{
+		title = [NSNull null];
+	}
+
+	NSNumber * indexNumber = NUMINT([pinview tag]);
+	NSString * newStateValue = [self annotationViewDragStateToString:newState];
+	NSString * oldStateValue = [self annotationViewDragStateToString:oldState];
+
+	NSDictionary * event = [NSDictionary dictionaryWithObjectsAndKeys:
+							viewProxy,@"annotation",
+							ourProxy,@"map",
+							title,@"title",
+							indexNumber,@"index",
+							newStateValue,@"newState",
+							oldStateValue,@"oldState",
+							nil];
+
+	if (parentWants)
+	{
+		[ourProxy fireEvent:@"pinchangedragstate" withObject:event];
+	}
+	if (viewWants)
+	{
+		[viewProxy fireEvent:@"pinchangedragstate" withObject:event];
+	}
+}
+
+#endif
+
 - (void)mapView:(MKMapView *)mapView didSelectAnnotationView:(MKAnnotationView *)view{
 	if ([view conformsToProtocol:@protocol(TiMapAnnotation)])
 	{
@@ -673,6 +747,15 @@
 			pinview.animatesDrop = [ann animatesDrop] && ![(TiMapAnnotationProxy *)annotation placed];
 			annView.calloutOffset = CGPointMake(-5, 5);
 		}
+		
+		// Get the value draggable from the annotation
+		BOOL draggable = [TiUtils boolValue: [ann valueForUndefinedKey:@"draggable"]];
+		// check if MapKit supports pin dragging
+		if (draggable && [[MKAnnotationView class] instancesRespondToSelector:NSSelectorFromString(@"isDraggable")])
+		{
+			[annView performSelector:NSSelectorFromString(@"setDraggable:") withObject:[NSNumber numberWithBool:YES]];
+		}
+		
 		annView.canShowCallout = YES;
 		annView.enabled = YES;
 		UIView *left = [ann leftViewAccessory];


### PR DESCRIPTION
This commit, makes support to make draggable annotations.
When you create an annotation, you just have to set the _draggable_ property (boolean) and it will works.

It's supported just by iOS4+.

When you drag and drop the annotation, will fire an event called _pinchangedragstate_. This event will return the new state and the old state from the annotation.

The coordinates from the annotation is changed automatically.
