### PR TITLE
[TIMOB-8939] Added property `hitRect` to `ScrollableView`

### DIFF
--- a/apidoc/Titanium/UI/ScrollableView.yml
+++ b/apidoc/Titanium/UI/ScrollableView.yml
@@ -300,6 +300,18 @@ properties:
     platforms: [iphone, ipad]
     availability: creation
 
+  - name: hitRect
+    summary: |
+        Sets a rect to perform hit testing on to determine if touches have occurred on this
+        view.
+    description: |
+        By setting this to some rect, one can override the normal hit testing.  Note that the
+        x and y specified are relative to the position of the view.
+    type: Dimension
+    default: undefined (hit against size of view)
+    platforms: [iphone, ipad]
+    since: "2.1"
+
 examples:
   - title: Simple Scrollable View with 3 Views
     example: |

--- a/iphone/Classes/TiUIScrollableView.m
+++ b/iphone/Classes/TiUIScrollableView.m
@@ -75,19 +75,14 @@
         if (CGRectContainsPoint(hitRect, point))
         {
             UIView * test = [super hitTest:point withEvent:event];
-            if (test == nil)
-            {
-                // If it misses super's hitTest then it's outside of the
-                // scrollview.  Just return scrollview; at least the scrolling
-                // events can be processed, though no touches will go through
-                // to the view inside of scrollview
-                return scrollview;
-            } 
-            else 
-            {
-                // otherwise just return whatever super got
-                return test;
-            }
+
+            // If it misses super's hitTest then it's outside of the
+            // scrollview.  Just return scrollview; at least the scrolling
+            // events can be processed, though no touches will go through
+            // to the view inside of scrollview. otherwise just return 
+            // whatever super got.
+
+            return test == nil ? scrollview : test;
         }
         else
         {

--- a/iphone/Classes/TiUIScrollableView.m
+++ b/iphone/Classes/TiUIScrollableView.m
@@ -63,6 +63,40 @@
 	return pageControl;
 }
 
+
+- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event 
+{
+    id value = [self.proxy valueForKey:@"hitRect"];
+    UIView * test = [super hitTest:point withEvent:event];
+
+    if (value != nil) 
+    {
+        CGRect hitRect = [TiUtils rectValue:value];
+        // As long as we're inside of hitRect..
+        if (CGRectContainsPoint(hitRect, point))
+        {
+            if (test == nil)
+            {
+                // If it misses super's hitTest then it's outside of the
+                // scrollview.  Just return scrollview; at least the scrolling
+                // events can be processed, though no touches will go through
+                // to the view inside of scrollview
+                return scrollview;
+            } 
+            else 
+            {
+                // otherwise just return whatever super got
+                return test;
+            }
+        }
+    }
+    else 
+    {
+        return test;
+    }
+    return nil;
+}
+
 -(UIScrollView*)scrollview 
 {
 	if (scrollview==nil)

--- a/iphone/Classes/TiUIScrollableView.m
+++ b/iphone/Classes/TiUIScrollableView.m
@@ -67,7 +67,6 @@
 - (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event 
 {
     id value = [self.proxy valueForKey:@"hitRect"];
-    UIView * test = [super hitTest:point withEvent:event];
 
     if (value != nil) 
     {
@@ -75,6 +74,7 @@
         // As long as we're inside of hitRect..
         if (CGRectContainsPoint(hitRect, point))
         {
+            UIView * test = [super hitTest:point withEvent:event];
             if (test == nil)
             {
                 // If it misses super's hitTest then it's outside of the
@@ -89,12 +89,15 @@
                 return test;
             }
         }
+        else
+        {
+            return nil;
+        }
     }
     else 
     {
-        return test;
+        return [super hitTest:point withEvent:event];
     }
-    return nil;
 }
 
 -(UIScrollView*)scrollview 


### PR DESCRIPTION
[JIRA: [TIMOB-8939] Allow hit rectangle of ScrollableViews to be modified](https://jira.appcelerator.org/browse/TIMOB-8939)

I am trying to replicate this:
http://blog.proculo.de/archives/180-Paging-enabled-UIScrollView-With-Previews.html

In order for this to work, we would need to allow modification of the hit testing for `ScrollableView`s.  I've chosen to do this by implementing a property `hitRect` which will allow a user to set a rect to be used for hit testing.

In combination with the `clipViews` property, this can be used to make a scrolling card view as seen in Safari.

Here's a test case:

``` javascript
var win = Ti.UI.createWindow();

var view1 = Ti.UI.createView({ backgroundColor:'#123', width: 250 });
var view2 = Ti.UI.createView({ backgroundColor:'#246', width: 250 });
var view3 = Ti.UI.createView({ backgroundColor:'#48b', width: 250 });

var scrollableView = Ti.UI.createScrollableView({
  views: [view1,view2,view3],
  showPagingControl: true,
  width: 260,
  height: 430,
  hitRect: {
    height: 480,
    width: 320,
    x: -30,
    y: 0
  }
});

win.add(scrollableView);
win.open();
```

Observe that, when the view is displayed, it's possible to drag the "preview" of the next view on the edge of the screen.

I should note that this isn't a particularly elegant solution to my problem.  I'm open to suggestions of better ways to solve it.
