### PR TITLE
[TIMOB-7024] Android: ActivityIndicator on window focus event crash

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/TiApplication.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiApplication.java
@@ -263,10 +263,10 @@ public abstract class TiApplication extends Application implements Handler.Callb
 
 		while ((activityStackSize = activityStack.size()) > 0) {
 			Activity activity = (activityStack.get(activityStackSize - 1)).get();
-			if (activity == null) {
-				Log.i(LCAT, "activity reference is invalid, removing from activity stack");
-				activityStack.remove(activityStackSize -1);
 
+			// Skip and remove any activities which are dead or in the process of finishing.
+			if (activity == null || activity.isFinishing()) {
+				activityStack.remove(activityStackSize -1);
 				continue;
 			}
 

--- a/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
@@ -680,7 +680,6 @@ public abstract class TiBaseActivity extends Activity
 			}
 			removeDialog(dialog);
 		}
-		dialogs = null;
 	}
 
 	@Override


### PR DESCRIPTION
Fixes a crash seen when creating and showing/dismissing an activity indicator dialog
when changing between activities. See JIRA ticket for a test case.

Try running the test case on emulator and device.
When the application first launches an activity indicator should show and go
away in 2 seconds.
Click the "open win2" button to open a new activity window.
Hit the back button to close the current window and return to the previous activity.
The activity indicator should be shown again and disappear in 2 seconds w/o crashing the app.
