### PR TITLE
[TIMOB-7562] Fix error in horizontal/vertical layouts with percent values

### DIFF
--- a/iphone/Classes/LayoutConstraint.m
+++ b/iphone/Classes/LayoutConstraint.m
@@ -40,6 +40,18 @@ CGSize SizeConstraintViewWithSizeAddingResizing(LayoutConstraint * constraint, N
 {
 	//TODO: Refactor for elegance.
 	CGFloat width;
+    BOOL ignorePercent = NO;
+    CGSize parentSize = CGSizeZero;
+    
+    if ([autoSizer isKindOfClass:[TiViewProxy class]]) {
+        TiViewProxy* parent = [(TiViewProxy*)autoSizer parent];
+        if (parent != nil && (!TiLayoutRuleIsAbsolute([parent layoutProperties]->layoutStyle))) {
+            //Sandbox with percent values is garbage
+            ignorePercent = YES;
+            parentSize = [parent size].rect.size;
+        }      
+    }
+    
 
 	if(resultResizing != NULL)
 	{
@@ -48,9 +60,16 @@ CGSize SizeConstraintViewWithSizeAddingResizing(LayoutConstraint * constraint, N
 
     switch (constraint->width.type)
     {
-        case TiDimensionTypePercent:
         case TiDimensionTypeDip:
             width = TiDimensionCalculateValue(constraint->width, referenceSize.width);
+            break;
+        case TiDimensionTypePercent:
+            if (ignorePercent) {
+                width = TiDimensionCalculateValue(constraint->width, parentSize.width);
+            }
+            else {
+                width = TiDimensionCalculateValue(constraint->width, referenceSize.width);
+            }
             break;
         case TiDimensionTypeUndefined:
             if (!TiDimensionIsUndefined(constraint->left) && !TiDimensionIsUndefined(constraint->centerX) ) {
@@ -111,9 +130,16 @@ CGSize SizeConstraintViewWithSizeAddingResizing(LayoutConstraint * constraint, N
 
     switch (constraint->height.type)
     {
-        case TiDimensionTypePercent:
         case TiDimensionTypeDip:
             height = TiDimensionCalculateValue(constraint->height, referenceSize.height);
+            break;
+        case TiDimensionTypePercent:
+            if (ignorePercent) {
+                height = TiDimensionCalculateValue(constraint->height, parentSize.height);
+            }
+            else {
+                height = TiDimensionCalculateValue(constraint->height, referenceSize.height);
+            }
             break;
         case TiDimensionTypeUndefined:
             if (!TiDimensionIsUndefined(constraint->top) && !TiDimensionIsUndefined(constraint->centerY) ) {

--- a/iphone/Classes/TiUIScrollView.m
+++ b/iphone/Classes/TiUIScrollView.m
@@ -90,7 +90,7 @@
 		}
 		case TiDimensionTypeAuto:
 		{
-			newContentSize.width = MAX(newContentSize.width,[(TiViewProxy *)[self proxy] autoWidthForSize:newContentSize]);
+			newContentSize.width = MAX(newContentSize.width,[(TiViewProxy *)[self proxy] autoWidthForSize:[self bounds].size]);
 			break;
 		}
 		default: {
@@ -107,7 +107,7 @@
 		}
 		case TiDimensionTypeAuto:
 		{
-			minimumContentHeight=[(TiViewProxy *)[self proxy] autoHeightForSize:newContentSize];
+			minimumContentHeight=[(TiViewProxy *)[self proxy] autoHeightForSize:[self bounds].size];
 			break;
 		}
 		default:

--- a/iphone/Classes/TiUIScrollViewProxy.m
+++ b/iphone/Classes/TiUIScrollViewProxy.m
@@ -121,6 +121,10 @@
 
 -(CGRect)computeChildSandbox:(TiViewProxy*)child withBounds:(CGRect)bounds
 {
+    if ([self viewAttached]) {
+        //ScrollView calls this with wrapper view bounds. Make sure it is set to the right bound
+        bounds = [[self view] bounds];
+    }
     if(TiLayoutRuleIsHorizontal(layoutProperties.layoutStyle))
     {
         //Horizontal Layout in scrollview is not a traditional horizontal layout. So need an override
@@ -142,17 +146,14 @@
         if (TiDimensionIsDip(constraint) || TiDimensionIsPercent(constraint))
         {
             //Percent or absolute of total width so leave the sandbox and just increment the boundary
-            bounds.size.width =  TiDimensionCalculateValue(constraint, boundingValue) + offset;
+            bounds.size.width =  TiDimensionCalculateValue(constraint, bounds.size.width) + offset;
             horizontalLayoutBoundary += bounds.size.width;
-            if (TiDimensionIsPercent(constraint)) {
-                bounds.size.width = boundingValue + offset;
-            }
         }
         else if (TiDimensionIsAutoFill(constraint))
         {
             //Fill up the remaining
-            bounds.size.width = boundingValue;
-            horizontalLayoutBoundary += bounds.size.width + offset;
+            bounds.size.width = boundingValue + offset;
+            horizontalLayoutBoundary += bounds.size.width;
         }
         else if (TiDimensionIsAutoSize(constraint))
         {
@@ -163,8 +164,8 @@
         {
             if (followsFillBehavior) {
                 //FILL behavior
-                bounds.size.width = boundingValue;
-                horizontalLayoutBoundary += bounds.size.width + offset;
+                bounds.size.width = boundingValue + offset;
+                horizontalLayoutBoundary += bounds.size.width;
             }
             else {
                 //SIZE behavior
@@ -180,8 +181,8 @@
                 horizontalLayoutBoundary += bounds.size.width;
             }
             else if (!TiDimensionIsUndefined([child layoutProperties]->left) && !TiDimensionIsUndefined([child layoutProperties]->right) ) {
-                bounds.size.width = boundingValue;
-                horizontalLayoutBoundary += boundingValue + offset;
+                bounds.size.width = boundingValue + offset;
+                horizontalLayoutBoundary += bounds.size.width;
             }
             else if (!TiDimensionIsUndefined([child layoutProperties]->centerX) && !TiDimensionIsUndefined([child layoutProperties]->right) ) {
                 CGFloat width = 2 * ( boundingValue - TiDimensionCalculateValue([child layoutProperties]->right, boundingValue) - TiDimensionCalculateValue([child layoutProperties]->centerX, boundingValue));
@@ -190,13 +191,13 @@
             }
             else if (followsFillBehavior) {
                 //FILL behavior
-                bounds.size.width = boundingValue;
-                horizontalLayoutBoundary += bounds.size.width + offset;
+                bounds.size.width = boundingValue + offset;
+                horizontalLayoutBoundary += bounds.size.width;
             }
             else {
                 //SIZE behavior
                 bounds.size.width = [child autoWidthForSize:CGSizeMake(boundingValue,bounds.size.height - offset2)] + offset;
-                horizontalLayoutBoundary += bounds.size.height;
+                horizontalLayoutBoundary += bounds.size.width;
             }
         }
         

--- a/iphone/Classes/TiViewProxy.h
+++ b/iphone/Classes/TiViewProxy.h
@@ -6,6 +6,7 @@
  */
 #import "TiProxy.h"
 #import "TiUIView.h"
+#import "TiRect.h"
 #import <pthread.h>
 
 /**
@@ -123,6 +124,8 @@ enum
 
 #pragma mark public API
 
+@property(nonatomic,readonly) TiRect * size;
+@property(nonatomic,readonly) TiRect * rect;
 /*
  Provides access to z-index value.
  */

--- a/iphone/Classes/TiViewProxy.m
+++ b/iphone/Classes/TiViewProxy.m
@@ -2232,16 +2232,17 @@ if(OSAtomicTestAndSetBarrier(flagBit, &dirtyflags))	\
             desiredWidth = [child autoWidthForSize:CGSizeMake(boundingWidth - offset,boundingHeight)];
         }
         CGFloat desiredHeight;
+        BOOL childIsPercent = TiDimensionIsPercent([child layoutProperties]->height);
+        if (childIsPercent)
+        {
+            desiredHeight = [child minimumParentHeightForSize:CGSizeMake(desiredWidth - offset,bounds.size.height)];
+        }
         if (desiredWidth > boundingWidth) {
             if (horizontalLayoutBoundary == 0.0) {
                 //This is start of row
                 bounds.origin.x = horizontalLayoutBoundary;
                 bounds.origin.y = verticalLayoutBoundary;
-                if (TiDimensionIsPercent([child layoutProperties]->height))
-                {
-                    desiredHeight = [child minimumParentHeightForSize:CGSizeMake(desiredWidth - offset,bounds.size.height)];
-                }
-                else 
+                if (!childIsPercent)
                 {
                     desiredHeight = [child minimumParentHeightForSize:CGSizeMake(desiredWidth - offset,boundingHeight)];
                 }
@@ -2268,11 +2269,7 @@ if(OSAtomicTestAndSetBarrier(flagBit, &dirtyflags))	\
                 
                 if (!recalculateWidth) {
                     if (desiredWidth < boundingWidth) {
-                        if (TiDimensionIsPercent([child layoutProperties]->height))
-                        {
-                            desiredHeight = [child minimumParentHeightForSize:CGSizeMake(desiredWidth - offset,bounds.size.height)];
-                        }
-                        else 
+                        if (!childIsPercent)
                         {
                             desiredHeight = [child minimumParentHeightForSize:CGSizeMake(desiredWidth - offset,boundingHeight)];
                         }                    
@@ -2283,11 +2280,7 @@ if(OSAtomicTestAndSetBarrier(flagBit, &dirtyflags))	\
                     }
                     else {
                         //Will take up whole row
-                        if (TiDimensionIsPercent([child layoutProperties]->height))
-                        {
-                            desiredHeight = [child minimumParentHeightForSize:CGSizeMake(boundingWidth - offset,bounds.size.height)];
-                        }
-                        else 
+                        if (!childIsPercent)
                         {
                             desiredHeight = [child minimumParentHeightForSize:CGSizeMake(boundingWidth - offset,boundingHeight)];
                         }                    
@@ -2297,11 +2290,7 @@ if(OSAtomicTestAndSetBarrier(flagBit, &dirtyflags))	\
                 }
                 else if (followsFillBehavior) {
                     //Will take up whole row
-                    if (TiDimensionIsPercent([child layoutProperties]->height))
-                    {
-                        desiredHeight = [child minimumParentHeightForSize:CGSizeMake(boundingWidth - offset,bounds.size.height)];
-                    }
-                    else 
+                    if (!childIsPercent)
                     {
                         desiredHeight = [child minimumParentHeightForSize:CGSizeMake(boundingWidth - offset,boundingHeight)];
                     }                    
@@ -2311,11 +2300,7 @@ if(OSAtomicTestAndSetBarrier(flagBit, &dirtyflags))	\
                 else {
                     desiredWidth = [child autoWidthForSize:CGSizeMake(boundingWidth - offset,boundingHeight - offset2)];
                     if (desiredWidth < boundingWidth) {
-                        if (TiDimensionIsPercent([child layoutProperties]->height))
-                        {
-                            desiredHeight = [child minimumParentHeightForSize:CGSizeMake(desiredWidth - offset,bounds.size.height)];
-                        }
-                        else 
+                        if (!childIsPercent)
                         {
                             desiredHeight = [child minimumParentHeightForSize:CGSizeMake(desiredWidth - offset,boundingHeight)];
                         }                    
@@ -2326,11 +2311,7 @@ if(OSAtomicTestAndSetBarrier(flagBit, &dirtyflags))	\
                     }
                     else {
                         //Will take up whole row
-                        if (TiDimensionIsPercent([child layoutProperties]->height))
-                        {
-                            desiredHeight = [child minimumParentHeightForSize:CGSizeMake(boundingWidth - offset,bounds.size.height)];
-                        }
-                        else 
+                        if (!childIsPercent)
                         {
                             desiredHeight = [child minimumParentHeightForSize:CGSizeMake(boundingWidth - offset,boundingHeight)];
                         }
@@ -2343,11 +2324,7 @@ if(OSAtomicTestAndSetBarrier(flagBit, &dirtyflags))	\
         }
         else {
             //If it fits update the horizontal layout row height
-            if (TiDimensionIsPercent([child layoutProperties]->height))
-            {
-                desiredHeight = [child minimumParentHeightForSize:CGSizeMake(desiredWidth - offset,bounds.size.height)];
-            }
-            else 
+            if (!childIsPercent)
             {
                 desiredHeight = [child minimumParentHeightForSize:CGSizeMake(desiredWidth - offset,boundingHeight)];
             }

--- a/iphone/Classes/TiViewProxy.m
+++ b/iphone/Classes/TiViewProxy.m
@@ -2235,7 +2235,8 @@ if(OSAtomicTestAndSetBarrier(flagBit, &dirtyflags))	\
         BOOL childIsPercent = TiDimensionIsPercent([child layoutProperties]->height);
         if (childIsPercent)
         {
-            desiredHeight = [child minimumParentHeightForSize:CGSizeMake(desiredWidth - offset,bounds.size.height)];
+            //For percent width is irrelevant
+            desiredHeight = [child minimumParentHeightForSize:CGSizeMake(0,bounds.size.height)];
         }
         if (desiredWidth > boundingWidth) {
             if (horizontalLayoutBoundary == 0.0) {


### PR DESCRIPTION
This PR fixes the following tickets
[TIMOB-7562](https://jira.appcelerator.org/browse/TIMOB-7562)
[TIMOB-7952](https://jira.appcelerator.org/browse/TIMOB-7952)
[TIMOB-7947](https://jira.appcelerator.org/browse/TIMOB-7947)
[TIMOB-7490](https://jira.appcelerator.org/browse/TIMOB-7490)

FR should include regression against the following tickets
[TIMOB-7958](https://jira.appcelerator.org/browse/TIMOB-7958)
[TIMOB-7810](https://jira.appcelerator.org/browse/TIMOB-7810). Run code from comments.
[TIMOB-7784](https://jira.appcelerator.org/browse/TIMOB-7784)
KS->Base UI->Vertical Layout
KS->Base UI->Horizontal Layout
KS->Base UI->Views->Table Views-> Table Auto Height
