### PR TITLE
[TIMOB-8547](1_8_X) iOS: switch change event gets fired when adding to a view or window

### DIFF
--- a/iphone/Classes/TiUISwitch.m
+++ b/iphone/Classes/TiUISwitch.m
@@ -53,11 +53,14 @@
 	BOOL newValue = [TiUtils boolValue:value];
 	BOOL animated = !reproxying;
 	UISwitch * ourSwitch = [self switchView];
+    if ([ourSwitch isOn] == newValue) {
+        return;
+    }
 	[ourSwitch setOn:newValue animated:animated];
 	
 	// Don't rely on switchChanged: - isOn can report erroneous values immediately after the value is changed!  
 	// This only seems to happen in 4.2+ - could be an Apple bug.
-	if (reproxying==NO && [self.proxy _hasListeners:@"change"])
+	if ((reproxying == NO) && configurationSet && [self.proxy _hasListeners:@"change"])
 	{
 		[self.proxy fireEvent:@"change" withObject:[NSDictionary dictionaryWithObject:value forKey:@"value"]];
 	}

--- a/iphone/Classes/TiUIView.h
+++ b/iphone/Classes/TiUIView.h
@@ -29,6 +29,9 @@ void ModifyScrollViewForKeyboardHeightAndContentHeightWithResponderRect(UIScroll
 
 @interface TiUIView : UIView<TiProxyDelegate,LayoutAutosizing> 
 {
+@protected
+    BOOL configurationSet;
+
 @private
 	TiProxy *proxy;
 	TiAnimation *animation;

--- a/iphone/Classes/TiUIView.m
+++ b/iphone/Classes/TiUIView.m
@@ -272,6 +272,7 @@ DEFINE_EXCEPTIONS
 -(void)configurationSet
 {
 	// can be used to trigger things after all properties are set
+    configurationSet = YES;
 }
 
 -(void)setProxy:(TiProxy *)p


### PR DESCRIPTION
Cherry-pick of #1942 into 1_8_X

[TIMOB-8547](https://jira.appcelerator.org/browse/TIMOB-8547)

Test case in JIRA.
