### PR TITLE
[TIMOB-9314] Support for mixed JS and Obj-C modules.

### DIFF
--- a/iphone/Classes/KrollBridge.mm
+++ b/iphone/Classes/KrollBridge.mm
@@ -839,7 +839,7 @@ CFMutableSetRef	krollBridgeRegistry = nil;
             TiDebuggerEndScript([self krollContext]);
         }
         
-		if (![module respondsToSelector:@selector(replaceValue:forKey:notification:)]) {
+		if (![wrapper respondsToSelector:@selector(replaceValue:forKey:notification:)]) {
 			@throw [NSException exceptionWithName:@"org.appcelerator.kroll" reason:[NSString stringWithFormat:@"Module \"%@\" failed to leave a valid exports object",path] userInfo:nil];
 		}
 		

--- a/iphone/Classes/KrollBridge.mm
+++ b/iphone/Classes/KrollBridge.mm
@@ -791,19 +791,19 @@ CFMutableSetRef	krollBridgeRegistry = nil;
 		if (moduleClass!=nil)
 		{
 			module = [[moduleClass alloc] _initWithPageContext:self];
-			// we might have a module that's simply a JS native module wrapper
-			// in which case we simply load it and don't register our native module
+            
+            // Load any JS associated with the module if there, so that it
+            // can be exported
 			if ([module isJSModule])
 			{
 				data = [module moduleJS];
 			}
-			else
-			{
-				[module setHost:host];
-				[module _setName:moduleClassName];
-				// register it
-				[modules setObject:module forKey:path];
-			}
+            
+            [module setHost:host];
+            [module _setName:moduleClassName];
+            // register it
+            [modules setObject:module forKey:path];
+            
 			[module autorelease];
 		}
 	}
@@ -825,15 +825,17 @@ CFMutableSetRef	krollBridgeRegistry = nil;
         NSString* urlPath = (filepath != nil) ? filepath : path;
 		NSURL *url_ = [TiHost resourceBasedURL:urlPath baseURL:NULL];
        	const char *urlCString = [[url_ absoluteString] UTF8String];
-        if ([[self host] debugMode]) {
+        KrollWrapper* wrapper = nil;
+        
+        if ([[self host] debugMode] && ![module isJSModule]) {
             TiDebuggerBeginScript([self krollContext],urlCString);
         }
         
 		NSString * dataContents = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-		module = [self loadCommonJSModule:dataContents withPath:path];
+		wrapper = [self loadCommonJSModule:dataContents withPath:path];
         [dataContents release];
 		
-        if ([[self host] debugMode]) {
+        if ([[self host] debugMode] && ![module isJSModule]) {
             TiDebuggerEndScript([self krollContext]);
         }
         
@@ -841,13 +843,39 @@ CFMutableSetRef	krollBridgeRegistry = nil;
 			@throw [NSException exceptionWithName:@"org.appcelerator.kroll" reason:[NSString stringWithFormat:@"Module \"%@\" failed to leave a valid exports object",path] userInfo:nil];
 		}
 		
-		// register it
-		[modules setObject:module forKey:path];
-		if (filepath!=nil && module!=nil)
-		{
-			// uri is optional but we point it to where we loaded it
-			[module replaceValue:[NSString stringWithFormat:@"app://%@",filepath] forKey:@"uri" notification:NO];
-		}
+		// register the module if it's pure JS
+        if (module == nil) {
+            module = (id)wrapper;
+            
+            [modules setObject:module forKey:path];
+            if (filepath!=nil && module!=nil)
+            {
+                // uri is optional but we point it to where we loaded it
+                [module replaceValue:[NSString stringWithFormat:@"app://%@",filepath] forKey:@"uri" notification:NO];
+            }
+        }
+        else {
+            // For right now, we need to mix any compiled JS on top of a compiled module, so that both components
+            // are accessible. We store the exports object and then put references to its properties on the toplevel
+            // object.
+            
+            TiContextRef jsContext = [[self krollContext] context];
+            TiObjectRef jsObject = [wrapper jsobject];
+            KrollObject* moduleObject = [module krollObjectForContext:[self krollContext]];
+            [moduleObject noteObject:jsObject forTiString:kTiStringExportsKey context:jsContext];
+            
+            TiPropertyNameArrayRef properties = TiObjectCopyPropertyNames(jsContext, jsObject);
+            size_t count = TiPropertyNameArrayGetCount(properties);
+            for (size_t i=0; i < count; i++) {
+                // Mixin the property onto the module JS object if it's not already there
+                TiStringRef propertyName = TiPropertyNameArrayGetNameAtIndex(properties, i);
+                if (!TiObjectHasProperty(jsContext, [moduleObject jsobject], propertyName)) {
+                    TiValueRef property = TiObjectGetProperty(jsContext, jsObject, propertyName, NULL);
+                    TiObjectSetProperty([[self krollContext] context], [moduleObject jsobject], propertyName, property, kTiPropertyAttributeReadOnly, NULL);
+                }
+            }
+            TiPropertyNameArrayRelease(properties);
+        }
 	}
 	
 	if (module!=nil)

