### PR TITLE
[TIMOB-8329] iOS: TiMediaVideoPlayerProxy is not properly removed as observer on MPMoviePlayerController when it' released

### DIFF
--- a/iphone/Classes/TiMediaVideoPlayerProxy.m
+++ b/iphone/Classes/TiMediaVideoPlayerProxy.m
@@ -405,7 +405,11 @@ NSArray* moviePlayerKeys = nil;
 	
 	if ([self viewAttached]) {
 		TiMediaVideoPlayer *video = (TiMediaVideoPlayer*)[self view];
-		[video setMovie:[self ensurePlayer]];
+        if (movie != nil) {
+            [movie setContentURL:url];
+        } else {
+            [self ensurePlayer];
+        }
 		[video frameSizeChanged:[video frame] bounds:[video bounds]];
 	}
 	

--- a/iphone/Classes/TiMediaVideoPlayerProxy.m
+++ b/iphone/Classes/TiMediaVideoPlayerProxy.m
@@ -74,12 +74,13 @@ NSArray* moviePlayerKeys = nil;
 		[movie stop];
 	}
 	
-	WARN_IF_BACKGROUND_THREAD;	//NSNotificationCenter is not threadsafe!
-	[[NSNotificationCenter defaultCenter] removeObserver:self];
+    TiThreadPerformOnMainThread(^{
+        [[NSNotificationCenter defaultCenter] removeObserver:self];
+        RELEASE_TO_NIL(movie);
+    }, YES);
 
 	RELEASE_TO_NIL(thumbnailCallback);
 	RELEASE_TO_NIL(tempFile);
-	RELEASE_TO_NIL(movie);
 	RELEASE_TO_NIL(url);
 	RELEASE_TO_NIL(loadProperties);
 	RELEASE_TO_NIL(playerLock);
@@ -155,6 +156,11 @@ NSArray* moviePlayerKeys = nil;
 		TiMediaVideoPlayer *vp = (TiMediaVideoPlayer*)[self view];
 		[vp setMovie:movie];
 	}
+}
+
+-(MPMoviePlayerController *)player
+{
+    return movie;
 }
 
 -(MPMoviePlayerController *)ensurePlayer
@@ -396,8 +402,6 @@ NSArray* moviePlayerKeys = nil;
 		[movie stop];
 		playing = NO;
 	}
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
-	RELEASE_TO_NIL_AUTORELEASE(movie);
 	
 	if ([self viewAttached]) {
 		TiMediaVideoPlayer *video = (TiMediaVideoPlayer*)[self view];
@@ -723,8 +727,6 @@ NSArray* moviePlayerKeys = nil;
     ENSURE_UI_THREAD(stop, args);
 	playing = NO;
 	[movie stop];
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
-	RELEASE_TO_NIL_AUTORELEASE(movie);
 }
 
 -(void)play:(id)args

--- a/iphone/Classes/TiMediaVideoPlayerProxy.m
+++ b/iphone/Classes/TiMediaVideoPlayerProxy.m
@@ -418,8 +418,12 @@ NSArray* moviePlayerKeys = nil;
 -(void)setUrl:(id)url_
 {
 	ENSURE_UI_THREAD(setUrl,url_);
+    NSURL* newUrl = [TiUtils toURL:url_ proxy:self];
+    if ([url isEqual:newUrl]) {
+        return;
+    }
 	RELEASE_TO_NIL(url);
-	url = [[TiUtils toURL:url_ proxy:self] retain];
+	url = [newUrl retain];
     loaded = NO;
 	
 	if (movie!=nil)

--- a/iphone/Classes/TiMediaVideoPlayerProxy.m
+++ b/iphone/Classes/TiMediaVideoPlayerProxy.m
@@ -75,8 +75,7 @@ NSArray* moviePlayerKeys = nil;
 	}
 	
 	WARN_IF_BACKGROUND_THREAD;	//NSNotificationCenter is not threadsafe!
-	NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
-	[nc removeObserver:self];
+	[[NSNotificationCenter defaultCenter] removeObserver:self];
 
 	RELEASE_TO_NIL(thumbnailCallback);
 	RELEASE_TO_NIL(tempFile);
@@ -195,6 +194,7 @@ NSArray* moviePlayerKeys = nil;
 -(void)viewDidDetach
 {
 	[movie stop];
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
 	RELEASE_TO_NIL(movie);
 	reallyAttached = NO;
 }
@@ -396,6 +396,7 @@ NSArray* moviePlayerKeys = nil;
 		[movie stop];
 		playing = NO;
 	}
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
 	RELEASE_TO_NIL_AUTORELEASE(movie);
 	
 	if ([self viewAttached]) {
@@ -722,6 +723,7 @@ NSArray* moviePlayerKeys = nil;
     ENSURE_UI_THREAD(stop, args);
 	playing = NO;
 	[movie stop];
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
 	RELEASE_TO_NIL_AUTORELEASE(movie);
 }
 


### PR DESCRIPTION
[TIMOB-8329](https://jira.appcelerator.org/browse/TIMOB-8329)

These changes are code cleanup that caused crashes at [TIMOB-7969](https://jira.appcelerator.org/browse/TIMOB-7969)

FT note: No test case available. Use KS video related tests.
