### PR TITLE
[TIMOB-7866] Don't Release At Completion

### DIFF
--- a/iphone/Classes/TiMediaVideoPlayerProxy.m
+++ b/iphone/Classes/TiMediaVideoPlayerProxy.m
@@ -808,9 +808,7 @@ NSArray* moviePlayerKeys = nil;
 			}
 			[self fireEvent:@"complete" withObject:event];
 		}
-		// Release memory
 		playing = NO;
-		RELEASE_TO_NIL_AUTORELEASE(movie);
 	}
 	else if ([name isEqualToString:MPMoviePlayerScalingModeDidChangeNotification] && [self _hasListeners:@"resize"])
 	{


### PR DESCRIPTION
Releasing the movie at completion means that we will no longer be able to programmatically control it (for example, the "stop" method won't have a reference to the movie).

The movie will be released when the proxy is destroyed.
