### PR TITLE
[TIDOC-556] Ti.Media MusicLibrary corrections

### DIFF
--- a/apidoc/Titanium/Media/Item.yml
+++ b/apidoc/Titanium/Media/Item.yml
@@ -1,64 +1,127 @@
 ---
 name: Titanium.Media.Item
-summary: A representation of a media item returned by the music picker as part of the `items` array in the dictionary passed to its `success` function.
+summary: A representation of a media item returned by [openMusicLibrary](Titanium.Media.openMusicLibrary) or [queryMusicLibrary](Titanium.Media.queryMusicLibrary).
+description: |
+    This is a read-only object that describes single media item, not a playlist. 
+    Titanium does not support access to playlists.
+    
+    `Item` objects cannot be created explicitly.  The 
+    [openMusicLibrary](Titanium.Media.openMusicLibrary) returns `Item` objects in its
+    `success` function, while [queryMusicLibrary](Titanium.Media.queryMusicLibrary)
+    returns an array of `Item` objects.
 extends: Titanium.Proxy
 since: "1.4.0"
 platforms: [iphone, ipad]
+creatable: false
 properties:
+
   - name: albumArtist
-    summary: the artist for the album of the item
+    summary: Artist credited for the album containing this item.
     type: String
+    permission: read-only
+
   - name: albumTitle
-    summary: the album title of the item
+    summary: Title of the album containing this item.
     type: String
+    permission: read-only
+
   - name: albumTrackCount
-    summary: the number of tracks for the album of the item
+    summary: Number of tracks for the album containing this item.
     type: Number
+    permission: read-only
+
   - name: albumTrackNumber
-    summary: the track number of the item
+    summary: Track number for this item.
     type: Number
+    permission: read-only
+
   - name: artist
-    summary: the artist of the item
+    summary: Artist credited for this item.
     type: String
+    permission: read-only
+
   - name: artwork
-    summary: a blob object containing the image for the item's artwork, or null if none
-    type: Object
+    summary: |
+        Image for the item's artwork as a `Blob` object,  or `null` if no artwork is
+        available.
+    type: Titanium.Blob
+    permission: read-only
+
   - name: composer
-    summary: the composer of the item
+    summary: Composer of this item.
     type: String
+    permission: read-only
+
   - name: discCount
-    summary: the total number of discs of the item
+    summary: Total number of discs for the album containing this item.
     type: Number
+    permission: read-only
+
   - name: discNumber
-    summary: the disc number of the item
+    summary: Disc number for this item in the album.
     type: Number
+    permission: read-only
+
   - name: genre
-    summary: the genre of the item
+    summary: Genre of this item.
     type: String
+    permission: read-only
+
   - name: isCompilation
-    summary: true if the item is part of a compilation album
+    summary: True if this item is part of a compilation album.
     type: Boolean
+    permission: read-only
+
   - name: lyrics
-    summary: the lyrics of the item
+    summary: Lyrics for this item.
     type: String
+    permission: read-only
+
   - name: mediaType
-    summary: the type of the item
+    summary: |
+        The type of the media. 
+    description: |
+        One of
+        [MUSIC_MEDIA_TYPE_ALL](Titanium.Media.MUSIC_MEDIA_TYPE_ALL),
+        [MUSIC_MEDIA_TYPE_ANY_AUDIO](Titanium.Media.MUSIC_MEDIA_TYPE_ANY_AUDIO),
+        [MUSIC_MEDIA_TYPE_AUDIOBOOK](Titanium.Media.MUSIC_MEDIA_TYPE_AUDIOBOOK),
+        [MUSIC_MEDIA_TYPE_MUSIC](Titanium.Media.MUSIC_MEDIA_TYPE_MUSIC), or
+        [MUSIC_MEDIA_TYPE_PODCAST](Titanium.Media.MUSIC_MEDIA_TYPE_PODCAST).
+        constants from <Titanium.Media>.
+
+        At least in theory, a single item can have more than one media type, in which case the
+        value represents a bitwise-OR of all the applicable media types.
     type: Number
+    permission: read-only
+
   - name: playCount
-    summary: the number of times the item has been played
+    summary: Number of times the item has been played.
     type: Number
+    permission: read-only
+
   - name: playbackDuration
-    summary: the length (in seconds) of the item
+    summary: Length (in seconds) of this item.
     type: Number
+    permission: read-only
+
   - name: podcastTitle
-    summary: the title of a podcast item.  Only for media types of <Titanium.Media.MUSIC_MEDIA_TYPE_PODCAST>.
+    summary: Title of a podcast item.  
+    description: |
+        Only included if the media type is <Titanium.Media.MUSIC_MEDIA_TYPE_PODCAST>.
     type: String
