### PR TITLE
[TIMOB-7718] Better memory management and synchronization of Socket.TCP

### DIFF
--- a/iphone/Classes/KrollContext.h
+++ b/iphone/Classes/KrollContext.h
@@ -67,6 +67,8 @@
 
 -(void)invokeOnThread:(id)callback_ method:(SEL)method_ withObject:(id)obj condition:(NSCondition*)condition_;
 -(void)invokeOnThread:(id)callback_ method:(SEL)method_ withObject:(id)obj callback:(id)callback selector:(SEL)selector_;
+-(void)invokeBlockOnThread:(void(^)(void))block;
+
 -(void)evalJS:(NSString*)code;
 -(id)evalJSAndWait:(NSString*)code;
 

--- a/iphone/Classes/KrollContext.mm
+++ b/iphone/Classes/KrollContext.mm
@@ -56,8 +56,6 @@ static pthread_rwlock_t KrollGarbageCollectionLock;
 
 @end
 
-
-
 @implementation KrollInvocation
 
 -(id)initWithTarget:(id)target_ method:(SEL)method_ withObject:(id)obj_ condition:(NSCondition*)condition_
@@ -949,6 +947,16 @@ static TiValueRef StringFormatDecimalCallback (TiContextRef jsContext, TiObjectR
 		return;
 	}
 	[self enqueue:invocation];
+}
+
+-(void)invokeBlockOnThread:(void (^)())block
+{
+    if ([self isKJSThread]) {
+        block();
+        return;
+    }
+    NSBlockOperation* blockOp = [NSBlockOperation blockOperationWithBlock:block];
+    [self enqueue:blockOp];
 }
 
 - (void)bindCallback:(NSString*)name callback:(TiObjectCallAsFunctionCallback)fn

--- a/iphone/Classes/TiNetworkSocketTCPProxy.h
+++ b/iphone/Classes/TiNetworkSocketTCPProxy.h
@@ -4,6 +4,12 @@
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
+
+// TODO: Migrate to GCD sockets (GCDAsyncSocket). This will resolve a number of really ugly issues:
+// * Lower thread counts
+// * Explicit synchronization (no more conditions, flags, or race conditons!)
+// * Maybe even synchronize with the context itself (when TIMOB-6990 complete)
+
 #ifdef USE_TI_NETWORKSOCKET
 #import <Foundation/Foundation.h>
 #import "TiStreamProxy.h"

--- a/iphone/Classes/TiNetworkSocketTCPProxy.m
+++ b/iphone/Classes/TiNetworkSocketTCPProxy.m
@@ -98,13 +98,13 @@ static NSString* ARG_KEY = @"arg";
     RELEASE_TO_NIL(socket);
 }
 
--(void)setConnectedSocket:(AsyncSocket*)sock
+-(void)setConnectedSocket:(AsyncSocket*)sock onThread:(NSThread*)thread
 {
     [self cleanupSocket];
     internalState = SOCKET_CONNECTED;
     socket = [sock retain];
     [socket setDelegate:self];
-    socketThread = [NSThread currentThread];
+    socketThread = thread;
 }
 
 #define AUTORELEASE_LOOP 5
@@ -213,40 +213,60 @@ static NSString* ARG_KEY = @"arg";
     // is blocking, we need to hold on to the conditions we wait on, and then release them once we're done with them. Introduces some extra
     // overhead, but it probably prevents DUMB CRASHES from happening.
     
-    // 1. Provide the run loop to the new socket...
+    // 1. Provide the run loop to the new socket and wait for it
     NSCondition* tempConditionRef = [readyCondition retain];
     [tempConditionRef lock];
     acceptRunLoop = [NSRunLoop currentRunLoop];
     [tempConditionRef signal];
-    [tempConditionRef unlock];
-    [tempConditionRef release];
     
