### PR TITLE
[TIMOB-7174]Terminate the ios-sim process in kill simulator

### DIFF
--- a/support/iphone/builder.py
+++ b/support/iphone/builder.py
@@ -72,6 +72,7 @@ def dequote(s):
 
 # force kill the simulator if running
 def kill_simulator():
+	run.run(['/usr/bin/killall',"ios-sim"],True)
 	run.run(['/usr/bin/killall',"iPhone Simulator"],True)
 
 def write_project_property(f,prop,val):

--- a/support/iphone/builder.py
+++ b/support/iphone/builder.py
@@ -1299,7 +1299,7 @@ def main(args):
 					def handler(signum, frame):
 						global script_ok
 						print "[INFO] Simulator is exiting"
-						sys.stdout.flush()
+						
 						if not log == None:
 							try:
 								os.system("kill -2 %s" % str(log.pid))


### PR DESCRIPTION
[TIMOB-7174](http://jira.appcelerator.org/browse/TIMOB-7174)
Test:
1. Run any app from TiStudio on iPhone Simulator
2. Quit the simulator
3. Run the following command in a terminal `ps -e | grep 'ios-sim' | wc -l`

Fail case: Will print 2 if ios-sim is not killed
Pass case: Will print 1 if ios-sim is killed.
