### PR TITLE
[TIMOB-7681] Preserve remote hires when caching + local file load fixes

### DIFF
--- a/iphone/Classes/ImageLoader.m
+++ b/iphone/Classes/ImageLoader.m
@@ -196,6 +196,7 @@
     if (self = [super init]) {
         remoteURL = [url retain];        
         local = NO;
+        
         if ([remoteURL isFileURL]) {
             localPath = [[remoteURL path] retain];
             local = YES;
@@ -222,11 +223,16 @@
 {
     if (!local && imageData != nil) {
         NSFileManager* fm = [NSFileManager defaultManager];
-        if ([fm isDeletableFileAtPath:localPath]) {
-            [fm removeItemAtPath:localPath error:nil];
+        NSString* path = localPath;
+        if (hires) {
+            path = [NSString stringWithFormat:@"%@@2x.%@", [localPath stringByDeletingPathExtension], [localPath pathExtension]];
         }
-        if (![fm createFileAtPath:localPath contents:imageData  attributes:nil]) {
-            NSLog(@"[WARN] Unknown error serializing image %@ to path %@", remoteURL, localPath);
+        
+        if ([fm isDeletableFileAtPath:path]) {
+            [fm removeItemAtPath:path error:nil];
+        }
+        if (![fm createFileAtPath:path contents:imageData  attributes:nil]) {
+            NSLog(@"[WARN] Unknown error serializing image %@ to path %@", remoteURL, path);
         }
     }
 }
@@ -378,7 +384,7 @@ DEFINE_EXCEPTIONS
 	return sharedLoader;
 }
 
--(ImageCacheEntry *)setImage:(id)image forKey:(NSURL *)url
+-(ImageCacheEntry *)setImage:(id)image forKey:(NSURL *)url hires:(BOOL)hires;
 {
 	NSString *urlString = [url absoluteString];
 	if (image==nil)
@@ -396,6 +402,7 @@ DEFINE_EXCEPTIONS
 #endif
 	}
 	ImageCacheEntry * newEntry = [[[ImageCacheEntry alloc] initWithURL:url] autorelease];
+    [newEntry setHires:hires];
     
     if ([image isKindOfClass:[UIImage class]]) {
         [newEntry setFullImage:image];
@@ -469,7 +476,7 @@ DEFINE_EXCEPTIONS
 					resultImage = [UIImage imageWithCGImage:[resultImage CGImage] scale:2.0 orientation:[resultImage imageOrientation]];
 				}
 			}
-		    result = [self setImage:resultImage forKey:url];
+		    result = [self setImage:resultImage forKey:url hires:NO];
 		}
         else // Check and see if we cached a file to disk
         {
@@ -479,7 +486,7 @@ DEFINE_EXCEPTIONS
                 NSLog(@"[CACHE DEBUG] Retrieving local image [prefetch]: %@", diskCache);
 #endif
                 UIImage* resultImage = [UIImage imageWithContentsOfFile:diskCache];
-                result = [self setImage:resultImage forKey:url];                
+                result = [self setImage:resultImage forKey:url hires:NO];                
             }
         }
 	}
@@ -487,14 +494,14 @@ DEFINE_EXCEPTIONS
 	return result;
 }
 
--(id)cache:(id)image forURL:(NSURL*)url size:(CGSize)imageSize
+-(id)cache:(id)image forURL:(NSURL*)url size:(CGSize)imageSize hires:(BOOL)hires
 {
-	return [[self setImage:image forKey:url] imageForSize:imageSize];
+	return [[self setImage:image forKey:url hires:hires] imageForSize:imageSize];
 }
 
 -(id)cache:(id)image forURL:(NSURL*)url
 {
-	return [self cache:image forURL:url size:CGSizeZero];
+	return [self cache:image forURL:url size:CGSizeZero hires:NO];
 }
 
 -(id)loadRemote:(NSURL*)url
