### PR TITLE
[TIMOB-7779] Re-enable emulator reference workaround.

### DIFF
--- a/android/runtime/v8/src/java/org/appcelerator/kroll/runtime/v8/ReferenceTable.java
+++ b/android/runtime/v8/src/java/org/appcelerator/kroll/runtime/v8/ReferenceTable.java
@@ -1,0 +1,73 @@
+package org.appcelerator.kroll.runtime.v8;
+
+import java.lang.ref.WeakReference;
+import java.util.HashMap;
+
+public final class ReferenceTable
+{
+	private static HashMap<Integer, Object> references = new HashMap<Integer, Object>();
+	private static int lastKey = 1;
+
+	/*
+	 * Creates a new reference.
+	 * @param object the object to reference and retain
+	 * @return an unique key for this reference
+	 */
+	public static int createReference(Object object)
+	{
+		int key = lastKey++;
+		references.put(key, object);
+		return key;
+	}
+
+	/*
+	 * Destroy the reference.
+	 * @param key the key for the reference to destroy.
+	 */
+	public static void destroyReference(int key)
+	{
+		references.remove(key);
+	}
+
+	/*
+	 * Makes the reference "weak" which allows it to be
+	 * collected if no other references remain.
+	 * @param key the key for the reference to weaken.
+	 */
+	public static void makeWeakReference(int key)
+	{
+		Object ref = references.get(key);
+		references.put(key, new WeakReference<Object>(ref));
+	}
+
+	/*
+	 * Make the reference strong again to prevent future collection.
+	 * This method will return null if the weak reference was
+	 * invalidated and the object collected.
+	 * @param key the key for the reference.
+	 * @return the referenced object if the reference is still valid.
+	 */
+	public static Object clearWeakReference(int key)
+	{
+		Object ref = references.get(key);
+		if (ref instanceof WeakReference) {
+			ref = ((WeakReference<?>)ref).get();
+			references.put(key, ref);
+		}
+		return ref;
+	}
+
+	/*
+	 * Returns the referenced object.
+	 * @param key the key of the reference.
+	 * @return the object if the reference is still valid otherwise null.
+	 */
+	public static Object getReference(int key)
+	{
+		Object ref = references.get(key);
+		if (ref instanceof WeakReference) {
+			ref = ((WeakReference<?>)ref).get();
+		}
+		return ref;
+	}
+}

--- a/android/runtime/v8/src/java/org/appcelerator/kroll/runtime/v8/V8Runtime.java
+++ b/android/runtime/v8/src/java/org/appcelerator/kroll/runtime/v8/V8Runtime.java
@@ -16,6 +16,7 @@ import org.appcelerator.kroll.KrollRuntime;
 import org.appcelerator.kroll.common.TiConfig;
 import org.appcelerator.kroll.common.TiDeployData;
 
+import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
 import android.os.Message;
@@ -43,16 +44,12 @@ public final class V8Runtime extends KrollRuntime implements Handler.Callback
 		boolean useGlobalRefs = true;
 		TiDeployData deployData = getKrollApplication().getDeployData();
 
