### PR TITLE
[TIMOB-8306] Android: Upgrade V8 to 3.9.24

### DIFF
--- a/android/build/libv8.properties
+++ b/android/build/libv8.properties
@@ -1,2 +1,2 @@
-libv8.version=3.6.4
+libv8.version=3.9.24
 libv8.mode=release

--- a/android/runtime/v8/src/ndk-modules/libv8/Android.mk
+++ b/android/runtime/v8/src/ndk-modules/libv8/Android.mk
@@ -9,7 +9,7 @@ LOCAL_PATH := $(call my-dir)
 
 include $(CLEAR_VARS)
 
-V8_VERSION=3.6.4
+V8_VERSION=3.9.24
 LIBV8_DIR := ../../../../../../dist/android/libv8/$(V8_VERSION)
 
 LIBV8 := libv8


### PR DESCRIPTION
Bump V8 to version 3.9.24. To test do a clean build using scons.
Install built SDK and try running various applications (ex: KitchenSink).
Make sure there is no crash at startup on both device and emulator.
