### PR TITLE
[TC-881] iOS navBarButtonTint

### DIFF
--- a/apidoc/Titanium/UI/Button.yml
+++ b/apidoc/Titanium/UI/Button.yml
@@ -140,6 +140,12 @@ properties:
         Text alignment, specified using one of the <Titanium.UI> text alignment constants: [TEXT_ALIGNMENT_LEFT](Titanium.UI.TEXT_ALIGNMENT_LEFT), [TEXT_ALIGNMENT_CENTER](Titanium.UI.TEXT_ALIGNMENT_CENTER), or [TEXT_ALIGNMENT_RIGHT](Titanium.UI.TEXT_ALIGNMENT_RIGHT).
     type: [String,Number]
     default: <Titanium.UI.TEXT_ALIGNMENT_CENTER>
+  - name: tintColor
+    summary: Button background color in the context of a Nav Bar.
+    description: |
+        Allows setting the button color independent of the barColor of the containing Nav Bar. iOS 5.0 or greater only. Will be ignored on older versions of iOS.
+    type: String
+    platforms: [iphone,ipad]
   - name: title
     summary: Button title.
     type: String

--- a/iphone/Classes/TiUIButton.h
+++ b/iphone/Classes/TiUIButton.h
@@ -22,6 +22,7 @@
 -(UIButton*)button;
 
 -(void)setEnabled_:(id)value;
+-(void)setTintColor_:(id)value;
 
 @end
 

--- a/iphone/Classes/TiUIButton.m
+++ b/iphone/Classes/TiUIButton.m
@@ -256,6 +256,15 @@
 	}
 }
 
+-(void)setTintColor_:(id)value
+{
+	if (value!=nil && [[self button] respondsToSelector:@selector(setTintColor:)])
+	{
+		TiColor *color = [TiUtils colorValue:value];
+		[[self button] setTintColor:[color _color]];
+	}
+}
+
 -(void)setFont_:(id)font
 {
 	if (font!=nil)

--- a/iphone/Classes/TiUINavBarButton.m
+++ b/iphone/Classes/TiUINavBarButton.m
@@ -101,6 +101,8 @@ DEFINE_EXCEPTIONS
 	{
 		id image = [proxy_ valueForKey:@"image"];
        id background = [proxy_ valueForKey:@"backgroundImage"];
+       id tint = [proxy_ valueForKey:@"tintColor"];
+
        if (background != nil) {
            self = [super initWithCustomView:[proxy_ view]];
            self.target = self;
@@ -119,6 +121,12 @@ DEFINE_EXCEPTIONS
 		else {
            self = [super initWithTitle:[self title:proxy_] style:[self style:proxy_] target:self action:@selector(clicked:)];
 		}
+		
+		if(tint != nil && [self respondsToSelector:@selector(setTintColor:)]) {
+			TiColor * theTintColor = [TiUtils colorValue:tint];
+			[self setTintColor:[theTintColor _color]];
+		}
+
 	}
 	proxy = proxy_; // Don't retain
 


### PR DESCRIPTION
This allows you to color a button in navbar, independent of barColor attribute.

Apple only added ability for tintColor in navBar/buttons under iOS 5. 
Checks for selector to make sure button has the capability, otherwise it will just ignore tint on older iOS.

JIRA: https://jira.appcelerator.org/browse/TC-881

![tint color](http://i.imgur.com/bJeUo.png)
