### PR TITLE
[TIMOB-8559] 2_0_X Ensure windows in nav group have parentVisible=YES

### DIFF
--- a/iphone/Classes/TiUIiPhoneNavigationGroup.m
+++ b/iphone/Classes/TiUIiPhoneNavigationGroup.m
@@ -141,7 +141,7 @@
 	[newWindow windowWillOpen];
     //TIMOB-8559. PR 1819 caused a regression that exposed an IOS issue. In IOS 5 and later, the nav controller calls 
     //UIViewControllerDelegate methods, but not in IOS 4.X. As a result the parentVisible flag is never flipped to true
-    //and the window never lays out. Using method call to ensure window goes into layout queue.
+    //and the window never lays out. Using this method sets the flag and ensures window goes into layout queue.
     [newWindow parentWillShow];
 }
 - (void)navigationController:(UINavigationController *)navigationController didShowViewController:(UIViewController *)viewController animated:(BOOL)animated

--- a/iphone/Classes/TiUIiPhoneNavigationGroup.m
+++ b/iphone/Classes/TiUIiPhoneNavigationGroup.m
@@ -138,8 +138,11 @@
 {
     TiWindowProxy *newWindow = (TiWindowProxy *)[(TiViewController*)viewController proxy];
 	[newWindow setupWindowDecorations];
-	
 	[newWindow windowWillOpen];
+    //TIMOB-8559. PR 1819 caused a regression that exposed an IOS issue. In IOS 5 and later, the nav controller calls 
+    //UIViewControllerDelegate methods, but not in IOS 4.X. As a result the parentVisible flag is never flipped to true
+    //and the window never lays out. Using method call to ensure window goes into layout queue.
+    [newWindow parentWillShow];
 }
 - (void)navigationController:(UINavigationController *)navigationController didShowViewController:(UIViewController *)viewController animated:(BOOL)animated
 {


### PR DESCRIPTION
Duplicate of PR #1969 against 2_0_X

Test is in [JIRA](https://jira.appcelerator.org/browse/TIMOB-8559)

Have got the go ahead from Thomas and Neeraj to merge this PR into 2_0_X if it is accepted