+    permission: read-only
+
   - name: rating
-    summary: the rating of the item
+    summary: Rating for this item.
     type: Number
+    permission: read-only
+
   - name: skipCount
-    summary: the number of times the item has been skipped
+    summary: Number of times this item has been skipped.
     type: Number
+    permission: read-only
+
   - name: title
-    summary: the title of the item
+    summary: Title of this item.
     type: String
+    permission: read-only

--- a/apidoc/Titanium/Media/Item.yml
+++ b/apidoc/Titanium/Media/Item.yml
@@ -2,12 +2,12 @@
 name: Titanium.Media.Item
 summary: A representation of a media item returned by [openMusicLibrary](Titanium.Media.openMusicLibrary) or [queryMusicLibrary](Titanium.Media.queryMusicLibrary).
 description: |
-    This is a read-only object that describes single media item, not a playlist. 
+    This is a read-only object that describes a single media item, not a playlist. 
     Titanium does not support access to playlists.
     
     `Item` objects cannot be created explicitly.  The 
     [openMusicLibrary](Titanium.Media.openMusicLibrary) returns `Item` objects in its
-    `success` function, while [queryMusicLibrary](Titanium.Media.queryMusicLibrary)
+    `success` callback function, while [queryMusicLibrary](Titanium.Media.queryMusicLibrary)
     returns an array of `Item` objects.
 extends: Titanium.Proxy
 since: "1.4.0"
@@ -81,13 +81,12 @@ properties:
     summary: |
         The type of the media. 
     description: |
-        One of
+        Specify one of the following constants from <Titanium.Media>:
         [MUSIC_MEDIA_TYPE_ALL](Titanium.Media.MUSIC_MEDIA_TYPE_ALL),
         [MUSIC_MEDIA_TYPE_ANY_AUDIO](Titanium.Media.MUSIC_MEDIA_TYPE_ANY_AUDIO),
         [MUSIC_MEDIA_TYPE_AUDIOBOOK](Titanium.Media.MUSIC_MEDIA_TYPE_AUDIOBOOK),
         [MUSIC_MEDIA_TYPE_MUSIC](Titanium.Media.MUSIC_MEDIA_TYPE_MUSIC), or
         [MUSIC_MEDIA_TYPE_PODCAST](Titanium.Media.MUSIC_MEDIA_TYPE_PODCAST).
-        constants from <Titanium.Media>.
 
         At least in theory, a single item can have more than one media type, in which case the
         value represents a bitwise-OR of all the applicable media types.

--- a/apidoc/Titanium/Media/Media.yml
+++ b/apidoc/Titanium/Media/Media.yml
@@ -862,7 +862,7 @@ properties:
 name: MusicLibraryResponseType
 summary: |
     Simple object passed to the [openMusicLibrary](Titanium.Media.openMusicLibrary)
-    success method.
+    `success` callback function.
 properties:
   - name: representative
     summary: A single representative of the selected items.

--- a/apidoc/Titanium/Media/Media.yml
+++ b/apidoc/Titanium/Media/Media.yml
@@ -20,8 +20,8 @@ methods:
   - name: hideMusicLibrary
     summary: Hides the music library.  
     description: |
-        Must be called after calling `showMusicLibrary` and only when `autohide` is 
-        set to `false`.
+        Must be called after calling [openMusicLibrary](Titanium.Media.openMusicLibrary) 
+        and only when `autohide` is set to `false`.
     platforms: [iphone, ipad]
   - name: isMediaTypeSupported
     summary: Returns `true` if the source supports the specified media type.
@@ -46,6 +46,16 @@ methods:
         summary: Media type to check, either `MEDIA_TYPE_PHOTO` or `MEDIA_TYPE_VIDEO`.
         type: String
     platforms: [iphone, ipad]
+  - name: openMusicLibrary
+    summary: Shows the music library and allows the user to select one or more tracks.
+    description: |
+        If `autohide` is set to `false`, you must hide the library explicitly using 
+        [hideMusicLibrary](Titanium.Media.hideMusicLibrary).
+    platforms: [iphone, ipad]
+    parameters:
+      - name: options
+        summary: A dictionary of options as described in <MusicLibraryOptionsType>.
+        type: MusicLibraryOptionsType
   - name: openPhotoGallery
     summary: Opens the photo gallery image picker.
     platforms: [iphone, ipad, android]
@@ -102,16 +112,6 @@ methods:
       - name: options
         summary: A dictionary of camera options as described in <CameraOptionsType>.
         type: CameraOptionsType
