### PR TITLE
[TIDOC-623] Adding add/remove methods back in.

### DIFF
--- a/apidoc/Titanium/UI/ActivityIndicator.yml
+++ b/apidoc/Titanium/UI/ActivityIndicator.yml
@@ -102,23 +102,24 @@ properties:
         <Titanium.UI.ActivityIndicatorStyle.BIG>, 
         <Titanium.UI.ActivityIndicatorStyle.BIG_DARK>, 
         or <Titanium.UI.ActivityIndicatorStyle.PLAIN>.
-		
-		On Mobile Web, setting the style automatically sets the indicator color and diameter.
+
+        On Mobile Web, setting the style automatically sets the indicator color and diameter.
+
+        See also: [indicatorColor](Titanium.UI.ActivityIndicator.indicatorColor),
+        [indicatorDiameter](Titanium.UI.ActivityIndicator.indicatorDiameter)
     type: Number
     default: <Titanium.UI.iPhone.ActivityIndicatorStyle.PLAIN> (iOS), <Titanium.UI.MobileWeb.ActivityIndicatorStyle.PLAIN> (Mobile Web)
     platforms: [iphone, ipad, mobileweb]
-	See also: [indicatorColor](Titanium.UI.ActivityIndicator.indicatorColor),
-		[indicatorDiameter](Titanium.UI.ActivityIndicator.indicatorDiameter)
 
   - name: indicatorColor
-    summary: The color of the animated indicator.
+    summary: Color of the animated indicator.
     since: "2.1.0"
     type: String
     default: "#fff"
     platforms: [mobileweb]
     
   - name: indicatorDiameter
-    summary: The diameter of the indicator
+    summary: Diameter of the indicator.
     description: |
         The diameter of the animated indicator, exclusive of any message text.
     since: "2.1.0"

--- a/apidoc/Titanium/UI/ActivityIndicatorStyle.yml
+++ b/apidoc/Titanium/UI/ActivityIndicatorStyle.yml
@@ -50,7 +50,7 @@ properties:
     platforms: [mobileweb]
     
   - name: PLAIN
-    summary: Small white spinning indicator (default.)
+    summary: Small white spinning indicator (default).
     description: |
         Used with the <Titanium.UI.ActivityIndicator.style> property.
         

--- a/apidoc/Titanium/UI/TableViewSection.yml
+++ b/apidoc/Titanium/UI/TableViewSection.yml
@@ -36,12 +36,17 @@ methods:
   - name: add
     summary: Adds a table view row to this section.
     description: |
-        Must be called before adding the section to a table.
+        Should be called before adding the section to a table. Calling `add` on a section
+        that's already been added to a table does not update the table.
 
         To add a row to a section after it's been added to a table, call one of the
         `TableView` methods, [insertRowBefore](Titanium.UI.TableView.insertRowBefore),
         [insertRowAfter](Titanium.UI.TableView.insertRowAfter), or
         [appendRow](Titanium.UI.TableView.appendRow).
+
+        On Android, it is possible to update a section by adding or removing rows and then 
+        resetting the table view's `data` property. However, this approach is not
+        portable and is not recommended.
     parameters:
       - name: row
         summary: Row to add.
@@ -50,11 +55,15 @@ methods:
   - name: remove
     summary: Removes a table view row from this section.
     description: |
-        Must be called before a section is added to a table. Calling `remove` on
+        Should be called before a section is added to a table. Calling `remove` on
         a section that's already been added to a table may throw an exception.
 
         To delete a row once the section is added to a table, use the `TableView`
         [deleteRow](Titanium.UI.TableView.deleteRow) method.
+
+        On Android, it is possible to update a section by adding or removing rows and then 
+        resetting the table view's `data` property. However, this approach is not
+        portable and is not recommended.
     parameters:
       - name: row
         summary: Row to remove.

--- a/apidoc/Titanium/UI/TableViewSection.yml
+++ b/apidoc/Titanium/UI/TableViewSection.yml
@@ -35,6 +35,13 @@ methods:
 
   - name: add
     summary: Adds a table view row to this section.
+    description: |
+        Must be called before adding the section to a table.
+
+        To add a row to a section after it's been added to a table, call one of the
+        `TableView` methods, [insertRowBefore](Titanium.UI.TableView.insertRowBefore),
+        [insertRowAfter](Titanium.UI.TableView.insertRowAfter), or
+        [appendRow](Titanium.UI.TableView.appendRow).
     parameters:
       - name: row
         summary: Row to add.
@@ -42,6 +49,12 @@ methods:
 
   - name: remove
     summary: Removes a table view row from this section.
+    description: |
+        Must be called before a section is added to a table. Calling `remove` on
+        a section that's already been added to a table may throw an exception.
+
+        To delete a row once the section is added to a table, use the `TableView`
+        [deleteRow](Titanium.UI.TableView.deleteRow) method.
     parameters:
       - name: row
         summary: Row to remove.

--- a/apidoc/Titanium/UI/TableViewSection.yml
+++ b/apidoc/Titanium/UI/TableViewSection.yml
@@ -32,6 +32,21 @@ extends: Titanium.Proxy
 since: "0.9"
 
 methods:
+
+  - name: add
+    summary: Adds a table view row to this section.
+    parameters:
+      - name: row
+        summary: Row to add.
+        type: Titanium.UI.TableViewRow
+
+  - name: remove
+    summary: Removes a table view row from this section.
+    parameters:
+      - name: row
+        summary: Row to remove.
+        type: Titanium.UI.TableViewRow
+
   - name: rowAtIndex
     summary: Returns a row in this section.
     platforms: [android]


### PR DESCRIPTION
Correction to previous inheritance fix. 

Missed that we needed to add the add/remove methods back in after changing the inheritance.
