### PR TITLE
[TIMOB-7344] iOS: apply percentage constraints correctly for reference(parent) size, not sandbox size

### DIFF
--- a/iphone/Classes/LayoutConstraint.h
+++ b/iphone/Classes/LayoutConstraint.h
@@ -92,6 +92,6 @@ typedef struct LayoutConstraint {
 @class TiUIView;
 void ApplyConstraintToViewWithBounds(LayoutConstraint * constraint, TiUIView * subView, CGRect viewBounds);
 CGFloat WidthFromConstraintGivenWidth(LayoutConstraint * constraint,CGFloat viewWidth);
-CGSize SizeConstraintViewWithSizeAddingResizing(LayoutConstraint * constraint, NSObject<LayoutAutosizing> * autoSizer, CGSize boundSize, UIViewAutoresizing * resultResizing);
-CGPoint PositionConstraintGivenSizeBoundsAddingResizing(LayoutConstraint * constraint, CGSize viewSize, CGPoint anchorPoint, CGSize superViewSize, UIViewAutoresizing * resultResizing);
+CGSize SizeConstraintViewWithSizeAddingResizing(LayoutConstraint * constraint, NSObject<LayoutAutosizing> * autoSizer, CGSize referenceSize, UIViewAutoresizing * resultResizing);
+CGPoint PositionConstraintGivenSizeBoundsAddingResizing(LayoutConstraint * constraint, CGSize viewSize, CGPoint anchorPoint, CGSize referenceSize, CGSize sandboxSize, UIViewAutoresizing * resultResizing);
 BOOL IsLayoutUndefined(LayoutConstraint *constraint);

--- a/iphone/Classes/LayoutConstraint.m
+++ b/iphone/Classes/LayoutConstraint.m
@@ -39,10 +39,10 @@ else (width is invalid)
 
 
 
-CGSize SizeConstraintViewWithSizeAddingResizing(LayoutConstraint * constraint, NSObject<LayoutAutosizing> * autoSizer, CGSize boundSize, UIViewAutoresizing * resultResizing)
+CGSize SizeConstraintViewWithSizeAddingResizing(LayoutConstraint * constraint, NSObject<LayoutAutosizing> * autoSizer, CGSize referenceSize, UIViewAutoresizing * resultResizing)
 {
 	//TODO: Refactor for elegance.
-	CGFloat width = 0.0f;
+	CGFloat width;
 
 	if(resultResizing != NULL)
 	{
@@ -53,11 +53,11 @@ CGSize SizeConstraintViewWithSizeAddingResizing(LayoutConstraint * constraint, N
 	{
 		case TiDimensionTypePercent:
 		case TiDimensionTypePixels:
-			width = TiDimensionCalculateValue(constraint->width, boundSize.width);
+			width = TiDimensionCalculateValue(constraint->width, referenceSize.width);
 			break;
 		default:
 			{
-				width = TiDimensionCalculateMargins(constraint->left, constraint->right, boundSize.width);
+				width = TiDimensionCalculateMargins(constraint->left, constraint->right, referenceSize.width);
 				if (TiDimensionIsAuto(constraint->width) && 
 					[autoSizer respondsToSelector:@selector(autoWidthForWidth:)])
 				{
@@ -76,15 +76,13 @@ CGSize SizeConstraintViewWithSizeAddingResizing(LayoutConstraint * constraint, N
 		width = [autoSizer verifyWidth:width];
 	}
 	
-	CGFloat height = boundSize.height;
+	CGFloat height;
 
 	switch (constraint->height.type)
 	{
 		case TiDimensionTypePercent:
-			height *= constraint->height.value;
-			break;
 		case TiDimensionTypePixels:
-			height = constraint->height.value;
+			height = TiDimensionCalculateValue(constraint->height, referenceSize.height);
 			break;
 		default:
 			{
@@ -95,7 +93,7 @@ CGSize SizeConstraintViewWithSizeAddingResizing(LayoutConstraint * constraint, N
 				}
 				else
 				{
-					height = TiDimensionCalculateMargins(constraint->top, constraint->bottom, boundSize.height);
+					height = TiDimensionCalculateMargins(constraint->top, constraint->bottom, referenceSize.height);
 					if(resultResizing != NULL)
 					{
 						*resultResizing |= UIViewAutoresizingFlexibleHeight;
@@ -126,7 +124,7 @@ CGSize SizeConstraintViewWithSizeAddingResizing(LayoutConstraint * constraint, N
 
 
 
-CGPoint PositionConstraintGivenSizeBoundsAddingResizing(LayoutConstraint * constraint, CGSize viewSize, CGPoint anchorPoint, CGSize superViewSize, UIViewAutoresizing * resultResizing)
+CGPoint PositionConstraintGivenSizeBoundsAddingResizing(LayoutConstraint * constraint, CGSize viewSize, CGPoint anchorPoint, CGSize referenceSize, CGSize sandboxSize, UIViewAutoresizing * resultResizing)
 {
 	BOOL flexibleSize = *resultResizing & UIViewAutoresizingFlexibleWidth;
 
@@ -137,7 +135,7 @@ CGPoint PositionConstraintGivenSizeBoundsAddingResizing(LayoutConstraint * const
 
 	if(!flexibleSize)
 	{
-		ignoreMargins = TiDimensionDidCalculateValue(constraint->centerX, superViewSize.width, &centerX);
+		ignoreMargins = TiDimensionDidCalculateValue(constraint->centerX, referenceSize.width, &centerX);
 	}
 	else
 	{
@@ -149,7 +147,7 @@ CGPoint PositionConstraintGivenSizeBoundsAddingResizing(LayoutConstraint * const
 	{
 		int marginSuggestions=0;
 		CGFloat frameLeft = 0.0;
-		if(TiDimensionDidCalculateValue(constraint->left, superViewSize.width, &frameLeft))
+		if(TiDimensionDidCalculateValue(constraint->left, referenceSize.width, &frameLeft))
 		{
 			marginSuggestions++;
 		}
@@ -159,10 +157,10 @@ CGPoint PositionConstraintGivenSizeBoundsAddingResizing(LayoutConstraint * const
 		}
 
 		CGFloat frameRight;
-		if(TiDimensionDidCalculateValue(constraint->right, superViewSize.width, &frameRight))
+		if(TiDimensionDidCalculateValue(constraint->right, referenceSize.width, &frameRight))
 		{
 			marginSuggestions++;
-			frameLeft += superViewSize.width - viewSize.width - frameRight;
+			frameLeft += sandboxSize.width - viewSize.width - frameRight;
 		}
 		else if (!flexibleSize)
 		{
@@ -171,7 +169,7 @@ CGPoint PositionConstraintGivenSizeBoundsAddingResizing(LayoutConstraint * const
 		
 		if (marginSuggestions < 1)
 		{
-			centerX = superViewSize.width/2.0 + viewSize.width*(anchorPoint.x-0.5);
+			centerX = sandboxSize.width/2.0 + viewSize.width*(anchorPoint.x-0.5);
 		}
 		else
 		{
@@ -184,7 +182,7 @@ CGPoint PositionConstraintGivenSizeBoundsAddingResizing(LayoutConstraint * const
 
 	if(!flexibleSize)
 	{
-		ignoreMargins = TiDimensionDidCalculateValue(constraint->centerY, superViewSize.width, &centerY);
+		ignoreMargins = TiDimensionDidCalculateValue(constraint->centerY, referenceSize.width, &centerY);
 	}
 	else
 	{
@@ -195,7 +193,7 @@ CGPoint PositionConstraintGivenSizeBoundsAddingResizing(LayoutConstraint * const
 	{
 		int marginSuggestions=0;
 		CGFloat frameTop = 0.0;
-		if(TiDimensionDidCalculateValue(constraint->top, superViewSize.height, &frameTop))
+		if(TiDimensionDidCalculateValue(constraint->top, referenceSize.height, &frameTop))
 		{
 			marginSuggestions++;
 		}
@@ -205,10 +203,10 @@ CGPoint PositionConstraintGivenSizeBoundsAddingResizing(LayoutConstraint * const
 		}
 
 		CGFloat frameBottom;
-		if(TiDimensionDidCalculateValue(constraint->bottom, superViewSize.height, &frameBottom))
+		if(TiDimensionDidCalculateValue(constraint->bottom, referenceSize.height, &frameBottom))
 		{
 			marginSuggestions++;
-			frameTop += superViewSize.height - viewSize.height - frameBottom;
+			frameTop += sandboxSize.height - viewSize.height - frameBottom;
 		}
 		else if (!flexibleSize)
 		{
@@ -217,7 +215,7 @@ CGPoint PositionConstraintGivenSizeBoundsAddingResizing(LayoutConstraint * const
 		
 		if (marginSuggestions < 1)
 		{
-			centerY = superViewSize.height/2.0 + viewSize.height*(anchorPoint.y-0.5);
+			centerY = sandboxSize.height/2.0 + viewSize.height*(anchorPoint.y-0.5);
 		}
 		else
 		{
@@ -242,7 +240,7 @@ void ApplyConstraintToViewWithBounds(LayoutConstraint * constraint, TiUIView * s
 	resultBounds.size = SizeConstraintViewWithSizeAddingResizing(constraint,(TiViewProxy *)[subView proxy], viewBounds.size, &resultMask);
 	
 	CGPoint resultCenter = PositionConstraintGivenSizeBoundsAddingResizing(constraint, resultBounds.size,
-			[[subView layer] anchorPoint], viewBounds.size, &resultMask);
+			[[subView layer] anchorPoint], viewBounds.size, viewBounds.size, &resultMask);
 	
 	resultCenter.x += resultBounds.origin.x + viewBounds.origin.x;
 	resultCenter.y += resultBounds.origin.y + viewBounds.origin.y;

--- a/iphone/Classes/TiViewProxy.m
+++ b/iphone/Classes/TiViewProxy.m
@@ -512,7 +512,9 @@ LAYOUTPROPERTIES_SETTER(setMinHeight,minimumHeight,TiFixedValueRuleFromObject,[s
 	else if(TiDimensionIsAuto(layoutProperties.width))
 	{
 		result += [self autoWidthForWidth:suggestedWidth - result];
-	}
+	} else if (TiDimensionIsPercent(layoutProperties.width)) {
+        result = TiDimensionCalculateValue(layoutProperties.width, suggestedWidth);
+    }
 	return result;
 }
 
@@ -1659,10 +1661,11 @@ if(OSAtomicTestAndSetBarrier(flagBit, &dirtyflags))	\
 		repositioning = YES;
 
 
-		sizeCache.size = SizeConstraintViewWithSizeAddingResizing(&layoutProperties,self, sandboxBounds.size, &autoresizeCache);
+        CGSize referenceSize = (parent != nil) ? parent.view.bounds.size : sandboxBounds.size;
+		sizeCache.size = SizeConstraintViewWithSizeAddingResizing(&layoutProperties,self, referenceSize, &autoresizeCache);
 
 		positionCache = PositionConstraintGivenSizeBoundsAddingResizing(&layoutProperties, sizeCache.size,
-		[[view layer] anchorPoint], sandboxBounds.size, &autoresizeCache);
+		[[view layer] anchorPoint], referenceSize, sandboxBounds.size, &autoresizeCache);
 
 		positionCache.x += sizeCache.origin.x + sandboxBounds.origin.x;
 		positionCache.y += sizeCache.origin.y + sandboxBounds.origin.y;

--- a/iphone/Classes/TiViewProxy.m
+++ b/iphone/Classes/TiViewProxy.m
@@ -1660,8 +1660,8 @@ if(OSAtomicTestAndSetBarrier(flagBit, &dirtyflags))	\
 
 		repositioning = YES;
 
-
-        CGSize referenceSize = (parent != nil) ? parent.view.bounds.size : sandboxBounds.size;
+        UIView *parentView = [parent parentViewForChild:self];
+        CGSize referenceSize = (parentView != nil) ? parentView.bounds.size : sandboxBounds.size;
 		sizeCache.size = SizeConstraintViewWithSizeAddingResizing(&layoutProperties,self, referenceSize, &autoresizeCache);
 
 		positionCache = PositionConstraintGivenSizeBoundsAddingResizing(&layoutProperties, sizeCache.size,


### PR DESCRIPTION
[TIMOB-7344](https://jira.appcelerator.org/browse/TIMOB-7344)
This PR replaces #1356

Test case in JIRA.

Stephen & Blain to review.
