### PR TITLE
[TIMOB-8373](2_0_X) iOS: TextFields and TextAreas should have a minimum height/width when they are SIZE and text is empty

### DIFF
--- a/iphone/Classes/TiUITextArea.m
+++ b/iphone/Classes/TiUITextArea.m
@@ -164,22 +164,23 @@ Text area constrains the text event though the content offset and edge insets ar
     if (value - txtWidth >= TXT_OFFSET) {
         return (txtWidth + TXT_OFFSET);
     }
-    return txtWidth;
+    return txtWidth + 2 * self.layer.borderWidth;
 }
 
 -(CGFloat)contentHeightForWidth:(CGFloat)value
 {
-    if (![self hasText]) {
-        return 0.0;
-    }
     CGFloat constrainedWidth = value - TXT_OFFSET;
     if (constrainedWidth < 0) {
         constrainedWidth = 0;
     }
     UITextView* ourView = (UITextView*)[self textWidgetView];
     NSString* txt = ourView.text;
+    if (txt.length == 0) {
+        txt = @" ";
+    }
     //sizeThatFits does not seem to work properly
-    return [txt sizeWithFont:ourView.font constrainedToSize:CGSizeMake(constrainedWidth, 1E100) lineBreakMode:UILineBreakModeWordWrap].height;
+    CGFloat txtHeight = [txt sizeWithFont:ourView.font constrainedToSize:CGSizeMake(constrainedWidth, 1E100) lineBreakMode:UILineBreakModeWordWrap].height;
+    return txtHeight + 2 * self.layer.borderWidth;
 }
 
 - (void)scrollViewDidScroll:(id)scrollView

--- a/iphone/Classes/TiUITextArea.m
+++ b/iphone/Classes/TiUITextArea.m
@@ -157,9 +157,6 @@ Text area constrains the text event though the content offset and edge insets ar
 #define TXT_OFFSET 20
 -(CGFloat)contentWidthForWidth:(CGFloat)value
 {
-    if (![self hasText]) {
-        return 0.0;
-    }
     UITextView* ourView = (UITextView*)[self textWidgetView];
     NSString* txt = ourView.text;
     //sizeThatFits does not seem to work properly.

--- a/iphone/Classes/TiUITextField.m
+++ b/iphone/Classes/TiUITextField.m
@@ -532,9 +532,6 @@
 
 -(CGFloat)contentHeightForWidth:(CGFloat)value
 {
-    if (![self hasText]) {
-        return 0.0;
-    }
 	return [[self textWidgetView] sizeThatFits:CGSizeMake(value, 0)].height;
 }
 

--- a/iphone/Classes/TiUITextField.m
+++ b/iphone/Classes/TiUITextField.m
@@ -527,9 +527,6 @@
 
 -(CGFloat)contentWidthForWidth:(CGFloat)value
 {
-    if (![self hasText]) {
-        return 0.0;
-    }
 	return [[self textWidgetView] sizeThatFits:CGSizeMake(value, 0)].width;
 }
 

--- a/iphone/Classes/TiUITextWidgetProxy.m
+++ b/iphone/Classes/TiUITextWidgetProxy.m
@@ -86,6 +86,7 @@ DEFINE_DEF_BOOL_PROP(suppressReturn,YES);
 {
 	if (![[self valueForKey:@"value"] isEqual:newValue])
 	{
+        [self contentsWillChange];
 		[self replaceValue:newValue forKey:@"value" notification:NO];
 		[self fireEvent:@"change" withObject:[NSDictionary dictionaryWithObject:newValue forKey:@"value"]];
 	}


### PR DESCRIPTION
[TIMOB-8373](https://jira.appcelerator.org/browse/TIMOB-8373)
The fix also addresses parity issue with Android where text field/area with SIZE hint adjust in width during typing.

Test case in JIRA comment.
Check regressions with KS Controls/Text Field/Text Area
