### PR TITLE
[TIMOB-8978] Ti.UI.View.size and Ti.UI.View.rect reported in default units

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/UIModule.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/UIModule.java
@@ -198,9 +198,9 @@ public class UIModule extends KrollModule implements Handler.Callback
 	}
 
 	@Kroll.method
-	public int convertUnits(String convertFromValue, String convertToUnits)
+	public double convertUnits(String convertFromValue, String convertToUnits)
 	{
-		int result = 0;
+		double result = 0;
 		TiDimension dimension = new TiDimension(convertFromValue, TiDimension.TYPE_UNDEFINED);
 
 		// TiDimension needs a view to grab the window manager, so we'll just use the decorview of the current window
@@ -208,7 +208,7 @@ public class UIModule extends KrollModule implements Handler.Callback
 
 		if (view != null) {
 			if (convertToUnits.equals(UNIT_PX)) {
-				result = dimension.getAsPixels(view);
+				result = (double) dimension.getAsPixels(view);
 			} else if (convertToUnits.equals(UNIT_MM)) {
 				result = dimension.getAsMillimeters(view);
 			} else if (convertToUnits.equals(UNIT_CM)) {
@@ -216,7 +216,7 @@ public class UIModule extends KrollModule implements Handler.Callback
 			} else if (convertToUnits.equals(UNIT_IN)) {
 				result = dimension.getAsInches(view);
 			} else if (convertToUnits.equals(UNIT_DIP)) {
-				result = dimension.getAsDIP(view);
+				result = (double) dimension.getAsDIP(view);
 			}
 		}
 

--- a/android/titanium/src/java/org/appcelerator/titanium/TiDimension.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiDimension.java
@@ -6,11 +6,13 @@
  */
 package org.appcelerator.titanium;
 
+import java.lang.ref.WeakReference;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.appcelerator.kroll.common.Log;
 import org.appcelerator.kroll.common.TiConfig;
+import org.appcelerator.titanium.proxy.TiViewProxy;
 
 import android.content.Context;
 import android.util.DisplayMetrics;
@@ -177,6 +179,7 @@ public class TiDimension
 	 * <li> TypedValue.COMPLEX_UNIT_SP </li>
 	 * <li> TypedValue.COMPLEX_UNIT_MM </li>
 	 * <li> TypedValue.COMPLEX_UNIT_IN </li>
+	 * <li> TypedValue.COMPLEX_UNIT_CM </li>
 	 * <li> TiDimension.COMPLEX_UNIT_PERCENT </li>
 	 * <li> TiDimension.COMPLEX_UNIT_AUTO </li>
 	 * <li> TiDimension.COMPLEX_UNIT_UNDEFINED </li>
@@ -262,6 +265,34 @@ public class TiDimension
 
 		return (int) Math.round((getPixels(parent) / getDisplayMetrics(parent).density));
 	}
+	
+	/**
+	 * Calculates and returns the dimension in the default units. If the default
+	 * unit is not valid, returns in PX.
+	 * @param parent the parent of the view used for calculation
+	 * @return the dimension in the system unit
+	 */
+	public int getAsDefault(View parent)
+	{
+		String defaultUnit = TiApplication.getInstance().getDefaultUnit();
+		if (UNIT_PX.equals(defaultUnit) || UNIT_SYSTEM.equals(defaultUnit)) {
+			return getAsPixels(parent);
+		}
+		else if (UNIT_DP.equals(defaultUnit) || UNIT_DIP.equals(defaultUnit)) {
+			return getAsDIP(parent);
+		}
+		else if (UNIT_MM.equals(defaultUnit)) {
+			return getAsMillimeters(parent);
+		}
+		else if (UNIT_CM.equals(defaultUnit)) {
+			return getAsCentimeters(parent);
+		}
+		else if (UNIT_IN.equals(defaultUnit)) {
+			return getAsInches(parent);
+		}
+
+		return getAsPixels(parent);
+	}
 
 	protected double getPercentPixels(View parent)
 	{
@@ -307,7 +338,7 @@ public class TiDimension
 		}
 		return -1;
 	}
-
+	
 	protected double getSizePixels(View parent)
 	{
 		DisplayMetrics metrics = getDisplayMetrics(parent);
@@ -328,6 +359,7 @@ public class TiDimension
 			default:
 				dpi = metrics.densityDpi;
 		}
+		
 		if (units == TypedValue.COMPLEX_UNIT_PT) {
 			return (this.value * (dpi / POINT_DPI));
 		} else if (units == TypedValue.COMPLEX_UNIT_MM) {

--- a/android/titanium/src/java/org/appcelerator/titanium/TiDimension.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiDimension.java
@@ -230,31 +230,31 @@ public class TiDimension
 		return (int) Math.round(getPixels(parent));
 	}
 
-	public int getAsMillimeters(View parent)
+	public double getAsMillimeters(View parent)
 	{
 		if (units == TypedValue.COMPLEX_UNIT_MM) {
-			return (int) this.value;
+			return this.value;
 		}
 
-		return (int) Math.round(((getPixels(parent) / getDisplayMetrics(parent).densityDpi) * MM_INCH));
+		return ((getPixels(parent) / getDisplayMetrics(parent).densityDpi) * MM_INCH);
 	}
 
