### PR TITLE
[TIMOB-8331]iOS: HW window fires open and focus events in wrong order

### DIFF
--- a/iphone/Classes/TiUIWindowProxy.m
+++ b/iphone/Classes/TiUIWindowProxy.m
@@ -161,7 +161,6 @@
 	// happen after the JS context is fully up and ready
 	if (contextReady && context!=nil)
 	{
-		[self fireFocus:YES];
 		return YES;
 	}
 	


### PR DESCRIPTION
**Testing Instruction in [JIRA](https://jira.appcelerator.org/browse/TIMOB-8331)** 
