### PR TITLE
TIDOC-591 APIDoc: Network.HTTPClient code missing from example block

### DIFF
--- a/apidoc/Titanium/Network/HTTPClient.yml
+++ b/apidoc/Titanium/Network/HTTPClient.yml
@@ -3,27 +3,27 @@ name: Titanium.Network.HTTPClient
 summary: HTTP client object that (mostly) implements the XMLHttpRequest specification.
 description: |
     Use <Titanium.Network.createHTTPClient> to create a new `HTTPClient` object.
-
+    
     An `HTTPClient` object is intended to be used for a single request. It may be 
     possible to re-use an `HTTPClient` object, but this use case is not tested. 
-
+    
     There are three steps in making a typical HTTP request:
-
+    
     * Creating an `HTTPClient` object.
     * Opening the `HTTPClient` object.
     * Sending the request.
-
+    
     Before opening the request, you must define one or more callbacks to handle
     the HTTP response, as well as errors, progress updates, and other conditions.
-
+    
     The `HTTPClient` callbacks operate somewhat differently from other
     Titanium callbacks, in accordance with the XMLHttpRequest specification.
-
+    
     When the callbacks are invoked, the `this` value is set to either the 
     original `HTTPClient` object itself, or a response object that holds all
     of the response-related properties defined for the `HTTPClient` object. So the 
     callbacks can use code like this to access the response values:
-
+    
         httpResponse = this.responseText;
         status = this.status;
     
@@ -39,19 +39,20 @@ description: |
     foo.example.com, then requests to any domain other than *.example.com will fail.
     
     There are two solutions to get around this problem:
-      
+    
     * Configure the destination server to support Cross-Origin Resource Sharing.
     * Use [Ti.Network.httpURLFormatter](Titanium.Network.httpURLFormatter) in conjunction 
       with a proxy on the server hosting the application.
     
     More information about Cross-Origin Resource Sharing can be found on the 
     [W3C Cross-Origin Resource Sharing](http://www.w3.org/TR/cors/) specification page.
-    
 extends: Titanium.Proxy
 since: "0.1"
+
 methods:
   - name: abort
     summary: Cancels a pending request.
+    
   - name: clearCookies
     summary: Clears any cookies stored for the host.
     parameters:
@@ -59,6 +60,7 @@ methods:
         summary: The URL of the host/domain to clear cookies for.
         type: String
     platforms: [android, iphone, ipad]
+    
   - name: getResponseHeader
     summary: Returns the value of the specified response header.
     returns:
@@ -67,184 +69,210 @@ methods:
       - name: name
         summary: Name of the header to retrieve.
         type: String
+    
   - name: open
-    summary: Opens the request and readies the connection.
+    summary: Opens the request and prepares the connection.
     parameters:
       - name: method
-        summary: |
-            HTTP method for this request, such as 'GET' or 'POST'.
+        summary: HTTP method for this request, such as 'GET' or 'POST'.
         type: String
+        
       - name: url
         summary: URL for the request.
         type: String
+        
       - name: async
-        summary: Whether the request should be made asynchronously. Only used on iOS.
+        summary: Determines whether the request should be made asynchronously. Only used on iOS.
         type: Boolean
         optional: true
         default: true
+    
   - name: send
     summary: Sends the request.
     description: |
         For POST requests, use the `data` parameter to send POST data.
-
-        If you pass a serializable JavaScript object, it is automatically
-        turned into form-encoded POST data. You can also send an arbitrary 
-        string or binary data (in the form of a <Titanium.Blob>).
-
-        On iOS, you can specify a synchronous request when you call `open` 
-        by passing `false` for the `async` parameter. In the case of a synchronous
-        request, `send` blocks until the request is complete. 
+        
+        If you pass a serializable JavaScript object, it is automatically turned into form-encoded 
+        POST data. You can also send an arbitrary string or binary data (in the form of a 
+        <Titanium.Blob>).
+        
+        On iOS, you can specify a synchronous request when you call `open` by passing `false` for 
+        the `async` parameter. In the case of a synchronous request, `send` blocks until the request 
+        is complete.
     parameters:
       - name: data
         summary: Data to send with a POST request. 
         type: [Object, String, Titanium.Filesystem.File, Titanium.Blob]
         optional: true
         default: no data
+    
   - name: setRequestHeader
-    summary: Sets the value for the specified request header. Must be called after `open` but before `send`.
+    summary: |
+        Sets the value for the specified request header. Must be called after `open` but before `send`.
     parameters:
       - name: name
         summary: Name of the header to set.
         type: String
+        
       - name: value
-        summary: Value to assign to the header. May be `null` to clear a default header value, 
-            such as X-Requested-With.
+        summary: |
+            Value to assign to the header. May be `null` to clear a default header value, such as 
+            X-Requested-With.
         type: String
+    
   - name: setTimeout
     summary: Sets the request timeout.
     parameters:
       - name: timeout
         summary: Timeout in milliseconds.
         type: Number
+
 properties:
   - name: DONE
     summary: Ready state constant indicating that the request is complete.
     description: |
         In this ready state, either the data has been transferred, or an error has occured.
-
+        
         See also [readyState](Titanium.Network.HTTPClient.readyState).
     type: Number
     permission: read-only
+    
   - name: HEADERS_RECEIVED
     summary: Ready state constant indicating that response headers have been received.
-    description: |
-        See also [readyState](Titanium.Network.HTTPClient.readyState).
+    description: See also [readyState](Titanium.Network.HTTPClient.readyState).
     type: Number
     permission: read-only
+    
   - name: LOADING
-    summary: Ready state constant indicating that response data is being received from the
-        remote server.
-    description: |
-        See also [readyState](Titanium.Network.HTTPClient.readyState).
+    summary: |
+        Ready state constant indicating that response data is being received from the remote server.
+    description: See also [readyState](Titanium.Network.HTTPClient.readyState).
     type: Number
     permission: read-only
+    
   - name: OPENED
-    summary: Ready state constant indicating that the connection has been opened, but the 
-        request has not yet been sent.
-    description: |
-        See also [readyState](Titanium.Network.HTTPClient.readyState).
+    summary: |
+        Ready state constant indicating that the connection has been opened, but the request has 
+        not yet been sent.
+    description: See also [readyState](Titanium.Network.HTTPClient.readyState).
     type: Number
     permission: read-only
+    
   - name: UNSENT
     summary: Ready state constant indicating that HTTPClient request has not been opened or sent.
-    description: |
-        See also [readyState](Titanium.Network.HTTPClient.readyState).
+    description: See also [readyState](Titanium.Network.HTTPClient.readyState).
     type: Number
     permission: read-only
+    
   - name: allResponseHeaders
-    summary: All of the response headers as a single string, or an empty string if no headers are available.
+    summary: All of the response headers.
     description: |
-        See also: [getResponseHeader](Titanium.Network.HTTPClient.getResponseHeader).
+        Contains a single string, or an empty string if no headers are available. 
+        
+        See also: [getResponseHeader](Titanium.Network.HTTPClient.getResponseHeader). 
     type: String
     permission: read-only
     platforms: [android]
+    
   - name: autoEncodeUrl
-    summary: Set to `false` to suppress URL-encoding of the specified URL.
+    summary: Determines whether automatic encoding is enabled for the specified URL.
+    description: Set to `false` to disable automatic URL-encoding.
     type: Boolean
     default: true
     platforms: [android]
+    
   - name: autoRedirect
-    summary: Set to `false` to disable automatic handling of HTTP redirects.
+    summary: Determines whether automatic automatic handling of HTTP redirects is enabled.
+    description: Set to `false` to disable automatic HTTP redirects handling.
     type: Boolean
     default: true
     platforms: [android, iphone, ipad]
+    
   - name: connected
-    summary: boolean to indicate that the response was successful
+    summary: Indicates whether the response was successful.
     type: Boolean
     permission: read-only
+    
   - name: connectionType
     summary: Connection type, normally either `GET` or `POST`.
     type: String
     permission: read-only
+    
   - name: enableKeepAlive
     summary: Determines whether the client should attempt to keep a persistent connection.
+    description: Set to `true` to maintain a persistent connection.
     type: Boolean
     default: false
     platforms: [iphone, ipad]
+    
   - name: file
-    summary: |
-        File to download contents to.  Can only be set **after** calling
-        [open](Titanium.Network.HTTPClient.open).
+    summary: Target local file to receive data.
+    description: Can only be set **after** calling [open](Titanium.Network.HTTPClient.open).
     type: String
     platforms: [iphone, ipad]
+    
   - name: location
     summary: Absolute URL of the request.
     type: String
     permission: read-only
+    
   - name: ondatastream
-    summary: Function to be called at regular intervals as the request data is being received. 
+    summary: Function to be called at regular intervals as the request data is being received.
     description: |
         Must be set before calling `open`.
-
-        The `progress` property of the event will contain a value from 0.0-1.0 with 
-        the progress of the request.
+        
+        The `progress` property of the event will contain a value from 0.0-1.0 with the progress of 
+        the request.
     type: Callback<Object>
+    
   - name: onerror
     summary: Function to be called upon a error response.
     description: |
         Must be set before calling `open`. 
         
-        The callback's argument is an object with a single 
-        property, `error`, containing the error string.
+        The callback's argument is an object with a single property, `error`, containing the error 
+        string.
     type: Callback<Object>
+    
   - name: onload
     summary: Function to be called upon a successful response.
     description: |
         Must be set before calling `open`. 
-
-        To access response data and headers, access the `HTTPClient` object itself 
-        (accessible as `this` during the callback, or the
-        `source` property of the callback event).
-
+        
+        To access response data and headers, access the `HTTPClient` object itself (accessible as 
+        `this` during the callback, or the `source` property of the callback event).
     type: Callback<Object>
+    
   - name: onreadystatechange
-    summary: Function to be called for each
-        [readyState](Titanium.Network.HTTPClient.readyState) change.
+    summary: |
+        Function to be called for each [readyState](Titanium.Network.HTTPClient.readyState) change.
     type: Callback<Object>
     description: |
         Must be set before calling `open`. 
         
         When the callback is invoked, `this.readyState` is set to one of the 
-        `HTTPClient` ready state constants,
-        [OPENED](Titanium.Network.HTTPClient.OPENED),
-        [HEADERS_RECEIVED](Titanium.Network.HTTPClient.HEADERS_RECEIVED),
-        [LOADING](Titanium.Network.HTTPClient.LOADING), or 
-        [DONE](Titanium.Network.HTTPClient.DONE).
+        `Titanium.Network.HTTPClient` ready-state constants, 
+        [OPENED](Titanium.Network.HTTPClient.OPENED), 
+        [HEADERS_RECEIVED](Titanium.Network.HTTPClient.HEADERS_RECEIVED), 
+        [LOADING](Titanium.Network.HTTPClient.LOADING), 
+        or [DONE](Titanium.Network.HTTPClient.DONE).
+    
   - name: onsendstream
-    summary: Function to be called at regular intervals as the request data is being transmitted. 
+    summary: Function to be called at regular intervals as the request data is being transmitted.
     description: |
         Must be set before calling `open`.
-
+        
         The `progress` property of the event will contain a value from 0.0-1.0 with the progress of
         the upload.
     type: Callback<Object>
+    
   - name: readyState
     summary: The current ready state of this HTTP request.
     description: |
-        The ready state describes the current state of the request. The ready state
-        is set to one of the five `HTTPClient` ready state constants. A typical HTTP
-        request goes through the states in this order:
-
+        The ready state describes the current state of the request. The ready state is set to one of 
+        the five `Titanium.Network.HTTPClient` ready state constants. A typical HTTP request goes 
+        through the states in this order:
+        
         * [UNSENT](Titanium.Network.HTTPClient.UNSENT)
         * [OPENED](Titanium.Network.HTTPClient.OPENED)
         * [HEADERS_RECEIVED](Titanium.Network.HTTPClient.HEADERS_RECEIVED)
@@ -254,82 +282,99 @@ properties:
         The `onreadystatechange` callback is invoked each time the ready state changes.
     type: Number
     permission: read-only
+    
   - name: responseData
     summary: Response data as a `Blob` object.
     type: Titanium.Blob
     permission: read-only
+    
   - name: responseText
-    summary: Response as text or `null` if an error was received or no data was returned.
+    summary: Response as text.
+    description: Set to `null` if an error was received or no data was returned.
     type: String
     permission: read-only
+    
   - name: responseXML
     summary: Response object as an XML DOM Document object. 
     description: 
-       Set to `null` if the content type returned by the server was not XML or if the 
-       content could not be parsed.
+       Set to `null` if the content type returned by the server was not XML or if the content could 
+       not be parsed.
     type: Titanium.XML.Document
     permission: read-only
+    
   - name: status
     summary: Response HTTP status code.
     type: Number
     permission: read-only
+    
   - name: statusText
     summary: Human-readable status message associated with the status code.
     type: String
     permission: read-only
+    
   - name: timeout
-    summary: Timeout in milliseconds when the connection should be aborted
+    summary: Timeout in milliseconds when the connection should be aborted.
     type: Number
+    
   - name: validatesSecureCertificate
-    summary: Controls how SSL certification validation is performed on connection.  
-    description: |
-        Note that on iOS, this value is always `false` by default. This is a known issue.
+    summary: Determines how SSL certification validation is performed on connection.  
+    description: Note that on iOS, this value is always `false` by default. This is a known issue.
     type: Boolean
-    default: False when running in the simulator or on device in testing mode, and true if built for release in distribution mode.
+    default: |
+        False when running in the simulator or on device in testing mode, and true if built for 
+        release in distribution mode.
     platforms: [android, iphone, ipad]
+    
   - name: withCredentials
-    summary: Tells the request to include any cookies and HTTP authentication information.
+    summary: |
+        Determines whether the request should include any cookies and HTTP authentication information.
     description: |
-        This property must be set before open() is called. Setting this to true will force the request to be asynchronous.
+        Set to `true` to include cookies and HTTP authentication information with the request. 
+        
+        This property must be set before open() is called. Setting this to true will force the 
+        request to be asynchronous.
     type: Boolean
     default: false
     platforms: [mobileweb]
+    
   - name: tlsVersion
     summary: Sets the TLS version to use for handshakes. 
     description: |
-        If you experience handshake failures, set this value to a lower
-        version using the TLS constants in <Titanium.Network>. 'undefined', 'null', or
-        unsupported values use the default behavior for that iOS version.
-    default:  undefined. For iOS 4, this is effectively [TLS_VERSION_1_0](Titanium.Network.TLS_VERSION_1_0).
-        For iOS 5 and greater, this is [TLS_VERSION_1_2](Titanium.Network.TLS_VERSION_1_2).
+        If you experience handshake failures, set this value to a lower version using the TLS 
+        constants in <Titanium.Network>. 'undefined', 'null', or unsupported values use the default 
+        behavior for that iOS version.
+    default: |
+        undefined. For iOS 4, this is effectively 
+        [TLS_VERSION_1_0](Titanium.Network.TLS_VERSION_1_0). For iOS 5 and greater, this is 
+        [TLS_VERSION_1_2](Titanium.Network.TLS_VERSION_1_2).
     type: Number
     since: "1.8.0"
     platforms: [iphone, ipad]
+    
   - name: cache
-    summary: Controls whether or not HTTP responses are cached.
+    summary: Determines whether HTTP responses are cached.
     description: |
-        If `cache` is set to `true`, requests using this HTTP client will cache
-        their responses (respecting headers such as "no-cache", "no-store",
-        and cache expiry). In this case, repeated requests to the same URL may
-        retrieve the initial response rather than triggering a new request. The
-        cache is shared between all instances of `HTTPClient`.
+        If `cache` is set to `true`, requests using this HTTP client will cache their responses 
+        (respecting headers such as "no-cache", "no-store", and cache expiry). In this case, repeated 
+        requests to the same URL may retrieve the initial response rather than triggering a new 
+        request. The cache is shared between all instances of `HTTPClient`.
         
-        Caching should only be enabled for HTTP requests which you
-        expect the result to remain consistent for.
+        Caching should only be enabled for HTTP requests which you expect the result to remain 
+        consistent for.
         
-        If `cache` is `false`, any request on this HTTP client will result
-        in a new HTTP request. 
+        If `cache` is `false`, any request on this HTTP client will result in a new HTTP request.
         
         This propery must be set before `open` is called.
     type: Boolean
     since: "1.9.0"
     default: false
     platforms: [iphone, ipad]
+
 examples:
   - title: Simple GET Request
     example: |
         The following code excerpt does a simple GET request and logs the response text.
-
+        
              var url = "http://www.appcelerator.com";
              var client = Ti.Network.createHTTPClient({
                  // function called when the response data is available

--- a/apidoc/Titanium/Network/HTTPClient.yml
+++ b/apidoc/Titanium/Network/HTTPClient.yml
@@ -387,7 +387,7 @@ examples:
                      Ti.API.debug(e.error);
                      alert('error');
                  },
-                 timeout : 5000  /* in milliseconds */
+                 timeout : 5000  // in milliseconds
              });
              // Prepare the connection.
              client.open("GET", url);


### PR DESCRIPTION
Formatting and wording consistency changes.

https://jira.appcelerator.org/browse/TIDOC-591
