### PR TITLE
[TIMOB-2653] Android: Complex/autogenerated remote image URLs fail, whereas simple URLs succeed

### DIFF
--- a/android/modules/network/src/java/ti/modules/titanium/network/TiHTTPClient.java
+++ b/android/modules/network/src/java/ti/modules/titanium/network/TiHTTPClient.java
@@ -84,6 +84,7 @@ import org.appcelerator.titanium.io.TiFile;
 import org.appcelerator.titanium.io.TiResourceFile;
 import org.appcelerator.titanium.util.TiConvert;
 import org.appcelerator.titanium.util.TiMimeTypeHelper;
+import org.appcelerator.titanium.util.TiUrl;
 
 import ti.modules.titanium.xml.DocumentProxy;
 import ti.modules.titanium.xml.XMLModule;
@@ -720,30 +721,6 @@ public class TiHTTPClient
 		return result;
 	}
 
-	private static Uri getCleanUri(String uri)
-	{
-		Uri base = Uri.parse(uri);
-
-		Uri.Builder builder = base.buildUpon();
-		builder.encodedQuery(Uri.encode(Uri.decode(base.getQuery()), "&="));
-		String encodedAuthority = Uri.encode(Uri.decode(base.getAuthority()),"/:@");
-		int firstAt = encodedAuthority.indexOf('@');
-		if (firstAt >= 0) {
-			int lastAt = encodedAuthority.lastIndexOf('@');
-			if (lastAt > firstAt) {
-				// We have a situation that might be like this:
-				// http://user@domain.com:password@api.mickey.com
-				// i.e., the user name is user@domain.com, and the host
-				// is api.mickey.com.  We need all at-signs prior to the final one (which
-				// indicates the host) to be encoded.
-				encodedAuthority = Uri.encode(encodedAuthority.substring(0, lastAt), "/:") + encodedAuthority.substring(lastAt);
-			}
-		}
-		builder.encodedAuthority(encodedAuthority);
-		builder.encodedPath(Uri.encode(Uri.decode(base.getPath()), "/"));
-		return builder.build();
-	}
-
 	public void open(String method, String url)
 	{
 		if (DBG) {
@@ -764,7 +741,7 @@ public class TiHTTPClient
 		}
 
 		if (autoEncodeUrl) {
-			this.uri = getCleanUri(url);
+			this.uri = TiUrl.getCleanUri(url);
 
 		} else {
 			this.uri = Uri.parse(url);

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIImageView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIImageView.java
@@ -732,6 +732,9 @@ public class TiUIImageView extends TiUIView implements OnLifecycleEvent, Handler
 				} catch (URISyntaxException e) {
 					Log.e(LCAT, "URISyntaxException for url " + imageref.getUrl(), e);
 					getAsync = false;
+				} catch (NullPointerException e) {
+					Log.e(LCAT, "NullPointerException for url " + imageref.getUrl(), e);
+					getAsync = false;
 				}
 				if (getAsync) {
 					imageref.getBitmapAsync(downloadListener);
@@ -844,6 +847,8 @@ public class TiUIImageView extends TiUIView implements OnLifecycleEvent, Handler
 				}
 
 			} catch (URISyntaxException e) {
+				setDefaultImageSource(defaultImage);
+			} catch (NullPointerException e) {
 				setDefaultImageSource(defaultImage);
 			}
 		}

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIImageView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIImageView.java
@@ -32,6 +32,7 @@ import org.appcelerator.titanium.util.TiConvert;
 import org.appcelerator.titanium.util.TiDownloadListener;
 import org.appcelerator.titanium.util.TiResponseCache;
 import org.appcelerator.titanium.util.TiUIHelper;
+import org.appcelerator.titanium.util.TiUrl;
 import org.appcelerator.titanium.view.TiDrawableReference;
 import org.appcelerator.titanium.view.TiUIView;
 
