### PR TITLE
[TIDOC-663][TIMOB-9438][TIMOB-9439] Make the zoom properties play nice with each other

### DIFF
--- a/apidoc/Titanium/UI/ScrollView.yml
+++ b/apidoc/Titanium/UI/ScrollView.yml
@@ -193,7 +193,7 @@ properties:
         It must be greater than the [minimum zoom scale](Titanium.UI.ScrollView.minZoomScale) for zooming to be enabled. 
         The default value is 1.0 unless otherwise specified.
         
-        Note that specifying a value less than or equal to 0 will hide all contents of the scroll view
+        Note that specifying a value less than or equal to 0 will hide all contents of the scroll view.
     type: Number
     default: 1.0
     platforms: [iphone, ipad]
@@ -257,7 +257,7 @@ properties:
   - name: zoomScale
     summary: Scaling factor of the scrollable region and its content.
     description: |
-        This value is bound by the [minZoomScale](Titanium.UI.ScrollView.minZoomScale) and [maxZoomScale](Titanium.UI.ScrollView.maxZoomScale) properties
+        This value is bound by the [minZoomScale](Titanium.UI.ScrollView.minZoomScale) and [maxZoomScale](Titanium.UI.ScrollView.maxZoomScale) properties.
     type: Number
     default: 1
     platforms: [iphone, ipad]

--- a/apidoc/Titanium/UI/ScrollView.yml
+++ b/apidoc/Titanium/UI/ScrollView.yml
@@ -188,12 +188,24 @@ properties:
     
   - name: maxZoomScale
     summary: Maximum scaling factor of the scrollable region and its content.
+    description: |
+        This value determines how large the content can be scaled. 
+        It must be greater than the [minimum zoom scale](Titanium.UI.ScrollView.minZoomScale) for zooming to be enabled. 
+        The default value is 1.0 unless otherwise specified.
+        
+        Note that specifying a value less than or equal to 0 will hide all contents of the scroll view
     type: Number
+    default: 1.0
     platforms: [iphone, ipad]
     
   - name: minZoomScale
     summary: Minimum scaling factor of the scrollable region and its content.
+    description: |
+        This value determines how small the content can be scaled. 
+        It must be less than the [maximum zoom scale](Titanium.UI.ScrollView.maxZoomScale) for zooming to be enabled. 
+        The default value is 1.0 unless otherwise specified.
     type: Number
+    default: 1.0
     platforms: [iphone, ipad]
     
   - name: scrollIndicatorStyle
@@ -244,6 +256,8 @@ properties:
     
   - name: zoomScale
     summary: Scaling factor of the scrollable region and its content.
+    description: |
+        This value is bound by the [minZoomScale](Titanium.UI.ScrollView.minZoomScale) and [maxZoomScale](Titanium.UI.ScrollView.maxZoomScale) properties
     type: Number
     default: 1
     platforms: [iphone, ipad]

--- a/iphone/Classes/TiUIScrollView.m
+++ b/iphone/Classes/TiUIScrollView.m
@@ -282,10 +282,10 @@
 
 -(void)setZoomScale_:(id)args
 {
-	CGFloat scale = [TiUtils floatValue:args];
+	CGFloat scale = [TiUtils floatValue:args def:1.0];
 	[[self scrollView] setZoomScale:scale];
 	scale = [[self scrollView] zoomScale]; //Why are we doing this? Because of minZoomScale or maxZoomScale.
-	[[self proxy] replaceValue:NUMFLOAT(scale) forKey:@"scale" notification:NO];
+	[[self proxy] replaceValue:NUMFLOAT(scale) forKey:@"zoomScale" notification:NO];
 	if ([self.proxy _hasListeners:@"scale"])
 	{
 		[self.proxy fireEvent:@"scale" withObject:[NSDictionary dictionaryWithObjectsAndKeys:
@@ -296,12 +296,23 @@
 
 -(void)setMaxZoomScale_:(id)args
 {
-	[[self scrollView] setMaximumZoomScale:[TiUtils floatValue:args]];
+    CGFloat val = [TiUtils floatValue:args def:1.0];
+    [[self scrollView] setMaximumZoomScale:val];
+    if ([[self scrollView] zoomScale] > val) {
+        [self setZoomScale_:args];
+    }
+    else if ([[self scrollView] zoomScale] < [[self scrollView] minimumZoomScale]){
+        [self setZoomScale_:[NSNumber numberWithFloat:[[self scrollView] minimumZoomScale]]];
+    }
 }
 
 -(void)setMinZoomScale_:(id)args
 {
-	[[self scrollView] setMinimumZoomScale:[TiUtils floatValue:args]];
+    CGFloat val = [TiUtils floatValue:args def:1.0];
+    [[self scrollView] setMinimumZoomScale:val];
+    if ([[self scrollView] zoomScale] < val) {
+        [self setZoomScale_:args];
+    }
 }
 
 -(void)setCanCancelEvents_:(id)args

--- a/iphone/Classes/TiUIScrollViewProxy.m
+++ b/iphone/Classes/TiUIScrollViewProxy.m
@@ -13,13 +13,24 @@
 
 @implementation TiUIScrollViewProxy
 
+static NSArray* scrollViewKeySequence;
+-(NSArray *)keySequence
+{
+    if (scrollViewKeySequence == nil)
+    {
+        //URL has to be processed first since the spinner depends on URL being remote
+        scrollViewKeySequence = [[NSArray arrayWithObjects:@"minZoomScale",@"maxZoomScale",@"zoomScale",nil] retain];
+    }
+    return scrollViewKeySequence;
+}
+
 -(void)_initWithProperties:(NSDictionary *)properties
 {
-	// set the initial scale to 1.0 which is the default
-	// FIXME: Not going to do this right before release because it might break some things, but we should rename this property to zoomScale and tie it to the scroll view's value.
-	[self replaceValue:NUMFLOAT(1.0) forKey:@"scale" notification:NO];
-	[self replaceValue:NUMBOOL(YES) forKey:@"canCancelEvents" notification:NO];
-	[super _initWithProperties:properties];
+    [self initializeProperty:@"minZoomScale" defaultValue:NUMFLOAT(1.0)];
+    [self initializeProperty:@"maxZoomScale" defaultValue:NUMFLOAT(1.0)];
+    [self initializeProperty:@"zoomScale" defaultValue:NUMFLOAT(1.0)];
+    [self initializeProperty:@"canCancelEvents" defaultValue:NUMBOOL(YES)];
+    [super _initWithProperties:properties];
 }
 
 -(TiPoint *) contentOffset{
@@ -299,7 +310,7 @@
 
 - (void)scrollViewDidEndZooming:(UIScrollView *)scrollView withView:(UIView *)view atScale:(float)scale
 {
-	[self replaceValue:NUMFLOAT(scale) forKey:@"scale" notification:NO];
+	[self replaceValue:NUMFLOAT(scale) forKey:@"zoomScale" notification:NO];
 	
 	if ([self _hasListeners:@"scale"])
 	{


### PR DESCRIPTION
Related [ticket](https://jira.appcelerator.org/browse/TIDOC-663)

This PR addresses a few issues
1. Doc update regarding the zoomScale and associated properties
2. Ensuring that the scrollView sets the zoomScale correctly when either of the bounding values are changed
