### PR TITLE
[TIMOB-7644][TIMOB-7152] iOS: Memory is not being released when a tab is removed from tabGroup

### DIFF
--- a/iphone/Classes/TiUITabGroup.m
+++ b/iphone/Classes/TiUITabGroup.m
@@ -366,7 +366,8 @@ DEFINE_EXCEPTIONS
 			[controllers addObject:[tabProxy controller]];
 			if ([TiUtils boolValue:[tabProxy valueForKey:@"active"]])
 			{
-				focused = tabProxy;
+                RELEASE_TO_NIL(focused);
+				focused = [tabProxy retain];
 			}
 		}
 
@@ -381,7 +382,7 @@ DEFINE_EXCEPTIONS
 	}
 	else
 	{
-		focused = nil;
+		RELEASE_TO_NIL(focused);
 		[self tabController].viewControllers = nil;
 	}
 

--- a/iphone/Classes/TiUITabGroupProxy.m
+++ b/iphone/Classes/TiUITabGroupProxy.m
@@ -89,8 +89,8 @@
 		
 		//TODO: close all the tabs and fire events
 		
+        [tabProxy removeFromTabGroup];
 		[tabProxy setParentOrientationController:nil];
-		[tabProxy setTabGroup:nil];
 		[tabs removeObject:tabProxy];
 		[self replaceValue:tabs forKey:@"tabs" notification:YES];
 		[self forgetProxy:tabProxy];

--- a/iphone/Classes/TiUITabProxy.m
+++ b/iphone/Classes/TiUITabProxy.m
@@ -34,6 +34,7 @@
     RELEASE_TO_NIL(controllerStack);
 	RELEASE_TO_NIL(tabGroup);
 	RELEASE_TO_NIL(rootController);
+    RELEASE_TO_NIL(controller);
 	RELEASE_TO_NIL(current);
 	[super _destroy];
 }
@@ -295,17 +296,21 @@
 	BOOL animated = [TiUtils boolValue:@"animated" properties:properties def:YES];
 	if ([current window] == window)
 	{
-		[[rootController navigationController] popViewControllerAnimated:animated];
-		return;
+		if ([[rootController navigationController] popViewControllerAnimated:animated] != nil) {
+            return;
+        }
 	}
-	
+    UIViewController *windowController = [[window controller] retain];
+	[self setTabGroup:nil];
+
 	// Manage the navigation controller stack
 	UINavigationController* navController = [rootController navigationController];
 	NSMutableArray* newControllerStack = [NSMutableArray arrayWithArray:[navController viewControllers]];
-	[newControllerStack removeObject:[window controller]];
+	[newControllerStack removeObject:windowController];
 	[navController setViewControllers:newControllerStack animated:animated];
     RELEASE_TO_NIL(controllerStack);
     controllerStack = [newControllerStack retain];
+    [windowController release];
 	
 	[window retain];
 	[window _tabBlur];
@@ -319,6 +324,9 @@
 	{
 		RELEASE_TO_NIL(current);
 	}
+    // this TiUITabController is retaining a reference to self which leads to a cycle, so release to nil
+	RELEASE_TO_NIL(rootController);
+    [window forgetSelf];
 	[window autorelease];
 }
 

--- a/iphone/Classes/TiUITabProxy.m
+++ b/iphone/Classes/TiUITabProxy.m
@@ -326,7 +326,6 @@
 	}
     // this TiUITabController is retaining a reference to self which leads to a cycle, so release to nil
 	RELEASE_TO_NIL(rootController);
-    [window forgetSelf];
 	[window autorelease];
 }
 


### PR DESCRIPTION
[TIMOB-7644](https://jira.appcelerator.org/browse/TIMOB-7644)
[TIMOB-7152](https://jira.appcelerator.org/browse/TIMOB-7152)

Test cases in JIRAs.
FR: Search for 'Proxy' and 'Controller' in Instruments.
