### PR TITLE
[TIMOB-9445] Android: Views - Missing color for View 3

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiUIView.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiUIView.java
@@ -582,7 +582,7 @@ public abstract class TiUIView
 				}
 				background.setBackgroundColor(bgColor);
 
-			} else {
+			} else if(!nativeViewNull) {
 				nativeView.setBackgroundColor(bgColor);
 			}
 		}

--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiUIView.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiUIView.java
@@ -570,7 +570,7 @@ public abstract class TiUIView
 		if (hasImage(d) || hasColorState(d) || hasGradient(d)) {
 			handleBackgroundImage(d);
 
-		} else if (d.containsKey(TiC.PROPERTY_BACKGROUND_COLOR)) {
+		} else if (d.containsKey(TiC.PROPERTY_BACKGROUND_COLOR) && !nativeViewNull) {
 			bgColor = TiConvert.toColor(d, TiC.PROPERTY_BACKGROUND_COLOR);
 
 			// Set the background color on the view directly only
@@ -582,7 +582,7 @@ public abstract class TiUIView
 				}
 				background.setBackgroundColor(bgColor);
 
-			} else if(!nativeViewNull) {
+			} else {
 				nativeView.setBackgroundColor(bgColor);
 			}
 		}

--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiUIView.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiUIView.java
@@ -567,13 +567,26 @@ public abstract class TiUIView
 
 		// Default background processing.
 		// Prefer image to color.
-		if (hasImage(d) || hasColorState(d) || hasBorder(d) || hasGradient(d)) {
+		if (hasImage(d) || hasColorState(d) || hasGradient(d)) {
 			handleBackgroundImage(d);
-		} else if (d.containsKey(TiC.PROPERTY_BACKGROUND_COLOR) && !nativeViewNull) {
+
+		} else if (d.containsKey(TiC.PROPERTY_BACKGROUND_COLOR)) {
 			bgColor = TiConvert.toColor(d, TiC.PROPERTY_BACKGROUND_COLOR);
-			nativeView.setBackgroundColor(bgColor);
+
+			// Set the background color on the view directly only
+			// if there is no border. If a border is present we must
+			// use the TiBackgroundDrawable.
+			if (hasBorder(d)) {
+				if (background == null) {
+					applyCustomBackground(false);
+				}
+				background.setBackgroundColor(bgColor);
+
+			} else {
+				nativeView.setBackgroundColor(bgColor);
+			}
 		}
-		
+
 		if (d.containsKey(TiC.PROPERTY_VISIBLE) && !nativeViewNull) {
 			nativeView.setVisibility(TiConvert.toBoolean(d, TiC.PROPERTY_VISIBLE) ? View.VISIBLE : View.INVISIBLE);
 			
@@ -760,14 +773,14 @@ public abstract class TiUIView
 	private void handleBackgroundImage(KrollDict d)
 	{
 		String bg = d.getString(TiC.PROPERTY_BACKGROUND_IMAGE);
-		String bgSelected = d.getString(TiC.PROPERTY_BACKGROUND_SELECTED_IMAGE);
-		String bgFocused = d.getString(TiC.PROPERTY_BACKGROUND_FOCUSED_IMAGE);
-		String bgDisabled = d.getString(TiC.PROPERTY_BACKGROUND_DISABLED_IMAGE);
+		String bgSelected = d.optString(TiC.PROPERTY_BACKGROUND_SELECTED_IMAGE, bg);
+		String bgFocused = d.optString(TiC.PROPERTY_BACKGROUND_FOCUSED_IMAGE, bg);
+		String bgDisabled = d.optString(TiC.PROPERTY_BACKGROUND_DISABLED_IMAGE, bg);
 		
 		String bgColor = d.getString(TiC.PROPERTY_BACKGROUND_COLOR);
-		String bgSelectedColor = d.getString(TiC.PROPERTY_BACKGROUND_SELECTED_COLOR);
-		String bgFocusedColor = d.getString(TiC.PROPERTY_BACKGROUND_FOCUSED_COLOR);
-		String bgDisabledColor = d.getString(TiC.PROPERTY_BACKGROUND_DISABLED_COLOR);
+		String bgSelectedColor = d.optString(TiC.PROPERTY_BACKGROUND_SELECTED_COLOR, bgColor);
+		String bgFocusedColor = d.optString(TiC.PROPERTY_BACKGROUND_FOCUSED_COLOR, bgColor);
+		String bgDisabledColor = d.optString(TiC.PROPERTY_BACKGROUND_DISABLED_COLOR, bgColor);
 
 		if (bg != null) {
 			bg = resolveImageUrl(bg);


### PR DESCRIPTION
This fixes a bug that was causing the view background colors to
disappear. The cause was due to how we setup the state list drawable when
there is only a "default" background color state.

Fixed issue by avoiding the state list if no color/image state properties are used (ex: backgroundSelectedColor). If we must use a state list, when no color/image is provided for
a state use the "default" state's color/image.

Test this by running the KS example  Base UI - Views - Remove Views.
You should see three views (prior to the fix the 3rd view was missing).
Also try clicking the views and make sure the color doesn't disappear.