@@ -516,7 +523,7 @@ DEFINE_EXCEPTIONS
 	{
 	   NSData *data = [req responseData];
 	   UIImage *resultImage = [UIImage imageWithData:data];
-	   ImageCacheEntry *result = [self setImage:resultImage forKey:url];
+	   ImageCacheEntry *result = [self setImage:resultImage forKey:url hires:NO];
 	   [result setData:data];
 	   return [result imageForSize:CGSizeZero];
 	}
@@ -740,9 +747,8 @@ DEFINE_EXCEPTIONS
 		{
 			BOOL hires = [TiUtils boolValue:[[req userInfo] valueForKey:@"hires"] def:NO];
             
-		    [self cache:data forURL:[req url]];
+		    [self cache:data forURL:[req url] size:CGSizeZero hires:hires];
 			ImageCacheEntry *entry = [self entryForKey:[req url]];
-			[entry setHires:hires];
             
             image = [entry fullImage];
 		}

--- a/iphone/Classes/ImageLoader.m
+++ b/iphone/Classes/ImageLoader.m
@@ -224,7 +224,7 @@
     if (!local && imageData != nil) {
         NSFileManager* fm = [NSFileManager defaultManager];
         NSString* path = localPath;
-        if (hires) {
+        if (hires && [TiUtils isRetinaDisplay]) { // Save as @2x w/retina
             path = [NSString stringWithFormat:@"%@@2x.%@", [localPath stringByDeletingPathExtension], [localPath pathExtension]];
         }
         

--- a/iphone/Classes/TiUIImageView.m
+++ b/iphone/Classes/TiUIImageView.m
@@ -540,8 +540,6 @@ DEFINE_EXCEPTIONS
 		image = [[ImageLoader sharedLoader] loadImmediateImage:fileUrl withSize:CGSizeMake(TiDimensionCalculateValue(width, autoWidth),
 																						   TiDimensionCalculateValue(height, autoHeight))];
 	}
-    else if ([arg isKindOfClass:[NSString class]]) {
-    }
 	else if ([arg isKindOfClass:[UIImage class]])
 	{
 		// called within this class

--- a/iphone/Classes/TiUIImageView.m
+++ b/iphone/Classes/TiUIImageView.m
@@ -431,12 +431,13 @@ DEFINE_EXCEPTIONS
 		// NOTE: Loading from URL means we can't pre-determine any % value.
 		CGSize imageSize = CGSizeMake(TiDimensionCalculateValue(width, 0.0), 
 									  TiDimensionCalculateValue(height,0.0));
+
 		if ([TiUtils boolValue:[[self proxy] valueForKey:@"hires"]])
 		{
 			imageSize.width *= 2;
 			imageSize.height *= 2;
 		}
-		
+        
 		UIImage *image = [[ImageLoader sharedLoader] loadImmediateImage:url_ withSize:imageSize];
 		if (image==nil)
 		{
@@ -661,7 +662,7 @@ DEFINE_EXCEPTIONS
 	
 	BOOL replaceProperty = YES;
 	UIImage *image = nil;
-	
+    NSURL* imageURL = nil;
 	if ([arg isKindOfClass:[UIImage class]]) 
 	{
 		// called within this class
@@ -680,7 +681,7 @@ DEFINE_EXCEPTIONS
 	{
 		if ([arg isKindOfClass:[NSString class]])
 		{
-			[self loadUrl:[NSURL URLWithString:arg]];
+			[self loadUrl:[TiUtils toURL:arg proxy:[self proxy]]];
 			return;
 		}
 		if ([arg isKindOfClass:[NSURL class]])


### PR DESCRIPTION
This fix should be regressed against [TIMOB-7051](https://jira.appcelerator.org/browse/TIMOB-7051). The most significant changes here are to loading resources from the filesystem directly (which now correctly displays the "default" image if a file doesn't load) and the `@2x` caching. This means that testers should:
- Regress against other known remote caching issues
- Test on: simulator, retina simulator, device, retina device (and ensure consistency of image)
