### PR TITLE
[TIMOB-8135] Element.getElementsByTagName() now conforms to DOM L2 spec.

### DIFF
--- a/iphone/Classes/TiDOMElementProxy.m
+++ b/iphone/Classes/TiDOMElementProxy.m
@@ -58,12 +58,12 @@
 {
 	ENSURE_SINGLE_ARG(args,NSString);
 	NSError *error = nil;
-	NSString *xpath = [NSString stringWithFormat:@"self::node()/descendant-or-self::*[local-name()='%@']",args];
+	NSString *xpath = [NSString stringWithFormat:@"self::node()/descendant::*[local-name()='%@']",args];
 	// see if it's a namespace
 	NSRange range = [args rangeOfString:@":"];
 	if (range.location!=NSNotFound)
 	{
-		xpath = [NSString stringWithFormat:@"self::node()/descendant-or-self::*[name()='%@']",args];
+		xpath = [NSString stringWithFormat:@"self::node()/descendant::*[name()='%@']",args];
 	}
 	NSArray *nodes = [element nodesForXPath:xpath error:&error];
 	if (error==nil)


### PR DESCRIPTION
Reverts TIMOB-7041, which was an inappropriate request.
