### PR TITLE
[TIMOB-8272]Ensure getAnnotations does not mangle order of array

### DIFF
--- a/iphone/Classes/TiMapViewProxy.m
+++ b/iphone/Classes/TiMapViewProxy.m
@@ -252,7 +252,7 @@
     if(attached) {
         TiThreadPerformOnMainThread(^{
             [(TiMapView*)[self view] setAnnotations_:newAnnotations];
-        }, NO);
+        }, YES);
         [currentAnnotations release];
     }
     else {

--- a/iphone/Classes/TiMapViewProxy.m
+++ b/iphone/Classes/TiMapViewProxy.m
@@ -216,7 +216,7 @@
     ENSURE_TYPE(arg,NSArray)
     
     //Save the passed in args as a property in our dyndns
-    [self replaceValue:arg forKey:@"setAnnotations_" notification:NO];
+    [self replaceValue:arg forKey:@"annotations_" notification:NO];
     
     NSMutableArray* newAnnotations = [NSMutableArray arrayWithCapacity:[arg count]];
     for (id ann in arg) {
@@ -265,7 +265,7 @@
 
 -(NSArray*)annotations
 {
-    return [self valueForUndefinedKey:@"setAnnotations_"];
+    return [self valueForUndefinedKey:@"annotations_"];
 }
 
 -(void)removeAnnotation:(id)arg

--- a/iphone/Classes/TiMapViewProxy.m
+++ b/iphone/Classes/TiMapViewProxy.m
@@ -215,6 +215,9 @@
 -(void)setAnnotations:(id)arg{
     ENSURE_TYPE(arg,NSArray)
     
+    //Save the passed in args as a property in our dyndns
+    [self replaceValue:arg forKey:@"setAnnotations_" notification:NO];
+    
     NSMutableArray* newAnnotations = [NSMutableArray arrayWithCapacity:[arg count]];
     for (id ann in arg) {
         [newAnnotations addObject:[self annotationFromArg:ann]];
@@ -262,16 +265,7 @@
 
 -(NSArray*)annotations
 {
-    if ([self viewAttached]) {
-        __block NSArray* currentAnnotations = nil;
-        TiThreadPerformOnMainThread(^{
-            currentAnnotations = [[(TiMapView*)[self view] customAnnotations] retain];
-        }, YES);
-        return [currentAnnotations autorelease];
-    }
-    else {
-        return annotationsToAdd;
-    }
+    return [self valueForUndefinedKey:@"setAnnotations_"];
 }
 
 -(void)removeAnnotation:(id)arg


### PR DESCRIPTION
Test is in [JIRA](https://jira.appcelerator.org/browse/TIMOB-8272)

getAnnotations() method and annotations property must return the value passed in setAnnotations() method.
