### PR TITLE
[TIMOB-8955] Set gradient page context as execution context only if available.

### DIFF
--- a/iphone/Classes/TiGradient.m
+++ b/iphone/Classes/TiGradient.m
@@ -280,7 +280,8 @@
 {
 	if ([value isKindOfClass:[NSDictionary class]])
 	{
-		TiGradient * newGradient = [[[TiGradient alloc] _initWithPageContext:[proxy executionContext]] autorelease];
+        id<TiEvaluator> context = ([proxy executionContext] == nil) ? [proxy pageContext] : [proxy executionContext];
+		TiGradient * newGradient = [[[TiGradient alloc] _initWithPageContext:context] autorelease];
 		[newGradient _initWithProperties:value];
 		return newGradient;
 	}


### PR DESCRIPTION
**NOTE:** Testing this fix as in the ticket is no longer valid; the [ERROR] message referenced there was removed (even at the Developer logging level). Instead the fix is based on previous fixes to this sort of issue; all that needs to be demonstrated is that the gradient is displayed correctly, without warnings at any level.
