### PR TITLE
[TIMOB-3215]Make the topmost Parent ScrollView handle the keyboardevents

### DIFF
--- a/iphone/Classes/TiRootViewController.m
+++ b/iphone/Classes/TiRootViewController.m
@@ -1156,6 +1156,7 @@
 		updatingAccessoryView = YES;
 		[self performSelector:@selector(handleNewKeyboardStatus) withObject:nil afterDelay:0.0];
 	}
+    RELEASE_TO_NIL_AUTORELEASE(keyboardFocusedProxy);
 }
 
 - (void)keyboardWillShow:(NSNotification*)notification 
@@ -1185,7 +1186,6 @@
 {
 	startFrame = endFrame;
     [self performSelector:@selector(adjustKeyboardHeight:) withObject:[NSNumber numberWithBool:NO] afterDelay:leaveDuration];
-    RELEASE_TO_NIL_AUTORELEASE(keyboardFocusedProxy);
 }
 
 - (void)keyboardDidShow:(NSNotification*)notification

--- a/iphone/Classes/TiRootViewController.m
+++ b/iphone/Classes/TiRootViewController.m
@@ -1078,7 +1078,7 @@
 			possibleScrollView = [possibleScrollView superview];
 		}
         
-        UIView<TiScrolling> *confirmedScrollViewsLastObject = (UIView<TiScrolling> *)[confirmedScrollViews lastObject];
+        UIView<TiScrolling> *confirmedScrollViewsLastObject = (UIView<TiScrolling> *)[confirmedScrollViews objectAtIndex:0];
         
         [confirmedScrollViewsLastObject keyboardDidShowAtHeight:keyboardHeight];
         [confirmedScrollViewsLastObject scrollToShowView:scrolledView withKeyboardHeight:keyboardHeight];

--- a/iphone/Classes/TiRootViewController.m
+++ b/iphone/Classes/TiRootViewController.m
@@ -1077,12 +1077,12 @@
 			}
 			possibleScrollView = [possibleScrollView superview];
 		}
-
-		[(UIView<TiScrolling> *)[confirmedScrollViews objectAtIndex:0] keyboardDidShowAtHeight:keyboardHeight];
-		for (UIView<TiScrolling> * confirmedScrollView in confirmedScrollViews)
-		{
-			[confirmedScrollView scrollToShowView:scrolledView withKeyboardHeight:keyboardHeight];
-		}
+        
+        UIView<TiScrolling> *confirmedScrollViewsLastObject = (UIView<TiScrolling> *)[confirmedScrollViews lastObject];
+        
+        [confirmedScrollViewsLastObject keyboardDidShowAtHeight:keyboardHeight];
+        [confirmedScrollViewsLastObject scrollToShowView:scrolledView withKeyboardHeight:keyboardHeight];
+		
 	}
 
 	//This is if the keyboard is hiding or showing due to hardware.
@@ -1185,6 +1185,7 @@
 {
 	startFrame = endFrame;
     [self performSelector:@selector(adjustKeyboardHeight:) withObject:[NSNumber numberWithBool:NO] afterDelay:leaveDuration];
+    RELEASE_TO_NIL_AUTORELEASE(keyboardFocusedProxy);
 }
 
 - (void)keyboardDidShow:(NSNotification*)notification
@@ -1232,8 +1233,7 @@
 		DeveloperLog(@"[WARN] Blurred for %@<%X>, despite %@<%X> being the focus.",blurredProxy,blurredProxy,keyboardFocusedProxy,keyboardFocusedProxy);
 		return;
 	}
-	RELEASE_TO_NIL_AUTORELEASE(keyboardFocusedProxy);
-
+	
 	//Question: Ideally (IE, shouldn't happen differently) the keyboardToolbar of the focusedProxy IS the accessoryView. Should we assume this?
 	//TODO: This can probably be optimized, but since how rarely this happens....
 	

--- a/iphone/Classes/TiRootViewController.m
+++ b/iphone/Classes/TiRootViewController.m
@@ -1150,13 +1150,13 @@
 	leaveDuration = [[userInfo valueForKey:UIKeyboardAnimationDurationUserInfoKey] floatValue];
 	[self extractKeyboardInfo:userInfo];
 	keyboardVisible = NO;
-
+    
 	if(!updatingAccessoryView)
 	{
 		updatingAccessoryView = YES;
 		[self performSelector:@selector(handleNewKeyboardStatus) withObject:nil afterDelay:0.0];
 	}
-    RELEASE_TO_NIL_AUTORELEASE(keyboardFocusedProxy);
+    
 }
 
 - (void)keyboardWillShow:(NSNotification*)notification 
@@ -1265,7 +1265,7 @@
             [confirmedScrollView keyboardDidShowAtHeight:keyboardHeight];
         }
 	}
-
+    RELEASE_TO_NIL_AUTORELEASE(keyboardFocusedProxy);
 	if((doomedView == nil) || (leavingAccessoryView == doomedView)){
 		//Nothing to worry about. No toolbar or it's on its way out.
 		return;


### PR DESCRIPTION
Test case in [Jira](https://jira.appcelerator.org/browse/TIMOB-3215)

Test for regression on the following tickets:
[TIMOB-5100](https://jira.appcelerator.org/browse/TIMOB-5100)
[TIMOB-7998](https://jira.appcelerator.org/browse/TIMOB-7998)
[TIMOB-8363](https://jira.appcelerator.org/browse/TIMOB-8363)
[TIMOB-8368](https://jira.appcelerator.org/browse/TIMOB-8368)
[TIMOB-8417](https://jira.appcelerator.org/browse/TIMOB-8417)
