### PR TITLE
[TIMOB-7664] iOS: Allow for custom Info.plist values via tiapp.xml

### DIFF
--- a/support/tiapp.py
+++ b/support/tiapp.py
@@ -344,6 +344,7 @@ class TiAppXML(object):
 				'CFBundleIdentifier', 'CFBundleInfoDictionaryVersion', 'CFBundleName', 'CFBundlePackageType', 'CFBundleSignature',
 				'CFBundleVersion', 'CFBundleShortVersionString', 'LSRequiresIPhoneOS']
 		
+		self.ios['plist'] = {}
 		for child in node.childNodes:
 			if child.nodeName == 'plist':
 				plist_dict = child.getElementsByTagName('dict')[0]

--- a/support/tiapp.py
+++ b/support/tiapp.py
@@ -73,6 +73,7 @@ class TiAppXML(object):
 		self.android = {}
 		self.android_manifest = {}
 		self.iphone = {}
+		self.ios = {};
 		
 		root = self.dom.documentElement
 		children = root.childNodes
@@ -108,6 +109,8 @@ class TiAppXML(object):
 					self.parse_android(child)
 				elif child.nodeName == 'iphone':
 					self.parse_iphone(child)
+				elif child.nodeName == 'ios':
+					self.parse_ios(child)
 				elif child.nodeName == 'property':
 					name = child.getAttribute('name')
 					value = getText(child.childNodes)
@@ -329,6 +332,27 @@ class TiAppXML(object):
 			if child.nodeName in parse_tags:
 				local_objects['parse_'+child.nodeName](child)
 
+	def parse_ios(self, node):
+		def getText(nodelist):
+		    rc = []
+		    for node in nodelist:
+		        if node.nodeType == node.TEXT_NODE:
+		            rc.append(node.data)
+		    return ''.join(rc)
+		
+		for child in node.childNodes:
+			if child.nodeName == 'plist':
+				plist_dict = child.getElementsByTagName('dict')[0]
+				plist = {}
+				keyName = ''
+				for e in plist_dict.childNodes:
+					if e.nodeName == 'key':
+						keyName = getText(e.childNodes)
+					elif e.nodeType == e.ELEMENT_NODE and keyName != '':
+						plist[keyName] = e.toxml('utf-8')
+						keyName = ''
+				self.ios['plist'] = plist
+
 	def has_app_property(self, property):
 		return property in self.app_properties
 
@@ -390,43 +414,47 @@ class TiAppXML(object):
 				propertyName = 'UISupportedInterfaceOrientations'
 				if prop == 'orientations_ipad':
 					propertyName += '~ipad'
-				propertyValue = '<array>\n'
+				propertyValue = '\t<array>\n'
 				for orientation in self.iphone[prop]:
-					propertyValue += "	<string>%s</string>\n" % orientation
-				propertyValue += '	</array>'
+					propertyValue += "\t\t<string>%s</string>\n" % orientation
+				propertyValue += '\t</array>'
 				self.infoplist_properties[propertyName]=propertyValue
 			if prop == 'background':
 				propertyName = 'UIBackgroundModes'
-				propertyValue = '<array>\n'
+				propertyValue = '\t<array>\n'
 				for mode in self.iphone[prop]:
-					propertyValue += "	<string>%s</string>\n" % mode
-				propertyValue += '	</array>'
+					propertyValue += "\t\t<string>%s</string>\n" % mode
+				propertyValue += '\t</array>'
 				self.infoplist_properties[propertyName]=propertyValue
 			if prop == 'requires':
 				propertyName = 'UIRequiredDeviceCapabilities'
-				propertyValue = '<array>\n'
+				propertyValue = '\t<array>\n'
 				for feature in self.iphone[prop]:
-					propertyValue += "	<string>%s</string>\n" % feature
-				propertyValue += '	</array>'
+					propertyValue += "\t\t<string>%s</string>\n" % feature
+				propertyValue += '\t</array>'
 				self.infoplist_properties[propertyName]=propertyValue
 			if prop == 'types':
 				propertyName = 'CFBundleDocumentTypes'
-				propertyValue = '<array>\n'
+				propertyValue = '\t<array>\n'
 				for type in self.iphone[prop]:
-					propertyValue += '<dict>\n'
-					propertyValue += "<key>CFBundleTypeName</key><string>%s</string>\n" % type['name']
-					propertyValue += "<key>CFBundleTypeIconFiles</key><array><string>%s</string></array>\n" % type['icon']
-					propertyValue += '<key>LSItemContentTypes</key><array>'
+					propertyValue += '\t\t<dict>\n'
+					propertyValue += "\t\t\t<key>CFBundleTypeName</key><string>%s</string>\n" % type['name']
+					propertyValue += "\t\t\t<key>CFBundleTypeIconFiles</key><array><string>%s</string></array>\n" % type['icon']
+					propertyValue += '\t\t\t<key>LSItemContentTypes</key>\n\t\t\t<array>'
 					for uti in type['uti']:
-						propertyValue += "<string>%s</string>" % uti
-					propertyValue += '</array>\n'
+						propertyValue += "\t\t\t\t<string>%s</string>" % uti
+					propertyValue += '\t\t\t</array>\n'
 					owner = 'Owner' if type['owner'] else 'Alternate'
