### PR TITLE
[TIMOB-7831] Android: Master/Detail Application Template: console logs JNI: DeleteGlobalRef(0xdebcce57) failed to find entry warnings

### DIFF
--- a/android/runtime/v8/src/native/JavaObject.cpp
+++ b/android/runtime/v8/src/native/JavaObject.cpp
@@ -173,6 +173,7 @@ void JavaObject::wrap(Handle<Object> jsObject)
 
 void JavaObject::attach(jobject javaObject)
 {
+	ASSERT(javaObject_ == NULL);
 	UPDATE_STATS(0, -1);
 
 	handle_.MakeWeak(this, DetachCallback);

--- a/android/runtime/v8/src/native/JavaObject.h
+++ b/android/runtime/v8/src/native/JavaObject.h
@@ -39,6 +39,9 @@ public:
 
 	// Attach to the given Java object. A reference
 	// to this object will be held until it is detached.
+	// You may only call this method once with a Java object.
+	// Future calls are only allowed by passing NULL for javaObject
+	// to trigger a re-attachment.
 	void attach(jobject javaObject);
 
 	// Unreference the Java object so it may be collected.

--- a/android/runtime/v8/src/native/TypeConverter.cpp
+++ b/android/runtime/v8/src/native/TypeConverter.cpp
@@ -592,9 +592,6 @@ v8::Handle<v8::Value> TypeConverter::javaObjectToJsValue(jobject javaObject)
 			if (v8ObjectPointer != 0) {
 				Persistent<Object> v8Object = Persistent<Object>((Object *) v8ObjectPointer);
 				JavaObject *jo = NativeObject::Unwrap<JavaObject>(v8Object);
-				if (jo->isDetached()) {
-					jo->attach(javaObject);
-				}
 				return v8Object;
 			}
 		}


### PR DESCRIPTION
This resolves JNI warnings seen due to an attach() call that is no longer
needed (re-attachment is automatic now when getJavaObject is invoked).

See [TIMOB-7831](https://jira.appcelerator.org/browse/TIMOB-7831) for testing details.
