### PR TITLE
[TIMOB-8050] Custom accessor for Ti.UI.TableViewRow.height

### DIFF
--- a/iphone/Classes/TiUITableViewRowProxy.m
+++ b/iphone/Classes/TiUITableViewRowProxy.m
@@ -290,6 +290,11 @@ TiProxy * DeepScanForProxyOfViewContainingPoint(UIView * targetView, CGPoint poi
 	return tableClass;
 }
 
+-(NSNumber*)height
+{
+    return [self valueForUndefinedKey:@"height"];
+}
+
 -(void)setHeight:(id)value
 {
 	height = [TiUtils dimensionValue:value];

--- a/iphone/Classes/TiUITableViewRowProxy.m
+++ b/iphone/Classes/TiUITableViewRowProxy.m
@@ -290,7 +290,7 @@ TiProxy * DeepScanForProxyOfViewContainingPoint(UIView * targetView, CGPoint poi
 	return tableClass;
 }
 
--(NSNumber*)height
+-(id)height
 {
     return [self valueForUndefinedKey:@"height"];
 }


### PR DESCRIPTION
Because the class has a "height" property, this causes issues with KVC. We need to standardize an internal naming scheme for properties on classes so that they can't conflict with API points in this manner.
