### PR TITLE
[TIMOB-8769] Add __IPHONE_5_x macros, fix bad cast

### DIFF
--- a/iphone/Classes/GeolocationModule.mm
+++ b/iphone/Classes/GeolocationModule.mm
@@ -194,7 +194,7 @@ extern BOOL const TI_APPLICATION_ANALYTICS;
 	{
 		for (KrollCallback *callback in [NSArray arrayWithArray:singleHeading])
 		{
-			KrollContext *ctx = (id<TiEvaluator>)[callback context];
+			KrollContext *ctx = (KrollContext*)[callback context];
 			if ([bridge krollContext] == ctx)
 			{
 				[singleHeading removeObject:callback];
@@ -210,7 +210,7 @@ extern BOOL const TI_APPLICATION_ANALYTICS;
 	{
 		for (KrollCallback *callback in [NSArray arrayWithArray:singleLocation])
 		{
-			KrollContext *ctx = (id<TiEvaluator>)[callback context];
+			KrollContext *ctx = (KrollContext*)[callback context];
 			if ([bridge krollContext] == ctx)
 			{
 				[singleLocation removeObject:callback];

--- a/iphone/Classes/TiAppiOSProxy.m
+++ b/iphone/Classes/TiAppiOSProxy.m
@@ -50,7 +50,7 @@
 	NSString* urlString = [[TiUtils toURL:[a objectForKey:@"url"] proxy:self]absoluteString];
 	
 	if ([urlString length] == 0) {
-		return;
+		return nil;
 	}
 	
 	if (backgroundServices == nil) {

--- a/iphone/Classes/TiBase.h
+++ b/iphone/Classes/TiBase.h
@@ -26,6 +26,18 @@ extern "C" {
 #define __IPHONE_4_2 40200
 #endif
 
+#ifndef __IPHONE_4_3
+#define __IPHONE_4_3 40300
+#endif
+    
+#ifndef __IPHONE_5_0
+#define __IPHONE_5_0 50000
+#endif
+    
+#ifndef __IPHONE_5_1
+#define __IPHONE_5_1 50100
+#endif
+    
 #ifdef DEBUG
 	// Kroll memory debugging
 	#define KROLLBRIDGE_MEMORY_DEBUG MEMORY_DEBUG

--- a/iphone/Classes/TiDOMElementProxy.m
+++ b/iphone/Classes/TiDOMElementProxy.m
@@ -494,7 +494,7 @@
         if(nodeToRemove == nil)
         {
             [self throwException:@"no node found to remove" subreason:nil location:CODELOCATION];
-            return;
+            return nil;
         }
         else
         {
@@ -510,7 +510,7 @@
     else
     {
         [self throwException:@"no node found to remove" subreason:nil location:CODELOCATION];
-        return;
+        return nil;
     }
 }
 
@@ -527,7 +527,7 @@
 	xmlNodePtr refNodePtr = [[refChild node]XMLNode];
 	xmlNodePtr newNodePtr = [[newChild node]XMLNode];
 	if (newNodePtr == refNodePtr)
-		return;
+		return newChild;
 	
 	TiDOMNodeListProxy* nodeList = [self childNodes];
 	
@@ -585,7 +585,7 @@
 	xmlNodePtr refNodePtr = [[refChild node]XMLNode];
 	xmlNodePtr newNodePtr = [[newChild node]XMLNode];
 	if (newNodePtr == refNodePtr)
-		return;
+		return refChild;
 	
 	TiDOMNodeListProxy* nodeList = [self childNodes];
 	


### PR DESCRIPTION
Note that this resolution MUST be tested on:
- A machine running OS 10.6 Snow Leopard
- A machine with a version of XCode which **does not include an iOS 5.0 SDK anywhere.** (outside of our compatibility matrix)
