### PR TITLE
[TIDOC-607] [TIDOC-598] Corrected platform support information for accur...

### DIFF
--- a/apidoc/Titanium/Geolocation/Android/Android.yml
+++ b/apidoc/Titanium/Geolocation/Android/Android.yml
@@ -3,6 +3,12 @@ name: Titanium.Geolocation.Android
 summary: Module for Android-specific geolocation functionality.
 description: |
     This module is used for manually configuring geolocation settings on Android. 
+
+    Manual configuration is recommended for applications that have more demanding 
+    geolocation needs (for example, driving directions). However, for basic geolocation
+    information, *simple mode* geolocation may be sufficient. For information on simple 
+    mode, see <Titanium.Geolocation>.
+
     Manual configuration involves managing *providers* and *rules*:
 
     *   *Location providers*, such as GPS, provide location updates.
@@ -75,7 +81,7 @@ description: |
             minUpdateTime: 60, 
             minUpdateDistance: 100
         });
-        Ti.Geolocation.Android.addProvider(gpsProvider);
+        Ti.Geolocation.Android.addLocationProvider(gpsProvider);
 
     As shown above, when you create a location provider, you can specify two
     properties to limit update frequency:
@@ -119,7 +125,7 @@ description: |
             // But  no more frequent than once per 10 seconds
             minAge: 10000
         });
-        Ti.Geolocation.Android.addRule(gpsRule);
+        Ti.Geolocation.Android.addLocationRule(gpsRule);
     
     Each rule can specify any combination of the following criteria:
 

--- a/apidoc/Titanium/Geolocation/Geolocation.yml
+++ b/apidoc/Titanium/Geolocation/Geolocation.yml
@@ -61,11 +61,33 @@ description: |
     
     Prior to Titanium Mobile 2.0, Titanium attempted to follow the iOS model on Android,
     but this didn't fit the native Android model well. In Release 2.0, three different
-    location service mode are supported on Android: *legacy*, *manual*, and *simple*.
+    location service modes are supported on Android: *simple*, *manual*, and *legacy*.
+
+    *   *Simple mode* provides a compromise mode that provides adaquate support for 
+        undemanding location applications without requiring developers to
+        write a lot of Android-specific code. To use simple mode:
+
+        1.   Leave the <Titanium.Geolocation.Android.manualMode> flag set to `false` (which is
+             its default value).
+        
+        2.   Set the [accuracy](Titanium.Geolocation.accuracy) property to 
+             either [ACCURACY_HIGH](Titanium.Geolocation.ACCURACY_HIGH) or 
+             [ACCURACY_LOW](Titanium.Geolocation.ACCURACY_LOW).
+
+    *   *Manual mode* gives developers low-level control of location updates, including
+        enabling individual location providers and filtering updates, for the best
+        combination of accuracy and battery life. 
+
+        Manual mode is used when the <Titanium.Geolocation.Android.manualMode> flag is set
+        to `true`. In manual mode, the `accuracy` property is not used, and all
+        configuration is done through the <Titanium.Geolocation.Android> module.
+
+        Note that *simple mode* uses the same basic mechanism as manual mode, except 
+        the platform handles enabling and disabling location providers and filtering location updates.
 
     *   *Legacy mode* is the mode that existed prior to 2.0. Legacy mode is 
-        used when you set the `accuracy` property to one of the iOS 
-        `ACCURACY` constants:
+        used when the `manualMode` flag is `false` and the `accuracy` property is 
+        set to one of the iOS `ACCURACY` constants:
 
         *   [ACCURACY_BEST](Titanium.Geolocation.ACCURACY_BEST) (highest accuracy and power consumption)
         *   [ACCURACY_NEAREST_TEN_METERS](Titanium.Geolocation.ACCURACY_NEAREST_TEN_METERS) 
@@ -87,25 +109,6 @@ description: |
         You can also specifying a desired update frequency using the
         [frequency](Titanium.Geolocation.frequency) property. The `preferredProvider`
         and `frequency` properties are not used in any other mode.
-
-    *   *Manual mode* gives developers low-level control of location updates, including
-        enabling individual location providers and filtering updates, for the best
-        combination of accuracy and battery life. 
-
-        Manual mode is used when the <Titanium.Geolocation.Android.manualMode> flag is set
-        to `true`. In manual mode, the `accuracy` property is not used, and all
-        configuration is done through the <Titanium.Geolocation.Android> module.
-
-    *   *Simple mode* provides a compromise mode that provides adaquate support for 
-        undemanding location applications without requiring developers to
-        write a lot of Android-specific code. 
-        
-        Setting the [accuracy](Titanium.Geolocation.accuracy) property to 
-        either [ACCURACY_HIGH](Titanium.Geolocation.ACCURACY_HIGH) or 
-        [ACCURACY_LOW](Titanium.Geolocation.ACCURACY_LOW) enables simple mode.
-
-        In this mode the platform handles enabling and disabling location providers and
-        filtering location updates.
 
     #### Configuring Location Updates on Mobile Web
 
