### PR TITLE
[TIMOB-9002] Fix application log messages

### DIFF
--- a/iphone/Classes/AnalyticsModule.mm
+++ b/iphone/Classes/AnalyticsModule.mm
@@ -56,7 +56,7 @@ NSString * const TI_DB_VERSION = @"1";
 		}
 		@catch (NSException * e) 
 		{
-			NSLog(@"[WARN] database error on shutdown: %@",e);
+			NSLog(@"[ERROR] database error on shutdown: %@",e);
 		}
 	}
 	RELEASE_TO_NIL(database);
@@ -102,7 +102,7 @@ NSString * const TI_DB_VERSION = @"1";
 	
 	if (count == TI_DB_WARN_ON_ATTEMPT_COUNT)
 	{
-		NSLog(@"[ERROR] %d analytics events attempted with no luck",count);
+		DebugLog(@"[WARN] %d analytics events attempted with no luck",count);
 	}
 	
 	NSString *sql = count == 0 ? @"insert into last_attempt VALUES (?,?)" : @"update last_attempt set date = ?, attempts = ?";
@@ -116,7 +116,7 @@ NSString * const TI_DB_VERSION = @"1";
 	if (retryTimer==nil)
 	{
 		// start our re-attempt timer
-		NSLog(@"[DEBUG] attempt to send analytics event but no network. will try again in %d seconds",TI_DB_RETRY_INTERVAL_IN_SEC);
+		DeveloperLog(@"[DEBUG] attempt to send analytics event but no network. will try again in %d seconds",TI_DB_RETRY_INTERVAL_IN_SEC);
 		retryTimer = [[NSTimer timerWithTimeInterval:TI_DB_RETRY_INTERVAL_IN_SEC target:self selector:@selector(backgroundFlushEventQueue) userInfo:nil repeats:YES] retain];
 		[[NSRunLoop mainRunLoop] addTimer:retryTimer forMode:NSDefaultRunLoopMode];
 	}
@@ -229,7 +229,6 @@ NSString * const TI_DB_VERSION = @"1";
 		NSError* error = [request error];
 		if (error != nil) {
 			NSLog(@"[ERROR] Analytics error sending request: %@", [error localizedDescription]);
-			NSLog(@"[ERROR] Will re-queue analytics");
 			[database rollbackTransaction];
 			[self requeueEventsOnTimer];
 			[lock unlock];
@@ -259,7 +258,7 @@ NSString * const TI_DB_VERSION = @"1";
 	}
 	@catch (NSException * e) 
 	{
-		NSLog(@"[ERROR] error sending analytics. %@",e);
+		NSLog(@"[ERROR] Error sending analytics: %@",e);
 		[database rollbackTransaction];
 	}
 	[lock unlock];
@@ -398,7 +397,7 @@ NSString * const TI_DB_VERSION = @"1";
 	database = [[PLSqliteDatabase alloc] initWithPath:filepath];
 	if (![database open])
 	{
-		NSLog(@"[ERROR] couldn't open analytics database");
+		NSLog(@"[ERROR] Couldn't open analytics database");
 		RELEASE_TO_NIL(database);
 		[lock unlock];
 		return;
@@ -447,7 +446,6 @@ NSString * const TI_DB_VERSION = @"1";
 		id online = [[self network] valueForKey:@"online"];
 		if ([TiUtils boolValue:online]==NO)
 		{
-			NSLog(@"[DEBUG] attempted to enroll, but we're offline. will try again in 10s");
 			[self performSelector:@selector(enroll) withObject:nil afterDelay:10];
 			return;
 		}
@@ -469,7 +467,7 @@ NSString * const TI_DB_VERSION = @"1";
 	}
 	@catch (NSException * e) 
 	{
-		NSLog(@"[ERROR] Error sending analytics event. %@",e);
+		NSLog(@"[ERROR] Error sending analytics event: %@",e);
 	}
     @finally {
         [pool release];
@@ -523,7 +521,7 @@ NSString * const TI_DB_VERSION = @"1";
 {
 	static bool AnalyticsStarted = NO;
 	
-	NSLog(@"[DEBUG] Analytics is enabled = %@", (TI_APPLICATION_ANALYTICS==NO ? @"NO":@"YES"));
+	DebugLog(@"[DEBUG] Analytics is enabled = %@", (TI_APPLICATION_ANALYTICS==NO ? @"NO":@"YES"));
 	
 	if (AnalyticsStarted || TI_APPLICATION_ANALYTICS==NO)
 	{
@@ -572,7 +570,7 @@ NSString * const TI_DB_VERSION = @"1";
 	}
 	else
 	{
-		NSLog(@"[ERROR] invalid analytics event received. excepted dictionary. was: %@",[userInfo class]);
+		DebugLog(@"[ERROR] invalid analytics event received. excepted dictionary. was: %@",[userInfo class]);
 	}
 }
 
@@ -624,7 +622,7 @@ NSString * const TI_DB_VERSION = @"1";
 	NSString *name = [args objectAtIndex:1];
 	id data = [args count] > 2 ? [args objectAtIndex:2] : [NSDictionary dictionary];
 	
-	NSLog(@"[INFO] Analytics->addEvent with type: %@, name: %@, data: %@",type,name,data);
+	DeveloperLog(@"[INFO] Analytics->addEvent with type: %@, name: %@, data: %@",type,name,data);
 	
 	[self queueEvent:type name:name data:[self dataToDictionary:data] immediate:NO];
 }
@@ -644,7 +642,7 @@ NSString * const TI_DB_VERSION = @"1";
 	NSDictionary *payload = [NSDictionary dictionaryWithObjectsAndKeys:from,@"from",
 						   to,@"to",[self dataToDictionary:data],@"data",nil];
 	
-	NSLog(@"[INFO] Analytics->navEvent with from: %@, to: %@, event: %@, data: %@",from,to,event,data);
+	DeveloperLog(@"[INFO] Analytics->navEvent with from: %@, to: %@, event: %@, data: %@",from,to,event,data);
 
 	[self queueEvent:@"app.nav" name:event data:payload immediate:NO];
 }
@@ -672,7 +670,7 @@ NSString * const TI_DB_VERSION = @"1";
 							 duration,@"duration",
 							 [self dataToDictionary:data],@"data",nil];
 	
-	NSLog(@"[INFO] Analytics->timedEvent with event: %@, start: %@, stop: %@, duration: %@, data: %@",event,start,stop,duration,data);
+	DeveloperLog(@"[INFO] Analytics->timedEvent with event: %@, start: %@, stop: %@, duration: %@, data: %@",event,start,stop,duration,data);
 
 	[self queueEvent:@"app.timed_event" name:event data:payload immediate:NO];
 }
@@ -680,7 +678,7 @@ NSString * const TI_DB_VERSION = @"1";
 #define PRINT_EVENT_DETAILS(name,args) \
   id event = [args objectAtIndex:0];\
   id data = [args count] > 1 ? [args objectAtIndex:1] : nil;\
-  NSLog(@"[INFO] Analytics->%s with event: %@, data: %@",#name,event,data);\
+  DeveloperLog(@"[INFO] Analytics->%s with event: %@, data: %@",#name,event,data);\
 
 
 -(void)featureEvent:(id)args

--- a/iphone/Classes/AnalyticsModule.mm
+++ b/iphone/Classes/AnalyticsModule.mm
@@ -56,7 +56,7 @@ NSString * const TI_DB_VERSION = @"1";
 		}
 		@catch (NSException * e) 
 		{
-			NSLog(@"[ERROR] database error on shutdown: %@",e);
+			NSLog(@"[ERROR] Analytics: database error on shutdown: %@",e);
 		}
 	}
 	RELEASE_TO_NIL(database);
@@ -102,7 +102,7 @@ NSString * const TI_DB_VERSION = @"1";
 	
 	if (count == TI_DB_WARN_ON_ATTEMPT_COUNT)
 	{
-		DebugLog(@"[WARN] %d analytics events attempted with no luck",count);
+		DebugLog(@"[WARN] Analytics: %d transmission attempts failed.",count);
 	}
 	
 	NSString *sql = count == 0 ? @"insert into last_attempt VALUES (?,?)" : @"update last_attempt set date = ?, attempts = ?";
@@ -116,7 +116,7 @@ NSString * const TI_DB_VERSION = @"1";
 	if (retryTimer==nil)
 	{
 		// start our re-attempt timer
-		DeveloperLog(@"[DEBUG] attempt to send analytics event but no network. will try again in %d seconds",TI_DB_RETRY_INTERVAL_IN_SEC);
+		DeveloperLog(@"[DEBUG] Attempted to send analytics event. No network; will try again in %d seconds.",TI_DB_RETRY_INTERVAL_IN_SEC);
 		retryTimer = [[NSTimer timerWithTimeInterval:TI_DB_RETRY_INTERVAL_IN_SEC target:self selector:@selector(backgroundFlushEventQueue) userInfo:nil repeats:YES] retain];
 		[[NSRunLoop mainRunLoop] addTimer:retryTimer forMode:NSDefaultRunLoopMode];
 	}
@@ -570,7 +570,7 @@ NSString * const TI_DB_VERSION = @"1";
 	}
 	else
 	{
-		DebugLog(@"[ERROR] invalid analytics event received. excepted dictionary. was: %@",[userInfo class]);
+		DebugLog(@"[ERROR] Invalid analytics event received. Expected dictionary, got: %@",[userInfo class]);
 	}
 }
 

--- a/iphone/Classes/AppModule.m
+++ b/iphone/Classes/AppModule.m
@@ -129,9 +129,7 @@ extern BOOL const TI_APPLICATION_ANALYTICS;
 		id type = [args objectAtIndex:0];
 		id obj = [args count] > 1 ? [args objectAtIndex:1] : nil;
 		
-#ifdef DEBUG
-		NSLog(@"[DEBUG] fire app event: %@",type);
-#endif
+		DebugLog(@"[DEBUG] fire app event: %@",type);
 		
 		NSArray *array = [appListeners objectForKey:type];
 		

--- a/iphone/Classes/AppModule.m
+++ b/iphone/Classes/AppModule.m
@@ -129,7 +129,7 @@ extern BOOL const TI_APPLICATION_ANALYTICS;
 		id type = [args objectAtIndex:0];
 		id obj = [args count] > 1 ? [args objectAtIndex:1] : nil;
 		
-		DebugLog(@"[DEBUG] fire app event: %@",type);
+		DebugLog(@"[DEBUG] Firing app event: %@",type);
 		
 		NSArray *array = [appListeners objectForKey:type];
 		

--- a/iphone/Classes/GeolocationModule.mm
+++ b/iphone/Classes/GeolocationModule.mm
@@ -266,7 +266,7 @@ extern BOOL const TI_APPLICATION_ANALYTICS;
 		
 		if (purpose==nil)
 		{ 
-			NSLog(@"[ERROR] Starting in iOS 3.2, you must set the Ti.Geolocation.purpose property to indicate the purpose of using Location services for your application");
+			DebugLog(@"[WARN] The Ti.Geolocation.purpose property must be set.");
 		}
 		else
 		{

--- a/iphone/Classes/ImageLoader.m
+++ b/iphone/Classes/ImageLoader.m
@@ -359,14 +359,14 @@ DEFINE_EXCEPTIONS
 	vm_statistics_data_t vmStats;
 	mach_msg_type_number_t infoCount = HOST_VM_INFO_COUNT;
 	kern_return_t kernReturn = host_statistics(mach_host_self(), HOST_VM_INFO, (host_info_t)&vmStats, &infoCount);
-	NSLog(@"[DEBUG] %d pages free before clearing image cache.",vmStats.free_count);
+	NSLog(@"[CACHE DEBUG] %d pages free before clearing image cache.",vmStats.free_count);
 #endif
     
     [cache removeAllObjects];
     
 #ifdef DEBUG_IMAGE_CACHE
 	kernReturn = host_statistics(mach_host_self(), HOST_VM_INFO, (host_info_t)&vmStats, &infoCount);
-	NSLog(@"[DEBUG] %d pages free after clearing image cache.",vmStats.free_count);
+	NSLog(@"[CACHE DEBUG] %d pages free after clearing image cache.",vmStats.free_count);
 #endif
 
 
@@ -416,7 +416,7 @@ DEFINE_EXCEPTIONS
     }
 	
 #ifdef DEBUG_IMAGE_CACHE
-    NSLog(@"[DEBUG] Caching: %@",newEntry);
+    NSLog(@"[CACHE DEBUG] Caching: %@",newEntry);
 #endif
     
     [cache setObject:newEntry forKey:urlString];
@@ -806,7 +806,7 @@ DEFINE_EXCEPTIONS
 -(void)cache:(NSCache *)cache willEvictObject:(id)obj
 {
 #ifdef DEBUG_IMAGE_CACHE
-    NSLog(@"[DEBUG] Purging image cache object %@", obj);
+    NSLog(@"[CACHE DEBUG] Purging image cache object %@", obj);
 #endif
 }
 

--- a/iphone/Classes/ImageLoader.m
+++ b/iphone/Classes/ImageLoader.m
@@ -232,7 +232,7 @@
             [fm removeItemAtPath:path error:nil];
         }
         if (![fm createFileAtPath:path contents:imageData  attributes:nil]) {
-            NSLog(@"[WARN] Unknown error serializing image %@ to path %@", remoteURL, path);
+            NSLog(@"[ERROR] Unknown error serializing image %@ to path %@", remoteURL, path);
         }
     }
 }
@@ -257,7 +257,7 @@
                                     create:YES 
                                      error:&error];
     if (error != nil) {
-        NSLog(@"[WARN] Error finding cache directory: %@", [error localizedDescription]);
+        NSLog(@"[ERROR] Error finding cache directory: %@", [error localizedDescription]);
         return nil;
     }
     
@@ -359,14 +359,14 @@ DEFINE_EXCEPTIONS
 	vm_statistics_data_t vmStats;
 	mach_msg_type_number_t infoCount = HOST_VM_INFO_COUNT;
 	kern_return_t kernReturn = host_statistics(mach_host_self(), HOST_VM_INFO, (host_info_t)&vmStats, &infoCount);
-	NSLog(@"[INFO] %d pages free before clearing image cache.",vmStats.free_count);
+	NSLog(@"[DEBUG] %d pages free before clearing image cache.",vmStats.free_count);
 #endif
     
     [cache removeAllObjects];
     
 #ifdef DEBUG_IMAGE_CACHE
 	kernReturn = host_statistics(mach_host_self(), HOST_VM_INFO, (host_info_t)&vmStats, &infoCount);
-	NSLog(@"[INFO] %d pages free after clearing image cache.",vmStats.free_count);
+	NSLog(@"[DEBUG] %d pages free after clearing image cache.",vmStats.free_count);
 #endif
 
 
@@ -411,12 +411,12 @@ DEFINE_EXCEPTIONS
         [newEntry setData:image];
     }
     else {
-        NSLog(@"[WARN] Unexpected image data type %@; not caching", [image class]);
+        DebugLog(@"[DEBUG] Unexpected image data type %@; not caching", [image class]);
         return nil;
     }
 	
 #ifdef DEBUG_IMAGE_CACHE
-    NSLog(@"Caching: %@",newEntry);
+    NSLog(@"[DEBUG] Caching: %@",newEntry);
 #endif
     
     [cache setObject:newEntry forKey:urlString];
@@ -806,7 +806,7 @@ DEFINE_EXCEPTIONS
 -(void)cache:(NSCache *)cache willEvictObject:(id)obj
 {
 #ifdef DEBUG_IMAGE_CACHE
-    NSLog(@"Purging image cache object %@", obj);
+    NSLog(@"[DEBUG] Purging image cache object %@", obj);
 #endif
 }
 

--- a/iphone/Classes/JSON/SBJsonParser.m
+++ b/iphone/Classes/JSON/SBJsonParser.m
@@ -342,7 +342,7 @@ static char ctrl[0x22];
             return NO;
             
         } else {
-            DeveloperLog(@"should not be able to get here");
+            NSLog(@"should not be able to get here");
         }
     } while (*c);
     

--- a/iphone/Classes/JSON/SBJsonParser.m
+++ b/iphone/Classes/JSON/SBJsonParser.m
@@ -342,7 +342,7 @@ static char ctrl[0x22];
             return NO;
             
         } else {
-            NSLog(@"should not be able to get here");
+            DeveloperLog(@"should not be able to get here");
         }
     } while (*c);
     

