### PR TITLE
DashboardView row/col count fixes for iPad; X buttons vanishing fix

### DIFF
--- a/iphone/Classes/LauncherView.m
+++ b/iphone/Classes/LauncherView.m
@@ -136,7 +136,7 @@ static const NSTimeInterval kLauncherViewFastTransitionDuration = 0.2;
 
 -(NSInteger)rowHeight
 {
-	return MAX(33,(scrollView.frame.size.height /3));
+	return MAX(33,(scrollView.frame.size.height / [self rowCount]));
 }
 
 - (NSMutableArray*)pageWithFreeSpace:(NSInteger)pageIndex 

--- a/iphone/Classes/LauncherView.m
+++ b/iphone/Classes/LauncherView.m
@@ -71,6 +71,17 @@ static const NSTimeInterval kLauncherViewFastTransitionDuration = 0.2;
     if ((self = [super initWithFrame:frame])) 
 	{
 		self.columnCount = kLauncherViewDefaultColumnCount;
+
+      // on iPad, default to 4 columns and 5 rows.
+      // on iPhone, default to 3 columns and 3 rows.
+      if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
+         self.columnCount = 4;
+         self.rowCount = 5;
+      } else {
+         self.columnCount = 3;
+         self.rowCount = 3;
+      }
+
 		self.rowCount = 0;
 		self.currentPageIndex = 0;
         self.editable = YES;
@@ -142,15 +153,6 @@ static const NSTimeInterval kLauncherViewFastTransitionDuration = 0.2;
 	NSMutableArray* page = [NSMutableArray array];
 	[pages addObject:page];
 	return page;
-}
-
-- (NSInteger)rowCount 
-{
-	if (!rowCount) 
-	{
-		rowCount = floor(self.frame.size.height / [self rowHeight]);
-	}
-	return rowCount;
 }
 
 - (NSInteger)currentPageIndex 
@@ -648,6 +650,9 @@ static const NSTimeInterval kLauncherViewFastTransitionDuration = 0.2;
 	[UIView setAnimationDelegate:self];
 	[UIView setAnimationDidStopSelector:@selector(endEditingAnimationDidStop:finished:context:)];
 	
+   /* Removing this as it appears to break the X buttons; they will
+    * sometimes be invisible when edit mode is activated
+
 	for (NSArray* buttonPage in buttons) 
 	{
 		for (LauncherButton* button in buttonPage) 
@@ -656,6 +661,8 @@ static const NSTimeInterval kLauncherViewFastTransitionDuration = 0.2;
 			button.closeButton.alpha = 0;
 		}
 	}
+
+   */
 	
 	[UIView commitAnimations];
 	


### PR DESCRIPTION
My coworker Aaron Richton reported this a long time ago: http://support.appcelerator.com/tickets/APP-539483/tickets  This JIRA ticket was +1'd: http://jira.appcelerator.org/browse/TIMOB-1871

Unfortunately, I was hoping for a fix which would allow me to set the rowHeight and therefore easily support iPad.  The ticket was closed with 'fixed' and the code now just sets the number of rows to 3.  This solution is unacceptable for iPad.

My change simply sets the default rowCount to 5 and columnCount to 4 on iPad. 

The other change (the commented lines around 650) fixes a bug I was experiencing where occasionally the x buttons on the dashboard items would be invisible when entering edit mode.
