### PR TITLE
timob-8689: Android: Setting height to Ti.UI.SIZE on a TableViewRow causes the row to not display

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiTableViewRowProxyItem.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiTableViewRowProxyItem.java
@@ -266,7 +266,8 @@ public class TiTableViewRowProxyItem extends TiBaseTableViewItem
 		}
 
 		if (props.containsKey(TiC.PROPERTY_HEIGHT)) {
-			if (!props.get(TiC.PROPERTY_HEIGHT).equals(TiC.SIZE_AUTO)) {
+			if (!props.get(TiC.PROPERTY_HEIGHT).equals(TiC.SIZE_AUTO)
+				&& !props.get(TiC.PROPERTY_HEIGHT).equals(TiC.LAYOUT_SIZE)) {
 				height = TiConvert.toTiDimension(TiConvert.toString(props, TiC.PROPERTY_HEIGHT), TiDimension.TYPE_HEIGHT);
 			}
 		}


### PR DESCRIPTION
https://jira.appcelerator.org/browse/TIMOB-8689
Test case in JIRA
