### PR TITLE
[TIMOB-7914] Safety checks for Ti.UI.TableView.updateRow()

### DIFF
--- a/iphone/Classes/TiUITableView.m
+++ b/iphone/Classes/TiUITableView.m
@@ -482,18 +482,24 @@
 	row.table = self;
 	NSMutableArray *rows = [row.section rows];
 	
+    TiUITableViewRowProxy* oldRow = nil;
 	if ([rows count] > row.row) {
-		TiUITableViewRowProxy* oldRow = [rows objectAtIndex:row.row];
-		[oldRow retain];
-		oldRow.table = nil;
-		oldRow.section = nil;
-		oldRow.parent = nil;
-		[row.section forgetProxy:oldRow];
-		[oldRow release];
-	}	
-	[row.section rememberProxy:row];
-	[rows replaceObjectAtIndex:row.row withObject:row];
-	[row.section reorderRows];
+		oldRow = [rows objectAtIndex:row.row];
+        if (oldRow != row) {
+            [oldRow retain];
+            oldRow.table = nil;
+            oldRow.section = nil;
+            oldRow.parent = nil;
+            [row.section forgetProxy:oldRow];
+            [oldRow release];
+        }
+	}
+    
+    if (oldRow != row) {
+        [row.section rememberProxy:row];
+        [rows replaceObjectAtIndex:row.row withObject:row];
+        [row.section reorderRows];
+    }
 }
 
 -(void)insertRow:(TiUITableViewRowProxy*)row before:(TiUITableViewRowProxy*)before 

--- a/iphone/Classes/TiUITableViewProxy.m
+++ b/iphone/Classes/TiUITableViewProxy.m
@@ -369,22 +369,24 @@ NSArray * tableKeySequence;
         return;
     }
     
-    [[rowProxy section] rememberProxy:newrow];
-    
-    newrow.section = rowProxy.section;
-    newrow.row = rowProxy.row;
-    newrow.parent = newrow.section;
-    
-    //We now need to disconnect the old row proxy.
-    rowProxy.section = nil;
-    rowProxy.parent = nil;
-    rowProxy.table = nil;
-    
-    
-    // Only update the row if we're loading it with data; but most of this should
-    // be taken care of by -[TiUITableViewProxy tableRowFromArg:] anyway, right?
-    if ([data isKindOfClass:[NSDictionary class]]) {
-        [newrow updateRow:data withObject:anim];
+    if (rowProxy != newrow) {
+        [[rowProxy section] rememberProxy:newrow];
+        
+        newrow.section = rowProxy.section;
+        newrow.row = rowProxy.row;
+        newrow.parent = newrow.section;
+        
+        //We now need to disconnect the old row proxy.
+        rowProxy.section = nil;
+        rowProxy.parent = nil;
+        rowProxy.table = nil;
+        
+        
+        // Only update the row if we're loading it with data; but most of this should
+        // be taken care of by -[TiUITableViewProxy tableRowFromArg:] anyway, right?
+        if ([data isKindOfClass:[NSDictionary class]]) {
+            [newrow updateRow:data withObject:anim];
+        }
     }
     
     TiThreadPerformOnMainThread(^{


### PR DESCRIPTION
Previously we weren't checking for identical objects during the row update process, meaning that rows which were intended to only have their contents re-evaluated/reloaded would be forgotten and garbage collected.
