### PR TITLE
[TIMOB-7715] Change main thread executions to use GCD groups

### DIFF
--- a/iphone/Classes/TiApp.mm
+++ b/iphone/Classes/TiApp.mm
@@ -110,7 +110,7 @@ TI_INLINE void waitForMemoryPanicCleared();   //WARNING: This must never be run 
 
 +(void)initialize
 {
-	TiThreadInitalize();
+	TiThreadInitialize();
 }
 
 + (TiApp*)app

--- a/iphone/Classes/TiBase.h
+++ b/iphone/Classes/TiBase.h
@@ -591,8 +591,7 @@ void TiThreadRemoveFromSuperviewOnMainThread(UIView* view,BOOL waitForFinish);
 
 BOOL TiThreadProcessPendingMainThreadBlocks(NSTimeInterval timeout, BOOL doneWhenEmpty, void * reserved );
 
-	
-void TiThreadInitalize();
+void TiThreadInitialize();
 
 #include "TiPublicAPI.h"
 

--- a/iphone/Classes/TiRootViewController.m
+++ b/iphone/Classes/TiRootViewController.m
@@ -273,13 +273,13 @@
 	[rootView release];
 }
 
-- (void)viewWillAppear:(BOOL)animated;    // Called when the view is about to made visible. Default does nothing
+- (void)viewWillAppear:(BOOL)animated;    
 {
 	TiThreadProcessPendingMainThreadBlocks(0.1, YES, nil);
 	[[viewControllerStack lastObject] viewWillAppear:animated];
 }
 
-- (void)viewWillDisappear:(BOOL)animated; // Called when the view is dismissed, covered or otherwise hidden. Default does nothing
+- (void)viewWillDisappear:(BOOL)animated; 
 {
 	[[viewControllerStack lastObject] viewWillDisappear:animated];
 }


### PR DESCRIPTION
Replaces the manual queue while ensuring serial behavior and giving a massive performance improvement (and it avoids deadlocks). This fix **does** need to be thoroughly checked to ensure that we avoid deadlocks and have consistent behavior.

This fix **regresses** [TIMOB-4538](https://jira.appcelerator.org/browse/TIMOB-4538) and [TIMOB-1542](https://jira.appcelerator.org/browse/TIMOB-1542). This is somewhat intentional because these special-case bugs are due to suspension interactions only and these regressions have been confirmed to be OK and fixed in the near term, due to the expense and danger of the manual queue. As part of merging this ticket, the responsible person should reopen these two bugs.
