### PR TITLE
[TIMOB-8616] 1_8_X Reinstate left and right gesture recognizers

### DIFF
--- a/iphone/Classes/TiUIView.h
+++ b/iphone/Classes/TiUIView.h
@@ -52,7 +52,8 @@ void ModifyScrollViewForKeyboardHeightAndContentHeightWithResponderRect(UIScroll
 	UITapGestureRecognizer*			doubleTapRecognizer;
 	UITapGestureRecognizer*			twoFingerTapRecognizer;
 	UIPinchGestureRecognizer*		pinchRecognizer;
-	UISwipeGestureRecognizer*		swipeRecognizer;
+	UISwipeGestureRecognizer*		leftSwipeRecognizer;
+	UISwipeGestureRecognizer*		rightSwipeRecognizer;
 	UILongPressGestureRecognizer*	longPressRecognizer;
 	
 	//Resizing handling
@@ -76,7 +77,8 @@ void ModifyScrollViewForKeyboardHeightAndContentHeightWithResponderRect(UIScroll
 @property(nonatomic,readonly)	UITapGestureRecognizer*			doubleTapRecognizer;
 @property(nonatomic,readonly)	UITapGestureRecognizer*			twoFingerTapRecognizer;
 @property(nonatomic,readonly)	UIPinchGestureRecognizer*		pinchRecognizer;
-@property(nonatomic,readonly)	UISwipeGestureRecognizer*		swipeRecognizer;
+@property(nonatomic,readonly)	UISwipeGestureRecognizer*		leftSwipeRecognizer;
+@property(nonatomic,readonly)	UISwipeGestureRecognizer*		rightSwipeRecognizer;
 @property(nonatomic,readonly)	UILongPressGestureRecognizer*	longPressRecognizer;
 
 - (UIGestureRecognizer *)gestureRecognizerForEvent:(NSString *)event;

--- a/iphone/Classes/TiUIView.m
+++ b/iphone/Classes/TiUIView.m
@@ -188,7 +188,8 @@ DEFINE_EXCEPTIONS
 	[doubleTapRecognizer release];
 	[twoFingerTapRecognizer release];
 	[pinchRecognizer release];
-	[swipeRecognizer release];
+	[leftSwipeRecognizer release];
+	[rightSwipeRecognizer release];
 	[longPressRecognizer release];
 	proxy = nil;
 	touchDelegate = nil;
@@ -810,17 +811,30 @@ DEFINE_EXCEPTIONS
 	return pinchRecognizer;
 }
 
--(UISwipeGestureRecognizer*)swipeRecognizer;
+-(UISwipeGestureRecognizer*)leftSwipeRecognizer;
 {
-	if (swipeRecognizer == nil) {
-		swipeRecognizer = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(recognizedSwipe:)];
-		[swipeRecognizer setDirection:UISwipeGestureRecognizerDirectionLeft|UISwipeGestureRecognizerDirectionRight];
-		[swipeRecognizer setCancelsTouchesInView:NO];
-		[self addGestureRecognizer:swipeRecognizer];
+	if (leftSwipeRecognizer == nil) {
+		leftSwipeRecognizer = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(recognizedSwipe:)];
+		[leftSwipeRecognizer setDirection:UISwipeGestureRecognizerDirectionLeft];
+		[leftSwipeRecognizer setCancelsTouchesInView:NO];
+		[self addGestureRecognizer:leftSwipeRecognizer];
 	   
 	   //If there are more gesture recognizer relationships, add it here.		
 	}
-	return swipeRecognizer;
+	return leftSwipeRecognizer;
+}
+
+-(UISwipeGestureRecognizer*)rightSwipeRecognizer;
+{
+	if (rightSwipeRecognizer == nil) {
+		rightSwipeRecognizer = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(recognizedSwipe:)];
+		[rightSwipeRecognizer setDirection:UISwipeGestureRecognizerDirectionRight];
+		[rightSwipeRecognizer setCancelsTouchesInView:NO];
+		[self addGestureRecognizer:rightSwipeRecognizer];
+        
+        //If there are more gesture recognizer relationships, add it here.		
+	}
+	return rightSwipeRecognizer;
 }
 
 -(UILongPressGestureRecognizer*)longPressRecognizer;
@@ -1128,23 +1142,26 @@ DEFINE_EXCEPTIONS
 
 - (UIGestureRecognizer *)gestureRecognizerForEvent:(NSString *)event
 {
-	if ([event isEqualToString:@"singletap"]) {
-		return [self singleTapRecognizer];
+    if ([event isEqualToString:@"singletap"]) {
+        return [self singleTapRecognizer];
     }
-	if ([event isEqualToString:@"doubletap"]) {
-		return [self doubleTapRecognizer];
+    if ([event isEqualToString:@"doubletap"]) {
+        return [self doubleTapRecognizer];
     }
-	if ([event isEqualToString:@"twofingertap"]) {
-		return [self twoFingerTapRecognizer];
+    if ([event isEqualToString:@"twofingertap"]) {
+        return [self twoFingerTapRecognizer];
     }
-	if ([event isEqualToString:@"swipe"]) {
-		return [self swipeRecognizer];
+    if ([event isEqualToString:@"lswipe"]) {
+        return [self leftSwipeRecognizer];
+    }
+    if ([event isEqualToString:@"rswipe"]) {
+        return [self rightSwipeRecognizer];
     }
     if ([event isEqualToString:@"pinch"]) {
-		return [self pinchRecognizer];
+        return [self pinchRecognizer];
     }
-	if ([event isEqualToString:@"longpress"]) {
-		return [self longPressRecognizer];
+    if ([event isEqualToString:@"longpress"]) {
+        return [self longPressRecognizer];
     }
     return nil;
 }
@@ -1153,7 +1170,13 @@ DEFINE_EXCEPTIONS
 {
 	ENSURE_UI_THREAD_1_ARG(event);
     [self updateTouchHandling];
-    [[self gestureRecognizerForEvent:event] setEnabled:YES];
+    if ([event isEqualToString:@"swipe"]) {
+        [[self gestureRecognizerForEvent:@"rswipe"] setEnabled:YES];
+        [[self gestureRecognizerForEvent:@"lswipe"] setEnabled:YES];
+    }
+    else {
+        [[self gestureRecognizerForEvent:event] setEnabled:YES];
+    }
 }
 
 -(void)handleListenerRemovedWithEvent:(NSString *)event
@@ -1163,7 +1186,13 @@ DEFINE_EXCEPTIONS
 	// since we might be removing one but we still have others
 
 	[self updateTouchHandling];
-    [[self gestureRecognizerForEvent:event] setEnabled:NO];
+    if ([event isEqualToString:@"swipe"]) {
+        [[self gestureRecognizerForEvent:@"rswipe"] setEnabled:NO];
+        [[self gestureRecognizerForEvent:@"lswipe"] setEnabled:NO];
+    }
+    else {
+        [[self gestureRecognizerForEvent:event] setEnabled:NO];
+    }
 }
 
 -(void)listenerAdded:(NSString*)event count:(int)count


### PR DESCRIPTION
Duplicate of PR #1965 against 1_8_X

Test is in [JIRA](https://jira.appcelerator.org/browse/TIMOB-8616)

FR should include a regression against [TIMOB-8497](https://jira.appcelerator.org/browse/TIMOB-8497)