-    // 2. ... And then wait for it to attach to the run loop.
-    AsyncSocket* newSocket = [[[info objectForKey:SOCK_KEY] retain] autorelease];
-    NSArray* arg = [info objectForKey:ARG_KEY];
-    TiNetworkSocketTCPProxy* proxy = [[[TiNetworkSocketTCPProxy alloc] _initWithPageContext:[self executionContext] args:arg] autorelease];
-    [proxy rememberSelf];
-    [proxy setConnectedSocket:newSocket];
-    
-    // TODO: remoteHost/remotePort & host/port?
-    [proxy setValue:[newSocket connectedHost] forKey:@"host"];
-    [proxy setValue:NUMINT([newSocket connectedPort]) forKey:@"port"];
-    
-    if (accepted != nil) {
-        NSDictionary* event = [NSDictionary dictionaryWithObjectsAndKeys:self,@"socket",proxy,@"inbound",nil];
-        [self _fireEventToListener:@"accepted" withObject:event listener:accepted thisObject:self];
-    }
-    
-    tempConditionRef = [readyCondition retain];
-    [tempConditionRef lock];
     if (!socketReady) {
         [tempConditionRef wait];
     }
+    socketReady = NO;
     [tempConditionRef unlock];
     [tempConditionRef release];
+        
+    // 2. Now, we configure the proxy for the current context (execution if available)
+    // AND allocate it on that kroll context. Otherwise, the memory management doesn't
+    // work and there can be garbage collection issues.
+    AsyncSocket* newSocket = [[[info objectForKey:SOCK_KEY] retain] autorelease];
+    NSArray* arg = [info objectForKey:ARG_KEY];
     
+    __block TiNetworkSocketTCPProxy* proxy = nil;
+    dispatch_semaphore_t contextSemaphore = dispatch_semaphore_create(0);
+    NSThread* acceptingThread = [NSThread currentThread];
+
+    id<TiEvaluator> context = ([self executionContext]) ? [self executionContext] : [self pageContext];
+    KrollContext* krollContext = [context krollContext];
+    void (^createBlock)(void) = ^{
+        proxy = [[TiNetworkSocketTCPProxy alloc] _initWithPageContext:context args:arg];
+        [proxy rememberSelf];
+        [proxy setConnectedSocket:newSocket onThread:acceptingThread];
+        
+        // TODO: remoteHost/remotePort & host/port?
+        [proxy setValue:[newSocket connectedHost] forKey:@"host"];
+        [proxy setValue:NUMINT([newSocket connectedPort]) forKey:@"port"];
+        
+        if (accepted != nil) {
+            NSDictionary* event = [NSDictionary dictionaryWithObjectsAndKeys:self,@"socket",proxy,@"inbound",nil];
+            [self _fireEventToListener:@"accepted" withObject:event listener:accepted thisObject:self];
+        }
+        dispatch_semaphore_signal(contextSemaphore);
+    };
+    
+    [krollContext invokeBlockOnThread:createBlock];
+    if (![krollContext isKJSThread])  {
+        dispatch_semaphore_wait(contextSemaphore, DISPATCH_TIME_FOREVER);
+    }    
+    dispatch_release(contextSemaphore);
+
     [proxy socketRunLoop];
-    [proxy forgetSelf];
+    
+    // Don't have to wait on a semaphore here; it's okay to clean out the pool without waiting.
+    [krollContext invokeBlockOnThread:^{
+        [proxy forgetSelf];
+        [proxy release];
+    }];
     
     [pool release];
 }

--- a/iphone/Classes/TiRootViewController.m
+++ b/iphone/Classes/TiRootViewController.m
@@ -38,6 +38,7 @@
 @interface TiRootViewController ()
 
 - (UIView *)keyboardAccessoryViewForProxy:(TiViewProxy<TiKeyboardFocusableView> *)visibleProxy withView:(UIView **)proxyView;
+-(UIView*)viewForKeyboardAccessory;
 
 -(void)updateBackground;
 -(void)updateOrientationHistory:(UIInterfaceOrientation)newOrientation;


### PR DESCRIPTION
This resolves a long-standing synchronization issue with accept socket creation and memory management. Also fixed an unnecessary warning message.

_NOTE_: This is also on the JIRA ticket, but testing must occur on a device which is on the same network (WIFI) as the machine connecting to it. Otherwise the device may not be discoverable.
