### PR TITLE
[TIMOB-9035] (2_0_X) Scrollview lays out improperly on close/open

### DIFF
--- a/iphone/Classes/TiUIScrollViewProxy.m
+++ b/iphone/Classes/TiUIScrollViewProxy.m
@@ -36,6 +36,16 @@
     return [contentOffset autorelease];
 }
 
+-(void)windowWillOpen
+{
+    [super windowWillOpen];
+    //Since layout children is overridden in scrollview need to make sure that 
+    //a full layout occurs atleast once if view is attached
+    if ([self viewAttached]) {
+        [self contentsWillChange];
+    }
+}
+
 -(void)contentsWillChange
 {
 	if ([self viewAttached])


### PR DESCRIPTION
Cherry Pick of PR #2198 for 2_0_X branch

Test is in [JIRA](https://jira.appcelerator.org/browse/TIMOB-9035)