--- a/iphone/Classes/KrollBridge.mm
+++ b/iphone/Classes/KrollBridge.mm
@@ -68,12 +68,12 @@ NSString * TitaniumModuleRequireFormat = @"(function(exports){"
 #if KROLLBRIDGE_MEMORY_DEBUG==1
 -(id)retain
 {
-	NSLog(@"[DEBUG] RETAIN: %@ (%d)",self,[self retainCount]+1);
+	NSLog(@"[MEMRORY DEBUG] RETAIN: %@ (%d)",self,[self retainCount]+1);
 	return [super retain];
 }
 -(oneway void)release 
 {
-	NSLog(@"[DEBUG] RELEASE: %@ (%d)",self,[self retainCount]-1);
+	NSLog(@"[MEMORY DEBUG] RELEASE: %@ (%d)",self,[self retainCount]-1);
 	[super release];
 }
 #endif
@@ -269,12 +269,12 @@ CFMutableSetRef	krollBridgeRegistry = nil;
 #if KROLLBRIDGE_MEMORY_DEBUG==1
 -(id)retain
 {
-	NSLog(@"[DEBUG] RETAIN: %@ (%d)",self,[self retainCount]+1);
+	NSLog(@"[MEMORY DEBUG] RETAIN: %@ (%d)",self,[self retainCount]+1);
 	return [super retain];
 }
 -(oneway void)release 
 {
-	NSLog(@"[DEBUG] RELEASE: %@ (%d)",self,[self retainCount]-1);
+	NSLog(@"[MEMORY DEBUG] RELEASE: %@ (%d)",self,[self retainCount]-1);
 	[super release];
 }
 #endif
