### PR TITLE
[TIMOB-7931] Custom Info.plist files without CFBundleShortVersionString throw an exception

### DIFF
--- a/support/tiapp.py
+++ b/support/tiapp.py
@@ -468,18 +468,22 @@ class TiAppXML(object):
 			plist = st + version + fn
 			
 		# replace the CFBundleShortVersionString in case it's changed
-		i = plist.index('CFBundleShortVersionString')
-		if i:
-			i = plist.index('<string>',i+1)
-			e = plist.index('</string>',i+1)
-			st = plist[0:i+8]
-			fn = plist[e:]
-			CFBundleShortVersionString = self.properties['version']
-			app_version_ = CFBundleShortVersionString.split('.')
-			if(len(app_version_) > 3):
-				CFBundleShortVersionString = app_version_[0]+'.'+app_version_[1]+'.'+app_version_[2]
-			plist = st + CFBundleShortVersionString + fn
-			
+		try:
+			i = plist.index('CFBundleShortVersionString')
+			if i:
+				i = plist.index('<string>',i+1)
+				e = plist.index('</string>',i+1)
+				st = plist[0:i+8]
+				fn = plist[e:]
+				CFBundleShortVersionString = self.properties['version']
+				app_version_ = CFBundleShortVersionString.split('.')
+				if(len(app_version_) > 3):
+					CFBundleShortVersionString = app_version_[0]+'.'+app_version_[1]+'.'+app_version_[2]
+				plist = st + CFBundleShortVersionString + fn
+		except ValueError:
+			print "[WARN] You appear to be using a custom Info.plist that does not contain the required CFBundleShortVersionString key."
+			print "[WARN] This will cause problems with App Store submissions if not corrected."
+		
 		i = plist.rindex('</dict>')	
 		if i:
 			before = plist[0:i]


### PR DESCRIPTION
Code change grabs the exception generated in TiApp.py if CFBundleShortVersionString is missing from a custom Info.plist and hands the user a friendly reminder via a console [WARN] that their custom Info.plist file needs to be updated.

While the original [TIMOB-7931] specifically addressed KitchenSink build problems, this code will help move users with projects built against older TiMobile sdks towards the current Apple submission requirements.

To test, use the current kitchen sink project.

Build using current code base and an exception is thrown in tiapp.py because the CFBundleShortVersion key does not exist in the custom Info.plist file from the {project} directory.

Add the key as listed in [TIMOB-7931] to the Info.plist and the build completes as expected.

Note:  By grabbing and handling the exception, this code allows the build to continue.  We could force the key to be added to the generated Info.plist but I feel that the user needs to update their original Info.plist without the build tools interference.
