### PR TITLE
[TIMOB-6463] Protect/unprotect keyboard toolbar items

### DIFF
--- a/iphone/Classes/KrollObject.m
+++ b/iphone/Classes/KrollObject.m
@@ -1193,6 +1193,11 @@ TI_INLINE TiStringRef TiStringCreateWithPointerValue(int value)
 		return;
 	}
 
+    // TODO: Enquing safeProtect here may not be enough to guarantee that the object is actually
+    // safely protected "in time" (i.e. it may be GC'd before the safe protect is evaluated
+    // by the queue processor). We need to seriously re-evaluate the memory model and thread
+    // interactions during such.
+    
 	if (![context isKJSThread])
 	{
 		NSOperation * safeProtect = [[NSInvocationOperation alloc] initWithTarget:self

--- a/iphone/Classes/TiBase.h
+++ b/iphone/Classes/TiBase.h
@@ -67,6 +67,8 @@ void TiLogMessage(NSString* str, ...);
 #define degreesToRadians(x) (M_PI * x / 180.0)
 #define radiansToDegrees(x) (x * (180.0 / M_PI))
 
+// TODO: Need to update RELEASE_TO_NIL etc. to be friendly to rememberproxy/forgetproxy for concurrent
+// memory mgt.
 #define RELEASE_TO_NIL(x) { if (x!=nil) { [x release]; x = nil; } }
 #define RELEASE_TO_NIL_AUTORELEASE(x) { if (x!=nil) { [x autorelease]; x = nil; } }
 #define RELEASE_AND_REPLACE(x,y) { [x release]; x = [y retain]; }

--- a/iphone/Classes/TiUITextWidgetProxy.m
+++ b/iphone/Classes/TiUITextWidgetProxy.m
@@ -24,6 +24,7 @@ DEFINE_DEF_BOOL_PROP(suppressReturn,YES);
 	for (TiViewProxy * thisToolBarItem in keyboardToolbarItems)
 	{
 		[thisToolBarItem windowWillClose];
+        [self forgetProxy:thisToolBarItem];
 	}
 	[super windowWillClose];
 }
@@ -33,6 +34,9 @@ DEFINE_DEF_BOOL_PROP(suppressReturn,YES);
 	[keyboardTiView removeFromSuperview];
 	[keyboardUIToolbar removeFromSuperview];
 	RELEASE_TO_NIL(keyboardTiView);
+    for (TiProxy* proxy in keyboardToolbarItems) {
+        [self forgetProxy:proxy];
+    }
 	RELEASE_TO_NIL(keyboardToolbarItems);
 	RELEASE_TO_NIL(keyboardUIToolbar);
 	[super dealloc];

--- a/iphone/Classes/TiUITextWidgetProxy.m
+++ b/iphone/Classes/TiUITextWidgetProxy.m
@@ -155,7 +155,7 @@ DEFINE_DEF_BOOL_PROP(suppressReturn,YES);
     // - Any property setter which is active on the main thread only MAY NOT protect their object
     // correctly or in time (see the comment in -[KrollObject noteKeylessKrollObject:]).
     //
-    // This may have to be done as part of TIMOB-6292 (convert KrollContext to serialized GCD)
+    // This may have to be done as part of TIMOB-6990 (convert KrollContext to serialized GCD)
     
     if ([value isKindOfClass:[NSArray class]]) {
         for (id item in value) {


### PR DESCRIPTION
This fix properly memory-manages the keyboard toolbar items constants for text fields.

Note that there are numerous `TODO`s added to the source regarding the inadequacy of our current memory management infrastructure and how it relates to timing and the "discovery" of proxy objects. I will likely file some TIMOB bugs related to them.
