### PR TITLE
Timob 7840 1 8 x : Blocker: Android: WebView.js: Runitme Error on launch: Uncaught TypeError: Object [object WebView] has no method 'setHtml'

### DIFF
--- a/demos/KitchenSink/Resources/examples/web_views.js
+++ b/demos/KitchenSink/Resources/examples/web_views.js
@@ -97,12 +97,14 @@ tableview.addEventListener('click', function(e)
 		win.tab.open(w);
 		var xhr = Titanium.Network.createHTTPClient();
 		var baseURL = 'http://www.google.com';
-		if (Titanium.Platform.name != 'android') { // TIMOB-7840
-			xhr.onload = function()
-			{
+		xhr.onload = function()
+		{
+			if (Titanium.Platform.name != 'android') { // TIMOB-7840
 				webview.setHtml(this.responseText, { baseURL: baseURL });
-			};
-		}
+			} else {
+				webview.html = this.responseText;
+			}
+		};
 		
 		// open the client
 		xhr.open('GET',baseURL);

--- a/demos/KitchenSink/Resources/examples/web_views.js
+++ b/demos/KitchenSink/Resources/examples/web_views.js
@@ -97,11 +97,13 @@ tableview.addEventListener('click', function(e)
 		win.tab.open(w);
 		var xhr = Titanium.Network.createHTTPClient();
 		var baseURL = 'http://www.google.com';
-		xhr.onload = function()
-		{
-			webview.setHtml(this.responseText, { baseURL: baseURL });
-		};
-
+		if (Titanium.Platform.name != 'android') { // TIMOB-7840
+			xhr.onload = function()
+			{
+				webview.setHtml(this.responseText, { baseURL: baseURL });
+			};
+		}
+		
 		// open the client
 		xhr.open('GET',baseURL);
 		


### PR DESCRIPTION
https://jira.appcelerator.org/browse/TIMOB-7840
For 1.8.2 release, we just skip setHtml() test for Android since this method is not exposed to users on Android in this release.
Testing steps are in the ticket.
