### PR TITLE
[TIMOB-8486] Add ability for TiUIViews to tell touch handlers their content was touched

### DIFF
--- a/iphone/Classes/TiMediaVideoPlayer.m
+++ b/iphone/Classes/TiMediaVideoPlayer.m
@@ -105,6 +105,17 @@
 	}
 }
 
+-(BOOL)touchedContentViewWithEvent:(UIEvent *)event
+{
+    // The view hierarchy of the movie player controller's view is subject to change,
+    // and traversing it is dangerous. If we received a touch which isn't on a TiUIView,
+    // assume it falls into the movie player view hiearchy; this matches previous
+    // behavior as well.
+    
+    UITouch* touch = [[event allTouches] anyObject];
+    return (![[touch view] isKindOfClass:[TiUIView class]]);
+}
+
 -(void)dealloc
 {
 	[[controller view] removeFromSuperview];

--- a/iphone/Classes/TiUIView.h
+++ b/iphone/Classes/TiUIView.h
@@ -228,6 +228,12 @@ void ModifyScrollViewForKeyboardHeightAndContentHeightWithResponderRect(UIScroll
 -(UIView *)gradientWrapperView;
 -(void)checkBounds;
 
+/**
+ Whether or not a view not normally picked up by the Titanium view hierarchy (such as wrapped iOS UIViews) was touched.
+ @return _YES_ if the view contains specialized content (such as a system view) which should register as a touch for this view, _NO_ otherwise.
+ */
+-(BOOL)touchedContentViewWithEvent:(UIEvent*)event;
+
 - (void)processTouchesBegan:(NSSet *)touches withEvent:(UIEvent *)event;
 - (void)processTouchesMoved:(NSSet *)touches withEvent:(UIEvent *)event;
 - (void)processTouchesEnded:(NSSet *)touches withEvent:(UIEvent *)event;

--- a/iphone/Classes/TiUIView.m
+++ b/iphone/Classes/TiUIView.m
@@ -1010,9 +1010,15 @@ DEFINE_EXCEPTIONS
 	}
 }
 
+// For subclasses
+-(BOOL)touchedContentViewWithEvent:(UIEvent *)event
+{
+    return NO;
+}
+
 - (void)touchesBegan:(NSSet *)touches withEvent:(UIEvent *)event
 {
-    if ([[event touchesForView:self] count] > 0) {
+    if ([[event touchesForView:self] count] > 0 || [self touchedContentViewWithEvent:event]) {
         [self processTouchesBegan:touches withEvent:event];
     }
     [super touchesBegan:touches withEvent:event];
@@ -1052,7 +1058,7 @@ DEFINE_EXCEPTIONS
 
 - (void)touchesMoved:(NSSet *)touches withEvent:(UIEvent *)event
 {
-    if ([[event touchesForView:self] count] > 0) {
+    if ([[event touchesForView:self] count] > 0 || [self touchedContentViewWithEvent:event]) {
         [self processTouchesMoved:touches withEvent:event];
     }
     [super touchesMoved:touches withEvent:event];
@@ -1079,7 +1085,7 @@ DEFINE_EXCEPTIONS
 
 - (void)touchesEnded:(NSSet *)touches withEvent:(UIEvent *)event 
 {
-    if ([[event touchesForView:self] count] > 0) {
+    if ([[event touchesForView:self] count] > 0 || [self touchedContentViewWithEvent:event]) {
         [self processTouchesEnded:touches withEvent:event];
     }
     [super touchesEnded:touches withEvent:event];
@@ -1107,7 +1113,7 @@ DEFINE_EXCEPTIONS
 
 - (void)touchesCancelled:(NSSet *)touches withEvent:(UIEvent *)event 
 {
-    if ([[event touchesForView:self] count] > 0) {
+    if ([[event touchesForView:self] count] > 0 || [self touchedContentViewWithEvent:event]) {
         [self processTouchesCancelled:touches withEvent:event];
     }
     [super touchesCancelled:touches withEvent:event];


### PR DESCRIPTION
Note that the test in JIRA may lead to some very strange behavior, due to the fact that the alert display interrupts main thread UI processing and cancels touch events (and may do so at weird times). This means that the bug _may_ appear to not be fixed, due to bad code in the test.

If this appears, change the line

```
    alert('click!');
```

to

```
    Ti.API.info('click!');
```

so that the event processing continues as normal. This seems to be rare during normal operation but happens more frequently with debugging and may be a problem on single-core devices, so test and check and modify the ticket appropriately during functional.
