### PR TITLE
[TIMOB-8100] iOS: barImage hides nav buttons after window transition

### DIFF
--- a/iphone/Classes/TiUIWindowProxy.m
+++ b/iphone/Classes/TiUIWindowProxy.m
@@ -328,7 +328,7 @@
 	[self replaceValue:[self sanitizeURL:value] forKey:@"barImage" notification:NO];
 	if (controller!=nil)
 	{
-		TiThreadPerformOnMainThread(^{[self updateBarImage];}, [NSThread isMainThread]);
+		TiThreadPerformOnMainThread(^{[self updateBarImage];}, NO);
 	}
 }
 


### PR DESCRIPTION
REGRESSION CAUSED BY:

```
  commit :  ac9e131fb95428b8aa0fd90bdc7dc6da244e1666
  ticket : [TIMOB-7363 Update barImage immediately if it is main thread](https://jira.appcelerator.org/browse/TIMOB-7363).
```

Interestingly enough reverting the fixing undo's the problem and the fix for it was introduced also does not exist any more.

**TESTING INTRUCTIONS**
[TIMOB-8100](https://jira.appcelerator.org/browse/TIMOB-8100)
[TIMOB-7455](https://jira.appcelerator.org/browse/TIMOB-7455)
[TIMOB-7425](https://jira.appcelerator.org/browse/TIMOB-7425)
[TIMOB-7363](https://jira.appcelerator.org/browse/TIMOB-7363) 
