### PR TITLE
[TIMOB-7417] add Titanium.UI.ImageView.resume method to iOS

### DIFF
--- a/demos/KitchenSink/Resources/examples/image_view_animated.js
+++ b/demos/KitchenSink/Resources/examples/image_view_animated.js
@@ -94,7 +94,7 @@ var reverse = Titanium.UI.createButton({
 	height:30,
 	width:120,
 	font:{fontSize:13, fontFamily:'Helvetica Neue'},
-	top:90,
+	top:130,
 	left:10
 });
 reverse.addEventListener('click', function()
@@ -128,7 +128,7 @@ var pause = Titanium.UI.createButton({
 	width:120,
 	font:{fontSize:13, fontFamily:'Helvetica Neue'},
 	top:90,
-	right:10
+	left:10
 });
 pause.addEventListener('click', function()
 {
@@ -138,6 +138,24 @@ pause.addEventListener('click', function()
 	}
 });
 win.add(pause);
+
+// resume animation
+var resume = Titanium.UI.createButton({
+	title:'Resume Animation',
+	height:30,
+	width:120,
+	font:{fontSize:13, fontFamily:'Helvetica Neue'},
+	top:90,
+	right:10
+});
+resume.addEventListener('click', function()
+{
+	if (imageView.paused)
+	{
+		imageView.resume();
+	}
+});
+win.add(resume);
 
 // increase duration
 var durationUp = Titanium.UI.createButton({

--- a/iphone/Classes/TiUIImageView.h
+++ b/iphone/Classes/TiUIImageView.h
@@ -29,7 +29,6 @@
 	BOOL ready;
 	BOOL stopped;
 	BOOL reverse;
-	BOOL paused;
 	BOOL placeholderLoading;
 	TiDimension width;
 	TiDimension height;
@@ -44,6 +43,7 @@
 -(void)start;
 -(void)stop;
 -(void)pause;
+-(void)resume;
 
 -(void)setImage_:(id)arg;
 

--- a/iphone/Classes/TiUIImageView.m
+++ b/iphone/Classes/TiUIImageView.m
@@ -100,9 +100,7 @@ DEFINE_EXCEPTIONS
 
 -(void)timerFired:(id)arg
 {
-	// if paused, just ignore this timer loop until restared/stoped
-	if (paused||stopped)
-	{
+	if (stopped) {
 		return;
 	}
 	
@@ -181,7 +179,7 @@ DEFINE_EXCEPTIONS
 	[[OperationQueue sharedQueue] queue:@selector(loadImageInBackground:) target:self arg:[NSNumber numberWithInt:index_] after:nil on:nil ui:NO];
 }
 
--(void)startTimer
+-(void)startTimerWithEvent:(NSString *)eventName
 {
 	RELEASE_TO_NIL(timer);
 	if (stopped)
@@ -189,9 +187,23 @@ DEFINE_EXCEPTIONS
 		return;
 	}
 	timer = [[NSTimer scheduledTimerWithTimeInterval:interval target:self selector:@selector(timerFired:) userInfo:nil repeats:YES] retain]; 
-	if ([self.proxy _hasListeners:@"start"])
+	if ([self.proxy _hasListeners:eventName])
 	{
-		[self.proxy fireEvent:@"start" withObject:nil];
+		[self.proxy fireEvent:eventName withObject:nil];
+	}
+}
+
+-(void)stopTimerWithEvent:(NSString *)eventName
+{
+    if (!stopped) {
+        return;
+    }
+	if (timer != nil) {
+		[timer invalidate];
+		RELEASE_TO_NIL(timer);
+		if ([self.proxy _hasListeners:eventName]) {
+			[self.proxy fireEvent:eventName withObject:nil];
+		}
 	}
 }
 
@@ -282,7 +294,7 @@ DEFINE_EXCEPTIONS
 			readyCount = 0;
 			ready = NO;
 			
-			[self startTimer];
+			[self startTimerWithEvent:@"start"];
 		}
 	}
 }
@@ -553,16 +565,7 @@ DEFINE_EXCEPTIONS
 -(void)stop
 {
 	stopped = YES;
-	if (timer!=nil)
-	{
-		[timer invalidate];
-		RELEASE_TO_NIL(timer);
-		if ([self.proxy _hasListeners:@"stop"])
-		{
-			[self.proxy fireEvent:@"stop" withObject:nil];
-		}
-	}
-	paused = NO;
+    [self stopTimerWithEvent:@"stop"];
 	ready = NO;
 	index = -1;
 	[self.proxy replaceValue:NUMBOOL(NO) forKey:@"animating" notification:NO];
@@ -581,7 +584,6 @@ DEFINE_EXCEPTIONS
 		interval = (1.0/30.0)*(30.0/loadTotal);
 	}
 	
