### PR TITLE
[Timob-9122][2_0_X] iOS: Drillbit fails on Filesystem test

### DIFF
--- a/drillbit/tests/filesystem/filesystem.js
+++ b/drillbit/tests/filesystem/filesystem.js
@@ -462,17 +462,19 @@ describe("Ti.Filesystem tests", {
 		}
 	},
 	filesInApplicationCacheDirectoryExists: function() {
-		var newDirectory = Ti.Filesystem.getFile(Ti.Filesystem.applicationCacheDirectory, 'newDir');
-		newDirectory.createDirectory();
-
-		var newFile = Ti.Filesystem.getFile(newDirectory.getNativePath(), 'this-file-exists.js');
-		newFile.write("testing a file");
-
-		var appDataFileDoesNotExist = Ti.Filesystem.getFile(newDirectory.getNativePath(), 'this-file-does-not-exist.js');
-
-		valueOf(newDirectory.isDirectory()).shouldBeTrue();
-		valueOf(newDirectory.exists()).shouldBeTrue();
-		valueOf(newFile.exists()).shouldBeTrue();
-		valueOf(appDataFileDoesNotExist.exists()).shouldBeFalse();
+		if(Ti.Platform.osname === 'android') {
+			var newDirectory = Ti.Filesystem.getFile(Ti.Filesystem.applicationCacheDirectory, 'newDir');
+			newDirectory.createDirectory();
+		
+			var newFile = Ti.Filesystem.getFile(newDirectory.getNativePath(), 'this-file-exists.js');
+			newFile.write("testing a file");
+		
+			var appDataFileDoesNotExist = Ti.Filesystem.getFile(newDirectory.getNativePath(), 'this-file-does-not-exist.js');
+		
+			valueOf(newDirectory.isDirectory()).shouldBeTrue();
+			valueOf(newDirectory.exists()).shouldBeTrue();
+			valueOf(newFile.exists()).shouldBeTrue();
+			valueOf(appDataFileDoesNotExist.exists()).shouldBeFalse();
+		}
 	}
 });


### PR DESCRIPTION
Duplicate of PR #2183

PR #2164 and PR #1982 failed to add the android check on the newly added android drillbit test.

Testing Instruction.
Run drillbit filesystem test. It should pass
