### PR TITLE
[TIMOB-7749] Add asynchronous sequences to Drillbit

### DIFF
--- a/drillbit/modules/drillbit/0.1.0/drillbitTest.js
+++ b/drillbit/modules/drillbit/0.1.0/drillbitTest.js
@@ -519,7 +519,7 @@ AsyncTest.prototype.async = function(fn) {
 				self.sequence.shift().call(self);
 			} else {
 				if (self.timer != null) {
-					clearTimeout(self.time);
+					clearTimeout(self.timer);
 				}
 				self.callback.passed();
 			}

--- a/drillbit/modules/drillbit/0.1.0/drillbitTest.js
+++ b/drillbit/modules/drillbit/0.1.0/drillbitTest.js
@@ -507,18 +507,22 @@ function AsyncTest(args) {
 	this.timeoutError = args.timeoutError || null;
 	this.onTimeoutFn = args.onTimeout || null;
 	this.timer = null;
+	this.sequence = [];
 };
 
 AsyncTest.prototype.async = function(fn) {
 	var self = this;
 	return function() {
 		try {
-			if (self.timer != null) {
-				clearTimeout(self.timer);
+			fn.apply(self,arguments);
+			if (self.sequence.length > 0) {
+				self.sequence.shift().call(self);
+			} else {
+				if (self.timer != null) {
+					clearTimeout(self.time);
+				}
+				self.callback.passed();
 			}
-			
-			fn.apply(this, arguments);
-			self.callback.passed();
 		} catch (e) {
 			self.callback.failed(e);
 		}
@@ -544,6 +548,9 @@ AsyncTest.prototype.start = function(callback) {
 					callback.failed(message);
 				}
 			}, this.timeout);
+		}
+		if (this.sequence.length > 0) {
+			this.sequence.shift().call(this);
 		}
 	} catch (e) {
 		callback.failed(e);


### PR DESCRIPTION
Sequences of asynchronous tests can now be defined (see TIMOB-7749 for examples). Asynchronous tests are added by pushing to the this.sequence array (e.g. this.sequence.push(...)). Uses the existing `async` function generator for callbacks. Asynchronous tests are automatically started upon return from the `start` function.
