### PR TITLE
[TIMOB-8615] Safeguard against race conditions

### DIFF
--- a/iphone/Classes/TiUIOptionDialogProxy.m
+++ b/iphone/Classes/TiUIOptionDialogProxy.m
@@ -84,24 +84,26 @@
 
 -(void)completeWithButton:(int)buttonIndex
 {
-	showDialog = NO;
-	if ([self _hasListeners:@"click"])
-	{
-		NSDictionary *event = [NSDictionary dictionaryWithObjectsAndKeys:
-							   [NSNumber numberWithInt:buttonIndex],@"index",
-							   [NSNumber numberWithInt:[actionSheet cancelButtonIndex]],@"cancel",
-							   [NSNumber numberWithInt:[actionSheet destructiveButtonIndex]],@"destructive",
-							   nil];
-		[self fireEvent:@"click" withObject:event];
-	}
-	[[NSNotificationCenter defaultCenter] removeObserver:self name:UIApplicationWillChangeStatusBarOrientationNotification object:nil];
-	[self forgetSelf];
-	[self release];
+    if (showDialog) {
+        showDialog = NO;
+        if ([self _hasListeners:@"click"])
+        {
+            NSDictionary *event = [NSDictionary dictionaryWithObjectsAndKeys:
+                                   [NSNumber numberWithInt:buttonIndex],@"index",
+                                   [NSNumber numberWithInt:[actionSheet cancelButtonIndex]],@"cancel",
+                                   [NSNumber numberWithInt:[actionSheet destructiveButtonIndex]],@"destructive",
+                                   nil];
+            [self fireEvent:@"click" withObject:event];
+        }
+        [[NSNotificationCenter defaultCenter] removeObserver:self name:UIApplicationWillChangeStatusBarOrientationNotification object:nil];
+        [self forgetSelf];
+        [self release];
+    }
 }
 
 -(void)hide:(id)args
 {
-	if(actionSheet == nil){
+	if(actionSheet == nil || !showDialog){
 		return;
 	}
 
@@ -111,17 +113,14 @@
 	}
 	BOOL animatedhide = [TiUtils boolValue:@"animated" properties:options def:YES];
 
-	TiThreadPerformOnMainThread(^{
-		if ([actionSheet isVisible]) {
-			showDialog = NO;
-			[actionSheet dismissWithClickedButtonIndex:[actionSheet cancelButtonIndex] animated:animatedhide];
-		}
-		else if(showDialog) {
-			//This is to avoid double-releasing.
-			showDialog = NO;
-			[self completeWithButton:[actionSheet cancelButtonIndex]];
-		}
-	}, NO);
+    TiThreadPerformOnMainThread(^{
+        if ([actionSheet isVisible]) {
+            [actionSheet dismissWithClickedButtonIndex:[actionSheet cancelButtonIndex] animated:animatedhide];
+        }
+        else if(showDialog) {
+            [self completeWithButton:[actionSheet cancelButtonIndex]];
+        }
+    }, NO);
 }
 
 #pragma mark AlertView Delegate


### PR DESCRIPTION
Test is in [JIRA](https://jira.appcelerator.org/browse/TIMOB-8615)

Need ipod 3rd gen with 4.0.2 to test. Will not reproduce on later OS versions.

The bug seems to be an apple bug where [actionSheet isVisible] always return false (Test device ipod 3rd gen running 4.0.2). So we were releasing the proxy twice. Once on the hide method and then when the user touched the button. Basically the PR safeguards against the release being called twice by checking the showDialog flag in the completeWithButton method
