### PR TITLE
[TIMOB-6530] Increase the stack stack size so rhino's recursive include works in drillbit test

### DIFF
--- a/drillbit/tests/includes/tiapp.xml
+++ b/drillbit/tests/includes/tiapp.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ti:app xmlns:ti="http://ti.appcelerator.org" xmlns:android="http://schemas.android.com/apk/res/android">
+    <id>org.appcelerator.titanium.testharness</id>
+    <name>test_harness</name>
+    <version>1.0.1</version>
+    <publisher>test publisher</publisher>
+    <url>http://www.test.com</url>
+    <description>test description</description>
+    <copyright>copyright 2010 test</copyright>
+    <icon>appicon.png</icon>
+    <persistent-wifi>false</persistent-wifi>
+    <prerendered-icon>false</prerendered-icon>
+    <statusbar-style>default</statusbar-style>
+    <statusbar-hidden>false</statusbar-hidden>
+    <fullscreen>false</fullscreen>
+    <navbar-hidden>false</navbar-hidden>
+    <analytics>false</analytics>
+    <guid></guid>
+	<android>
+		<screens small="false" normal="true" large="true" anyDensity="false"/>
+		<manifest>
+			<instrumentation
+				android:targetPackage="org.appcelerator.titanium.testharness"
+				android:name="org.appcelerator.titanium.drillbit.TestHarnessRunner">
+				<meta-data android:name="class" android:value="org.appcelerator.titanium.testharness.Test_harnessActivity"/>
+			</instrumentation>
+		</manifest>
+	</android>
+	<property name="ti.android.enablecoverage" type="bool">true</property>
+	<property name="ti.android.include_all_modules" type="bool">true</property>
+	<property name="ti.android.fastdev" type="bool">false</property>
+	<property name="ti.android.runtime"><%= androidRuntime %></property>
+
+	<property name="ti.ios.enablecoverage" type="bool">true</property>
+	<property name="ti.ios.enablemdfind" type="bool">false</property>
+	<property name="ti.android.threadstacksize" type="int">32768</property>
+</ti:app>


### PR DESCRIPTION
Looks like this is unfortunately the only way to do it due to how Rhino's recursion mechanism for `include` behaves. 
