### PR TITLE
[TIMOB-8329][TIMOB-8353][TIMOB-8337][TIMOB-8650](2_0_X) iOS: TiMediaVideoPlayerProxy is not properly removed as observer on MPMoviePlayerController when it' released

### DIFF
--- a/iphone/Classes/TiMediaVideoPlayerProxy.m
+++ b/iphone/Classes/TiMediaVideoPlayerProxy.m
@@ -405,7 +405,11 @@ NSArray* moviePlayerKeys = nil;
 	
 	if ([self viewAttached]) {
 		TiMediaVideoPlayer *video = (TiMediaVideoPlayer*)[self view];
-		[video setMovie:[self ensurePlayer]];
+        if (movie != nil) {
+            [movie setContentURL:url];
+        } else {
+            [self ensurePlayer];
+        }
 		[video frameSizeChanged:[video frame] bounds:[video bounds]];
 	}
 	

--- a/iphone/Classes/TiMediaVideoPlayerProxy.m
+++ b/iphone/Classes/TiMediaVideoPlayerProxy.m
@@ -74,12 +74,13 @@ NSArray* moviePlayerKeys = nil;
 		[movie stop];
 	}
 	
-	WARN_IF_BACKGROUND_THREAD;	//NSNotificationCenter is not threadsafe!
-	[[NSNotificationCenter defaultCenter] removeObserver:self];
+    TiThreadPerformOnMainThread(^{
+        [[NSNotificationCenter defaultCenter] removeObserver:self];
+        RELEASE_TO_NIL(movie);
+    }, YES);
 
 	RELEASE_TO_NIL(thumbnailCallback);
 	RELEASE_TO_NIL(tempFile);
-	RELEASE_TO_NIL(movie);
 	RELEASE_TO_NIL(url);
 	RELEASE_TO_NIL(loadProperties);
 	RELEASE_TO_NIL(playerLock);
@@ -155,6 +156,11 @@ NSArray* moviePlayerKeys = nil;
 		TiMediaVideoPlayer *vp = (TiMediaVideoPlayer*)[self view];
 		[vp setMovie:movie];
 	}
+}
+
+-(MPMoviePlayerController *)player
+{
+    return movie;
 }
 
 -(MPMoviePlayerController *)ensurePlayer
@@ -396,8 +402,6 @@ NSArray* moviePlayerKeys = nil;
 		[movie stop];
 		playing = NO;
 	}
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
-	RELEASE_TO_NIL_AUTORELEASE(movie);
 	
 	if ([self viewAttached]) {
 		TiMediaVideoPlayer *video = (TiMediaVideoPlayer*)[self view];
@@ -723,8 +727,6 @@ NSArray* moviePlayerKeys = nil;
     ENSURE_UI_THREAD(stop, args);
 	playing = NO;
 	[movie stop];
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
-	RELEASE_TO_NIL_AUTORELEASE(movie);
 }
 
 -(void)play:(id)args

--- a/iphone/Classes/TiMediaVideoPlayerProxy.m
+++ b/iphone/Classes/TiMediaVideoPlayerProxy.m
@@ -418,8 +418,12 @@ NSArray* moviePlayerKeys = nil;
 -(void)setUrl:(id)url_
 {
 	ENSURE_UI_THREAD(setUrl,url_);
+    NSURL* newUrl = [TiUtils toURL:url_ proxy:self];
+    if ([url isEqual:newUrl]) {
+        return;
+    }
 	RELEASE_TO_NIL(url);
-	url = [[TiUtils toURL:url_ proxy:self] retain];
+	url = [newUrl retain];
     loaded = NO;
 	
 	if (movie!=nil)

--- a/iphone/Classes/TiMediaVideoPlayerProxy.m
+++ b/iphone/Classes/TiMediaVideoPlayerProxy.m
@@ -75,8 +75,7 @@ NSArray* moviePlayerKeys = nil;
 	}
 	
 	WARN_IF_BACKGROUND_THREAD;	//NSNotificationCenter is not threadsafe!
-	NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
-	[nc removeObserver:self];
+	[[NSNotificationCenter defaultCenter] removeObserver:self];
 
 	RELEASE_TO_NIL(thumbnailCallback);
 	RELEASE_TO_NIL(tempFile);
@@ -195,6 +194,7 @@ NSArray* moviePlayerKeys = nil;
 -(void)viewDidDetach
 {
 	[movie stop];
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
 	RELEASE_TO_NIL(movie);
 	reallyAttached = NO;
 }
