### PR TITLE
[TIMOB-9150] workaround android NDK project path limitation when packaging a module

### DIFF
--- a/support/module/android/build.xml
+++ b/support/module/android/build.xml
@@ -311,7 +311,7 @@ timodule.xml.
 			<property name="tmpdir" value="${java.io.tmpdir}/${user.name}/${ant.project.name}-generated" />
 
 			<mkdir dir="${tmpdir}" />
-			<copy todir="${tmpdir}" preservelastmodified="true" overwrite="true" force="true" includeEmptyDirs="true">
+			<copy todir="${tmpdir}" preservelastmodified="true" overwrite="true" includeEmptyDirs="true">
 				<fileset dir="@{gendir}"/>
 			</copy>
 			<exec executable="${ndk.build}" dir="${tmpdir}" failonerror="true">
@@ -322,7 +322,7 @@ timodule.xml.
 				<arg value="V=${ndk.verbose}"/>
 			</exec>
 
-			<move todir="@{gendir}" preservelastmodified="true" overwrite="true" force="true" includeEmptyDirs="true">
+			<move todir="@{gendir}" preservelastmodified="true" overwrite="true" includeEmptyDirs="true">
 				<fileset dir="${tmpdir}"/>
 			</move>
 		</sequential>

--- a/support/module/android/build.xml
+++ b/support/module/android/build.xml
@@ -308,14 +308,23 @@ timodule.xml.
 			
 			<property name="mobilesdk.dir" location="${titanium.platform}/.."/>
 			<property name="ndk.verbose" value="0"/>
-	
-			<exec executable="${ndk.build}" dir="@{gendir}" failonerror="true">
+			<property name="tmpdir" value="${java.io.tmpdir}/${user.name}/${ant.project.name}-generated" />
+
+			<mkdir dir="${tmpdir}" />
+			<copy todir="${tmpdir}" preservelastmodified="true" overwrite="true" force="true" includeEmptyDirs="true">
+				<fileset dir="@{gendir}"/>
+			</copy>
+			<exec executable="${ndk.build}" dir="${tmpdir}" failonerror="true">
 				<arg value="TI_MOBILE_SDK=${mobilesdk.dir}"/>
-				<arg value="NDK_PROJECT_PATH=@{gendir}"/>
-				<arg value="NDK_APPLICATION_MK=@{gendir}/Application.mk"/>
+				<arg value="NDK_PROJECT_PATH=${tmpdir}"/>
+				<arg value="NDK_APPLICATION_MK=${tmpdir}/Application.mk"/>
 				<arg value="PYTHON=${python.exec}"/>
 				<arg value="V=${ndk.verbose}"/>
 			</exec>
+
+			<move todir="@{gendir}" preservelastmodified="true" overwrite="true" force="true" includeEmptyDirs="true">
+				<fileset dir="${tmpdir}"/>
+			</move>
 		</sequential>
 	</macrodef>
 	


### PR DESCRIPTION
[TIMOB-9150](https://jira.appcelerator.org/browse/TIMOB-9150)

Test instructions in JIRA.
Should be tested on all supported platforms.