@@ -724,7 +725,9 @@ public class TiUIImageView extends TiUIView implements OnLifecycleEvent, Handler
 				}
 				boolean getAsync = true;
 				try {
-					URI uri = new URI(imageref.getUrl());
+					String imageUrl = TiUrl.getCleanUri(imageref.getUrl()).toString();
+					
+					URI uri = new URI(imageUrl);
 					getAsync = !TiResponseCache.peek(uri);
 				} catch (URISyntaxException e) {
 					Log.e(LCAT, "URISyntaxException for url " + imageref.getUrl(), e);
@@ -830,7 +833,7 @@ public class TiUIImageView extends TiUIView implements OnLifecycleEvent, Handler
 				Object image = d.get(TiC.PROPERTY_IMAGE);
 
 				if (image instanceof String) {
-					String imageUrl = (String) image;
+					String imageUrl = TiUrl.getCleanUri((String)image).toString();
 					URI imageUri = new URI(imageUrl);
 					if (URLUtil.isNetworkUrl(imageUrl) && !TiResponseCache.peek(imageUri)) {
 						setDefaultImageSource(defaultImage);

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiUrl.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiUrl.java
@@ -31,6 +31,7 @@ public class TiUrl
 	public static final String CURRENT_PATH = ".";
 	public static final String PARENT_PATH_WITH_SEPARATOR = "../";
 	public static final String CURRENT_PATH_WITH_SEPARATOR = "./";
+    
 
 	public String baseUrl;
 	public String url;
@@ -287,6 +288,42 @@ public class TiUrl
 		} catch (URISyntaxException e) {
 			Log.w(TAG, "Error parsing url: " + e.getMessage(), e);
 			return url;
+		}
+	}
+	
+	public static Uri getCleanUri(String argString) {
+		try
+		{
+			if (argString == null)
+			{
+				return null;
+			}
+			
+			Uri base = Uri.parse(argString);
+	
+			Uri.Builder builder = base.buildUpon();
+			builder.encodedQuery(Uri.encode(Uri.decode(base.getQuery()), "&="));
+			String encodedAuthority = Uri.encode(Uri.decode(base.getAuthority()),"/:@");
+			int firstAt = encodedAuthority.indexOf('@');
+			if (firstAt >= 0) {
+				int lastAt = encodedAuthority.lastIndexOf('@');
+				if (lastAt > firstAt) {
+					// We have a situation that might be like this:
+					// http://user@domain.com:password@api.mickey.com
+					// i.e., the user name is user@domain.com, and the host
+					// is api.mickey.com.  We need all at-signs prior to the final one (which
+					// indicates the host) to be encoded.
+					encodedAuthority = Uri.encode(encodedAuthority.substring(0, lastAt), "/:") + encodedAuthority.substring(lastAt);
+				}
+			}
+			builder.encodedAuthority(encodedAuthority);
+			builder.encodedPath(Uri.encode(Uri.decode(base.getPath()), "/"));
+			return builder.build();
+		}
+		catch (Exception e)
+		{
+			Log.e(TAG, "Exception in encodeURI srgString= " + argString, e);
+			return null;
 		}
 	}
 }

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiUrl.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiUrl.java
@@ -291,11 +291,10 @@ public class TiUrl
 		}
 	}
 	
-	public static Uri getCleanUri(String argString) {
-		try
-		{
-			if (argString == null)
-			{
+	public static Uri getCleanUri(String argString) 
+	{
+		try {
+			if (argString == null) {
 				return null;
 			}
 			
@@ -319,9 +318,7 @@ public class TiUrl
 			builder.encodedAuthority(encodedAuthority);
 			builder.encodedPath(Uri.encode(Uri.decode(base.getPath()), "/"));
 			return builder.build();
-		}
-		catch (Exception e)
-		{
+		} catch (Exception e) {
 			Log.e(TAG, "Exception in getCleanUri argString= " + argString, e);
 			return null;
 		}

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiUrl.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiUrl.java
@@ -322,7 +322,7 @@ public class TiUrl
 		}
 		catch (Exception e)
 		{
-			Log.e(TAG, "Exception in encodeURI srgString= " + argString, e);
+			Log.e(TAG, "Exception in getCleanUri argString= " + argString, e);
 			return null;
 		}
 	}

--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiDrawableReference.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiDrawableReference.java
@@ -33,6 +33,7 @@ import org.appcelerator.titanium.util.TiDownloadListener;
 import org.appcelerator.titanium.util.TiDownloadManager;
 import org.appcelerator.titanium.util.TiFileHelper;
 import org.appcelerator.titanium.util.TiUIHelper;
+import org.appcelerator.titanium.util.TiUrl;
 
 import android.app.Activity;
 import android.content.pm.ApplicationInfo;
@@ -625,7 +626,7 @@ public class TiDrawableReference
 		}
 		
 		try {
-			TiDownloadManager.getInstance().download(new URI(url), listener);
+			TiDownloadManager.getInstance().download(new URI(TiUrl.getCleanUri(url).toString()), listener);
 		} catch (URISyntaxException e) {
 			Log.e(LCAT, "URI Invalid: " + url, e);
 		}

--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiDrawableReference.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiDrawableReference.java
@@ -629,6 +629,8 @@ public class TiDrawableReference
 			TiDownloadManager.getInstance().download(new URI(TiUrl.getCleanUri(url).toString()), listener);
 		} catch (URISyntaxException e) {
 			Log.e(LCAT, "URI Invalid: " + url, e);
+		} catch (NullPointerException e) {
+			Log.e(LCAT, "NullPointerException: " + url, e);
 		}
 	}
 


### PR DESCRIPTION
Associated ticket [JIRA](https://jira.appcelerator.org/browse/TIMOB-2653)

Note the Test case in the ticket no longer succeeds. But the error message in now one of file not found instead of URISyntax exception.
