### PR TITLE
TIMOB-7839 Textfields shouldn't be focused during modal presentations.

### DIFF
--- a/iphone/Classes/TiApp.mm
+++ b/iphone/Classes/TiApp.mm
@@ -566,6 +566,14 @@ TI_INLINE void waitForMemoryPanicCleared();   //WARNING: This must never be run 
 		[windowView addSubview:rootView];
 	}
 
+	/*
+	 *	In iPad (TIMOB 7839) there is a bug in iOS where a text field having
+	 *	focus during a modal presentation can lead to an edge case.
+	 *	The new view is not attached yet, and any current view will be covered
+	 *	by the new modal controller. Because of this, there is no valid reason
+	 *	to have a text field with focus.
+	 */
+	[controller dismissKeyboard];
 
 	UINavigationController *navController = nil; //[(TiRootViewController *)controller focusedViewController];
 	if (navController==nil)

--- a/iphone/Classes/TiRootViewController.h
+++ b/iphone/Classes/TiRootViewController.h
@@ -80,3 +80,15 @@
 - (void)closeWindow:(TiWindowProxy *)window withObject:(id)args;
 
 @end
+
+@interface TiRootViewController (unsupported_internal)
+/*
+ *	Methods declarations stored or moved in this category are NOT to be used
+ *	by modules, as these methods can be added or removed from Titanium as
+ *	needed, and have not been vetted for long-term use. This category itself
+ *	may be moved to a private header later on, even.
+ */
+
+-(void)dismissKeyboard;
+
+@end

--- a/iphone/Classes/TiRootViewController.m
+++ b/iphone/Classes/TiRootViewController.m
@@ -254,6 +254,11 @@
 
 #pragma mark UIViewController methods
 
+-(void)dismissKeyboard
+{
+	[keyboardFocusedProxy blur:nil];
+}
+
 -(void)loadView
 {
 	TiRootView *rootView = [[TiRootView alloc] initWithFrame:[[UIScreen mainScreen] applicationFrame]];


### PR DESCRIPTION
Test is in Jira.