@@ -310,7 +310,7 @@ CFMutableSetRef	krollBridgeRegistry = nil;
 -(void)dealloc
 {
 #if KROLLBRIDGE_MEMORY_DEBUG==1
-	NSLog(@"[DEBUG] DEALLOC: %@",self);
+	NSLog(@"[MEMORY DEBUG] DEALLOC: %@",self);
 #endif
 		
 	[self removeProxies];
@@ -486,7 +486,7 @@ CFMutableSetRef	krollBridgeRegistry = nil;
 {
 	if (![listener isKindOfClass:[KrollCallback class]])
 	{
-		DebugLog(@"[ERROR] listener callback is of a non-supported type: %@",[listener class]);
+		DebugLog(@"[ERROR] Listener callback is of a non-supported type: %@",[listener class]);
 		return;
 	}
 
@@ -512,7 +512,7 @@ CFMutableSetRef	krollBridgeRegistry = nil;
 -(void)shutdown:(NSCondition*)condition
 {
 #if KROLLBRIDGE_MEMORY_DEBUG==1
-	NSLog(@"[DEBUG] DESTROY: %@",self);
+	NSLog(@"[MEMORY DEBUG] DESTROY: %@",self);
 #endif
 	
 	if (shutdown==NO)

--- a/iphone/Classes/KrollBridge.mm
+++ b/iphone/Classes/KrollBridge.mm
@@ -68,12 +68,12 @@ NSString * TitaniumModuleRequireFormat = @"(function(exports){"
 #if KROLLBRIDGE_MEMORY_DEBUG==1
 -(id)retain
 {
-	NSLog(@"RETAIN: %@ (%d)",self,[self retainCount]+1);
+	NSLog(@"[DEBUG] RETAIN: %@ (%d)",self,[self retainCount]+1);
 	return [super retain];
 }
 -(oneway void)release 
 {
-	NSLog(@"RELEASE: %@ (%d)",self,[self retainCount]-1);
+	NSLog(@"[DEBUG] RELEASE: %@ (%d)",self,[self retainCount]-1);
 	[super release];
 }
 #endif
@@ -210,7 +210,7 @@ CFMutableSetRef	krollBridgeRegistry = nil;
 	if (self = [super init])
 	{
 #if KROLLBRIDGE_MEMORY_DEBUG==1
-		NSLog(@"INIT: %@",self);
+		NSLog(@"[DEBUG] INIT: %@",self);
 #endif		
 		modules = [[NSMutableDictionary alloc] init];
 		proxyLock = OS_SPINLOCK_INIT;
@@ -269,12 +269,12 @@ CFMutableSetRef	krollBridgeRegistry = nil;
 #if KROLLBRIDGE_MEMORY_DEBUG==1
 -(id)retain
 {
-	NSLog(@"RETAIN: %@ (%d)",self,[self retainCount]+1);
+	NSLog(@"[DEBUG] RETAIN: %@ (%d)",self,[self retainCount]+1);
 	return [super retain];
 }
 -(oneway void)release 
 {
-	NSLog(@"RELEASE: %@ (%d)",self,[self retainCount]-1);
+	NSLog(@"[DEBUG] RELEASE: %@ (%d)",self,[self retainCount]-1);
 	[super release];
 }
 #endif
@@ -310,7 +310,7 @@ CFMutableSetRef	krollBridgeRegistry = nil;
 -(void)dealloc
 {
 #if KROLLBRIDGE_MEMORY_DEBUG==1
-	NSLog(@"DEALLOC: %@",self);
+	NSLog(@"[DEBUG] DEALLOC: %@",self);
 #endif
 		
 	[self removeProxies];
@@ -414,7 +414,7 @@ CFMutableSetRef	krollBridgeRegistry = nil;
 	
 	if (error!=nil)
 	{
-		NSLog(@"[ERROR] error loading path: %@, %@",path,error);
+		NSLog(@"[ERROR] Error loading path: %@, %@",path,error);
 		
 		// check for file not found a give a friendlier message
 		if ([error code]==260 && [error domain]==NSCocoaErrorDomain)
@@ -438,7 +438,7 @@ CFMutableSetRef	krollBridgeRegistry = nil;
 	if (!TiCheckScriptSyntax(jsContext,jsCode,jsURL,1,&exception))
 	{
 		id excm = [KrollObject toID:context value:exception];
-		NSLog(@"[ERROR] Syntax Error = %@",[TiUtils exceptionMessage:excm]);
+		DebugLog(@"[ERROR] Syntax Error = %@",[TiUtils exceptionMessage:excm]);
 		[self scriptError:[TiUtils exceptionMessage:excm]];
 	}
 	
@@ -458,7 +458,7 @@ CFMutableSetRef	krollBridgeRegistry = nil;
 		if (exception!=NULL)
 		{
 			id excm = [KrollObject toID:context value:exception];
-			NSLog(@"[ERROR] Script Error = %@.",[TiUtils exceptionMessage:excm]);
+			DebugLog(@"[ERROR] Script Error = %@.",[TiUtils exceptionMessage:excm]);
 			[self scriptError:[TiUtils exceptionMessage:excm]];
 		}
         else {
@@ -486,7 +486,7 @@ CFMutableSetRef	krollBridgeRegistry = nil;
 {
 	if (![listener isKindOfClass:[KrollCallback class]])
 	{
-		NSLog(@"[ERROR] listener callback is of a non-supported type: %@",[listener class]);
+		DebugLog(@"[ERROR] listener callback is of a non-supported type: %@",[listener class]);
 		return;
 	}
 
@@ -512,7 +512,7 @@ CFMutableSetRef	krollBridgeRegistry = nil;
 -(void)shutdown:(NSCondition*)condition
 {
 #if KROLLBRIDGE_MEMORY_DEBUG==1
-	NSLog(@"DESTROY: %@",self);
+	NSLog(@"[DEBUG] DESTROY: %@",self);
 #endif
 	
 	if (shutdown==NO)
@@ -725,7 +725,7 @@ CFMutableSetRef	krollBridgeRegistry = nil;
 	
 	if (exception != NULL) {
 		id excm = [KrollObject toID:context value:exception];
-		NSLog(@"[ERROR] Script Error = %@",[TiUtils exceptionMessage:excm]);
+		DebugLog(@"[ERROR] Script Error = %@",[TiUtils exceptionMessage:excm]);
 		fflush(stderr);
 		@throw excm;
 	}

--- a/iphone/Classes/KrollCallback.m
+++ b/iphone/Classes/KrollCallback.m
@@ -144,7 +144,7 @@ static NSLock *callbackLock;
 	TiValueRef retVal = TiObjectCallAsFunction(jsContext,function,tp,[args count],_args,&exception);
 	if (exception!=NULL)
 	{
-		NSLog(@"[WARN] Exception in event callback. %@",[KrollObject toID:context value:exception]);
+		DebugLog(@"[ERROR] Exception in event callback: %@",[KrollObject toID:context value:exception]);
 	}
 	if (top!=NULL)
 	{
@@ -208,7 +208,7 @@ static NSLock *callbackLock;
 
 	if (![[bridge krollContext] isKJSThread])
 	{
-		NSLog(@"[WARN] KrollWrapper trying to protect in the wrong thread.%@",CODELOCATION);
+		DeveloperLog(@"[WARN] KrollWrapper trying to protect in the wrong thread.%@",CODELOCATION);
 		return;
 	}
 	protecting = YES;
@@ -224,7 +224,7 @@ static NSLock *callbackLock;
 	
 	if (![[bridge krollContext] isKJSThread])
 	{
-		NSLog(@"[WARN] KrollWrapper trying to unprotect in the wrong thread.%@",CODELOCATION);
+		DeveloperLog(@"[WARN] KrollWrapper trying to unprotect in the wrong thread.%@",CODELOCATION);
 		return;
 	}
 	protecting = NO;

--- a/iphone/Classes/KrollContext.mm
+++ b/iphone/Classes/KrollContext.mm
@@ -145,7 +145,8 @@ static TiValueRef MakeTimer(TiContextRef context, TiObjectRef jsFunction, TiValu
 	double duration = TiValueToNumber(context, durationRef, &exception);
 	if (exception!=NULL)
 	{
-		DebugLog(@"[ERROR] timer duration conversion failed");
+		DebugLog(@"[ERROR] Conversion of timer duration to number failed.");
+        return TiValueMakeUndefined(context);
 	}
 	KrollTimer *timer = [[KrollTimer alloc] initWithContext:globalContext function:fnRef jsThis:jsThis duration:duration onetime:onetime kroll:ctx timerId:timerID];
 	[ctx registerTimer:timer timerId:timerID];

--- a/iphone/Classes/KrollContext.mm
+++ b/iphone/Classes/KrollContext.mm
@@ -145,7 +145,7 @@ static TiValueRef MakeTimer(TiContextRef context, TiObjectRef jsFunction, TiValu
 	double duration = TiValueToNumber(context, durationRef, &exception);
 	if (exception!=NULL)
 	{
-		NSLog(@"[ERROR] timer duration conversion failed");
+		DebugLog(@"[ERROR] timer duration conversion failed");
 	}
 	KrollTimer *timer = [[KrollTimer alloc] initWithContext:globalContext function:fnRef jsThis:jsThis duration:duration onetime:onetime kroll:ctx timerId:timerID];
 	[ctx registerTimer:timer timerId:timerID];
@@ -597,7 +597,7 @@ static TiValueRef StringFormatDecimalCallback (TiContextRef jsContext, TiObjectR
 	if (exception!=NULL)
 	{
 		id excm = [KrollObject toID:context value:exception];
-		NSLog(@"[ERROR] Script Error = %@",[TiUtils exceptionMessage:excm]);
+		DebugLog(@"[ERROR] Script Error = %@",[TiUtils exceptionMessage:excm]);
 		fflush(stderr);
 	}
     pthread_mutex_unlock(&KrollEntryLock);
@@ -612,7 +612,7 @@ static TiValueRef StringFormatDecimalCallback (TiContextRef jsContext, TiObjectR
 	if (exception!=NULL)
 	{
 		id excm = [KrollObject toID:context value:exception];
-		NSLog(@"[ERROR] Script Error = %@",[TiUtils exceptionMessage:excm]);
+		DebugLog(@"[ERROR] Script Error = %@",[TiUtils exceptionMessage:excm]);
 		fflush(stderr);
         
         pthread_mutex_unlock(&KrollEntryLock);
@@ -702,7 +702,7 @@ static TiValueRef StringFormatDecimalCallback (TiContextRef jsContext, TiObjectR
 	if (self = [super init])
 	{
 #if CONTEXT_MEMORY_DEBUG==1
-		NSLog(@"INIT: %@",self);
+		NSLog(@"[DEBUG] INIT: %@",self);
 #endif
 		contextId = [[NSString stringWithFormat:@"kroll$%d",++KrollContextIdCounter] copy];
 		condition = [[NSCondition alloc] init];
@@ -725,7 +725,7 @@ static TiValueRef StringFormatDecimalCallback (TiContextRef jsContext, TiObjectR
 -(void)destroy
 {
 #if CONTEXT_MEMORY_DEBUG==1
-	NSLog(@"DESTROY: %@",self);
+	NSLog(@"[DEBUG] DESTROY: %@",self);
 #endif
 	[self stop];
 	RELEASE_TO_NIL(condition);
@@ -752,12 +752,12 @@ static TiValueRef StringFormatDecimalCallback (TiContextRef jsContext, TiObjectR
 #if CONTEXT_MEMORY_DEBUG==1
 -(id)retain
 {
-	NSLog(@"RETAIN: %@ (%d)",self,[self retainCount]+1);
+	NSLog(@"[DEBUG] RETAIN: %@ (%d)",self,[self retainCount]+1);
 	return [super retain];
 }
 -(oneway void)release 
 {
-	NSLog(@"RELEASE: %@ (%d)",self,[self retainCount]-1);
+	NSLog(@"[DEBUG] RELEASE: %@ (%d)",self,[self retainCount]-1);
 	[super release]; 
 }
 #endif
@@ -771,7 +771,7 @@ static TiValueRef StringFormatDecimalCallback (TiContextRef jsContext, TiObjectR
 -(void)dealloc
 {
 #if CONTEXT_MEMORY_DEBUG==1
-	NSLog(@"DEALLOC: %@",self);
+	NSLog(@"[DEBUG] DEALLOC: %@",self);
 #endif
 	assert(!destroyed);
 	destroyed = YES;
@@ -946,7 +946,7 @@ static TiValueRef StringFormatDecimalCallback (TiContextRef jsContext, TiObjectR
 {
 	if (![self isKJSThread])
 	{
-		NSLog(@"[ERROR] attempted to evaluate JS and not on correct Thread! Aborting!");
+		DeveloperLog(@"[ERROR] attempted to evaluate JS and not on correct Thread! Aborting!");
 		@throw @"Invalid Thread Access";
 	}
 	KrollEval *eval = [[[KrollEval alloc] initWithCode:code] autorelease];
@@ -1021,7 +1021,7 @@ static TiValueRef StringFormatDecimalCallback (TiContextRef jsContext, TiObjectR
 {
 	NSAutoreleasePool * garbagePool = [[NSAutoreleasePool alloc] init];
 #if CONTEXT_DEBUG == 1	
-	NSLog(@"CONTEXT<%@>: forced garbage collection requested",self);
+	NSLog(@"[DEBUG] CONTEXT<%@>: forced garbage collection requested",self);
 #endif
 	pthread_mutex_lock(&KrollEntryLock);
 	TiGarbageCollect(context);
@@ -1186,7 +1186,7 @@ static TiValueRef StringFormatDecimalCallback (TiContextRef jsContext, TiObjectR
 			[lock unlock];
 
 #if CONTEXT_DEBUG == 1	
-			NSLog(@"CONTEXT<%@>: shutdown, queue_count = %d",self,queue_count);
+			NSLog(@"[DEBUG] CONTEXT<%@>: shutdown, queue_count = %d",self,queue_count);
 #endif
 			
 			// we're stopped, nothing in the queue, time to bail
@@ -1244,18 +1244,18 @@ static TiValueRef StringFormatDecimalCallback (TiContextRef jsContext, TiObjectR
 				@try 
 				{
 #if CONTEXT_DEBUG == 1	
-					NSLog(@"CONTEXT<%@>: before action event invoke: %@, queue size: %d",self,entry,queueSize-1);
+					NSLog(@"[DEBUG] CONTEXT<%@>: before action event invoke: %@, queue size: %d",self,entry,queueSize-1);
 #endif
 					[self invoke:entry];
 #if CONTEXT_DEBUG == 1	
-					NSLog(@"CONTEXT<%@>: after action event invoke: %@",self,entry);
+					NSLog(@"[DEBUG] CONTEXT<%@>: after action event invoke: %@",self,entry);
 #endif
 				}
 				@catch (NSException * e) 
 				{
 					// this should never happen as we raise a JS exception inside the 
 					// method above but this is a guard anyway
-					NSLog(@"[ERROR] application raised an exception. %@",e);
+					DebugLog(@"[ERROR] Application raised an exception: %@",e);
 				}
 				@finally 
 				{
@@ -1282,7 +1282,7 @@ static TiValueRef StringFormatDecimalCallback (TiContextRef jsContext, TiObjectR
 		
 		
 #if CONTEXT_DEBUG == 1	
-		NSLog(@"CONTEXT<%@>: waiting for new event (count=%d)",self,KrollContextCount);
+		NSLog(@"[DEBUG] CONTEXT<%@>: waiting for new event (count=%d)",self,KrollContextCount);
 #endif
 		
 		[condition lock];
@@ -1300,14 +1300,14 @@ static TiValueRef StringFormatDecimalCallback (TiContextRef jsContext, TiObjectR
 		[condition unlock]; 
 		
 #if CONTEXT_DEBUG == 1	
-		NSLog(@"CONTEXT<%@>: woke up for new event (count=%d)",self,KrollContextCount);
+		NSLog(@"[DEBUG] CONTEXT<%@>: woke up for new event (count=%d)",self,KrollContextCount);
 #endif
 		
 		RELEASE_TO_NIL(innerpool);
 	}
 
 #if CONTEXT_DEBUG == 1	
-	NSLog(@"CONTEXT<%@>: is shutting down",self);
+	NSLog(@"[DEBUG] CONTEXT<%@>: is shutting down",self);
 #endif
 	
 	// call before we start the shutdown while context and timers are alive
@@ -1338,8 +1338,8 @@ static TiValueRef StringFormatDecimalCallback (TiContextRef jsContext, TiObjectR
 	}
 
 #if CONTEXT_MEMORY_DEBUG==1
-	NSLog(@"SHUTDOWN: %@",self);
-	NSLog(@"KROLL RETAIN COUNT: %d",[kroll retainCount]);
+	NSLog(@"[DEBUG] SHUTDOWN: %@",self);
+	NSLog(@"[DEBUG] KROLL RETAIN COUNT: %d",[kroll retainCount]);
 #endif
 	[self destroy];
 

--- a/iphone/Classes/KrollMethod.m
+++ b/iphone/Classes/KrollMethod.m
@@ -44,12 +44,12 @@ TiValueRef KrollCallAsFunction(TiContextRef jsContext, TiObjectRef func, TiObjec
 		}
 #if KMETHOD_DEBUG == 1
 		NSDate *reftime = [NSDate date];
-		NSLog(@"Invoking %@ with args: %@",o,args);
+		NSLog(@"[DEBUG] Invoking %@ with args: %@",o,args);
 #endif
 		id result = [o call:args];
 #if KMETHOD_DEBUG == 1
 		double elapsed = [[NSDate date] timeIntervalSinceDate:reftime];
-		NSLog(@"Invoked %@ with result: %@ [took: %f]",o,result,elapsed);
+		NSLog(@"[DEBUG] Invoked %@ with result: %@ [took: %f]",o,result,elapsed);
 #endif
 		[args release];
 		return [KrollObject toValue:[o context] value:result];
@@ -310,7 +310,7 @@ TiValueRef KrollCallAsFunction(TiContextRef jsContext, TiObjectRef func, TiObjec
 		}
 		default:
 		{
-			NSLog(@"[ERROR] unknown & unsupported primitive return type: %c for target:%@->%@",t,target,NSStringFromSelector(selector));
+			DeveloperLog(@"[ERROR] Unsupported primitive return type: %c for target:%@->%@",t,target,NSStringFromSelector(selector));
 			break;
 		}
 	}

--- a/iphone/Classes/KrollObject.m
+++ b/iphone/Classes/KrollObject.m
@@ -330,11 +330,11 @@ void KrollFinalizer(TiObjectRef ref)
 	}
 	if (![o isKindOfClass:[KrollObject class]])
 	{
-		DebugLog(@"[WARN] object: %@ was not of the right class: %@",o,[o class]);
+		DeveloperLog(@"[WARN] Object %@ was not a KrollObject during finalization, was: %@",o,[o class]);
 		return;
 	}
 #if KOBJECT_MEMORY_DEBUG == 1
-	NSLog(@"[DEBUG] KROLL FINALIZER: %@, retain:%d",o,[o retainCount]);
+	NSLog(@"[KROLL DEBUG] KROLL FINALIZER: %@, retain:%d",o,[o retainCount]);
 #endif
 
 	[(KrollObject *)o setFinalized:YES];
@@ -382,7 +382,7 @@ void KrollInitializer(TiContextRef ctx, TiObjectRef object)
 		return;
 	}
 #if KOBJECT_MEMORY_DEBUG == 1
-	NSLog(@"[DEBUG] KROLL RETAINER: %@ (%@), retain:%d",o,[o class],[o retainCount]);
+	NSLog(@"[KROLL DEBUG] KROLL RETAINER: %@ (%@), retain:%d",o,[o class],[o retainCount]);
 #endif
  
 	if ([o isKindOfClass:[KrollObject class]])
@@ -457,7 +457,7 @@ TiValueRef KrollGetProperty(TiContextRef jsContext, TiObjectRef object, TiString
 		}
 
 #if KOBJECT_DEBUG == 1
-		NSLog(@"[DEBUG] KROLL GET PROPERTY: %@=%@",name,result);
+		NSLog(@"[KROLL DEBUG] KROLL GET PROPERTY: %@=%@",name,result);
 #endif
 		return jsResult;
 	}
@@ -486,7 +486,7 @@ bool KrollSetProperty(TiContextRef jsContext, TiObjectRef object, TiStringRef pr
 
 		id v = TiValueToId([o context], value);
 #if KOBJECT_DEBUG == 1
-		NSLog(@"[DEBUG] KROLL SET PROPERTY: %@=%@ against %@",name,v,o);
+		NSLog(@"[KROLL DEBUG] KROLL SET PROPERTY: %@=%@ against %@",name,v,o);
 #endif
 		if ([v isKindOfClass:[TiProxy class]])
 		{
@@ -633,15 +633,13 @@ bool KrollHasInstance(TiContextRef ctx, TiObjectRef constructor, TiValueRef poss
 		//TODO: See if this actually happens, and if not, remove this extra check.
 		if ([(KrollBridge *)[context_ delegate] usesProxy:target_] && [self isMemberOfClass:[KrollObject class]])
 		{
-			DebugLog(@"[WARN] %@ already has %@!",[context_ delegate],target_);
+			DeveloperLog(@"[WARN] Bridge %@ already has target %@!",[context_ delegate],target_);
 		}
 
 		if (![context_ isKJSThread])
 		{
-			DebugLog(@"[WARN] %@->%@ is being made in a thread not owned by %@",self,target_,context_);
+			DeveloperLog(@"[WARN] %@->%@ is being made in a thread not owned by %@.",self,target_,context_);
 		}
-
-
 #endif
 		target = [target_ retain];
 		context = context_; // don't retain
@@ -678,7 +676,7 @@ bool KrollHasInstance(TiContextRef ctx, TiObjectRef constructor, TiValueRef poss
 -(void)dealloc
 {
 #if KOBJECT_MEMORY_DEBUG == 1
-	NSLog(@"[DEBUG] DEALLOC KROLLOBJECT: %@",[self description]);
+	NSLog(@"[KROLL DEBUG] DEALLOC KROLLOBJECT: %@",[self description]);
 #endif
 	RELEASE_TO_NIL(properties);
 	RELEASE_TO_NIL(target);
@@ -690,7 +688,7 @@ bool KrollHasInstance(TiContextRef ctx, TiObjectRef constructor, TiValueRef poss
 #if KOBJECT_MEMORY_DEBUG == 1
 -(id)description
 {
-	return [NSString stringWithFormat:@"KrollObject[%@] held:%d",target,[target retainCount]];
+	return [NSString stringWithFormat:@"[KROLL DEBUG] KrollObject[%@] held:%d",target,[target retainCount]];
 }
 #endif
 
@@ -1258,7 +1256,7 @@ TI_INLINE TiStringRef TiStringCreateWithPointerValue(int value)
 {
 	if (![context isKJSThread])
 	{
-		DeveloperLog(@"[WARN] %@ tried to note the callback for %@ in the wrong thead.",target,key);
+		DeveloperLog(@"[WARN] %@ tried to protect callback for %@ in the wrong thead.",target,key);
 		NSOperation * safeInvoke = [[ExpandedInvocationOperation alloc]
 				initWithTarget:self selector:_cmd object:eventCallback object:key];
 		[context enqueue:safeInvoke];

--- a/iphone/Classes/KrollObject.m
+++ b/iphone/Classes/KrollObject.m
@@ -296,7 +296,7 @@ TiValueRef ConvertIdTiValue(KrollContext *context, id obj)
 			{
 				if (![context isKJSThread])
 				{
-					NSLog(@"[WARN] Creating %@ in a different context than the calling function.",obj);
+					DebugLog(@"[WARN] Creating %@ in a different context than the calling function.",obj);
 					ourBridge = [KrollBridge krollBridgeForThreadName:[[NSThread currentThread] name]];
 				}
 				return [[ourBridge registerProxy:obj] jsobject];
@@ -305,7 +305,7 @@ TiValueRef ConvertIdTiValue(KrollContext *context, id obj)
 			return [objKrollObject jsobject];
 		}
 		
-		NSLog(@"[WARN] Generating a new TiObject for KrollObject %@ because the contexts %@ and its context %@ differed.",obj,context,ourBridge);
+		DebugLog(@"[WARN] Generating a new TiObject for KrollObject %@ because the contexts %@ and its context %@ differed.",obj,context,ourBridge);
 #ifdef KROLL_COVERAGE
 		KrollObject *o = [[[KrollCoverageObject alloc] initWithTarget:obj context:context] autorelease];
 #else
@@ -330,11 +330,11 @@ void KrollFinalizer(TiObjectRef ref)
 	}
 	if (![o isKindOfClass:[KrollObject class]])
 	{
-		NSLog(@"[WARN] object: %@ was not of the right class: %@",o,[o class]);
+		DebugLog(@"[WARN] object: %@ was not of the right class: %@",o,[o class]);
 		return;
 	}
 #if KOBJECT_MEMORY_DEBUG == 1
-	NSLog(@"KROLL FINALIZER: %@, retain:%d",o,[o retainCount]);
+	NSLog(@"[DEBUG] KROLL FINALIZER: %@, retain:%d",o,[o retainCount]);
 #endif
 
 	[(KrollObject *)o setFinalized:YES];
@@ -382,7 +382,7 @@ void KrollInitializer(TiContextRef ctx, TiObjectRef object)
 		return;
 	}
 #if KOBJECT_MEMORY_DEBUG == 1
-	NSLog(@"KROLL RETAINER: %@ (%@), retain:%d",o,[o class],[o retainCount]);
+	NSLog(@"[DEBUG] KROLL RETAINER: %@ (%@), retain:%d",o,[o class],[o retainCount]);
 #endif
  
 	if ([o isKindOfClass:[KrollObject class]])
@@ -393,7 +393,7 @@ void KrollInitializer(TiContextRef ctx, TiObjectRef object)
 		[o setPropsObject:propsObject];
 	}
 	else {
-		NSLog(@"[DEBUG] initializer for %@",[o class]);
+		DeveloperLog(@"[DEBUG] Initializer for %@",[o class]);
 	}
 
 }
@@ -457,7 +457,7 @@ TiValueRef KrollGetProperty(TiContextRef jsContext, TiObjectRef object, TiString
 		}
 
 #if KOBJECT_DEBUG == 1
-		NSLog(@"KROLL GET PROPERTY: %@=%@",name,result);
+		NSLog(@"[DEBUG] KROLL GET PROPERTY: %@=%@",name,result);
 #endif
 		return jsResult;
 	}
@@ -486,7 +486,7 @@ bool KrollSetProperty(TiContextRef jsContext, TiObjectRef object, TiStringRef pr
 
 		id v = TiValueToId([o context], value);
 #if KOBJECT_DEBUG == 1
-		NSLog(@"KROLL SET PROPERTY: %@=%@ against %@",name,v,o);
+		NSLog(@"[DEBUG] KROLL SET PROPERTY: %@=%@ against %@",name,v,o);
 #endif
 		if ([v isKindOfClass:[TiProxy class]])
 		{
@@ -633,12 +633,12 @@ bool KrollHasInstance(TiContextRef ctx, TiObjectRef constructor, TiValueRef poss
 		//TODO: See if this actually happens, and if not, remove this extra check.
 		if ([(KrollBridge *)[context_ delegate] usesProxy:target_] && [self isMemberOfClass:[KrollObject class]])
 		{
-			NSLog(@"[WARN] %@ already has %@!",[context_ delegate],target_);
+			DebugLog(@"[WARN] %@ already has %@!",[context_ delegate],target_);
 		}
 
 		if (![context_ isKJSThread])
 		{
-			NSLog(@"[WARN] %@->%@ is being made in a thread not owned by %@",self,target_,context_);
+			DebugLog(@"[WARN] %@->%@ is being made in a thread not owned by %@",self,target_,context_);
 		}
 
 
@@ -678,7 +678,7 @@ bool KrollHasInstance(TiContextRef ctx, TiObjectRef constructor, TiValueRef poss
 -(void)dealloc
 {
 #if KOBJECT_MEMORY_DEBUG == 1
-	NSLog(@"DEALLOC KROLLOBJECT: %@",[self description]);
+	NSLog(@"[DEBUG] DEALLOC KROLLOBJECT: %@",[self description]);
 #endif
 	RELEASE_TO_NIL(properties);
 	RELEASE_TO_NIL(target);
@@ -1016,7 +1016,7 @@ bool KrollHasInstance(TiContextRef ctx, TiObjectRef constructor, TiValueRef poss
 				else 
 				{
 					// let it fall through and return undefined
-					NSLog(@"[WARN] unsupported property: %@ for %@, attributes = %@",key,target,attributes);
+					DeveloperLog(@"[WARN] Unsupported property: %@ for %@, attributes = %@",key,target,attributes);
 				}
 			}
 		}
@@ -1258,7 +1258,7 @@ TI_INLINE TiStringRef TiStringCreateWithPointerValue(int value)
 {
 	if (![context isKJSThread])
 	{
-		NSLog(@"[WARN] %@ tried to note the callback for %@ in the wrong thead.",target,key);
+		DeveloperLog(@"[WARN] %@ tried to note the callback for %@ in the wrong thead.",target,key);
 		NSOperation * safeInvoke = [[ExpandedInvocationOperation alloc]
 				initWithTarget:self selector:_cmd object:eventCallback object:key];
 		[context enqueue:safeInvoke];
@@ -1341,7 +1341,7 @@ TI_INLINE TiStringRef TiStringCreateWithPointerValue(int value)
 
 	if (![context isKJSThread])
 	{
-		NSLog(@"[WARN] %@ tried to note the callback for %@ in the wrong thead.",target,key);
+		DeveloperLog(@"[WARN] %@ tried to note the callback for %@ in the wrong thead.",target,key);
 		NSOperation * safeInvoke = [[ExpandedInvocationOperation alloc]
 				initWithTarget:self selector:_cmd object:value object:key];
 		[context enqueue:safeInvoke];
@@ -1565,7 +1565,7 @@ TI_INLINE TiStringRef TiStringCreateWithPointerValue(int value)
 		TiObjectCallAsFunction(jsContext, (TiObjectRef)currentCallback, [thisObject jsobject], 1, &jsEventData,&exception);
 		if (exception!=NULL)
 		{
-			NSLog(@"[WARN] Exception in event callback. %@",[KrollObject toID:context value:exception]);
+			DebugLog(@"[WARN] Exception in event callback. %@",[KrollObject toID:context value:exception]);
 		}
 	}
 }

--- a/iphone/Classes/KrollTimer.m
+++ b/iphone/Classes/KrollTimer.m
@@ -67,7 +67,7 @@
 	if (exception!=NULL)
 	{
 		id excm = [KrollObject toID:kroll value:exception];
-		NSLog(@"[ERROR] While executing Timer, received script error. '%@'",[TiUtils exceptionMessage:excm]);
+		DebugLog(@"[ERROR] While executing Timer, received script error. '%@'",[TiUtils exceptionMessage:excm]);
 	}
 	[invokeCond unlockWithCondition:1];
 }

--- a/iphone/Classes/LayoutConstraint.m
+++ b/iphone/Classes/LayoutConstraint.m
@@ -331,7 +331,7 @@ void ApplyConstraintToViewWithBounds(LayoutConstraint * constraint, TiUIView * s
 {
 	if(constraint == NULL)
 	{
-		NSLog(@"[ERROR] Trying to constraint a view without a proxy's layout.");
+		DebugLog(@"[ERROR] Trying to constrain a view without a proxy's layout.");
 		return;
 	}
 

--- a/iphone/Classes/LayoutConstraint.m
+++ b/iphone/Classes/LayoutConstraint.m
@@ -331,7 +331,7 @@ void ApplyConstraintToViewWithBounds(LayoutConstraint * constraint, TiUIView * s
 {
 	if(constraint == NULL)
 	{
-		DebugLog(@"[ERROR] Trying to constrain a view without a proxy's layout.");
+		DebugLog(@"[ERROR] No constraints available for view %@.", subView);
 		return;
 	}
 

--- a/iphone/Classes/MGSplitView/MGSplitViewController.m
+++ b/iphone/Classes/MGSplitView/MGSplitViewController.m
@@ -279,7 +279,7 @@
 	float height = fullSize.height;
 	
 	if (NO) { // Just for debugging.
-		NSLog(@"Target orientation is %@, dimensions will be %.0f x %.0f", 
+		DeveloperLog(@"Target orientation is %@, dimensions will be %.0f x %.0f", 
 			  [self nameOfInterfaceOrientation:theOrientation], width, height);
 	}
 	
@@ -961,7 +961,7 @@
 			self.masterViewController = [controllers objectAtIndex:0];
 			self.detailViewController = [controllers objectAtIndex:1];
 		} else {
-			NSLog(@"Error: %@ requires 2 view-controllers. (%@)", NSStringFromClass([self class]), NSStringFromSelector(_cmd));
+			DeveloperLog(@"[ERROR] %@ requires 2 view-controllers. (%@)", NSStringFromClass([self class]), NSStringFromSelector(_cmd));
 		}
 		
 		[self layoutSubviews];

--- a/iphone/Classes/MediaModule.m
+++ b/iphone/Classes/MediaModule.m
@@ -830,7 +830,7 @@ MAKE_SYSTEM_PROP(VIDEO_FINISH_REASON_USER_EXITED,MPMovieFinishReasonUserExited);
 	else 
 	{
 		RELEASE_TO_NIL(editor);
-		NSLog(@"[ERROR] unsupported video media. %@",[media class]);
+		NSLog(@"[ERROR] Unsupported video media: %@",[media class]);
 		return;
 	}
 	
@@ -1253,13 +1253,13 @@ MAKE_SYSTEM_PROP(VIDEO_FINISH_REASON_USER_EXITED,MPMovieFinishReasonUserExited);
 
 -(void)setDefaultAudioSessionMode:(NSNumber*)mode
 {
-	NSLog(@"[WARN] Deprecated; use 'audioSessionMode'");
+	DebugLog(@"[WARN] Deprecated; use 'audioSessionMode'");
     [[TiMediaAudioSession sharedSession] setSessionMode:[mode unsignedIntValue]];
 } 
 
 -(NSNumber*)defaultAudioSessionMode
 {
-	NSLog(@"[WARN] Deprecated; use 'audioSessionMode'");	
+	DebugLog(@"[WARN] Deprecated; use 'audioSessionMode'");	
     return [NSNumber numberWithUnsignedInt:[[TiMediaAudioSession sharedSession] sessionMode]];
 }
 

--- a/iphone/Classes/OperationQueue.m
+++ b/iphone/Classes/OperationQueue.m
@@ -73,7 +73,7 @@ OperationQueue *sharedQueue = nil;
 	}
 	@catch (NSException * e) 
 	{
-		DeveloperLog(@"[ERROR] unhandled exception raised in OperationQueue. Exception was %@",[e description]);
+		DeveloperLog(@"[ERROR] Unhandled exception raised in OperationQueue. Exception was %@",[e description]);
 	}
 	[pool release];
 }

--- a/iphone/Classes/OperationQueue.m
+++ b/iphone/Classes/OperationQueue.m
@@ -73,7 +73,7 @@ OperationQueue *sharedQueue = nil;
 	}
 	@catch (NSException * e) 
 	{
-		NSLog(@"[ERROR] unhandled exception raised in OperationQueue. Exception was %@",[e description]);
+		DeveloperLog(@"[ERROR] unhandled exception raised in OperationQueue. Exception was %@",[e description]);
 	}
 	[pool release];
 }

--- a/iphone/Classes/SBJSON.m
+++ b/iphone/Classes/SBJSON.m
@@ -144,11 +144,11 @@ static char ctrl[0x24];
 			
 			
 			// ATTEMPT TO FIGURE OUT WHAT WENT WRONG
-			NSLog(@"[DEBUG] QUERY URL = %@",inputUrl);
-			NSLog(@"[DEBUG] QUERY STRING = %@",queryString);
-			NSLog(@"[DEBUG] QUERY STRING PRE-ESCAPED = %@",prequery);
-			NSLog(@"[DEBUG] QUERY STRING ESCAPED = %@",query);
-			NSLog(@"[ERROR] Error in decodeUrlQuery(%@): %@",queryString,error);
+			DebugLog(@"[DEBUG] QUERY URL = %@",inputUrl);
+			DebugLog(@"[DEBUG] QUERY STRING = %@",queryString);
+			DebugLog(@"[DEBUG] QUERY STRING PRE-ESCAPED = %@",prequery);
+			DebugLog(@"[DEBUG] QUERY STRING ESCAPED = %@",query);
+			DebugLog(@"[ERROR] Error in decodeUrlQuery(%@): %@",queryString,error);
 		}
 		[jsonDecoder release];
 		return result;
@@ -163,7 +163,7 @@ static char ctrl[0x24];
 	NSString * result = [stringer stringWithFragment:inputObject error:&error];
 	[stringer release];
 	if (error != nil) {
-		NSLog(@"[ERROR] Error in stringify(%@): %@",inputObject,error);
+		DebugLog(@"[ERROR] Error in stringify(%@): %@",inputObject,error);
 	}
 	return result;
 }
@@ -585,7 +585,7 @@ static char ctrl[0x24];
         
         if (![self scanValue:&v error:error]) {
 			if(error){
-				NSLog(@"[DEBUG] error in parser = %@",*error);
+				DeveloperLog(@"[DEBUG] error in parser = %@",*error);
 				*error = errWithUnderlier(EPARSE, error, @"Expected value while parsing array");
 			}
             return NO;
@@ -808,7 +808,7 @@ static char ctrl[0x24];
             return NO;
             
         } else {
-            NSLog(@"[ERROR] should not be able to get here in SBJSON.m");
+            DeveloperLog(@"[ERROR] should not be able to get here in SBJSON.m");
         }
     } while (*c);
     

--- a/iphone/Classes/SBJSON.m
+++ b/iphone/Classes/SBJSON.m
@@ -585,7 +585,7 @@ static char ctrl[0x24];
         
         if (![self scanValue:&v error:error]) {
 			if(error){
-				DeveloperLog(@"[DEBUG] error in parser = %@",*error);
+				DeveloperLog(@"[DEBUG] Error in parser: %@",*error);
 				*error = errWithUnderlier(EPARSE, error, @"Expected value while parsing array");
 			}
             return NO;
@@ -808,7 +808,7 @@ static char ctrl[0x24];
             return NO;
             
         } else {
-            DeveloperLog(@"[ERROR] should not be able to get here in SBJSON.m");
+            DeveloperLog(@"[ERROR] Should not be able to get here in SBJSON.m");
         }
     } while (*c);
     

--- a/iphone/Classes/TiAnimation.m
+++ b/iphone/Classes/TiAnimation.m
@@ -234,7 +234,7 @@ self.p = v;\
 -(void)animationStarted:(NSString *)animationID context:(void *)context
 {
 #if ANIMATION_DEBUG==1	
-	NSLog(@"ANIMATION: STARTING %@, %@",self,(id)context);
+	NSLog(@"[DEBUG] ANIMATION: STARTING %@, %@",self,(id)context);
 #endif
 	
 	TiAnimation* animation = (TiAnimation*)context;
@@ -257,7 +257,7 @@ self.p = v;\
 -(void)animationCompleted:(NSString *)animationID finished:(NSNumber *)finished context:(void *)context
 {
 #if ANIMATION_DEBUG==1	
-	NSLog(@"ANIMATION: COMPLETED %@, %@",self,(id)context);
+	NSLog(@"[DEBUG] ANIMATION: COMPLETED %@, %@",self,(id)context);
 #endif
 	
 	TiAnimation* animation = (TiAnimation*)context;
@@ -346,7 +346,7 @@ if (!TiDimensionIsUndefined(autoreverseLayout.a)) {\
 	ENSURE_UI_THREAD(animate,args);
 
 #if ANIMATION_DEBUG==1
-	NSLog(@"ANIMATION: starting %@, %@, retain: %d",self,args,[self retainCount]);
+	NSLog(@"[DEBUG] ANIMATION: starting %@, %@, retain: %d",self,args,[self retainCount]);
 #endif
 	
 	UIView *theview = nil;
@@ -585,7 +585,7 @@ autoreverseLayout.a = TiDimensionUndefined; \
 
 	
 #if ANIMATION_DEBUG==1	
-	NSLog(@"ANIMATION: committed %@, %@",self,args);
+	NSLog(@"[DEBUG] ANIMATION: committed %@, %@",self,args);
 #endif
 }
 

--- a/iphone/Classes/TiApp.mm
+++ b/iphone/Classes/TiApp.mm
@@ -212,7 +212,7 @@ TI_INLINE void waitForMemoryPanicCleared();   //WARNING: This must never be run 
 
 - (void)boot
 {
-	NSLog(@"[INFO] %@/%@ (%s.__GITHASH__)",TI_APPLICATION_NAME,TI_APPLICATION_VERSION,TI_VERSION_STR);
+	DebugLog(@"[INFO] %@/%@ (%s.__GITHASH__)",TI_APPLICATION_NAME,TI_APPLICATION_VERSION,TI_VERSION_STR);
 	
 	sessionId = [[TiUtils createUUID] retain];
 	TITANIUM_VERSION = [[NSString stringWithCString:TI_VERSION_STR encoding:NSUTF8StringEncoding] retain];
@@ -245,7 +245,7 @@ TI_INLINE void waitForMemoryPanicCleared();   //WARNING: This must never be run 
 {
 	if ([bridge isKindOfClass:[KrollBridge class]])
 	{
-		NSLog(@"[DEBUG] application booted in %f ms", ([NSDate timeIntervalSinceReferenceDate]-started) * 1000);
+		DebugLog(@"[DEBUG] application booted in %f ms", ([NSDate timeIntervalSinceReferenceDate]-started) * 1000);
 		fflush(stderr);
 		TiThreadPerformOnMainThread(^{[self validator];}, YES);
 	}
@@ -268,12 +268,12 @@ TI_INLINE void waitForMemoryPanicCleared();   //WARNING: This must never be run 
 	for (id key in aps) 
 	{
 		if ([dict objectForKey:key] != nil) {
-			NSLog(@"[WARN] Conflicting keys in push APS dictionary and notification dictionary `%@`, not copying to toplevel from APS", key);
+			DebugLog(@"[WARN] Conflicting keys in push APS dictionary and notification dictionary `%@`, not copying to toplevel from APS", key);
 			continue;
 		}
 		[remoteNotification setValue:[aps valueForKey:key] forKey:key];
 	}
-	NSLog(@"[WARN] Accessing APS keys from toplevel of notification is deprecated");
+	DebugLog(@"[WARN] Accessing APS keys from toplevel of notification is deprecated");
 }
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions_
@@ -514,7 +514,7 @@ TI_INLINE void waitForMemoryPanicCleared();   //WARNING: This must never be run 
 		[[NSUserDefaults standardUserDefaults] setObject:remoteDeviceUUID forKey:@"APNSRemoteDeviceUUID"];
 		NSDictionary *userInfo = [NSDictionary dictionaryWithObject:remoteDeviceUUID forKey:@"deviceid"];
 		[[NSNotificationCenter defaultCenter] postNotificationName:kTiRemoteDeviceUUIDNotification object:self userInfo:userInfo];
-		NSLog(@"[DEBUG] registered new device ready for remote push notifications: %@",remoteDeviceUUID);
+		DebugLog(@"[DEBUG] registered new device ready for remote push notifications: %@",remoteDeviceUUID);
 	}
 	
 	if (remoteNotificationDelegate!=nil)
@@ -538,7 +538,7 @@ TI_INLINE void waitForMemoryPanicCleared();   //WARNING: This must never be run 
 {
 	if ([TI_APPLICATION_DEPLOYTYPE isEqualToString:@"production"])
 	{
-		NSLog(@"[ERROR] application received error: %@",message);
+		NSLog(@"[ERROR] Application received error: %@",message);
 		return;
 	}
 	ENSURE_UI_THREAD(showModalError,message);
@@ -552,7 +552,7 @@ TI_INLINE void waitForMemoryPanicCleared();   //WARNING: This must never be run 
 
 	if (currentModalController == modalController)
 	{
-		NSLog(@"[WARN] Trying to present a modal window that already is a modal window.");
+		DeveloperLog(@"[WARN] Trying to present a modal window that already is a modal window.");
 		return;
 	}
 	if (currentModalController == nil)

--- a/iphone/Classes/TiApp.mm
+++ b/iphone/Classes/TiApp.mm
@@ -245,7 +245,7 @@ TI_INLINE void waitForMemoryPanicCleared();   //WARNING: This must never be run 
 {
 	if ([bridge isKindOfClass:[KrollBridge class]])
 	{
-		DebugLog(@"[DEBUG] application booted in %f ms", ([NSDate timeIntervalSinceReferenceDate]-started) * 1000);
+		DebugLog(@"[DEBUG] Application booted in %f ms", ([NSDate timeIntervalSinceReferenceDate]-started) * 1000);
 		fflush(stderr);
 		TiThreadPerformOnMainThread(^{[self validator];}, YES);
 	}
@@ -514,7 +514,7 @@ TI_INLINE void waitForMemoryPanicCleared();   //WARNING: This must never be run 
 		[[NSUserDefaults standardUserDefaults] setObject:remoteDeviceUUID forKey:@"APNSRemoteDeviceUUID"];
 		NSDictionary *userInfo = [NSDictionary dictionaryWithObject:remoteDeviceUUID forKey:@"deviceid"];
 		[[NSNotificationCenter defaultCenter] postNotificationName:kTiRemoteDeviceUUIDNotification object:self userInfo:userInfo];
-		DebugLog(@"[DEBUG] registered new device ready for remote push notifications: %@",remoteDeviceUUID);
+		DebugLog(@"[DEBUG] Registered new device for remote push notifications: %@",remoteDeviceUUID);
 	}
 	
 	if (remoteNotificationDelegate!=nil)

--- a/iphone/Classes/TiBase.h
+++ b/iphone/Classes/TiBase.h
@@ -368,13 +368,13 @@ return map;\
 }\
 
 #define DEPRECATED_REMOVED(api,in,removed) \
-NSLog(@"[WARN] Ti%@.%@ DEPRECATED in %@: REMOVED in %@",@"tanium",api,in,removed);
+DebugLog(@"[WARN] Ti%@.%@ DEPRECATED in %@: REMOVED in %@",@"tanium",api,in,removed);
     
 #define DEPRECATED_REPLACED_REMOVED(api,in,removed,newapi) \
-NSLog(@"[WARN] Ti%@.%@ DEPRECATED in %@, in favor of %@: REMOVED in %@",@"tanium",api,in,newapi,removed);
+DebugLog(@"[WARN] Ti%@.%@ DEPRECATED in %@, in favor of %@: REMOVED in %@",@"tanium",api,in,newapi,removed);
 
 #define DEPRECATED_REPLACED(api,in,newapi) \
-NSLog(@"[WARN] Ti%@.%@ DEPRECATED in %@, in favor of %@.",@"tanium",api,in,newapi);
+DebugLog(@"[WARN] Ti%@.%@ DEPRECATED in %@, in favor of %@.",@"tanium",api,in,newapi);
     
 #define NUMBOOL(x) \
 [NSNumber numberWithBool:x]\
@@ -480,15 +480,23 @@ return value;\
 //#define VERBOSE
 
 #ifdef VERBOSE
-
 #define VerboseLog(...)	{NSLog(__VA_ARGS__);}
-
 #else
-
 #define VerboseLog(...)	{}
-
 #endif
 
+#ifdef DEVELOPER
+#define DeveloperLog(...) { NSLog(__VA_ARGS__); }
+#else
+#define DeveloperLog(...) {}
+#endif
+    
+#if defined(DEBUG) || defined(DEVELOPER)
+#define DebugLog(...) { NSLog(__VA_ARGS__); }
+#else
+#define DebugLog(...) {}
+#endif
+    
 #define VAL_OR_NSNULL(foo)	(((foo) != nil)?((id)foo):[NSNull null])
 
 

--- a/iphone/Classes/TiBase.m
+++ b/iphone/Classes/TiBase.m
@@ -233,7 +233,7 @@ void TiThreadPerformOnMainThread(void (^mainBlock)(void),BOOL waitForFinish)
         dispatch_time_t oneSecond = dispatch_time(DISPATCH_TIME_NOW, NSEC_PER_SEC);
         BOOL waiting = dispatch_semaphore_wait(waitSemaphore, oneSecond);
         if (waiting) {
-            NSLog(@"[WARN] Timing out waiting on main thread. Possibly a deadlock? %@",CODELOCATION);
+            DeveloperLog(@"[WARN] Timing out waiting on main thread. Possibly a deadlock? %@",CODELOCATION);
             dispatch_semaphore_wait(waitSemaphore, DISPATCH_TIME_FOREVER);
         }
         dispatch_release(waitSemaphore);

--- a/iphone/Classes/TiDataStream.m
+++ b/iphone/Classes/TiDataStream.m
@@ -89,7 +89,7 @@
     // Sanity check for mutable data (just in case...)
     if (![data isKindOfClass:[NSMutableData class]]) {
         NSString* errorStr = [NSString stringWithFormat:@"[ERROR] Attempt to write to unwritable stream"];
-        NSLog(errorStr);
+        DebugLog(errorStr);
         if (callback != nil) {
             NSDictionary* event = [NSDictionary dictionaryWithObjectsAndKeys:self,@"source",NUMINT(-1),@"bytesProcessed",errorStr,@"errorDescription",NUMINT(-1),@"errorState", nil];
             [self _fireEventToListener:@"write" withObject:event listener:callback thisObject:nil];

--- a/iphone/Classes/TiDimension.h
+++ b/iphone/Classes/TiDimension.h
@@ -164,12 +164,12 @@ TI_INLINE TiDimension TiDimensionFromObject(id object)
                 return TiDimensionMake(TiDimensionTypeDip, convertPixelsToDip(pixelVal));
             }
             else {
-                NSLog(@"Property ti.ui.defaultunit is not valid value. Defaulting to system");
+                DebugLog(@"[WARN] Property ti.ui.defaultunit is not valid value. Defaulting to system");
                 return TiDimensionMake(TiDimensionTypeDip, [object floatValue]);
             }
         }
         else {
-            NSLog(@"Property ti.ui.defaultunit is not of type string. Defaulting to system");
+            DebugLog(@"[WARN] Property ti.ui.defaultunit is not of type string. Defaulting to system");
             return TiDimensionMake(TiDimensionTypeDip, [object floatValue]);
         }
 	}

--- a/iphone/Classes/TiDimension.m
+++ b/iphone/Classes/TiDimension.m
@@ -18,11 +18,11 @@ const TiDimension TiDimensionUndefined = {TiDimensionTypeUndefined, 0};
 TiDimension TiDimensionMake(TiDimensionType type, CGFloat value)
 {
 	if ((value!=0)&&(!isnormal(value))) {
-		NSLog(@"[FATAL] Invalid dimension value (%f) requested. Making the dimension undefined instead.",value);
+		DebugLog(@"[WARN] Invalid dimension value (%f) requested. Making the dimension undefined instead.",value);
 		return TiDimensionUndefined;
 	}
 	if (!((value > -1e5)&&(value < 1e5))) {
-		NSLog(@"[FATAL] Extreme dimension value (%f) requested. Allowing, just in case this is intended.",value);
+		DebugLog(@"[WARN] Extreme dimension value (%f) requested. Allowing, just in case this is intended.",value);
 	}
 	TiDimension dimension;
 	dimension.type = type;

--- a/iphone/Classes/TiFacebookLoginButton.m
+++ b/iphone/Classes/TiFacebookLoginButton.m
@@ -63,12 +63,12 @@
 	if ([style isEqualToString:@"wide"]) 
 	{
 		buttonStyle = FB_LOGIN_BUTTON_WIDE;
-		NSLog(@"[WARN] Styling Options 'wide' will be DEPRECATED in 1.8.0 in favour of Ti.Facebook.BUTTON_STYLE_WIDE: REMOVED in 1.9) ");
+		DebugLog(@"[WARN] Styling Options 'wide' will be DEPRECATED in 1.8.0 in favour of Ti.Facebook.BUTTON_STYLE_WIDE: REMOVED in 1.9) ");
 		
 	}
 	if([style isEqualToString:@"normal"]) {
 		buttonStyle = FB_LOGIN_BUTTON_NORMAL;
-		NSLog(@"[WARN] Styling Options 'normal' will be DEPRECATED in 1.8.0 in favour of Ti.Facebook.BUTTON_STYLE_NORMAL: REMOVED in 1.9) ");
+		DebugLog(@"[WARN] Styling Options 'normal' will be DEPRECATED in 1.8.0 in favour of Ti.Facebook.BUTTON_STYLE_NORMAL: REMOVED in 1.9) ");
 	}
 	
 	

--- a/iphone/Classes/TiFacebookLoginButton.m
+++ b/iphone/Classes/TiFacebookLoginButton.m
@@ -60,17 +60,6 @@
 -(int)getStyleAndChangeSize:(id)style
 {
 	int buttonStyle = [TiUtils intValue:style];
-	if ([style isEqualToString:@"wide"]) 
-	{
-		buttonStyle = FB_LOGIN_BUTTON_WIDE;
-		DebugLog(@"[WARN] Styling Options 'wide' will be DEPRECATED in 1.8.0 in favour of Ti.Facebook.BUTTON_STYLE_WIDE: REMOVED in 1.9) ");
-		
-	}
-	if([style isEqualToString:@"normal"]) {
-		buttonStyle = FB_LOGIN_BUTTON_NORMAL;
-		DebugLog(@"[WARN] Styling Options 'normal' will be DEPRECATED in 1.8.0 in favour of Ti.Facebook.BUTTON_STYLE_NORMAL: REMOVED in 1.9) ");
-	}
-	
 	
 	CGRect frame = [self frameForButtonStyle:buttonStyle];
 	

--- a/iphone/Classes/TiHost.m
+++ b/iphone/Classes/TiHost.m
@@ -169,7 +169,7 @@ extern NSString * const TI_APPLICATION_ID;
 -(void)fireEvent:(id)listener withObject:(id)obj remove:(BOOL)yn context:(id<TiEvaluator>)evaluator thisObject:(TiProxy*)thisObject_
 {
 #if DEBUG_EVENTS==1
-	NSLog(@"fireEvent: %@, object: %@",listener,obj);
+	NSLog(@"[DEBUG] fireEvent: %@, object: %@",listener,obj);
 #endif	
 	[evaluator fireEvent:listener withObject:obj remove:yn thisObject:thisObject_];
 }

--- a/iphone/Classes/TiMediaAudioPlayerProxy.m
+++ b/iphone/Classes/TiMediaAudioPlayerProxy.m
@@ -262,16 +262,16 @@ MAKE_SYSTEM_PROP(STATE_PAUSED,AS_PAUSED);
 {
     UInt32 newMode = [mode unsignedIntegerValue]; // Close as we can get to UInt32
     if (newMode == kAudioSessionCategory_RecordAudio) {
-        NSLog(@"[WARN] Invalid mode for audio player... setting to default.");
+        DebugLog(@"[WARN] Invalid mode for audio player... setting to default.");
         newMode = kAudioSessionCategory_SoloAmbientSound;
     }
-	NSLog(@"[WARN] 'Titanium.Media.AudioPlayer.audioSessionMode' is deprecated; use 'Titanium.Media.audioSessionMode'");
+	DebugLog(@"[WARN] 'Titanium.Media.AudioPlayer.audioSessionMode' is deprecated; use 'Titanium.Media.audioSessionMode'");
 	[[TiMediaAudioSession sharedSession] setSessionMode:newMode];
 }
 
 -(NSNumber*)audioSessionMode
 {
-	NSLog(@"[WARN] 'Titanium.Media.AudioPlayer.audioSessionMode' is deprecated; use 'Titanium.Media.audioSessionMode'");	
+	DebugLog(@"[WARN] 'Titanium.Media.AudioPlayer.audioSessionMode' is deprecated; use 'Titanium.Media.audioSessionMode'");	
     return [NSNumber numberWithUnsignedInteger:[[TiMediaAudioSession sharedSession] sessionMode]];
 }
 

--- a/iphone/Classes/TiMediaAudioRecorderProxy.mm
+++ b/iphone/Classes/TiMediaAudioRecorderProxy.mm
@@ -116,7 +116,7 @@
 				break;
 			default:
 			{
-				NSLog(@"[WARN] unsupported recording audio format: %d",fmt);
+				NSLog(@"[WARN] Unsupported recording audio format: %d",fmt);
 			}
 		}
 		
@@ -201,16 +201,16 @@
 {
     UInt32 newMode = [mode unsignedIntegerValue]; // Close as we can get to UInt32
     if (newMode != kAudioSessionCategory_RecordAudio && newMode != kAudioSessionCategory_PlayAndRecord) {
-        NSLog(@"[WARN] Invalid mode for audio recorder... setting to default.");
+        DebugLog(@"[WARN] Invalid mode for audio recorder... setting to default.");
         newMode = kAudioSessionCategory_RecordAudio;
     }
-	NSLog(@"[WARN] 'Titanium.Media.AudioRecorder.audioSessionMode' is deprecated; use 'Titanium.Media.audioSessionMode'");
+	DebugLog(@"[WARN] 'Titanium.Media.AudioRecorder.audioSessionMode' is deprecated; use 'Titanium.Media.audioSessionMode'");
 	[[TiMediaAudioSession sharedSession] setSessionMode:newMode];
 }
 
 -(NSNumber*)audioSessionMode
 {
-	NSLog(@"[WARN] 'Titanium.Media.AudioRecorder.audioSessionMode' is deprecated; use 'Titanium.Media.audioSessionMode'");	
+	DebugLog(@"[WARN] 'Titanium.Media.AudioRecorder.audioSessionMode' is deprecated; use 'Titanium.Media.audioSessionMode'");	
     return [NSNumber numberWithUnsignedInt:[[TiMediaAudioSession sharedSession] sessionMode]];
 }
 

--- a/iphone/Classes/TiMediaAudioSession.m
+++ b/iphone/Classes/TiMediaAudioSession.m
@@ -122,7 +122,7 @@ void TiAudioSessionInputAvailableCallback(void* inUserData, AudioSessionProperty
 
 - (void)dealloc {
     if ([self isActive]) {
-        NSLog(@"[WARN] AudioSession being deallocated is still active");
+        DeveloperLog(@"[WARN] AudioSession being deallocated is still active");
         [self deactivateSession];
     }
     RELEASE_TO_NIL(lock);
@@ -276,7 +276,7 @@ void TiAudioSessionInputAvailableCallback(void* inUserData, AudioSessionProperty
 -(void)setSessionMode:(UInt32)mode
 {
 	if ([self isActive]) {
-		NSLog(@"[WARN] Setting audio mode while playing audio... changes will not take effect until audio is restarted.");
+		DebugLog(@"[WARN] Setting audio mode while playing audio... changes will not take effect until audio is restarted.");
 	}
 	AudioSessionSetProperty(kAudioSessionProperty_AudioCategory, sizeof(mode), &mode);
 }

--- a/iphone/Classes/TiMediaSoundProxy.m
+++ b/iphone/Classes/TiMediaSoundProxy.m
@@ -274,13 +274,6 @@
     });
 }
 
-// For backwards compatibility
--(void)setSound:(id)sound
-{
-	DebugLog(@"[WARN] Deprecated; use 'url'");
-	[self setUrl:sound];
-}
-
 -(NSURL*)url
 {
 	return url;

--- a/iphone/Classes/TiMediaSoundProxy.m
+++ b/iphone/Classes/TiMediaSoundProxy.m
@@ -277,7 +277,7 @@
 // For backwards compatibility
 -(void)setSound:(id)sound
 {
-	NSLog(@"[WARN] Deprecated; use 'url'");
+	DebugLog(@"[WARN] Deprecated; use 'url'");
 	[self setUrl:sound];
 }
 
@@ -290,16 +290,16 @@
 {
     UInt32 newMode = [mode unsignedIntegerValue]; // Close as we can get to UInt32
     if (newMode == kAudioSessionCategory_RecordAudio) {
-        NSLog(@"[WARN] Invalid mode for audio player... setting to default.");
+        DebugLog(@"[WARN] Invalid mode for audio player... setting to default.");
         newMode = kAudioSessionCategory_SoloAmbientSound;
     }
-	NSLog(@"[WARN] 'Titanium.Media.Sound.audioSessionMode' is deprecated; use 'Titanium.Media.audioSessionMode'");
+	DebugLog(@"[WARN] 'Titanium.Media.Sound.audioSessionMode' is deprecated; use 'Titanium.Media.audioSessionMode'");
 	[[TiMediaAudioSession sharedSession] setSessionMode:newMode];
 }
 
 -(NSNumber*)audioSessionMode
 {
-	NSLog(@"[WARN] 'Titanium.Media.Sound.audioSessionMode' is deprecated; use 'Titanium.Media.audioSessionMode'");
+	DebugLog(@"[WARN] 'Titanium.Media.Sound.audioSessionMode' is deprecated; use 'Titanium.Media.audioSessionMode'");
     return [NSNumber numberWithUnsignedInteger:[[TiMediaAudioSession sharedSession] sessionMode]];
 }
 

--- a/iphone/Classes/TiMediaVideoPlayerProxy.m
+++ b/iphone/Classes/TiMediaVideoPlayerProxy.m
@@ -389,7 +389,7 @@ NSArray* moviePlayerKeys = nil;
 		}
 		else
 		{
-			NSLog(@"[ERROR] unsupported blob for video player. %@",media_);
+			NSLog(@"[ERROR] Unsupported blob for video player: %@",media_);
 		}
 	}
 	else 

--- a/iphone/Classes/TiModule.m
+++ b/iphone/Classes/TiModule.m
@@ -149,7 +149,7 @@
 		resultClass = NSClassFromString(className);
 		if (resultClass==nil)
 		{
-			DebugLog(@"[WARN] attempted to load: %@",className);
+			DebugLog(@"[WARN] Attempted to load %@: Could not find class definition.",className);
 			@throw [NSException exceptionWithName:@"org.appcelerator.module" 
 										   reason:[NSString stringWithFormat:@"invalid method (%@) passed to %@",name,[self class]] 
 										 userInfo:nil];

--- a/iphone/Classes/TiModule.m
+++ b/iphone/Classes/TiModule.m
@@ -149,7 +149,7 @@
 		resultClass = NSClassFromString(className);
 		if (resultClass==nil)
 		{
-			NSLog(@"[WARN] attempted to load: %@",className);
+			DebugLog(@"[WARN] attempted to load: %@",className);
 			@throw [NSException exceptionWithName:@"org.appcelerator.module" 
 										   reason:[NSString stringWithFormat:@"invalid method (%@) passed to %@",name,[self class]] 
 										 userInfo:nil];

--- a/iphone/Classes/TiNetworkHTTPClientProxy.m
+++ b/iphone/Classes/TiNetworkHTTPClientProxy.m
@@ -477,7 +477,7 @@ extern NSString * const TI_APPLICATION_DEPLOYTYPE;
 	// HACK: We are never actually in the "OPENED" state.  Needs to be fixed with XHR refactor.
 	if (readyState != NetworkClientStateHeaders && readyState != NetworkClientStateOpened) {
 		// TODO: Throw an exception here as per XHR standard
-		NSLog(@"[ERROR] Must set a connection to OPENED before send()");
+		DebugLog(@"[ERROR] Must set a connection to OPENED before send()");
 		return;
 	}
 	

--- a/iphone/Classes/TiNetworkSocketTCPProxy.m
+++ b/iphone/Classes/TiNetworkSocketTCPProxy.m
@@ -529,7 +529,6 @@ TYPESAFE_SETTER(setError, error, KrollCallback)
             [operationInfo setObject:asynchInfo forKey:NUMINT(tag)];
             asynchTagCount = (asynchTagCount + 1) % INT_MAX;
         }
-        NSLog(@"Queuing up my write!");
         [socket writeData:subdata withTimeout:-1 tag:tag];
         
         // TODO: Actually need the amount of data written - similar to readDataLength, for writes

--- a/iphone/Classes/TiProxy.m
+++ b/iphone/Classes/TiProxy.m
@@ -198,7 +198,7 @@ void DoProxyDelegateReadValuesWithKeysFromProxy(UIView<TiProxyDelegate> * target
 	if (self = [super init])
 	{
 #if PROXY_MEMORY_TRACK == 1
-		NSLog(@"INIT: %@ (%d)",self,[self hash]);
+		NSLog(@"[DEBUG] INIT: %@ (%d)",self,[self hash]);
 #endif
 		pthread_rwlock_init(&listenerLock, NULL);
 		pthread_rwlock_init(&dynpropsLock, NULL);
@@ -276,7 +276,7 @@ void DoProxyDelegateReadValuesWithKeysFromProxy(UIView<TiProxyDelegate> * target
 {
 	if(OSAtomicDecrement32(&bridgeCount)<0)
 	{
-		NSLog(@"[WARN] BridgeCount for %@ is now at %d",self,bridgeCount);
+		DeveloperLog(@"[WARN] BridgeCount for %@ is now at %d",self,bridgeCount);
 	}
 	if(oldBridge == pageContext) {
 		pageKrollObject = nil;
@@ -375,7 +375,7 @@ void DoProxyDelegateReadValuesWithKeysFromProxy(UIView<TiProxyDelegate> * target
 	destroyed = YES;
 	
 #if PROXY_MEMORY_TRACK == 1
-	NSLog(@"DESTROY: %@ (%d)",self,[self hash]);
+	NSLog(@"[DEBUG] DESTROY: %@ (%d)",self,[self hash]);
 #endif
 
 	if ((bridgeCount == 1) && (pageKrollObject != nil) && (pageContext != nil))
@@ -423,7 +423,7 @@ void DoProxyDelegateReadValuesWithKeysFromProxy(UIView<TiProxyDelegate> * target
 -(void)dealloc
 {
 #if PROXY_MEMORY_TRACK == 1
-	NSLog(@"DEALLOC: %@ (%d)",self,[self hash]);
+	NSLog(@"[DEBUG] DEALLOC: %@ (%d)",self,[self hash]);
 #endif
 	[self _destroy];
 	pthread_rwlock_destroy(&listenerLock);
@@ -582,7 +582,7 @@ void DoProxyDelegateReadValuesWithKeysFromProxy(UIView<TiProxyDelegate> * target
 		
 	if(![bridge usesProxy:self])
 	{
-		NSLog(@"[DEBUG] Proxy may be missing its javascript representation.");
+		DeveloperLog(@"[DEBUG] Proxy %@ may be missing its javascript representation.", self);
 	}
 	
 	return [bridge krollObjectForProxy:self];
@@ -599,7 +599,7 @@ void DoProxyDelegateReadValuesWithKeysFromProxy(UIView<TiProxyDelegate> * target
 	
 	if(![ourBridge usesProxy:self])
 	{
-		NSLog(@"[DEBUG] Proxy may be missing its javascript representation.");
+		DeveloperLog(@"[DEBUG] Proxy %@ may be missing its javascript representation.", self);
 	}
 
 	return [ourBridge krollObjectForProxy:self];
@@ -627,7 +627,7 @@ void DoProxyDelegateReadValuesWithKeysFromProxy(UIView<TiProxyDelegate> * target
 	}
 	if (bridgeCount < 1)
 	{
-		NSLog(@"[DEBUG] Proxy %@ is missing its javascript representation needed to remember %@.",self,rememberedProxy);
+		DeveloperLog(@"[DEBUG] Proxy %@ is missing its javascript representation needed to remember %@.",self,rememberedProxy);
 		return;
 	}
 	

--- a/iphone/Classes/TiRootViewController.m
+++ b/iphone/Classes/TiRootViewController.m
@@ -622,7 +622,7 @@
         if ([thisWindow closing] == NO) {
             if([thisWindow modalFlagValue] == YES){
                 isInsideModalWindow = YES;
-                NSLog(@"[WARN] Trying to open a new window from within a Modal Window is unsupported.");
+                DebugLog(@"[WARN] Trying to open a new window from within a Modal Window is unsupported.");
                 break;
             }
             
@@ -1214,7 +1214,7 @@
 	WARN_IF_BACKGROUND_THREAD_OBJ
 	if (blurredProxy != keyboardFocusedProxy)
 	{
-		NSLog(@"[WARN] Blurred for %@<%X>, despite %@<%X> being the focus.",blurredProxy,blurredProxy,keyboardFocusedProxy,keyboardFocusedProxy);
+		DeveloperLog(@"[WARN] Blurred for %@<%X>, despite %@<%X> being the focus.",blurredProxy,blurredProxy,keyboardFocusedProxy,keyboardFocusedProxy);
 		return;
 	}
 	RELEASE_TO_NIL_AUTORELEASE(keyboardFocusedProxy);
@@ -1227,7 +1227,7 @@
 
 	if(doomedView != accessoryView)
 	{
-		NSLog(@"[WARN] Trying to blur out %@, but %@ is the one with focus.",doomedView,accessoryView);
+		DeveloperLog(@"[WARN] Trying to blur out %@, but %@ is the one with focus.",doomedView,accessoryView);
 		return;
 	}
 
@@ -1258,7 +1258,7 @@
 	
 	if(leavingAccessoryView != nil)
 	{
-		NSLog(@"[WARN] Trying to blur out %@, but %@ is already leaving focus.",accessoryView,leavingAccessoryView);
+		DeveloperLog(@"[WARN] Trying to blur out %@, but %@ is already leaving focus.",accessoryView,leavingAccessoryView);
         [leavingAccessoryView removeFromSuperview];
 		RELEASE_TO_NIL_AUTORELEASE(leavingAccessoryView);
 	}
@@ -1279,12 +1279,12 @@
 	WARN_IF_BACKGROUND_THREAD_OBJ
 	if (visibleProxy == keyboardFocusedProxy)
 	{
-		NSLog(@"[WARN] Focused for %@<%X>, despite it already being the focus.",keyboardFocusedProxy,keyboardFocusedProxy);
+		DeveloperLog(@"[WARN] Focused for %@<%X>, despite it already being the focus.",keyboardFocusedProxy,keyboardFocusedProxy);
 		return;
 	}
 	if (nil != keyboardFocusedProxy)
 	{
-		NSLog(@"[WARN] Focused for %@<%X>, despite %@<%X> already being the focus.",visibleProxy,visibleProxy,keyboardFocusedProxy,keyboardFocusedProxy);
+		DeveloperLog(@"[WARN] Focused for %@<%X>, despite %@<%X> already being the focus.",visibleProxy,visibleProxy,keyboardFocusedProxy,keyboardFocusedProxy);
 		[self didKeyboardBlurOnProxy:keyboardFocusedProxy];
 	}
 	
@@ -1303,7 +1303,7 @@
 	{
 		if(enteringAccessoryView != nil)
 		{
-			NSLog(@"[WARN] Moving in view %@, despite %@ already in line to move in.",newView,enteringAccessoryView);
+			DebugLog(@"[WARN] Moving in view %@, despite %@ already in line to move in.",newView,enteringAccessoryView);
 			[enteringAccessoryView release];
 		}
 		

--- a/iphone/Classes/TiStylesheet.m
+++ b/iphone/Classes/TiStylesheet.m
@@ -17,7 +17,7 @@
 	{
 		NSString *mainBundlePath = [[NSBundle mainBundle] bundlePath];
 		NSString *plistPath = [mainBundlePath stringByAppendingPathComponent:@"stylesheet.plist"];
-		DebugLog(@"[DEBUG] reading stylesheet from: %@",plistPath);
+		DebugLog(@"[DEBUG] Reading stylesheet from: %@",plistPath);
 		NSDictionary *dictionary = [[NSDictionary alloc] initWithContentsOfFile:plistPath];
 		classesDict = [[dictionary objectForKey:@"classes"] retain];
 		classesDictByDensity = [[dictionary objectForKey:@"classes_density"] retain];
@@ -27,10 +27,10 @@
 		tagsDictByDensity = [[dictionary objectForKey:@"tags_density"] retain];
 	   
 #if defined(DEBUG) && DEBUG_STYLESHEETS==1
-		NSLog(@"[DEBUG] classesDict = %@",classesDict);
-		NSLog(@"[DEBUG] classesDictByDensity = %@",classesDictByDensity);
-		NSLog(@"[DEBUG] idsDict = %@",idsDict);
-		NSLog(@"[DEBUG] idsDictByDensity = %@",idsDictByDensity);
+		NSLog(@"[STYLESHEET DEBUG] ClassesDict = %@",classesDict);
+		NSLog(@"[STYLESHEET DEBUG] ClassesDictByDensity = %@",classesDictByDensity);
+		NSLog(@"[STYLESHEET DEBUG] IdsDict = %@",idsDict);
+		NSLog(@"[STYLESHEET DEBUG] IdsDictByDensity = %@",idsDictByDensity);
 #endif
 		[dictionary release];
 	}
@@ -51,13 +51,13 @@
 -(id)stylesheet:(NSString*)objectId density:(NSString*)density basename:(NSString*)basename classes:(NSArray*)classes tags:(NSArray*) tags
 {
 #if DEBUG_STYLESHEETS==1
-	NSLog(@"[DEBUG] stylesheet -> objectId: %@, density: %@, basename: %@",objectId,density,basename);
+	NSLog(@"[STYLESHEET DEBUG] stylesheet -> objectId: %@, density: %@, basename: %@",objectId,density,basename);
 	for (int i = 0; i < [classes count]; i++) {
-		NSLog(@"[DEBUG] -> class: %@",[classes objectAtIndex:i]);
+		NSLog(@"[STYLESHEET DEBUG] -> class: %@",[classes objectAtIndex:i]);
 	}
 
 	for(int i = 0; i < [tags count]; i++) {
-		NSLog(@"[DEBUG] -> tag: %@", [tags objectAtIndex:i]);
+		NSLog(@"[STYLESHEET DEBUG] -> tag: %@", [tags objectAtIndex:i]);
 	}
 #endif
 	
@@ -114,7 +114,7 @@
 	}
 
 #if DEBUG_STYLESHEETS==1
-	NSLog(@"[DEBUG] stylesheet -> %@",result);
+	NSLog(@"[STYLESHEET DEBUG] stylesheet -> %@",result);
 #endif
 	return result;
 }

--- a/iphone/Classes/TiStylesheet.m
+++ b/iphone/Classes/TiStylesheet.m
@@ -17,7 +17,7 @@
 	{
 		NSString *mainBundlePath = [[NSBundle mainBundle] bundlePath];
 		NSString *plistPath = [mainBundlePath stringByAppendingPathComponent:@"stylesheet.plist"];
-		NSLog(@"[DEBUG] reading stylesheet from: %@",plistPath);
+		DebugLog(@"[DEBUG] reading stylesheet from: %@",plistPath);
 		NSDictionary *dictionary = [[NSDictionary alloc] initWithContentsOfFile:plistPath];
 		classesDict = [[dictionary objectForKey:@"classes"] retain];
 		classesDictByDensity = [[dictionary objectForKey:@"classes_density"] retain];

--- a/iphone/Classes/TiThreading.h
+++ b/iphone/Classes/TiThreading.h
@@ -66,13 +66,13 @@ return [self _sync_##method:nil];\
 #define WARN_IF_BACKGROUND_THREAD	\
 if(![NSThread isMainThread])	\
 {	\
-	NSLog(@"[WARN] %@ not running on the main thread.",CODELOCATION);	\
+	DeveloperLog(@"[WARN] %@ not running on the main thread.",CODELOCATION);	\
 }	\
 
 #define WARN_IF_BACKGROUND_THREAD_OBJ	\
 if(![NSThread isMainThread])	\
 {	\
-	NSLog(@"[WARN] %@%@ was not running on the main thread.",NSStringFromClass([self class]),CODELOCATION);	\
+	DeveloperLog(@"[WARN] %@%@ was not running on the main thread.",NSStringFromClass([self class]),CODELOCATION);	\
 }	\
 
 #else

--- a/iphone/Classes/TiUIImageView.m
+++ b/iphone/Classes/TiUIImageView.m
@@ -738,7 +738,7 @@ DEFINE_EXCEPTIONS
 // trouble in tableview repaints
 -(void)setUrl_:(id)img
 {
-	NSLog(@"[WARN] the 'url' property on ImageView has been deprecated. Please use 'image' instead");
+	DebugLog(@"[WARN] the 'url' property on ImageView has been deprecated. Please use 'image' instead");
 	// setImage_ does the property replacement for us; no need to do it twice.
 	[self setImage_:img];
 	return;

--- a/iphone/Classes/TiUIImageView.m
+++ b/iphone/Classes/TiUIImageView.m
@@ -738,7 +738,7 @@ DEFINE_EXCEPTIONS
 // trouble in tableview repaints
 -(void)setUrl_:(id)img
 {
-	DebugLog(@"[WARN] the 'url' property on ImageView has been deprecated. Please use 'image' instead");
+    DEPRECATED_REPLACED(@"UI.ImageView.url", @"1.5.0", @"Ti.UI.ImageView.image");
 	// setImage_ does the property replacement for us; no need to do it twice.
 	[self setImage_:img];
 	return;

--- a/iphone/Classes/TiUINavBarButton.m
+++ b/iphone/Classes/TiUINavBarButton.m
@@ -25,13 +25,13 @@ DEFINE_EXCEPTIONS
 #if NAVBAR_MEMORY_DEBUG==1
 -(id)retain
 {
-	NSLog(@"Retaining %X (%d)",self,[self retainCount]);
+	NSLog(@"[DEBUG] Retaining %X (%d)",self,[self retainCount]);
 	return [super retain];
 }
 
 -(void)release
 {
-	NSLog(@"Releasing %X (%d)",self,[self retainCount]);
+	NSLog(@"[DEBUG] Releasing %X (%d)",self,[self retainCount]);
 	[super release];
 }
 #endif
@@ -39,7 +39,7 @@ DEFINE_EXCEPTIONS
 -(void)dealloc
 {
 #if NAVBAR_MEMORY_DEBUG==1
-	NSLog(@"Deallocing %X (%d)",self,[self retainCount]);
+	NSLog(@"[DEBUG] Deallocing %X (%d)",self,[self retainCount]);
 #endif
 	RELEASE_TO_NIL(activityDelegate);
 	[super dealloc];

--- a/iphone/Classes/TiUIScrollViewProxy.m
+++ b/iphone/Classes/TiUIScrollViewProxy.m
@@ -118,10 +118,6 @@
             result = [self verifyHeight:result];
         }
         
-        if (result == 0)
-        {
-            NSLog(@"[WARN] %@ has an auto height value of 0, meaning this view may not be visible.",self);
-        }
         return result;
     }
     else {

--- a/iphone/Classes/TiUIScrollableView.m
+++ b/iphone/Classes/TiUIScrollableView.m
@@ -345,7 +345,7 @@
         newCacheSize = 3;
     }
     if (newCacheSize % 2 == 0) {
-        NSLog(@"[WARN] Even scrollable cache size %d; setting to %d", newCacheSize, newCacheSize-1);
+        DebugLog(@"[WARN] Even scrollable cache size %d; setting to %d", newCacheSize, newCacheSize-1);
         newCacheSize -= 1;
     }
     cacheSize = newCacheSize;

--- a/iphone/Classes/TiUITableViewProxy.m
+++ b/iphone/Classes/TiUITableViewProxy.m
@@ -415,7 +415,7 @@ NSArray * tableKeySequence;
 		
 	if ([sections count]==0)
 	{
-		DebugLog(@"[WARN] no rows found in table, ignoring delete");
+		DebugLog(@"[WARN] No rows found in table, ignoring delete");
 		return;
 	}
 	
@@ -424,7 +424,7 @@ NSArray * tableKeySequence;
 	
 	if (section==nil || row == nil)
 	{
-		DebugLog(@"[WARN] no row found for index: %d",index);
+		DebugLog(@"[WARN] No row found for index: %d",index);
 		return;
 	}
 	
@@ -521,7 +521,7 @@ NSArray * tableKeySequence;
 	{
 		//No table, we have to do the data update ourselves.
 		//TODO: Implement. Better yet, refactor.
-		DebugLog(@"[WARN] Table view was not in place before insertRowBefore was called. (Tell Blain or Steve to fix it!)");
+		DebugLog(@"[WARN] Table view was not in place before insertRowBefore was called.");
 	}
 
 }
@@ -598,7 +598,7 @@ NSArray * tableKeySequence;
 	{
 		//No table, we have to do the data update ourselves.
 		//TODO: Implement. Better yet, refactor.
-		DebugLog(@"[WARN] Table view was not in place before insertRowAfter was called. (Tell Blain or Steve to fix it!)");
+		DebugLog(@"[WARN] Table view was not in place before insertRowAfter was called.");
 	}
 
 }

--- a/iphone/Classes/TiUITableViewProxy.m
+++ b/iphone/Classes/TiUITableViewProxy.m
@@ -415,7 +415,7 @@ NSArray * tableKeySequence;
 		
 	if ([sections count]==0)
 	{
-		NSLog(@"[WARN] no rows found in table, ignoring delete");
+		DebugLog(@"[WARN] no rows found in table, ignoring delete");
 		return;
 	}
 	
@@ -424,7 +424,7 @@ NSArray * tableKeySequence;
 	
 	if (section==nil || row == nil)
 	{
-		NSLog(@"[WARN] no row found for index: %d",index);
+		DebugLog(@"[WARN] no row found for index: %d",index);
 		return;
 	}
 	
@@ -521,7 +521,7 @@ NSArray * tableKeySequence;
 	{
 		//No table, we have to do the data update ourselves.
 		//TODO: Implement. Better yet, refactor.
-		NSLog(@"[WARN] Table view was not in place before insertRowBefore was called. (Tell Blain or Steve to fix it!)");
+		DebugLog(@"[WARN] Table view was not in place before insertRowBefore was called. (Tell Blain or Steve to fix it!)");
 	}
 
 }
@@ -598,7 +598,7 @@ NSArray * tableKeySequence;
 	{
 		//No table, we have to do the data update ourselves.
 		//TODO: Implement. Better yet, refactor.
-		NSLog(@"[WARN] Table view was not in place before insertRowAfter was called. (Tell Blain or Steve to fix it!)");
+		DebugLog(@"[WARN] Table view was not in place before insertRowAfter was called. (Tell Blain or Steve to fix it!)");
 	}
 
 }

--- a/iphone/Classes/TiUIView.h
+++ b/iphone/Classes/TiUIView.h
@@ -246,7 +246,7 @@ void ModifyScrollViewForKeyboardHeightAndContentHeightWithResponderRect(UIScroll
 #define USE_PROXY_FOR_METHOD(resultType,methodname,inputType)	\
 -(resultType)methodname:(inputType)value	\
 {	\
-	NSLog(@"[DEBUG] Using view proxy via redirection instead of directly for %@.",self);	\
+	DeveloperLog(@"[DEBUG] Using view proxy via redirection instead of directly for %@.",self);	\
 	return [(TiViewProxy *)[self proxy] methodname:value];	\
 }
 

--- a/iphone/Classes/TiUIView.m
+++ b/iphone/Classes/TiUIView.m
@@ -611,14 +611,10 @@ DEFINE_EXCEPTIONS
 	
 	if ([self.proxy isKindOfClass:[TiViewProxy class]] && [(TiViewProxy*)self.proxy viewReady]==NO)
 	{
-#ifdef DEBUG
-		NSLog(@"[DEBUG] animated called and we're not ready ... (will try again) %@",self);
-#endif		
+		DebugLog(@"[DEBUG] animated called and we're not ready ... (will try again) %@",self);
 		if (animationDelayGuard++ > 5)
 		{
-#ifdef DEBUG
-			NSLog(@"[DEBUG] animation guard triggered, we exceeded the timeout on waiting for view to become ready");
-#endif		
+			DebugLog(@"[DEBUG] animation guard triggered, we exceeded the timeout on waiting for view to become ready");
 			return;
 		}
 		[self performSelector:@selector(animate:) withObject:newAnimation afterDelay:0.01];
@@ -636,7 +632,7 @@ DEFINE_EXCEPTIONS
 	}	
 	else
 	{
-		NSLog(@"[WARN] animate called with %@ but couldn't make an animation object",newAnimation);
+		DebugLog(@"[WARN] animate called with %@ but couldn't make an animation object",newAnimation);
 	}
 }
 

--- a/iphone/Classes/TiUIView.m
+++ b/iphone/Classes/TiUIView.m
@@ -611,10 +611,11 @@ DEFINE_EXCEPTIONS
 	
 	if ([self.proxy isKindOfClass:[TiViewProxy class]] && [(TiViewProxy*)self.proxy viewReady]==NO)
 	{
-		DebugLog(@"[DEBUG] animated called and we're not ready ... (will try again) %@",self);
+		DebugLog(@"[DEBUG] Ti.View.animate() called before view %@ was ready: Will re-attempt", self);
 		if (animationDelayGuard++ > 5)
 		{
-			DebugLog(@"[DEBUG] animation guard triggered, we exceeded the timeout on waiting for view to become ready");
+			DebugLog(@"[DEBUG] Animation guard triggered, exceeded timeout to perform animation.");
+            animationDelayGuard = 0;
 			return;
 		}
 		[self performSelector:@selector(animate:) withObject:newAnimation afterDelay:0.01];
@@ -632,7 +633,7 @@ DEFINE_EXCEPTIONS
 	}	
 	else
 	{
-		DebugLog(@"[WARN] animate called with %@ but couldn't make an animation object",newAnimation);
+		DebugLog(@"[WARN] Ti.View.animate() (view %@) could not make animation from: %@", self, newAnimation);
 	}
 }
 

--- a/iphone/Classes/TiUIWebView.m
+++ b/iphone/Classes/TiUIWebView.m
@@ -518,7 +518,7 @@ static NSString * const kTitaniumJavascript = @"Ti.App={};Ti.API={};Ti.App._list
 				}
 				else 
 				{
-					DebugLog(@"[WARN] I have no idea what the appropriate text encoding is for: %@. Please report this to Appcelerator support.",url);
+					DebugLog(@"[WARN] Could not determine correct text encoding for content: %@.",url);
 				}
 			}
 			if ((error!=nil && [error code]==261) || [mimeType isEqualToString:(NSString*)svgMimeType])

--- a/iphone/Classes/TiUIWebView.m
+++ b/iphone/Classes/TiUIWebView.m
@@ -480,7 +480,7 @@ static NSString * const kTitaniumJavascript = @"Ti.App={};Ti.API={};Ti.App._list
 				{
 					//step 3: try an appropriate legacy encoding (if one) -- what's that? Latin-1?
 					//at this point we're just going to fail
-					NSLog(@"[ERROR] Couldn't determine the proper encoding. Make sure this file: %@ is UTF-8 encoded.",[path lastPathComponent]);
+					DebugLog(@"[ERROR] Couldn't determine the proper encoding. Make sure this file: %@ is UTF-8 encoded.",[path lastPathComponent]);
 				}
 				else
 				{
@@ -518,7 +518,7 @@ static NSString * const kTitaniumJavascript = @"Ti.App={};Ti.API={};Ti.App._list
 				}
 				else 
 				{
-					NSLog(@"[WARN] I have no idea what the appropriate text encoding is for: %@. Please report this to Appcelerator support.",url);
+					DebugLog(@"[WARN] I have no idea what the appropriate text encoding is for: %@. Please report this to Appcelerator support.",url);
 				}
 			}
 			if ((error!=nil && [error code]==261) || [mimeType isEqualToString:(NSString*)svgMimeType])
@@ -535,7 +535,7 @@ static NSString * const kTitaniumJavascript = @"Ti.App={};Ti.API={};Ti.App._list
 			}
 			else if (error!=nil)
 			{
-				NSLog(@"[ERROR] error loading file: %@. Message was: %@",path,error);
+				NSLog(@"[ERROR] Error loading file: %@. Message was: %@",path,error);
 				RELEASE_TO_NIL(url);
 			}
 		}
@@ -647,7 +647,7 @@ static NSString * const kTitaniumJavascript = @"Ti.App={};Ti.API={};Ti.App._list
 	NSString * scheme = [[newUrl scheme] lowercaseString];
 	if ([scheme hasPrefix:@"http"] || [scheme hasPrefix:@"app"] || [scheme hasPrefix:@"file"] || [scheme hasPrefix:@"ftp"])
 	{
-		NSLog(@"New scheme: %@",request);
+		DebugLog(@"[DEBUG] New scheme: %@",request);
 		if (ignoreNextRequest)
 		{
 			ignoreNextRequest = NO;

--- a/iphone/Classes/TiUIWindowProxy.m
+++ b/iphone/Classes/TiUIWindowProxy.m
@@ -203,7 +203,7 @@
 		}
 		else 
 		{
-			NSLog(@"[ERROR] url not supported in a window. %@",url);
+			DebugLog(@"[ERROR] Url not supported in a window. %@",url);
 		}
 	}
 	

--- a/iphone/Classes/TiUIiOSCoverFlowView.m
+++ b/iphone/Classes/TiUIiOSCoverFlowView.m
@@ -184,7 +184,7 @@
 	}
 	else
 	{
-		DebugLog(@"[ERROR] attempt to set index: %d that is out of bounds. number of images: %d",index,[flow numberOfImages]);
+		DebugLog(@"[ERROR] Attempted to set index: %d that is out of bounds. Number of images: %d",index,[flow numberOfImages]);
 	}
 }
 

--- a/iphone/Classes/TiUIiOSCoverFlowView.m
+++ b/iphone/Classes/TiUIiOSCoverFlowView.m
@@ -126,7 +126,7 @@
 		[flow centerOnSelectedCover:YES];
 	}
 	else {
-		NSLog(@"[ERROR] attempt to select index: %d that is out of bounds. Number of images: %d",index,[flow numberOfImages]);
+		DebugLog(@"[ERROR] attempt to select index: %d that is out of bounds. Number of images: %d",index,[flow numberOfImages]);
 	}
 }
 
@@ -184,7 +184,7 @@
 	}
 	else
 	{
-		NSLog(@"[ERROR] attempt to set index: %d that is out of bounds. number of images: %d",index,[flow numberOfImages]);
+		DebugLog(@"[ERROR] attempt to set index: %d that is out of bounds. number of images: %d",index,[flow numberOfImages]);
 	}
 }
 

--- a/iphone/Classes/TiUIiOSToolbar.m
+++ b/iphone/Classes/TiUIiOSToolbar.m
@@ -94,7 +94,7 @@
 			if (![thisProxy supportsNavBarPositioning])
 			{
 				//TODO: This is an exception that should have been raised long ago.
-				NSLog(@"[ERROR] %@ does not support being in a toolbar!",thisProxy);
+				DebugLog(@"[ERROR] %@ does not support being in a toolbar!",thisProxy);
 				//continue;
 			}
 			if ([thisProxy conformsToProtocol:@protocol(TiToolbarButton)])

--- a/iphone/Classes/TiUIiPadPopoverProxy.m
+++ b/iphone/Classes/TiUIiPadPopoverProxy.m
@@ -264,7 +264,7 @@ TiUIiPadPopoverProxy * currentlyDisplaying = nil;
 			[[self popoverController] presentPopoverFromBarButtonItem: ourButtonItem permittedArrowDirections:directions animated:animated];
 		}
 		@catch (NSException *exception) {
-			NSLog(@"[WARN] Popover requested on view not attached to current window.");
+			DebugLog(@"[WARN] Popover requested on view not attached to current window.");
 		}
 	}
 	else
@@ -272,7 +272,7 @@ TiUIiPadPopoverProxy * currentlyDisplaying = nil;
 		UIView *view_ = [popoverView view];
 		if ([view_ window] == nil) {
 			// No window, so we can't display the popover...
-			NSLog(@"[WARN] Unable to display popover; view is not attached to the current window");
+			DebugLog(@"[WARN] Unable to display popover; view is not attached to the current window");
             return;
 		}
 		

--- a/iphone/Classes/TiUtils.m
+++ b/iphone/Classes/TiUtils.m
@@ -1261,7 +1261,7 @@ if ([str isEqualToString:@#orientation]) return (UIDeviceOrientation)orientation
 			{
 				appurlstr = [appurlstr substringFromIndex:1];
 			}
-			DebugLog(@"[DEBUG] loading: %@, resource: %@",urlstring,appurlstr);
+			DebugLog(@"[DEBUG] Loading: %@, Resource: %@",urlstring,appurlstr);
 			return [AppRouter performSelector:@selector(resolveAppAsset:) withObject:appurlstr];
 		}
 	}

--- a/iphone/Classes/TiUtils.m
+++ b/iphone/Classes/TiUtils.m
@@ -618,7 +618,6 @@ If the new path starts with / and the base url is app://..., we have to massage 
 
 	if(![relativeString isKindOfClass:[NSString class]])
 	{
-		//NSLog(@"[WARN] <%@> was an %@, not an NSString. Converting.",relativeString,[relativeString class]);
 		relativeString = [TiUtils stringValue:relativeString];
 	}
 
@@ -1262,9 +1261,7 @@ if ([str isEqualToString:@#orientation]) return (UIDeviceOrientation)orientation
 			{
 				appurlstr = [appurlstr substringFromIndex:1];
 			}
-#ifdef DEBUG			
-			NSLog(@"[DEBUG] loading: %@, resource: %@",urlstring,appurlstr);
-#endif			
+			DebugLog(@"[DEBUG] loading: %@, resource: %@",urlstring,appurlstr);
 			return [AppRouter performSelector:@selector(resolveAppAsset:) withObject:appurlstr];
 		}
 	}

--- a/iphone/Classes/TiViewProxy.h
+++ b/iphone/Classes/TiViewProxy.h
@@ -552,7 +552,6 @@ enum
  */
 -(void)relayout;
 
--(void)insertIntoView:(UIView*)view bounds:(CGRect)bounds;
 -(void)reposition;	//Todo: Replace
 
 -(BOOL)willBeRelaying;	//Todo: Replace

--- a/iphone/Classes/TiViewProxy.m
+++ b/iphone/Classes/TiViewProxy.m
@@ -202,7 +202,7 @@
 	else
 	{
 		pthread_rwlock_unlock(&childrenLock);
-		DebugLog(@"[WARN] called remove for %@ on %@, but %@ isn't a child or has already been removed",arg,self,arg);
+		DebugLog(@"[WARN] Called remove for %@ on %@, but %@ isn't a child or has already been removed.",arg,self,arg);
 		return;
 	}
 
@@ -2024,20 +2024,6 @@ if(OSAtomicTestAndSetBarrier(flagBit, &dirtyflags))	\
 
 }
 
--(void)insertIntoView:(UIView*)newSuperview bounds:(CGRect)bounds
-{
-	if (newSuperview==view)
-	{
-		DebugLog(@"[ERROR] invalid call to insertIntoView, new super view is same as myself");
-		return;
-	}
-	ApplyConstraintToViewWithBounds(&layoutProperties, [self view], bounds);
-	if([view superview]!=newSuperview)	//TODO: Refactor out.
-	{
-		[newSuperview addSubview:view];
-	}
-}
-
 -(void)layoutChildrenIfNeeded
 {
 	IGNORE_IF_NOT_OPENED
@@ -2513,7 +2499,7 @@ if(OSAtomicTestAndSetBarrier(flagBit, &dirtyflags))	\
 	if ([[child view] animating])
 	{
         // changing the layout while animating is bad, ignore for now
-		DebugLog(@"[DEBUG] ignoring new layout while animating in layout Child..");
+        DebugLog(@"[WARN] New layout set while view %@ animating: Will relayout after animation.", child);
 	}
 	else
 	{

--- a/iphone/Classes/TiViewProxy.m
+++ b/iphone/Classes/TiViewProxy.m
@@ -687,11 +687,6 @@ LAYOUTPROPERTIES_SETTER(setMinHeight,minimumHeight,TiFixedValueRuleFromObject,[s
 	{
 		result = [self verifyWidth:result];
 	}
-
-	if (result == 0)
-	{
-		NSLog(@"[WARN] %@ has an auto width value of 0, meaning this view may not be visible.",self);
-	}
     
     return result;
 }
@@ -750,11 +745,7 @@ LAYOUTPROPERTIES_SETTER(setMinHeight,minimumHeight,TiFixedValueRuleFromObject,[s
 	{
 		result = [self verifyHeight:result];
 	}
-	
-	if (result == 0)
-	{
-		NSLog(@"[WARN] %@ has an auto height value of 0, meaning this view may not be visible.",self);
-	}
+
 	return result;
 }
 
@@ -2020,6 +2011,15 @@ if(OSAtomicTestAndSetBarrier(flagBit, &dirtyflags))	\
             [observer proxyDidRelayout:self];
         }
 
+#ifdef DEBUG
+        if ((sizeCache.size.width == 0) && !TiDimensionIsDip(layoutProperties->width)) {
+            DebugLog(@"[WARN] Computed width for %@ is 0; view may not be visible", self);
+        }
+        if ((sizeCache.size.height == 0) && !TiDimensionIsDip(layoutProperties->height)) {
+            DebugLog(@"[WARN] Computed height for %@ is 0; view may not be visible", self);
+        }
+#endif
+        
         if ([self _hasListeners:@"postlayout"]) {
             [self fireEvent:@"postlayout" withObject:nil];
         }
@@ -2027,7 +2027,7 @@ if(OSAtomicTestAndSetBarrier(flagBit, &dirtyflags))	\
 #ifdef VERBOSE
 	else
 	{
-		NSLog(@"[INFO] %@ Calling Relayout from within relayout.",self);
+		DeveloperLog(@"[INFO] %@ Calling Relayout from within relayout.",self);
 	}
 #endif
 

--- a/iphone/Classes/TiViewProxy.m
+++ b/iphone/Classes/TiViewProxy.m
@@ -202,7 +202,7 @@
 	else
 	{
 		pthread_rwlock_unlock(&childrenLock);
-		NSLog(@"[WARN] called remove for %@ on %@, but %@ isn't a child or has already been removed",arg,self,arg);
+		DebugLog(@"[WARN] called remove for %@ on %@, but %@ isn't a child or has already been removed",arg,self,arg);
 		return;
 	}
 
@@ -308,7 +308,7 @@ if (ENFORCE_BATCH_UPDATE) { \
     }\
     else {\
         if (!TiDimensionIsUndefined(result)) {\
-            NSLog(@"[WARN] Invalid value %@ specified for property %@",[TiUtils stringValue:value],@#layoutName); \
+            DebugLog(@"[WARN] Invalid value %@ specified for property %@",[TiUtils stringValue:value],@#layoutName); \
         } \
         layoutProperties.layoutName = TiDimensionUndefined;\
     }\
@@ -1362,7 +1362,7 @@ LAYOUTPROPERTIES_SETTER(setMinHeight,minimumHeight,TiFixedValueRuleFromObject,[s
 	}
 	else
 	{
-		NSLog(@"[WARN] No TiView for Proxy: %@, couldn't find class: %@",self,proxyName);
+		DeveloperLog(@"[WARN] No TiView for Proxy: %@, couldn't find class: %@",self,proxyName);
 	}
 	return [[TiUIView alloc] initWithFrame:[self appFrame]];
 }
@@ -2037,7 +2037,7 @@ if(OSAtomicTestAndSetBarrier(flagBit, &dirtyflags))	\
 {
 	if (newSuperview==view)
 	{
-		NSLog(@"[ERROR] invalid call to insertIntoView, new super view is same as myself");
+		DebugLog(@"[ERROR] invalid call to insertIntoView, new super view is same as myself");
 		return;
 	}
 	ApplyConstraintToViewWithBounds(&layoutProperties, [self view], bounds);
@@ -2521,10 +2521,8 @@ if(OSAtomicTestAndSetBarrier(flagBit, &dirtyflags))	\
 	[child setSandboxBounds:bounds];
 	if ([[child view] animating])
 	{
-#ifdef DEBUG
-	// changing the layout while animating is bad, ignore for now
-		NSLog(@"[DEBUG] ignoring new layout while animating in layout Child..");
-#endif
+        // changing the layout while animating is bad, ignore for now
+		DebugLog(@"[DEBUG] ignoring new layout while animating in layout Child..");
 	}
 	else
 	{

--- a/iphone/Classes/TiViewProxy.m
+++ b/iphone/Classes/TiViewProxy.m
@@ -2011,15 +2011,6 @@ if(OSAtomicTestAndSetBarrier(flagBit, &dirtyflags))	\
             [observer proxyDidRelayout:self];
         }
 
-#ifdef DEBUG
-        if ((sizeCache.size.width == 0) && !TiDimensionIsDip(layoutProperties->width)) {
-            DebugLog(@"[WARN] Computed width for %@ is 0; view may not be visible", self);
-        }
-        if ((sizeCache.size.height == 0) && !TiDimensionIsDip(layoutProperties->height)) {
-            DebugLog(@"[WARN] Computed height for %@ is 0; view may not be visible", self);
-        }
-#endif
-        
         if ([self _hasListeners:@"postlayout"]) {
             [self fireEvent:@"postlayout" withObject:nil];
         }

--- a/iphone/Classes/TiWindowProxy.m
+++ b/iphone/Classes/TiWindowProxy.m
@@ -31,21 +31,17 @@ TiOrientationFlags TiOrientationFlagsFromObject(id args)
 			case UIDeviceOrientationLandscapeRight:
 				TI_ORIENTATION_SET(result,orientation);
 				break;
-#if DEBUG
 			case UIDeviceOrientationUnknown:
-				NSLog(@"[WARN] Ti.Gesture.UNKNOWN / Ti.UI.UNKNOWN is an invalid orientation mode.");
+				DebugLog(@"[WARN] Ti.Gesture.UNKNOWN / Ti.UI.UNKNOWN is an invalid orientation mode.");
 				break;
 			case UIDeviceOrientationFaceDown:
-				NSLog(@"[WARN] Ti.Gesture.FACE_DOWN / Ti.UI.FACE_DOWN is an invalid orientation mode.");
+				DebugLog(@"[WARN] Ti.Gesture.FACE_DOWN / Ti.UI.FACE_DOWN is an invalid orientation mode.");
 				break;
 			case UIDeviceOrientationFaceUp:
-				NSLog(@"[WARN] Ti.Gesture.FACE_UP / Ti.UI.FACE_UP is an invalid orientation mode.");
+				DebugLog(@"[WARN] Ti.Gesture.FACE_UP / Ti.UI.FACE_UP is an invalid orientation mode.");
 				break;
-#endif
 			default:
-#if DEBUG
-				NSLog(@"[WARN] An invalid orientation was requested. Ignoring.");
-#endif
+				DebugLog(@"[WARN] An invalid orientation was requested. Ignoring.");
 				break;
 		}
 	}
@@ -754,12 +750,10 @@ TiOrientationFlags TiOrientationFlagsFromObject(id args)
 	{
 		[self fireFocus:YES];
 	}
-#ifdef VERBOSE
 	else
 	{
-		NSLog(@"[DEBUG] Focused was already set while in viewDidAppear.");
+		DeveloperLog(@"[DEBUG] Focused was already set while in viewDidAppear.");
 	}
-#endif	
 }
 
 -(void)viewWillDisappear:(BOOL)animated
@@ -768,12 +762,10 @@ TiOrientationFlags TiOrientationFlagsFromObject(id args)
 	{
 		[self fireFocus:NO];
 	}
-#ifdef VERBOSE
 	else
 	{
-		NSLog(@"[DEBUG] Focused was already cleared while in viewWillDisappear.");
+		DeveloperLog(@"[DEBUG] Focused was already cleared while in viewWillDisappear.");
 	}
-#endif
 }
 
 -(void)viewWillAppear:(BOOL)animated

--- a/iphone/Classes/TopTiModule.m
+++ b/iphone/Classes/TopTiModule.m
@@ -53,7 +53,7 @@
 		// only allow includes that are local to our execution context url
 		// for security, refuse to load non-compiled in Javascript code
 		NSURL *url = [TiUtils toURL:file relativeToURL:rootURL];
-		DebugLog(@"[DEBUG] include url: %@",[url absoluteString]);
+		DebugLog(@"[DEBUG] Include url: %@",[url absoluteString]);
 		[context setCurrentURL:url];
 		[context evalFile:[url absoluteString]];
 	}
@@ -67,7 +67,7 @@
 {
 	for (id file in jsfiles)
 	{
-		DebugLog(@"[DEBUG] absolute url: %@", file);
+		DebugLog(@"[DEBUG] Absolute url: %@", file);
 
 		NSURL *url = nil;
 		if (![file hasPrefix:@"file:"]) {
@@ -75,7 +75,6 @@
 		} else {
 			url = [[NSURL fileURLWithPath:file] standardizedURL];
 		}
-		DebugLog(@"[DEBUG] include absolute url: %@", [url absoluteString]);
 		[[self executionContext] evalFile:[url absoluteString]];
 	}
 }

--- a/iphone/Classes/TopTiModule.m
+++ b/iphone/Classes/TopTiModule.m
@@ -53,9 +53,7 @@
 		// only allow includes that are local to our execution context url
 		// for security, refuse to load non-compiled in Javascript code
 		NSURL *url = [TiUtils toURL:file relativeToURL:rootURL];
-#ifdef DEBUG
-		NSLog(@"[DEBUG] include url: %@",[url absoluteString]);
-#endif
+		DebugLog(@"[DEBUG] include url: %@",[url absoluteString]);
 		[context setCurrentURL:url];
 		[context evalFile:[url absoluteString]];
 	}
@@ -69,7 +67,7 @@
 {
 	for (id file in jsfiles)
 	{
-		NSLog(@"[DEBUG] absolute url: %@", file);
+		DebugLog(@"[DEBUG] absolute url: %@", file);
 
 		NSURL *url = nil;
 		if (![file hasPrefix:@"file:"]) {
@@ -77,7 +75,7 @@
 		} else {
 			url = [[NSURL fileURLWithPath:file] standardizedURL];
 		}
-		NSLog(@"[DEBUG] include absolute url: %@", [url absoluteString]);
+		DebugLog(@"[DEBUG] include absolute url: %@", [url absoluteString]);
 		[[self executionContext] evalFile:[url absoluteString]];
 	}
 }

--- a/iphone/Classes/Webcolor.m
+++ b/iphone/Classes/Webcolor.m
@@ -170,7 +170,7 @@ int toASCIIHexValue(unichar c) {return (c & 0xF) + (c < 'A' ? 0 : 9); }
 	float alpha = 1.0;
     if ((length != 3) && (length != 4) && (length != 6) && (length!=7) && (length != 8))
 	{
-		NSLog(@"[WARN] Hex color passed looks invalid: %@",hexCode);
+		DebugLog(@"[WARN] Hex color passed looks invalid: %@",hexCode);
         return nil;
 	}
     unsigned value = 0;

--- a/iphone/Classes/XHRBridge.m
+++ b/iphone/Classes/XHRBridge.m
@@ -112,7 +112,7 @@ static XHRBridge *xhrBridge = nil;
 	}
 	else 
 	{
-		NSLog(@"[ERROR] Error loading %@",url);
+		DebugLog(@"[ERROR] Error loading %@",url);
 		[client URLProtocol:self didFailWithError:[NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorResourceUnavailable userInfo:nil]];
 		[client URLProtocolDidFinishLoading:self];
 	}
@@ -131,9 +131,7 @@ static XHRBridge *xhrBridge = nil;
 		return;
 	}
 
-#ifdef DEBUG	
-	NSLog(@"[DEBUG] app protocol, loading: %@",url);
-#endif
+	DebugLog(@"[DEBUG] app protocol, loading: %@",url);
 		
 	// see if it's a compiled resource
 	NSData *data = [TiUtils loadAppResource:url];

--- a/iphone/Classes/XHRBridge.m
+++ b/iphone/Classes/XHRBridge.m
@@ -131,7 +131,7 @@ static XHRBridge *xhrBridge = nil;
 		return;
 	}
 
-	DebugLog(@"[DEBUG] app protocol, loading: %@",url);
+	DebugLog(@"[DEBUG] Requested resource via app protocol, loading: %@",url);
 		
 	// see if it's a compiled resource
 	NSData *data = [TiUtils loadAppResource:url];

--- a/iphone/iphone/Titanium.xcodeproj/project.pbxproj
+++ b/iphone/iphone/Titanium.xcodeproj/project.pbxproj
@@ -4215,6 +4215,172 @@
 			};
 			name = Release;
 		};
+		DA60651C155C6EB200CEA37C /* Developer */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 241EAEC5118E2BA90081A5BE /* project.xcconfig */;
+			buildSettings = {
+				ARCHS = (
+					armv6,
+					armv7,
+				);
+				"ARCHS[sdk=iphoneos*]" = (
+					armv6,
+					armv7,
+				);
+				"ARCHS[sdk=iphonesimulator*]" = i386;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				GCC_C_LANGUAGE_STANDARD = c99;
+				GCC_PREPROCESSOR_DEFINITIONS = "TI_VERSION=$(TI_VERSION)";
+				GCC_TREAT_WARNINGS_AS_ERRORS = NO;
+				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
+				GCC_WARN_ABOUT_RETURN_TYPE = NO;
+				GCC_WARN_MISSING_PARENTHESES = NO;
+				GCC_WARN_SHADOW = NO;
+				GCC_WARN_STRICT_SELECTOR_MATCH = NO;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_PARAMETER = NO;
+				GCC_WARN_UNUSED_VALUE = NO;
+				GCC_WARN_UNUSED_VARIABLE = NO;
+				HEADER_SEARCH_PATHS = (
+					"${SDKROOT}/usr/include/libxml2",
+					../headers,
+				);
+				IPHONEOS_DEPLOYMENT_TARGET = 4.0;
+				OTHER_CFLAGS = (
+					"-DDEBUG",
+					"-DTI_POST_1_2",
+					"-DDEVELOPER",
+				);
+				OTHER_LDFLAGS = "-ObjC";
+				PROVISIONING_PROFILE = "";
+				"PROVISIONING_PROFILE[sdk=iphoneos*]" = "";
+				RUN_CLANG_STATIC_ANALYZER = NO;
+				SDKROOT = iphoneos;
+				USER_HEADER_SEARCH_PATHS = "";
+			};
+			name = Developer;
+		};
+		DA60651D155C6EB200CEA37C /* Developer */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 241EAEC5118E2BA90081A5BE /* project.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COPY_PHASE_STRIP = NO;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_ENABLE_CPP_RTTI = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = Titanium_Prefix.pch;
+				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
+				INFOPLIST_FILE = Titanium.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 4.0;
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SRCROOT)/../lib\"",
+				);
+				OTHER_CFLAGS = (
+					"-DDEBUG",
+					"-DTI_POST_1_2",
+				);
+				"OTHER_LDFLAGS[sdk=iphoneos*]" = (
+					"$(inherited)",
+					"-weak_framework",
+					iAd,
+					"-weak_framework",
+					CoreMedia,
+					"-weak_framework",
+					CoreVideo,
+				);
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
+					"$(inherited)",
+					"-weak_framework",
+					iAd,
+				);
+				PRODUCT_NAME = Titanium;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Developer;
+		};
+		DA60651E155C6EB200CEA37C /* Developer */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 241EAEC5118E2BA90081A5BE /* project.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COPY_PHASE_STRIP = NO;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = Titanium_Prefix.pch;
+				INFOPLIST_FILE = Titanium.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 4.0;
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SRCROOT)/../lib\"",
+				);
+				OTHER_CFLAGS = (
+					"-DIPAD",
+					"-DTI_POST_1_2",
+					"-DDEBUG",
+				);
+				"OTHER_LDFLAGS[sdk=iphoneos*]" = (
+					"$(inherited)",
+					"-weak_framework",
+					iAd,
+					"-weak_framework",
+					CoreMedia,
+					"-weak_framework",
+					CoreVideo,
+				);
+				PRODUCT_NAME = Titanium;
+				TARGETED_DEVICE_FAMILY = 2;
+				VALID_ARCHS = "armv6 armv7 i386";
+			};
+			name = Developer;
+		};
+		DA60651F155C6EB200CEA37C /* Developer */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 241EAEC5118E2BA90081A5BE /* project.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COPY_PHASE_STRIP = NO;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = Titanium_Prefix.pch;
+				INFOPLIST_FILE = Titanium.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 4.0;
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SRCROOT)/../lib\"",
+				);
+				OTHER_CFLAGS = (
+					"-DIPAD",
+					"-DTI_POST_1_2",
+					"-DDEBUG",
+				);
+				"OTHER_CFLAGS[arch=*]" = (
+					"-DIPAD",
+					"-DTI_POST_1_2",
+					"-DDEBUG",
+				);
+				"OTHER_LDFLAGS[sdk=iphoneos*]" = (
+					"$(inherited)",
+					"-weak_framework",
+					iAd,
+					"-weak_framework",
+					CoreVideo,
+					"-weak_framework",
+					CoreMedia,
+				);
+				PRODUCT_NAME = Titanium;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALID_ARCHS = "armv6 armv7 i386";
+			};
+			name = Developer;
+		};
 		DABB37BA12E8CB280026A6EA /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 241EAEC5118E2BA90081A5BE /* project.xcconfig */;
@@ -4299,6 +4465,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				1D6058940D05DD3E006BFB54 /* Debug */,
+				DA60651D155C6EB200CEA37C /* Developer */,
 				1D6058950D05DD3E006BFB54 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
@@ -4308,6 +4475,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				24D8E4AF119B9D8A00F8CAA6 /* Debug */,
+				DA60651E155C6EB200CEA37C /* Developer */,
 				24D8E4B0119B9D8A00F8CAA6 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
@@ -4317,6 +4485,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				C01FCF4F08A954540054247B /* Debug */,
+				DA60651C155C6EB200CEA37C /* Developer */,
 				C01FCF5008A954540054247B /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
@@ -4326,6 +4495,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				DABB37BA12E8CB280026A6EA /* Debug */,
+				DA60651F155C6EB200CEA37C /* Developer */,
 				DABB37BB12E8CB280026A6EA /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;


### PR DESCRIPTION
This changes logging so that there are three levels of logging:

NSLog -> Logged at all levels (Release, Debug, Developer)
DebugLog -> Logged at (Debug, Developer)
DeveloperLog -> Logged at (Developer)

There is also a new build configuration, Developer, intended to be used in-house by the development team to catch and diagnose _properly reported_ issues. Each logged message/warning/error should be evaluated for
- Appropriateness of log level (INFO, WARN, ERROR, etc.)
- Appropriateness of display (end users, Titanium SDK users, Appcelerator development team)

This pull request also removes the "auto width/height 0" warning which is now frequently spurious due to the layout rewrite. 

@arthurevans is required to participate in this pull request as a reviewer to review log messages as documentation.

[JIRA](https://jira.appcelerator.org/browse/TIMOB-9002)
