### PR TITLE
[TIMOB-8668] iOS: OptionDialog has wrong rotation inside Modal Windows

### DIFF
--- a/iphone/Classes/TiApp.h
+++ b/iphone/Classes/TiApp.h
@@ -101,6 +101,8 @@ TI_INLINE void waitForMemoryPanicCleared()   //WARNING: This must never be run o
 
 -(BOOL)windowIsKeyWindow;
 
+-(UIView *) topMostView;
+
 -(void)attachXHRBridgeIfRequired;
 
 /**

--- a/iphone/Classes/TiApp.mm
+++ b/iphone/Classes/TiApp.mm
@@ -185,11 +185,8 @@ TI_INLINE void waitForMemoryPanicCleared();   //WARNING: This must never be run 
 
 -(UIView *) topMostView
 {
-    UIWindow  *topWindow = [[[UIApplication sharedApplication].windows sortedArrayUsingComparator: 
-                             ^NSComparisonResult(UIWindow * win1, UIWindow * win2){
-                                 return win1.windowLevel - win2.windowLevel;
-                             }] lastObject];
-    return [[topWindow subviews] lastObject];
+    UIWindow  *currentKeyWindow_ = [[UIApplication sharedApplication] keyWindow];
+    return [[currentKeyWindow_ subviews] lastObject];
 }
 -(void)attachXHRBridgeIfRequired
 {

--- a/iphone/Classes/TiApp.mm
+++ b/iphone/Classes/TiApp.mm
@@ -183,6 +183,14 @@ TI_INLINE void waitForMemoryPanicCleared();   //WARNING: This must never be run 
     return [window isKeyWindow];
 }
 
+-(UIView *) topMostView
+{
+    UIWindow  *topWindow = [[[UIApplication sharedApplication].windows sortedArrayUsingComparator: 
+                             ^NSComparisonResult(UIWindow * win1, UIWindow * win2){
+                                 return win1.windowLevel - win2.windowLevel;
+                             }] lastObject];
+    return [[topWindow subviews] lastObject];
+}
 -(void)attachXHRBridgeIfRequired
 {
 #ifdef USE_TI_UIWEBVIEW

--- a/iphone/Classes/TiUIOptionDialogProxy.m
+++ b/iphone/Classes/TiUIOptionDialogProxy.m
@@ -79,7 +79,7 @@
 		[self updateOptionDialogNow];
 		return;
 	}
-	[actionSheet showInView:[[TiApp controller] view]];
+	[actionSheet showInView:[[TiApp app] topMostView]];
 }
 
 -(void)completeWithButton:(int)buttonIndex


### PR DESCRIPTION
Seems like we where not attaching the ActionSheet/OptionDialog to the topmostview in the app and instead where attaching it to the RootviewController's view.

**Test Instruction in [Jira](https://jira.appcelerator.org/browse/TIMOB-8668)**
**Run a pass on KitchenSink also to make sure there is no regressions**
