### PR TITLE
[TIMOB-7255] ensure underlying text widget is always created 

### DIFF
--- a/demos/KitchenSink/Resources/examples/textfield_borders.js
+++ b/demos/KitchenSink/Resources/examples/textfield_borders.js
@@ -51,11 +51,18 @@ var tf4 = Titanium.UI.createTextField({
 	borderStyle:Titanium.UI.INPUT_BORDERSTYLE_NONE
 });
 
-
 var tf5 = Titanium.UI.createTextField({
+	height:35,
+	top:190,
+	left:10,
+	right:60
+});
+
+
+var tf6 = Titanium.UI.createTextField({
 	hintText:'custom background image',
 	height:32,
-	top:190,
+	top:235,
 	backgroundImage:'../images/inputfield.png',
 	paddingLeft:10,
 	left:10,
@@ -72,6 +79,7 @@ if (Titanium.Platform.name == 'iPhone OS')
 	scrolly.add(tf2);
 	scrolly.add(tf3);
 	scrolly.add(tf4);
+	scrolly.add(tf5);
 }
 
-scrolly.add(tf5);
+scrolly.add(tf6);

--- a/iphone/Classes/TiUITextWidget.m
+++ b/iphone/Classes/TiUITextWidget.m
@@ -20,6 +20,7 @@
 	if (self != nil)
 	{
 		suppressReturn = YES;
+        [self textWidgetView];
 	}
 	return self;
 }


### PR DESCRIPTION
[[TIMOB-7255] iOS: TextField - Field not displaying when font and borderStyle and hintText not set](http://jira.appcelerator.org/browse/TIMOB-7255)

Test case:
open KS, Controls, Text Field, Border Style.
Ensure that the text field between "no border" and "custom background image" could receive focus.
