### PR TITLE
[TIMOB-7933] Windows follow same code path with or without open animation

### DIFF
--- a/iphone/Classes/TiWindowProxy.m
+++ b/iphone/Classes/TiWindowProxy.m
@@ -419,9 +419,7 @@ TiOrientationFlags TiOrientationFlagsFromObject(id args)
 		{
 			if (rootViewAttached)
 			{
-				[[TiApp controller] willShowViewController:[self controller] animated:YES];
 				[self attachViewToTopLevelWindow];
-				[[TiApp controller] didShowViewController:[self controller] animated:YES];
 			}
 			if ([openAnimation isTransitionAnimation])
 			{


### PR DESCRIPTION
Test is in [JIRA](https://jira.appcelerator.org/browse/TIMOB-7933)
