### PR TITLE
[TIMOB-4313]New icons for iPad 2012 with 'corrected name'

### DIFF
--- a/support/tiapp.py
+++ b/support/tiapp.py
@@ -438,7 +438,7 @@ class TiAppXML(object):
 		tempiconslist = sorted(os.listdir(iconsdir1))
 		tempiconslist += sorted(os.listdir(iconsdir2))
 		iconslist = list(set(sorted(tempiconslist)))
-		iconorder = list([iconname+".png",iconname+"@2x.png",iconname+"-72.png",iconname+"-Small-50.png",iconname+"-Small.png",iconname+"-Small@2x.png",iconname+"-144.png",iconname+"-Small-100.png",iconname+"-Small-58.png"])
+		iconorder = list([iconname+".png",iconname+"@2x.png",iconname+"-72.png",iconname+"-72@2x.png",iconname+"-Small-50.png",iconname+"-Small-50@2x.png",iconname+"-Small.png",iconname+"-Small@2x.png"])
 		for type in iconorder:
 			for nexticon in iconslist:
 				if type == nexticon:


### PR DESCRIPTION
The new iPad icons are **appname-72@2x.png** ,**appname-Small-50@2x.png** , **appname-Small@2x.png**.

Added an new [test file](http://db.tt/96EUpkPS) for making testing easier. 

**Testing Instructions**
*Download the test file. 
*Build and see if the 3 new icons appear in info.plist
*On device see if the appicon shows 144, spotlight search of the app shows show small-100.png and setting icon shows 58
