### PR TITLE
[TIMOB-7712] V8: When backing out of an application a crash occurs during nativeDispose.

### DIFF
--- a/android/runtime/v8/src/native/V8Runtime.cpp
+++ b/android/runtime/v8/src/native/V8Runtime.cpp
@@ -261,7 +261,8 @@ JNIEXPORT void JNICALL Java_org_appcelerator_kroll_runtime_v8_V8Runtime_nativeDi
 			// WrappedContext is simply a C++ wrapper for the V8 Context object,
 			// and is used to expose the Context to javascript. See ScriptsModule for
 			// implementation details
-			WrappedContext *wrappedContext = NativeObject::Unwrap<WrappedContext>(moduleContext->ToObject());
+			WrappedContext *wrappedContext = WrappedContext::Unwrap(moduleContext->ToObject());
+			ASSERT(wrappedContext != NULL);
 
 			// Detach each context's global object, and dispose the context
 			wrappedContext->GetV8Context()->DetachGlobal();


### PR DESCRIPTION
See JIRA ticket [7712](https://jira.appcelerator.org/browse/TIMOB-7712) for details.
