### PR TITLE
[TIMOB-9436] Android:Tabgroup:Focus and Blur event listeners for a tabgroup are not getting called.

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUITabGroup.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUITabGroup.java
@@ -129,7 +129,12 @@ public class TiUITabGroup extends TiUIView
 	}
 
 	public KrollDict getTabChangeEvent() {
-		return tabChangeEventData;
+		if (tabChangeEventData != null) {
+			// Return a copy since this may get modified by the caller.
+			return new KrollDict(tabChangeEventData);
+		}
+
+		return null;
 	}
 
 	@Override

--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/TiWindowProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/TiWindowProxy.java
@@ -86,6 +86,16 @@ public abstract class TiWindowProxy extends TiViewProxy
 	}
 
 	@Override
+	public boolean fireEvent(String eventName, Object data) {
+		// Notify tab of any focus or blur events.
+		if (tab != null && (eventName.equals(TiC.EVENT_FOCUS) || eventName.equals(TiC.EVENT_BLUR))) {
+			tab.fireEvent(eventName, data);
+		}
+
+		return super.fireEvent(eventName, data);
+	}
+
+	@Override
 	public TiUIView createView(Activity activity)
 	{
 		throw new IllegalStateException("Windows are created during open");


### PR DESCRIPTION
This fixes blur and focus events for Tab and TabGroup.
See JIRA ticket for test case and instructions.
