### PR TITLE
[TIMOB-7388] iOS: splitView - Rotating iPad with modal window displayed causes UI rendering problems

### DIFF
--- a/iphone/Classes/TiRootViewController.m
+++ b/iphone/Classes/TiRootViewController.m
@@ -534,8 +534,10 @@
         if (windowOrientation != [[UIApplication sharedApplication] statusBarOrientation]) {
             [[UIApplication sharedApplication] setStatusBarOrientation:windowOrientation animated:NO];
         }
-		//Nothing to do here.
-		return;
+        if (TI_ORIENTATION_ALLOWED(allowedOrientations, orientationHistory[0])) {
+            //Nothing to do here.
+            return;
+        }
 	}
 	
 	[self manuallyRotateToOrientation:newOrientation duration:duration];


### PR DESCRIPTION
[TIMOB-7388](http://jira.appcelerator.org/browse/TIMOB-7388)
Steps in JIRA.

Note for FRer: in upside down mode there is an extra rotation in a wrong direction performed by iOS itself which I was not able to eliminate, but the original rendering problem is fixed.
