### PR TITLE
[TIMOB-6763] Don't add nil object to NSMutableDictionary

### DIFF
--- a/iphone/Classes/TiMediaAudioSession.m
+++ b/iphone/Classes/TiMediaAudioSession.m
@@ -94,13 +94,7 @@ void TiAudioSessionAudioRouteChangeCallback(void *inUserData, AudioSessionProper
 		}
 	}
     id oldRouteObject = [dict objectForKey:@"OutputDeviceDidChange_OldRoute"];
-    if (oldRouteObject == nil) {
-        [event setObject:[NSNull null] forKey:@"oldRoute"];
-    }
-    else {
-        [event setObject:oldRouteObject forKey:@"oldRoute"];
-    }
-	
+    [event setObject:((oldRouteObject == nil) ? [NSNull null] : oldRouteObject) forKey:@"oldRoute"];
 	[event setObject:reason forKey:@"reason"];
 	WARN_IF_BACKGROUND_THREAD;	//NSNotificationCenter is not threadsafe!
 	[[NSNotificationCenter defaultCenter] postNotificationName:kTiMediaAudioSessionRouteChange object:session userInfo:event];

--- a/iphone/Classes/TiMediaAudioSession.m
+++ b/iphone/Classes/TiMediaAudioSession.m
@@ -93,7 +93,14 @@ void TiAudioSessionAudioRouteChangeCallback(void *inUserData, AudioSessionProper
 			break;
 		}
 	}
-	[event setObject:[dict objectForKey:@"OutputDeviceDidChange_OldRoute"] forKey:@"oldRoute"];
+    id oldRouteObject = [dict objectForKey:@"OutputDeviceDidChange_OldRoute"];
+    if (oldRouteObject == nil) {
+        [event setObject:[NSNull null] forKey:@"oldRoute"];
+    }
+    else {
+        [event setObject:oldRouteObject forKey:@"oldRoute"];
+    }
+	
 	[event setObject:reason forKey:@"reason"];
 	WARN_IF_BACKGROUND_THREAD;	//NSNotificationCenter is not threadsafe!
 	[[NSNotificationCenter defaultCenter] postNotificationName:kTiMediaAudioSessionRouteChange object:session userInfo:event];


### PR DESCRIPTION
[TIMOB-6763](http://jira.appcelerator.org/browse/TIMOB-6763)
Based on the crash logs (12th Jan_Tobias_Crash_Open).
Line 211 of the log:
Jan 12 22:44:07 unknown grouptime[107] <Error>: **\* Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[__NSCFDictionary setObject:forKey:]: attempt to insert nil value (key: oldRoute)'
