### PR TITLE
[TIMOB-8709] Query tableview subviews to appropriately compute row height.

### DIFF
--- a/iphone/Classes/TiUITableView.m
+++ b/iphone/Classes/TiUITableView.m
@@ -19,6 +19,12 @@
 
 #define DEFAULT_SECTION_HEADERFOOTER_HEIGHT 20.0
 
+@interface TiUITableView ()
+@property (nonatomic,copy,readwrite) NSString * searchString;
+- (void)updateSearchResultIndexes;
+- (CGFloat)computeRowWidth;
+@end
+
 @implementation TiUITableViewCell
 @synthesize hitPoint,proxy;
 #pragma mark Touch event handling
@@ -65,7 +71,7 @@
 {
     CGFloat width = 0;
     if ([proxy table] != nil) {
-        width = [proxy sizeWidthForDecorations:[[proxy table] tableView].bounds.size.width forceResizing:YES];        
+        width = [proxy sizeWidthForDecorations:[[proxy table] computeRowWidth] forceResizing:YES];        
     }
 	CGFloat height = [proxy rowHeight:width];
 	height = [[proxy table] tableRowHeight:height];
@@ -244,12 +250,6 @@
 }
 
 
-
-@end
-
-@interface TiUITableView ()
-@property (nonatomic,copy,readwrite) NSString * searchString;
-- (void)updateSearchResultIndexes;
 
 @end
 


### PR DESCRIPTION
Note that this solution (in fact, any "mostly reliable" solution) requires an oblique reference to a private API class (UITableViewIndex) although it does not access any class-specific methods or properties. It is possible to remove the class name reference and do a pure subview hierarchy search, but this is significantly more fragile.

It may be required as part of QE vetting that an app using this fix is vetted via the automated submission checker (not a full submission/acceptance process).
