### PR TITLE
timob-7842: 'return' event should only fire once when search key is clicked

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIText.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIText.java
@@ -290,8 +290,8 @@ public class TiUIText extends TiUIView
 		if (DBG) {
 			Log.d(LCAT, "ActionID: " + actionId + " KeyEvent: " + (keyEvent != null ? keyEvent.getKeyCode() : null));
 		}
-		//checking keyEvent is a workaround for a known android bug: this method is called twice when return key is clicked.
-		if (keyEvent != null && actionId != EditorInfo.IME_ACTION_GO && actionId != EditorInfo.IME_ACTION_SEND) {
+		//This check is a workaround for a known android bug: this method is called twice when return key is clicked.
+		if (actionId != EditorInfo.IME_ACTION_SEARCH && actionId != EditorInfo.IME_ACTION_GO && actionId != EditorInfo.IME_ACTION_SEND) {
 			proxy.fireEvent("return", data);
 		}
 

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIText.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIText.java
@@ -290,7 +290,8 @@ public class TiUIText extends TiUIView
 		if (DBG) {
 			Log.d(LCAT, "ActionID: " + actionId + " KeyEvent: " + (keyEvent != null ? keyEvent.getKeyCode() : null));
 		}
-		//This check is a workaround for a known android bug: this method is called twice when return key is clicked.
+		//This is to prevent 'return' event from being fired twice when return key is hit. In other words, when return key is clicked
+		//this callback is triggered twice: the first time with actionId = EditorInfo.IME_NULL, the 2nd time with the corresponding return key actionId.
 		if (actionId != EditorInfo.IME_NULL) {
 			proxy.fireEvent("return", data);
 		}

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIText.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIText.java
@@ -291,7 +291,7 @@ public class TiUIText extends TiUIView
 			Log.d(LCAT, "ActionID: " + actionId + " KeyEvent: " + (keyEvent != null ? keyEvent.getKeyCode() : null));
 		}
 		//This check is a workaround for a known android bug: this method is called twice when return key is clicked.
-		if (actionId != EditorInfo.IME_ACTION_SEARCH && actionId != EditorInfo.IME_ACTION_GO && actionId != EditorInfo.IME_ACTION_SEND) {
+		if (actionId != EditorInfo.IME_NULL) {
 			proxy.fireEvent("return", data);
 		}
 


### PR DESCRIPTION
JIRA ticket: https://jira.appcelerator.org/browse/TIMOB-7842
Testing steps in JIRA, there are 2 tests: the first is in description, the 2nd is in my last comment.
