### PR TITLE
[TIMOB-7363][TIMOB-7425][TIMOB-7455] [1_7_X] barImage handling

### DIFF
--- a/iphone/Classes/TiUIWindowProxy.m
+++ b/iphone/Classes/TiUIWindowProxy.m
@@ -297,41 +297,26 @@
 	UINavigationBar * ourNB = [[controller navigationController] navigationBar];
 	CGRect barFrame = [ourNB bounds];
 	UIImage * newImage = [TiUtils toImage:[self valueForUndefinedKey:@"barImage"]
-			proxy:self size:barFrame.size];
-
-	if (newImage == nil)
-	{
-		[barImageView removeFromSuperview];
-		RELEASE_TO_NIL(barImageView);
-		return;
-	}
-	
-	if (barImageView == nil)
-	{
-		barImageView = [[UIImageView alloc]initWithImage:newImage];
-	}
-	else
-	{
-		[barImageView setImage:newImage];
-	}
-	
-	[barImageView setFrame:barFrame];
-	
-	int barImageViewIndex = 0;
-	if ([ourNB respondsToSelector:@selector(setBackgroundImage:forBarMetrics:)]) {
-	/*
-	 *	While iOS 5 has methods for setting the background Image, using it requires
-	 *	linking to that SDK (the mentioned bar metrics is an enumeration) which,
-	 *	while iOS 5 is behind the NDA, isn't an option.
-	 *	TODO: Update when iOS 5 is not NDAed for something more elegant.
-	 */
-		barImageViewIndex = 1;
-	}
-	
-	if ([[ourNB subviews] indexOfObject:barImageView] != barImageViewIndex)
-	{
-		[ourNB insertSubview:barImageView atIndex:barImageViewIndex];
-	}
+                                    proxy:self size:barFrame.size];
+    if ([TiUtils isIOS5OrGreater]) {
+        [ourNB setBackgroundImage:newImage forBarMetrics:UIBarMetricsDefault];
+    } else {
+        if (newImage == nil) {
+            [barImageView removeFromSuperview];
+            RELEASE_TO_NIL(barImageView);
+            return;
+        }
+        if (barImageView == nil) {
+            barImageView = [[UIImageView alloc]initWithImage:newImage];
+        } else {
+            [barImageView setImage:newImage];
+        }
+        [barImageView setFrame:barFrame];
+        int barImageViewIndex = 0;
+        if ([[ourNB subviews] indexOfObject:barImageView] != barImageViewIndex) {
+            [ourNB insertSubview:barImageView atIndex:barImageViewIndex];
+        }
+    }
 }
 
 -(void)setBarImage:(id)value
@@ -505,6 +490,7 @@
 	}
 	[[parentController navigationItem] setBackBarButtonItem:backButton];
 	[backButton release];
+    [self updateBarImage];
 }
 
 -(void)setBackButtonTitle:(id)proxy
@@ -568,6 +554,7 @@
 	}
 
 	[ourNavItem setTitleView:newTitleView];
+    [self updateBarImage];
 }
 
 

--- a/iphone/Classes/TiUIWindowProxy.m
+++ b/iphone/Classes/TiUIWindowProxy.m
@@ -339,7 +339,7 @@
 	[self replaceValue:[self sanitizeURL:value] forKey:@"barImage" notification:NO];
 	if (controller!=nil)
 	{
-		[self performSelectorOnMainThread:@selector(updateBarImage) withObject:nil waitUntilDone:NO];
+		[self performSelectorOnMainThread:@selector(updateBarImage) withObject:nil waitUntilDone:[NSThread isMainThread]];
 	}
 }
 

--- a/iphone/Classes/TiUIWindowProxy.m
+++ b/iphone/Classes/TiUIWindowProxy.m
@@ -300,23 +300,21 @@
                                     proxy:self size:barFrame.size];
     if ([TiUtils isIOS5OrGreater]) {
         [ourNB setBackgroundImage:newImage forBarMetrics:UIBarMetricsDefault];
-    } else {
-        if (newImage == nil) {
-            [barImageView removeFromSuperview];
-            RELEASE_TO_NIL(barImageView);
-            return;
-        }
-        if (barImageView == nil) {
-            barImageView = [[UIImageView alloc]initWithImage:newImage];
-        } else {
-            [barImageView setImage:newImage];
-        }
-        [barImageView setFrame:barFrame];
-        int barImageViewIndex = 0;
-        if ([[ourNB subviews] indexOfObject:barImageView] != barImageViewIndex) {
-            [ourNB insertSubview:barImageView atIndex:barImageViewIndex];
-        }
+    } 
+    else {
+        [barImageView setImage:newImage];
     }
