### PR TITLE
[TIMOB-7397] Streamline hide/show of search file on tableview.

### DIFF
--- a/apidoc/Titanium/UI/TableView.yml
+++ b/apidoc/Titanium/UI/TableView.yml
@@ -388,6 +388,18 @@ properties:
   - name: footerTitle
     summary: Table view footer title.
     type: String
+  - name: hideOnSearch
+    summary: Boolean to indicate whether or not the search field should hide on completion.
+    description: |
+        Once a row is clicked in a search result, if this value is `true`,
+        the search bar is hidden (if appropriate).
+        
+        Many standard applications (such as Contacts) have a behavior
+        equivalent to `false` for this value, but the default is `true`
+        for legacy reasons.
+    type: Boolean
+    default: true
+    platforms: [iphone, ipad]
   - name: footerView
     summary: Table view footer as a view that will be rendered instead of a label.
     type: Titanium.UI.View

--- a/apidoc/Titanium/UI/TableView.yml
+++ b/apidoc/Titanium/UI/TableView.yml
@@ -397,6 +397,8 @@ properties:
         Many standard applications (such as Contacts) have a behavior
         equivalent to `false` for this value, but the default is `true`
         for legacy reasons.
+        
+        The Android platform behaves as though this value were `false`.
     type: Boolean
     default: true
     platforms: [iphone, ipad]

--- a/apidoc/Titanium/UI/TableView.yml
+++ b/apidoc/Titanium/UI/TableView.yml
@@ -388,7 +388,7 @@ properties:
   - name: footerTitle
     summary: Table view footer title.
     type: String
-  - name: hideOnSearch
+  - name: hideSearchOnSelection
     summary: Boolean to indicate whether or not the search field should hide on completion.
     description: |
         Once a row is clicked in a search result, if this value is `true`,

--- a/iphone/Classes/TiProxy.h
+++ b/iphone/Classes/TiProxy.h
@@ -147,6 +147,7 @@ void DoProxyDelegateReadValuesWithKeysFromProxy(UIView<TiProxyDelegate> * target
 -(void)fireEvent:(NSString*)type withObject:(id)obj propagate:(BOOL)yn;
 
 -(NSDictionary*)allProperties;
+-(void)initializeProperty:(NSString*)name defaultValue:(id)value;
 -(void)replaceValue:(id)value forKey:(NSString*)key notification:(BOOL)notify;
 -(void)deleteKey:(NSString*)key;
 

--- a/iphone/Classes/TiProxy.m
+++ b/iphone/Classes/TiProxy.m
@@ -214,6 +214,15 @@ void DoProxyDelegateReadValuesWithKeysFromProxy(UIView<TiProxyDelegate> * target
 	return self;
 }
 
+-(void)initializeProperty:(NSString*)name defaultValue:(id)value
+{
+    pthread_rwlock_wrlock(&dynpropsLock);
+    if ([dynprops valueForKey:name] == nil) {
+        [dynprops setValue:((value == nil) ? [NSNull null] : value) forKey:name];
+    }
+    pthread_rwlock_unlock(&dynpropsLock);
+}
+
 +(BOOL)shouldRegisterOnInit
 {
 	return YES;

--- a/iphone/Classes/TiUITableView.h
+++ b/iphone/Classes/TiUITableView.h
@@ -67,7 +67,6 @@
 	id	lastFocusedView; //DOES NOT RETAIN.	
 	UITableViewController *tableController;
 	UISearchDisplayController *searchController;
-	BOOL searchHiddenSet;
 	NSInteger frameChanges;
 }
 

--- a/iphone/Classes/TiUITableView.h
+++ b/iphone/Classes/TiUITableView.h
@@ -46,7 +46,6 @@
 	BOOL editing;
 	BOOL searchHidden;
     BOOL animateHide;
-    BOOL isHiding;
 	BOOL editable;
 	BOOL moveable;
 	BOOL initiallyDisplayed;

--- a/iphone/Classes/TiUITableView.h
+++ b/iphone/Classes/TiUITableView.h
@@ -45,6 +45,8 @@
 	BOOL moving;
 	BOOL editing;
 	BOOL searchHidden;
+    BOOL animateHide;
+    BOOL isHiding;
 	BOOL editable;
 	BOOL moveable;
 	BOOL initiallyDisplayed;

--- a/iphone/Classes/TiUITableView.h
+++ b/iphone/Classes/TiUITableView.h
@@ -45,6 +45,7 @@
 	BOOL moving;
 	BOOL editing;
 	BOOL searchHidden;
+    BOOL hideOnSearch; // For backcompat, default 'true'
     BOOL animateHide;
 	BOOL editable;
 	BOOL moveable;

--- a/iphone/Classes/TiUITableView.m
+++ b/iphone/Classes/TiUITableView.m
@@ -248,6 +248,14 @@
 	return self;
 }
 
