### PR TITLE
[TIMOB-7367] iOS: fix options dialog rotation issues

### DIFF
--- a/iphone/Classes/TiUIOptionDialogProxy.m
+++ b/iphone/Classes/TiUIOptionDialogProxy.m
@@ -104,6 +104,11 @@
 {
     [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(updateOptionDialogNow) object:nil];
     NSTimeInterval delay = [[UIApplication sharedApplication] statusBarOrientationAnimationDuration];
+    UIInterfaceOrientation nextOrientation = [[notification.userInfo objectForKey:UIApplicationStatusBarOrientationUserInfoKey] intValue];
+    UIInterfaceOrientation currentOrientation = [UIApplication sharedApplication].statusBarOrientation;
+    if (UIInterfaceOrientationIsPortrait(currentOrientation) == UIInterfaceOrientationIsPortrait(nextOrientation)) {
+        ++accumulatedOrientationChanges; // double for a 180 degree orientation change
+    }
     if (++accumulatedOrientationChanges > 1) {
         delay *= MIN(accumulatedOrientationChanges, 4);
     }


### PR DESCRIPTION
[TIMOB-7367](http://jira.appcelerator.org/browse/TIMOB-7367)
This change is a followup on #1315 and basically reapplies changes made in the first commit of #1315.

Test instructions are in JIRA. iPad should be rotated 180/270 degrees **very** fast.
