### PR TITLE
[TIMOB-8682] Android: Setting "top" to null causes "bottom" to not be recognized

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiConvert.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiConvert.java
@@ -545,7 +545,8 @@ public class TiConvert
 	{
 		if (value instanceof Number) {
 			value = value.toString() + TiApplication.getInstance().getDefaultUnit();
-		} else if (value instanceof String) {
+		}
+		if (value instanceof String) {
 			return toTiDimension((String) value, valueType);
 		}
 		return null;

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiConvert.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiConvert.java
@@ -545,9 +545,10 @@ public class TiConvert
 	{
 		if (value instanceof Number) {
 			value = value.toString() + TiApplication.getInstance().getDefaultUnit();
+		} else if (value instanceof String) {
+			return toTiDimension((String) value, valueType);
 		}
-
-		return toTiDimension((String) value, valueType);
+		return null;
 	}
 	/**
 	 * Takes a value out of a hash table then attempts to convert it using {@link #toTiDimension(Object, int)} for more details.


### PR DESCRIPTION
[TIMOB-8682](https://jira.appcelerator.org/browse/TIMOB-8682)
Also fixes [TIMOB-8742](https://jira.appcelerator.org/browse/TIMOB-8742)

Test cases in JIRAs. For TIMOB-8682 try both _null_ and _undefined_.
Also fixes potential ClassCastException when value other than number or string is assigned to a property.
