### PR TITLE
Android support for sending files in HTTP request body

### DIFF
--- a/android/modules/network/src/java/ti/modules/titanium/network/TiHTTPClient.java
+++ b/android/modules/network/src/java/ti/modules/titanium/network/TiHTTPClient.java
@@ -58,6 +58,7 @@ import org.apache.http.conn.scheme.SchemeRegistry;
 import org.apache.http.conn.ssl.SSLSocketFactory;
 import org.apache.http.cookie.Cookie;
 import org.apache.http.entity.AbstractHttpEntity;
+import org.apache.http.entity.FileEntity;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.entity.mime.MultipartEntity;
 import org.apache.http.entity.mime.content.ContentBody;
@@ -141,6 +142,7 @@ public class TiHTTPClient
 	private ArrayList<NameValuePair> nvPairs;
 	private HashMap<String, ContentBody> parts;
 	private String data;
+	private TiBaseFile dataFile;
 	private boolean needMultipart;
 	private Thread clientThread;
 	private boolean aborted;
@@ -1075,6 +1077,15 @@ public class TiHTTPClient
 					this.url = uri.toString();
 				}
 
+			} else if (userData instanceof TiBaseFile || userData instanceof TiFileProxy) {
+				// Sending binary objects in the request body as-is.
+				// Important for PUT requests. (Sending files to S3)
+				if (userData instanceof TiFileProxy) {
+					userData = ((TiFileProxy) userData).getBaseFile();
+				}
+
+				dataFile = (TiBaseFile)userData;
+				totalLength = dataFile.size();
 			} else {
 				addStringData(TiConvert.toString(userData));
 			}
@@ -1126,46 +1137,57 @@ public class TiHTTPClient
 					credentials = null;
 				}
 				client.setRedirectHandler(new RedirectHandler());
-				if(request instanceof BasicHttpEntityEnclosingRequest) {
+				if (request instanceof BasicHttpEntityEnclosingRequest) {
 
-					UrlEncodedFormEntity form = null;
-					MultipartEntity mpe = null;
+					HttpEntity ent = null;
 
-					if (nvPairs.size() > 0) {
-						try {
-							form = new UrlEncodedFormEntity(nvPairs, "UTF-8");
+					if (dataFile != null) {
+						ent = new FileEntity(dataFile.getNativeFile(), "");
+					} else {
+						UrlEncodedFormEntity form = null;
+						MultipartEntity mpe = null;
 
-						} catch (UnsupportedEncodingException e) {
-							Log.e(LCAT, "Unsupported encoding: ", e);
-						}
-					}
-
-					if (parts.size() > 0 && needMultipart) {
-						mpe = new MultipartEntity();
-						for(String name : parts.keySet()) {
-							if (DBG) {
-								Log.d(LCAT, "adding part " + name + ", part type: " + parts.get(name).getMimeType() + ", len: " + parts.get(name).getContentLength());
-							}
-							mpe.addPart(name, parts.get(name));
-						}
-
-						if (form != null) {
+						if (nvPairs.size() > 0) {
 							try {
-								ByteArrayOutputStream bos = new ByteArrayOutputStream((int) form.getContentLength());
-								form.writeTo(bos);
-								mpe.addPart("form", new StringBody(bos.toString(), "application/x-www-form-urlencoded", Charset.forName("UTF-8")));
+								form = new UrlEncodedFormEntity(nvPairs, "UTF-8");
 
 							} catch (UnsupportedEncodingException e) {
 								Log.e(LCAT, "Unsupported encoding: ", e);
-
-							} catch (IOException e) {
-								Log.e(LCAT, "Error converting form to string: ", e);
 							}
 						}
 
+						if (parts.size() > 0 && needMultipart) {
+							ent = mpe = new MultipartEntity();
+							for (String name : parts.keySet()) {
+								if (DBG) {
+									Log.d(LCAT, "adding part " + name + ", part type: " + parts.get(name).getMimeType() + ", len: " + parts.get(name).getContentLength());
+								}
+								mpe.addPart(name, parts.get(name));
+							}
+
+							if (form != null) {
+								try {
+									ByteArrayOutputStream bos = new ByteArrayOutputStream((int) form.getContentLength());
+									form.writeTo(bos);
+									mpe.addPart("form", new StringBody(bos.toString(), "application/x-www-form-urlencoded", Charset.forName("UTF-8")));
+
+								} catch (UnsupportedEncodingException e) {
+									Log.e(LCAT, "Unsupported encoding: ", e);
+
+								} catch (IOException e) {
+									Log.e(LCAT, "Error converting form to string: ", e);
+								}
+							}
+
+						} else {
+							handleURLEncodedData(form);
+						}
+					}
+
+					if (ent != null) {
 						HttpEntityEnclosingRequest e = (HttpEntityEnclosingRequest) request;
 
-						ProgressEntity progressEntity = new ProgressEntity(mpe, new ProgressListener() {
+						ProgressEntity progressEntity = new ProgressEntity(ent, new ProgressListener() {
 							public void progress(int progress) {
 								KrollFunction cb = getCallback(ON_SEND_STREAM);
 								if (cb != null) {
@@ -1180,14 +1202,8 @@ public class TiHTTPClient
 
 						e.addHeader("Length", totalLength+"");
 
-					} else {
-						handleURLEncodedData(form);
-					}
-
-					//Remove Content-Length header if entity is set since setEntity implicitly sets Content-Length
-					HttpEntityEnclosingRequest enclosingEntity = (HttpEntityEnclosingRequest) request;
-					if (enclosingEntity.getEntity() != null) {
-						request.removeHeaders("Content-Length");
+						// Can't do this, or sending blobs and files won't work
+						// e.removeHeaders("Content-Length");
 					}
 				}
 


### PR DESCRIPTION
Hi gents,

Here's the patch that lets you send files in the body of the request, like it's possible in iOS:

```
xhr.send(Ti.Filesystem.getFile(...))
```

This is the one that makes PUT-ing files to Amanzon S3 directly possible on Android. I've seen lots of requests re this support, and figured you might find it useful.

(I have a backport for 2.0.2GA too, btw)
