### PR TITLE
[TIMOB-8417](2_0_X) iOS: Textfield in a scrollview scrolls if bluetooth keyboard is connected to iPad

### DIFF
--- a/iphone/Classes/TiRootViewController.m
+++ b/iphone/Classes/TiRootViewController.m
@@ -1001,12 +1001,12 @@
 	CGRect focusedToolbarBounds = CGRectMake(0, 0, endingFrame.size.width, [keyboardFocusedProxy keyboardAccessoryHeight]);
 	[focusedToolbar setBounds:focusedToolbarBounds];
 
-	if(scrolledView != nil)	//If this isn't IN the toolbar, then we update the scrollviews to compensate.
+    CGFloat keyboardHeight = endingFrame.origin.y;
+    if(focusedToolbar != nil){
+        keyboardHeight -= focusedToolbarBounds.size.height;
+    }
+	if ((scrolledView != nil) && (keyboardHeight > 0))	//If this isn't IN the toolbar, then we update the scrollviews to compensate.
 	{
-		CGFloat keyboardHeight = endingFrame.origin.y;
-		if(focusedToolbar != nil){
-			keyboardHeight -= focusedToolbarBounds.size.height;
-		}
 		UIView * possibleScrollView = [scrolledView superview];
 		NSMutableArray * confirmedScrollViews = nil;
 		
@@ -1183,18 +1183,21 @@
 	if(scrolledView != nil)	//If this isn't IN the toolbar, then we update the scrollviews to compensate.
 	{
 		UIView * ourView = [self viewForKeyboardAccessory];
-		CGFloat keyboardHeight = [ourView convertRect:endFrame fromView:nil].origin.y;
-		UIView * possibleScrollView = [scrolledView superview];
-		UIView<TiScrolling> * confirmedScrollView = nil;
-		while (possibleScrollView != nil)
-		{
-			if ([possibleScrollView conformsToProtocol:@protocol(TiScrolling)])
-			{
-				confirmedScrollView = (UIView<TiScrolling>*)possibleScrollView;
-			}
-			possibleScrollView = [possibleScrollView superview];
-		}
-		[confirmedScrollView keyboardDidShowAtHeight:keyboardHeight];
+        CGRect rect = [ourView convertRect:endFrame fromView:nil];
+		CGFloat keyboardHeight = rect.origin.y + rect.size.height;
+        if (keyboardHeight > 0) {
+            UIView * possibleScrollView = [scrolledView superview];
+            UIView<TiScrolling> * confirmedScrollView = nil;
+            while (possibleScrollView != nil)
+            {
+                if ([possibleScrollView conformsToProtocol:@protocol(TiScrolling)])
+                {
+                    confirmedScrollView = (UIView<TiScrolling>*)possibleScrollView;
+                }
+                possibleScrollView = [possibleScrollView superview];
+            }
+            [confirmedScrollView keyboardDidShowAtHeight:keyboardHeight];
+        }
 	}
 
 	if((doomedView == nil) || (leavingAccessoryView == doomedView)){


### PR DESCRIPTION
[TIMOB-8417](https://jira.appcelerator.org/browse/TIMOB-8417)

Test case in JIRA.

FT note: test on real iPad with BT keyboard before and after the fix.
