### PR TITLE
[TIMOB-8295] Force calculated 'width' when blitting

### DIFF
--- a/iphone/Classes/TiViewProxy.m
+++ b/iphone/Classes/TiViewProxy.m
@@ -536,7 +536,7 @@ LAYOUTPROPERTIES_SETTER(setMinHeight,minimumHeight,TiFixedValueRuleFromObject,[s
 		if (CGSizeEqualToSize(size, CGSizeZero) || size.width==0 || size.height==0)
 		{
 			CGFloat width = [self autoWidthForSize:CGSizeMake(1000,1000)];
-			CGFloat height = [self autoHeightForSize:CGSizeMake(width,1000)];
+			CGFloat height = [self autoHeightForSize:CGSizeMake(width,0)];
 			if (width > 0 && height > 0)
 			{
 				size = CGSizeMake(width, height);

--- a/iphone/Classes/TiViewProxy.m
+++ b/iphone/Classes/TiViewProxy.m
@@ -42,18 +42,15 @@
 @synthesize children;
 -(NSArray*)children
 {
-    NSArray* copy = nil;
-    
 	pthread_rwlock_rdlock(&childrenLock);
 	if (windowOpened==NO && children==nil && pendingAdds!=nil)
 	{
-		copy = [pendingAdds mutableCopy];
+		NSArray *copy = [pendingAdds mutableCopy];
+		pthread_rwlock_unlock(&childrenLock);
+		return [copy autorelease];
 	}
-    else {
-        copy = [children mutableCopy];
-    }
 	pthread_rwlock_unlock(&childrenLock);
-	return [copy autorelease];
+	return children;
 }
 
 -(void)setVisible:(NSNumber *)newVisible withObject:(id)args

--- a/iphone/Classes/TiViewProxy.m
+++ b/iphone/Classes/TiViewProxy.m
@@ -42,15 +42,18 @@
 @synthesize children;
 -(NSArray*)children
 {
+    NSArray* copy = nil;
+    
 	pthread_rwlock_rdlock(&childrenLock);
 	if (windowOpened==NO && children==nil && pendingAdds!=nil)
 	{
-		NSArray *copy = [pendingAdds mutableCopy];
-		pthread_rwlock_unlock(&childrenLock);
-		return [copy autorelease];
+		copy = [pendingAdds mutableCopy];
 	}
+    else {
+        copy = [children mutableCopy];
+    }
 	pthread_rwlock_unlock(&childrenLock);
-	return children;
+	return [copy autorelease];
 }
 
 -(void)setVisible:(NSNumber *)newVisible withObject:(id)args


### PR DESCRIPTION
This fix forces a blit that's occurring without a layout beforehand to use the height implicitly calculated from the width. Note that Undefined, SIZE, and FILL all result in this behavior (which is probably appropriate).
