### PR TITLE
[TIMOB-9340] Remove 'iphone' from list of excluded directories during compile

### DIFF
--- a/support/iphone/compiler.py
+++ b/support/iphone/compiler.py
@@ -21,7 +21,7 @@ except:
 	import simplejson as json
 
 ignoreFiles = ['.gitignore', '.cvsignore', '.DS_Store'];
-ignoreDirs = ['.git','.svn','_svn','CVS','android','iphone','mobileweb'];
+ignoreDirs = ['.git','.svn','_svn','CVS','android','mobileweb'];
 
 HEADER = """/**
  * Appcelerator Titanium Mobile


### PR DESCRIPTION
Change allows JS files specific to iphone to be compiled in.
