### PR TITLE
[TIMOB-7820] Cleanup tab group event firing.

### DIFF
--- a/iphone/Classes/TiUITabGroup.m
+++ b/iphone/Classes/TiUITabGroup.m
@@ -75,6 +75,11 @@ DEFINE_EXCEPTIONS
 
 - (void)handleDidShowTab:(TiUITabProxy *)newFocus
 {
+    // Do nothing if no tabs are being focused or blurred (or the window is opening)
+    if ((focused == nil && newFocus == nil)) {
+        return;
+    }
+    
 	NSMutableDictionary * event = [NSMutableDictionary dictionaryWithCapacity:4];
 
 	NSArray * tabArray = [controller viewControllers];
@@ -106,7 +111,10 @@ DEFINE_EXCEPTIONS
 	[self.proxy replaceValue:focused forKey:@"activeTab" notification:NO];
     [focused replaceValue:[NSNumber numberWithBool:YES] forKey:@"active" notification:NO];
 
-	[self.proxy fireEvent:@"focus" withObject:event];
+    // If we're in the middle of opening, the focus happens once the tabgroup is opened
+    if (![(TiWindowProxy*)[self proxy] opening]) {
+        [self.proxy fireEvent:@"focus" withObject:event];
+    }
 	[focused handleDidFocus:event];
 }
 
@@ -399,7 +407,9 @@ DEFINE_EXCEPTIONS
 	// on an open, make sure we send the focus event to initial tab
 	NSDictionary *event = [NSDictionary dictionaryWithObjectsAndKeys:focused,@"tab",NUMINT(0),@"index",NUMINT(-1),@"previousIndex",[NSNull null],@"previousTab",nil];
 	[self.proxy fireEvent:@"focus" withObject:event];
-	[focused handleDidFocus:event];
+    
+    // Tab has already been focused by the tab controller delegate
+	//[focused handleDidFocus:event];
 }
 
 -(void)close:(id)args


### PR DESCRIPTION
This prevents certain events from firing out of sequence, specifically while tab groups are opening.
