### PR TITLE
[TIMOB-8293] Ensure HTML property is set on proxy for persistence

### DIFF
--- a/iphone/Classes/TiUIWebViewProxy.m
+++ b/iphone/Classes/TiUIWebViewProxy.m
@@ -107,6 +107,7 @@ USE_VIEW_FOR_CONTENT_WIDTH
 
 -(void)setHtml:(NSString*)content withObject:(id)property
 {
+    [self replaceValue:content forKey:@"html" notification:NO];
     TiThreadPerformOnMainThread(^{
         [(TiUIWebView *)[self view] setHtml_:content withObject:property];
     }, YES);


### PR DESCRIPTION
Resolves an issue which appears to be very common with custom setters - we do not in any way persistently cache the property. In this case when the webview was deallocated (the window it was in was closed) the lack of HTML property persistence was causing some kind of load issue.
