### PR TITLE
TIMOB-7252 Only call dispose() on prototype classes that are actually used in the application, to avoid VFY warnings in Android.

### DIFF
--- a/android/kroll-apt/src/java/org/appcelerator/kroll/annotations/generator/KrollGeneratedBindingsRhino.java.fm
+++ b/android/kroll-apt/src/java/org/appcelerator/kroll/annotations/generator/KrollGeneratedBindingsRhino.java.fm
@@ -1,11 +1,32 @@
+/**
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2011-2012 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+
 package org.appcelerator.kroll.runtime.rhino;
 
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.Collections;
+import org.appcelerator.kroll.common.Log;
+import java.lang.reflect.Method;
+
 
 public class KrollGeneratedBindings
 {
 	private static HashMap<String, GeneratedBinding> genBindings =
 		new HashMap<String, GeneratedBinding>();
+
+	<#-- Track the prototypes that are actually in use in the program, so
+	we can dispose just those. See TIMOB-7252 for why.-->
+	private static HashSet<Class<? extends Proxy>> usedPrototypeClasses =
+		new HashSet<Class<? extends Proxy>>();
+
+	private static final String DISPOSE = "dispose";
+	private static final String TAG = "KrollGeneratedBindings";
 
 	private static class GeneratedBinding
 	{
@@ -47,8 +68,25 @@ public class KrollGeneratedBindings
 
 	public static void dispose()
 	{
-		<#list bindings as binding>
-		${binding.class}Prototype.dispose();
-		</#list>
+		if (usedPrototypeClasses == null) {
+			return;
+		}
+		for (Class<? extends Proxy> cls : usedPrototypeClasses) {
+			if (cls == null) {
+				continue;
+			}
+			try {
+				Method disposeMethod = cls.getMethod(DISPOSE);
+				disposeMethod.invoke(null);
+			} catch(Exception e) {
+				Log.e(TAG, e.getClass().getSimpleName() + " disposing " + cls.getSimpleName() + ": " + e.getMessage());
+			}
+		}
+		usedPrototypeClasses.clear();
+	}
+
+	public static void registerUsedPrototypeClass(Class<? extends Proxy> cls)
+	{
+		usedPrototypeClasses.add(cls);
 	}
 }

--- a/android/kroll-apt/src/java/org/appcelerator/kroll/annotations/generator/ProxyBindingRhino.java.fm
+++ b/android/kroll-apt/src/java/org/appcelerator/kroll/annotations/generator/ProxyBindingRhino.java.fm
@@ -1,9 +1,10 @@
 /**
  * Appcelerator Titanium Mobile
- * Copyright (c) 2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2011-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
+
 package ${packageName};
 
 import org.mozilla.javascript.Context;
@@ -22,6 +23,7 @@ import org.appcelerator.kroll.KrollRuntime;
 import org.appcelerator.kroll.common.TiConfig;
 
 import org.appcelerator.kroll.runtime.rhino.KrollBindings;
+import org.appcelerator.kroll.runtime.rhino.KrollGeneratedBindings;
 import org.appcelerator.kroll.runtime.rhino.Proxy;
 import org.appcelerator.kroll.runtime.rhino.ProxyFactory;
 import org.appcelerator.kroll.runtime.rhino.RhinoRuntime;
@@ -66,6 +68,9 @@ public class ${className}Prototype extends ${superProxy}
 
 	public static void dispose()
 	{
+		if (DBG) {
+			Log.d(TAG, "dispose()");
+		}
 		${protoVar} = null;
 	}
 
@@ -73,6 +78,8 @@ public class ${className}Prototype extends ${superProxy}
 	{
 		if (${protoVar} == null && getClass().equals(${className}Prototype.class)) {
 			${protoVar} = this;
+			<#-- Enables us later to only dispose() classes that were actually used. Helps avoid VFY warnings in Android. -->
+			KrollGeneratedBindings.registerUsedPrototypeClass(getClass());
 		}
 
 		<#if isModule>


### PR DESCRIPTION
http://jira.appcelerator.org/browse/TIMOB-7252 -- Testing notes are in the JIRA item description.

If you are interested in a description of the problem, see [this comment](http://jira.appcelerator.org/browse/TIMOB-7252?focusedCommentId=181396&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-181396).
