### PR TITLE
[TIMOB-7362] Store 'nil' as an NSNull object in the props dict

### DIFF
--- a/iphone/Classes/TiProxy.m
+++ b/iphone/Classes/TiProxy.m
@@ -989,18 +989,12 @@ DEFINE_EXCEPTIONS
 		dynprops = [[NSMutableDictionary alloc] init];
 	}
     
-	id propvalue = value;
-	
-	if (value == nil)
-	{
-		propvalue = [NSNull null];
-	}
-	else if (value == [NSNull null])
-	{
-		value = nil;
-	}
+    // TODO: Clarify internal difference between nil/NSNull
+    // (which represent different JS values, but possibly consistent internal behavior)
     
-    BOOL newValue = (current != value && ![current isEqual:value]);
+    id propvalue = (value == nil) ? [NSNull null] : value;
+    
+    BOOL newValue = (current != propvalue && ![current isEqual:propvalue]);
     
     // We need to stage this out; the problem at hand is that some values
     // we might store as properties (such as NSArray) use isEqual: as a
@@ -1019,7 +1013,10 @@ DEFINE_EXCEPTIONS
     if (self.modelDelegate!=nil && notify)
     {
         [[(NSObject*)self.modelDelegate retain] autorelease];
-        [self.modelDelegate propertyChanged:key oldValue:current newValue:value proxy:self];
+        [self.modelDelegate propertyChanged:key 
+                                   oldValue:current 
+                                   newValue:propvalue
+                                      proxy:self];
     }
     
     // Forget any old proxies so that they get cleaned up


### PR DESCRIPTION
This appears to be "classic" behavior and is something we need to be aware of; many properties require the ability to distinguish between "no property ever set" (technically undefined/nil) and "null stored" (null/NSNull).
