### PR TITLE
[TIMOB-9108] Android: Network change listener does not fire

### DIFF
--- a/android/runtime/common/src/js/invoker.js
+++ b/android/runtime/common/src/js/invoker.js
@@ -56,7 +56,17 @@ function genInvoker(wrapperAPI, realAPI, apiName, invocationAPI, scopeVars) {
 			api = apiNamespace[name];
 
 		} else {
-			function SandboxAPI() {}
+			function SandboxAPI() {
+				var proto = this.__proto__;
+				Object.defineProperty(this, '_events', {
+					get: function() {
+						return proto._events;
+					},
+					set: function(value) {
+						proto._events = value;
+					}
+				});
+			}
 			SandboxAPI.prototype = apiNamespace[name];
 
 			api = new SandboxAPI();


### PR DESCRIPTION
This fixes an issue with dispatching events onto a module which uses invocation APIs.

See the JIRA ticket for a test case and instructions.