+-(void)configurationSet
+{
+    [super configurationSet];
+    
+    [[self proxy] initializeProperty:@"searchHidden" defaultValue:NUMBOOL(NO)];
+    [[self proxy] initializeProperty:@"hideOnSearch" defaultValue:NUMBOOL(YES)];
+}
+
 -(void)dealloc
 {
 	if (searchField!=nil)
@@ -1093,7 +1101,20 @@
         if (([visibleRows count] == 0) ||
             ([tableview contentOffset].y < offset.y && [visibleRows containsObject:[NSIndexPath indexPathForRow:0 inSection:0]]))
         {
-            [tableview setContentOffset:offset animated:animateHide];
+            void (^hide)(void) = ^{
+                [tableview setContentOffset:offset animated:NO];
+            };
+            
+            // 0.2s was the default for UIView animation blocks pre-iOS 4, which is what was used here.
+            // Note that we have to invoke the animation subsystem directly rather than implicitly to avoid
+            // some undesirable redraw or multiple scroll behavior.
+            
+            if (animateHide) {
+                [UIView animateWithDuration:0.2 animations:hide];
+            }
+            else {
+                hide();
+            }
         }
     }
     // Reset the animation hide flag to its default value

--- a/iphone/Classes/TiUITableView.m
+++ b/iphone/Classes/TiUITableView.m
@@ -1396,7 +1396,7 @@
 	}
 }
 
--(void)setHideOnSearch_:(id)yn
+-(void)setHideSearchOnSelection_:(id)yn
 {
     hideOnSearch = [TiUtils boolValue:yn def:YES];
 }

--- a/iphone/Classes/TiUITableView.m
+++ b/iphone/Classes/TiUITableView.m
@@ -253,7 +253,7 @@
     [super configurationSet];
     
     [[self proxy] initializeProperty:@"searchHidden" defaultValue:NUMBOOL(NO)];
-    [[self proxy] initializeProperty:@"hideOnSearch" defaultValue:NUMBOOL(YES)];
+    [[self proxy] initializeProperty:@"hideSearchOnSelection" defaultValue:NUMBOOL(YES)];
 }
 
 -(void)dealloc

--- a/iphone/Classes/TiUITableView.m
+++ b/iphone/Classes/TiUITableView.m
@@ -735,7 +735,7 @@
 		//On data reload if the search screen is inactive,
 		//make sure that the searchHidden flag is honored
 		if (![searchController isActive] && searchHidden) {
-			[self hideSearchScreen:self];
+			[self hideSearchScreen:nil];
 		}
 	}
 }
@@ -845,15 +845,15 @@
 
 	CGPoint globalPoint = [thisCell convertPoint:point toView:nil];
 	[eventObject setObject:[TiUtils pointToDictionary:globalPoint] forKey:@"globalPoint"];
-
-	if ([target _hasListeners:name])
-	{
-		[target fireEvent:name withObject:eventObject];
-	}	
 	
 	if (viaSearch) {
 		[self hideSearchScreen:nil];
 	}
+    
+    if ([target _hasListeners:name])
+	{
+		[target fireEvent:name withObject:eventObject];
+	}	
 }
 
 #pragma mark Overloaded view handling
@@ -974,7 +974,7 @@
 	{
 		if (searchField!=nil && searchHiddenSet)
 		{
-			[self performSelector:@selector(hideSearchScreen:) withObject:self];
+			[self performSelector:@selector(hideSearchScreen:) withObject:nil];
 		}
 	}
 	else 
@@ -1060,27 +1060,20 @@
 		[self performSelector:@selector(hideSearchScreen:) withObject:sender afterDelay:0.1];
 		return;
 	}
+    
     if ([[searchField view] isFirstResponder]) {
         [[searchField view] resignFirstResponder];
         [self makeRootViewFirstResponder];
     }
