### PR TITLE
[TIMOB-7467] iOS: fix map annotations memory issue when views being queu...

### DIFF
--- a/iphone/Classes/TiMapView.m
+++ b/iphone/Classes/TiMapView.m
@@ -646,10 +646,7 @@
 		static NSString *identifier = @"timap";
 		MKAnnotationView *annView = nil;
 		
-		if (![ann needsRefreshingWithSelection])
-		{
-			annView = (MKAnnotationView*) [mapView dequeueReusableAnnotationViewWithIdentifier:identifier];
-		}
+		annView = (MKAnnotationView*) [mapView dequeueReusableAnnotationViewWithIdentifier:identifier];
 		if (annView==nil)
 		{
 			id imagePath = [ann valueForUndefinedKey:@"image"];


### PR DESCRIPTION
[TIMOB-7467](http://jira.appcelerator.org/browse/TIMOB-7467)
fix map annotations memory issue when views being queued for reuse and never dequeued

The fix relates to the [changes](https://github.com/appcelerator/titanium_mobile/commit/3328be99875f5468f4c6fae0dd9a4358d63ac0bb) made by Stephen long time ago.

Test case in JIRA
