### PR TITLE
[TIMOB-8016] fix a race condition when TiThreadReleaseOnMainThread releases object on the current thread instead of main thread due to block release which could occur after the block execution on main thread

### DIFF
--- a/iphone/Classes/TiBase.m
+++ b/iphone/Classes/TiBase.m
@@ -123,7 +123,8 @@ void TiThreadReleaseOnMainThread(id releasedObject,BOOL waitForFinish)
 	}
 	else
 	{
-		TiThreadPerformOnMainThread(^{[releasedObject release];}, waitForFinish);
+        __block id blockVar = releasedObject;
+		TiThreadPerformOnMainThread(^{[blockVar release];}, waitForFinish);
 	}
 }
 
@@ -137,7 +138,8 @@ void TiThreadRemoveFromSuperviewOnMainThread(UIView* view,BOOL waitForFinish)
 	}
 	else
 	{
-		TiThreadPerformOnMainThread(^{[view removeFromSuperview];}, waitForFinish);
+        __block UIView* blockVar = view;
+		TiThreadPerformOnMainThread(^{[blockVar removeFromSuperview];}, waitForFinish);
 	}
 }
 


### PR DESCRIPTION
[TIMOB-8016](https://jira.appcelerator.org/browse/TIMOB-8016)

Test case in JIRA.
