### PR TITLE
[TIMOB-7586] save image blob in a format corresponding to its mime type and set default mime type for TiView.toImage() to image/png

### DIFF
--- a/iphone/Classes/TiBlob.m
+++ b/iphone/Classes/TiBlob.m
@@ -175,7 +175,10 @@
 		}
 		case TiBlobTypeImage:
 		{
-			return UIImageJPEGRepresentation(image,1.0);
+            if ([@"image/png" isEqualToString:mimetype]) {
+                return UIImagePNGRepresentation(image);
+            }
+            return UIImageJPEGRepresentation(image,1.0);
 		}
 		default: {
 			break;

--- a/iphone/Classes/TiViewProxy.m
+++ b/iphone/Classes/TiViewProxy.m
@@ -547,6 +547,7 @@ LAYOUTPROPERTIES_SETTER(setMinHeight,minimumHeight,TiFixedValueRuleFromObject,[s
 		[myview.layer renderInContext:UIGraphicsGetCurrentContext()];
 		UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
 		[blob setImage:image];
+        [blob setMimeType:@"image/png" type:TiBlobTypeImage];
 		UIGraphicsEndImageContext();
 		if (callback != nil)
 		{


### PR DESCRIPTION
[TIMOB-7586](https://jira.appcelerator.org/browse/TIMOB-7586)
[TIMOB-4594](https://jira.appcelerator.org/browse/TIMOB-4594)

Saving in PNG by default also resolves a parity issue with Android where view.toImage() always returns PNG.

Test instructions:
Use code from [TIMOB-7586](https://jira.appcelerator.org/browse/TIMOB-7586), run it, then verify file contents at ~/Library/Application\ Support/iPhone\ Simulator/4.3.2/Applications/XXXXXX/Documents/tst.png' with Preview.app (toggle menu View/Show Image Background)
