### PR TITLE
[TIMOB-9322] Android: Adding Label properties after creation causes the application to crash

### DIFF
--- a/android/kroll-apt/src/java/org/appcelerator/kroll/annotations/generator/ProxyBindingV8.cpp.fm
+++ b/android/kroll-apt/src/java/org/appcelerator/kroll/annotations/generator/ProxyBindingV8.cpp.fm
@@ -298,7 +298,7 @@ void ${className}::setter_${name}(Local<String> property, Local<Value> value, co
 	<@Proxy.verifyAndConvertArgument expr="value" index=0 info=typeInfo logOnly=true isOptional=false/>
 
 	jobject javaProxy = proxy->getJavaObject();
-	<@Proxy.callJNIMethod [], property.setHasInvocation, property.setReturnType, "methodID", "javaProxy", "jArguments", false ;
+	<@Proxy.callJNIMethod property.setMethodArgs, property.setHasInvocation, property.setReturnType, "methodID", "javaProxy", "jArguments", false ;
 		hasResult, resultVar>
 	</@Proxy.callJNIMethod>
 


### PR DESCRIPTION
Fixes a JNI local reference overflow seen on emulator. See JIRA ticket for testing details.
