### PR TITLE
[TIMOB-5799] Android: Child element does not respect opacity of parent

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiView.java
@@ -14,6 +14,8 @@ import org.appcelerator.titanium.view.TiCompositeLayout;
 import org.appcelerator.titanium.view.TiCompositeLayout.LayoutArrangement;
 import org.appcelerator.titanium.view.TiUIView;
 
+import android.view.View;
+
 public class TiView extends TiUIView
 {
 
@@ -30,6 +32,14 @@ public class TiView extends TiUIView
 			}
 		}
 		setNativeView(new TiCompositeLayout(proxy.getActivity(), arrangement, proxy));
+	}
+
+	@Override
+	protected void setOpacity(View view, float opacity)
+	{
+		super.setOpacity(view, opacity);
+		TiCompositeLayout layout = (TiCompositeLayout) nativeView;
+		layout.setAlphaCompat(opacity);
 	}
 
 	@Override

--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiCompositeLayout.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiCompositeLayout.java
@@ -7,6 +7,7 @@
 package org.appcelerator.titanium.view;
 
 import java.lang.ref.WeakReference;
+import java.lang.reflect.Method;
 import java.util.Comparator;
 import java.util.TreeSet;
 
@@ -17,6 +18,9 @@ import org.appcelerator.titanium.TiDimension;
 import org.appcelerator.titanium.proxy.TiViewProxy;
 
 import android.content.Context;
+import android.graphics.Canvas;
+import android.graphics.Rect;
+import android.graphics.RectF;
 import android.os.Build;
 import android.view.View;
 import android.view.ViewGroup;
@@ -61,6 +65,9 @@ public class TiCompositeLayout extends ViewGroup
 	private int horizontalLayoutCurrentLeft = 0;
 	private int horizontalLayoutLineHeight = 0;
 	private boolean disableHorizontalWrap = false;
+
+	private float alpha = 1.0f;
+	private Method setAlphaMethod;
 
 	private WeakReference<TiViewProxy> proxy;
 	private static final int HAS_SIZE_FILL_CONFLICT = 1;
@@ -573,6 +580,79 @@ public class TiCompositeLayout extends ViewGroup
 			int offset = (dist - measuredSize) / 2;
 			pos[0] = layoutPosition0 + offset;
 			pos[1] = pos[0] + measuredSize;
+		}
+	}
+
+	/*
+	 * Set the opacity of the view using View.setAlpha if available.
+	 *
+	 * @param alpha the opacity of the view
+	 * @return true if opacity was set, otherwise false if View.setAlpha failed or was not available.
+	 */
+	private boolean nativeSetAlpha(float alpha)
+	{
+		if (Build.VERSION.SDK_INT < 11) {
+			// Only available in API level 11 or higher.
+			return false;
+		}
+
+		if (setAlphaMethod == null) {
+			try {
+				setAlphaMethod = getClass().getMethod("setAlpha", float.class);
+			} catch (NoSuchMethodException e) {
+				Log.w(TAG, "Unable to find setAlpha() method.", e);
+				return false;
+			}
+		}
+
+		try {
+			setAlphaMethod.invoke(this, alpha);
+		} catch (Exception e) {
+			Log.e(TAG, "Failed to call setAlpha().", e);
+			return false;
+		}
+
+		return true;
+	}
+
+	/*
+	 * Set the alpha of the view. Provides backwards compatibility
+	 * with older versions of Android which don't support View.setAlpha().
+	 *
+	 * @param alpha the opacity of the view
+	 */
+	public void setAlphaCompat(float alpha)
+	{
+		// Try using the native setAlpha() method first.
+		if (nativeSetAlpha(alpha)) {
+			return;
+		}
+
+		// If setAlpha() is not supported on this platform,
+		// use the backwards compatibility workaround.
+		// See dispatchDraw() for details.
+		this.alpha = alpha;
+	}
+
+	@Override
+	protected void dispatchDraw(Canvas canvas)
+	{
+		// To support alpha in older versions of Android (API level less than 11),
+		// create a new layer to draw the children. Specify the alpha value to use
+		// later when we transfer this layer back onto the canvas.
+		if (alpha < 1.0f) {
+			Rect bounds = new Rect();
+			getDrawingRect(bounds);
+			canvas.saveLayerAlpha(new RectF(bounds), Math.round(alpha * 255), Canvas.ALL_SAVE_FLAG);
+		}
+
+		super.dispatchDraw(canvas);
+
+		if (alpha < 1.0f) {
+			// Restore the canvas once the children have been drawn to the layer.
+			// This will draw the layer's offscreen bitmap onto the canvas using
+			// the alpha value we specified earlier.
+			canvas.restore();
 		}
 	}
 


### PR DESCRIPTION
See [TIMOB-5799](https://jira.appcelerator.org/browse/TIMOB-5799) for testing details.
There are two test cases attached.

The first is the original test case attached to the ticket.
When you run this test case w/ this fix you should see image, just a blank white window.

The second test case provides a similar setup, but includes sliders to adjust
the opacity of the parent and child views. Try adjusting the child opacity first. This should
only affect the child view and not change the parent's opacity. Then try adjusting the parent opacity.
You should notice both the parent and child have their opacity changed.

The behavior should be compared to iOS as well to make sure we have parity.