-		/* TODO: Disabling this workaround for emulator to resolve issues
-		 *       seen in TIMOB-7779. Once it has been determined this workaround
-		 *       will never be needed it should be removed (TIMOB-7706).
 		if (Build.PRODUCT.equals("sdk") || Build.PRODUCT.equals("google_sdk") || Build.FINGERPRINT.startsWith("generic")) {
 			if (DBG) {
 				Log.d(TAG, "Emulator detected, storing global references in a global Map");
 			}
 			useGlobalRefs = false;
 		}
-		*/
 
 		if (!libLoaded) {
 			System.loadLibrary("stlport_shared");

--- a/android/runtime/v8/src/native/JNIUtil.cpp
+++ b/android/runtime/v8/src/native/JNIUtil.cpp
@@ -48,8 +48,8 @@ jclass JNIUtil::krollObjectClass = NULL;
 jclass JNIUtil::krollProxyClass = NULL;
 jclass JNIUtil::krollAssetHelperClass = NULL;
 jclass JNIUtil::krollLoggingClass = NULL;
-
 jclass JNIUtil::tiJsErrorDialogClass = NULL;
+jclass JNIUtil::referenceTableClass = NULL;
 
 jmethodID JNIUtil::classGetNameMethod = NULL;
 jmethodID JNIUtil::arrayListInitMethod = NULL;
@@ -75,6 +75,12 @@ jmethodID JNIUtil::throwableGetMessageMethod = NULL;
 jfieldID JNIUtil::v8ObjectPtrField = NULL;
 jmethodID JNIUtil::v8ObjectInitMethod = NULL;
 jmethodID JNIUtil::v8FunctionInitMethod = NULL;
+
+jmethodID JNIUtil::referenceTableCreateReferenceMethod = NULL;
+jmethodID JNIUtil::referenceTableDestroyReferenceMethod = NULL;
+jmethodID JNIUtil::referenceTableMakeWeakReferenceMethod = NULL;
+jmethodID JNIUtil::referenceTableClearWeakReferenceMethod = NULL;
+jmethodID JNIUtil::referenceTableGetReferenceMethod = NULL;
 
 jint JNIUtil::krollRuntimeDontIntercept = -1;
 jmethodID JNIUtil::krollInvocationInitMethod = NULL;
@@ -283,6 +289,7 @@ void JNIUtil::initCache()
 	krollAssetHelperClass = findClass("org/appcelerator/kroll/util/KrollAssetHelper");
 	krollLoggingClass = findClass("org/appcelerator/kroll/KrollLogging");
 	tiJsErrorDialogClass = findClass("org/appcelerator/kroll/common/TiJSErrorDialog");
+	referenceTableClass = findClass("org/appcelerator/kroll/runtime/v8/ReferenceTable");
 
 	classGetNameMethod = getMethodID(classClass, "getName", "()Ljava/lang/String;", false);
 	arrayListInitMethod = getMethodID(arrayListClass, "<init>", "()V", false);
@@ -312,6 +319,12 @@ void JNIUtil::initCache()
 	v8ObjectPtrField = getFieldID(v8ObjectClass, "ptr", "J");
 	v8ObjectInitMethod = getMethodID(v8ObjectClass, "<init>", "(J)V", false);
 	v8FunctionInitMethod = getMethodID(v8FunctionClass, "<init>", "(J)V", false);
+
+	referenceTableCreateReferenceMethod = getMethodID(referenceTableClass, "createReference", "(Ljava/lang/Object;)I", true);
+	referenceTableDestroyReferenceMethod = getMethodID(referenceTableClass, "destroyReference", "(I)V", true);
+	referenceTableMakeWeakReferenceMethod = getMethodID(referenceTableClass, "makeWeakReference", "(I)V", true);
+	referenceTableClearWeakReferenceMethod = getMethodID(referenceTableClass, "clearWeakReference", "(I)Ljava/lang/Object;", true);
+	referenceTableGetReferenceMethod = getMethodID(referenceTableClass, "getReference", "(I)Ljava/lang/Object;", true);
 
 	jfieldID dontInterceptField = env->GetStaticFieldID(krollRuntimeClass, "DONT_INTERCEPT", "I");
 	krollRuntimeDontIntercept = env->GetStaticIntField(krollRuntimeClass, dontInterceptField);

--- a/android/runtime/v8/src/native/JNIUtil.h
+++ b/android/runtime/v8/src/native/JNIUtil.h
@@ -72,6 +72,7 @@ public:
 	static jclass krollAssetHelperClass;
 	static jclass krollLoggingClass;
 	static jclass tiJsErrorDialogClass;
+	static jclass referenceTableClass;
 
 	// Java methods
 	static jmethodID classGetNameMethod;
@@ -99,6 +100,12 @@ public:
 	static jfieldID v8ObjectPtrField;
 	static jmethodID v8ObjectInitMethod;
 	static jmethodID v8FunctionInitMethod;
+
+	static jmethodID referenceTableCreateReferenceMethod;
+	static jmethodID referenceTableDestroyReferenceMethod;
+	static jmethodID referenceTableMakeWeakReferenceMethod;
+	static jmethodID referenceTableClearWeakReferenceMethod;
+	static jmethodID referenceTableGetReferenceMethod;
 
 	static jint krollRuntimeDontIntercept;
 	static jmethodID krollInvocationInitMethod;

--- a/android/runtime/v8/src/native/JavaObject.cpp
+++ b/android/runtime/v8/src/native/JavaObject.cpp
@@ -9,6 +9,7 @@
 #include "EventEmitter.h"
 #include "JavaObject.h"
 #include "JNIUtil.h"
+#include "ReferenceTable.h"
 
 #include <v8.h>
 
@@ -39,6 +40,7 @@ static struct {
 JavaObject::JavaObject(jobject javaObject)
 	: EventEmitter()
 	, javaObject_(NULL)
+	, refTableKey_(0)
 	, isWeakRef_(false)
 {
 	UPDATE_STATS(1, 1);
@@ -52,9 +54,9 @@ void JavaObject::newGlobalRef()
 {
 	JNIEnv *env = JNIUtil::getJNIEnv();
 	ASSERT(env != NULL);
-	ASSERT(javaObject_ != NULL);
 
 	if (useGlobalRefs) {
+		ASSERT(javaObject_ != NULL);
 		jobject globalRef = env->NewGlobalRef(javaObject_);
 		if (isWeakRef_) {
 			env->DeleteWeakGlobalRef(javaObject_);
@@ -62,18 +64,8 @@ void JavaObject::newGlobalRef()
 		}
 		javaObject_ = globalRef;
 	} else {
-		// We store a single global reference to an object list that holds our actual ref list for the emulator
-		// (or whenever the reference limit is artificially limited)
-		if (!objectMap) {
-			objectMap = env->NewGlobalRef(
-				env->NewObject(JNIUtil::hashMapClass, JNIUtil::hashMapInitMethod, 2000));
-		}
-		jobject longObject = env->NewObject(JNIUtil::longClass, JNIUtil::longInitMethod, (jlong) this);
-		jobject r = env->CallObjectMethod(objectMap, JNIUtil::hashMapPutMethod, longObject, javaObject_);
-		env->DeleteLocalRef(r);
-		env->DeleteLocalRef(longObject);
-
-		// This will be requeried from getJavaObject()
+		ASSERT(refTableKey_ == 0);
+		refTableKey_ = ReferenceTable::createReference(javaObject_);
 		javaObject_ = NULL;
 	}
 }
@@ -93,18 +85,15 @@ jobject JavaObject::getJavaObject()
 
 		return javaObject_;
 	} else {
-		// Pull from the global object list. This is inefficient, but it's probably
-		// the only workaround for hard limits on the JNI global reference count
-		JNIEnv *env = JNIUtil::getJNIEnv();
-		if (!env) {
-			LOGE(TAG, "Failed to get JNI environment.");
-			return NULL;
+		if (isWeakRef_) {
+			jobject javaObject = ReferenceTable::clearWeakReference(refTableKey_);
+			if (javaObject == NULL) {
+				LOGE(TAG, "Java object reference has been invalidated.");
+			}
+			isWeakRef_ = false;
+			return javaObject;
 		}
-
-		jobject longObject = env->NewObject(JNIUtil::longClass, JNIUtil::longInitMethod, (jlong) this);
-		jobject javaObject = env->CallObjectMethod(objectMap, JNIUtil::hashMapGetMethod, longObject);
-		env->DeleteLocalRef(longObject);
-		return javaObject;
+		return ReferenceTable::getReference(refTableKey_);
 	}
 }
 
@@ -118,11 +107,11 @@ void JavaObject::weakGlobalRef()
 		jweak weakRef = env->NewWeakGlobalRef(javaObject_);
 		env->DeleteGlobalRef(javaObject_);
 		javaObject_ = weakRef;
-		isWeakRef_ = true;
+	} else {
+		ReferenceTable::makeWeakReference(refTableKey_);
 	}
 
-	// TODO: Implement weak references when using
-	// our emulator global reference hack.
+	isWeakRef_ = true;
 }
 
 void JavaObject::deleteGlobalRef()
