### PR TITLE
Issue with cookies not being deleted on Facebook.logout()

### DIFF
--- a/iphone/Classes/FBConnect/Facebook.m
+++ b/iphone/Classes/FBConnect/Facebook.m
@@ -382,7 +382,7 @@ static NSString* kSDKVersion = @"2";
 
   NSHTTPCookieStorage* cookies = [NSHTTPCookieStorage sharedHTTPCookieStorage];
   NSArray* facebookCookies = [cookies cookiesForURL:
-    [NSURL URLWithString:@"http://login.facebook.com"]];
+    [NSURL URLWithString:@"https://login.facebook.com"]];
 
   for (NSHTTPCookie* cookie in facebookCookies) {
     [cookies deleteCookie:cookie];


### PR DESCRIPTION
This resulted in one automatically being logged in after calling
Facebook.authorize. The expected behavior was for the Dialog to appear
and ask for credentials.

This behavior will now work as expected.
