### PR TITLE
[TIMOB-7985] Android: KitchenSink silent crash on exit when using the Geolocation test

### DIFF
--- a/android/runtime/common/src/java/org/appcelerator/kroll/KrollRuntime.java
+++ b/android/runtime/common/src/java/org/appcelerator/kroll/KrollRuntime.java
@@ -131,6 +131,14 @@ public abstract class KrollRuntime implements Handler.Callback
 		}
 	}
 
+	public static boolean isInitialized()
+	{
+		if (instance != null) {
+			return instance.initialized.get();
+		}
+		return false;
+	}
+
 	public KrollApplication getKrollApplication()
 	{
 		if (krollApplication != null) {

--- a/android/runtime/v8/src/java/org/appcelerator/kroll/runtime/v8/V8Function.java
+++ b/android/runtime/v8/src/java/org/appcelerator/kroll/runtime/v8/V8Function.java
@@ -17,6 +17,7 @@ import org.appcelerator.kroll.common.TiMessenger;
 
 import android.os.Handler;
 import android.os.Message;
+import android.util.Log;
 
 
 public class V8Function extends V8Object implements KrollFunction, Handler.Callback
@@ -25,6 +26,8 @@ public class V8Function extends V8Object implements KrollFunction, Handler.Callb
 
 	protected static final int MSG_CALL_SYNC = V8Object.MSG_LAST_ID + 100;
 	protected static final int MSG_LAST_ID = MSG_CALL_SYNC;
+
+	private static final String LCAT = "V8Function";
 
 
 	public V8Function(long pointer)
@@ -52,6 +55,10 @@ public class V8Function extends V8Object implements KrollFunction, Handler.Callb
 
 	public Object callSync(KrollObject krollObject, Object[] args)
 	{
+		if (!KrollRuntime.isInitialized()) {
+			Log.w(LCAT, "Runtime disposed, cannot call function.");
+			return null;
+		}
 		return nativeInvoke(((V8Object) krollObject).getPointer(), getPointer(), args);
 	}
 

--- a/android/runtime/v8/src/java/org/appcelerator/kroll/runtime/v8/V8Function.java
+++ b/android/runtime/v8/src/java/org/appcelerator/kroll/runtime/v8/V8Function.java
@@ -27,7 +27,7 @@ public class V8Function extends V8Object implements KrollFunction, Handler.Callb
 	protected static final int MSG_CALL_SYNC = V8Object.MSG_LAST_ID + 100;
 	protected static final int MSG_LAST_ID = MSG_CALL_SYNC;
 
-	private static final String LCAT = "V8Function";
+	private static final String TAG = "V8Function";
 
 
 	public V8Function(long pointer)
@@ -56,7 +56,7 @@ public class V8Function extends V8Object implements KrollFunction, Handler.Callb
 	public Object callSync(KrollObject krollObject, Object[] args)
 	{
 		if (!KrollRuntime.isInitialized()) {
-			Log.w(LCAT, "Runtime disposed, cannot call function.");
+			Log.w(TAG, "Runtime disposed, cannot call function.");
 			return null;
 		}
 		return nativeInvoke(((V8Object) krollObject).getPointer(), getPointer(), args);

--- a/android/runtime/v8/src/java/org/appcelerator/kroll/runtime/v8/V8Object.java
+++ b/android/runtime/v8/src/java/org/appcelerator/kroll/runtime/v8/V8Object.java
@@ -14,7 +14,7 @@ import android.util.Log;
 
 public class V8Object extends KrollObject
 {
-	private static final String LCAT = "V8Object";
+	private static final String TAG = "V8Object";
 
 	private volatile long ptr;
 
@@ -44,7 +44,7 @@ public class V8Object extends KrollObject
 	public void setProperty(String name, Object value)
 	{
 		if (!KrollRuntime.isInitialized()) {
-			Log.w(LCAT, "Runtime disposed, cannot set property '" + name + "'");
+			Log.w(TAG, "Runtime disposed, cannot set property '" + name + "'");
 			return;
 		}
 		nativeSetProperty(ptr, name, value);
@@ -54,7 +54,7 @@ public class V8Object extends KrollObject
 	public boolean fireEvent(String type, Object data)
 	{
 		if (!KrollRuntime.isInitialized()) {
-			Log.w(LCAT, "Runtime disposed, cannot fire event '" + type + "'");
+			Log.w(TAG, "Runtime disposed, cannot fire event '" + type + "'");
 			return false;
 		}
 		return nativeFireEvent(ptr, type, data);

--- a/android/runtime/v8/src/java/org/appcelerator/kroll/runtime/v8/V8Object.java
+++ b/android/runtime/v8/src/java/org/appcelerator/kroll/runtime/v8/V8Object.java
@@ -9,9 +9,13 @@ package org.appcelerator.kroll.runtime.v8;
 import org.appcelerator.kroll.KrollObject;
 import org.appcelerator.kroll.KrollRuntime;
 
+import android.util.Log;
+
 
 public class V8Object extends KrollObject
 {
+	private static final String LCAT = "V8Object";
+
 	private volatile long ptr;
 
 
@@ -39,12 +43,20 @@ public class V8Object extends KrollObject
 	@Override
 	public void setProperty(String name, Object value)
 	{
+		if (!KrollRuntime.isInitialized()) {
+			Log.w(LCAT, "Runtime disposed, cannot set property '" + name + "'");
+			return;
+		}
 		nativeSetProperty(ptr, name, value);
 	}
 
 	@Override
 	public boolean fireEvent(String type, Object data)
 	{
+		if (!KrollRuntime.isInitialized()) {
+			Log.w(LCAT, "Runtime disposed, cannot fire event '" + type + "'");
+			return false;
+		}
 		return nativeFireEvent(ptr, type, data);
 	}
 


### PR DESCRIPTION
This resolves a crash seen when you completely back out of an application
starting from the Phone > Geolocation example in KitchenSink.

The root cause of this issue was due to a race condition in TiSensorHelper
causing sensor listeners to not be removed properly.

See [TIMOB-7985](https://jira.appcelerator.org/browse/TIMOB-7985) for further details.
