### PR TITLE
[TIMOB-8979](2_0_X)iOS: Ti.Media.openPhotoGallery's cancel event doesn't trigger on popover.

### DIFF
--- a/iphone/Classes/MediaModule.m
+++ b/iphone/Classes/MediaModule.m
@@ -317,7 +317,7 @@ static NSDictionary* TI_filterableItemProperties;
 	}
 	
 	RELEASE_TO_NIL(popover);
-	[self destroyPicker];
+	[self sendPickerCancel];
 	//Unregister for interface change notification 
 	[[NSNotificationCenter defaultCenter] removeObserver:self name:UIApplicationWillChangeStatusBarOrientationNotification object:nil];
 	[[NSNotificationCenter defaultCenter] removeObserver:self name:UIDeviceOrientationDidChangeNotification object:nil];


### PR DESCRIPTION
Duplicate of PR #2149

Test in [JIRA](https://jira.appcelerator.org/browse/TIMOB-8979)
