### PR TITLE
[TIMOD-8109] Rewrite tostring methond properly display the class name

### DIFF
--- a/iphone/Classes/TiProxy.m
+++ b/iphone/Classes/TiProxy.m
@@ -1110,11 +1110,14 @@ DEFINE_EXCEPTIONS
 	if (krollDescription==nil) 
 	{ 
 		// if we have a cached id, use it for our identifier
-		NSString *cn = [self valueForUndefinedKey:@"id"];
-		if (cn==nil)
-		{
-			cn = [[self class] description];
-		}
+        id temp = [self valueForUndefinedKey:@"id"];
+        NSString *cn =nil;
+        if (temp==nil||![temp isKindOfClass:[NSString class]]){
+              cn = NSStringFromClass([self class]);
+        }
+        else {
+            cn = temp;
+        }
 		krollDescription = [[NSString stringWithFormat:@"[object %@]",[cn stringByReplacingOccurrencesOfString:@"Proxy" withString:@""]] retain];
 	}
 


### PR DESCRIPTION
The checks on tostring where not proper, which was leading to the crash.

Test in [Jira](https://jira.appcelerator.org/browse/TIMOB-8109)

The actual bug causing the regression is a correct fix and does not need to regressed against.

The regression causing commit was :  [TableViewRow Bug Fix](https://github.com/appcelerator/titanium_mobile/commit/6a3428dd0ccc432ffd5c58b65c93fa6fa9fc35fe), i believe this was part of the layout fixes. 
