### PR TITLE
[TIMOB-8247] Constrain both width and height during layout

### DIFF
--- a/iphone/Classes/LayoutConstraint.m
+++ b/iphone/Classes/LayoutConstraint.m
@@ -179,7 +179,8 @@ CGSize SizeConstraintViewWithSizeAddingResizing(LayoutConstraint * constraint, N
             //If it comes here it has to follow size behavior
             if ([autoSizer respondsToSelector:@selector(autoHeightForSize:)])
             {
-                height = [autoSizer autoHeightForSize:CGSizeMake(width, height)];
+                CGFloat desiredHeight = [autoSizer autoHeightForSize:CGSizeMake(width, height)];
+                height = height < desiredHeight?height:desiredHeight;
             }
             else if(resultResizing != NULL)
             {


### PR DESCRIPTION
Test is in [JIRA](https://jira.appcelerator.org/browse/TIMOB-8247)

FR should regress against the following tickets
[TIMOB-7562](https://jira.appcelerator.org/browse/TIMOB-7562)
[TIMOB-7952](https://jira.appcelerator.org/browse/TIMOB-7952)
[TIMOB-7947](https://jira.appcelerator.org/browse/TIMOB-7947)
[TIMOB-7490](https://jira.appcelerator.org/browse/TIMOB-7490)
[TIMOB-7958](https://jira.appcelerator.org/browse/TIMOB-7958)
[TIMOB-7810](https://jira.appcelerator.org/browse/TIMOB-7810). Run code from comments.
[TIMOB-7784](https://jira.appcelerator.org/browse/TIMOB-7784)
[TIMOB-8193](https://jira.appcelerator.org/browse/TIMOB-8193)
KS->Base UI->Vertical Layout
KS->Base UI->Horizontal Layout
KS->Base UI->Views->Table Views-> Table Auto Height
