### PR TITLE
[TIMOB-9173] Declare TiUILabel to be NO-OPTIMIZE, fix zindex shortcircuit

### DIFF
--- a/iphone/Classes/TiUILabelProxy.m
+++ b/iphone/Classes/TiUILabelProxy.m
@@ -66,6 +66,11 @@ USE_VIEW_FOR_CONTENT_WIDTH
     return TiDimensionAutoSize;
 }
 
+// TiUILabel has non-TiUIView subviews and is not intended for use as a viewgroup, either
+-(BOOL)optimizeSubviewInsertion
+{
+    return NO;
+}
 
 @end
 

--- a/iphone/Classes/TiViewProxy.m
+++ b/iphone/Classes/TiViewProxy.m
@@ -2487,7 +2487,7 @@ if(OSAtomicTestAndSetBarrier(flagBit, &dirtyflags))	\
 
 			for (TiUIView * thisView in [ourView subviews])
 			{
-				if ( (!optimizeInsertion) && (![thisView isKindOfClass:[TiUIView class]]) )
+				if (![thisView isKindOfClass:[TiUIView class]])
 				{
 					insertPosition ++;
 					continue;


### PR DESCRIPTION
There may be some other views here that we're missing, where a proxy's view contains non-TiUIView elements as its subviews, which are then attempted to have their proxies referenced.

Requires a regression against [TIMOB-8776](https://jira.appcelerator.org/browse/TIMOB-8776).
