### PR TITLE
[TIMOB-1902] iOS: Scrollview can scroll to much on when keyboard blurs

### DIFF
--- a/iphone/Classes/TiRootViewController.m
+++ b/iphone/Classes/TiRootViewController.m
@@ -1169,7 +1169,8 @@
 	if(scrolledView != nil)	//If this isn't IN the toolbar, then we update the scrollviews to compensate.
 	{
 		UIView * ourView = [self viewForKeyboardAccessory];
-		CGFloat keyboardHeight = [ourView convertRect:endFrame fromView:nil].origin.y;
+        CGRect rect = [ourView convertRect:endFrame fromView:nil];
+		CGFloat keyboardHeight = rect.origin.y + rect.size.height;
 		UIView * possibleScrollView = [scrolledView superview];
 		UIView<TiScrolling> * confirmedScrollView = nil;
 		while (possibleScrollView != nil)


### PR DESCRIPTION
[TIMOB-1902](https://jira.appcelerator.org/browse/TIMOB-1902)

Test case in JIRA comments.
