### PR TITLE
[TIMOB-9554] Don't pass empty arguments to AVD launcher.

### DIFF
--- a/support/android/builder.py
+++ b/support/android/builder.py
@@ -490,7 +490,7 @@ class Builder(object):
 			'-partition-size',
 			'128' # in between nexusone and droid
 		]
-		emulator_cmd.extend(add_args);
+		emulator_cmd.extend([arg.strip() for arg in add_args if len(arg.strip()) > 0])
 		debug(' '.join(emulator_cmd))
 		
 		p = subprocess.Popen(emulator_cmd)


### PR DESCRIPTION
This is required to make sure that ABI selection works with "legacy" backcompat correctly (which may require passing in an empty arg) and is good practice besides.
