### PR TITLE
[TIMOB-8751] Android: Ti.Geolocation.getPreferredProvider() crashes the app when location services are disabled

### DIFF
--- a/android/kroll-apt/src/java/org/appcelerator/kroll/annotations/generator/ProxyBindingV8.cpp.fm
+++ b/android/kroll-apt/src/java/org/appcelerator/kroll/annotations/generator/ProxyBindingV8.cpp.fm
@@ -201,7 +201,7 @@ Handle<FunctionTemplate> ${className}::getProxyTemplate()
 		titanium::Proxy::getProperty,
 		titanium::Proxy::onPropertyChanged,
 		Handle<Value>(), DEFAULT);
-	DEFINE_PROTOTYPE_METHOD(proxyTemplate, "${getter}", titanium::Proxy::getProperty);
+	DEFINE_PROTOTYPE_METHOD_DATA(proxyTemplate, "${getter}", titanium::Proxy::getProperty, String::NewSymbol("${name}"));
 	DEFINE_PROTOTYPE_METHOD_DATA(proxyTemplate, "${setter}", titanium::Proxy::onPropertyChanged, String::NewSymbol("${name}"));
 	</@Proxy.listPropertyAccessors>
 

--- a/android/runtime/v8/src/native/Proxy.cpp
+++ b/android/runtime/v8/src/native/Proxy.cpp
@@ -89,11 +89,19 @@ Handle<Value> Proxy::getProperty(Local<String> property, const AccessorInfo& inf
 
 Handle<Value> Proxy::getProperty(const Arguments& args)
 {
-	if (args.Length() < 1) {
-		return JSException::Error("Requires property name as first argument.");
+	// The name of the property can be passed either as
+	// an argument or a data parameter.
+	Local<String> name;
+	if (args.Length() >= 1) {
+		name = args[0]->ToString();
+
+	} else if (args.Data()->IsString()) {
+		name = args.Data()->ToString();
+
+	} else {
+		return JSException::Error("Requires property name.");
 	}
 
-	Local<String> name = args[0]->ToString();
 	return getPropertyForProxy(name, args.Holder());
 }
 


### PR DESCRIPTION
This fixes a bug with accessor property getter methods.
See [TIMOB-8751](https://jira.appcelerator.org/browse/TIMOB-8751) for a test case.
