### PR TITLE
[TIMOB-9054] Android: Loosing the value of the source in an event

### DIFF
--- a/android/runtime/common/src/js/events.js
+++ b/android/runtime/common/src/js/events.js
@@ -69,9 +69,9 @@ Object.defineProperty(EventEmitter.prototype, "emit", {
 			}
 		}*/
 
-        if (this._hasJavaListener) {
-            this._onEventFired( type,  arguments[1] || {});
-        }
+		if (this._hasJavaListener) {
+			this._onEventFired( type,  arguments[1] || {});
+		}
 
 		if (!this._events) {
 			//kroll.log(TAG, "no events for " + type + ", not emitting");
@@ -156,7 +156,7 @@ Object.defineProperty(EventEmitter.prototype, "addListener", {
 		var listenerWrapper = {};
 		listenerWrapper.listener = listener;
 		listenerWrapper.self = view;
-        
+
 		if (!this._events[type]) {
 			// Optimize the case of one listener. Don't need the extra array object.
 			this._events[type] = listenerWrapper;

--- a/android/runtime/common/src/js/events.js
+++ b/android/runtime/common/src/js/events.js
@@ -42,7 +42,7 @@ Object.defineProperty(EventEmitter.prototype, "callHandler", {
 		if (data instanceof Object) {
 			data.type = type;
 		} else if (!data) {
-			data = { type: type };
+			data = { type: type, source: this };
 		}
 		if (handler.self && (data.source == handler.self.view)) {
 			data.source = handler.self;

--- a/android/runtime/common/src/js/events.js
+++ b/android/runtime/common/src/js/events.js
@@ -42,7 +42,7 @@ Object.defineProperty(EventEmitter.prototype, "callHandler", {
 		// Create event object, copy any custom event data,
 		// and setting the "type" and "source" properties.
 		var event = { type: type, source: this };
-		if (data instanceof Object) {
+		if (Object.prototype.toString.call(data) === "[object Object]") {
 			kroll.extend(event, data);
 		}
 

--- a/android/runtime/common/src/js/events.js
+++ b/android/runtime/common/src/js/events.js
@@ -39,15 +39,17 @@ Object.defineProperty(EventEmitter.prototype, "callHandler", {
 			return;
 		}
 
+		// Create event object, copy any custom event data,
+		// and setting the "type" and "source" properties.
+		var event = { type: type, source: this };
 		if (data instanceof Object) {
-			data.type = type;
-		} else if (!data) {
-			data = { type: type, source: this };
+			kroll.extend(event, data);
 		}
-		if (handler.self && (data.source == handler.self.view)) {
-			data.source = handler.self;
+
+		if (handler.self && (event.source == handler.self.view)) {
+			event.source = handler.self;
 		}
-		handler.listener.call(this, data);
+		handler.listener.call(this, event);
 	},
 	enumerable: false
 });


### PR DESCRIPTION
Fix to include the "source" of the event when firing a custom event via fireEvent().

Please test the simplified test case in comments plus the original test case from the reporter.
For the original test case you should see an alert with source being a Button proxy.
