### PR TITLE
[TIMOB-8076] Android: V8: GC lag can cause crash on older devices

### DIFF
--- a/android/runtime/v8/src/native/JavaObject.cpp
+++ b/android/runtime/v8/src/native/JavaObject.cpp
@@ -162,6 +162,7 @@ void JavaObject::attach(jobject javaObject)
 	UPDATE_STATS(0, -1);
 
 	handle_.MakeWeak(this, DetachCallback);
+	handle_.MarkIndependent();
 
 	if (javaObject) {
 		javaObject_ = javaObject;

--- a/android/runtime/v8/src/native/NativeObject.h
+++ b/android/runtime/v8/src/native/NativeObject.h
@@ -65,6 +65,7 @@ protected:
 	inline void MakeWeak(void)
 	{
 		handle_.MakeWeak(this, WeakCallback);
+		handle_.MarkIndependent();
 	}
 
 	/* Ref() marks the object as being attached to an event loop.


### PR DESCRIPTION
Marking weak handles as weak plus the upgrade of V8 appears to fix the out of memory issues
with the test case for [TIMOB-7865](https://jira.appcelerator.org/browse/TIMOB-7865).

Run the test case and monitor the heap via DDMS. The heap size should eventually hit a ceiling
and stop growing in size. My testing on the Xoom keeps the heap bellow 15mb.
