### PR TITLE
[TIMOB-8620] Ensure Ti.UI.View.children is a copy, not a live reference.

### DIFF
--- a/iphone/Classes/TiViewProxy.m
+++ b/iphone/Classes/TiViewProxy.m
@@ -42,15 +42,18 @@
 @synthesize children;
 -(NSArray*)children
 {
+    NSArray* copy = nil;
+    
 	pthread_rwlock_rdlock(&childrenLock);
 	if (windowOpened==NO && children==nil && pendingAdds!=nil)
 	{
-		NSArray *copy = [pendingAdds mutableCopy];
-		pthread_rwlock_unlock(&childrenLock);
-		return [copy autorelease];
+		copy = [pendingAdds mutableCopy];
 	}
+    else {
+        copy = [children mutableCopy];
+    }
 	pthread_rwlock_unlock(&childrenLock);
-	return children;
+	return [copy autorelease];
 }
 
 -(void)setVisible:(NSNumber *)newVisible withObject:(id)args


### PR DESCRIPTION
Exactly as described. See ticket for test and some caveats.