-	public int getAsCentimeters(View parent)
+	public double getAsCentimeters(View parent)
 	{
 		if (units == COMPLEX_UNIT_CM) {
-			return (int) this.value;
+			return this.value;
 		}
 
-		return (int) Math.round(((getPixels(parent) / getDisplayMetrics(parent).densityDpi) * CM_INCH));
+		return ((getPixels(parent) / getDisplayMetrics(parent).densityDpi) * CM_INCH);
 	}
 
-	public int getAsInches(View parent)
+	public double getAsInches(View parent)
 	{
 		if (units == TypedValue.COMPLEX_UNIT_IN) {
-			return (int) this.value;
+			return this.value;
 		}
 
-		return (int) Math.round((getPixels(parent) / getDisplayMetrics(parent).densityDpi));
+		return (getPixels(parent) / getDisplayMetrics(parent).densityDpi);
 	}
 
 	public int getAsDIP(View parent)
@@ -272,14 +272,11 @@ public class TiDimension
 	 * @param parent the parent of the view used for calculation
 	 * @return the dimension in the system unit
 	 */
-	public int getAsDefault(View parent)
+	public double getAsDefault(View parent)
 	{
 		String defaultUnit = TiApplication.getInstance().getDefaultUnit();
-		if (UNIT_PX.equals(defaultUnit) || UNIT_SYSTEM.equals(defaultUnit)) {
-			return getAsPixels(parent);
-		}
-		else if (UNIT_DP.equals(defaultUnit) || UNIT_DIP.equals(defaultUnit)) {
-			return getAsDIP(parent);
+		if (UNIT_DP.equals(defaultUnit) || UNIT_DIP.equals(defaultUnit)) {
+			return (double) getAsDIP(parent);
 		}
 		else if (UNIT_MM.equals(defaultUnit)) {
 			return getAsMillimeters(parent);
@@ -291,7 +288,8 @@ public class TiDimension
 			return getAsInches(parent);
 		}
 
-		return getAsPixels(parent);
+		// Returned for PX, SYSTEM, and unknown values
+		return (double) getAsPixels(parent);
 	}
 
 	protected double getPercentPixels(View parent)

--- a/android/titanium/src/java/org/appcelerator/titanium/TiDimension.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiDimension.java
@@ -236,7 +236,7 @@ public class TiDimension
 			return this.value;
 		}
 
-		return ((getPixels(parent) / getDisplayMetrics(parent).densityDpi) * MM_INCH);
+		return ((getPixels(parent) / getDPIForType(parent)) * MM_INCH);
 	}
 
 	public double getAsCentimeters(View parent)
@@ -245,7 +245,7 @@ public class TiDimension
 			return this.value;
 		}
 
-		return ((getPixels(parent) / getDisplayMetrics(parent).densityDpi) * CM_INCH);
+		return ((getPixels(parent) / getDPIForType(parent)) * CM_INCH);
 	}
 
 	public double getAsInches(View parent)
@@ -254,7 +254,7 @@ public class TiDimension
 			return this.value;
 		}
 
-		return (getPixels(parent) / getDisplayMetrics(parent).densityDpi);
+		return (getPixels(parent) / getDPIForType(parent));
 	}
 
 	public int getAsDIP(View parent)
@@ -337,9 +337,9 @@ public class TiDimension
 		return -1;
 	}
 	
