### PR TITLE
[TIMOB-9171] Remove unnecessary cast.

### DIFF
--- a/iphone/Classes/TiUIWindow.m
+++ b/iphone/Classes/TiUIWindow.m
@@ -31,8 +31,14 @@
 -(void)frameSizeChanged:(CGRect)frame bounds:(CGRect)bounds
 {
     [super frameSizeChanged:frame bounds:bounds];
+    
     //Need the delay so that we get the right navbar bounds
-    [(TiUIWindowProxy*)[self proxy] performSelector:@selector(_updateTitleView) withObject:nil afterDelay:[[UIApplication sharedApplication] statusBarOrientationAnimationDuration] ];
+    TiProxy* windowProxy = [self proxy];
+    if ([windowProxy respondsToSelector:@selector(_updateTitleView)]) {
+        [windowProxy performSelector:@selector(_updateTitleView) 
+                           withObject:nil 
+                           afterDelay:[[UIApplication sharedApplication] statusBarOrientationAnimationDuration] ];
+    }
 }
 
 


### PR DESCRIPTION
This fixes a compilation error which results from the fact that because `TiUIWindow` has compilation dependencies outside of the UI system (in `TiWindow`), it can't be casted to a specific proxy type. Much safer to do this than an `#ifdef` guard + other code changes.

[JIRA](https://jira.appcelerator.org/browse/TIMOB-9171)