-  - name: showMusicLibrary
-    summary: Shows the music library and allows the user to select one or more tracks.
-    description: |
-        If `autohide` is set to `false`, you must hide the library explicitly using 
-        [hideMusicLibrary](Titanium.Media.hideMusicLibrary).
-    platforms: [iphone, ipad]
-    parameters:
-      - name: options
-        summary: A dictionary of options as described in <MusicLibraryOptionsType>.
-        type: MusicLibraryOptionsType
   - name: queryMusicLibrary
     summary: Searches the music library for items matching the specified search predicates.
     platforms: [iphone, ipad]
@@ -120,7 +120,7 @@ methods:
         summary: The query object to extract information from.
         type: MediaQueryType
     returns:
-        type: Array<MediaItemType>
+        type: Array<Titanium.Media.Item>
   - name: startMicrophoneMonitor
     summary: Starts monitoring the microphone sound level.
     platforms: [iphone, ipad]
@@ -818,12 +818,12 @@ properties:
 # Pseudo-type for showMusicLibrary argument
 ---
 name: MusicLibraryOptionsType
-summary: Simple object for specifying options to [showMusicLibrary](Titanium.Media.showMusicLibrary).
+summary: Simple object for specifying options to [openMusicLibrary](Titanium.Media.openMusicLibrary).
 platforms: [iphone, ipad]
 properties:
   - name: success
     summary: Function to call when the music library selection is made.
-    type: Callback<Object>
+    type: Callback<MusicLibraryResponseType>
   - name:  error 
     summary: Function to call upon receiving an error. 
     type: Callback<Object>
@@ -857,6 +857,25 @@ properties:
     summary: Set to `true` to allow the user to select multiple items from the library.
     type: Boolean
     default: false
+
+---
+name: MusicLibraryResponseType
+summary: |
+    Simple object passed to the [openMusicLibrary](Titanium.Media.openMusicLibrary)
+    success method.
+properties:
+  - name: representative
+    summary: A single representative of the selected items.
+    type: Titanium.Media.Item
+  - name: items
+    summary: A list of all the items chosen by the user.
+    type: Array<Titanium.Media.Item>
+  - name: types
+    summary: |
+        Media types in this collection, represented as the bitwise OR of the media type
+        values for all media types represented in `items`.
+    type: Number
+   
 # Pseudo-type for queryMediaLibrary argument
 ---
 name: MediaQueryType
@@ -914,69 +933,6 @@ properties:
         default is `true`.
     type: Boolean
     
-# Pseudo-type for media library results
----
-name: MediaItemType
-summary: An object representing an entry in the iPod's music library.
-platforms: [iphone, ipad]
-since: "1.5"
-properties:
-  - name: mediaType
-    summary: The type of the media. One of the `MUSIC_MEDIA_TYPE_*`
-        constants on <Titanium.Media>.
-    type: Number
-  - name: title
-    summary: The title ID3 tag contents.
-    type: String
-  - name: albumTitle
-    summary: The album title ID3 tag contents.
-    type: String
-  - name: artist
-    summary: The artist ID3 tag contents.
-    type: String
-  - name: albumArtist
-    summary: The album artist ID3 tag contents.
-    type: String
-  - name: genre
-    summary: The genre ID3 tag contents.
-    type: String
-  - name: composer
-    summary: The composer ID3 tag contents.
-    type: String
-  - name: isCompilation
-    summary: Whether or not the media is part of a compilation album.
-    type: Boolean
-  - name: playbackDuration
-    summary: The playback length.
-    type: Number
-  - name: albumTrackNumber
-    summary: The track number of the album.
-    type: Number
-  - name: albumTrackCount
-    summary: The total number of tracks on the album.
-    type: Number
-  - name: discNumber
-    summary: The disc number of the album.
-    type: Number
-  - name: discCount
-    summary: The total number of discs comprising the album.
-    type: Number
-  - name: lyrics
-    summary: The lyrics ID3 tag contents.
-    type: String
-  - name: podcastTitle
-    summary: The podcast title. Only valid for media of type
-        `MUSIC_MEDIA_TYPE_PODCAST`.
-    type: String
-  - name: playCount
-    summary: The total number of plays.
-    type: Number
-  - name: skipCount
-    summary: The total number of skips.
-    type: Number
-  - name: rating
-    summary: The user rating.
-    type: Number
 # Camera options pseudo-type
 ---
 name: CameraOptionsType


### PR DESCRIPTION
- openMusicLibrary was erroneously doc'd as showMusicLibrary
- corrected return type for success callback
- corrected return type for queryMusicLibrary
- removed unnecessary pseudotype (duplicated Ti.Media.Item).