--- a/iphone/Classes/KrollObject.h
+++ b/iphone/Classes/KrollObject.h
@@ -10,6 +10,7 @@
 
 @class KrollContext, KrollCallback;
 extern TiClassRef KrollObjectClassRef;
+extern TiStringRef kTiStringExportsKey;
 
 void KrollFinalizer(TiObjectRef ref);
 void KrollInitializer(TiContextRef ctx, TiObjectRef object);

--- a/iphone/Classes/KrollObject.m
+++ b/iphone/Classes/KrollObject.m
@@ -35,6 +35,7 @@ TiStringRef kTiStringNewObject;
 TiStringRef kTiStringTiPropertyKey;
 TiStringRef kTiStringPropertyKey;
 TiStringRef kTiStringEventKey;
+TiStringRef kTiStringExportsKey;
 
 
 id TiValueToId(KrollContext* context, TiValueRef v);
@@ -413,6 +414,14 @@ TiValueRef KrollGetProperty(TiContextRef jsContext, TiObjectRef object, TiString
 		{
 			return NULL;
 		}
+        
+        // Attempt to retrieve the property from the exports, before going through
+        // the routing
+        TiObjectRef exports = [o objectForTiString:kTiStringExportsKey context:jsContext];
+        if ((exports != NULL) && TiObjectHasProperty(jsContext, exports, prop)) {
+            return TiObjectGetProperty(jsContext, exports, prop, NULL);
+        }
+        
 		
 		NSString* name = (NSString*)TiStringCopyCFString(kCFAllocatorDefault, prop);
 		[name autorelease];		
@@ -617,6 +626,7 @@ bool KrollHasInstance(TiContextRef ctx, TiObjectRef constructor, TiValueRef poss
 		kTiStringTiPropertyKey = TiStringCreateWithUTF8CString("__TI");
 		kTiStringPropertyKey = TiStringCreateWithUTF8CString("__PR");
 		kTiStringEventKey = TiStringCreateWithUTF8CString("__EV");
+        kTiStringExportsKey = TiStringCreateWithUTF8CString("__EX");
 	}
 }
 

--- a/support/iphone/builder.py
+++ b/support/iphone/builder.py
@@ -408,10 +408,14 @@ def is_indexing_enabled(tiapp, simulator_dir, **kwargs):
 	mount_point_status = {}
 	for i in range(0, len(lines), 2):
 		mount_point = lines[i].rstrip(':')
-		status = lines[i+1].strip('\t.')
-		# Only add mount points that the simulator_dir starts with
-		if simulator_dir.startswith(mount_point):
-			mount_point_status[mount_point] = status
+		if len(lines) > (i+1):
+			status = lines[i+1].strip('\t.')
+			# Only add mount points that the simulator_dir starts with
+			if simulator_dir.startswith(mount_point):
+				mount_point_status[mount_point] = status
+		# mdutil must be disabled if we don't get the right amount of output
+		else:
+			return False
 
 	if len(mount_point_status) > 0:
 		# There may be multiple volumes that have a mount point that the

--- a/support/iphone/tools.py
+++ b/support/iphone/tools.py
@@ -1,11 +1,11 @@
 
-import os, sys, codecs, shutil, filecmp
+import os, sys, codecs, shutil, filecmp, subprocess
 
 # the template_dir is the path where this file lives on disk
 template_dir = os.path.abspath(os.path.dirname(sys._getframe(0).f_code.co_filename))
 
 def ensure_dev_path(debug=True):
-	rc = os.system("xcode-select -print-path >/dev/null 2>/dev/null")
+	rc = subprocess.call(["xcode-select", "-print-path"], stdout=open(os.devnull, 'w'), stderr=open(os.devnull, 'w'))
 	if rc == 0 :
 		return
 	if debug:


### PR DESCRIPTION
This allows modules which are built with both a JS file and Objective-C code to coexist. Both are exported to the user.

This also includes fixes which prevented building for iOS simulator on machines with spotlight disabled.
