### PR TITLE
Timob 8472: Android: setting backgroundImage of TableViewRow to null or empty string crashes app

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiBaseTableViewItem.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiBaseTableViewItem.java
@@ -178,9 +178,9 @@ public abstract class TiBaseTableViewItem extends ViewGroup implements Handler.C
 
 	public void setBackgroundFromProxy(KrollProxy proxy) {
 		Drawable background = null;
-		if (proxy.hasProperty(TiC.PROPERTY_BACKGROUND_IMAGE)) {
+		if (proxy.hasProperty(TiC.PROPERTY_BACKGROUND_IMAGE) && proxy.getProperty(TiC.PROPERTY_BACKGROUND_IMAGE) != null) {
 			background = getBackgroundImageDrawable(proxy, proxy.getProperty(TiC.PROPERTY_BACKGROUND_IMAGE).toString());
-		} else if (proxy.hasProperty(TiC.PROPERTY_BACKGROUND_COLOR)) {
+		} else if (proxy.hasProperty(TiC.PROPERTY_BACKGROUND_COLOR) && proxy.getProperty(TiC.PROPERTY_BACKGROUND_COLOR) != null) {
 			Integer bgColor = TiConvert.toColor(proxy.getProperty(TiC.PROPERTY_BACKGROUND_COLOR).toString());
 			background = new ColorDrawable(bgColor);
 		}

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiBaseTableViewItem.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiBaseTableViewItem.java
@@ -178,10 +178,12 @@ public abstract class TiBaseTableViewItem extends ViewGroup implements Handler.C
 
 	public void setBackgroundFromProxy(KrollProxy proxy) {
 		Drawable background = null;
-		if (proxy.hasProperty(TiC.PROPERTY_BACKGROUND_IMAGE) && proxy.getProperty(TiC.PROPERTY_BACKGROUND_IMAGE) != null) {
-			background = getBackgroundImageDrawable(proxy, proxy.getProperty(TiC.PROPERTY_BACKGROUND_IMAGE).toString());
-		} else if (proxy.hasProperty(TiC.PROPERTY_BACKGROUND_COLOR) && proxy.getProperty(TiC.PROPERTY_BACKGROUND_COLOR) != null) {
-			Integer bgColor = TiConvert.toColor(proxy.getProperty(TiC.PROPERTY_BACKGROUND_COLOR).toString());
+		Object bkgdImage = proxy.getProperty(TiC.PROPERTY_BACKGROUND_IMAGE);
+		Object bkgdColor = proxy.getProperty(TiC.PROPERTY_BACKGROUND_COLOR);
+		if (bkgdImage != null) {
+			background = getBackgroundImageDrawable(proxy, bkgdImage.toString());
+		} else if (bkgdColor != null) {
+			Integer bgColor = TiConvert.toColor(bkgdColor.toString());
 			background = new ColorDrawable(bgColor);
 		}
 


### PR DESCRIPTION
https://jira.appcelerator.org/browse/TIMOB-8472
Test case in jira.