@@ -139,12 +128,8 @@ void JavaObject::deleteGlobalRef()
 		}
 		javaObject_ = NULL;
 	} else {
-		// Clear from the global object list
-		if (objectMap) {
-			jobject longObject = env->NewObject(JNIUtil::longClass, JNIUtil::longInitMethod, (jlong) this);
-			env->CallObjectMethod(objectMap, JNIUtil::hashMapRemoveMethod, longObject);
-			env->DeleteLocalRef(longObject);
-		}
+		ReferenceTable::destroyReference(refTableKey_);
+		refTableKey_ = 0;
 	}
 }
 
@@ -152,7 +137,7 @@ JavaObject::~JavaObject()
 {
 	UPDATE_STATS(-1, isDetached() ? -1 : 0);
 
-	if (javaObject_) {
+	if (javaObject_ || refTableKey_ > 0) {
 		deleteGlobalRef();
 	}
 }
@@ -196,18 +181,7 @@ void JavaObject::detach()
 
 bool JavaObject::isDetached()
 {
-	// Fast check if using real global references.
-	if (useGlobalRefs) {
-		return javaObject_ == NULL || isWeakRef_;
-	}
-
-	jobject javaObject = getJavaObject();
-	if (javaObject == NULL) {
-		return true;
-	}
-	JNIEnv *env = JNIUtil::getJNIEnv();
-	env->DeleteLocalRef(javaObject);
-	return false;
+	return (javaObject_ == NULL && refTableKey_ == 0) || isWeakRef_;
 }
 
 }

