### PR TITLE
[TC-842] Android: added `ScrollableView`.`scrollingEnabled`

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/ScrollableViewProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/ScrollableViewProxy.java
@@ -39,6 +39,7 @@ public class ScrollableViewProxy extends TiViewProxy
 	public static final int MSG_ADD_VIEW = MSG_FIRST_ID + 106;
 	public static final int MSG_SET_CURRENT = MSG_FIRST_ID + 107;
 	public static final int MSG_REMOVE_VIEW = MSG_FIRST_ID + 108;
+	public static final int MSG_SET_ENABLED = MSG_FIRST_ID + 109;
 	public static final int MSG_LAST_ID = MSG_FIRST_ID + 999;
 	
 	private static final int DEFAULT_PAGING_CONTROL_TIMEOUT = 3000;
@@ -131,6 +132,11 @@ public class ScrollableViewProxy extends TiViewProxy
 				holder.setResult(null);
 				break;
 			}
+			case MSG_SET_ENABLED: {
+				getView().setEnabled(msg.obj);
+				handled = true;
+				break;
+			}
 			default:
 				handled = super.handleMessage(msg);
 		}
@@ -213,6 +219,18 @@ public class ScrollableViewProxy extends TiViewProxy
 			options.put("currentPage", getView().getCurrentPage());
 			fireEvent(TiC.EVENT_SCROLL, options);
 		}
+	}
+
+	@Kroll.setProperty @Kroll.method
+	public void setScrollingEnabled(Object enabled)
+	{
+		getMainHandler().obtainMessage(MSG_SET_ENABLED, enabled).sendToTarget();
+	}
+
+	@Kroll.getProperty @Kroll.method
+	public boolean getScrollingEnabled()
+	{
+		return getView().getEnabled();
 	}
 
 	@Kroll.getProperty @Kroll.method

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIScrollableView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIScrollableView.java
@@ -46,6 +46,7 @@ public class TiUIScrollableView extends TiUIView
 	private final RelativeLayout mPagingControl;
 
 	private int mCurIndex = -1;
+	private boolean mEnabled = true;
 
 	public TiUIScrollableView(ScrollableViewProxy proxy)
 	{
@@ -66,7 +67,27 @@ public class TiUIScrollableView extends TiUIView
 
 	private ViewPager buildViewPager(Context context, ViewPagerAdapter adapter)
 	{
-		ViewPager pager = new ViewPager(context);
+		ViewPager pager = (new ViewPager(context)
+		{
+			@Override
+			public boolean onTouchEvent(MotionEvent event) {
+				if (mEnabled) {
+					return super.onTouchEvent(event);
+				}
+
+				return false;
+			}
+
+			@Override
+			public boolean onInterceptTouchEvent(MotionEvent event) {
+				if (mEnabled) {
+					return super.onInterceptTouchEvent(event);
+				}
+
+				return false;
+			}
+		});
+
 		pager.setAdapter(adapter);
 		pager.setOnPageChangeListener(new ViewPager.SimpleOnPageChangeListener()
 		{
@@ -133,7 +154,9 @@ public class TiUIScrollableView extends TiUIView
 		left.setOnClickListener(new OnClickListener(){
 			public void onClick(View v)
 			{
-				movePrevious();
+				if (mEnabled) {
+					movePrevious();
+				}
 			}});
 		RelativeLayout.LayoutParams params = new RelativeLayout.LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT);
 		params.addRule(RelativeLayout.ALIGN_PARENT_LEFT);
@@ -149,7 +172,9 @@ public class TiUIScrollableView extends TiUIView
 		right.setOnClickListener(new OnClickListener(){
 			public void onClick(View v)
 			{
-				moveNext();
+				if (mEnabled) {
+					moveNext();
+				}
 			}});
 		params = new RelativeLayout.LayoutParams(LayoutParams.WRAP_CONTENT,
 				LayoutParams.WRAP_CONTENT);
@@ -186,6 +211,10 @@ public class TiUIScrollableView extends TiUIView
 			}
 		}
 
+		if (d.containsKey(TiC.PROPERTY_SCROLLINGENABLED)) {
+			mEnabled = TiConvert.toBoolean(d, TiC.PROPERTY_SCROLLINGENABLED);
+		}
+
 		super.processProperties(d);
 
 	}