+    [barImageView setFrame:barFrame];
+    int barImageViewIndex = 0;
+    if ([ourNB respondsToSelector:@selector(setBackgroundImage:forBarMetrics:)]) {
+        //We should ideally be using the setBackgroundImage:forBarMetrics:
+        //method. Revisit after 1.8.1 release
+        barImageViewIndex = 1;
+    }
+    if ([[ourNB subviews] indexOfObject:barImageView] != barImageViewIndex) {
+        [ourNB insertSubview:barImageView atIndex:barImageViewIndex];
+    }
+    
 }
 
 -(void)setBarImage:(id)value

--- a/iphone/Classes/TiUIWindowProxy.m
+++ b/iphone/Classes/TiUIWindowProxy.m
@@ -362,8 +362,7 @@
 			if (proxy!=nil)
 			{
 				// add the new one
-				BOOL animated = [TiUtils boolValue:@"animated" properties:properties def:YES];
-				[controller.navigationItem setRightBarButtonItem:[proxy barButtonItem] animated:animated];
+				[controller.navigationItem setRightBarButtonItem:[proxy barButtonItem] animated:NO];
 				[self updateBarImage];
 			}
 			else 
@@ -409,8 +408,7 @@
 			if (proxy!=nil)
 			{
 				// add the new one
-				BOOL animated = [TiUtils boolValue:@"animated" properties:properties def:YES];
-				[controller.navigationItem setLeftBarButtonItem:[proxy barButtonItem] animated:animated];
+				[controller.navigationItem setLeftBarButtonItem:[proxy barButtonItem] animated:NO];
 				[self updateBarImage];
 			}
 			else 

--- a/iphone/Classes/TiUIWindowProxy.m
+++ b/iphone/Classes/TiUIWindowProxy.m
@@ -362,8 +362,9 @@
 			if (proxy!=nil)
 			{
 				// add the new one
-				[controller.navigationItem setRightBarButtonItem:[proxy barButtonItem] animated:NO];
-				[self updateBarImage];
+                BOOL animated = [TiUtils boolValue:@"animated" properties:properties def:NO];
+                [controller.navigationItem setRightBarButtonItem:[proxy barButtonItem] animated:animated];
+                [self updateBarImage];
 			}
 			else 
 			{
@@ -408,8 +409,9 @@
 			if (proxy!=nil)
 			{
 				// add the new one
-				[controller.navigationItem setLeftBarButtonItem:[proxy barButtonItem] animated:NO];
-				[self updateBarImage];
+                BOOL animated = [TiUtils boolValue:@"animated" properties:properties def:NO];
+                [controller.navigationItem setLeftBarButtonItem:[proxy barButtonItem] animated:animated];
+                [self updateBarImage];
 			}
 			else 
 			{

--- a/iphone/Classes/TiUIWindowProxy.m
+++ b/iphone/Classes/TiUIWindowProxy.m
@@ -298,7 +298,7 @@
 	CGRect barFrame = [ourNB bounds];
 	UIImage * newImage = [TiUtils toImage:[self valueForUndefinedKey:@"barImage"]
                                     proxy:self size:barFrame.size];
-    if ([TiUtils isIOS5OrGreater]) {
+    if ([ourNB respondsToSelector:@selector(setBackgroundImage:forBarMetrics:)]) {
         [ourNB setBackgroundImage:newImage forBarMetrics:UIBarMetricsDefault];
     } 
     else {

--- a/iphone/Classes/TiUtils.h
+++ b/iphone/Classes/TiUtils.h
@@ -202,6 +202,8 @@ typedef enum {
 
 +(BOOL)isIOS4_2OrGreater;
 
++(BOOL)isIOS5OrGreater;
+
 +(BOOL)isIPhone4;
 
 +(BOOL)isRetinaDisplay;

--- a/iphone/Classes/TiUtils.m
+++ b/iphone/Classes/TiUtils.m
@@ -112,6 +112,11 @@ static void getAddrInternal(char* macAddress, const char* ifName) {
 	return [UIView instancesRespondToSelector:@selector(drawRect:forViewPrintFormatter:)];
 }
 
++(BOOL)isIOS5OrGreater
+{
+    return [UIAlertView instancesRespondToSelector:@selector(alertViewStyle)];
+}
+
 +(BOOL)isIOS4OrGreater
 {
 	return [UIView instancesRespondToSelector:@selector(contentScaleFactor)];


### PR DESCRIPTION
Duplicate of PR #1252 for 1_7_X.

Should not be reviewed by myself or Vishal. But see comments below regarding the other cherry-picks to resolve the regressions introduced by the original fix. All three tickets should be tested as well as a KS pass on barImage to ensure that there is no behavior difference from vanilla 1.7.x.