+    
+    //searchHidden = YES;
 	[self.proxy replaceValue:NUMBOOL(YES) forKey:@"searchHidden" notification:NO];
-	[searchController setActive:NO animated:YES];
-	
-	[tableview reloadRowsAtIndexPaths:[tableview indexPathsForVisibleRows] withRowAnimation:UITableViewRowAnimationNone];
+	[searchController setActive:NO animated:[searchController isActive]];
 
-	if (sender==nil)
-	{
-		[UIView beginAnimations:@"searchy" context:nil];
-	}
-	if (searchHidden)
-	{
-		[tableview setContentOffset:CGPointMake(0,MAX(TI_NAVBAR_HEIGHT,searchField.view.frame.size.height)) animated:NO];
-	}
-	if (sender==nil)
-	{
-		[UIView commitAnimations];
-	}
+    if (searchHidden) {
+        [tableview setContentOffset:CGPointMake(0,MAX(TI_NAVBAR_HEIGHT,searchField.view.frame.size.height)) animated:YES];
+    }
+	[tableview reloadRowsAtIndexPaths:[tableview indexPathsForVisibleRows] withRowAnimation:UITableViewRowAnimationNone];
 }
 
 -(void)scrollToTop:(NSInteger)top animated:(BOOL)animated

--- a/iphone/Classes/TiUITableView.m
+++ b/iphone/Classes/TiUITableView.m
@@ -1083,7 +1083,17 @@
         [self makeRootViewFirstResponder];
     }
     
-	[searchController setActive:NO animated:[searchController isActive]];
+    // This logic here is contingent on search controller deactivation 
+    // (-[TiUITableView searchDisplayControllerDidEndSearch:]) triggering a hide;
+    // doing this ensures that:
+    // 
+    // * The hide when the search controller was active is animated
+    // * The animation only occurs once
+    
+    if ([searchController isActive]) {
+        [searchController setActive:NO animated:YES];
+        return;
+    }
 
     // NOTE: Because of how tableview row reloads are scheduled, we always need to do this
     // because of where the hide might be triggered from.
@@ -1092,9 +1102,8 @@
     [tableview reloadRowsAtIndexPaths:visibleRows withRowAnimation:UITableViewRowAnimationNone];
     
     // We only want to scroll if the following conditions are met:
-    // 1. The search bar is not already hidden
-    // 2. The top row of the first section (and hence searchbar) are visible (or there are no rows)
-    // 3. The current offset is smaller than the new offset (otherwise the search is already hidden)
+    // 1. The top row of the first section (and hence searchbar) are visible (or there are no rows)
+    // 2. The current offset is smaller than the new offset (otherwise the search is already hidden)
     
     if (searchHidden) {
         CGPoint offset = CGPointMake(0,MAX(TI_NAVBAR_HEIGHT, searchField.view.frame.size.height));
@@ -2118,7 +2127,7 @@ if(ourTableView != tableview)	\
 - (void) searchDisplayControllerDidEndSearch:(UISearchDisplayController *)controller
 {
     animateHide = YES;
-	[self hideSearchScreen:nil];
+    [self hideSearchScreen:nil];
 }
 
 @end

--- a/iphone/Classes/TiUITableView.m
+++ b/iphone/Classes/TiUITableView.m
@@ -241,7 +241,6 @@
 {
 	if (self = [super init])
 	{
-        animateHide = YES;
 		filterCaseInsensitive = YES; // defaults to true on search
 		searchString = @"";
 	}
@@ -735,7 +734,6 @@
 		}
 	}
     else if (searchHidden) {
-        animateHide = NO;
         [self hideSearchScreen:nil];
     }
 }
@@ -847,6 +845,7 @@
 	[eventObject setObject:[TiUtils pointToDictionary:globalPoint] forKey:@"globalPoint"];
 	
 	if (viaSearch) {
+        animateHide = YES;
 		[self hideSearchScreen:nil];
 	}
     
@@ -972,9 +971,8 @@
 {
 	if (searchHidden)
 	{
-		if (searchField!=nil && searchHiddenSet)
+		if (searchField!=nil)
 		{
-            animateHide = NO;
 			[self performSelector:@selector(hideSearchScreen:) withObject:nil];
 		}
 	}
@@ -1067,7 +1065,6 @@
         [self makeRootViewFirstResponder];
     }
     