-	protected double getSizePixels(View parent)
+	protected double getDPIForType(View parent)
 	{
-		DisplayMetrics metrics = getDisplayMetrics(parent);
+		DisplayMetrics metrics = getDisplayMetrics(parent);		
 		float dpi = -1;
 		switch (valueType) {
 			case TYPE_TOP:
@@ -357,6 +357,13 @@ public class TiDimension
 			default:
 				dpi = metrics.densityDpi;
 		}
+		
+		return dpi;
+	}
+	
+	protected double getSizePixels(View parent)
+	{
+		double dpi = getDPIForType(parent);
 		
 		if (units == TypedValue.COMPLEX_UNIT_PT) {
 			return (this.value * (dpi / POINT_DPI));

--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/TiViewProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/TiViewProxy.java
@@ -43,9 +43,9 @@ import android.view.View;
  */
 @Kroll.proxy(propertyAccessors={
 	// background properties
-	"backgroundImage", "backgroundRepeat", "backgroundSelectedImage", 
-	"backgroundFocusedImage", "backgroundDisabledImage", "backgroundColor", 
-	"backgroundSelectedColor", "backgroundFocusedColor", "backgroundDisabledColor", 
+	"backgroundImage", "backgroundRepeat", "backgroundSelectedImage",
+	"backgroundFocusedImage", "backgroundDisabledImage", "backgroundColor",
+	"backgroundSelectedColor", "backgroundFocusedColor", "backgroundDisabledColor",
 	"backgroundPadding", "backgroundGradient",
 
 	// border properties
@@ -89,7 +89,7 @@ public abstract class TiViewProxy extends KrollProxy implements Handler.Callback
 	protected TiAnimationBuilder pendingAnimation;
 	private boolean isDecorView = false;
 	private AtomicBoolean layoutStarted = new AtomicBoolean();
-	
+
 	/**
 	 * Constructs a new TiViewProxy instance.
 	 * @module.api
@@ -119,7 +119,7 @@ public abstract class TiViewProxy extends KrollProxy implements Handler.Callback
 		} else {
 			baseUrl = creationUrl.resolve();
 		}
-		
+
 		int idx = baseUrl.lastIndexOf("/");
 		if (idx != -1) {
 			baseUrl = baseUrl.substring(idx + 1).replace(".js", "");
@@ -133,7 +133,7 @@ public abstract class TiViewProxy extends KrollProxy implements Handler.Callback
 		String viewId = getProxyId();
 		TreeSet<String> styleClasses = new TreeSet<String>();
 		// TODO styleClasses.add(getShortAPIName().toLowerCase());
-		
+
 		if (options.containsKey(TiC.PROPERTY_ID)) {
 			viewId = TiConvert.toString(options, TiC.PROPERTY_ID);
 		}
@@ -155,7 +155,7 @@ public abstract class TiViewProxy extends KrollProxy implements Handler.Callback
 				}
 			}
 		}
-		
+
 		String baseUrl = getBaseUrlForStylesheet();
 		KrollDict dict = TiApplication.getInstance().getStylesheet(baseUrl, styleClasses, viewId);
 		if (dict.size() > 0) {
@@ -250,7 +250,7 @@ public abstract class TiViewProxy extends KrollProxy implements Handler.Callback
 
 						// TiDimension needs a view to grab the window manager, so we'll just use the decorview of the current window
 						View decorView = TiApplication.getAppCurrentActivity().getWindow().getDecorView();
-						
+
 						d.put(TiC.PROPERTY_WIDTH, nativeWidth.getAsDefault(decorView));
 						d.put(TiC.PROPERTY_HEIGHT, nativeHeight.getAsDefault(decorView));
 					}
@@ -273,11 +273,11 @@ public abstract class TiViewProxy extends KrollProxy implements Handler.Callback
 						TiDimension nativeWidth = new TiDimension(v.getWidth(), TiDimension.TYPE_WIDTH);
 						TiDimension nativeHeight = new TiDimension(v.getHeight(), TiDimension.TYPE_HEIGHT);
 						TiDimension nativeLeft = new TiDimension(v.getLeft(), TiDimension.TYPE_LEFT);
-						TiDimension nativeTop = new TiDimension(v.getTop(), TiDimension.TYPE_RIGHT);
-						
+						TiDimension nativeTop = new TiDimension(v.getTop(), TiDimension.TYPE_TOP);
+
 						// TiDimension needs a view to grab the window manager, so we'll just use the decorview of the current window
 						View decorView = TiApplication.getAppCurrentActivity().getWindow().getDecorView();
-						
+
 						d.put(TiC.PROPERTY_WIDTH, nativeWidth.getAsDefault(decorView));
 						d.put(TiC.PROPERTY_HEIGHT, nativeHeight.getAsDefault(decorView));
 						d.put(TiC.PROPERTY_X, nativeLeft.getAsDefault(decorView));
@@ -413,7 +413,7 @@ public abstract class TiViewProxy extends KrollProxy implements Handler.Callback
 
 		return (TiUIView) TiMessenger.sendBlockingMainMessage(getMainHandler().obtainMessage(MSG_GETVIEW), 0);
 	}
-	
+
 	protected TiUIView handleGetView()
 	{
 		if (view == null) {
@@ -452,7 +452,7 @@ public abstract class TiViewProxy extends KrollProxy implements Handler.Callback
 				Log.e(LCAT, e.getMessage(), e);
 			}
 		}
-		
+
 		synchronized(pendingAnimationLock) {
 			if (pendingAnimation != null) {
 				handlePendingAnimation(true);
@@ -525,7 +525,7 @@ public abstract class TiViewProxy extends KrollProxy implements Handler.Callback
 				child.isDecorView = true;
 			}
 			TiUIView cv = child.getOrCreateView();
-			
+
 			view.add(cv);
 		}
 	}
@@ -856,7 +856,7 @@ public abstract class TiViewProxy extends KrollProxy implements Handler.Callback
 				keepScreenOn = nv.getKeepScreenOn();
 			}
 		}
-		
+
 		//Keep the proxy in the correct state
 		Object current = getProperty(TiC.PROPERTY_KEEP_SCREEN_ON);
 		if (current != null) {
@@ -877,16 +877,16 @@ public abstract class TiViewProxy extends KrollProxy implements Handler.Callback
 
 			setProperty(TiC.PROPERTY_KEEP_SCREEN_ON, keepScreenOn);
 		}
-	
+
 		return keepScreenOn;
 	}
-	
+
 	@Kroll.method @Kroll.setProperty(retain=false)
 	public void setKeepScreenOn(boolean keepScreenOn)
 	{
 		setPropertyAndFire(TiC.PROPERTY_KEEP_SCREEN_ON, keepScreenOn);
 	}
-	
+
 	@Kroll.method
 	public KrollDict convertPointToView(KrollDict point, TiViewProxy dest)
 	{

--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/TiViewProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/TiViewProxy.java
@@ -273,7 +273,7 @@ public abstract class TiViewProxy extends KrollProxy implements Handler.Callback
 						TiDimension nativeWidth = new TiDimension(v.getWidth(), TiDimension.TYPE_WIDTH);
 						TiDimension nativeHeight = new TiDimension(v.getHeight(), TiDimension.TYPE_HEIGHT);
 						TiDimension nativeLeft = new TiDimension(v.getLeft(), TiDimension.TYPE_LEFT);
-						TiDimension nativeRight = new TiDimension(v.getRight(), TiDimension.TYPE_RIGHT);
+						TiDimension nativeTop = new TiDimension(v.getTop(), TiDimension.TYPE_RIGHT);
 						
 						// TiDimension needs a view to grab the window manager, so we'll just use the decorview of the current window
 						View decorView = TiApplication.getAppCurrentActivity().getWindow().getDecorView();
@@ -281,7 +281,7 @@ public abstract class TiViewProxy extends KrollProxy implements Handler.Callback
 						d.put(TiC.PROPERTY_WIDTH, nativeWidth.getAsDefault(decorView));
 						d.put(TiC.PROPERTY_HEIGHT, nativeHeight.getAsDefault(decorView));
 						d.put(TiC.PROPERTY_X, nativeLeft.getAsDefault(decorView));
-						d.put(TiC.PROPERTY_Y, nativeRight.getAsDefault(decorView));
+						d.put(TiC.PROPERTY_Y, nativeTop.getAsDefault(decorView));
 					}
 				}
 				if (!d.containsKey(TiC.PROPERTY_WIDTH)) {

--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/TiViewProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/TiViewProxy.java
@@ -26,6 +26,7 @@ import org.appcelerator.kroll.common.TiMessenger;
 import org.appcelerator.titanium.TiApplication;
 import org.appcelerator.titanium.TiBaseActivity;
 import org.appcelerator.titanium.TiC;
+import org.appcelerator.titanium.TiDimension;
 import org.appcelerator.titanium.util.TiAnimationBuilder;
 import org.appcelerator.titanium.util.TiConvert;
 import org.appcelerator.titanium.util.TiUrl;
@@ -244,8 +245,11 @@ public abstract class TiViewProxy extends KrollProxy implements Handler.Callback
 				if (view != null) {
 					View v = view.getNativeView();
 					if (v != null) {
-						d.put(TiC.PROPERTY_WIDTH, v.getWidth());
-						d.put(TiC.PROPERTY_HEIGHT, v.getHeight());
+						TiDimension nativeWidth = new TiDimension(v.getWidth(), TiDimension.TYPE_WIDTH);
+						TiDimension nativeHeight = new TiDimension(v.getHeight(), TiDimension.TYPE_HEIGHT);
+						
+						d.put(TiC.PROPERTY_WIDTH, nativeWidth.getAsDefault(parent.get().peekView().getNativeView()));
+						d.put(TiC.PROPERTY_HEIGHT, nativeHeight.getAsDefault(parent.get().peekView().getNativeView()));
 					}
 				}
 				if (!d.containsKey(TiC.PROPERTY_WIDTH)) {
@@ -263,10 +267,15 @@ public abstract class TiViewProxy extends KrollProxy implements Handler.Callback
 				if (view != null) {
 					View v = view.getNativeView();
 					if (v != null) {
-						d.put(TiC.PROPERTY_WIDTH, v.getWidth());
-						d.put(TiC.PROPERTY_HEIGHT, v.getHeight());
-						d.put(TiC.PROPERTY_X, v.getLeft());
-						d.put(TiC.PROPERTY_Y, v.getTop());
+						TiDimension nativeWidth = new TiDimension(v.getWidth(), TiDimension.TYPE_WIDTH);
+						TiDimension nativeHeight = new TiDimension(v.getHeight(), TiDimension.TYPE_HEIGHT);
+						TiDimension nativeLeft = new TiDimension(v.getLeft(), TiDimension.TYPE_LEFT);
+						TiDimension nativeRight = new TiDimension(v.getRight(), TiDimension.TYPE_RIGHT);
+						
+						d.put(TiC.PROPERTY_WIDTH, nativeWidth.getAsDefault(parent.get().peekView().getNativeView()));
+						d.put(TiC.PROPERTY_HEIGHT, nativeHeight.getAsDefault(parent.get().peekView().getNativeView()));
+						d.put(TiC.PROPERTY_X, nativeLeft.getAsDefault(parent.get().peekView().getNativeView()));
+						d.put(TiC.PROPERTY_Y, nativeRight.getAsDefault(parent.get().peekView().getNativeView()));
 					}
 				}
 				if (!d.containsKey(TiC.PROPERTY_WIDTH)) {

--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/TiViewProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/TiViewProxy.java
@@ -247,9 +247,12 @@ public abstract class TiViewProxy extends KrollProxy implements Handler.Callback
 					if (v != null) {
 						TiDimension nativeWidth = new TiDimension(v.getWidth(), TiDimension.TYPE_WIDTH);
 						TiDimension nativeHeight = new TiDimension(v.getHeight(), TiDimension.TYPE_HEIGHT);
+
+						// TiDimension needs a view to grab the window manager, so we'll just use the decorview of the current window
+						View decorView = TiApplication.getAppCurrentActivity().getWindow().getDecorView();
 						
-						d.put(TiC.PROPERTY_WIDTH, nativeWidth.getAsDefault(parent.get().peekView().getNativeView()));
-						d.put(TiC.PROPERTY_HEIGHT, nativeHeight.getAsDefault(parent.get().peekView().getNativeView()));
+						d.put(TiC.PROPERTY_WIDTH, nativeWidth.getAsDefault(decorView));
+						d.put(TiC.PROPERTY_HEIGHT, nativeHeight.getAsDefault(decorView));
 					}
 				}
 				if (!d.containsKey(TiC.PROPERTY_WIDTH)) {
@@ -272,10 +275,13 @@ public abstract class TiViewProxy extends KrollProxy implements Handler.Callback
 						TiDimension nativeLeft = new TiDimension(v.getLeft(), TiDimension.TYPE_LEFT);
 						TiDimension nativeRight = new TiDimension(v.getRight(), TiDimension.TYPE_RIGHT);
 						
-						d.put(TiC.PROPERTY_WIDTH, nativeWidth.getAsDefault(parent.get().peekView().getNativeView()));
-						d.put(TiC.PROPERTY_HEIGHT, nativeHeight.getAsDefault(parent.get().peekView().getNativeView()));
-						d.put(TiC.PROPERTY_X, nativeLeft.getAsDefault(parent.get().peekView().getNativeView()));
-						d.put(TiC.PROPERTY_Y, nativeRight.getAsDefault(parent.get().peekView().getNativeView()));
+						// TiDimension needs a view to grab the window manager, so we'll just use the decorview of the current window
+						View decorView = TiApplication.getAppCurrentActivity().getWindow().getDecorView();
+						
+						d.put(TiC.PROPERTY_WIDTH, nativeWidth.getAsDefault(decorView));
+						d.put(TiC.PROPERTY_HEIGHT, nativeHeight.getAsDefault(decorView));
+						d.put(TiC.PROPERTY_X, nativeLeft.getAsDefault(decorView));
+						d.put(TiC.PROPERTY_Y, nativeRight.getAsDefault(decorView));
 					}
 				}
 				if (!d.containsKey(TiC.PROPERTY_WIDTH)) {

--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/TiViewProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/TiViewProxy.java
@@ -353,9 +353,12 @@ public abstract class TiViewProxy extends KrollProxy implements Handler.Callback
 					if (v != null) {
 						TiDimension nativeWidth = new TiDimension(v.getWidth(), TiDimension.TYPE_WIDTH);
 						TiDimension nativeHeight = new TiDimension(v.getHeight(), TiDimension.TYPE_HEIGHT);
+
+						// TiDimension needs a view to grab the window manager, so we'll just use the decorview of the current window
+						View decorView = TiApplication.getAppCurrentActivity().getWindow().getDecorView();
 						
-						d.put(TiC.PROPERTY_WIDTH, nativeWidth.getAsDefault(parent.get().peekView().getNativeView()));
-						d.put(TiC.PROPERTY_HEIGHT, nativeHeight.getAsDefault(parent.get().peekView().getNativeView()));
+						d.put(TiC.PROPERTY_WIDTH, nativeWidth.getAsDefault(decorView));
+						d.put(TiC.PROPERTY_HEIGHT, nativeHeight.getAsDefault(decorView));
 					}
 				}
 				if (!d.containsKey(TiC.PROPERTY_WIDTH)) {
@@ -378,10 +381,13 @@ public abstract class TiViewProxy extends KrollProxy implements Handler.Callback
 						TiDimension nativeLeft = new TiDimension(v.getLeft(), TiDimension.TYPE_LEFT);
 						TiDimension nativeRight = new TiDimension(v.getRight(), TiDimension.TYPE_RIGHT);
 						
-						d.put(TiC.PROPERTY_WIDTH, nativeWidth.getAsDefault(parent.get().peekView().getNativeView()));
-						d.put(TiC.PROPERTY_HEIGHT, nativeHeight.getAsDefault(parent.get().peekView().getNativeView()));
-						d.put(TiC.PROPERTY_X, nativeLeft.getAsDefault(parent.get().peekView().getNativeView()));
-						d.put(TiC.PROPERTY_Y, nativeRight.getAsDefault(parent.get().peekView().getNativeView()));
+						// TiDimension needs a view to grab the window manager, so we'll just use the decorview of the current window
+						View decorView = TiApplication.getAppCurrentActivity().getWindow().getDecorView();
+						
+						d.put(TiC.PROPERTY_WIDTH, nativeWidth.getAsDefault(decorView));
+						d.put(TiC.PROPERTY_HEIGHT, nativeHeight.getAsDefault(decorView));
+						d.put(TiC.PROPERTY_X, nativeLeft.getAsDefault(decorView));
+						d.put(TiC.PROPERTY_Y, nativeRight.getAsDefault(decorView));
 					}
 				}
 				if (!d.containsKey(TiC.PROPERTY_WIDTH)) {

--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/TiViewProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/TiViewProxy.java
@@ -26,6 +26,7 @@ import org.appcelerator.kroll.common.TiMessenger;
 import org.appcelerator.titanium.TiApplication;
 import org.appcelerator.titanium.TiBaseActivity;
 import org.appcelerator.titanium.TiC;
+import org.appcelerator.titanium.TiDimension;
 import org.appcelerator.titanium.util.TiAnimationBuilder;
 import org.appcelerator.titanium.util.TiConvert;
 import org.appcelerator.titanium.util.TiRHelper;
@@ -350,8 +351,11 @@ public abstract class TiViewProxy extends KrollProxy implements Handler.Callback
 				if (view != null) {
 					View v = view.getNativeView();
 					if (v != null) {
-						d.put(TiC.PROPERTY_WIDTH, v.getWidth());
-						d.put(TiC.PROPERTY_HEIGHT, v.getHeight());
+						TiDimension nativeWidth = new TiDimension(v.getWidth(), TiDimension.TYPE_WIDTH);
+						TiDimension nativeHeight = new TiDimension(v.getHeight(), TiDimension.TYPE_HEIGHT);
+						
+						d.put(TiC.PROPERTY_WIDTH, nativeWidth.getAsDefault(parent.get().peekView().getNativeView()));
+						d.put(TiC.PROPERTY_HEIGHT, nativeHeight.getAsDefault(parent.get().peekView().getNativeView()));
 					}
 				}
 				if (!d.containsKey(TiC.PROPERTY_WIDTH)) {
@@ -369,10 +373,15 @@ public abstract class TiViewProxy extends KrollProxy implements Handler.Callback
 				if (view != null) {
 					View v = view.getNativeView();
 					if (v != null) {
-						d.put(TiC.PROPERTY_WIDTH, v.getWidth());
-						d.put(TiC.PROPERTY_HEIGHT, v.getHeight());
-						d.put(TiC.PROPERTY_X, v.getLeft());
-						d.put(TiC.PROPERTY_Y, v.getTop());
+						TiDimension nativeWidth = new TiDimension(v.getWidth(), TiDimension.TYPE_WIDTH);
+						TiDimension nativeHeight = new TiDimension(v.getHeight(), TiDimension.TYPE_HEIGHT);
+						TiDimension nativeLeft = new TiDimension(v.getLeft(), TiDimension.TYPE_LEFT);
+						TiDimension nativeRight = new TiDimension(v.getRight(), TiDimension.TYPE_RIGHT);
+						
+						d.put(TiC.PROPERTY_WIDTH, nativeWidth.getAsDefault(parent.get().peekView().getNativeView()));
+						d.put(TiC.PROPERTY_HEIGHT, nativeHeight.getAsDefault(parent.get().peekView().getNativeView()));
+						d.put(TiC.PROPERTY_X, nativeLeft.getAsDefault(parent.get().peekView().getNativeView()));
+						d.put(TiC.PROPERTY_Y, nativeRight.getAsDefault(parent.get().peekView().getNativeView()));
 					}
 				}
 				if (!d.containsKey(TiC.PROPERTY_WIDTH)) {

--- a/iphone/Classes/TiDimension.h
+++ b/iphone/Classes/TiDimension.h
@@ -45,6 +45,8 @@ CGFloat convertInchToPixels(CGFloat value);
 CGFloat convertPixelsToDip(CGFloat value);
 CGFloat convertDipToInch(CGFloat value);
 
+CGFloat convertDipToPixels(CGFloat value);
+
 TI_INLINE TiDimension TiDimensionDip(CGFloat value)
 {
 	return TiDimensionMake(TiDimensionTypeDip,value);

--- a/iphone/Classes/TiDimension.m
+++ b/iphone/Classes/TiDimension.m
@@ -38,7 +38,7 @@ CGFloat convertInchToPixels(CGFloat value)
 CGFloat convertPixelsToDip(CGFloat value)
 {
     if ([TiUtils isRetinaDisplay]) {
-        return value/2;
+        return value/2.0;
     }
     return value;
 }
@@ -46,10 +46,17 @@ CGFloat convertPixelsToDip(CGFloat value)
 CGFloat convertDipToInch(CGFloat value)
 {
     if ([TiUtils isRetinaDisplay]) {
-        return (value*2)/[TiUtils dpi];
+        return (value*2.0)/[TiUtils dpi];
     }
     return value/[TiUtils dpi];
 }
 
+CGFloat convertDipToPixels(CGFloat value)
+{
+    if ([TiUtils isRetinaDisplay]) {
+        return (value * 2.0);
+    }
+    return value;
+}
 
 

--- a/iphone/Classes/TiMediaVideoPlayerProxy.m
+++ b/iphone/Classes/TiMediaVideoPlayerProxy.m
@@ -68,14 +68,6 @@ NSArray* moviePlayerKeys = nil;
 	[super _initWithProperties:properties];
 }
 
-/**
- Legacy class that needs to do the subView insertion checks.
- TODO: Implement wrapperView code.
-*/
--(BOOL)optimizeSubviewInsertion
-{
-    return NO;
-}
 
 -(void)_destroy
 {

--- a/iphone/Classes/TiRect.h
+++ b/iphone/Classes/TiRect.h
@@ -45,4 +45,10 @@
  */
 @property(nonatomic,retain) NSNumber *height;
 
+/**
+ Converts a rect to the specified unit. Assumes that the current rect size is in dip.
+ @param unit The unit type (as a string) to convert the rect to.
+ */
+-(void)convertToUnit:(NSString*)unit;
+
 @end

--- a/iphone/Classes/TiRect.m
+++ b/iphone/Classes/TiRect.m
@@ -6,7 +6,7 @@
  */
 
 #import "TiRect.h"
-
+#import "TiDimension.h"
 
 @implementation TiRect
 
@@ -82,6 +82,34 @@
 -(id)bottom
 {
 	return [NSNumber numberWithFloat:(rect.origin.y + rect.size.height)];
+}
+
+-(void)convertToUnit:(NSString *)unit
+{    
+    if ([unit caseInsensitiveCompare:kTiUnitCm] == NSOrderedSame) {
+        rect.origin.x = convertDipToInch(rect.origin.x) * INCH_IN_CM;
+        rect.origin.y = convertDipToInch(rect.origin.y) * INCH_IN_CM;
+        rect.size.width = convertDipToInch(rect.size.width) * INCH_IN_CM;
+        rect.size.height = convertDipToInch(rect.size.width) * INCH_IN_CM;
+    }
+    else if ([unit caseInsensitiveCompare:kTiUnitInch] == NSOrderedSame) {
+        rect.origin.x = convertDipToInch(rect.origin.x);
+        rect.origin.y = convertDipToInch(rect.origin.y);
+        rect.size.width = convertDipToInch(rect.size.width);
+        rect.size.height = convertDipToInch(rect.size.height);
+    }
+    else if ([unit caseInsensitiveCompare:kTiUnitMm] == NSOrderedSame) {
+        rect.origin.x = convertDipToInch(rect.origin.x) * INCH_IN_MM;
+        rect.origin.y = convertDipToInch(rect.origin.y) * INCH_IN_MM;
+        rect.size.width = convertDipToInch(rect.size.width) * INCH_IN_MM;
+        rect.size.height = convertDipToInch(rect.size.height) * INCH_IN_MM;
+    }
+    else if ([unit caseInsensitiveCompare:kTiUnitPixel] == NSOrderedSame) {
+        rect.origin.x = convertDipToPixels(rect.origin.x);
+        rect.origin.y = convertDipToPixels(rect.origin.y);
+        rect.size.width = convertDipToPixels(rect.size.width);
+        rect.size.height = convertDipToPixels(rect.size.height);
+    }
 }
 
 @end

--- a/iphone/Classes/TiUIButtonProxy.m
+++ b/iphone/Classes/TiUIButtonProxy.m
@@ -105,6 +105,11 @@
 	return suggestedResizing;
 }
 
+-(BOOL)optimizeSubviewInsertion
+{
+    return YES;
+}
+
 -(UIView *) parentViewForChild:(TiViewProxy *)child
 {
 	return [(TiUIButton *)[self view] viewGroupWrapper];

--- a/iphone/Classes/TiUILabelProxy.m
+++ b/iphone/Classes/TiUILabelProxy.m
@@ -66,11 +66,6 @@ USE_VIEW_FOR_CONTENT_WIDTH
     return TiDimensionAutoSize;
 }
 
-// TiUILabel has non-TiUIView subviews and is not intended for use as a viewgroup, either
--(BOOL)optimizeSubviewInsertion
-{
-    return NO;
-}
 
 @end
 

--- a/iphone/Classes/TiUIScrollViewProxy.m
+++ b/iphone/Classes/TiUIScrollViewProxy.m
@@ -245,6 +245,11 @@
 	[(TiUIScrollView *)[self view] setNeedsHandleContentSizeIfAutosizing];
 }
 
+-(BOOL)optimizeSubviewInsertion
+{
+    return YES;
+}
+
 -(UIView *)parentViewForChild:(TiViewProxy *)child
 {
 	return [(TiUIScrollView *)[self view] wrapperView];

--- a/iphone/Classes/TiViewProxy.m
+++ b/iphone/Classes/TiViewProxy.m
@@ -368,10 +368,15 @@ LAYOUTPROPERTIES_SETTER(setMinHeight,minimumHeight,TiFixedValueRuleFromObject,[s
 	TiRect *rect = [[TiRect alloc] init];
     if ([self viewAttached]) {
         [self makeViewPerformSelector:@selector(fillBoundsToRect:) withObject:rect createIfNeeded:YES waitUntilDone:YES];
+        id defaultUnit = [[NSUserDefaults standardUserDefaults] objectForKey:@"ti.ui.defaultunit"];
+        if ([defaultUnit isKindOfClass:[NSString class]]) {
+            [rect convertToUnit:defaultUnit];
+        }
     }
     else {
         [rect setRect:CGRectZero];
     }
+    
     return [rect autorelease];
 }
 
@@ -395,6 +400,11 @@ LAYOUTPROPERTIES_SETTER(setMinHeight,minimumHeight,TiFixedValueRuleFromObject,[s
         viewRect.origin.x += viewPosition.x;
         viewRect.origin.y += viewPosition.y;
         [rect setRect:viewRect];
+        
+        id defaultUnit = [[NSUserDefaults standardUserDefaults] objectForKey:@"ti.ui.defaultunit"];
+        if ([defaultUnit isKindOfClass:[NSString class]]) {
+            [rect convertToUnit:defaultUnit];
+        }       
     }
     else {
         [rect setRect:CGRectZero];

--- a/iphone/Classes/TiViewProxy.m
+++ b/iphone/Classes/TiViewProxy.m
@@ -1016,8 +1016,10 @@ LAYOUTPROPERTIES_SETTER(setMinHeight,minimumHeight,TiFixedValueRuleFromObject,[s
 #pragma mark Methods subclasses should override for behavior changes
 -(BOOL)optimizeSubviewInsertion
 {
-    return YES;
+    //Return YES for any view that implements a wrapperView that is a TiUIView (Button and ScrollView currently) and a basic view
+    return ( (view != nil) && ([view isMemberOfClass:[TiUIView class]]) ) ;
 }
+
 -(BOOL)suppressesRelayout
 {
 	return NO;
@@ -2499,7 +2501,7 @@ if(OSAtomicTestAndSetBarrier(flagBit, &dirtyflags))	\
 
 			for (TiUIView * thisView in [ourView subviews])
 			{
-				if (![thisView isKindOfClass:[TiUIView class]])
+				if ( (!optimizeInsertion) && (![thisView isKindOfClass:[TiUIView class]]) )
 				{
 					insertPosition ++;
 					continue;

--- a/iphone/Classes/TiViewProxy.m
+++ b/iphone/Classes/TiViewProxy.m
@@ -1017,7 +1017,7 @@ LAYOUTPROPERTIES_SETTER(setMinHeight,minimumHeight,TiFixedValueRuleFromObject,[s
 -(BOOL)optimizeSubviewInsertion
 {
     //Return YES for any view that implements a wrapperView that is a TiUIView (Button and ScrollView currently) and a basic view
-    return ( (view != nil) && ([view isMemberOfClass:[TiUIView class]]) ) ;
+    return ( [view isMemberOfClass:[TiUIView class]] ) ;
 }
 
 -(BOOL)suppressesRelayout

--- a/support/android/builder.py
+++ b/support/android/builder.py
@@ -1506,8 +1506,9 @@ class Builder(object):
 		apk_zip.write(os.path.join(sdk_native_libs, 'armeabi', 'libtiverify.so'), 'lib/armeabi/libtiverify.so')
 		apk_zip.write(os.path.join(sdk_native_libs, 'armeabi-v7a', 'libtiverify.so'), 'lib/armeabi-v7a/libtiverify.so')
 		# See below about x86 and production
-		if self.deploy_type != 'production':
-			apk_zip.write(os.path.join(sdk_native_libs, 'x86', 'libtiverify.so'), 'lib/x86/libtiverify.so')
+		x86_dir = os.path.join(sdk_native_libs, 'x86')
+		if self.deploy_type != 'production' and os.path.exists(x86_dir):
+			apk_zip.write(os.path.join(x86_dir, 'libtiverify.so'), 'lib/x86/libtiverify.so')
 
 		if self.runtime == 'v8':
 			apk_zip.write(os.path.join(sdk_native_libs, 'armeabi', 'libkroll-v8.so'), 'lib/armeabi/libkroll-v8.so')
@@ -1516,9 +1517,9 @@ class Builder(object):
 			apk_zip.write(os.path.join(sdk_native_libs, 'armeabi-v7a', 'libstlport_shared.so'), 'lib/armeabi-v7a/libstlport_shared.so')
 			# Only include x86 in non-production builds for now, since there are
 			# no x86 devices on the market
-			if self.deploy_type != 'production':
-				apk_zip.write(os.path.join(sdk_native_libs, 'x86', 'libkroll-v8.so'), 'lib/x86/libkroll-v8.so')
-				apk_zip.write(os.path.join(sdk_native_libs, 'x86', 'libstlport_shared.so'), 'lib/x86/libstlport_shared.so')
+			if self.deploy_type != 'production' and os.path.exists(x86_dir):
+				apk_zip.write(os.path.join(x86_dir, 'libkroll-v8.so'), 'lib/x86/libkroll-v8.so')
+				apk_zip.write(os.path.join(x86_dir, 'libstlport_shared.so'), 'lib/x86/libstlport_shared.so')
 
 				
 		self.apk_updated = True

--- a/support/android/builder.py
+++ b/support/android/builder.py
@@ -1496,8 +1496,9 @@ class Builder(object):
 		apk_zip.write(os.path.join(sdk_native_libs, 'armeabi', 'libtiverify.so'), 'lib/armeabi/libtiverify.so')
 		apk_zip.write(os.path.join(sdk_native_libs, 'armeabi-v7a', 'libtiverify.so'), 'lib/armeabi-v7a/libtiverify.so')
 		# See below about x86 and production
-		if self.deploy_type != 'production':
-			apk_zip.write(os.path.join(sdk_native_libs, 'x86', 'libtiverify.so'), 'lib/x86/libtiverify.so')
+		x86_dir = os.path.join(sdk_native_libs, 'x86')
+		if self.deploy_type != 'production' and os.path.exists(x86_dir):
+			apk_zip.write(os.path.join(x86_dir, 'libtiverify.so'), 'lib/x86/libtiverify.so')
 
 		if self.runtime == 'v8':
 			apk_zip.write(os.path.join(sdk_native_libs, 'armeabi', 'libkroll-v8.so'), 'lib/armeabi/libkroll-v8.so')
@@ -1506,9 +1507,9 @@ class Builder(object):
 			apk_zip.write(os.path.join(sdk_native_libs, 'armeabi-v7a', 'libstlport_shared.so'), 'lib/armeabi-v7a/libstlport_shared.so')
 			# Only include x86 in non-production builds for now, since there are
 			# no x86 devices on the market
-			if self.deploy_type != 'production':
-				apk_zip.write(os.path.join(sdk_native_libs, 'x86', 'libkroll-v8.so'), 'lib/x86/libkroll-v8.so')
-				apk_zip.write(os.path.join(sdk_native_libs, 'x86', 'libstlport_shared.so'), 'lib/x86/libstlport_shared.so')
+			if self.deploy_type != 'production' and os.path.exists(x86_dir):
+				apk_zip.write(os.path.join(x86_dir, 'libkroll-v8.so'), 'lib/x86/libkroll-v8.so')
+				apk_zip.write(os.path.join(x86_dir, 'libstlport_shared.so'), 'lib/x86/libstlport_shared.so')
 
 				
 		self.apk_updated = True


### PR DESCRIPTION
Note that this fix only affects Android and iOS - MW has a separate bug [TIMOB-8959](https://jira.appcelerator.org/browse/TIMOB-8959) to add support for this, which is not currently scheduled for the next release.

As an added bonus this fix also:
- Makes it possible to work with Android dists sconsed with build_x86=0
- Fixes unit conversions to in, mm, cm by not rounding them to the nearest integer on Android
