### PR TITLE
TIMOB-6873: Android: Inconsistent Focus and Blur events with Textfield in TableViewRow

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiTableView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiTableView.java
@@ -486,4 +486,27 @@ public class TiTableView extends FrameLayout
 		viewModel = null;
 		itemClickListener = null;
 	}
+
+	@Override
+	protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
+		// To prevent undesired "focus" and "blur" events during layout caused
+		// by ListView temporarily taking focus, we will disable focus events until
+		// layout has finished.
+		OnFocusChangeListener focusListener = null;
+		View focusedView = listView.findFocus();
+		if (focusedView != null) {
+			OnFocusChangeListener listener = focusedView.getOnFocusChangeListener();
+			if (listener != null && listener instanceof TiUIView) {
+				focusedView.setOnFocusChangeListener(null);
+				focusListener = listener;
+			}
+		}
+
+		super.onLayout(changed, left, top, right, bottom);
+
+		// Layout is finished, re-enable focus events.
+		if (focusListener != null) {
+			focusedView.setOnFocusChangeListener(focusListener);
+		}
+	}
 }

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiTableView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiTableView.java
@@ -507,6 +507,7 @@ public class TiTableView extends FrameLayout
 		// Layout is finished, re-enable focus events.
 		if (focusListener != null) {
 			focusedView.setOnFocusChangeListener(focusListener);
+			// If the configuration changed, we manually fire the blur event
 			if (changed) {
 				focusListener.onFocusChange(focusedView, false);
 			}

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiTableView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiTableView.java
@@ -507,6 +507,9 @@ public class TiTableView extends FrameLayout
 		// Layout is finished, re-enable focus events.
 		if (focusListener != null) {
 			focusedView.setOnFocusChangeListener(focusListener);
+			if (changed) {
+				focusListener.onFocusChange(focusedView, false);
+			}
 		}
 	}
 }


### PR DESCRIPTION
https://jira.appcelerator.org/browse/TIMOB-6873

Test case in jira.

NOTE: The order of events should be blur THEN focus when switching between textfields.  However in android the focus dialog hides the blur dialog (which makes is seem that the focus event was fired first).  To verify that the order is correct, please look at the log, and make sure the blur event is fired before the focus event.
