### PR TITLE
Label background color

### DIFF
--- a/iphone/Classes/TiUILabel.m
+++ b/iphone/Classes/TiUILabel.m
@@ -6,6 +6,7 @@
  */
 #ifdef USE_TI_UILABEL
 
+#import "TiColor.h"
 #import "TiUILabel.h"
 #import "TiUILabelProxy.h"
 #import "TiUtils.h"
@@ -173,6 +174,15 @@
         [[self label] setMinimumFontSize:newSize];
     }
     
+}
+
+-(void)setBackgroundColor_:(id)value
+{
+	if (value!=nil)
+	{
+		TiColor *color = [TiUtils colorValue:value];
+		[[self label] setBackgroundColor:[color _color]];
+	}
 }
 
 -(void)setBackgroundImage_:(id)url


### PR DESCRIPTION
Problem: You couldn't assign a backgroundColor directly to a label. It is initialized to clear. 

This can lead to performance penalty, as described in this post: http://blogs.captechconsulting.com/blog/john-szumski/performance-tuning-older-ios-devices

Solution: Enabled setBackgroundColor_ for label. Performs as before - if no color given, defaults to clear (transparent) else assigns bg color to the label directly. If dev's care, they can take the time to set the proper label backgroundColor now. 