@@ -447,22 +450,25 @@ properties:
   - name: accuracy
     summary: Specifies the requested accuracy for location updates.
     description: |
-        Use of this property varies by platform.
+        For basic location updates on all platforms, set `accuracy` to either:
 
-        For iOS, specify one of ACCURACY_BEST, ACCURACY_NEAREST_TEN_METERS,
-        ACCURACY_HUNDRED_METERS, ACCURACY_KILOMETER, ACCURACY_THREE_KILOMETERS.
+        *   [ACCURACY_HIGH](Titanium.Geolocation.ACCURACY_HIGH) for higher-quality location
+            updates, with the higher power consumption.
+        *   [ACCURACY_LOW](Titanium.Geolocation.ACCURACY_LOW) for lower-quality location
+            updates with lower power consumption.
 
-        For Android in *legacy mode*, specify one of the iOS accuracy constants. This
-        usage is deprecated.
+        For finer-grained control on iOS, specify one of `ACCURACY_BEST`, 
+        `ACCURACY_NEAREST_TEN_METERS`, `ACCURACY_HUNDRED_METERS`, `ACCURACY_KILOMETER`, or
+        `ACCURACY_THREE_KILOMETERS`. 
 
-        For Android in *simple mode*, specify either ACCURACY_HIGH or ACCURACY_LOW.
+        For finer-grained control on Android, use *manual mode*, instead of specifing an accuracy. 
+        This mode requires more active management on the part of the application, but it 
+        is recommended to maximize accuracy and battery life.
+        See <Titanium.Geolocation.Android> for details on using manual mode.
 
-        For Android in *manual mode*, do not specify an accuracy. Use location providers
-        and location rules to control geolocation behavior as described in
-        <Titanium.Geolocation.Android>.
-
-        For Mobile Web, specify either ACCURACY_HIGH or ACCURACY_LOW.
-
+        Note that for backwards compatibility, Android supports using the iOS accuracy constants. 
+        This usage is deprecated. Applications using one of the iOS constants should
+        migrate to using `ACCURACY_HIGH`, `ACCURACY_LOW`, or Android manual mode.
     type: Number
 
   - name: distanceFilter

--- a/apidoc/Titanium/Geolocation/Geolocation.yml
+++ b/apidoc/Titanium/Geolocation/Geolocation.yml
@@ -67,8 +67,8 @@ description: |
         undemanding location applications without requiring developers to
         write a lot of Android-specific code. To use simple mode:
 
-        1.   Leave the <Titanium.Geolocation.Android.manualMode> flag set to `false` (which is
-             its default value).
+        1.   Leave the <Titanium.Geolocation.Android.manualMode> flag set to `false` (the 
+             default value).
         
         2.   Set the [accuracy](Titanium.Geolocation.accuracy) property to 
              either [ACCURACY_HIGH](Titanium.Geolocation.ACCURACY_HIGH) or 
@@ -81,9 +81,6 @@ description: |
         Manual mode is used when the <Titanium.Geolocation.Android.manualMode> flag is set
         to `true`. In manual mode, the `accuracy` property is not used, and all
         configuration is done through the <Titanium.Geolocation.Android> module.
-
-        Note that *simple mode* uses the same basic mechanism as manual mode, except 
-        the platform handles enabling and disabling location providers and filtering location updates.
 
     *   *Legacy mode* is the mode that existed prior to 2.0. Legacy mode is 
         used when the `manualMode` flag is `false` and the `accuracy` property is 

--- a/apidoc/Titanium/Geolocation/Geolocation.yml
+++ b/apidoc/Titanium/Geolocation/Geolocation.yml
@@ -247,6 +247,7 @@ properties:
         recommended. 
     type: Number
     permission: read-only
+    platforms: [android, iphone, ipad]
 
   - name: ACCURACY_HUNDRED_METERS
     summary: |
@@ -257,6 +258,7 @@ properties:
         recommended. 
     type: Number
     permission: read-only
+    platforms: [android, iphone, ipad]
 
   - name: ACCURACY_KILOMETER
     summary: |
@@ -267,6 +269,7 @@ properties:
         recommended. 
     type: Number
     permission: read-only
+    platforms: [android, iphone, ipad]
 
   - name: ACCURACY_NEAREST_TEN_METERS
     summary: |
@@ -277,6 +280,7 @@ properties:
         recommended. 
     type: Number
     permission: read-only
+    platforms: [android, iphone, ipad]
 
   - name: ACCURACY_THREE_KILOMETERS
     summary: |
@@ -287,6 +291,7 @@ properties:
         recommended. 
     type: Number
     permission: read-only
+    platforms: [android, iphone, ipad]
 
   - name: ACCURACY_HIGH
     summary: |


### PR DESCRIPTION
...acy values.

Reordered docs to emphasize "simple" and "manual" modes on Android and de-emphasize the legacy mode.
Also some rewrites to make it clearer that ACCURACY_HIGH and ACCURACY_LOW work across platforms.

Corrected sample code in Android.yml and added reference to simple mode, so users realize there is an alternative to manual mode. Apparently some users were confused by this.
