### PR TITLE
[TIMOB-7861] workaround for iOS issue when UITableView with sections is updated when UISearchDisplayController is active

### DIFF
--- a/iphone/Classes/TiUITableView.h
+++ b/iphone/Classes/TiUITableView.h
@@ -63,6 +63,7 @@
 	NSString * filterAttribute;
 	NSString * searchString;
 	NSMutableArray * searchResultIndexes;
+    BOOL searchActivated;
 	BOOL filterCaseInsensitive;
 	BOOL allowsSelectionSet;
 	id	lastFocusedView; //DOES NOT RETAIN.	

--- a/iphone/Classes/TiUITableView.m
+++ b/iphone/Classes/TiUITableView.m
@@ -955,6 +955,10 @@
 
 - (void)updateSearchResultIndexes
 {
+	if ([searchString length]==0) {
+        RELEASE_TO_NIL(searchResultIndexes);
+		return;
+	}
 	NSEnumerator * searchResultIndexEnumerator;
 	if(searchResultIndexes == nil)
 	{
@@ -1210,18 +1214,14 @@
 {
 	// called when text starts editing
 	[self showSearchScreen:nil];
+    searchActivated = YES;
+    [tableview reloadData];
 }
 
 - (void)searchBar:(UISearchBar *)searchBar textDidChange:(NSString *)searchText
 {
 	[self setSearchString:searchText];
 	// called when text changes (including clear)
-	if([searchText length]==0)
-	{
-		// Redraw visible cells
-        [tableview reloadRowsAtIndexPaths:[tableview indexPathsForVisibleRows] withRowAnimation:UITableViewRowAnimationNone];
-		return;
-	}
 	[self updateSearchResultIndexes];
 }
 
@@ -1236,6 +1236,8 @@
 {
 	// called when cancel button pressed
 	[searchBar setText:nil];
+    searchActivated = NO;
+    [tableview reloadData];
 }
 
 #pragma mark Section Header / Footer
@@ -1569,6 +1571,12 @@
 if(ourTableView != tableview)	\
 {	\
 	return result;	\
+}
+
+#define RETURN_IF_SEARCH_IS_ACTIVE(result)	\
+if(searchActivated)	\
+{	\
+return result;	\
 }
 
 - (NSInteger)tableView:(UITableView *)table numberOfRowsInSection:(NSInteger)section
@@ -1960,6 +1968,7 @@ if(ourTableView != tableview)	\
 - (CGFloat)tableView:(UITableView *)ourTableView heightForHeaderInSection:(NSInteger)section
 {
 	RETURN_IF_SEARCH_TABLE_VIEW(0.0);
+    RETURN_IF_SEARCH_IS_ACTIVE(0.0);
 	TiUITableViewSectionProxy *sectionProxy = nil;
 	TiUIView *view = [self sectionView:section forLocation:@"headerView" section:&sectionProxy];
 	TiViewProxy *viewProxy = (TiViewProxy *)[view proxy];
@@ -2007,6 +2016,7 @@ if(ourTableView != tableview)	\
 - (CGFloat)tableView:(UITableView *)ourTableView heightForFooterInSection:(NSInteger)section
 {
 	RETURN_IF_SEARCH_TABLE_VIEW(0.0);
+    RETURN_IF_SEARCH_IS_ACTIVE(0.0);
 	TiUITableViewSectionProxy *sectionProxy = nil;
 	TiUIView *view = [self sectionView:section forLocation:@"footerView" section:&sectionProxy];
 	TiViewProxy *viewProxy = (TiViewProxy *)[view proxy];

--- a/iphone/Classes/TiUITableView.m
+++ b/iphone/Classes/TiUITableView.m
@@ -1218,6 +1218,14 @@
     [tableview reloadData];
 }
 
+- (void)searchBarTextDidEndEditing:(UISearchBar *)searchBar
+{
+    if (searchActivated && ([searchBar.text length] == 0)) {
+        searchActivated = NO;
+        [tableview reloadData];
+    }
+}
+
 - (void)searchBar:(UISearchBar *)searchBar textDidChange:(NSString *)searchText
 {
 	[self setSearchString:searchText];
@@ -1236,8 +1244,10 @@
 {
 	// called when cancel button pressed
 	[searchBar setText:nil];
-    searchActivated = NO;
-    [tableview reloadData];
+    if (searchActivated) {
+        searchActivated = NO;
+        [tableview reloadData];
+    }
 }
 
 #pragma mark Section Header / Footer


### PR DESCRIPTION
[TIMOB-7861](https://jira.appcelerator.org/browse/TIMOB-7861)

The issue is not a Titanium bug but the behavior of UITableView.  E.g. see http://stackoverflow.com/questions/3647319/reloading-uitableview-behind-uisearchdisplaycontroller
The proper fix would be to avoid any updates to original UITableView. But it's not completely possible due to the way Titanium APIs implemented.
I tried many different ways before coming to the solution with zero section height. which I think the most elegant.

Test instructions in JIRA. + KS Table View tests with Search Bar