-	[self.proxy replaceValue:NUMBOOL(YES) forKey:@"searchHidden" notification:NO];
 	[searchController setActive:NO animated:[searchController isActive]];
 
     if (searchHidden) {
@@ -1179,6 +1176,7 @@
 {
 	// called when cancel button pressed
 	[searchBar setText:nil];
+    animateHide = YES;
 	[self hideSearchScreen:nil];
 }
 
@@ -1317,23 +1315,17 @@
 		
 		[self updateSearchView];
 
-		if (searchHiddenSet==NO)
-		{
-			return;
-		}
-		
 		if (searchHidden)
 		{
+            // This seems like inconsistent behavior, as much of our 'search hide' logic works out to
+            
+            animateHide = YES;
 			[self hideSearchScreen:nil];
 			return;
 		}
-		searchHidden = NO;
-		[self.proxy replaceValue:NUMBOOL(NO) forKey:@"searchHidden" notification:NO];
 	}
 	else 
 	{
-		searchHidden = YES;
-		[self.proxy replaceValue:NUMBOOL(NO) forKey:@"searchHidden" notification:NO];
 		[self updateSearchView];
 	}
 }
@@ -1343,28 +1335,14 @@
 	[[self tableView] setShowsVerticalScrollIndicator:[TiUtils boolValue:value]];
 }
 
--(void)configurationSet
-{
-	[super configurationSet];
-	
-	if ([self.proxy valueForUndefinedKey:@"searchHidden"]==nil && 
-		[self.proxy valueForUndefinedKey:@"search"]==nil)
-	{
-		searchHidden = YES;
-		[self.proxy replaceValue:NUMBOOL(YES) forKey:@"searchHidden" notification:NO];
-	}
-}
-
 -(void)setSearchHidden_:(id)hide
 {
-	searchHiddenSet = YES;
-    [self.proxy replaceValue:hide forKey:@"searchHidden" notification:NO];
-	
 	if ([TiUtils boolValue:hide])
 	{
 		searchHidden=YES;
 		if (searchField)
 		{
+            animateHide = YES;
 			[self hideSearchScreen:nil];
 		}
 	}
@@ -2103,6 +2081,7 @@ if(ourTableView != tableview)	\
 
 - (void) searchDisplayControllerDidEndSearch:(UISearchDisplayController *)controller
 {
+    animateHide = YES;
 	[self hideSearchScreen:nil];
 }
 

--- a/iphone/Classes/TiUITableView.m
+++ b/iphone/Classes/TiUITableView.m
@@ -1096,8 +1096,6 @@
             [tableview setContentOffset:offset animated:animateHide];
         }
     }
-    NSLog(@"Hide offset: %f", [tableview contentOffset].y);
-
     // Reset the animation hide flag to its default value
     animateHide = NO;
 }
@@ -2041,7 +2039,6 @@ if(ourTableView != tableview)	\
 
 - (void)scrollViewDidScroll:(UIScrollView *)scrollView
 {	
-    NSLog(@"Scroll offset: %f", [scrollView contentOffset].y);
 	if (scrollView.isDragging || scrollView.isDecelerating) 
 	{
 		if ([self.proxy _hasListeners:@"scroll"])

--- a/iphone/Classes/TiUITableViewProxy.m
+++ b/iphone/Classes/TiUITableViewProxy.m
@@ -275,15 +275,6 @@ NSArray * tableKeySequence;
 
 #pragma mark Public APIs
 
--(void)setSearchHidden:(id)args
-{
-	// we implement here to force it regardless of the current state 
-	// since the user can manually change the search field by pulling 
-	// down the row
-	ENSURE_SINGLE_ARG(args,NSObject);
-	[self replaceValue:args forKey:@"searchHidden" notification:YES];
-}
-
 -(void)selectRow:(id)args
 {
 	[[self view] performSelectorOnMainThread:@selector(selectRow:) withObject:args waitUntilDone:NO];


### PR DESCRIPTION
Cleanup of some search/hide code. The most significant change is that search hide is guaranteed to occur before any click event callback is triggered, which could avoid certain animation hiccups.

Testing instructions on JIRA. I was unable to ever reliably duplicate the bug but this fix should avoid synchronization issues like those described.
