### PR TITLE
[TIMOB-5268] Ensure TiRefreshViewEnqueued is cleared on early return

### DIFF
--- a/iphone/Classes/TiViewProxy.m
+++ b/iphone/Classes/TiViewProxy.m
@@ -1709,6 +1709,7 @@ if(OSAtomicTestAndSetBarrier(flagBit, &dirtyflags))	\
 		// if not visible, ignore layout
 		if (view.hidden)
 		{
+			OSAtomicTestAndClearBarrier(TiRefreshViewEnqueued, &dirtyflags);
 			return;
 		}
 		


### PR DESCRIPTION
Test is in [JIRA](https://jira.appcelerator.org/browse/TIMOB-5268)

Did not see any flickering but show() was not working properly. 
