### PR TITLE
[TIMOB-8725] Handling new window inside a modal window.

### DIFF
--- a/iphone/Classes/TiRootViewController.m
+++ b/iphone/Classes/TiRootViewController.m
@@ -621,7 +621,7 @@
             if([thisWindow modalFlagValue] == YES){
                 isInsideModalWindow = YES;
                 NSLog(@"[WARN] Trying to open a new window from within a Modal Window is unsupported.");
-                
+                break;
             }
             
         }

--- a/iphone/Classes/TiRootViewController.m
+++ b/iphone/Classes/TiRootViewController.m
@@ -607,6 +607,27 @@
         return;
     }   
     
+    /*Find out if we are inside a modal view controller . 
+     *TODO : There is currently a ticket open TIMOB-8902 to expose the 
+     *navigation controller of the modal window so that windows can 
+     *be added to it, instead of adding it here. when that ticket is resolved.
+     *this entire logic should be removed.
+     */
+    
+    BOOL isInsideModalWindow = NO;
+    for (TiWindowProxy * thisWindow in [windowProxies reverseObjectEnumerator])
+	{
+        if ([thisWindow closing] == NO) {
+            if([thisWindow modalFlagValue] == YES){
+                isInsideModalWindow = YES;
+                NSLog(@"[WARN] Trying to open a new window from within a Modal Window is unsupported.");
+                
+            }
+            
+        }
+    }
+    
+
     if ((newOrientation == windowOrientation) &&
         (oldFlags & allowedOrientations))
     {
@@ -616,7 +637,7 @@
             [[UIApplication sharedApplication] setStatusBarOrientation:windowOrientation animated:NO];
         }
                 
-        if (TI_ORIENTATION_ALLOWED(allowedOrientations, orientationHistory[0])) {
+        if (TI_ORIENTATION_ALLOWED(allowedOrientations, orientationHistory[0]) && (isInsideModalWindow == NO)) {
              //Nothing to do here.
             return;
         }


### PR DESCRIPTION
**Make sure there are no regressions**

***TESTING INSTRUCTIONS.**
*[TIMOB-8725](https://jira.appcelerator.org/browse/TIMOB-8725)
TEST FOR REGRESSIONS IN THE FOLLOWING TICKET
*[TIMOB-7486](https://jira.appcelerator.org/browse/TIMOB-7486) -- The sandwiched case still fails the same way. 
*[TIMOB-7627](https://jira.appcelerator.org/browse/TIMOB-7627)
*[TIMOB-6551](https://jira.appcelerator.org/browse/TIMOB-6551)
*[TIMOB-6391](https://jira.appcelerator.org/browse/TIMOB-6391)
*[TIMOB-4619](https://jira.appcelerator.org/browse/TIMOB-4619)
*[TIMOB-1634](https://jira.appcelerator.org/browse/TIMOB-1634)

This is PR throws out a warning when user try's to open a new window from within a model window. and possibly to correct the orientation is some cases(*NOT ALL). 
