### PR TITLE
[TIMOB-7259] Android: remember initial orientation on activity start to avoid double orientation notifications

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
@@ -812,6 +812,8 @@ public abstract class TiBaseActivity extends Activity
 				}
 			}
 		}
+		// store current configuration orientation
+		// This fixed bug with double orientation chnage firing when activity starts in landscape 
 		previousOrientation = getResources().getConfiguration().orientation;
 	}
 

--- a/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
@@ -812,6 +812,7 @@ public abstract class TiBaseActivity extends Activity
 				}
 			}
 		}
+		previousOrientation = getResources().getConfiguration().orientation;
 	}
 
 	@Override


### PR DESCRIPTION
[TIMOB-7259](https://jira.appcelerator.org/browse/TIMOB-7259)

Test case in JIRA.
