### PR TITLE
[TIMOB-4884] toImage() on device with retina display is pixellated

### DIFF
--- a/apidoc/Titanium/UI/View.yml
+++ b/apidoc/Titanium/UI/View.yml
@@ -158,7 +158,7 @@ methods:
         optional: true
       - name: honorScaleFactor
         summary: | 
-            When set to true, the image is scaled basd on scale factor of main screen.
+            When set to true, the image is scaled based on scale factor of main screen.
             When set to false the image in the blob has the same dimensions for retina and non retina devices.
         type: Boolean
         optional: true

--- a/apidoc/Titanium/UI/View.yml
+++ b/apidoc/Titanium/UI/View.yml
@@ -142,6 +142,26 @@ methods:
             performed asynchronously. If null, it will be performed immediately.
         type: Callback<Object>
         optional: true
+        
+  - name: toImage
+    since: 1.9.0  
+    summary: Returns an image of the rendered view, as a Blob.
+    platforms: [iphone, ipad]
+    returns:
+        type: Titanium.Blob
+    parameters:
+      - name: f
+        summary: | 
+            Function to be invoked upon completion. If non-null, this method will be 
+            performed asynchronously. If null, it will be performed immediately.
+        type: Callback<Object>
+        optional: true
+      - name: honorScaleFactor
+        summary: | 
+            When set to true, the image is scaled basd on scale factor of main screen.
+            When set to false the image in the blob has the same dimensions for retina and non retina devices.
+        type: Boolean
+        optional: true
   - name: convertPointToView
     summary: |
         Translates a point from this view's coordinate system to another 

--- a/iphone/Classes/TiViewProxy.m
+++ b/iphone/Classes/TiViewProxy.m
@@ -338,7 +338,7 @@ LAYOUTPROPERTIES_SETTER(setMinHeight,minimumHeight,TiFixedValueRuleFromObject,[s
 
 -(TiBlob*)toImage:(id)args
 {
-	KrollCallback *callback = nil;
+    KrollCallback *callback = nil;
     BOOL honorScale = NO;
     
     NSObject *obj = nil;
@@ -377,7 +377,7 @@ LAYOUTPROPERTIES_SETTER(setMinHeight,minimumHeight,TiFixedValueRuleFromObject,[s
 			CGRect rect = CGRectMake(0, 0, size.width, size.height);
 			[TiUtils setView:myview positionRect:rect];
 		}
-        UIGraphicsBeginImageContextWithOptions(size, [myview.layer isOpaque], (honorScale?0.0:1.0));
+		UIGraphicsBeginImageContextWithOptions(size, [myview.layer isOpaque], (honorScale ? 0.0 : 1.0));
 		[myview.layer renderInContext:UIGraphicsGetCurrentContext()];
 		UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
 		[blob setImage:image];

--- a/iphone/Classes/TiViewProxy.m
+++ b/iphone/Classes/TiViewProxy.m
@@ -338,7 +338,22 @@ LAYOUTPROPERTIES_SETTER(setMinHeight,minimumHeight,TiFixedValueRuleFromObject,[s
 
 -(TiBlob*)toImage:(id)args
 {
-	KrollCallback *callback = [args count] > 0 ? [args objectAtIndex:0] : nil;
+	KrollCallback *callback = nil;
+    BOOL honorScale = NO;
+    
+    NSObject *obj = nil;
+    if( [args count] > 0) {
+        obj = [args objectAtIndex:0];
+        
+        if (obj == [NSNull null]) {
+            obj = nil;
+        }
+        
+        if( [args count] > 1) {
+            honorScale = [TiUtils boolValue:[args objectAtIndex:1] def:NO];
+        }
+    }
+    callback = (KrollCallback*)obj;
 	TiBlob *blob = [[[TiBlob alloc] init] autorelease];
 	// we spin on the UI thread and have him convert and then add back to the blob
 	// if you pass a callback function, we'll run the render asynchronously, if you
@@ -362,7 +377,7 @@ LAYOUTPROPERTIES_SETTER(setMinHeight,minimumHeight,TiFixedValueRuleFromObject,[s
 			CGRect rect = CGRectMake(0, 0, size.width, size.height);
 			[TiUtils setView:myview positionRect:rect];
 		}
-		UIGraphicsBeginImageContext(size);
+        UIGraphicsBeginImageContextWithOptions(size, [myview.layer isOpaque], (honorScale?0.0:1.0));
 		[myview.layer renderInContext:UIGraphicsGetCurrentContext()];
 		UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
 		[blob setImage:image];


### PR DESCRIPTION
Test is in JIRA [TIMOB-4884](https://jira.appcelerator.org/browse/TIMOB-4884?focusedCommentId=183063&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-183063)

On IOS toImage can now take 2 parameters with the second boolean parameter. When set to true, the toImage method honors the screen scale factor. 
