### PR TITLE
[TIMOB-3432]Ensure url is cleared when app enters background

### DIFF
--- a/demos/KitchenSink/Resources/app.js
+++ b/demos/KitchenSink/Resources/app.js
@@ -365,7 +365,11 @@ if (isiOS4Plus())
 	var service = Ti.App.iOS.registerBackgroundService({url:'bg.js'});
 
 	Ti.API.info("registered background service = "+service);
-
+	
+	if(Ti.App.getArguments().url)
+	{
+		alert(Ti.App.getArguments().url);
+	}
 	// listen for a local notification event
 	Ti.App.iOS.addEventListener('notification',function(e)
 	{
@@ -375,6 +379,10 @@ if (isiOS4Plus())
 	// fired when an app resumes for suspension
 	Ti.App.addEventListener('resume',function(e){
 		Ti.API.info("app is resuming from the background");
+		if(Ti.App.getArguments().url)
+		{
+			alert(Ti.App.getArguments().url);
+		}
 	});
 	Ti.App.addEventListener('resumed',function(e){
 		Ti.API.info("app has resumed from the background");

--- a/demos/KitchenSink/Resources/app.js
+++ b/demos/KitchenSink/Resources/app.js
@@ -379,13 +379,13 @@ if (isiOS4Plus())
 	// fired when an app resumes for suspension
 	Ti.App.addEventListener('resume',function(e){
 		Ti.API.info("app is resuming from the background");
+	});
+	Ti.App.addEventListener('resumed',function(e){
+		Ti.API.info("app has resumed from the background");
 		if(Ti.App.getArguments().url)
 		{
 			alert(Ti.App.getArguments().url);
 		}
-	});
-	Ti.App.addEventListener('resumed',function(e){
-		Ti.API.info("app has resumed from the background");
 	});
 
 	Ti.App.addEventListener('pause',function(e){

--- a/iphone/Classes/TiApp.mm
+++ b/iphone/Classes/TiApp.mm
@@ -416,9 +416,6 @@ TI_INLINE void waitForMemoryPanicCleared();   //WARNING: This must never be run 
 {
 	[TiUtils queueAnalytics:@"ti.background" name:@"ti.background" data:nil];
 
-    //TIMOB-3432. Ensure url is cleared when app enters background.
-    [launchOptions removeObjectForKey:@"url"];
-
 	if (backgroundServices==nil)
 	{
 		return;
@@ -451,10 +448,13 @@ TI_INLINE void waitForMemoryPanicCleared();   //WARNING: This must never be run 
     [sessionId release];
     sessionId = [[TiUtils createUUID] retain];
     
+    //TIMOB-3432. Ensure url is cleared when resume event is fired.
+    [launchOptions removeObjectForKey:@"url"];
+
 	[[NSNotificationCenter defaultCenter] postNotificationName:kTiResumeNotification object:self];
 	
 	[TiUtils queueAnalytics:@"ti.foreground" name:@"ti.foreground" data:nil];
-	
+    
 	if (backgroundServices==nil)
 	{
 		return;

--- a/iphone/Classes/TiApp.mm
+++ b/iphone/Classes/TiApp.mm
@@ -416,7 +416,9 @@ TI_INLINE void waitForMemoryPanicCleared();   //WARNING: This must never be run 
 {
 	[TiUtils queueAnalytics:@"ti.background" name:@"ti.background" data:nil];
 
-	
+    //TIMOB-3432. Ensure url is cleared when app enters background.
+    [launchOptions removeObjectForKey:@"url"];
+
 	if (backgroundServices==nil)
 	{
 		return;


### PR DESCRIPTION
[TIMOB-3432](https://jira.appcelerator.org/browse/TIMOB-3432)
Testing instructions.

Install KS on device/sim. Ensure KS is killed.
Open safari and type in kitchensink://hello

KS should launch and you should see an alert.
Background KS and relaunch again. 
Alert should not be shown (new behavior). 

Current behavior (alert will be shown every time until the app is killed completely)
