### PR TITLE
[TIDOC-592] Adding property `clipViews` to ScrollableView docs

### DIFF
--- a/apidoc/Titanium/UI/ScrollableView.yml
+++ b/apidoc/Titanium/UI/ScrollableView.yml
@@ -291,6 +291,15 @@ properties:
     summary: Sets the views within this Scrollable View.
     type: Array<Titanium.UI.View>
 
+  - name: clipViews
+    summary: |
+        Determines whether the content which is being scrolled will be clipped to the frame of
+        the view.
+    type: Boolean
+    default: true
+    platforms: [iphone, ipad]
+    availability: creation
+
 examples:
   - title: Simple Scrollable View with 3 Views
     example: |


### PR DESCRIPTION
[JIRA: [TIDOC-592] Property `clipViews` of `ScrollableView` not documented](https://jira.appcelerator.org/browse/TIDOC-592)

This is implemented but undocumented, so I added it.
