### PR TITLE
After socket-connection, if it read nothing for the "timeout"-period, ti...

### DIFF
--- a/android/modules/network/src/java/ti/modules/titanium/network/socket/TCPProxy.java
+++ b/android/modules/network/src/java/ti/modules/titanium/network/socket/TCPProxy.java
@@ -209,7 +209,6 @@ public class TCPProxy extends KrollProxy implements TiStream
 					int timeout = TiConvert.toInt(timeoutProperty);
 
 					clientSocket = new Socket();
-					clientSocket.setSoTimeout(timeout);
 					clientSocket.connect(new InetSocketAddress(host, TiConvert.toInt(getProperty("port"))), timeout);
 
 				} else {


### PR DESCRIPTION
...meout-error occur.  By the modification, no timeout-error occure after the connection. It is same behavior as Socket.TCP's connect of iOS version.

Of course, with this modification, regular connection timeout works correctly. It means an error occurs when the "timeout"-period spent waiting connect to the destination socket after connect() executed.
