### PR TITLE
[TIMOB-7908] iOS: User Location blue dot disappears often disappears on the device when using annotations

### DIFF
--- a/iphone/Classes/TiMapView.h
+++ b/iphone/Classes/TiMapView.h
@@ -42,6 +42,7 @@
 
 @property (nonatomic, readonly) CLLocationDegrees longitudeDelta;
 @property (nonatomic, readonly) CLLocationDegrees latitudeDelta;
+@property (nonatomic, readonly) NSArray *customAnnotations;
 
 #pragma mark Public APIs
 -(void)addAnnotation:(id)args;

--- a/iphone/Classes/TiMapView.m
+++ b/iphone/Classes/TiMapView.m
@@ -66,6 +66,13 @@
 	return map;
 }
 
+- (NSArray *)customAnnotations
+{
+    NSMutableArray *annotations = [NSMutableArray arrayWithArray:self.map.annotations];
+    [annotations removeObject:self.map.userLocation];
+    return annotations;
+}
+
 -(void)willFirePropertyChanges
 {
 	regionFits = [TiUtils boolValue:[self.proxy valueForKey:@"regionFit"]];
@@ -161,7 +168,7 @@
 	{
 		// for pre 0.9, we supporting removing by passing the annotation title
 		NSString *title = [TiUtils stringValue:args];
-		for (id<MKAnnotation>an in [NSArray arrayWithArray:[self map].annotations])
+		for (id<MKAnnotation>an in [NSArray arrayWithArray:self.customAnnotations])
 		{
 			if ([title isEqualToString:an.title])
 			{
@@ -188,14 +195,14 @@
 -(void)removeAllAnnotations:(id)args
 {
 	ENSURE_UI_THREAD(removeAllAnnotations,args);
-	[[self map] removeAnnotations:[[self map] annotations]];
+	[self.map removeAnnotations:self.customAnnotations];
 }
 
 -(void)setAnnotations_:(id)value
 {
 	ENSURE_TYPE_OR_NIL(value,NSArray);
 	ENSURE_UI_THREAD(setAnnotations_,value)
-	[[self map] removeAnnotations:[[self map] annotations]];
+	[self.map removeAnnotations:self.customAnnotations];
 	if (value != nil) {
 		[[self map] addAnnotations:[self annotationsFromArgs:value]];
 	}

--- a/iphone/Classes/TiMapView.m
+++ b/iphone/Classes/TiMapView.m
@@ -168,7 +168,7 @@
 	{
 		// for pre 0.9, we supporting removing by passing the annotation title
 		NSString *title = [TiUtils stringValue:args];
-		for (id<MKAnnotation>an in [NSArray arrayWithArray:self.customAnnotations])
+		for (id<MKAnnotation>an in self.customAnnotations)
 		{
 			if ([title isEqualToString:an.title])
 			{


### PR DESCRIPTION
[TIMOB-7908](https://jira.appcelerator.org/browse/TIMOB-7908)
Exclude MKUserLocation annotation from the list of annotation to remove since its visibility is controlled by userLocation property.

Test case in JIRA.
