### PR TITLE
[TIMOB-6985] Protect elements of NodeList from garbage collection

### DIFF
--- a/iphone/Classes/TiDOMNodeListProxy.m
+++ b/iphone/Classes/TiDOMNodeListProxy.m
@@ -20,8 +20,17 @@
 
 -(void)setNodes:(NSArray*)nodes_
 {
+    if (nodes != nil) {
+        for (TiDOMNodeProxy *node in nodes) {
+            [self forgetProxy:node];
+        }
+    }
 	RELEASE_TO_NIL(nodes);
 	nodes = [nodes_ retain];
+    for (TiDOMNodeProxy *node in nodes) {
+        [[self pageContext] registerProxy:node];
+        [self rememberProxy:node];
+    }
 }
 
 -(id)item:(id)args

--- a/iphone/Classes/TiDOMNodeListProxy.m
+++ b/iphone/Classes/TiDOMNodeListProxy.m
@@ -14,15 +14,20 @@
 
 -(void)dealloc
 {
-	[self setNodes:nil];
+	[nodes release];
 	[super dealloc];
 }
 
 -(void)setNodes:(NSArray*)nodes_
 {
+    if (nodes == nodes_) {
+        return;
+    }
     if (nodes != nil) {
         for (TiDOMNodeProxy *node in nodes) {
-            [self forgetProxy:node];
+            if (![nodes_ containsObject:node]) {
+                [self forgetProxy:node];
+            }
         }
     }
 	RELEASE_TO_NIL(nodes);

--- a/iphone/Classes/TiDOMNodeListProxy.m
+++ b/iphone/Classes/TiDOMNodeListProxy.m
@@ -14,7 +14,7 @@
 
 -(void)dealloc
 {
-	RELEASE_TO_NIL(nodes);
+	[self setNodes:nil];
 	[super dealloc];
 }
 
@@ -26,6 +26,9 @@
         }
     }
 	RELEASE_TO_NIL(nodes);
+    if (nodes_ == nil) {
+        return;
+    }
 	nodes = [nodes_ retain];
     for (TiDOMNodeProxy *node in nodes) {
         [[self pageContext] registerProxy:node];

--- a/iphone/Classes/TiDOMNodeListProxy.m
+++ b/iphone/Classes/TiDOMNodeListProxy.m
@@ -23,17 +23,12 @@
     if (nodes == nodes_) {
         return;
     }
-    if (nodes != nil) {
-        for (TiDOMNodeProxy *node in nodes) {
-            if (![nodes_ containsObject:node]) {
-                [self forgetProxy:node];
-            }
+    for (TiDOMNodeProxy *node in nodes) {
+        if (![nodes_ containsObject:node]) {
+            [self forgetProxy:node];
         }
     }
-	RELEASE_TO_NIL(nodes);
-    if (nodes_ == nil) {
-        return;
-    }
+	[nodes release];
 	nodes = [nodes_ retain];
     for (TiDOMNodeProxy *node in nodes) {
         [[self pageContext] registerProxy:node];


### PR DESCRIPTION
[TIMOB-6985](http://jira.appcelerator.org/browse/TIMOB-6985) iOS: When Parsing large amounts of XML and referencing nodes, randomly a node will either be nulled, or change type

[Test Case](http://jira.appcelerator.org/browse/TIMOB-6985?focusedCommentId=179595#comment-179595)
