### PR TITLE
[TIDOC-420] APIDoc: Bad link in Ti.Filesystem

### DIFF
--- a/apidoc/Titanium/Filesystem/Filesystem.yml
+++ b/apidoc/Titanium/Filesystem/Filesystem.yml
@@ -62,8 +62,8 @@ methods:
     parameters:
       - name: mode
         summary: |
-            Access mode. Either <Titanium.Stream.MODE_READ>, <Titanium.Stream.MODE_WRITE>, or 
-            <Titanium.Stream. MODE_APPEND>.
+            Access mode. Either <Titanium.Filesystem.MODE_READ>, <Titanium.Filesystem.MODE_WRITE>, or 
+            <Titanium.Filesystem.MODE_APPEND>.
         type: Number
         
       - name: path


### PR DESCRIPTION
https://jira.appcelerator.org/browse/TIDOC-420
