### PR TITLE
Timob 2578 - Fire 'request' event in WebView before requesting new page

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiWebViewClient.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiWebViewClient.java
@@ -70,6 +70,11 @@ public class TiWebViewClient extends WebViewClient
 
 	@Override
 	public boolean shouldOverrideUrlLoading(final WebView view, String url) {
+		//Fire a request event on the WebView
+		KrollDict data = new KrollDict();
+		data.put("url", url);
+		webView.getProxy().fireEvent("request", data);
+		
 		if (DBG) {
 			Log.d(LCAT, "url=" + url);
 		}

--- a/iphone/Classes/TiUIWebView.m
+++ b/iphone/Classes/TiUIWebView.m
@@ -640,6 +640,13 @@ static NSString * const kTitaniumJavascript = @"Ti.App={};Ti.API={};Ti.App._list
 {
 	NSURL * newUrl = [request URL];
 	NSString * scheme = [[newUrl scheme] lowercaseString];
+	
+	if ([self.proxy _hasListeners:@"request"])
+	{
+		NSDictionary *event = [NSDictionary dictionaryWithObject:[newUrl absoluteString] forKey:@"url"];
+		[self.proxy fireEvent:@"request" withObject:event];
+	}
+	
 	if ([scheme hasPrefix:@"http"] || [scheme hasPrefix:@"app"] || [scheme hasPrefix:@"file"] || [scheme hasPrefix:@"ftp"])
 	{
 		NSLog(@"New scheme: %@",request);


### PR DESCRIPTION
I've added an event within existing methods in the Android and iPhone SDKs to fire a 'request' event when a new page is requested. 

To test:
var win = Ti.UI.currentWindow;
var webView = Ti.UI.createWebView();
win.add(webView);
webView.addEventListener('request', function (e){
  alert('request: '+e.url);
});
webView.url = 'http://www.google.com';

After the page loads, click any link to see an alert fired before the request, which will tell the requested URL.