-					propertyValue += "<key>LSHandlerRank</key><string>%s</string>\n" % owner
-					propertyValue += '</dict>\n'
-				propertyValue += '</array>'
+					propertyValue += "\t\t\t<key>LSHandlerRank</key><string>%s</string>\n" % owner
+					propertyValue += '\t\t</dict>\n'
+				propertyValue += '\t</array>'
 				
 				self.infoplist_properties[propertyName]=propertyValue
-
+		
+		plist_props = self.ios['plist']
+		for prop in plist_props:
+			self.infoplist_properties[prop] = plist_props[prop]
+		
 		plist = codecs.open(file,'r','utf-8','replace').read()
 		plist = plist.replace('__APPICON__',iconname)
 
@@ -442,8 +470,8 @@ class TiAppXML(object):
 		for type in iconorder:
 			for nexticon in iconslist:
 				if type == nexticon:
-					propertyValue += "\t<string>%s</string>\n" % nexticon
-		propertyValue += '</array>\n'
+					propertyValue += "\t\t<string>%s</string>\n" % nexticon
+		propertyValue += '\t</array>\n'
 		self.infoplist_properties[propertyName]=propertyValue
 		
 		# replace the bundle id with the app id 
@@ -498,7 +526,7 @@ class TiAppXML(object):
 			newcontent = ''
 			for p in self.infoplist_properties:
 				v = self.infoplist_properties[p]
-				newcontent += '        <key>%s</key>\n        %s\n' %(p,v)
+				newcontent += '\t<key>%s</key>\n\t%s\n' %(p,v)
 			plist = before + newcontent + after
 
 		f = codecs.open(file,'w+','utf-8','replace')

--- a/support/tiapp.py
+++ b/support/tiapp.py
@@ -344,7 +344,6 @@ class TiAppXML(object):
 				'CFBundleIdentifier', 'CFBundleInfoDictionaryVersion', 'CFBundleName', 'CFBundlePackageType', 'CFBundleSignature',
 				'CFBundleVersion', 'CFBundleShortVersionString', 'LSRequiresIPhoneOS']
 		
-		self.ios['plist'] = {}
 		for child in node.childNodes:
 			if child.nodeName == 'plist':
 				plist_dict = child.getElementsByTagName('dict')[0]
@@ -467,7 +466,10 @@ class TiAppXML(object):
 				
 				self.infoplist_properties[propertyName]=propertyValue
 		
-		plist_props = self.ios['plist']
+		plist_props = {}
+		if 'plist' in self.ios:
+			plist_props = self.ios['plist']
+		
 		for prop in plist_props:
 			if prop[0] != '+':
 				self.infoplist_properties[prop] = plist_props[prop]

--- a/support/tiapp.py
+++ b/support/tiapp.py
@@ -340,7 +340,7 @@ class TiAppXML(object):
 		            rc.append(node.data)
 		    return ''.join(rc)
 		
-		ignore_keys = ['CFBundleDevelopmentRegion', 'CFBundleDisplayName', 'CFBundleExecutable', 'CFBundleIconFile',
+		ignore_keys = ['CFBundleDisplayName', 'CFBundleExecutable', 'CFBundleIconFile',
 				'CFBundleIdentifier', 'CFBundleInfoDictionaryVersion', 'CFBundleName', 'CFBundlePackageType', 'CFBundleSignature',
 				'CFBundleVersion', 'CFBundleShortVersionString', 'LSRequiresIPhoneOS']
 		
@@ -362,6 +362,8 @@ class TiAppXML(object):
 							for ee in e.getElementsByTagName('dict'):
 								types_string = types_string + ee.toxml('utf-8')
 							plist['+'+keyName] = types_string
+						elif keyName == 'CFBundleDevelopmentRegion':
+							plist['+'+keyName] = e.toxml('utf-8');
 						else:
 							plist[keyName] = e.toxml('utf-8')
 						keyName = ''
@@ -480,7 +482,16 @@ class TiAppXML(object):
 				st = plist[0:i+8]
 				fn = plist[i+8:]
 				plist = st + plist_props['+CFBundleURLTypes'] + fn
-			
+		
+		# replace the development region from plist section
+		if '+CFBundleDevelopmentRegion' in plist_props:
+			i = plist.index('CFBundleDevelopmentRegion')
+			if i:
+				i = plist.index('<string>',i+1)
+				e = plist.index('</string>',i+1)
+				st = plist[0:i]
+				fn = plist[e+9:]
+				plist = st + plist_props['+CFBundleDevelopmentRegion'] + fn
 
 		#Creating proper CFBundleIconFiles rather than hard coding the values in there
 		propertyName = 'CFBundleIconFiles'


### PR DESCRIPTION
[TIMOB-7664](https://jira.appcelerator.org/browse/TIMOB-7664)

FT: paste ios section example from JIRA into tiapp.xml. Build/launch in Simulator the app from TiStudio, then open build/iphone/Info.plist file to verify values.

The changes also addresses some Info.plist indentation formatting issues.