@@ -396,6 +396,7 @@ NSArray* moviePlayerKeys = nil;
 		[movie stop];
 		playing = NO;
 	}
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
 	RELEASE_TO_NIL_AUTORELEASE(movie);
 	
 	if ([self viewAttached]) {
@@ -722,6 +723,7 @@ NSArray* moviePlayerKeys = nil;
     ENSURE_UI_THREAD(stop, args);
 	playing = NO;
 	[movie stop];
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
 	RELEASE_TO_NIL_AUTORELEASE(movie);
 }
 

--- a/iphone/Classes/TiUISlider.m
+++ b/iphone/Classes/TiUISlider.m
@@ -16,7 +16,7 @@
 {
 	[sliderView removeTarget:self action:@selector(sliderChanged:) forControlEvents:UIControlEventValueChanged];
 	[sliderView removeTarget:self action:@selector(sliderBegin:) forControlEvents:UIControlEventTouchDown];
-	[sliderView removeTarget:self action:@selector(sliderEnd:) forControlEvents:(UIControlEventTouchUpInside | UIControlEventTouchUpOutside)];
+	[sliderView removeTarget:self action:@selector(sliderEnd:) forControlEvents:(UIControlEventTouchUpInside | UIControlEventTouchUpOutside | UIControlEventTouchCancel)];
 	RELEASE_TO_NIL(sliderView);
 	RELEASE_TO_NIL(lastTouchUp);
 	[super dealloc];
@@ -42,7 +42,7 @@
 		
 		[sliderView addTarget:self action:@selector(sliderChanged:) forControlEvents:UIControlEventValueChanged];
 		[sliderView addTarget:self action:@selector(sliderBegin:) forControlEvents:UIControlEventTouchDown];
-		[sliderView addTarget:self action:@selector(sliderEnd:) forControlEvents:(UIControlEventTouchUpInside | UIControlEventTouchUpOutside)];
+		[sliderView addTarget:self action:@selector(sliderEnd:) forControlEvents:(UIControlEventTouchUpInside | UIControlEventTouchUpOutside | UIControlEventTouchCancel)];
 		[self addSubview:sliderView];
 		lastTouchUp = [[NSDate alloc] init];
 		lastTimeInterval = 1.0; // Short-circuit so that we don't ignore the first fire

--- a/iphone/Classes/TiUIView.h
+++ b/iphone/Classes/TiUIView.h
@@ -124,6 +124,9 @@ void ModifyScrollViewForKeyboardHeightAndContentHeightWithResponderRect(UIScroll
 @property(nonatomic,readonly)	UISwipeGestureRecognizer*		rightSwipeRecognizer;
 @property(nonatomic,readonly)	UILongPressGestureRecognizer*	longPressRecognizer;
 
+-(void)configureGestureRecognizer:(UIGestureRecognizer*)gestureRecognizer;
+-(UIGestureRecognizer *)gestureRecognizerForEvent:(NSString *)event;
+
 /**
  Returns CA layer for the background of the view.
  */

--- a/iphone/Classes/TiUIView.m
+++ b/iphone/Classes/TiUIView.m
@@ -764,13 +764,12 @@ DEFINE_EXCEPTIONS
 {
 	if (singleTapRecognizer == nil) {
 		singleTapRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(recognizedTap:)];
-		[singleTapRecognizer setCancelsTouchesInView:NO];
+		[self configureGestureRecognizer:singleTapRecognizer];
 		[self addGestureRecognizer:singleTapRecognizer];
 
 		if (doubleTapRecognizer != nil) {
 			[singleTapRecognizer requireGestureRecognizerToFail:doubleTapRecognizer];
 		}
-		//If there are more gesture recognizer relationships, add it here.
 	}
 	return singleTapRecognizer;
 }
@@ -780,14 +779,12 @@ DEFINE_EXCEPTIONS
 	if (doubleTapRecognizer == nil) {
 		doubleTapRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(recognizedTap:)];
 		[doubleTapRecognizer setNumberOfTapsRequired:2];
-		[doubleTapRecognizer setDelaysTouchesBegan:NO];
-		[doubleTapRecognizer setCancelsTouchesInView:NO];
+		[self configureGestureRecognizer:doubleTapRecognizer];
 		[self addGestureRecognizer:doubleTapRecognizer];
 		
 		if (singleTapRecognizer != nil) {
 			[singleTapRecognizer requireGestureRecognizerToFail:doubleTapRecognizer];
 		}		
-		//If there are more gesture recognizer relationships, add it here.
 	}
 	return doubleTapRecognizer;
 }
