### PR TITLE
[TIMOB-8909] Always have Ti.UI.View.children return a valid array

### DIFF
--- a/drillbit/drillbit.py
+++ b/drillbit/drillbit.py
@@ -115,7 +115,7 @@ def usage():
 
 
     iPhone Specific Arguments
-    --iphone-version=DIR            The iPhone SDK version to build against (default: 4.0)
+    --iphone-version=DIR            The iPhone SDK version to build against (default: 5.0)
     
     Android Specific Arguments
     --android-sdk=DIR               Android SDK is loaded from DIR

--- a/drillbit/modules/drillbit/0.1.0/drillbitmodule.js
+++ b/drillbit/modules/drillbit/0.1.0/drillbitmodule.js
@@ -126,8 +126,8 @@ Drillbit.prototype.initPlatforms = function() {
 	
 	if (ti.Platform.isOSX()) {
 		if (platformsArg == null || platformsArg.indexOf('iphone') != -1) {
-			// Default to 4.0 iPhone SDK
-			var iphoneVersion = 'iphoneVersion' in this.argv ? this.argv.iphoneVersion : "4.0";
+			// Default to 5.0 iPhone SDK
+			var iphoneVersion = 'iphoneVersion' in this.argv ? this.argv.iphoneVersion : "5.0";
 			ti.api.info('Adding iPhone SDK to list of drillbit target platforms: ' + iphoneVersion);
 			
 			ti.include(ti.path.join(this.module.getPath(), 'iphone.js'));

--- a/drillbit/tests/ui/ui.js
+++ b/drillbit/tests/ui/ui.js
@@ -459,6 +459,14 @@ describe("Ti.UI tests", {
 		setTimeout(function() {
 			callback.failed("Test timeout");
 		}, 3000);
+	},
+	
+	// https://jira.appcelerator.org/browse/TIMOB-8909
+	childrenArrayEmpty: function() {
+		var view = Ti.UI.createView();
+		valueOf(view).shouldNotBeNull();
+		valueOf(view.children).shouldNotBeNull();
+		valueOf(view.children).shouldNotBeUndefined();
+		valueOf(view.children).shouldBe(0);
 	}
-
 });

--- a/drillbit/tests/ui/ui.js
+++ b/drillbit/tests/ui/ui.js
@@ -465,8 +465,11 @@ describe("Ti.UI tests", {
 	childrenArrayEmpty: function() {
 		var view = Ti.UI.createView();
 		valueOf(view).shouldNotBeNull();
+		valueOf(view).shouldBeObject();
+		
 		valueOf(view.children).shouldNotBeNull();
 		valueOf(view.children).shouldNotBeUndefined();
+		valueOf(view.children).shouldBeObject();
 		valueOf(view.children).shouldBe(0);
 	}
 });

--- a/iphone/Classes/TiUIDashboardItem.m
+++ b/iphone/Classes/TiUIDashboardItem.m
@@ -21,7 +21,8 @@
 	TiViewProxy *p = (TiViewProxy*)self.proxy;
 	[super frameSizeChanged:frame bounds:bounds];
 	
-	for (TiViewProxy *proxy in [p children])
+    NSArray* children = [p children];
+	for (TiViewProxy *proxy in children)
 	{
 		[(TiUIView*)[proxy view] frameSizeChanged:self.frame bounds:self.bounds];
 	}

--- a/iphone/Classes/TiUITableViewRowProxy.m
+++ b/iphone/Classes/TiUITableViewRowProxy.m
@@ -615,7 +615,8 @@ TiProxy * DeepScanForProxyOfViewContainingPoint(UIView * targetView, CGPoint poi
 -(void)redelegateViews:(TiViewProxy *)proxy toView:(UIView *)touchDelegate;
 {
 	[[proxy view] setTouchDelegate:touchDelegate];
-	for (TiViewProxy * childProxy in [proxy children])
+    NSArray* children = [proxy children];
+	for (TiViewProxy * childProxy in children)
 	{
 		[self redelegateViews:childProxy toView:touchDelegate];
 	}
@@ -651,7 +652,7 @@ TiProxy * DeepScanForProxyOfViewContainingPoint(UIView * targetView, CGPoint poi
 	// to be initialized. on subsequent repaints of a re-used
 	// table cell, the updateChildren below will be called instead
 	configuredChildren = YES;
-	if (self.children!=nil)
+	if ([[self children] count] > 0)
 	{
 		UIView *contentView = cell.contentView;
 		CGRect rect = [contentView frame];
@@ -676,7 +677,8 @@ TiProxy * DeepScanForProxyOfViewContainingPoint(UIView * targetView, CGPoint poi
 		[rowContainerView setBackgroundColor:[UIColor clearColor]];
 		[rowContainerView setAutoresizingMask:UIViewAutoresizingFlexibleWidth|UIViewAutoresizingFlexibleHeight];
 		
-		for (TiViewProxy *proxy in self.children)
+        NSArray* subviews = [self children];
+		for (TiViewProxy *proxy in subviews)
 		{
 			if (!CGRectEqualToRect([proxy sandboxBounds], rect)) {
 				[proxy setSandboxBounds:rect];
@@ -716,7 +718,8 @@ TiProxy * DeepScanForProxyOfViewContainingPoint(UIView * targetView, CGPoint poi
 -(void)willShow
 {
 	pthread_rwlock_rdlock(&childrenLock);
-	for (TiViewProxy* child in [self children]) {
+    NSArray* subproxies = [self children];
+	for (TiViewProxy* child in subproxies) {
 		[child setParentVisible:YES];
 	}
 	pthread_rwlock_unlock(&childrenLock);

--- a/iphone/Classes/TiViewProxy.m
+++ b/iphone/Classes/TiViewProxy.m
@@ -53,7 +53,7 @@
         copy = [children mutableCopy];
     }
 	pthread_rwlock_unlock(&childrenLock);
-	return [copy autorelease];
+	return ((copy != nil) ? [copy autorelease] : [NSMutableArray array]);
 }
 
 -(void)setVisible:(NSNumber *)newVisible withObject:(id)args

--- a/iphone/Classes/TiViewProxy.m
+++ b/iphone/Classes/TiViewProxy.m
@@ -658,7 +658,8 @@ LAYOUTPROPERTIES_SETTER(setMinHeight,minimumHeight,TiFixedValueRuleFromObject,[s
     CGFloat thisWidth = 0.0;
 
 	pthread_rwlock_rdlock(&childrenLock);
-	for (TiViewProxy * thisChildProxy in self.children)
+    NSArray* subproxies = [self children];
+	for (TiViewProxy * thisChildProxy in subproxies)
 	{
         if (isHorizontal) {
             sandBox = CGRectZero;
@@ -960,7 +961,7 @@ LAYOUTPROPERTIES_SETTER(setMinHeight,minimumHeight,TiFixedValueRuleFromObject,[s
 		[view configurationSet];
 
 		pthread_rwlock_rdlock(&childrenLock);
-		NSArray * childrenArray = [[self children] copy];
+		NSArray * childrenArray = [[self children] retain];
 		pthread_rwlock_unlock(&childrenLock);
 		
 		for (id child in childrenArray)
@@ -2520,7 +2521,7 @@ if(OSAtomicTestAndSetBarrier(flagBit, &dirtyflags))	\
 
 //TODO: This is really expensive, but what can you do? Laying out the child needs the lock again.
 	pthread_rwlock_rdlock(&childrenLock);
-	NSArray * childrenArray = [[self children] copy];
+	NSArray * childrenArray = [[self children] retain];
 	pthread_rwlock_unlock(&childrenLock);
     
     NSUInteger childCount = [childrenArray count];

--- a/iphone/Classes/TiWindowProxy.m
+++ b/iphone/Classes/TiWindowProxy.m
@@ -62,7 +62,8 @@ TiOrientationFlags TiOrientationFlagsFromObject(id args)
 
 - (void)willAnimateRotationToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation duration:(NSTimeInterval)duration
 {
-	for (TiViewProxy * thisProxy in [self children])
+    NSArray* childProxies = [self children];
+	for (TiViewProxy * thisProxy in childProxies)
 	{
 		if ([thisProxy respondsToSelector:@selector(willAnimateRotationToInterfaceOrientation:duration:)])
 		{
@@ -236,7 +237,8 @@ TiOrientationFlags TiOrientationFlagsFromObject(id args)
 	//TODO: Since windowDidClose also calls detachView, is this necessary?
 	[self detachView];
 	// notify our child that his window is closing
-	for (TiViewProxy *child in self.children)
+    NSArray* childProxies = [self children];
+	for (TiViewProxy *child in childProxies)
 	{
 		[child windowDidClose];
 	}


### PR DESCRIPTION
Commit has a drillbit test associated with it to be run as functional. Reviewers should ensure that the iOS source does not contain any point where children is checked to be `nil` rather than `count > 0`.
