### PR TITLE
[TIMOB-7990] Android: Master/Detail Application Template: SIGSEGV crash on use

### DIFF
--- a/android/runtime/v8/src/java/org/appcelerator/kroll/runtime/v8/V8Object.java
+++ b/android/runtime/v8/src/java/org/appcelerator/kroll/runtime/v8/V8Object.java
@@ -51,8 +51,14 @@ public class V8Object extends KrollObject
 	@Override
 	public void doRelease()
 	{
-		nativeRelease(ptr);
-		KrollRuntime.suggestGC();
+		if (ptr == 0) {
+			return;
+		}
+
+		if (nativeRelease(ptr)) {
+			ptr = 0;
+			KrollRuntime.suggestGC();
+		}
 	}
 
 	@Override
@@ -74,7 +80,7 @@ public class V8Object extends KrollObject
 
 	// JNI method prototypes
 	protected static native void nativeInitObject(Class<?> proxyClass, Object proxyObject);
-	private static native void nativeRelease(long ptr);
+	private static native boolean nativeRelease(long ptr);
 
 	private native void nativeSetProperty(long ptr, String name, Object value);
 	private native boolean nativeFireEvent(long ptr, String event, Object data);

--- a/android/runtime/v8/src/native/V8Object.cpp
+++ b/android/runtime/v8/src/native/V8Object.cpp
@@ -109,7 +109,7 @@ Java_org_appcelerator_kroll_runtime_v8_V8Object_nativeFireEvent
 	return JNI_FALSE;
 }
 
-JNIEXPORT void JNICALL
+JNIEXPORT jboolean JNICALL
 Java_org_appcelerator_kroll_runtime_v8_V8Object_nativeRelease
 	(JNIEnv *env, jclass clazz, jlong refPointer)
 {
@@ -121,8 +121,11 @@ Java_org_appcelerator_kroll_runtime_v8_V8Object_nativeRelease
 		JavaObject *javaObject = NativeObject::Unwrap<JavaObject>(handle);
 		if (javaObject && javaObject->isDetached()) {
 			delete javaObject;
+			return true;
 		}
 	}
+
+	return false;
 }
 
 JNIEXPORT void JNICALL


### PR DESCRIPTION
Fix a crash that occurs during the Master/Detail application. The cause
was due to double releasing of the Kroll object. Added a check to bail out
in the event the Kroll object is already released.

See [TIMOB-7990](https://jira.appcelerator.org/browse/TIMOB-7990) for testing details.
