### PR TITLE
[TIMOB-7933] Windows follow same code path with or without open animation

### DIFF
--- a/iphone/Classes/TiWindowProxy.m
+++ b/iphone/Classes/TiWindowProxy.m
@@ -415,9 +415,7 @@ END_UI_THREAD_PROTECTED_VALUE(opened)
 		{
 			if (rootViewAttached)
 			{
-				[[TiApp controller] willShowViewController:[self controller] animated:YES];
 				[self attachViewToTopLevelWindow];
-				[[TiApp controller] didShowViewController:[self controller] animated:YES];
 			}
 			if ([openAnimation isTransitionAnimation])
 			{


### PR DESCRIPTION
Duplicate of PR #1687 for the 1_8_X branch

Test is in [JIRA](https://jira.appcelerator.org/browse/TIMOB-7933)
