### PR TITLE
[TIMOB-9481] - iOS Fixed Ti.App.iOS.cancelLocalNotification()

### DIFF
--- a/iphone/Classes/TiAppiOSProxy.m
+++ b/iphone/Classes/TiAppiOSProxy.m
@@ -169,29 +169,18 @@
 {
 	ENSURE_SINGLE_ARG(args,NSObject);
 	ENSURE_UI_THREAD(cancelLocalNotification,args);
-	NSInteger theid = [TiUtils intValue:args];
 	NSArray *notifications = [[UIApplication sharedApplication] scheduledLocalNotifications];
 	if (notifications!=nil)
 	{
-		UILocalNotification *notification = nil;
-		
-		for (notification in notifications)
+		for (UILocalNotification *notification in notifications)
 		{
-			id i = [[notification userInfo] objectForKey:@"id"];
-			if (i!=nil)
+			if([[[notification userInfo] objectForKey:@"id"] isEqual:args])
 			{
-				if ([i intValue]==theid)
-				{
-					break;
-				}
+				[[UIApplication sharedApplication] cancelLocalNotification:notification];
+				return;
 			}
-			notification = nil;
 		}
-		if (notification!=nil)
-		{
-			notification.userInfo = nil;
-			[[UIApplication sharedApplication] cancelLocalNotification:notification];
-		}
+		
 	}
 }
 


### PR DESCRIPTION
Ti.App.iOS.cancelLocalNotification() was not working, Fixed now.

Jira ticket: https://jira.appcelerator.org/browse/TIMOB-9481
