### PR TITLE
[TIMOB-9216] MobileWeb - Added "up" and "down" swipe events

### DIFF
--- a/apidoc/Titanium/UI/View.yml
+++ b/apidoc/Titanium/UI/View.yml
@@ -466,7 +466,7 @@ events:
     platforms: [android,iphone,ipad,mobileweb]
     properties:
       - name: direction
-        summary: Direction of the swipe--either 'left', 'right', 'up', and 'down'.
+        summary: Direction of the swipe--either 'left', 'right', 'up', or 'down'.
         type: String
       - name: y
         summary: Y coordinate of the event's endpoint from the `source` view's coordinate system.

--- a/apidoc/Titanium/UI/View.yml
+++ b/apidoc/Titanium/UI/View.yml
@@ -466,7 +466,7 @@ events:
     platforms: [android,iphone,ipad,mobileweb]
     properties:
       - name: direction
-        summary: Direction of the swipe--either 'left' or 'right'. Android also supports 'up' and 'down'.
+        summary: Direction of the swipe--either 'left', 'right', 'up', and 'down'.
         type: String
       - name: y
         summary: Y coordinate of the event's endpoint from the `source` view's coordinate system.

--- a/iphone/Classes/TiUIView.h
+++ b/iphone/Classes/TiUIView.h
@@ -73,6 +73,8 @@ void ModifyScrollViewForKeyboardHeightAndContentHeightWithResponderRect(UIScroll
 	UIPinchGestureRecognizer*		pinchRecognizer;
 	UISwipeGestureRecognizer*		leftSwipeRecognizer;
 	UISwipeGestureRecognizer*		rightSwipeRecognizer;
+	UISwipeGestureRecognizer*		upSwipeRecognizer;
+	UISwipeGestureRecognizer*		downSwipeRecognizer;
 	UILongPressGestureRecognizer*	longPressRecognizer;
 	
 	//Resizing handling

--- a/iphone/Classes/TiUIView.m
+++ b/iphone/Classes/TiUIView.m
@@ -190,6 +190,8 @@ DEFINE_EXCEPTIONS
 	[pinchRecognizer release];
 	[leftSwipeRecognizer release];
 	[rightSwipeRecognizer release];
+	[upSwipeRecognizer release];
+	[downSwipeRecognizer release];
 	[longPressRecognizer release];
 	proxy = nil;
 	touchDelegate = nil;

--- a/iphone/Classes/TiUIView.m
+++ b/iphone/Classes/TiUIView.m
@@ -832,6 +832,26 @@ DEFINE_EXCEPTIONS
 	}
 	return rightSwipeRecognizer;
 }
+-(UISwipeGestureRecognizer*)upSwipeRecognizer;
+{
+	if (upSwipeRecognizer == nil) {
+		upSwipeRecognizer = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(recognizedSwipe:)];
+		[upSwipeRecognizer setDirection:UISwipeGestureRecognizerDirectionUp];
+		[self configureGestureRecognizer:upSwipeRecognizer];
+		[self addGestureRecognizer:upSwipeRecognizer];
+	}
+	return upSwipeRecognizer;
+}
+-(UISwipeGestureRecognizer*)downSwipeRecognizer;
+{
+	if (downSwipeRecognizer == nil) {
+		downSwipeRecognizer = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(recognizedSwipe:)];
+		[downSwipeRecognizer setDirection:UISwipeGestureRecognizerDirectionDown];
+		[self configureGestureRecognizer:downSwipeRecognizer];
+		[self addGestureRecognizer:downSwipeRecognizer];
+	}
+	return downSwipeRecognizer;
+}
 
 -(UILongPressGestureRecognizer*)longPressRecognizer;
 {
@@ -1161,6 +1181,12 @@ DEFINE_EXCEPTIONS
     if ([event isEqualToString:@"rswipe"]) {
         return [self rightSwipeRecognizer];
     }
+    if ([event isEqualToString:@"uswipe"]) {
+        return [self upSwipeRecognizer];
+    }
+    if ([event isEqualToString:@"dswipe"]) {
+        return [self downSwipeRecognizer];
+    }
     if ([event isEqualToString:@"pinch"]) {
         return [self pinchRecognizer];
     }
@@ -1175,6 +1201,8 @@ DEFINE_EXCEPTIONS
 	ENSURE_UI_THREAD_1_ARG(event);
     [self updateTouchHandling];
     if ([event isEqualToString:@"swipe"]) {
+        [[self gestureRecognizerForEvent:@"uswipe"] setEnabled:YES];
+        [[self gestureRecognizerForEvent:@"dswipe"] setEnabled:YES];
         [[self gestureRecognizerForEvent:@"rswipe"] setEnabled:YES];
         [[self gestureRecognizerForEvent:@"lswipe"] setEnabled:YES];
     }

--- a/mobileweb/titanium/Ti/_/Gestures/Swipe.js
+++ b/mobileweb/titanium/Ti/_/Gestures/Swipe.js
@@ -72,20 +72,17 @@ define(["Ti/_/declare", "Ti/_/lang","Ti/_/Gestures/GestureRecognizer"], function
 							if (xDiff > yDiff) {
 								direction =  this._touchStartLocation.x - x > 0 ? "left" : "right";
 							} else {
-								direction =  this._touchStartLocation.y - y > 0 ? "down" : "up";
+								direction =  this._touchStartLocation.y - y < 0 ? "down" : "up";
 							}
 							
-							// Right now only left and right are supported
-							if (direction === "left" || direction === "right") {
-								lang.hitch(element,element._handleTouchEvent(this.name,{
-									x: x,
-									y: y,
-									direction: direction,
-									_distance: x - this._touchStartLocation.x,
-									_finishedSwiping: finishedSwiping,
-									source: this.getSourceNode(e,element)
-								}));
-							}
+							lang.hitch(element,element._handleTouchEvent(this.name,{
+								x: x,
+								y: y,
+								direction: direction,
+								_distance: x - this._touchStartLocation.x,
+								_finishedSwiping: finishedSwiping,
+								source: this.getSourceNode(e,element)
+							}));
 						}
 					}
 				}


### PR DESCRIPTION
The "up" and "down" swipe events where not implemented in MobileWeb. They were already there but not allowed to be triggered. They where also upside down.