@@ -203,6 +232,8 @@ public class TiUIScrollableView extends TiUIView
 			} else {
 				hidePager();
 			}
+		} else if (TiC.PROPERTY_SCROLLINGENABLED.equals(key)) {
+			mEnabled = TiConvert.toBoolean(newValue);
 		} else {
 			super.propertyChanged(key, oldValue, newValue, proxy);
 		}
@@ -280,6 +311,16 @@ public class TiUIScrollableView extends TiUIView
 	public void setCurrentPage(Object view)
 	{
 		scrollTo(view);
+	}
+
+	public void setEnabled(Object value)
+	{
+		mEnabled = TiConvert.toBoolean(value);
+	}
+
+	public boolean getEnabled()
+	{
+		return mEnabled;
 	}
 
 	private void clearViewsList()

--- a/android/titanium/src/java/org/appcelerator/titanium/TiC.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiC.java
@@ -437,6 +437,11 @@ public class TiC
 	/**
 	 * @module.api
 	 */
+	public static final String PROPERTY_SCROLLINGENABLED = "scrollingEnabled";
+
+	/**
+	 * @module.api
+	 */
 	public static final String PROPERTY_ACTION = "action";
 
 	/**

--- a/apidoc/Titanium/UI/ScrollableView.yml
+++ b/apidoc/Titanium/UI/ScrollableView.yml
@@ -277,16 +277,16 @@ properties:
     default: 3000
     platforms: [android, mobileweb]
     availability: creation
-    
+
   - name: scrollingEnabled
     summary: |
         Determines whether scrolling is enabled on the Scrollable view.
         If this property is not set, scrolling is enabled.
     type: Boolean
-    platforms: [iphone,ipad]
+    platforms: [iphone, ipad, android]
     default: undefined (scrolling enabled)
     since: "2.0"
-    
+
   - name: views
     summary: Sets the views within this Scrollable View.
     type: Array<Titanium.UI.View>

--- a/apidoc/Titanium/UI/ScrollableView.yml
+++ b/apidoc/Titanium/UI/ScrollableView.yml
@@ -285,7 +285,7 @@ properties:
     type: Boolean
     platforms: [iphone, ipad, android]
     default: undefined (scrolling enabled)
-    since: "2.0"
+    since: { android: "2.1", iphone: "2.0", ipad: "2.0" }
 
   - name: views
     summary: Sets the views within this Scrollable View.


### PR DESCRIPTION
[JIRA: [TC-842] Android: `ScrollableView` should support `scrollingEnabled` property](https://jira.appcelerator.org/browse/TC-842)

Adds support for the `scrollingEnabled` property on Android.  Here's a test:

``` javascript
var win = Ti.UI.createWindow({layout:'horizontal'});

var view1 = Ti.UI.createView({ backgroundColor:'#123', width: 250 });
var view2 = Ti.UI.createView({ backgroundColor:'#246', width: 250 });
var view3 = Ti.UI.createView({ backgroundColor:'#48b', width: 250 });

var scrollableView = Ti.UI.createScrollableView({
  views: [view1,view2,view3],
  showPagingControl: true,
  width: 300,
  height: 430
});

win.add(scrollableView);
win.open();

setTimeout(function () {
  scrollableView.scrollingEnabled = false;
  setTimeout(function () {
    scrollableView.setScrollingEnabled(true);
  }, 5000);
}, 5000);
```

After 5 seconds, the view should stop being scrollable.  Five seconds after that, it should once again be able to be scrolled.
