### PR TITLE
timob-7573: open/close fix for tabgroup

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TiUIActivityWindow.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TiUIActivityWindow.java
@@ -292,6 +292,13 @@ public class TiUIActivityWindow extends TiUIView
 		if (post) {
 			proxy.getMainHandler().post(new Runnable() {
 				public void run() {
+					/*
+					 *This is a check to prevent a race condition- when user execute open, open, close on the window.
+					 *setActivityBackground is being called in KrollRuntime thread, which may cause a race condition: windowActivity
+					 *is set to null in the middle of closing process, while the 2nd call of open gets here. In the case of
+					 *"open, open, close, open", this would work b/c the assigning of windowActivity and setting it to null are both being done 
+					 *on the same thread.
+					 */
 					if (windowActivity != null) {
 						windowActivity.getWindow().setBackgroundDrawable(drawable);
 					}

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TiUIActivityWindow.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TiUIActivityWindow.java
@@ -292,7 +292,9 @@ public class TiUIActivityWindow extends TiUIView
 		if (post) {
 			proxy.getMainHandler().post(new Runnable() {
 				public void run() {
-					windowActivity.getWindow().setBackgroundDrawable(drawable);
+					if (windowActivity != null) {
+						windowActivity.getWindow().setBackgroundDrawable(drawable);
+					}
 				}
 			});
 


### PR DESCRIPTION
This bug can be reproduced by open/close the tab window very very fast. This is caused by 3 consecutive clicks: open, open, close. It's a race condition, when the tabgroup is closing while open is being called on the same tabgroup. 
JIRA ticket: https://jira.appcelerator.org/browse/TIMOB-7573
Testing steps in JIRA