--- a/android/runtime/v8/src/native/JavaObject.h
+++ b/android/runtime/v8/src/native/JavaObject.h
@@ -64,6 +64,7 @@ public:
 	static bool useGlobalRefs;
 private:
 	jobject javaObject_;
+	jint refTableKey_;
 	bool isWeakRef_;
 
 	void newGlobalRef();

--- a/android/runtime/v8/src/native/ReferenceTable.cpp
+++ b/android/runtime/v8/src/native/ReferenceTable.cpp
@@ -1,0 +1,60 @@
+/**
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2012 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+
+#include "ReferenceTable.h"
+
+#include "JNIUtil.h"
+
+namespace titanium {
+
+jint ReferenceTable::createReference(jobject object)
+{
+	JNIEnv* env = JNIUtil::getJNIEnv();
+	return env->CallStaticIntMethod(
+		JNIUtil::referenceTableClass,
+		JNIUtil::referenceTableCreateReferenceMethod,
+		object);
+}
+
+void ReferenceTable::destroyReference(jint key)
+{
+	JNIEnv* env = JNIUtil::getJNIEnv();
+	env->CallStaticVoidMethod(
+		JNIUtil::referenceTableClass,
+		JNIUtil::referenceTableDestroyReferenceMethod,
+		key);
+}
+
+void ReferenceTable::makeWeakReference(jint key)
+{
+	JNIEnv* env = JNIUtil::getJNIEnv();
+	env->CallStaticVoidMethod(
+		JNIUtil::referenceTableClass,
+		JNIUtil::referenceTableMakeWeakReferenceMethod,
+		key);
+}
+
+jobject ReferenceTable::clearWeakReference(jint key)
+{
+	JNIEnv* env = JNIUtil::getJNIEnv();
+	return env->CallStaticObjectMethod(
+		JNIUtil::referenceTableClass,
+		JNIUtil::referenceTableClearWeakReferenceMethod,
+		key);
+}
+
+jobject ReferenceTable::getReference(jint key)
+{
+	JNIEnv* env = JNIUtil::getJNIEnv();
+	return env->CallStaticObjectMethod(
+		JNIUtil::referenceTableClass,
+		JNIUtil::referenceTableGetReferenceMethod,
+		key);
+}
+
+} // namespace titanium
+

--- a/android/runtime/v8/src/native/ReferenceTable.h
+++ b/android/runtime/v8/src/native/ReferenceTable.h
@@ -1,0 +1,36 @@
+/**
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2012 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+
+#ifndef TI_KROLL_REFERENCE_TABLE_H
+#define TI_KROLL_REFERENCE_TABLE_H
+
+#include <jni.h>
+
+namespace titanium {
+
+/*
+ * A reference table for Java objects. The purpose
+ * of this is to workaround JNI global reference limits
+ * put in place on certain devices (ex: emulator).
+ * It is implemented by placing the referenced
+ * objects into a container (HashMap) and accessing
+ * them later by an unique integer key. See
+ * ReferenceTable.java in kroll-v8 project.
+ */
+class ReferenceTable
+{
+public:
+	static jint createReference(jobject object);
+	static void destroyReference(jint key);
+	static void makeWeakReference(jint key);
+	static jobject clearWeakReference(jint key);
+	static jobject getReference(jint key);
+};
+
+} // namespace titanium
+
+#endif


### PR DESCRIPTION
This re-enables a workaround to prevent hitting the JNI reference limit on emulator.
Includes improvements to fix memory leaks seen previously with the workaround.
## Testing
1. See [TIMOB-7779](https://jira.appcelerator.org/browse/TIMOB-7779) for test cases. Run these on emulator and verify we don't hit the JNI reference limit.
2. Verify ABI compatibility by testing if a module compiled against 1.8.2 still runs with these changes.
