### PR TITLE
[TIMOB-7970] Upgrade TiCore to remove offending (to Apple) ICU symbols.

### DIFF
--- a/iphone/SConstruct
+++ b/iphone/SConstruct
@@ -5,7 +5,7 @@
 import os,platform,sys,urllib,gzip,glob
 from progressbar import ProgressBar
 
-ticore_version = '16'
+ticore_version = '17'
 
 # NOTE: this is simply a pre-built version of the source at http://github.com/appcelerator/tijscore
 # since this is so freaking complicated to setup and build in an stable environment, and since 


### PR DESCRIPTION
This removes symbols from libicu (ucol) which Apple has deemed to be "non-public" APIs from TiCore. No other updates were required.
