### PR TITLE
[TIMOB-8025] Force a PCH file touch to resync when performing a full rebuild

### DIFF
--- a/support/iphone/builder.py
+++ b/support/iphone/builder.py
@@ -1214,6 +1214,11 @@ def main(args):
 						print "[INFO] Executing XCode build..."
 						print "[BEGIN_VERBOSE] Executing XCode Compiler  <span>[toggle output]</span>"
 
+					# h/t cbarber for this; occasionally the PCH header info gets out of sync
+					# with the PCH file if you do the "wrong thing" and xcode isn't
+					# smart enough to pick up these changes (since the PCH file hasn't 'changed').
+					run.run(['touch', '%s_Prefix.pch' % ti.properties['name']], debug=False)
+					
 					output = run.run(args,False,False,o)
 
 					if print_output:


### PR DESCRIPTION
Thanks to Chris Barber for catching this and helping me work through to find a solution to the problem.
