### PR TITLE
Socket.TCP timeout for accept() (Android)

### DIFF
--- a/android/modules/network/src/java/ti/modules/titanium/network/socket/TCPProxy.java
+++ b/android/modules/network/src/java/ti/modules/titanium/network/socket/TCPProxy.java
@@ -240,6 +240,11 @@ public class TCPProxy extends KrollProxy implements TiStream
 			while(true) {
 				if(accepting) {
 					try {
+						Object timeoutProperty = getProperty("timeout");
+						if (timeoutProperty != null) {
+							int timeout = TiConvert.toInt(timeoutProperty);
+							serverSocket.setSoTimeout(timeout);
+						}
 						Socket acceptedSocket = serverSocket.accept();
 
 						TCPProxy acceptedTcpProxy = new TCPProxy();


### PR DESCRIPTION
You can use timeout option for accept, like, socket.listen(); socket.timeout = 5
000; socket.accept();, then it wait 5 seconds for incomming connection.
It will explicitly distinct with socket.accept({timeout: 5000}).
