### PR TITLE
[TIMOB-7397] Visual glitch on screen transition from search results

### DIFF
--- a/iphone/Classes/TiUITableView.m
+++ b/iphone/Classes/TiUITableView.m
@@ -867,8 +867,21 @@
 		[target fireEvent:name withObject:eventObject];
 	}	
     
-    if (viaSearch && hideOnSearch) {
-        [self hideSearchScreen:nil];
+    if (viaSearch) {
+        if (hideOnSearch) {
+            [self hideSearchScreen:nil];
+        }
+        else {
+            /*
+             TIMOB-7397. Observed that `searchBarTextDidBeginEditing` delegate 
+             method was being called on screen transition which was causing a 
+             visual glitch. Checking for isFirstResponder at this point always 
+             returns false. Calling blur here so that the UISearchBar resigns 
+             as first responder on main thread
+            */
+            [searchField performSelector:@selector(blur:) withObject:nil];
+        }
+        
     }
 }
 


### PR DESCRIPTION
[TIMOB-7397](http://jira.appcelerator.org/browse/TIMOB-7397)

The visual glitch is not reproducible on the simulator but can be seen on device.

FR should include the EMC application and a regression against TIMOB-5289, TIMOB-5441 and against the [code](http://jira.appcelerator.org/browse/TIMOB-7397?focusedCommentId=181246&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-181246) attached to the ticket.
