### PR TITLE
[TIMOB-2502] Support for text-shadow

### DIFF
--- a/support/common/css/csscompiler.py
+++ b/support/common/css/csscompiler.py
@@ -204,10 +204,10 @@ class CSSCompiler(object):
 								shadowoffset = newdict[key][sel]['shadowOffset']
 							else:
 								shadowoffset = {}
-								shadowoffset['x'] = offset_x
-								shadowoffset['y'] = offset_y
-								newdict[key][sel]['shadowOffset'] = shadowoffset
-								newdict[key][sel]['shadowColor'] = shadow_color
+							shadowoffset['x'] = offset_x
+							shadowoffset['y'] = offset_y
+							newdict[key][sel]['shadowOffset'] = shadowoffset
+							newdict[key][sel]['shadowColor'] = shadow_color
 					else:
 						newdict[key][sel][prop]=value
 		return newdict

--- a/support/common/css/csscompiler.py
+++ b/support/common/css/csscompiler.py
@@ -196,6 +196,18 @@ class CSSCompiler(object):
 						newprop = toks[0] + toks[1].capitalize()
 						font[newprop] = value
 						newdict[key][sel]['font'] = font
+					elif prop.startswith('text-shadow'):
+						# support CSS text-shadow: x y color
+						if len(value.split()) == 3:
+							offset_x, offset_y, shadow_color = value.split()
+							if newdict[key][sel].has_key('shadowOffset'):
+								shadowoffset = newdict[key][sel]['shadowOffset']
+							else:
+								shadowoffset = {}
+								shadowoffset['x'] = offset_x
+								shadowoffset['y'] = offset_y
+								newdict[key][sel]['shadowOffset'] = shadowoffset
+								newdict[key][sel]['shadowColor'] = shadow_color
 					else:
 						newdict[key][sel][prop]=value
 		return newdict

--- a/support/common/css/csscompiler.py
+++ b/support/common/css/csscompiler.py
@@ -199,11 +199,10 @@ class CSSCompiler(object):
 					elif prop.startswith('text-shadow'):
 						# support CSS text-shadow: x y color
 						if len(value.split()) == 3:
+							shadowoffset = {}
 							offset_x, offset_y, shadow_color = value.split()
 							if newdict[key][sel].has_key('shadowOffset'):
 								shadowoffset = newdict[key][sel]['shadowOffset']
-							else:
-								shadowoffset = {}
 							shadowoffset['x'] = offset_x
 							shadowoffset['y'] = offset_y
 							newdict[key][sel]['shadowOffset'] = shadowoffset


### PR DESCRIPTION
Per MAK-12868-443 and TIMOB-2502, there is currently no way to apply shadowOffset: { x: 0, y: 1 } via JSS.

This commit adds support for the CSS "text-shadow: x y color" format to the CSS compiler, similarly to how the code handles font-size and font-weight, as a part of transform_fonts(). This makes sense since the shadow\* elements apply to fonts only anyhow.
