### PR TITLE
[TIMOB-7803] iOS: DashboardView - fix crash when endEditing called from dealloc; cancel delayed beginEditing when dashboard item to edit is already destroyed

### DIFF
--- a/iphone/Classes/LauncherView.m
+++ b/iphone/Classes/LauncherView.m
@@ -99,6 +99,7 @@ static const NSTimeInterval kLauncherViewFastTransitionDuration = 0.2;
 
 - (void)dealloc 
 {
+	delegate = nil;
 	if (editing)
 	{
 		[self endEditing];
@@ -107,7 +108,6 @@ static const NSTimeInterval kLauncherViewFastTransitionDuration = 0.2;
 	[buttons release];
 	[scrollView release];
 	[pages release];
-	delegate = nil;
     [super dealloc];
 }
 
@@ -687,11 +687,14 @@ static const NSTimeInterval kLauncherViewFastTransitionDuration = 0.2;
 {
     editHoldTimer = nil;
 
-	[self beginEditing];
-	
 	NSArray *data = timer.userInfo;
 	LauncherButton *button = [data objectAtIndex:0];
 	UIEvent *event = [data objectAtIndex:1];
+    if (button.item.userData == nil) {
+        return;
+    }
+	
+	[self beginEditing];
 	
 	button.selected = NO;
 	button.highlighted = NO;

--- a/iphone/Classes/TiUIDashboardView.m
+++ b/iphone/Classes/TiUIDashboardView.m
@@ -19,11 +19,11 @@
 
 -(void)dealloc
 {
+	launcher.delegate = nil;
 	if (launcher.editing)
 	{
 		[launcher endEditing];
 	}
-	launcher.delegate = nil;
 	RELEASE_TO_NIL(launcher);
 	[super dealloc];
 }


### PR DESCRIPTION
[TIMOB-7803](https://jira.appcelerator.org/browse/TIMOB-7803)

Test case in JIRA.
FT note: make sure to reproduce the crash before the fix. easier on a device.
