### PR TITLE
[TIMOB-8776] iOS: KitchenSink 2.1.0 - Expected label is not displayed

### DIFF
--- a/iphone/Classes/TiMediaVideoPlayerProxy.m
+++ b/iphone/Classes/TiMediaVideoPlayerProxy.m
@@ -68,6 +68,10 @@ NSArray* moviePlayerKeys = nil;
 	[super _initWithProperties:properties];
 }
 
+/**
+ Legacy class that needs to do the subView insertion checks.
+ TODO: Implement wrapperView code.
+*/
 -(BOOL)optimizeSubviewInsertion
 {
     return NO;

--- a/iphone/Classes/TiMediaVideoPlayerProxy.m
+++ b/iphone/Classes/TiMediaVideoPlayerProxy.m
@@ -68,7 +68,7 @@ NSArray* moviePlayerKeys = nil;
 	[super _initWithProperties:properties];
 }
 
--(BOOL)optimizeSubviewTraversal
+-(BOOL)optimizeSubviewInsertion
 {
     return NO;
 }

--- a/iphone/Classes/TiMediaVideoPlayerProxy.m
+++ b/iphone/Classes/TiMediaVideoPlayerProxy.m
@@ -68,6 +68,11 @@ NSArray* moviePlayerKeys = nil;
 	[super _initWithProperties:properties];
 }
 
+-(BOOL)optimizeSubviewTraversal
+{
+    return NO;
+}
+
 -(void)_destroy
 {
 	if (playing) {

--- a/iphone/Classes/TiViewProxy.h
+++ b/iphone/Classes/TiViewProxy.h
@@ -251,6 +251,14 @@ enum
 #pragma mark Methods subclasses should override for behavior changes
 
 /**
+ Whether or not the view proxy can have non Ti-Views which have to be pushed to the bottom when adding children.
+ 
+ Subclasses may override.
+ @return _NO_ if the view proxy can have non Ti-Views in its view heirarchy
+ */
+-(BOOL)optimizeSubviewTraversal;
+
+/**
  Whether or not the view proxy needs to suppress relayout.
  
  Subclasses may override.

--- a/iphone/Classes/TiViewProxy.h
+++ b/iphone/Classes/TiViewProxy.h
@@ -252,7 +252,7 @@ enum
 
 /**
  Whether or not the view proxy can have non Ti-Views which have to be pushed to the bottom when adding children.
- 
+ **This method is only meant for legacy classes. New classes must implement the proper wrapperView code**
  Subclasses may override.
  @return _NO_ if the view proxy can have non Ti-Views in its view heirarchy
  */

--- a/iphone/Classes/TiViewProxy.h
+++ b/iphone/Classes/TiViewProxy.h
@@ -256,7 +256,7 @@ enum
  Subclasses may override.
  @return _NO_ if the view proxy can have non Ti-Views in its view heirarchy
  */
--(BOOL)optimizeSubviewTraversal;
+-(BOOL)optimizeSubviewInsertion;
 
 /**
  Whether or not the view proxy needs to suppress relayout.

--- a/iphone/Classes/TiViewProxy.m
+++ b/iphone/Classes/TiViewProxy.m
@@ -1014,7 +1014,7 @@ LAYOUTPROPERTIES_SETTER(setMinHeight,minimumHeight,TiFixedValueRuleFromObject,[s
 }
 
 #pragma mark Methods subclasses should override for behavior changes
--(BOOL)optimizeSubviewTraversal
+-(BOOL)optimizeSubviewInsertion
 {
     return YES;
 }
@@ -1940,7 +1940,7 @@ if(OSAtomicTestAndSetBarrier(flagBit, &dirtyflags))	\
 	BOOL earlierSibling = YES;
 	UIView * ourView = [self parentViewForChild:childProxy];
 
-    if (![self optimizeSubviewTraversal]) {
+    if (![self optimizeSubviewInsertion]) {
         for (UIView* subview in [ourView subviews]) 
         {
             if (![subview isKindOfClass:[TiUIView class]]) {
@@ -2472,11 +2472,11 @@ if(OSAtomicTestAndSetBarrier(flagBit, &dirtyflags))	\
 			pthread_rwlock_rdlock(&childrenLock);
 			int childProxyIndex = [children indexOfObject:child];
             
-			BOOL optimizeTraversal = [self optimizeSubviewTraversal];
+			BOOL optimizeInsertion = [self optimizeSubviewInsertion];
 
 			for (TiUIView * thisView in [ourView subviews])
 			{
-				if ( (!optimizeTraversal) && (![thisView isKindOfClass:[TiUIView class]]) )
+				if ( (!optimizeInsertion) && (![thisView isKindOfClass:[TiUIView class]]) )
 				{
 					insertPosition ++;
 					continue;


### PR DESCRIPTION
Test is in [JIRA](https://jira.appcelerator.org/browse/TIMOB-8776)

Regression caused by PR #1892 for TIMOB-7841. Need to go through other view proxies as well to see where this issue might be a problem.
