### PR TITLE
[TIMOB-8113] Android: Ti.UI.WebView doesn't seem to load pages that try to open a new window

### DIFF
--- a/android/runtime/rhino/src/java/org/appcelerator/kroll/runtime/rhino/KrollBindings.java
+++ b/android/runtime/rhino/src/java/org/appcelerator/kroll/runtime/rhino/KrollBindings.java
@@ -25,6 +25,7 @@ import org.appcelerator.kroll.runtime.rhino.js.ui;
 import org.appcelerator.kroll.runtime.rhino.js.url;
 import org.appcelerator.kroll.runtime.rhino.js.vm;
 import org.appcelerator.kroll.runtime.rhino.js.window;
+import org.appcelerator.kroll.runtime.rhino.js.webview;
 import org.appcelerator.kroll.runtime.rhino.js.yahoo;
 import org.appcelerator.kroll.runtime.rhino.modules.AssetsModule;
 import org.appcelerator.kroll.runtime.rhino.modules.ScriptsModule;
@@ -79,6 +80,7 @@ public class KrollBindings
 		addJsBinding("url", url.class);
 		addJsBinding("vm", vm.class);
 		addJsBinding("window", window.class);
+		addJsBinding("webview", webview.class);
 		addJsBinding("yahoo", yahoo.class);
 	}
 


### PR DESCRIPTION
This PR fixes a bug with the Rhino runtime not being able to find the "webview" module.

See [TIMOB-8113](https://jira.appcelerator.org/browse/TIMOB-8113) for test case.
Package application for Rhino runtime and run application.
