### PR TITLE
[TIMOB-7616] Titanium.UI.WebView: iOS5: evalJS causes app freeze and deadlock warning

### DIFF
--- a/iphone/Classes/TiUIWebViewProxy.h
+++ b/iphone/Classes/TiUIWebViewProxy.h
@@ -12,6 +12,7 @@
 @interface TiUIWebViewProxy : TiViewProxy<TiEvaluator> {
 @private
 	NSString *pageToken;
+    NSString *evalResult;
 }
 -(void)setPageToken:(NSString*)pageToken;
 

--- a/iphone/Classes/TiUIWebViewProxy.h
+++ b/iphone/Classes/TiUIWebViewProxy.h
@@ -12,7 +12,6 @@
 @interface TiUIWebViewProxy : TiViewProxy<TiEvaluator> {
 @private
 	NSString *pageToken;
-    NSString *evalResult;
 }
 -(void)setPageToken:(NSString*)pageToken;
 

--- a/iphone/Classes/TiUIWebViewProxy.h
+++ b/iphone/Classes/TiUIWebViewProxy.h
@@ -13,6 +13,7 @@
 @private
 	NSString *pageToken;
     NSString *evalResult;
+    BOOL inKJSThread;
 }
 -(void)setPageToken:(NSString*)pageToken;
 

--- a/iphone/Classes/TiUIWebViewProxy.m
+++ b/iphone/Classes/TiUIWebViewProxy.m
@@ -52,13 +52,14 @@
      does not work reliably for evalJS on 5.0 and above. See sample in TIMOB-7616 for fail case.
      */
     if (![NSThread isMainThread]) {
+        inKJSThread = YES;
         [self performSelectorOnMainThread:@selector(evalJS:) withObject:code waitUntilDone:YES];
-        return [evalResult autorelease];
+        inKJSThread = NO;
     }
     else {
         evalResult = [[(TiUIWebView*)[self view] stringByEvaluatingJavaScriptFromString:code] retain];
-        return evalResult;
     }
+    return (inKJSThread ? evalResult : [evalResult autorelease]);
 }
 
 USE_VIEW_FOR_AUTO_HEIGHT

--- a/iphone/Classes/TiUIWebViewProxy.m
+++ b/iphone/Classes/TiUIWebViewProxy.m
@@ -53,12 +53,13 @@
      */
     if (![NSThread isMainThread]) {
         [self performSelectorOnMainThread:@selector(evalJS:) withObject:code waitUntilDone:YES];
+        return [evalResult autorelease];
     }
     else {
         RELEASE_TO_NIL(evalResult);
         evalResult = [[(TiUIWebView*)[self view] stringByEvaluatingJavaScriptFromString:code] retain];
+        return evalResult;
     }
-    return evalResult;
 }
 
 USE_VIEW_FOR_AUTO_HEIGHT

--- a/iphone/Classes/TiUIWebViewProxy.m
+++ b/iphone/Classes/TiUIWebViewProxy.m
@@ -52,12 +52,13 @@
      does not work reliably for evalJS on 5.0 and above. See sample in TIMOB-7616 for fail case.
      */
     if (![NSThread isMainThread]) {
-        [self performSelectorOnMainThread:@selector(evalJS:) withObject:code waitUntilDone:NO];
-        return nil;
+        [self performSelectorOnMainThread:@selector(evalJS:) withObject:code waitUntilDone:YES];
     }
     else {
-        return [(TiUIWebView*)[self view] stringByEvaluatingJavaScriptFromString:code];
+        RELEASE_TO_NIL(evalResult);
+        evalResult = [[(TiUIWebView*)[self view] stringByEvaluatingJavaScriptFromString:code] retain];
     }
+    return evalResult;
 }
 
 USE_VIEW_FOR_AUTO_HEIGHT
@@ -158,6 +159,7 @@ USE_VIEW_FOR_AUTO_WIDTH
 		[[self host] unregisterContext:(id<TiEvaluator>)self forToken:pageToken];
 		RELEASE_TO_NIL(pageToken);
 	}
+    RELEASE_TO_NIL(evalResult);
 	[super _destroy];
 }
 

--- a/iphone/Classes/TiUIWebViewProxy.m
+++ b/iphone/Classes/TiUIWebViewProxy.m
@@ -56,7 +56,6 @@
         return [evalResult autorelease];
     }
     else {
-        RELEASE_TO_NIL(evalResult);
         evalResult = [[(TiUIWebView*)[self view] stringByEvaluatingJavaScriptFromString:code] retain];
         return evalResult;
     }
@@ -160,8 +159,7 @@ USE_VIEW_FOR_AUTO_WIDTH
 		[[self host] unregisterContext:(id<TiEvaluator>)self forToken:pageToken];
 		RELEASE_TO_NIL(pageToken);
 	}
-    RELEASE_TO_NIL(evalResult);
-	[super _destroy];
+    [super _destroy];
 }
 
 -(void)setPageToken:(NSString*)pageToken_


### PR DESCRIPTION
Test is in [JIRA](https://jira.appcelerator.org/browse/TIMOB-7616)
