### PR TITLE
[TIMOB-8941] iOS: Children views inside scrollview aren't calculating size properly

### DIFF
--- a/iphone/Classes/TiUILabel.m
+++ b/iphone/Classes/TiUILabel.m
@@ -45,6 +45,11 @@
 	CGSize maxSize = CGSizeMake(suggestedWidth<=0 ? 480 : suggestedWidth, 1000);
 	CGSize shadowOffset = [label shadowOffset];
 	requiresLayout = YES;
+	if ((suggestedWidth > 0) && [value characterAtIndex:value.length-1] == ' ') {
+		// (CGSize)sizeWithFont:(UIFont *)font constrainedToSize:(CGSize)size lineBreakMode:(UILineBreakMode)lineBreakMode method truncates
+		// the string having trailing spaces when given size parameter width is equal to the expected return width, so we adjust it here.
+		maxSize.width += 0.00001;
+	}
 	CGSize size = [value sizeWithFont:font constrainedToSize:maxSize lineBreakMode:UILineBreakModeTailTruncation];
 	if (shadowOffset.width > 0)
 	{

--- a/iphone/Classes/TiUIScrollViewProxy.m
+++ b/iphone/Classes/TiUIScrollViewProxy.m
@@ -188,7 +188,7 @@
         }
         else if (TiDimensionIsAutoSize(constraint))
         {
-            bounds.size.width = [child autoWidthForSize:CGSizeMake(boundingValue,bounds.size.height - offset2)] + offset;
+            bounds.size.width = [child autoWidthForSize:CGSizeMake(-1,bounds.size.height - offset2)] + offset;
             horizontalLayoutBoundary += bounds.size.width;
         }
         else if (TiDimensionIsAuto(constraint) )

--- a/iphone/Classes/TiUIScrollViewProxy.m
+++ b/iphone/Classes/TiUIScrollViewProxy.m
@@ -188,6 +188,7 @@
         }
         else if (TiDimensionIsAutoSize(constraint))
         {
+			// allow child to take as much horizontal space as scroll view width
             bounds.size.width = [child autoWidthForSize:CGSizeMake(bounds.size.width,bounds.size.height - offset2)] + offset;
             horizontalLayoutBoundary += bounds.size.width;
         }
@@ -200,7 +201,8 @@
             }
             else {
                 //SIZE behavior
-                bounds.size.width = [child autoWidthForSize:CGSizeMake(boundingValue,bounds.size.height - offset2)] + offset;
+				// allow child to take as much horizontal space as scroll view width
+                bounds.size.width = [child autoWidthForSize:CGSizeMake(bounds.size.width,bounds.size.height - offset2)] + offset;
                 horizontalLayoutBoundary += bounds.size.width;
             }
         }
@@ -227,7 +229,8 @@
             }
             else {
                 //SIZE behavior
-                bounds.size.width = [child autoWidthForSize:CGSizeMake(boundingValue,bounds.size.height - offset2)] + offset;
+				// allow child to take as much horizontal space as scroll view width
+                bounds.size.width = [child autoWidthForSize:CGSizeMake(bounds.size.width,bounds.size.height - offset2)] + offset;
                 horizontalLayoutBoundary += bounds.size.width;
             }
         }

--- a/iphone/Classes/TiUIScrollViewProxy.m
+++ b/iphone/Classes/TiUIScrollViewProxy.m
@@ -188,7 +188,7 @@
         }
         else if (TiDimensionIsAutoSize(constraint))
         {
-            bounds.size.width = [child autoWidthForSize:CGSizeMake(-1,bounds.size.height - offset2)] + offset;
+            bounds.size.width = [child autoWidthForSize:CGSizeMake(bounds.size.width,bounds.size.height - offset2)] + offset;
             horizontalLayoutBoundary += bounds.size.width;
         }
         else if (TiDimensionIsAuto(constraint) )


### PR DESCRIPTION
[TIMOB-8941](https://jira.appcelerator.org/browse/TIMOB-8941)

Test case in JIRA.

Please note that this fixes actually two bug embedded into single JIRA: one with layout calculations and another with size for label with trailing spaces.
