### PR TITLE
[TIMOB-7692] Use __block ref to self during dealloc.

### DIFF
--- a/iphone/Classes/TiModule.m
+++ b/iphone/Classes/TiModule.m
@@ -21,7 +21,14 @@
 
 -(void)dealloc
 {	
-	TiThreadPerformOnMainThread(^{[self unregisterForNotifications];}, YES);
+    // Have to jump through a hoop here to keep the dealloc block from
+    // retaining 'self' by creating a __block access ref. Note that
+    // this is only safe as long as the block until completion is YES.
+    __block id bself = self;
+	TiThreadPerformOnMainThread(^{
+        [bself unregisterForNotifications];
+    }, YES);
+    
 	RELEASE_TO_NIL(host);
 	if (classNameLookup != NULL)
 	{

--- a/iphone/Classes/TiThreading.h
+++ b/iphone/Classes/TiThreading.h
@@ -52,7 +52,8 @@ return result;\
 if (![NSThread isMainThread])\
 {\
 __block id result=nil;\
-TiThreadPerformOnMainThread(^{result=[[self _sync_##method:nil] retain];},YES); \
+__block id bself=self;\
+TiThreadPerformOnMainThread(^{result=[[bself _sync_##method:nil] retain];},YES); \
 return [result autorelease];\
 }\
 return [self _sync_##method:nil];\


### PR DESCRIPTION
Self-explanatory. Avoids `retain` because of how `__block` access works.
