### PR TITLE
[TIMOB-7329] Ensure opening is properly set before queuing a close

### DIFF
--- a/iphone/Classes/TiWindowProxy.m
+++ b/iphone/Classes/TiWindowProxy.m
@@ -539,6 +539,7 @@ END_UI_THREAD_PROTECTED_VALUE(opened)
     
     if (opening) {
         TiThreadPerformOnMainThread(^{
+            opening = NO; // Preemptively clear 'opening' so we don't hit this block again
             [self close:args];
         }, YES);
         return;


### PR DESCRIPTION
Fixes a synchronization issue that could lead to infinite loops, based on scheduling.
