### PR TITLE
[TIMOB-7345][TIMOB-7354] Notify delegates of value change

### DIFF
--- a/iphone/Classes/TiProxy.m
+++ b/iphone/Classes/TiProxy.m
@@ -1000,26 +1000,32 @@ DEFINE_EXCEPTIONS
 		value = nil;
 	}
     
-	// notify our delegate
-	if (current!=value)
-	{
+    BOOL newValue = (current != value || ![current isEqual:value]);
+    
+    // We need to stage this out; the problem at hand is that some values
+    // we might store as properties (such as NSArray) use isEqual: as a
+    // strict address/hash comparison. So the notification must always
+    // occur, and it's up to the delegate to make sense of it (for now).
+    
+    if (newValue) {
         // Remember any proxies set on us so they don't get GC'd
         if ([propvalue isKindOfClass:[TiProxy class]]) {
             [self rememberProxy:propvalue];
         }
 		[dynprops setValue:propvalue forKey:key];
-		pthread_rwlock_unlock(&dynpropsLock);
-		if (self.modelDelegate!=nil && notify)
-		{
-			[[(NSObject*)self.modelDelegate retain] autorelease];
-			[self.modelDelegate propertyChanged:key oldValue:current newValue:value proxy:self];
-		}
-        if ([current isKindOfClass:[TiProxy class]]) {
-            [self forgetProxy:current];
-        }
-		return; // so we don't unlock twice
-	}
+    }
 	pthread_rwlock_unlock(&dynpropsLock);
+    
+    if (self.modelDelegate!=nil && notify)
+    {
+        [[(NSObject*)self.modelDelegate retain] autorelease];
+        [self.modelDelegate propertyChanged:key oldValue:current newValue:value proxy:self];
+    }
+    
+    // Forget any old proxies so that they get cleaned up
+    if (newValue && [current isKindOfClass:[TiProxy class]]) {
+        [self forgetProxy:current];
+    }
 }
 
 // TODO: Shouldn't we be forgetting proxies and unprotecting callbacks and such here?

--- a/iphone/Classes/TiProxy.m
+++ b/iphone/Classes/TiProxy.m
@@ -1000,7 +1000,7 @@ DEFINE_EXCEPTIONS
 		value = nil;
 	}
     
-    BOOL newValue = (current != value || ![current isEqual:value]);
+    BOOL newValue = (current != value && ![current isEqual:value]);
     
     // We need to stage this out; the problem at hand is that some values
     // we might store as properties (such as NSArray) use isEqual: as a


### PR DESCRIPTION
There was an important difference between the old KVC setter and value change notification I didn't initially catch; that the delegate was always notified when the value changed if the value change notification was `YES`. This fixes that issue.

All bugs mentioned for this PR must be functional tested.
