### PR TITLE
[TIMOB-8954] Android: Cancelable ActivityIndicator

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/ActivityIndicatorProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/ActivityIndicatorProxy.java
@@ -8,6 +8,7 @@ package ti.modules.titanium.ui;
 
 import org.appcelerator.kroll.KrollDict;
 import org.appcelerator.kroll.annotations.Kroll;
+import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.TiContext;
 import org.appcelerator.titanium.view.TiUIView;
 
@@ -17,7 +18,8 @@ import android.app.Activity;
 @Kroll.proxy(creatableInModule=UIModule.class, propertyAccessors = {
 	"message", "value",
 	"location", "min", "max",
-	"messageid", "type"
+	"messageid", "type",
+	TiC.PROPERTY_CANCELABLE
 })
 @Kroll.dynamicApis(methods = {
 	"hide", "show"

--- a/android/titanium/src/java/org/appcelerator/titanium/TiC.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiC.java
@@ -66,6 +66,11 @@ public class TiC
 	/**
 	 * @module.api
 	 */
+	public static final String EVENT_CANCEL = "cancel";
+
+	/**
+	 * @module.api
+	 */
 	public static final String EVENT_CHANGE = "change";
 
 	/**
@@ -635,6 +640,11 @@ public class TiC
 	 * @module.api
 	 */
 	public static final String PROPERTY_CANCEL = "cancel";
+
+	/**
+	 * @module.api
+	 */
+	public static final String PROPERTY_CANCELABLE = "cancelable";
 
 	/**
 	 * @module.api

--- a/apidoc/Titanium/UI/ActivityIndicator.yml
+++ b/apidoc/Titanium/UI/ActivityIndicator.yml
@@ -36,6 +36,13 @@ properties:
     type: [Number, String]
     platforms: [iphone, ipad]
     
+  - name: cancelable
+    summary: |
+        When `true` allows the user to cancel the activity indicator dialog by
+        pressing the BACK button.
+    type: Boolean
+    platforms: [android]
+
   - name: color
     summary: |
         Color of the message text, as a color name or hex triplet.
@@ -110,6 +117,14 @@ properties:
         display the message and to position the view correctly.
     type: String
     platforms: [iphone, ipad]
+
+events:
+  - name: cancel
+    summary: Fired when the user has canceled the activity indicator dialog.
+    description: |
+        The user triggers this event by pressing the BACK button when the dialog is visible.
+        The dialog will be hidden and this event dispatched.
+    platforms: [android]
     
 examples:
   - title: Simple Activity Indicator


### PR DESCRIPTION
New feature! Adds a "cancelable" property and "cancel" event to ActivityIndicator.
This is an Android only feature since it doesn't apply to the other platforms.

See [TIMOB-8954](https://jira.appcelerator.org/browse/TIMOB-8954) for your testing details.

Also included is documentation updates.
