### PR TITLE
[TIMOB-9016]Clearing text on tableview searchbar causing rendering issues.

### DIFF
--- a/iphone/Classes/TiUITableView.m
+++ b/iphone/Classes/TiUITableView.m
@@ -982,7 +982,12 @@
 {
 	if ([searchString length]==0) {
         RELEASE_TO_NIL(searchResultIndexes);
-		return;
+        
+        //Need to reload the tableview, as some of the cells might be reused as part
+        //of a previous search and as a result may not be visible on screen.
+        [tableview reloadData];
+        
+        return;
 	}
 	NSEnumerator * searchResultIndexEnumerator;
 	if(searchResultIndexes == nil)


### PR DESCRIPTION
While testing original bug found another related issue, where after searching for a text if we trying clear out the text manually the greyed out tableview in the background shows some missing blank cells. This happens as table views cells themselves have been reused and is no longer available. 

**TESTING INSTRUCTION**
- Run the code in [JIRA](https://jira.appcelerator.org/browse/TIMOB-9016)
- Type row in searchbar.
- Clear out the entire text manually. 
- The background tableview should not have any missing cells. 
