### PR TITLE
[TIMOB-8690] Fire event "shouldload" in UIWebView

### DIFF
--- a/apidoc/Titanium/UI/WebView.yml
+++ b/apidoc/Titanium/UI/WebView.yml
@@ -208,6 +208,16 @@ methods:
 
 events:
 
+  - name: shouldload
+    summary: Fired before the web view begins loading a frame.
+    description: |
+        This event is fired before the "beforeload" event. The primary functionality of this event
+        is prevent to load an incorrect page.
+
+        This event is used many times to intercept page redirect. For example: If you are entering
+        in a page that redirects automatically to another page, this event will be fired twice
+        (with two URLs - original and the redirect URL).
+
   - name: beforeload
     summary: Fired before the web view starts loading its content.
     description: |

--- a/iphone/Classes/TiUIWebView.m
+++ b/iphone/Classes/TiUIWebView.m
@@ -638,10 +638,10 @@ static NSString * const kTitaniumJavascript = @"Ti.App={};Ti.API={};Ti.App._list
 {
 	NSURL * newUrl = [request URL];
 
-	if ([self.proxy _hasListeners:@"beforeload"])
+	if ([self.proxy _hasListeners:@"shouldload"])
 	{
 		NSDictionary *event = newUrl == nil ? nil : [NSDictionary dictionaryWithObject:[newUrl absoluteString] forKey:@"url"];
-		[self.proxy fireEvent:@"beforeload" withObject:event];
+		[self.proxy fireEvent:@"shouldload" withObject:event];
 	}
 
 	NSString * scheme = [[newUrl scheme] lowercaseString];
@@ -675,6 +675,11 @@ static NSString * const kTitaniumJavascript = @"Ti.App={};Ti.API={};Ti.App._list
 
 - (void)webViewDidStartLoad:(UIWebView *)webView
 {
+	if ([self.proxy _hasListeners:@"beforeload"])
+	{
+		NSDictionary *event = newUrl == nil ? nil : [NSDictionary dictionaryWithObject:[newUrl absoluteString] forKey:@"url"];
+		[self.proxy fireEvent:@"beforeload" withObject:event];
+	}
 }
 
 - (void)webViewDidFinishLoad:(UIWebView *)webView


### PR DESCRIPTION
Just modify the name of event (was called beforeload) to _shouldload_. And created a new event called _beforeload_ in the "webViewDidStartLoad" delegate.

Update the documentation too.

TIMOB: https://jira.appcelerator.org/browse/TIMOB-8690
