### PR TITLE
timob-7240: remove tab from activity stack properly when user hits back key

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TiTabActivity.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TiTabActivity.java
@@ -198,7 +198,7 @@ public class TiTabActivity extends TabActivity
 	@Override
 	protected void onDestroy()
 	{
-
+		TiApplication.removeFromActivityStack(this);
 		super.onDestroy();
 
 		if (!isFinishing())


### PR DESCRIPTION
This PR's purpose is to fix a mistake made in https://github.com/appcelerator/titanium_mobile/pull/1338 - to remove tab activity properly from stack when back key is hit. 
JIRA ticket: https://jira.appcelerator.org/browse/TIMOB-7240
Testing steps in JIRA.
