### PR TITLE
[TIDOC-416] Removed bogus Filesystem.createFile method.

### DIFF
--- a/apidoc/Titanium/Filesystem/File.yml
+++ b/apidoc/Titanium/Filesystem/File.yml
@@ -43,6 +43,7 @@ description: |
 extends: Titanium.Proxy
 since: "0.1"
 platforms: [android, iphone, ipad]
+createable: false
 examples: 
   - title: Reading a File
     example: |


### PR DESCRIPTION
File.yml was missing the createable: false flag.
