### PR TITLE
TIMOB-9062: Clean-up other activities in the activity stack when the roo...

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TiTabActivity.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TiTabActivity.java
@@ -176,7 +176,6 @@ public class TiTabActivity extends TabActivity
 				}
 			}
 		});
-		
 	}
 
 	public TiApplication getTiApp()

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIActivityIndicator.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIActivityIndicator.java
@@ -130,7 +130,8 @@ public class TiUIActivityIndicator extends TiUIView
 
 	public void show(KrollDict options)
 	{
-		if (visible) {
+		// Don't try to show indicator if the root activity is not available
+		if (visible || !TiApplication.getInstance().isRootActivityAvailable()) {
 			return;
 		}
 		handleShow();

--- a/android/titanium/src/java/org/appcelerator/titanium/TiApplication.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiApplication.java
@@ -185,7 +185,7 @@ public abstract class TiApplication extends Application implements Handler.Callb
 	}
 
 	// Calls finish on the list of activities in the stack. This should only be called when we want to terminate the
-	// application (typically when the launch activity is destroyed)
+	// application (typically when the root activity is destroyed)
 	public static void terminateActivityStack()
 	{
 		if (activityStack == null || activityStack.size() == 0) {
@@ -193,11 +193,15 @@ public abstract class TiApplication extends Application implements Handler.Callb
 		}
 
 		WeakReference<Activity> activityRef;
+		Activity currentActivity;
 
 		for (int i = activityStack.size() - 1; i >= 0; i--) {
 			activityRef = activityStack.get(i);
 			if (activityRef != null) {
-				activityRef.get().finish();
+				currentActivity = activityRef.get();
+				if (currentActivity != null) {
+					currentActivity.finish();
+				}
 			}
 		}
 		activityStack.clear();
@@ -464,7 +468,14 @@ public abstract class TiApplication extends Application implements Handler.Callb
 	 */
 	public boolean isRootActivityAvailable()
 	{
-		return rootActivity != null && !rootActivity.get().isFinishing();
+		if (rootActivity != null) {
+			Activity activity = rootActivity.get();
+			if (activity != null) {
+				return !activity.isFinishing();
+			}
+		}
+
+		return false;
 	}
 
 	public void setCurrentActivity(Activity callingActivity, Activity newValue)

--- a/android/titanium/src/java/org/appcelerator/titanium/TiApplication.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiApplication.java
@@ -184,6 +184,25 @@ public abstract class TiApplication extends Application implements Handler.Callb
 		activityStack.remove(activity);
 	}
 
+	// Calls finish on the list of activities in the stack. This should only be called when we want to terminate the
+	// application (typically when the launch activity is destroyed)
+	public static void terminateActivityStack()
+	{
+		if (activityStack == null || activityStack.size() == 0) {
+			return;
+		}
+
+		WeakReference<Activity> activityRef;
+
+		for (int i = activityStack.size() - 1; i >= 0; i--) {
+			activityRef = activityStack.get(i);
+			if (activityRef != null) {
+				activityRef.get().finish();
+			}
+		}
+		activityStack.clear();
+	}
+
 	public boolean activityStackHasLaunchActivity()
 	{
 		if (activityStack == null || activityStack.size() == 0) {
@@ -438,6 +457,14 @@ public abstract class TiApplication extends Application implements Handler.Callb
 		}
 
 		return rootActivity.get();
+	}
+
+	/**
+	 * @return whether the root activity is available
+	 */
+	public boolean isRootActivityAvailable()
+	{
+		return rootActivity != null && !rootActivity.get().isFinishing();
 	}
 
 	public void setCurrentActivity(Activity callingActivity, Activity newValue)

--- a/android/titanium/src/java/org/appcelerator/titanium/TiLaunchActivity.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiLaunchActivity.java
@@ -59,7 +59,6 @@ public abstract class TiLaunchActivity extends TiBaseActivity
 	private AlarmManager restartAlarmManager = null;
 	private int restartDelay = 0;
 	protected boolean invalidKindleFireRelaunch = false;
-	private boolean finishing = false;
 
 	/**
 	 * @return The Javascript URL that this Activity should run
@@ -435,16 +434,4 @@ public abstract class TiLaunchActivity extends TiBaseActivity
 		super.onDestroy();
 	}
 
-	@Override
-	public void finish()
-	{
-		// Ensure we only run the finish logic once. We want to avoid an infinite loop since this method can be called
-		// from the finish method inside TiBaseActivity ( which can be triggered by terminateActivityStack() )
-		if (!finishing) {
-			finishing = true;
-			TiApplication.removeFromActivityStack(this);
-			TiApplication.terminateActivityStack();
-			super.finish();
-		}
-	}
 }

--- a/android/titanium/src/java/org/appcelerator/titanium/TiLaunchActivity.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiLaunchActivity.java
@@ -59,6 +59,7 @@ public abstract class TiLaunchActivity extends TiBaseActivity
 	private AlarmManager restartAlarmManager = null;
 	private int restartDelay = 0;
 	protected boolean invalidKindleFireRelaunch = false;
+	private boolean finishing = false;
 
 	/**
 	 * @return The Javascript URL that this Activity should run
@@ -427,10 +428,23 @@ public abstract class TiLaunchActivity extends TiBaseActivity
 		if (tiApp != null) {
 			tiApp.postAnalyticsEvent(TiAnalyticsEventFactory.createAppEndEvent());
 		}
-		
+
 		// Create a new session ID for next session
 		TiPlatformHelper.resetSid();
-		
+
 		super.onDestroy();
+	}
+
+	@Override
+	public void finish()
+	{
+		// Ensure we only run the finish logic once. We want to avoid an infinite loop since this method can be called
+		// from the finish method inside TiBaseActivity ( which can be triggered by terminateActivityStack() )
+		if (!finishing) {
+			finishing = true;
+			TiApplication.removeFromActivityStack(this);
+			TiApplication.terminateActivityStack();
+			super.finish();
+		}
 	}
 }

--- a/android/titanium/src/java/org/appcelerator/titanium/TiRootActivity.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiRootActivity.java
@@ -24,6 +24,7 @@ public class TiRootActivity extends TiLaunchActivity
 {
 	private static final String LCAT = "TiRootActivity";
 	private static final boolean DBG = TiConfig.LOGD;
+	private boolean finishing = false;
 
 	private Drawable[] backgroundLayers = {null, null};
 
@@ -150,6 +151,19 @@ public class TiRootActivity extends TiLaunchActivity
 			Log.d(LCAT, "root activity onDestroy, activity = " + this);
 		}
 		TiFastDev.onDestroy();
+	}
+
+	@Override
+	public void finish()
+	{
+		// Ensure we only run the finish logic once. We want to avoid an infinite loop since this method can be called
+		// from the finish method inside TiBaseActivity ( which can be triggered by terminateActivityStack() )
+		if (!finishing) {
+			finishing = true;
+			TiApplication.removeFromActivityStack(this);
+			TiApplication.terminateActivityStack();
+			super.finish();
+		}
 	}
 
 }

--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/TiViewProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/TiViewProxy.java
@@ -37,7 +37,6 @@ import org.appcelerator.titanium.view.TiUIView;
 import android.app.Activity;
 import android.os.Handler;
 import android.os.Message;
-import android.provider.OpenableColumns;
 import android.view.View;
 
 /**

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiUrl.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiUrl.java
@@ -177,7 +177,7 @@ public class TiUrl
 				throw new IllegalArgumentException("Scheme not implemented for " + url);
 			}
 		} catch (URISyntaxException e) {
-			Log.w(TAG, "Error parsing url: " + e.getMessage(), e);
+			Log.w(TAG, "Error parsing url: " + e.getMessage());
 		}
 		return new TiUrl(baseUrl, url);
 	}
@@ -286,7 +286,7 @@ public class TiUrl
 				return uri.toString();
 			}
 		} catch (URISyntaxException e) {
-			Log.w(TAG, "Error parsing url: " + e.getMessage(), e);
+			Log.w(TAG, "Error parsing url: " + e.getMessage());
 			return url;
 		}
 	}
@@ -319,7 +319,7 @@ public class TiUrl
 			builder.encodedPath(Uri.encode(Uri.decode(base.getPath()), "/"));
 			return builder.build();
 		} catch (Exception e) {
-			Log.e(TAG, "Exception in getCleanUri argString= " + argString, e);
+			Log.e(TAG, "Exception in getCleanUri argString= " + argString);
 			return null;
 		}
 	}

--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiCompositeLayout.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiCompositeLayout.java
@@ -532,7 +532,7 @@ public class TiCompositeLayout extends ViewGroup
 				}
 
 				if (!TiApplication.getInstance().isRootActivityAvailable()) {
-					Log.e(TAG, "The root activity is no longer available.  Skipping layout pass.");
+					Log.w(TAG, "The root activity is no longer available.  Skipping layout pass.");
 					return;
 				}
 

--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiCompositeLayout.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiCompositeLayout.java
@@ -13,6 +13,7 @@ import java.util.TreeSet;
 
 import org.appcelerator.kroll.common.Log;
 import org.appcelerator.kroll.common.TiConfig;
+import org.appcelerator.titanium.TiApplication;
 import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.TiDimension;
 import org.appcelerator.titanium.proxy.TiViewProxy;
@@ -529,6 +530,12 @@ public class TiCompositeLayout extends ViewGroup
 					int newHeightSpec = MeasureSpec.makeMeasureSpec(newHeight, MeasureSpec.EXACTLY);
 					child.measure(newWidthSpec, newHeightSpec);
 				}
+
+				if (!TiApplication.getInstance().isRootActivityAvailable()) {
+					Log.e(TAG, "The root activity is no longer available.  Skipping layout pass.");
+					return;
+				}
+
 				child.layout(horizontal[0], vertical[0], horizontal[1], vertical[1]);
 
 				currentHeight += newHeight;


### PR DESCRIPTION
...t activity is finishing.

https://jira.appcelerator.org/browse/TIMOB-9062

This PR essentially corrects the "exitOnClose" behavior.  Before, we were not cleaning up activities from the activity stack when the root activity has been destroyed.  As a result, the app is still able to run afterwards.  With this change, exitOnClose should also kill all other activities in the activity stack, which forces the app to close.

This should also fix https://jira.appcelerator.org/browse/TIMOB-9140 since the app exits immediately.

Test case is in the jira ticket for timob-9062
