### PR TITLE
package modules API doc generation config into SDK build

### DIFF
--- a/site_scons/package.py
+++ b/site_scons/package.py
@@ -247,6 +247,7 @@ def zip_iphone_ipad(zf,basepath,platform,version,version_tag):
 	zip_dir(zf,os.path.join(top_dir,'iphone','Classes'),basepath+'/iphone/Classes',subs)
 	zip_dir(zf,os.path.join(top_dir,'iphone','headers'),basepath+'/iphone/headers',subs)
 	zip_dir(zf,os.path.join(top_dir,'iphone','iphone'),basepath+'/iphone/iphone',subs)
+	zf.write(os.path.join(top_dir, 'iphone', 'AppledocSettings.plist'),'%s/iphone/AppledocSettings.plist'%(basepath))
 	
 	ticore_lib = os.path.join(top_dir,'iphone','lib')
 	


### PR DESCRIPTION
The change includes AppledocSettings.plist into SDK build so users will be able to generate and integrate modules API doc into Xcode.

Test instructions: 
1. scons iphone=1
2. unpack resulting SDK zip
3. verify that iphone/AppledocSettings.plist exists.
