### PR TITLE
TIMOB-8872 fix tab eventing to make sure focus and blur events that bubb...

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TabGroupProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TabGroupProxy.java
@@ -20,6 +20,7 @@ import org.appcelerator.titanium.TiApplication;
 import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.TiContext;
 import org.appcelerator.titanium.proxy.TiBaseWindowProxy;
+import org.appcelerator.titanium.proxy.TiViewProxy;
 import org.appcelerator.titanium.proxy.TiWindowProxy;
 import org.appcelerator.titanium.util.TiConvert;
 import org.appcelerator.titanium.util.TiUIHelper;
@@ -354,7 +355,6 @@ public class TabGroupProxy extends TiWindowProxy
 
 		return e;
 	}
-
 
 	private void fillIntent(Activity activity, Intent intent)
 	{

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TabGroupProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TabGroupProxy.java
@@ -20,7 +20,6 @@ import org.appcelerator.titanium.TiApplication;
 import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.TiContext;
 import org.appcelerator.titanium.proxy.TiBaseWindowProxy;
-import org.appcelerator.titanium.proxy.TiViewProxy;
 import org.appcelerator.titanium.proxy.TiWindowProxy;
 import org.appcelerator.titanium.util.TiConvert;
 import org.appcelerator.titanium.util.TiUIHelper;

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TabProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TabProxy.java
@@ -73,7 +73,7 @@ public class TabProxy extends TiViewProxy
 	{
 		if (eventName == TiC.EVENT_BLUR || eventName == TiC.EVENT_FOCUS) {
 			TiUIView tabGroupView = tabGroupProxy.peekView();
-			if (tabGroupView != null || tabGroupView instanceof TiUITabGroup) {
+			if (tabGroupView instanceof TiUITabGroup) {
 				data = ((TiUITabGroup) tabGroupView).getTabChangeEvent();
 
 			} else {

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TabProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TabProxy.java
@@ -8,11 +8,14 @@ package ti.modules.titanium.ui;
 
 import org.appcelerator.kroll.KrollDict;
 import org.appcelerator.kroll.annotations.Kroll;
+import org.appcelerator.kroll.common.Log;
 import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.TiContext;
 import org.appcelerator.titanium.proxy.TiViewProxy;
 import org.appcelerator.titanium.proxy.TiWindowProxy;
 import org.appcelerator.titanium.view.TiUIView;
+
+import ti.modules.titanium.ui.widget.TiUITabGroup;
 
 import android.app.Activity;
 import android.content.Intent;
@@ -25,6 +28,8 @@ propertyAccessors = {
 })
 public class TabProxy extends TiViewProxy
 {
+	private static final String TAG = "TabProxy";
+
 	private TiWindowProxy win;
 	private TabGroupProxy tabGroupProxy;
 	private int windowId;
@@ -61,6 +66,22 @@ public class TabProxy extends TiViewProxy
 		if (window instanceof TiWindowProxy) {
 			setWindow((TiWindowProxy) window);
 		}
+	}
+
+	@Override
+	public boolean fireEvent(String eventName, Object data)
+	{
+		if (eventName == TiC.EVENT_BLUR || eventName == TiC.EVENT_FOCUS) {
+			TiUIView tabGroupView = tabGroupProxy.peekView();
+			if (tabGroupView != null || tabGroupView instanceof TiUITabGroup) {
+				data = ((TiUITabGroup) tabGroupView).getTabChangeEvent();
+
+			} else {
+				Log.e(TAG, "unable to populate <" + eventName + "> event, view is incorrect type!");
+			}
+		}
+
+		return super.fireEvent(eventName, data);
 	}
 
 	@Kroll.method @Kroll.setProperty


### PR DESCRIPTION
...le up from window have the correct data structure

https://jira.appcelerator.org/browse/TIMOB-8872

Fixes several issues with tab eventing where focus and blur events were being fired twice or fired with the wrong data structure.

Test is attached to ticket.  KS test should be run against this change.
