### PR TITLE
[TIMOB-8631] Added touchcancel handling for table view rows.

### DIFF
--- a/demos/KitchenSink/Resources/examples/table_view_touch.js
+++ b/demos/KitchenSink/Resources/examples/table_view_touch.js
@@ -3,7 +3,6 @@ var data = [];
 
 for (var x=0;x<4;x++)
 {
-	//var view = Ti.UI.createView();
 	var label = Ti.UI.createLabel({
 		text:'Row Label ' + x,
 		height:'auto',
@@ -12,7 +11,6 @@ for (var x=0;x<4;x++)
 		left:10
 	});
 	var row = Ti.UI.createTableViewRow({height:50});
-	//view.add(label);
 	row.add(label);
 	data.push(row);
 }
@@ -24,13 +22,16 @@ var tableview = Titanium.UI.createTableView({
 
 tableview.addEventListener('touchstart', function(e)
 {
-	e.row.children[0].color = '#fff';
+	e.row.children[0].color = 'red';
 });
 
-tableview.addEventListener('touchend', function(e)
-{
+function cleanup(e) {
 	e.row.children[0].color = '#336699';
-});
+}
+
+
+tableview.addEventListener('touchend', cleanup);
+tableview.addEventListener('touchcancel', cleanup);
 
 
 // add table view to the window

--- a/iphone/Classes/TiUITableView.m
+++ b/iphone/Classes/TiUITableView.m
@@ -125,6 +125,14 @@
     [super touchesEnded:touches withEvent:event];
 }
 
+-(void)touchesCancelled:(NSSet *)touches withEvent:(UIEvent *)event
+{
+    if ([proxy _hasListeners:@"touchcancel"]) {
+        [proxy fireEvent:@"touchcancel" withObject:[proxy createEventObject:nil] propagate:YES];
+    }
+    [super touchesCancelled:touches withEvent:event];
+}
+
 
 -(void)setHighlighted:(BOOL)yn animated:(BOOL)animated
 {


### PR DESCRIPTION
It turns out that on scrolling, tableview sends the "touchcancel" to any cell being currently interacted with. We need the capability to capture this so users can treat it like "touchend" (or any other state restore).

Updated the KS test for table row touch events as well.
