### PR TITLE
[TIMOB-8151] Android: camera image is stretched when using an overlay

### DIFF
--- a/android/modules/media/src/java/ti/modules/titanium/media/TiCameraActivity.java
+++ b/android/modules/media/src/java/ti/modules/titanium/media/TiCameraActivity.java
@@ -65,11 +65,17 @@ public class TiCameraActivity extends TiBaseActivity implements SurfaceHolder.Ca
 	public void surfaceCreated(SurfaceHolder previewHolder) {
 		camera = Camera.open();
 
-		// using default preview size may be causing problem on some devices, setting dimensions manually
+		/*
+		 * Disabling this since it can end up picking a bad preview
+		 * size which can create stretching issues (TIMOB-8151).
+		 * Original words of wisdom left by some unknown person:
+		 * "using default preview size may be causing problem on some devices, setting dimensions manually"
+		 * We may want to expose camera parameters to the developer for extra control.
 		Parameters cameraParams = camera.getParameters();
 		Camera.Size previewSize = cameraParams.getSupportedPreviewSizes().get((cameraParams.getSupportedPreviewSizes().size()) - 1);
 		cameraParams.setPreviewSize(previewSize.width, previewSize.height );
 		camera.setParameters(cameraParams);
+		*/
 
 		try {
 			Log.i(LCAT, "setting preview display");


### PR DESCRIPTION
This disables code which overrides the default camera preview size.
On some of devices picking the "last" preview size might end up producing
a low quality image.

See [TIMOB-8151](https://jira.appcelerator.org/browse/TIMOB-8151) for a test case.
This should be tested on as many devices as possible. If we do see some devices
showing bad image quality with the "default" values, we might want to consider another plan.
