### PR TITLE
[TIMOB-7607] 1_8_X: Fix method name typo from earlier commit.

### DIFF
--- a/iphone/Classes/TiMediaVideoPlayerProxy.m
+++ b/iphone/Classes/TiMediaVideoPlayerProxy.m
@@ -497,7 +497,7 @@ NSArray* moviePlayerKeys = nil;
 	NSNumber* option = [args objectAtIndex:1];
 	thumbnailCallback = [[args objectAtIndex:2] retain];
 	
-	[[self player] requestThumbnailImagesAtTimes:array timeOption:[option intValue]];
+	[[self ensurePlayer] requestThumbnailImagesAtTimes:array timeOption:[option intValue]];
 
 }
 


### PR DESCRIPTION
Fix for bad code review of #1879. Mea culpa.
