### PR TITLE
[TIMOB-7779] Android: V8: Proxy memory leak on emulator.

### DIFF
--- a/android/runtime/v8/src/java/org/appcelerator/kroll/runtime/v8/V8Runtime.java
+++ b/android/runtime/v8/src/java/org/appcelerator/kroll/runtime/v8/V8Runtime.java
@@ -15,7 +15,6 @@ import org.appcelerator.kroll.KrollRuntime;
 import org.appcelerator.kroll.common.TiConfig;
 import org.appcelerator.kroll.common.TiDeployData;
 
-import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
 import android.os.Message;
@@ -40,12 +39,16 @@ public final class V8Runtime extends KrollRuntime implements Handler.Callback
 		boolean useGlobalRefs = true;
 		TiDeployData deployData = getKrollApplication().getDeployData();
 
+		/* TODO: Disabling this workaround for emulator to resolve issues
+		 *       seen in TIMOB-7779. Once it has been determined this workaround
+		 *       will never be needed it should be removed (TIMOB-7706).
 		if (Build.PRODUCT.equals("sdk") || Build.PRODUCT.equals("google_sdk") || Build.FINGERPRINT.startsWith("generic")) {
 			if (DBG) {
 				Log.d(TAG, "Emulator detected, storing global references in a global Map");
 			}
 			useGlobalRefs = false;
 		}
+		*/
 
 		if (!libLoaded) {
 			System.loadLibrary("stlport_shared");


### PR DESCRIPTION
This change disables the JNI reference workaround we used only for the emulator.
It is believed this is no longer required with the memory fixes we have made
and now does not function correctly.

For testing run the test cases in the description section of TIMOB-7779.
