### PR TITLE
TIMOB-9086 Change the Android module eclipse .project template so it:

### DIFF
--- a/support/module/android/templates/eclipse_project
+++ b/support/module/android/templates/eclipse_project
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>titanium-___PROJECTNAME___</name>
+	<name>___PROJECTNAME___</name>
 	<comment></comment>
 	<projects>
 	</projects>
 	<buildSpec>
+		<buildCommand>
+			<name>com.appcelerator.titanium.core.builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>com.aptana.ide.core.unifiedBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 		<buildCommand>
 			<name>org.eclipse.jdt.core.javabuilder</name>
 			<arguments>
@@ -13,5 +23,7 @@
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>com.appcelerator.titanium.mobile.module.nature</nature>
+		<nature>com.aptana.projects.webnature</nature>
 	</natures>
 </projectDescription>


### PR DESCRIPTION
- Stops prefixing "titanium-" to the name.
- Includes the builder and natures for Titanium Studio.

This makes it possible to use in Eclipse and Ti Studio without changing the name.

https://jira.appcelerator.org/browse/TIMOB-9086

Test case is as described by Dustin in the ticket.
