### PR TITLE
timob-9162: removing Content-Length header when an entity is added to the request

### DIFF
--- a/android/modules/network/src/java/ti/modules/titanium/network/TiHTTPClient.java
+++ b/android/modules/network/src/java/ti/modules/titanium/network/TiHTTPClient.java
@@ -1112,6 +1112,12 @@ public class TiHTTPClient
 					Log.d(LCAT, "Preparing to execute request");
 				}
 
+				//Remove Content-Length header if entity is set since setEntity implicitly sets Content-Length
+				HttpEntityEnclosingRequest enclosingEntity = (HttpEntityEnclosingRequest) request;
+				if (enclosingEntity.getEntity() != null) {
+					request.removeHeaders("Content-Length");
+				}
+
 				String result = null;
 				try {
 					result = client.execute(host, request, handler);


### PR DESCRIPTION
testing steps in JIRA: https://jira.appcelerator.org/browse/TIMOB-9162