@@ -797,10 +794,8 @@ DEFINE_EXCEPTIONS
 	if (twoFingerTapRecognizer == nil) {
 		twoFingerTapRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(recognizedTap:)];
 		[twoFingerTapRecognizer setNumberOfTouchesRequired:2];
-		[twoFingerTapRecognizer setCancelsTouchesInView:NO];
+		[self configureGestureRecognizer:twoFingerTapRecognizer];
 		[self addGestureRecognizer:twoFingerTapRecognizer];
-		
-		//If there are more gesture recognizer relationships, add it here.
 	}
 	return twoFingerTapRecognizer;
 }
@@ -809,10 +804,8 @@ DEFINE_EXCEPTIONS
 {
 	if (pinchRecognizer == nil) {
 		pinchRecognizer = [[UIPinchGestureRecognizer alloc] initWithTarget:self action:@selector(recognizedPinch:)];
-		[pinchRecognizer setCancelsTouchesInView:NO];
+		[self configureGestureRecognizer:pinchRecognizer];
 		[self addGestureRecognizer:pinchRecognizer];
-		
-		//If there are more gesture recognizer relationships, add it here.		
 	}
 	return pinchRecognizer;
 }
@@ -822,10 +815,8 @@ DEFINE_EXCEPTIONS
 	if (leftSwipeRecognizer == nil) {
 		leftSwipeRecognizer = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(recognizedSwipe:)];
 		[leftSwipeRecognizer setDirection:UISwipeGestureRecognizerDirectionLeft];
-		[leftSwipeRecognizer setCancelsTouchesInView:NO];
+		[self configureGestureRecognizer:leftSwipeRecognizer];
 		[self addGestureRecognizer:leftSwipeRecognizer];
-	   
-	   //If there are more gesture recognizer relationships, add it here.		
 	}
 	return leftSwipeRecognizer;
 }
@@ -834,11 +825,9 @@ DEFINE_EXCEPTIONS
 {
 	if (rightSwipeRecognizer == nil) {
 		rightSwipeRecognizer = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(recognizedSwipe:)];
-		[rightSwipeRecognizer setDirection: UISwipeGestureRecognizerDirectionRight];
-		[rightSwipeRecognizer setCancelsTouchesInView:NO];
+		[rightSwipeRecognizer setDirection:UISwipeGestureRecognizerDirectionRight];
+		[self configureGestureRecognizer:rightSwipeRecognizer];
 		[self addGestureRecognizer:rightSwipeRecognizer];
-		
-		//If there are more gesture recognizer relationships, add it here.		
 	}
 	return rightSwipeRecognizer;
 }
@@ -847,10 +836,8 @@ DEFINE_EXCEPTIONS
 {
 	if (longPressRecognizer == nil) {
 		longPressRecognizer = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(recognizedLongPress:)];
-		[longPressRecognizer setCancelsTouchesInView:NO];
+		[self configureGestureRecognizer:longPressRecognizer];
 		[self addGestureRecognizer:longPressRecognizer];
-		
-		//If there are more gesture recognizer relationships, add it here.				
 	}
 	return longPressRecognizer;
 }
@@ -1143,7 +1130,14 @@ DEFINE_EXCEPTIONS
     }
 }
 
--(void)handleListenerAddedWithEvent:(NSString *)event
+-(void)configureGestureRecognizer:(UIGestureRecognizer*)gestureRecognizer
+{
+    [gestureRecognizer setDelaysTouchesBegan:NO];
+    [gestureRecognizer setDelaysTouchesEnded:NO];
+    [gestureRecognizer setCancelsTouchesInView:NO];
+}
+
+-(UIGestureRecognizer *)gestureRecognizerForEvent:(NSString *)event
 {
 	ENSURE_UI_THREAD_1_ARG(event);
     [self updateTouchHandling];


### PR DESCRIPTION
This is a backport of #1855 and #2003 into 2_0_X

[TIMOB-8329](https://jira.appcelerator.org/browse/TIMOB-8329)
[TIMOB-8650](https://jira.appcelerator.org/browse/TIMOB-8650)

These changes are code cleanup that caused crashes at [TIMOB-7969](https://jira.appcelerator.org/browse/TIMOB-7969), [TIMOB-8353](https://jira.appcelerator.org/browse/TIMOB-8353) and [TIMOB-8337](https://jira.appcelerator.org/browse/TIMOB-8337)

FT note: No test case available. Use KS video related tests.
