### PR TITLE
TIMOB-9189: Android: TableView - V8: Last item in table view gets shifte...

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TableViewProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TableViewProxy.java
@@ -457,6 +457,7 @@ public class TableViewProxy extends TiViewProxy
 				rowProxy = new TableViewRowProxy();
 				rowProxy.setCreationUrl(creationUrl.getNormalizedUrl());
 				rowProxy.handleCreationDict(rowDict);
+				rowProxy.setProperty(TiC.PROPERTY_CLASS_NAME, CLASSNAME_NORMAL);
 				rowProxy.setCreationProperties(rowDict);
 				rowProxy.setProperty(TiC.PROPERTY_ROW_DATA, row);
 				rowProxy.setActivity(getActivity());


### PR DESCRIPTION
...d in and off alignment from the rest

https://jira.appcelerator.org/browse/TIMOB-9189

I had to revert some of the logic from https://github.com/appcelerator/titanium_mobile/pull/2039, which caused the regression.

Test Instructions:

This only happens on nook/ kindle fire.  This fix just reverts KS back to the original behavior, which causes ALL the rows to be indented instead of just one.  I have filed a bug fo this: TIMOB-9208.

To test, follow the test case in TIMOB-9189, and verify that all the rows are indented after you hit back.  Essentially, we want to verify that it has the same behavior as 2.0.1GA2.

Please also test TIMOB-7796 to make sure it is still fixed.
