### PR TITLE
[TIMOB-9332] Added centerOffset property to TiMapView.m

### DIFF
--- a/apidoc/Titanium/Map/Annotation.yml
+++ b/apidoc/Titanium/Map/Annotation.yml
@@ -54,6 +54,16 @@ properties:
         Must be set before the annotation is added to the map view.
     type: Boolean
 
+  - name: centerOffset
+    summary: |
+        Dictionary with the x and y values to offset the position of the custom image.
+        Relative to center of the image. This x and y offset values are measured in pixels.
+        Positive offset values move the annotation view down and to the right,
+        while negative values move it up and to the left.
+    type: Dictionary
+    platforms: [iphone, ipad]
+    since: "2.1.0" 
+
   - name: draggable
     summary: Determines whether the pin can be dragged by the user.
     description: |

--- a/iphone/Classes/TiMapAnnotationProxy.m
+++ b/iphone/Classes/TiMapAnnotationProxy.m
@@ -264,6 +264,12 @@
 	return tag;
 }
 
+- (void)setCenterOffset:(id)setCenterOffset
+{
+	id current = [self valueForUndefinedKey:@"centerOffset"];
+	[self replaceValue:centeroffset forKey:@"centerOffset" notification:NO];
+}
+
 @end
 
 #endif

--- a/iphone/Classes/TiMapView.m
+++ b/iphone/Classes/TiMapView.m
@@ -669,6 +669,11 @@
             if ([identifier isEqualToString:@"timap-image"])
             {
                 annView=[[[TiMapImageAnnotationView alloc] initWithAnnotation:ann reuseIdentifier:identifier map:self image:image] autorelease];
+                id offsetValue = [ann valueForUndefinedKey: @"centerOffset"];
+                if(offsetValue != nil){
+                    CGPoint centerOffset = [TiUtils pointValue: offsetValue];
+                    annView.centerOffset = centerOffset;
+                }
             }
             else
             {


### PR DESCRIPTION
This commit corresponds to this jira ticket: https://jira.appcelerator.org/browse/TIMOB-9332

It enables to use centerOffset property in a Ti.Map.Annotation.

``` javascript
annotation.setCenterOffset({x: 0, y:-25});
//or
Ti.Map.createAnnotation({
centerOffset: {x:0, y:-25}
});

```

The CLA is signed with e-mail: joscandreu@gmail.com with the name: Jose Carlos Andreu Galan
I'm going to provide a simple test case in the comments of the jira ticket.
