### PR TITLE
[TIMOB-7429]iOS: Coverflow - setting initial selected image in overflow results presentation issues

### DIFF
--- a/iphone/Classes/AFOpenFlow/AFOpenFlowView.m
+++ b/iphone/Classes/AFOpenFlow/AFOpenFlowView.m
@@ -338,6 +338,7 @@ const static CGFloat kReflectionFraction = 0.85;
 
 - (void)centerOnSelectedCover:(BOOL)animated {
 	CGPoint selectedOffset = CGPointMake(COVER_SPACING * selectedCoverView.number, 0);
+    animated &= (self.frame.size.width > 0);
 	[scrollView setContentOffset:selectedOffset animated:animated];
 }
 


### PR DESCRIPTION
[TIMOB-7429](https://jira.appcelerator.org/browse/TIMOB-7429)

Test case in JIRA.
FR Notes: The issue did only happen with iOS 5.0+, and worked fine in 4.3. So make sure to test both. 
