### PR TITLE
[TIMOB-9222][TIMOB-9223] Clipboard fixes in honor of Hal.

### DIFF
--- a/drillbit/tests/ui.clipboard.js
+++ b/drillbit/tests/ui.clipboard.js
@@ -1,0 +1,38 @@
+describe("Ti.UI.Clipboard tests", {
+    setAndGetText: function() {
+        Ti.UI.Clipboard.setText('hello');
+        valueOf(Ti.UI.Clipboard.hasText()).shouldBeTrue();
+        valueOf(Ti.UI.Clipboard.getText()).shouldBe('hello');
+    },
+
+    clearText: function() {
+        valueOf(function() {
+            Ti.UI.Clipboard.clearText();
+        }).shouldNotThrowException();
+            valueOf(Ti.UI.Clipboard.hasText()).shouldBeFalse();
+            // Return value of getText() varies by platform: TIMOB-9224
+            // So we can't test it, but at least it shouldn't throw an exception.
+        valueOf(function() {
+            Ti.UI.Clipboard.getText();
+        }).shouldNotThrowException();
+    },
+
+    // Using setData to store text with a mime type.
+    setAndGetHTML: function() {
+        // Clear all data first.
+        Ti.UI.Clipboard.clearData();
+        Ti.UI.Clipboard.setData('text/html', "<p>How is <em>this</em> for data?</p>");
+        valueOf(Ti.UI.Clipboard.hasData('text/html')).shouldBeTrue();
+        valueOf(Ti.UI.Clipboard.getData('text/html'))
+            .shouldBe("<p>How is <em>this</em> for data?</p>");
+    },
+
+    // Data with mimeType 'text/url-list' or 'url' is treated as a URL on iOS, so 
+    // follows a different code path than plain text or images.
+    urlData: function() {
+        Ti.UI.Clipboard.clearData();
+        Ti.UI.Clipboard.setData('text/url-list', "http://www.appcelerator.com");
+        valueOf(Ti.UI.Clipboard.getData('text/url-list')).shouldBe("http://www.appcelerator.com");
+    }
+
+});

--- a/iphone/Classes/TiUIClipboardProxy.h
+++ b/iphone/Classes/TiUIClipboardProxy.h
@@ -18,8 +18,8 @@
 -(void)clearText:(id)args;
 -(id)getData:(id)args;
 -(NSString *)getText:(id)args;
--(BOOL)hasData:(id)args;
--(BOOL)hasText:(id)args;
+-(id)hasData:(id)args;
+-(id)hasText:(id)args;
 -(void)setData:(id)args;
 -(void)setText:(id)args;
 

--- a/iphone/Classes/TiUIClipboardProxy.m
+++ b/iphone/Classes/TiUIClipboardProxy.m
@@ -100,8 +100,20 @@ static NSString *mimeTypeToUTType(NSString *mimeType)
 	board.strings = nil;
 }
 	 
--(id)getData:(id)arg
+-(id)getData:(id)args
 {
+    id arg = nil;
+    if ([args isKindOfClass:[NSArray class]])
+    {
+        if ([args count] > 0)
+        {
+            arg = [args objectAtIndex:0];
+        }
+    }
+    else 
+    {
+        arg = args;
+    }
 	ENSURE_STRING(arg);
 	NSString *mimeType = arg;
 	__block id result;
@@ -153,8 +165,20 @@ static NSString *mimeTypeToUTType(NSString *mimeType)
 	return [self getData: @"text/plain"];
 }
 	 
--(BOOL)hasData:(id)arg
+-(id)hasData:(id)args
 {
+    id arg = nil;
+    if ([args isKindOfClass:[NSArray class]])
+    {
+        if ([args count] > 0)
+        {
+            arg = [args objectAtIndex:0];
+        }
+    }
+    else 
+    {
+        arg = args;
+    }
 	ENSURE_STRING_OR_NIL(arg);
 	NSString *mimeType = arg;
 	__block BOOL result=NO;
@@ -187,10 +211,10 @@ static NSString *mimeTypeToUTType(NSString *mimeType)
 			}
 		}
 	}, YES);
-	return result;
+	return NUMBOOL(result);
 }
 	 
--(BOOL)hasText:(id)args
+-(id)hasText:(id)args
 {
 	return [self hasData: @"text/plain"];
 }
@@ -202,6 +226,10 @@ static NSString *mimeTypeToUTType(NSString *mimeType)
 	
 	NSString *mimeType = [TiUtils stringValue: [args objectAtIndex: 0]];
 	id data = [args objectAtIndex: 1];
+    if (data == nil) {
+        DebugLog(@"[WARN] setData: data object was nil.");
+        return;
+    }
 	UIPasteboard *board = [UIPasteboard generalPasteboard];
 	ClipboardType dataType = mimeTypeToDataType(mimeType);
 	


### PR DESCRIPTION
In honor of @pauldowsett's last week with us, I'm fixing a couple of the bugs he filed on Clipboard. Note that this is a code PR, not docs.

Fixed crashes on setData, hasData.  [TIMOB-9222](https://jira.appcelerator.org/browse/TIMOB-9222)
Also fixed hasText, hasData return values.  [TIMOB-9223](https://jira.appcelerator.org/browse/TIMOB-9223)

Also added drillbit tests for Clipboard. Note that these fail on Android because of Bug #9263, fixed in PR#2280:

https://github.com/appcelerator/titanium_mobile/pull/2280

With that fix, 2 tests still fail on Android because clearData's argument should be optional, but isn't.

I could change the tests to accomodate this bug, but it would be preferable to simply fix clearData while we're doing a PR on Clipboard.