-	paused = NO;
 	[self.proxy replaceValue:NUMBOOL(NO) forKey:@"paused" notification:NO];
 	
 	if (iterations<0)
@@ -612,20 +614,25 @@ DEFINE_EXCEPTIONS
 		{
 			readyCount = 0;
 			ready = NO;
-			[self startTimer];
+			[self startTimerWithEvent:@"start"];
 		}
 	}
 }
 
 -(void)pause
 {
-	paused = YES;
+	stopped = YES;
 	[self.proxy replaceValue:NUMBOOL(YES) forKey:@"paused" notification:NO];
 	[self.proxy replaceValue:NUMBOOL(NO) forKey:@"animating" notification:NO];
-	if ([self.proxy _hasListeners:@"pause"])
-	{
-		[self.proxy fireEvent:@"pause" withObject:nil];
-	}
+    [self stopTimerWithEvent:@"pause"];
+}
+
+-(void)resume
+{
+	stopped = NO;
+	[self.proxy replaceValue:NUMBOOL(NO) forKey:@"paused" notification:NO];
+	[self.proxy replaceValue:NUMBOOL(YES) forKey:@"animating" notification:NO];
+    [self startTimerWithEvent:@"resume"];
 }
 
 -(void)setWidth_:(id)width_

--- a/iphone/Classes/TiUIImageView.m
+++ b/iphone/Classes/TiUIImageView.m
@@ -20,6 +20,11 @@
 
 #define IMAGEVIEW_DEBUG 0
 
+@interface TiUIImageView()
+-(void)startTimerWithEvent:(NSString *)eventName;
+-(void)stopTimerWithEvent:(NSString *)eventName;
+@end
+
 @implementation TiUIImageView
 
 #pragma mark Internal
@@ -150,14 +155,9 @@ DEFINE_EXCEPTIONS
 	if (repeatCount > 0 && ((reverse==NO && nextIndex == loadTotal) || (reverse && nextIndex==0)))
 	{
 		iterations++;
-		if (iterations == repeatCount)
-		{
-			[timer invalidate];
-			RELEASE_TO_NIL(timer);
-			if ([self.proxy _hasListeners:@"stop"])
-			{
-				[self.proxy fireEvent:@"stop" withObject:nil];
-			}
+		if (iterations == repeatCount) {
+            stopped = YES;
+            [self stopTimerWithEvent:@"stop"];
 		}
 	}
 }

--- a/iphone/Classes/TiUIImageViewProxy.m
+++ b/iphone/Classes/TiUIImageViewProxy.m
@@ -56,9 +56,10 @@ static NSArray* imageKeySequence;
 
 -(void)start:(id)args
 {
-	ENSURE_UI_THREAD(start,args);
-	TiUIImageView *iv= (TiUIImageView*)[self view];
-	[iv start];
+    TiThreadPerformOnMainThread(^{
+        TiUIImageView *iv = (TiUIImageView*)[self view];
+        [iv start];
+    }, NO);
 }
 
 -(void)stop:(id)args
@@ -78,16 +79,18 @@ static NSArray* imageKeySequence;
 
 -(void)pause:(id)args
 {
-	ENSURE_UI_THREAD(pause,args);
-	TiUIImageView *iv= (TiUIImageView*)[self view];
-	[iv pause];
+    TiThreadPerformOnMainThread(^{
+        TiUIImageView *iv = (TiUIImageView*)[self view];
+        [iv pause];
+    }, NO);
 }
 
 -(void)resume:(id)args
 {
-	ENSURE_UI_THREAD(resume,args);
-	TiUIImageView *iv= (TiUIImageView*)[self view];
-	[iv resume];
+    TiThreadPerformOnMainThread(^{
+        TiUIImageView *iv = (TiUIImageView*)[self view];
+        [iv resume];
+    }, NO);
 }
 
 -(void)viewWillDetach

--- a/iphone/Classes/TiUIImageViewProxy.m
+++ b/iphone/Classes/TiUIImageViewProxy.m
@@ -83,6 +83,13 @@ static NSArray* imageKeySequence;
 	[iv pause];
 }
 
+-(void)resume:(id)args
+{
+	ENSURE_UI_THREAD(resume,args);
+	TiUIImageView *iv= (TiUIImageView*)[self view];
+	[iv resume];
+}
+
 -(void)viewWillDetach
 {
 	[self stop:nil];


### PR DESCRIPTION
[TIMOB-7417](http://jira.appcelerator.org/browse/TIMOB-7417)
Parity change for https://github.com/appcelerator/titanium_mobile/pull/1223

Test steps:
In KitchenSink, open BaseUI/Views/Image Views/Animated.
Verify that Resume animation continues from paused state.
