### PR TITLE
[TIDOC-583] Document draggable annotation changes.

### DIFF
--- a/apidoc/Titanium/Map/Annotation.yml
+++ b/apidoc/Titanium/Map/Annotation.yml
@@ -50,13 +50,18 @@ properties:
 
   - name: animate
     summary: Boolean to indicate whether the pin should animate when dropped.
+    description: |
+        Must be set before the annotation is added to the map view.
     type: Boolean
 
   - name: draggable
     summary: Determines whether the pin can be dragged by the user.
+    description: |
+        Must be set before the annotation is added to the map view.
     type: Boolean
     default: false
     platforms: [iphone, ipad]
+    since: "2.1.0"
 
   - name: image
     summary: Image to use for the the pin.

--- a/apidoc/Titanium/Map/Annotation.yml
+++ b/apidoc/Titanium/Map/Annotation.yml
@@ -52,6 +52,12 @@ properties:
     summary: Boolean to indicate whether the pin should animate when dropped.
     type: Boolean
 
+  - name: draggable
+    summary: Determines whether the pin can be dragged by the user.
+    type: Boolean
+    default: false
+    platforms: [iphone, ipad]
+
   - name: image
     summary: Image to use for the the pin.
     description: |

--- a/apidoc/Titanium/Map/Map.yml
+++ b/apidoc/Titanium/Map/Map.yml
@@ -13,6 +13,7 @@ properties:
     type: Number
     permission: read-only
     platforms: [iphone, ipad]
+    since: "2.1.0"
 
   - name: ANNOTATION_DRAG_STATE_START
     summary: |
@@ -21,6 +22,7 @@ properties:
     type: Number
     permission: read-only
     platforms: [iphone, ipad]
+    since: "2.1.0"
 
   - name: ANNOTATION_DRAG_STATE_DRAG
     summary: |
@@ -29,6 +31,7 @@ properties:
     type: Number
     permission: read-only
     platforms: [iphone, ipad]
+    since: "2.1.0"
 
   - name: ANNOTATION_DRAG_STATE_CANCEL
     summary: |
@@ -37,6 +40,7 @@ properties:
     type: Number
     permission: read-only
     platforms: [iphone, ipad]
+    since: "2.1.0"
 
   - name: ANNOTATION_DRAG_STATE_END
     summary: |
@@ -45,6 +49,7 @@ properties:
     type: Number
     permission: read-only
     platforms: [iphone, ipad]
+    since: "2.1.0"
 
   - name: ANNOTATION_GREEN
     summary: |

--- a/apidoc/Titanium/Map/Map.yml
+++ b/apidoc/Titanium/Map/Map.yml
@@ -5,6 +5,47 @@ extends: Titanium.Module
 since: "0.8"
 platforms: [android, iphone, ipad, mobileweb]
 properties:
+
+  - name: ANNOTATION_DRAG_STATE_NONE
+    summary: |
+        Used in the [pinchangedragstate](Titanium.Map.View.pinchangedragstate) event 
+        to indicate that the annotation is not being dragged.
+    type: Number
+    permission: read-only
+    platforms: [iphone, ipad]
+
+  - name: ANNOTATION_DRAG_STATE_START
+    summary: |
+        Used in the [pinchangedragstate](Titanium.Map.View.pinchangedragstate) event 
+        to indicate that the user started dragging the annotation.
+    type: Number
+    permission: read-only
+    platforms: [iphone, ipad]
+
+  - name: ANNOTATION_DRAG_STATE_DRAG
+    summary: |
+        Used in the [pinchangedragstate](Titanium.Map.View.pinchangedragstate) event 
+        to indicate that the user moved the annotation.
+    type: Number
+    permission: read-only
+    platforms: [iphone, ipad]
+
+  - name: ANNOTATION_DRAG_STATE_CANCEL
+    summary: |
+        Used in the [pinchangedragstate](Titanium.Map.View.pinchangedragstate) event 
+        to indicate that the user canceled the drag action.
+    type: Number
+    permission: read-only
+    platforms: [iphone, ipad]
+
+  - name: ANNOTATION_DRAG_STATE_END
+    summary: |
+        Used in the [pinchangedragstate](Titanium.Map.View.pinchangedragstate) event 
+        to indicate that the user finished moving the annotation.
+    type: Number
+    permission: read-only
+    platforms: [iphone, ipad]
+
   - name: ANNOTATION_GREEN
     summary: |
         Color constant used to set a map annotation to green via the 

--- a/apidoc/Titanium/Map/View.yml
+++ b/apidoc/Titanium/Map/View.yml
@@ -257,6 +257,47 @@ events:
     summary: Fired when the map begins loading.
     platforms: [iphone, ipad, mobileweb]
 
+  - name: pinchangedragstate
+    summary: Fired when the user interacts with a draggable annotation.
+    properties:
+
+      - name: annotation
+        summary: Annotation being dragged.
+        type: Titanium.Map.Annotation
+
+      - name: map
+        summary: This map view.
+        type: Titanium.Map.View
+        
+      - name: title
+        summary: Annotation title.
+        type: String
+
+      - name: index
+        summary: Index of the annotation.
+        type: Number
+
+      - name: newState
+        summary: |
+            New drag state for the annotation, one of
+            [ANNOTATION_DRAG_STATE_NONE](Titanium.Map.ANNOTATION_DRAG_STATE_NONE),
+            [ANNOTATION_DRAG_STATE_START](Titanium.Map.ANNOTATION_DRAG_STATE_START),
+            [ANNOTATION_DRAG_STATE_DRAG](Titanium.Map.ANNOTATION_DRAG_STATE_DRAG),
+            [ANNOTATION_DRAG_STATE_CANCEL](Titanium.Map.ANNOTATION_DRAG_STATE_CANCEL) or
+            [ANNOTATION_DRAG_STATE_END](Titanium.Map.ANNOTATION_DRAG_STATE_END).
+        type: Number
+
+      - name: oldState
+        summary: |
+            Previous drag state for the annotation, one of
+            [ANNOTATION_DRAG_STATE_NONE](Titanium.Map.ANNOTATION_DRAG_STATE_NONE),
+            [ANNOTATION_DRAG_STATE_START](Titanium.Map.ANNOTATION_DRAG_STATE_START),
+            [ANNOTATION_DRAG_STATE_DRAG](Titanium.Map.ANNOTATION_DRAG_STATE_DRAG),
+            [ANNOTATION_DRAG_STATE_CANCEL](Titanium.Map.ANNOTATION_DRAG_STATE_CANCEL) or
+            [ANNOTATION_DRAG_STATE_END](Titanium.Map.ANNOTATION_DRAG_STATE_END).
+        type: Number
+    platforms: [iphone, ipad]
+
   - name: regionChanged
     summary: Fired when the mapping region changes.
     properties:

--- a/apidoc/Titanium/Map/View.yml
+++ b/apidoc/Titanium/Map/View.yml
@@ -297,6 +297,7 @@ events:
             [ANNOTATION_DRAG_STATE_END](Titanium.Map.ANNOTATION_DRAG_STATE_END).
         type: Number
     platforms: [iphone, ipad]
+    since: "2.1.0"
 
   - name: regionChanged
     summary: Fired when the mapping region changes.


### PR DESCRIPTION
Not clear to me whether this is completely correct: As written, it generates getters/setters for Annotation.draggable (as well as Annotation.animate, for instance). I don't see these in the code, so this may need to be documented as a creation-only property.

Please advise, O Wise iOS types.
