### PR TITLE
TIMOB-7792 Studio needs an additional command for iphone/builder.py that performs adhoc distribution builds

### DIFF
--- a/support/iphone/builder.py
+++ b/support/iphone/builder.py
@@ -730,6 +730,16 @@ def main(args):
 			link_version = iphone_version
 			appuuid = dequote(args[6].decode("utf-8"))
 			dist_name = dequote(args[7].decode("utf-8"))
+			if argc > 8:
+				devicefamily = dequote(args[8].decode("utf-8"))
+			if argc > 9:
+				# this is host:port from the debugger
+				debughost = dequote(args[9].decode("utf-8"))
+				if debughost=='':
+					debughost=None
+					debugport=None
+				else:
+					debughost,debugport = debughost.split(":")
 			target = 'Release'
 			deploytype = 'production'
 			


### PR DESCRIPTION
Changes to builder.py:
-Copied logic from the "install" command and added "adhoc" command
-"adhoc" command has the following differences:
 -Utilizes an iPhone distribution certificate instead of iPhone development certificate
 -Does not install into iTunes nor launches iTunes
