### PR TITLE
[TIMOB-7605][TIMOB-5052] Added Ti.Network.HTTPClient.cache

### DIFF
--- a/apidoc/Titanium/Network/HTTPClient.yml
+++ b/apidoc/Titanium/Network/HTTPClient.yml
@@ -279,14 +279,17 @@ properties:
   - name: cache
     summary: Controls whether or not HTTP responses are cached.
     description: |
-        By default, HTTP responses are not cached. If you cache HTTP responses,
-        when making a request to the same source multiple times, you may retrieve
-        the initial response rather than a new one - this is true even for
-        REST calls. Caching should only be enabled for HTTP requests which you
+        If `cache` is set to `true`, requests using this HTTP client will cache
+        their responses (respecting headers such as "no-cache", "no-store",
+        and cache expiry). In this case, repeated requests to the same URL may
+        retrieve the initial response rather than triggering a new request. The
+        cache is shared between all instances of `HTTPClient`.
+        
+        Caching should only be enabled for HTTP requests which you
         expect the result to remain consistent for.
         
-        If this is `true`, respects the "no-cache", "no-store", and cache
-        expiration headers of the response.
+        If `cache` is `false`, any request on this HTTP client will result
+        in a new HTTP request. 
         
         This propery must be set before `open` is called.
     type: Boolean

--- a/apidoc/Titanium/Network/HTTPClient.yml
+++ b/apidoc/Titanium/Network/HTTPClient.yml
@@ -276,6 +276,23 @@ properties:
     type: Number
     since: "1.8.0"
     platforms: [iphone, ipad]
+  - name: cache
+    summary: Controls whether or not HTTP responses are cached.
+    description: |
+        By default, HTTP responses are not cached. If you cache HTTP responses,
+        when making a request to the same source multiple times, you may retrieve
+        the initial response rather than a new one - this is true even for
+        REST calls. Caching should only be enabled for HTTP requests which you
+        expect the result to remain consistent for.
+        
+        If this is `true`, respects the "no-cache", "no-store", and cache
+        expiration headers of the response.
+        
+        This propery must be set before `open` is called.
+    type: Boolean
+    since: "1.9.0"
+    default: false
+    platforms: [iphone, ipad]
 examples:
   - title: Simple GET Request
     example: |

--- a/iphone/Classes/TiNetworkHTTPClientProxy.m
+++ b/iphone/Classes/TiNetworkHTTPClientProxy.m
@@ -108,6 +108,11 @@ extern NSString * const TI_APPLICATION_DEPLOYTYPE;
 	return self;
 }
 
+-(void)_configure
+{
+    [self initializeProperty:@"cache" defaultValue:NUMBOOL(NO)];
+}
+
 -(void)setOnload:(KrollCallback *)callback
 {
 	hasOnload = [callback isKindOfClass:[KrollCallback class]];
@@ -356,7 +361,12 @@ extern NSString * const TI_APPLICATION_DEPLOYTYPE;
 	}
 	
 	request = [[ASIFormDataRequest requestWithURL:url] retain];	
-    [request setDownloadCache:[ASIDownloadCache sharedCache]];
+    if ([TiUtils boolValue:[self valueForUndefinedKey:@"cache"] def:NO]) {
+        [request setDownloadCache:[ASIDownloadCache sharedCache]];
+    }
+    else {
+        [request setDownloadCache:nil];
+    }
 	[request setDelegate:self];
     if (timeout) {
         NSTimeInterval timeoutVal = [timeout doubleValue] / 1000;


### PR DESCRIPTION
This property controls caching and is set to `false` by default for parity with earlier behavior and also Android (which does not do HTTP response caching).
