### PR TITLE
Update the 'fromJSON' method of 'KrollDict' to map JSONObject.NULL to null.

### DIFF
--- a/android/titanium/src/java/org/appcelerator/kroll/KrollDict.java
+++ b/android/titanium/src/java/org/appcelerator/kroll/KrollDict.java
@@ -56,6 +56,8 @@ public class KrollDict
 					values[i] = fromJSON(array.get(i));
 				}
 				return values;
+			} else if (value == JSONObject.NULL) {
+				return null;
 			}
 		} catch (JSONException e) {
 			Log.e(TAG, "Error parsing JSON", e);


### PR DESCRIPTION
Currently the KrollDict.fromJSON method ignores JSONObject.NULL values and inserts them into the Map unmodified. This is generally not a huge deal, but if you try to pass the resulting KrollDict instance to the Javascript layer via a KrollFunction callback, the JNI layer crashes:

https://gist.github.com/2dd449f4fbb9e6c5b7f3

I'm not sure if you're going to like this patch, but I thought I'd take a stab at it. I'm unsure if any tests would need to be modified, because I'm not familiar with your development stack.

Looking for feedback.
