### PR TITLE
[TIMOB-8045]SIZE views do not work well with left,right,top,bottom pins set

### DIFF
--- a/drillbit/tests/ui.layout/ui.layout.js
+++ b/drillbit/tests/ui.layout/ui.layout.js
@@ -535,7 +535,9 @@ describe("Ti.UI Layout tests", {
 		    contentHeight:'auto',
 		    contentWidth:'auto',
 		    showVerticalScrollIndicator:true,
-		    showHorizontalScrollIndicator:true
+		    showHorizontalScrollIndicator:true,
+		    width:Ti.UI.SIZE,
+		    height:Ti.UI.SIZE		
 		});
 		var scrollView2 = Titanium.UI.createScrollView({
 		    contentHeight:'auto',

--- a/iphone/Classes/TiUIScrollViewProxy.m
+++ b/iphone/Classes/TiUIScrollViewProxy.m
@@ -80,11 +80,6 @@
             contentHeight = [self contentHeightForWidth:size.width];
         }
         
-        CGFloat offset = TiDimensionCalculateValue(layoutProperties.left, size.width)
-        + TiDimensionCalculateValue(layoutProperties.right, size.width);
-        CGFloat offset2 = TiDimensionCalculateValue(layoutProperties.top, size.height)
-        + TiDimensionCalculateValue(layoutProperties.bottom, size.height);
-        
         CGFloat result=0.0;
         CGFloat thisHeight = 0.0;
         pthread_rwlock_rdlock(&childrenLock);
@@ -92,7 +87,7 @@
         
         for (TiViewProxy * thisChildProxy in array)
         {
-            thisHeight = [thisChildProxy minimumParentHeightForSize:CGSizeMake(size.width - offset, size.height - offset2)];
+            thisHeight = [thisChildProxy minimumParentHeightForSize:size];
             if(result<thisHeight) {
                 result = thisHeight;
             }

--- a/iphone/Classes/TiUITableViewRowProxy.m
+++ b/iphone/Classes/TiUITableViewRowProxy.m
@@ -358,7 +358,7 @@ TiProxy * DeepScanForProxyOfViewContainingPoint(UIView * targetView, CGPoint poi
 	CGFloat result = 0;
 	if (TiDimensionIsAuto(height) || TiDimensionIsAutoSize(height) || TiDimensionIsUndefined(height))
 	{
-		result = [self autoHeightForSize:CGSizeMake(width,1000)];
+		result = [self minimumParentHeightForSize:CGSizeMake(width, [self table].bounds.size.height)];
 	}
     if (TiDimensionIsPercent(height) && [self table] != nil) {
         result = TiDimensionCalculateValue(height, [self table].bounds.size.height);

--- a/iphone/Classes/TiViewProxy.m
+++ b/iphone/Classes/TiViewProxy.m
@@ -637,11 +637,6 @@ LAYOUTPROPERTIES_SETTER(setMinHeight,minimumHeight,TiFixedValueRuleFromObject,[s
         contentWidth = [self contentWidthForWidth:suggestedWidth];
     }
     
-    CGFloat offset = TiDimensionCalculateValue(layoutProperties.left, suggestedWidth)
-    + TiDimensionCalculateValue(layoutProperties.right, suggestedWidth);
-    CGFloat offset2 = TiDimensionCalculateValue(layoutProperties.top, size.height)
-    + TiDimensionCalculateValue(layoutProperties.bottom, size.height);
-
 	BOOL isHorizontal = TiLayoutRuleIsHorizontal(layoutProperties.layoutStyle);
 	CGFloat result = 0.0;
 	
@@ -665,7 +660,7 @@ LAYOUTPROPERTIES_SETTER(setMinHeight,minimumHeight,TiFixedValueRuleFromObject,[s
             thisWidth = sandBox.origin.x + sandBox.size.width;
         }
         else {
-            thisWidth = [thisChildProxy minimumParentWidthForSize:CGSizeMake(suggestedWidth - offset, size.height - offset2)];
+            thisWidth = [thisChildProxy minimumParentWidthForSize:size];
         }
         if(result<thisWidth)
         {
@@ -699,12 +694,7 @@ LAYOUTPROPERTIES_SETTER(setMinHeight,minimumHeight,TiFixedValueRuleFromObject,[s
     if ([self respondsToSelector:@selector(contentHeightForWidth:)]) {
         contentHeight = [self contentHeightForWidth:width];
     }
-    
-    CGFloat offset = TiDimensionCalculateValue(layoutProperties.left, width)
-    + TiDimensionCalculateValue(layoutProperties.right, width);
-    CGFloat offset2 = TiDimensionCalculateValue(layoutProperties.top, size.height)
-    + TiDimensionCalculateValue(layoutProperties.bottom, size.height);
-    
+        
     BOOL isAbsolute = TiLayoutRuleIsAbsolute(layoutProperties.layoutStyle);
     
 	CGFloat result=0.0;
@@ -731,7 +721,7 @@ LAYOUTPROPERTIES_SETTER(setMinHeight,minimumHeight,TiFixedValueRuleFromObject,[s
             thisHeight = sandBox.origin.y + sandBox.size.height;
         }
         else {
-            thisHeight = [thisChildProxy minimumParentHeightForSize:CGSizeMake(width - offset, size.height - offset2)];
+            thisHeight = [thisChildProxy minimumParentHeightForSize:size];
         }
         if(result<thisHeight)
         {

--- a/iphone/Classes/TiViewProxy.m
+++ b/iphone/Classes/TiViewProxy.m
@@ -752,6 +752,7 @@ LAYOUTPROPERTIES_SETTER(setMinHeight,minimumHeight,TiFixedValueRuleFromObject,[s
 {
     CGFloat suggestedWidth = size.width;
     BOOL followsFillBehavior = TiDimensionIsAutoFill([self defaultAutoWidthBehavior:nil]);
+    BOOL recheckForFill = NO;
     
     CGFloat offset = TiDimensionCalculateValue(layoutProperties.left, size.width)
     + TiDimensionCalculateValue(layoutProperties.right, size.width);
@@ -767,7 +768,8 @@ LAYOUTPROPERTIES_SETTER(setMinHeight,minimumHeight,TiFixedValueRuleFromObject,[s
 	}
 	else if (TiDimensionIsAutoFill(layoutProperties.width) || (TiDimensionIsAuto(layoutProperties.width) && followsFillBehavior) ) 
 	{
-		result = suggestedWidth;
+		recheckForFill = YES;
+		result += [self autoWidthForSize:CGSizeMake(size.width - offset, size.height - offset2)];
 	}
     else if (TiDimensionIsUndefined(layoutProperties.width))
     {
@@ -781,18 +783,17 @@ LAYOUTPROPERTIES_SETTER(setMinHeight,minimumHeight,TiFixedValueRuleFromObject,[s
             result += 2 * ( size.width - TiDimensionCalculateValue(layoutProperties.right, suggestedWidth) - TiDimensionCalculateValue(layoutProperties.centerX, suggestedWidth));
         }
         else {
-            if (followsFillBehavior) {
-                result = suggestedWidth;
-            }
-            else {
-                result += [self autoWidthForSize:CGSizeMake(size.width - offset, size.height - offset2)];
-            }
+            recheckForFill = followsFillBehavior;
+            result += [self autoWidthForSize:CGSizeMake(size.width - offset, size.height - offset2)];
         }       
     }
 	else
 	{
 		result += [self autoWidthForSize:CGSizeMake(size.width - offset, size.height - offset2)];
 	}
+    if (recheckForFill && (result < suggestedWidth) ) {
+        result = suggestedWidth;
+    }
 	return result;
 }
 
@@ -800,6 +801,7 @@ LAYOUTPROPERTIES_SETTER(setMinHeight,minimumHeight,TiFixedValueRuleFromObject,[s
 {
     CGFloat suggestedHeight = size.height;
     BOOL followsFillBehavior = TiDimensionIsAutoFill([self defaultAutoHeightBehavior:nil]);
+    BOOL recheckForFill = NO;
 	    
     CGFloat offset = TiDimensionCalculateValue(layoutProperties.left, size.width)
     + TiDimensionCalculateValue(layoutProperties.right, size.width);
@@ -814,7 +816,8 @@ LAYOUTPROPERTIES_SETTER(setMinHeight,minimumHeight,TiFixedValueRuleFromObject,[s
 	}
     else if (TiDimensionIsAutoFill(layoutProperties.height) || (TiDimensionIsAuto(layoutProperties.height) && followsFillBehavior) ) 
 	{
-		result = suggestedHeight;
+		recheckForFill = YES;
+		result += [self autoHeightForSize:CGSizeMake(size.width - offset, size.height - offset2)];
 	}
     else if (TiDimensionIsUndefined(layoutProperties.height))
     {
@@ -828,18 +831,17 @@ LAYOUTPROPERTIES_SETTER(setMinHeight,minimumHeight,TiFixedValueRuleFromObject,[s
             result += 2 * ( suggestedHeight - TiDimensionCalculateValue(layoutProperties.bottom, suggestedHeight) - TiDimensionCalculateValue(layoutProperties.centerY, suggestedHeight));
         }
         else {
-            if (followsFillBehavior) {
-                result = suggestedHeight;
-            }
-            else {
-                result += [self autoHeightForSize:CGSizeMake(size.width - offset, size.height - offset2)];
-            }
+            recheckForFill = followsFillBehavior;
+            result += [self autoHeightForSize:CGSizeMake(size.width - offset, size.height - offset2)];
         }       
     }
 	else
 	{
 		result += [self autoHeightForSize:CGSizeMake(size.width - offset, size.height - offset2)];
 	}
+    if (recheckForFill && (result < suggestedHeight) ) {
+        result = suggestedHeight;
+    }
 	return result;
 }
 
@@ -1972,15 +1974,13 @@ if(OSAtomicTestAndSetBarrier(flagBit, &dirtyflags))	\
 
         UIView *parentView = [parent parentViewForChild:self];
         CGSize referenceSize = (parentView != nil) ? parentView.bounds.size : sandboxBounds.size;
-       if (parent) {
-            //Always use sandbox bounds if parent is not absolute layout
-            if (!TiLayoutRuleIsAbsolute([parent layoutProperties]->layoutStyle)) {
-                referenceSize = sandboxBounds.size;
-            }
+        if (parent != nil && (!TiLayoutRuleIsAbsolute([parent layoutProperties]->layoutStyle)) ) {
+            sizeCache.size = SizeConstraintViewWithSizeAddingResizing(&layoutProperties,self, sandboxBounds.size, &autoresizeCache);
         }
-
-		sizeCache.size = SizeConstraintViewWithSizeAddingResizing(&layoutProperties,self, referenceSize, &autoresizeCache);
-
+        else {
+            sizeCache.size = SizeConstraintViewWithSizeAddingResizing(&layoutProperties,self, referenceSize, &autoresizeCache);
+        }
+       
 		positionCache = PositionConstraintGivenSizeBoundsAddingResizing(&layoutProperties, self, sizeCache.size,
 		[[view layer] anchorPoint], referenceSize, sandboxBounds.size, &autoresizeCache);
 
@@ -2182,11 +2182,11 @@ if(OSAtomicTestAndSetBarrier(flagBit, &dirtyflags))	\
         CGFloat boundingHeight = bounds.size.height-verticalLayoutBoundary;
         
         //LEFT + RIGHT
-        CGFloat offset = TiDimensionCalculateValue([child layoutProperties]->left, boundingWidth)
-        + TiDimensionCalculateValue([child layoutProperties]->right, boundingWidth);
+        CGFloat offset = TiDimensionCalculateValue([child layoutProperties]->left, bounds.size.width)
+        + TiDimensionCalculateValue([child layoutProperties]->right, bounds.size.width);
         //TOP + BOTTOM
-        CGFloat offset2 = TiDimensionCalculateValue([child layoutProperties]->top, boundingHeight)
-        + TiDimensionCalculateValue([child layoutProperties]->bottom, boundingHeight);
+        CGFloat offset2 = TiDimensionCalculateValue([child layoutProperties]->top, bounds.size.height)
+        + TiDimensionCalculateValue([child layoutProperties]->bottom, bounds.size.height);
         
         TiDimension constraint = [child layoutProperties]->width;
         
@@ -2206,7 +2206,7 @@ if(OSAtomicTestAndSetBarrier(flagBit, &dirtyflags))	\
             else if (!TiDimensionIsUndefined([child layoutProperties]->left) && !TiDimensionIsUndefined([child layoutProperties]->right) ) {
                 recalculateWidth = YES;
                 followsFillBehavior = YES;
-                desiredWidth = [child autoWidthForSize:CGSizeMake(boundingWidth - offset,boundingHeight)];
+                desiredWidth = [child autoWidthForSize:CGSizeMake(boundingWidth - offset,boundingHeight - offset2)] + offset;
             }
             else if (!TiDimensionIsUndefined([child layoutProperties]->centerX) && !TiDimensionIsUndefined([child layoutProperties]->right) ) {
                 CGFloat height = 2 * ( boundingWidth - TiDimensionCalculateValue([child layoutProperties]->right, boundingWidth) - TiDimensionCalculateValue([child layoutProperties]->centerX, boundingWidth));
@@ -2214,30 +2214,31 @@ if(OSAtomicTestAndSetBarrier(flagBit, &dirtyflags))	\
             }
             else {
                 recalculateWidth = YES;
-                desiredWidth = [child autoWidthForSize:CGSizeMake(boundingWidth - offset,boundingHeight)];
+                desiredWidth = [child autoWidthForSize:CGSizeMake(boundingWidth - offset,boundingHeight - offset2)] + offset;
             }
         }
         else {
             recalculateWidth = YES;
-            desiredWidth = [child autoWidthForSize:CGSizeMake(boundingWidth - offset,boundingHeight)];
+            desiredWidth = [child autoWidthForSize:CGSizeMake(boundingWidth - offset,boundingHeight - offset2)] + offset;
         }
         CGFloat desiredHeight;
-        BOOL childIsPercent = TiDimensionIsPercent([child layoutProperties]->height);
-        if (childIsPercent)
+        BOOL childIsFixedHeight = TiDimensionIsPercent([child layoutProperties]->height) || TiDimensionIsDip([child layoutProperties]->height);
+        if (childIsFixedHeight)
         {
             //For percent width is irrelevant
             desiredHeight = [child minimumParentHeightForSize:CGSizeMake(0,bounds.size.height)];
+            bounds.size.height = desiredHeight;
         }
         if (desiredWidth > boundingWidth) {
             if (horizontalLayoutBoundary == 0.0) {
                 //This is start of row
                 bounds.origin.x = horizontalLayoutBoundary;
                 bounds.origin.y = verticalLayoutBoundary;
-                if (!childIsPercent)
+                if (!childIsFixedHeight)
                 {
                     desiredHeight = [child minimumParentHeightForSize:CGSizeMake(desiredWidth - offset,boundingHeight)];
+                    bounds.size.height = desiredHeight + offset2;
                 }
-                bounds.size.height = desiredHeight + offset2;
                 verticalLayoutBoundary += bounds.size.height;
                 horizontalLayoutRowHeight = 0.0;
             }
@@ -2252,61 +2253,55 @@ if(OSAtomicTestAndSetBarrier(flagBit, &dirtyflags))	\
                 boundingWidth = bounds.size.width;
                 boundingHeight = bounds.size.height - verticalLayoutBoundary;
                 
-                offset = TiDimensionCalculateValue([child layoutProperties]->left, boundingWidth)
-                + TiDimensionCalculateValue([child layoutProperties]->right, boundingWidth);
-                
-                offset2 = TiDimensionCalculateValue([child layoutProperties]->top, boundingHeight)
-                + TiDimensionCalculateValue([child layoutProperties]->bottom, boundingHeight);
-                
                 if (!recalculateWidth) {
                     if (desiredWidth < boundingWidth) {
-                        if (!childIsPercent)
+                        if (!childIsFixedHeight)
                         {
                             desiredHeight = [child minimumParentHeightForSize:CGSizeMake(desiredWidth - offset,boundingHeight)];
+                            bounds.size.height = desiredHeight + offset2;
                         }                    
-                        bounds.size.height = desiredHeight + offset2;
                         horizontalLayoutBoundary += desiredWidth;
                         bounds.size.width = desiredWidth;
                         horizontalLayoutRowHeight = bounds.size.height;
                     }
                     else {
                         //Will take up whole row
-                        if (!childIsPercent)
+                        if (!childIsFixedHeight)
                         {
                             desiredHeight = [child minimumParentHeightForSize:CGSizeMake(boundingWidth - offset,boundingHeight)];
+                            bounds.size.height = desiredHeight + offset2;
                         }                    
-                        bounds.size.height = desiredHeight + offset2;
                         verticalLayoutBoundary += bounds.size.height;
                     }
                 }
                 else if (followsFillBehavior) {
                     //Will take up whole row
-                    if (!childIsPercent)
+                    if (!childIsFixedHeight)
                     {
                         desiredHeight = [child minimumParentHeightForSize:CGSizeMake(boundingWidth - offset,boundingHeight)];
+                        bounds.size.height = desiredHeight + offset2;
                     }                    
-                    bounds.size.height = desiredHeight + offset2;
                     verticalLayoutBoundary += bounds.size.height;
                 }
                 else {
-                    desiredWidth = [child autoWidthForSize:CGSizeMake(boundingWidth - offset,boundingHeight - offset2)];
+                    desiredWidth = [child autoWidthForSize:CGSizeMake(boundingWidth - offset,boundingHeight - offset2)] + offset;
                     if (desiredWidth < boundingWidth) {
-                        if (!childIsPercent)
+                        if (!childIsFixedHeight)
                         {
                             desiredHeight = [child minimumParentHeightForSize:CGSizeMake(desiredWidth - offset,boundingHeight)];
+                            bounds.size.height = desiredHeight + offset2;
                         }                    
-                        bounds.size.height = desiredHeight + offset2;
                         bounds.size.width = desiredWidth + offset;
                         horizontalLayoutBoundary = bounds.size.width;
                         horizontalLayoutRowHeight = bounds.size.height;
                     }
                     else {
                         //Will take up whole row
-                        if (!childIsPercent)
+                        if (!childIsFixedHeight)
                         {
                             desiredHeight = [child minimumParentHeightForSize:CGSizeMake(boundingWidth - offset,boundingHeight)];
+                            bounds.size.height = desiredHeight + offset2;
                         }
-                        bounds.size.height = desiredHeight + offset2;
                         verticalLayoutBoundary += bounds.size.height;
                     }
                 }
@@ -2315,19 +2310,20 @@ if(OSAtomicTestAndSetBarrier(flagBit, &dirtyflags))	\
         }
         else {
             //If it fits update the horizontal layout row height
-            if (!childIsPercent)
+            if (!childIsFixedHeight)
             {
                 desiredHeight = [child minimumParentHeightForSize:CGSizeMake(desiredWidth - offset,boundingHeight)];
+                bounds.size.height = desiredHeight + offset2;
             }
             bounds.origin.x = horizontalLayoutBoundary;
             bounds.origin.y = verticalLayoutBoundary;
-            bounds.size.height = desiredHeight + offset2;
+            
             if (bounds.size.height > horizontalLayoutRowHeight) {
                 horizontalLayoutRowHeight = bounds.size.height;
             }
             if (!recalculateWidth) {
                 //DIP,PERCENT,UNDEFINED WITH ATLEAST 2 PINS one of them being centerX
-                bounds.size.width = desiredWidth + offset;
+                bounds.size.width = desiredWidth;
                 horizontalLayoutBoundary += bounds.size.width;
             }
             else if(followsFillBehavior)
@@ -2341,11 +2337,10 @@ if(OSAtomicTestAndSetBarrier(flagBit, &dirtyflags))	\
             else
             {
                 //SIZE behavior
-                bounds.size.width = desiredWidth + offset;
+                bounds.size.width = desiredWidth;
                 horizontalLayoutBoundary += bounds.size.width;
             }
         }
-        
     }
     
     return bounds;


### PR DESCRIPTION
autoWidthForSize and autoHeightForSize methods were subtracting the boundaries. These methods are always called with the boundaries subtracted so the process does not need to be repeated again. This PR fixes that issue.

Test is in [JIRA](https://jira.appcelerator.org/browse/TIMOB-8045)
