### PR TITLE
[TIMOB-7051] Prevent excessive sanitization of Ti.Ui.ImageView.image

### DIFF
--- a/iphone/Classes/KrollBridge.mm
+++ b/iphone/Classes/KrollBridge.mm
@@ -373,6 +373,8 @@ CFMutableSetRef	krollBridgeRegistry = nil;
 
 - (void)evalFileOnThread:(NSString*)path context:(KrollContext*)context_ 
 {
+    NSAutoreleasePool* pool = [[NSAutoreleasePool alloc] init];
+    
 	NSError *error = nil;
 	TiValueRef exception = NULL;
 	
@@ -460,6 +462,8 @@ CFMutableSetRef	krollBridgeRegistry = nil;
 	
 	TiStringRelease(jsCode);
 	TiStringRelease(jsURL);
+    
+    [pool release];
 }
 
 - (void)evalFile:(NSString*)path callback:(id)callback selector:(SEL)selector
@@ -540,6 +544,8 @@ CFMutableSetRef	krollBridgeRegistry = nil;
 -(void)didStartNewContext:(KrollContext*)kroll
 {
 	// create Titanium global object
+    NSAutoreleasePool* pool = [[NSAutoreleasePool alloc] init];
+    
 	NSString *basePath = (url==nil) ? [TiHost resourcePath] : [[[url path] stringByDeletingLastPathComponent] stringByAppendingPathComponent:@"."];
 	titanium = [[TitaniumObject alloc] initWithContext:kroll host:host context:self baseURL:[NSURL fileURLWithPath:basePath]];
 	
@@ -582,6 +588,8 @@ CFMutableSetRef	krollBridgeRegistry = nil;
 		NSURL *startURL = [host startURL];
 		[self evalFile:[startURL absoluteString] callback:self selector:@selector(booted)];
 	}
+    
+    [pool release];
 }
 
 -(void)willStopNewContext:(KrollContext*)kroll

--- a/iphone/Classes/TiProxy.h
+++ b/iphone/Classes/TiProxy.h
@@ -73,7 +73,6 @@ void DoProxyDelegateReadValuesWithKeysFromProxy(UIView<TiProxyDelegate> * target
 	pthread_rwlock_t listenerLock;
 	BOOL reproxying;
 @protected
-	BOOL	ignoreValueChanged;	//This is done only at initialization where we know the dynprops were properly set by _initWithProperties.
 	NSMutableDictionary *dynprops; 
 	pthread_rwlock_t dynpropsLock; // NOTE: You must respect the dynprops lock when accessing dynprops elsewhere!
 

--- a/iphone/Classes/TiUIImageViewProxy.m
+++ b/iphone/Classes/TiUIImageViewProxy.m
@@ -160,11 +160,12 @@ USE_VIEW_FOR_AUTO_HEIGHT
 
 -(void)setImage:(id)newImage
 {
-	if ([newImage isEqual:@""])
-	{
-		newImage = nil;
-	}
-	[self replaceValue:[self sanitizeURL:newImage] forKey:@"image" notification:YES];
+    id image = newImage;
+    if ([image isEqual:@""])
+    {
+        image = nil;
+    }
+    [self replaceValue:image forKey:@"image" notification:YES];
 }
 
 -(void)startImageLoad:(NSURL *)url;

--- a/iphone/Classes/TiUtils.m
+++ b/iphone/Classes/TiUtils.m
@@ -707,62 +707,7 @@ If the new path starts with / and the base url is app://..., we have to massage 
 
 +(NSURL*)toURL:(NSString *)object proxy:(TiProxy*)proxy
 {
-	return [self toURL:object relativeToURL:[proxy _baseURL]];
-//	NSURL *url = nil;
-//	
-//	if ([object isKindOfClass:[NSString class]])
-//	{
-//		if ([object hasPrefix:@"/"])
-//		{
-//			return [TiUtils checkFor2XImage:[NSURL fileURLWithPath:object]];
-//		}
-//		if ([object hasPrefix:@"sms:"] || 
-//			[object hasPrefix:@"tel:"] ||
-//			[object hasPrefix:@"mailto:"])
-//		{
-//			return [NSURL URLWithString:object];
-//		}
-//		
-//		// don't bother if we don't at least have a path and it's not remote
-//		///TODO: This looks ugly and klugy.
-//		NSString *urlString = [TiUtils stringValue:object];
-//		if ([urlString hasPrefix:@"http"])
-//		{
-//			NSRange range = [urlString rangeOfString:@"/" options:0 range:NSMakeRange(7, [urlString length]-7)];
-//			if (range.location!=NSNotFound)
-//			{
-//				NSString *firstPortion = [urlString substringToIndex:range.location];
-//				NSString *pathPortion = [urlString substringFromIndex:range.location];
-//				CFStringRef escapedPath = CFURLCreateStringByAddingPercentEscapes(kCFAllocatorDefault,
-//						(CFStringRef)pathPortion, charactersToNotEscape,charactersThatNeedEscaping,
-//						kCFStringEncodingUTF8);
-//				urlString = [firstPortion stringByAppendingString:(NSString *)escapedPath];
-//				if(escapedPath != NULL)
-//				{
-//					CFRelease(escapedPath);
-//				}
-//			}
-//		}
-//		
-//		url = [NSURL URLWithString:urlString relativeToURL:[proxy _baseURL]];
-//		
-//		if (url==nil)
-//		{
-//			//encoding problem - fail fast and make sure we re-escape
-//			NSRange range = [object rangeOfString:@"?"];
-//			if (range.location != NSNotFound)
-//			{
-//				NSString *qs = [TiUtils encodeURIParameters:[object substringFromIndex:range.location+1]];
-//				NSString *newurl = [NSString stringWithFormat:@"%@?%@",[object substringToIndex:range.location],qs];
-//				return [TiUtils checkFor2XImage:[NSURL URLWithString:newurl]];
-//			}
-//		}
-//	}
-//	else if ([object isKindOfClass:[NSURL class]])
-//	{
-//		return [TiUtils checkFor2XImage:[NSURL URLWithString:[(NSURL *)object absoluteString] relativeToURL:[proxy _baseURL]]];
-//	}
-//	return [TiUtils checkFor2XImage:url];			  
+	return [self toURL:object relativeToURL:[proxy _baseURL]];  
 }
 
 +(UIImage *)stretchableImage:(id)object proxy:(TiProxy*)proxy


### PR DESCRIPTION
This was apparently leading to memory leaks (not sure why - the autorelease pools are all correctly managed and we don't manually allocate anywhere during sanitization or the image setting process).

There are also some code cleanup fixes that resulted from debugging to isolate the problem.
