### PR TITLE
Fix https://jira.appcelerator.org/browse/TIMOB-6839

### DIFF
--- a/support/module/android/android.py
+++ b/support/module/android/android.py
@@ -32,7 +32,9 @@ class android(module.ModulePlatform):
 			self.sdk.get_android_jar(),
 			self.sdk.get_maps_jar(),
 			'/'.join([sdk_android_dir, 'titanium.jar']),
-			'/'.join([sdk_android_dir, 'js.jar'])
+			'/'.join([sdk_android_dir, 'js.jar']),
+			'/'.join([sdk_android_dir, 'kroll-common.jar']),
+			'/'.join([sdk_android_dir, 'kroll-apt.jar'])
 		]
 		self.classpath = ""
 		for lib in classpath_libs:


### PR DESCRIPTION
A simple fix to add missing Jar files into the .classpath that is generated for the Eclipse project.
Right now, we get Java compilation errors right after creating a new Mobile Module project in Titanium Studio, so this is pretty important.
Thanks!
