### PR TITLE
[TIDOC-383]: APIDoc - iOS-only Ti.API.timestamp method undocumented

### DIFF
--- a/apidoc/Titanium/API/API.yml
+++ b/apidoc/Titanium/API/API.yml
@@ -9,22 +9,22 @@ methods:
     summary: Logs messages with a `debug` severity-level.
     parameters:
       - name: message
-        summary: Message to log.
-        type: String
+        summary: Message to log. Accepts an array on iOS only.
+        type: [Array<String>, String]
         
   - name: error
     summary: Logs messages with an `error` severity-level.
     parameters:
       - name: message
-        summary: Message to log.
-        type: String
+        summary: Message to log. Accepts an array on iOS only.
+        type: [Array<String>, String]
         
   - name: info
     summary: Logs messages with an `info` severity-level.
     parameters:
       - name: message
-        summary: Message to log.
-        type: String
+        summary: Message to log. Accepts an array on iOS only.
+        type: [Array<String>, String]
         
   - name: log
     summary: Logs messages with the specified severity-level.
@@ -36,19 +36,29 @@ methods:
         type: String
         
       - name: message
-        summary: Message to log.
-        type: String
+        summary: Message to log. Accepts an array on iOS only.
+        type: [Array<String>, String]
+
+  - name: timestamp
+    summary: |
+        Logs messages with a `timestamp` severity-level, prefixed with a timestamp float number 
+        representing the number of seconds since January 1st, 2001.
+    platforms: [iphone, ipad]
+    parameters:
+      - name: message
+        summary: Message to log. Accepts an array on iOS only.
+        type: [Array<String>, String]
         
   - name: trace
     summary: Logs messages with a `trace` severity-level.
     parameters:
       - name: message
-        summary: Message to log.
-        type: String
+        summary: Message to log. Accepts an array on iOS only.
+        type: [Array<String>, String]
         
   - name: warn
     summary: Logs messages with a `warn` severity-level.
     parameters:
       - name: message
-        summary: Message to log.
-        type: String
+        summary: Message to log. Accepts an array on iOS only.
+        type: [Array<String>, String]


### PR DESCRIPTION
https://jira.appcelerator.org/browse/TIDOC-383
