### PR TITLE
[TIMOB-8628] 2_0_X Call UIViewControllerDelegate methods explicitly for 4.x

### DIFF
--- a/iphone/Classes/TiUIiPhoneNavigationGroup.m
+++ b/iphone/Classes/TiUIiPhoneNavigationGroup.m
@@ -139,33 +139,43 @@
     TiWindowProxy *newWindow = (TiWindowProxy *)[(TiViewController*)viewController proxy];
 	[newWindow setupWindowDecorations];
 	[newWindow windowWillOpen];
-    //TIMOB-8559. PR 1819 caused a regression that exposed an IOS issue. In IOS 5 and later, the nav controller calls 
+    //TIMOB-8559.TIMOB-8628. PR 1819 caused a regression that exposed an IOS issue. In IOS 5 and later, the nav controller calls 
     //UIViewControllerDelegate methods, but not in IOS 4.X. As a result the parentVisible flag is never flipped to true
-    //and the window never lays out. Using this method sets the flag and ensures window goes into layout queue.
-    [newWindow parentWillShow];
+    //and the window never lays out. Call them explicitly.
+    if (![TiUtils isIOS5OrGreater]) {
+        [visibleProxy viewWillDisappear:animated];
+        [newWindow viewWillAppear:animated];
+    }
 }
 - (void)navigationController:(UINavigationController *)navigationController didShowViewController:(UIViewController *)viewController animated:(BOOL)animated
 {
-	TiViewController *wincontroller = (TiViewController*)viewController;
-	TiWindowProxy *newWindow = (TiWindowProxy *)[wincontroller proxy];
-	BOOL visibleProxyDidChange = NO;
-	if (newWindow!=visibleProxy)
-	{
-		if (visibleProxy != nil && visibleProxy!=root && opening==NO)
-		{
-			//TODO: This is an expedient fix, but NavGroup needs rewriting anyways
-			[(TiUIiPhoneNavigationGroupProxy*)[self proxy] close:[NSArray arrayWithObject:visibleProxy]];
-		}
-		visibleProxyDidChange = YES;
-		[self setVisibleProxy:newWindow];
-	}
-	[closingProxy close:nil];
-	[closingProxy release];
-	closingProxy = nil;
-	opening = NO;
-	if (visibleProxyDidChange) {
-		[newWindow windowDidOpen];
-	}
+    TiViewController *wincontroller = (TiViewController*)viewController;
+    TiWindowProxy *newWindow = (TiWindowProxy *)[wincontroller proxy];
+    BOOL visibleProxyDidChange = NO;
+    if (newWindow!=visibleProxy)
+    {
+        if (visibleProxy != nil && visibleProxy!=root && opening==NO)
+        {
+            //TODO: This is an expedient fix, but NavGroup needs rewriting anyways
+            [(TiUIiPhoneNavigationGroupProxy*)[self proxy] close:[NSArray arrayWithObject:visibleProxy]];   
+        }
+        visibleProxyDidChange = YES;
+        
+        //TIMOB-8559.TIMOB-8628. In IOS 5 and later, the nav controller calls 
+        //UIViewControllerDelegate methods, but not in IOS 4.X.Call them explicitly
+        if (![TiUtils isIOS5OrGreater]) {
+            [visibleProxy viewDidDisappear:animated];
+            [newWindow viewDidAppear:animated];
+        }
+        [self setVisibleProxy:newWindow];
+    }
+    [closingProxy close:nil];
+    [closingProxy release];
+    closingProxy = nil;
+    opening = NO;
+    if (visibleProxyDidChange) {
+        [newWindow windowDidOpen];
+    }
 }
 
 


### PR DESCRIPTION
Dupe of PR #2090 against 2_0_X

Test is in [JIRA](https://jira.appcelerator.org/browse/TIMOB-8628)

FR should include a regression against [TIMOB-8559](https://jira.appcelerator.org/browse/TIMOB-8559)
