### PR TITLE
iOS: Socket.TCP connect() wait too long when timeout set

### DIFF
--- a/iphone/Classes/TiNetworkSocketTCPProxy.m
+++ b/iphone/Classes/TiNetworkSocketTCPProxy.m
@@ -147,7 +147,9 @@ static NSString* ARG_KEY = @"arg";
         success = [socket connectToHost:host onPort:[TiUtils intValue:port] error:&err];
     }
     else {
-        success = [socket connectToHost:host onPort:[port intValue] withTimeout:[timeout doubleValue] error:&err];
+        success = [socket connectToHost:host onPort:[port intValue] 
+                            withTimeout:[timeout doubleValue] / 1000
+                                  error:&err];
     }
     
     if (err || !success) {


### PR DESCRIPTION
If socket.timeout = 5000; socket.connet();, then it does not timeout after 5000 seconds, not 5 second.  After this modification, it just wait 5 seconds.
