### PR TITLE
[TIMOB-8638] Android: MapView loses user location when it loses focus or on resume

### DIFF
--- a/android/modules/map/src/java/ti/modules/titanium/map/TiMapView.java
+++ b/android/modules/map/src/java/ti/modules/titanium/map/TiMapView.java
@@ -816,6 +816,8 @@ public class TiMapView extends TiUIView
 
 	public void doUserLocation(boolean userLocation)
 	{
+		this.userLocation = userLocation;
+
 		if (view != null) {
 			if (userLocation) {
 				if (myLocation == null) {

--- a/android/modules/map/src/java/ti/modules/titanium/map/ViewProxy.java
+++ b/android/modules/map/src/java/ti/modules/titanium/map/ViewProxy.java
@@ -121,6 +121,7 @@ public class ViewProxy extends TiViewProxy
 				public void onDestroy(Activity activity)
 				{
 					if (activity != null && activity.equals(rootActivity)) {
+						destroyMapActivity();
 						lam = null;
 					}
 				}
@@ -404,12 +405,7 @@ public class ViewProxy extends TiViewProxy
 	}
 
 	public void onDestroy(Activity activity) {
-		if (lam != null && !destroyed) {
-			destroyed = true;
-			lam.dispatchDestroy(true);
-			lam.destroyActivity("TIMAP", true);
-		}
-		mapWindow = null;
+		destroyMapActivity();
 	}
 
 	public void onPause(Activity activity)
@@ -442,5 +438,14 @@ public class ViewProxy extends TiViewProxy
 	{
 		super.releaseViews();
 		onDestroy(null);
+	}
+
+	private void destroyMapActivity()
+	{
+		if (lam != null && !destroyed) {
+			destroyed = true;
+			lam.dispatchDestroy(true);
+		}
+		mapWindow = null;
 	}
 }


### PR DESCRIPTION
Fixes a couples issues:
- User location is re-enabled when map activity resumes
- Map activity is shutdown when the root/base activity is destroyed.

See TIMOB-8638 for testing details.
