### PR TITLE
TC-614 : Enable/Disable cache in the NetworkHttpClientProxy with a new property (useCache)

### DIFF
--- a/iphone/Classes/TiNetworkHTTPClientProxy.h
+++ b/iphone/Classes/TiNetworkHTTPClientProxy.h
@@ -36,6 +36,7 @@ typedef enum {
 	NSNumber* validatesSecureCertificate;
     NSNumber* timeout;
     NSNumber* autoRedirect;
+    NSNumber* useCache;
 	
 	// callbacks are now in the JS object
 	BOOL hasOnload;
@@ -66,6 +67,7 @@ typedef enum {
 @property(nonatomic,retain,readwrite) NSNumber* validatesSecureCertificate;
 @property(nonatomic,retain,readwrite) NSNumber* timeout;
 @property(nonatomic,retain,readwrite) NSNumber* autoRedirect;
+@property(nonatomic,retain,readwrite) NSNumber* useCache;
 
 // constants
 @property(nonatomic,readonly) NSInteger UNSENT;

--- a/iphone/Classes/TiNetworkHTTPClientProxy.m
+++ b/iphone/Classes/TiNetworkHTTPClientProxy.m
@@ -95,7 +95,7 @@ extern NSString * const TI_APPLICATION_DEPLOYTYPE;
 
 @implementation TiNetworkHTTPClientProxy
 
-@synthesize timeout, validatesSecureCertificate, autoRedirect;
+@synthesize timeout, validatesSecureCertificate, autoRedirect, useCache;
 
 -(id)init
 {
@@ -104,6 +104,7 @@ extern NSString * const TI_APPLICATION_DEPLOYTYPE;
 		readyState = NetworkClientStateUnsent;
 		autoRedirect = [[NSNumber alloc] initWithBool:YES];
 		validatesSecureCertificate = [[NSNumber alloc] initWithBool:NO];
+		useCache = [[NSNumber alloc] initWithBool:YES];
 	}
 	return self;
 }
@@ -149,6 +150,7 @@ extern NSString * const TI_APPLICATION_DEPLOYTYPE;
 	RELEASE_TO_NIL(autoRedirect);
     RELEASE_TO_NIL(timeout);
     RELEASE_TO_NIL(validatesSecureCertificate);
+    RELEASE_TO_NIL(useCache);
 	[super _destroy];
 }
 
@@ -355,8 +357,11 @@ extern NSString * const TI_APPLICATION_DEPLOYTYPE;
 		async = YES;
 	}
 	
-	request = [[ASIFormDataRequest requestWithURL:url] retain];	
-    [request setDownloadCache:[ASIDownloadCache sharedCache]];
+	request = [[ASIFormDataRequest requestWithURL:url] retain];
+	if ([useCache boolValue])
+	{
+	    [request setDownloadCache:[ASIDownloadCache sharedCache]];
+	}
 	[request setDelegate:self];
     if (timeout) {
         NSTimeInterval timeoutVal = [timeout doubleValue] / 1000;


### PR DESCRIPTION
Added a "useCache" property to the Ti.Network.httpClient to enable/disable use the ASIDownloadCache

Default is true, but developers should be able to decide whether their XHR objects have to use cache or not.

The reason is that if you use XHR to download a lot of files (and not for API calls and such for instance), cache is useless and even problematic since at next startup and first open() method call, the app will hang for a few seconds, collecting data about the cache.

Original Q&A thread I created when add the hang problem : 

http://developer.appcelerator.com/question/131438/application-hangs-at-startup-at-first-tinetwork-use-attempt
