### PR TITLE
[TIMOB-7300] Android: Titanium.UI.TabGroup.open(): crash when TabGroup child Tab.window is uninitialized

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUITabGroup.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUITabGroup.java
@@ -183,12 +183,18 @@ public class TiUITabGroup extends TiUIView
 
 		if (tabChangeEventData != null) {
 			if (previousTab != null) {
-				getTabWindow(previousTab).fireEvent(TiC.EVENT_BLUR, null);
+				TiViewProxy previousTabWindow = getTabWindow(previousTab);
+				if (previousTabWindow != null) {
+					previousTabWindow.fireEvent(TiC.EVENT_BLUR, null);
+				}
 			}
 		}
 
 		tabChangeEventData = tabGroupProxy.buildFocusEvent(currentTabID, previousTabID);
-		getTabWindow(currentTab).fireEvent(TiC.EVENT_FOCUS, null);
+		TiViewProxy currentTabWindow = getTabWindow(currentTab);
+		if (currentTabWindow != null) {
+			currentTabWindow.fireEvent(TiC.EVENT_FOCUS, null);
+		}
 		previousTabID = currentTabID;
 
 	}


### PR DESCRIPTION
Fixes a crash seen when opening a tab group which contains a tab that has no window set.

See [TIMOB-7300](https://jira.appcelerator.org/browse/TIMOB-7300) for a test case.
