### PR TITLE
[TIMOB-8099] Cleaned up indentation in build scripts to be correct.

### DIFF
--- a/support/iphone/compiler.py
+++ b/support/iphone/compiler.py
@@ -305,9 +305,9 @@ class Compiler(object):
 				variables = {}
 				mods.write(MODULE_IMPL_HEADER)
 				for module in modules:
-				    if module.js:
-					# CommonJS module
-					module_js.append({'from': module.js, 'path': 'modules/' + os.path.basename(module.js)})
+					if module.js:
+						# CommonJS module
+						module_js.append({'from': module.js, 'path': 'modules/' + os.path.basename(module.js)})
 					module_id = module.manifest.moduleid.lower()
 					module_name = module.manifest.name.lower()
 					module_version = module.manifest.version

--- a/support/iphone/logger.py
+++ b/support/iphone/logger.py
@@ -59,7 +59,7 @@ def main(args):
 	try:
 	  	for line in t:
 	  		print line
-			sys.stdout.flush()
+	  		sys.stdout.flush()
 	except:
 		sys.stdout.flush()
 		sys.exit(0)

--- a/support/iphone/projector.py
+++ b/support/iphone/projector.py
@@ -117,8 +117,9 @@ class Projector(object):
 				if splitext(file_)[-1] in fileTargets:
 					processed = self.process_file(from_,to_)	
 				if not processed:	
-				 	if os.path.exists(to_): os.remove(to_)
-					print "[DEBUG] copying: %s => %s" % (from_,to_)
+				 	if os.path.exists(to_):
+				 		os.remove(to_)
+				 	print "[DEBUG] copying: %s => %s" % (from_,to_)
 				 	copyfile(from_, to_)
 	
 	def process_xcode(self,content):


### PR DESCRIPTION
We should regularly be running tabnanny on the build scripts to ensure that there aren't any hidden mistakes. It turns out that there was one in the logger, which means we could have been losing information for an extended period of time.
