### PR TITLE
[TIMOB-8747] iOS: tabGroup not correctly reopened after being closed (2_0_X)

### DIFF
--- a/iphone/Classes/TiUITabGroup.m
+++ b/iphone/Classes/TiUITabGroup.m
@@ -76,7 +76,7 @@ DEFINE_EXCEPTIONS
 - (void)handleDidShowTab:(TiUITabProxy *)newFocus
 {
     // Do nothing if no tabs are being focused or blurred (or the window is opening)
-    if ((focused == nil && newFocus == nil)) {
+    if ((focused == nil && newFocus == nil) || (focused == newFocus)) {
         return;
     }
     

--- a/iphone/Classes/TiUITabGroup.m
+++ b/iphone/Classes/TiUITabGroup.m
@@ -404,8 +404,14 @@ DEFINE_EXCEPTIONS
 	[view setFrame:[self bounds]];
 	[self addSubview:view];
 
-	// on an open, make sure we send the focus event to initial tab
-	NSDictionary *event = [NSDictionary dictionaryWithObjectsAndKeys:focused,@"tab",NUMINT(0),@"index",NUMINT(-1),@"previousIndex",[NSNull null],@"previousTab",nil];
+	// on an open, make sure we send the focus event to focused tab
+    NSArray * tabArray = [controller viewControllers];
+    int index = 0;
+    if (focused != nil)
+	{
+		index = [tabArray indexOfObject:[(TiUITabProxy *)focused controller]];
+	}
+	NSDictionary *event = [NSDictionary dictionaryWithObjectsAndKeys:focused,@"tab",NUMINT(index),@"index",NUMINT(-1),@"previousIndex",[NSNull null],@"previousTab",nil];
 	[self.proxy fireEvent:@"focus" withObject:event];
     
     // Tab has already been focused by the tab controller delegate
@@ -426,6 +432,7 @@ DEFINE_EXCEPTIONS
 		controller.viewControllers = nil;
 	}
 	RELEASE_TO_NIL(controller);
+    [focused replaceValue:NUMBOOL(NO) forKey:@"active" notification:NO];
 	RELEASE_TO_NIL(focused);
 }
 

--- a/iphone/Classes/TiUITabProxy.m
+++ b/iphone/Classes/TiUITabProxy.m
@@ -194,7 +194,7 @@
 - (void)navigationController:(UINavigationController *)navigationController didShowViewController:(UIViewController *)viewController animated:(BOOL)animated
 {
     id activeTab = [tabGroup valueForKey:@"activeTab"];
-    if (activeTab == nil) {
+    if (activeTab == nil || activeTab == [NSNull null]) {
         //Make sure that the activeTab property is set
         [self setActive:[NSNumber numberWithBool:YES]];
     }


### PR DESCRIPTION
Duplicate of PR #2024 against 2_0_X
Test is in [JIRA](https://jira.appcelerator.org/browse/TIMOB-8747)
