### PR TITLE
[TIMOB-4800] Android: Ti.UI.backgroundColor/Ti.UI.backgroundImage not translucent

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/UIModule.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/UIModule.java
@@ -15,13 +15,16 @@ import org.appcelerator.titanium.TiBaseActivity;
 import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.TiContext;
 import org.appcelerator.titanium.TiDimension;
+import org.appcelerator.titanium.TiRootActivity;
 import org.appcelerator.titanium.proxy.TiWindowProxy;
+import org.appcelerator.titanium.util.TiColorHelper;
 import org.appcelerator.titanium.util.TiConvert;
 import org.appcelerator.titanium.util.TiOrientationHelper;
 import org.appcelerator.titanium.util.TiUIHelper;
 
 import android.app.Activity;
 import android.content.res.Resources;
+import android.graphics.Color;
 import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
 import android.os.Handler;
@@ -147,9 +150,9 @@ public class UIModule extends KrollModule implements Handler.Callback
 
 	protected void doSetBackgroundColor(String color)
 	{
-		Window w = TiApplication.getInstance().getRootActivity().getWindow();
-		if (w != null) {
-			w.setBackgroundDrawable(new ColorDrawable(TiConvert.toColor((String)color)));
+		TiRootActivity root = TiApplication.getInstance().getRootActivity();
+		if (root != null) {
+			root.setBackgroundColor(color != null ? TiColorHelper.parseColor(color) : Color.TRANSPARENT);
 		}
 	}
 
@@ -167,22 +170,21 @@ public class UIModule extends KrollModule implements Handler.Callback
 
 	protected void doSetBackgroundImage(Object image)
 	{
-		Window w = TiApplication.getInstance().getRootActivity().getWindow();
-		if (w != null) {
+		TiRootActivity root = TiApplication.getInstance().getRootActivity();
+		if (root != null) {
+			Drawable imageDrawable = null;
+
 			if (image instanceof Number) {
 				try {
-					w.setBackgroundDrawableResource(((Number)image).intValue());
+					imageDrawable = TiUIHelper.getResourceDrawable((Integer)image);
 				} catch (Resources.NotFoundException e) {
 					Log.w(LCAT , "Unable to set background drawable for root window.  An integer id was provided but no such drawable resource exists.");
 				}
-				return;
+			} else {
+				imageDrawable = TiUIHelper.getResourceDrawable(image);
 			}
-			// TODO - current activity should work just fine in this instance - verify?
-			Drawable d = TiUIHelper.getResourceDrawable(image);
 
-			if (d != null) {
-				w.setBackgroundDrawable(d);
-			}
+			root.setBackgroundImage(imageDrawable);
 		}
 	}
 

--- a/android/titanium/src/java/org/appcelerator/titanium/TiRootActivity.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiRootActivity.java
@@ -13,14 +13,56 @@ import org.appcelerator.titanium.util.TiActivitySupport;
 import org.appcelerator.titanium.util.TiRHelper;
 
 import android.content.res.Configuration;
+import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
+import android.graphics.drawable.LayerDrawable;
 import android.os.Bundle;
+import android.view.Window;
 
 public class TiRootActivity extends TiLaunchActivity
 	implements TiActivitySupport
 {
 	private static final String LCAT = "TiRootActivity";
 	private static final boolean DBG = TiConfig.LOGD;
+
+	private Drawable[] backgroundLayers = {null, null};
+
+	public void setBackgroundColor(int color)
+	{
+		Window window = getWindow();
+		if (window == null) {
+			return;
+		}
+
+		Drawable colorDrawable = new ColorDrawable(color);
+		backgroundLayers[0] = colorDrawable;
+
+		if (backgroundLayers[1] != null) {
+			window.setBackgroundDrawable(new LayerDrawable(backgroundLayers));
+		} else {
+			window.setBackgroundDrawable(colorDrawable);
+		}
+	}
+
+	public void setBackgroundImage(Drawable image)
+	{
+		Window window = getWindow();
+		if (window == null) {
+			return;
+		}
+
+		backgroundLayers[1] = image;
+		if (image == null) {
+			window.setBackgroundDrawable(backgroundLayers[0]);
+			return;
+		}
+
+		if (backgroundLayers[0] != null) {
+			window.setBackgroundDrawable(new LayerDrawable(backgroundLayers));
+		} else {
+			window.setBackgroundDrawable(image);
+		}
+	}
 
 	@Override
 	public String getUrl()

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiUIHelper.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiUIHelper.java
@@ -61,6 +61,7 @@ import android.graphics.Typeface;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
+import android.graphics.drawable.LayerDrawable;
 import android.graphics.drawable.StateListDrawable;
 import android.os.AsyncTask;
 import android.os.Build;
@@ -451,6 +452,67 @@ public class TiUIHelper
 		textView.setPadding(rawHPadding, rawVPadding, rawHPadding, rawVPadding);
 	}
 
+	private static Drawable buildBackgroundDrawable(String color, String image, boolean tileImage)
+	{
+		Drawable colorDrawable = null;
+		if (color != null) {
+			colorDrawable = new ColorDrawable(TiColorHelper.parseColor(color));
+		}
+
+		Drawable imageDrawable = null;
+		if (image != null) {
+			TiFileHelper tfh = TiFileHelper.getInstance();
+			Context appContext = TiApplication.getInstance();
+
+			if (tileImage) {
+				InputStream inputStream;
+				try {
+					inputStream = tfh.openInputStream(image, false);
+					if (inputStream != null) {
+						BitmapDrawable tiledBackground = new BitmapDrawable(appContext.getResources(), inputStream);
+						tiledBackground.setTileModeX(Shader.TileMode.REPEAT);
+						tiledBackground.setTileModeY(Shader.TileMode.REPEAT);
+
+						imageDrawable = tiledBackground;
+					}
+
+				} catch (IOException e) {
+					Log.e(LCAT, "Exception occured when trying to open stream to specified background image: ", e);
+				}
+
+			} else {
+				imageDrawable = tfh.loadDrawable(image, false, true);
+			}
+		}
+
+		if (colorDrawable != null && imageDrawable != null) {
+			return new LayerDrawable(new Drawable[] {colorDrawable, imageDrawable});
+		} else {
+			return colorDrawable != null ? colorDrawable : imageDrawable;
+		}
+	}
+
+	private static final int[] BACKGROUND_DEFAULT_STATE_1 = {
+		android.R.attr.state_window_focused,
+		android.R.attr.state_enabled
+	};
+	private static final int[] BACKGROUND_DEFAULT_STATE_2 = {
+		android.R.attr.state_enabled
+	};
+	private static final int[] BACKGROUND_SELECTED_STATE = {
+		android.R.attr.state_window_focused,
+		android.R.attr.state_enabled,
+		android.R.attr.state_pressed
+	};
+	private static final int[] BACKGROUND_FOCUSED_STATE = {
+		android.R.attr.state_focused,
+		android.R.attr.state_window_focused,
+		android.R.attr.state_enabled
+	};
+	private static final int[] BACKGROUND_DISABLED_STATE = {
+		-android.R.attr.state_enabled
+	};
+
 	public static StateListDrawable buildBackgroundDrawable(
 		String image,
 		boolean tileImage,
@@ -462,120 +524,27 @@ public class TiUIHelper
 		String focusedImage,
 		String focusedColor)
 	{
-		StateListDrawable sld = null;
+		StateListDrawable sld = new StateListDrawable();
 
-		Drawable bgDrawable = null;
-		Drawable bgSelectedDrawable = null;
-		Drawable bgFocusedDrawable = null;
-		Drawable bgDisabledDrawable = null;
-
-		Context appContext = TiApplication.getInstance();
-		TiFileHelper tfh = new TiFileHelper(appContext);
-
-		if (image != null) {
-			if (tileImage) {
-				InputStream inputStream;
-				try {
-					inputStream = tfh.openInputStream(image, false);
-					if (inputStream != null) {
-						BitmapDrawable tiledBackground = new BitmapDrawable(appContext.getResources(), inputStream);
-						tiledBackground.setTileModeX(Shader.TileMode.REPEAT);
-						tiledBackground.setTileModeY(Shader.TileMode.REPEAT);
-
-						bgDrawable = tiledBackground;
-					}
-
-				} catch (IOException e) {
-					Log.e(LCAT, "Exception occured when trying to open stream to specified background image: ", e);
-				}
-
-			} else {
-				bgDrawable = tfh.loadDrawable(image, false, true);
-			}
-
-		} else if (color != null) {
-			bgDrawable = new ColorDrawable(TiConvert.toColor(color));
+		Drawable bgSelectedDrawable = buildBackgroundDrawable(selectedColor, selectedImage, false);
+		if (bgSelectedDrawable != null) {
+			sld.addState(BACKGROUND_SELECTED_STATE, bgSelectedDrawable);
 		}
 
-		if (selectedImage != null) {
-			bgSelectedDrawable = tfh.loadDrawable(selectedImage, false, true);
-
-		} else if (selectedColor != null) {
-			bgSelectedDrawable = new ColorDrawable(TiConvert.toColor(selectedColor));
-
-		} else if (bgDrawable != null) {
-			bgSelectedDrawable = bgDrawable;			
+		Drawable bgFocusedDrawable = buildBackgroundDrawable(focusedColor, focusedImage, false);
+		if (bgFocusedDrawable != null) {
+			sld.addState(BACKGROUND_FOCUSED_STATE, bgFocusedDrawable);
 		}
 
-		if (focusedImage != null) {
-			bgFocusedDrawable = tfh.loadDrawable(focusedImage, false, true);
-
-		} else if (focusedColor != null) {
-			bgFocusedDrawable = new ColorDrawable(TiConvert.toColor(focusedColor));
-
-		} else if (bgDrawable != null) {
-			bgFocusedDrawable = bgDrawable;			
+		Drawable bgDisabledDrawable = buildBackgroundDrawable(disabledColor, disabledImage, false);
+		if (bgDisabledDrawable != null) {
+			sld.addState(BACKGROUND_DISABLED_STATE, bgDisabledDrawable);
 		}
 
-		if (disabledImage != null) {
-			bgDisabledDrawable = tfh.loadDrawable(disabledImage, false, true);
-
-		} else if (disabledColor != null) {
-			bgDisabledDrawable = new ColorDrawable(TiConvert.toColor(disabledColor));
-
-		} else if (bgDrawable != null) {
-			bgDisabledDrawable = bgDrawable;			
-		}
-
-		if (bgDrawable != null || bgSelectedDrawable != null || bgFocusedDrawable != null || bgDisabledDrawable != null) {
-			sld = new StateListDrawable();
-
-			if (bgDisabledDrawable != null) {
-				int[] stateSet = {
-					-android.R.attr.state_enabled
-				};
-				sld.addState(stateSet, bgDisabledDrawable);
-			}
-
-			if (bgFocusedDrawable != null) {
-				int[] ss = {
-					android.R.attr.state_focused,
-					android.R.attr.state_window_focused,
-					android.R.attr.state_enabled
-				};
-				sld.addState(ss, bgFocusedDrawable);
-			}
-
-			if (bgSelectedDrawable != null) {
-				int[] ss = {
-						android.R.attr.state_window_focused,
-						android.R.attr.state_enabled,
-						android.R.attr.state_pressed
-					};
-				sld.addState(ss, bgSelectedDrawable);
-
-
-				int[] ss1 = {
-					android.R.attr.state_focused,
-					android.R.attr.state_window_focused,
-					android.R.attr.state_enabled,
-					android.R.attr.state_pressed
-				};
-				sld.addState(ss1, bgSelectedDrawable);
-				
-//				int[] ss2 = { android.R.attr.state_selected };
-//				sld.addState(ss2, bgSelectedDrawable);
-			}
-
-			if (bgDrawable != null) {
-				int[] ss1 = {
-					android.R.attr.state_window_focused,
-					android.R.attr.state_enabled
-				};
-				sld.addState(ss1, bgDrawable);
-				int[] ss2 = { android.R.attr.state_enabled };
-				sld.addState(ss2, bgDrawable);
-			}
+		Drawable bgDrawable = buildBackgroundDrawable(color, image, tileImage);
+		if (bgDrawable != null) {
+			sld.addState(BACKGROUND_DEFAULT_STATE_1, bgDrawable);
+			sld.addState(BACKGROUND_DEFAULT_STATE_2, bgDrawable);
 		}
 
 		return sld;


### PR DESCRIPTION
This fixes issues seen when setting both a color and image for a background on
a view or the root window (ex: Ti.UI.backgroundColor = "blue").

See [TIMOB-4800](https://jira.appcelerator.org/browse/TIMOB-4800) for testing details.
