### PR TITLE
[TIMOB-9344] iOS:Moving 3DMatrix to common namespace

### DIFF
--- a/apidoc/Titanium/UI/3DMatrix.yml
+++ b/apidoc/Titanium/UI/3DMatrix.yml
@@ -1,9 +1,8 @@
 ---
 name: Titanium.UI.3DMatrix
-summary: Use <Titanium.UI.iOS.3DMatrix> instead.
+summary:  The 3D Matrix is an object for holding values for an affine transformation matrix. 
 description: |
-    The 3D Matrix is an object for holding values for an affine transformation matrix. 
-
+   
     The 3DMatrix is created by <Titanium.UI.create3DMatrix>. A 3D matrix is
     used to rotate, scale, translate, or skew the objects in a three-dimensional
     space. A 3D matrix is represented by a 4 by 4 matrix. 
@@ -13,11 +12,11 @@ description: |
 extends: Titanium.Proxy
 since: "0.9"
 platforms: [iphone, ipad]
-deprecated: 
-    since: 1.8.0
+
 methods:
   - name: invert
-    summary: Returns a matrix constructed by inverting an existing matrix
+    summary: Returns a matrix constructed by inverting an existing matrix.
+    
   - name: multiply
     summary: Returns a matrix constructed by combining two existing matrix.
     returns:
@@ -26,6 +25,7 @@ methods:
       - name: t2
         summary: The second matrix. This matrix is concatenated to the matrix instance against which the function is invoked.  The result of this function is the first matrix multiplied by the second matrix. You might perform several multiplications in order to create a single matrix that contains the cumulative effects of several transformations. Note that matrix operations are not commutative - the order in which you concatenate matrices is important. That is, the result of multiplying matrix t1 by matrix t2 does not necessarily equal the result of multiplying matrix t2 by matrix t1.
         type: Titanium.UI.3DMatrix
+        
   - name: rotate
     summary: Returns a matrix constructed by rotating an existing matrix
     returns:
@@ -43,10 +43,12 @@ methods:
       - name: z
         summary: The z part of the vector about which to rotate
         type: Number
+        
   - name: scale
     summary: Returns a matrix constructed by scaling an existing matrix
     returns:
         type: Titanium.UI.3DMatrix
+        
     parameters:
       - name: sx
         summary: The value by which to scale x values of the matrix
@@ -57,6 +59,7 @@ methods:
       - name: sz
         summary: The value by which to scale z values of the matrix
         type: Number
+        
   - name: translate
     summary: Returns a matrix constructed by translating an existing matrix
     returns:
@@ -71,52 +74,68 @@ methods:
       - name: tz
         summary: The value by which to move z values with the matrix
         type: Number
+        
 properties:
   - name: m11
     summary: The entry at position [1,1] in the matrix.
     type: Number
+    
   - name: m12
     summary: The entry at position [1,2] in the matrix.
     type: Number
+    
   - name: m13
     summary: The entry at position [1,3] in the matrix.
     type: Number
+    
   - name: m14
     summary: The entry at position [1,4] in the matrix.
     type: Number
+    
   - name: m21
     summary: The entry at position [2,1] in the matrix.
     type: Number
+    
   - name: m22
     summary: The entry at position [2,2] in the matrix.
     type: Number
+    
   - name: m23
     summary: The entry at position [2,3] in the matrix.
     type: Number
+    
   - name: m24
     summary: The entry at position [2,4] in the matrix.
     type: Number
+    
   - name: m31
     summary: The entry at position [3,1] in the matrix.
     type: Number
+    
   - name: m32
     summary: The entry at position [3,2] in the matrix.
     type: Number
+    
   - name: m33
     summary: The entry at position [3,3] in the matrix.
     type: Number
+    
   - name: m34
     summary: The entry at position [3,4] in the matrix.
     type: Number
+    
   - name: m41
     summary: The entry at position [4,1] in the matrix.
     type: Number
+    
   - name: m42
     summary: The entry at position [4,2] in the matrix.
     type: Number
+    
   - name: m43
     summary: The entry at position [4,3] in the matrix.
     type: Number
+    
   - name: m44
     summary: The entry at position [4,4] in the matrix.
     type: Number

--- a/apidoc/Titanium/UI/iOS/3DMatrix.yml
+++ b/apidoc/Titanium/UI/iOS/3DMatrix.yml
@@ -1,8 +1,10 @@
 ---
 name: Titanium.UI.iOS.3DMatrix
-summary: The 3D Matrix is an object for holding values for an affine transformation matrix. 
+summary: Use <Titanium.UI.3DMatrix> instead.
 description: |
-    The 3DMatrix is created by the <Titanium.UI.iOS.create3DMatrix> method. 
+	The 3D Matrix is an object for holding values for an affine transformation matrix.
+	
+    The 3DMatrix is created by the <Titanium.UI.create3DMatrix> method. 
     
     A 3D matrix, represented by a 4 by 4 matrix, is used to rotate, scale, translate, or skew 
     objects in a three-dimensional space.
@@ -11,7 +13,9 @@ description: |
 extends: Titanium.Proxy
 since: "0.9"
 platforms: [iphone, ipad]
-
+deprecated: 
+    since: 2.1.0
+    
 methods:
   - name: invert
     summary: Returns a matrix constructed by inverting an existing matrix.
@@ -19,7 +23,7 @@ methods:
   - name: multiply
     summary: Returns a matrix constructed by combining two existing matrices.
     returns:
-        type: Titanium.UI.iOS.3DMatrix
+        type: Titanium.UI.3DMatrix
     parameters:
       - name: t2
         summary: |
@@ -31,12 +35,12 @@ methods:
             Note that matrix operations are not commutative - the order in which you concatenate 
             matrices is important. That is, the result of multiplying matrix t1 by matrix t2 does 
             not necessarily equal the result of multiplying matrix t2 by matrix t1.
-        type: Titanium.UI.iOS.3DMatrix
+        type: Titanium.UI.3DMatrix
         
   - name: rotate
     summary: Returns a matrix constructed by rotating an existing matrix.
     returns:
-        type: Titanium.UI.iOS.3DMatrix
+        type: Titanium.UI.3DMatrix
     parameters:
       - name: angle
         summary: |
@@ -59,7 +63,7 @@ methods:
   - name: scale
     summary: Returns a matrix constructed by scaling an existing matrix.
     returns:
-        type: Titanium.UI.iOS.3DMatrix
+        type: Titanium.UI.3DMatrix
     parameters:
       - name: sx
         summary: The value by which to scale x values of the matrix.
@@ -76,7 +80,7 @@ methods:
   - name: translate
     summary: Returns a matrix constructed by translating an existing matrix.
     returns:
-        type: Titanium.UI.iOS.3DMatrix
+        type: Titanium.UI.3DMatrix
     parameters:
       - name: tx
         summary: The value by which to move x values with the matrix.
@@ -185,7 +189,7 @@ examples:
             win.add(button);
             
             button.addEventListener('click', function(){
-              var t1 = Ti.UI.iOS.create3DMatrix();
+              var t1 = Ti.UI.create3DMatrix();
               t1 = t1.translate(0, 100, 200);
               t1.m34 = 1.0/-90;
               var a1 = Ti.UI.createAnimation();

--- a/demos/KitchenSink/Resources/examples/3d_transform.js
+++ b/demos/KitchenSink/Resources/examples/3d_transform.js
@@ -67,7 +67,7 @@ button.addEventListener('click', function()
 					a3.repeat = 1;
 					a3.addEventListener('complete',function()
 					{
-						view.animate({transform:Ti.UI.iOS.create3DMatrix(),duration:500});
+						view.animate({transform:Ti.UI.create3DMatrix(),duration:500});
 					});
 					view.animate(a3);
 			});

--- a/demos/KitchenSink/Resources/examples/control_animation.js
+++ b/demos/KitchenSink/Resources/examples/control_animation.js
@@ -12,7 +12,7 @@ win.add(button);
 
 button.addEventListener('click', function()
 {
-	var t = Titanium.UI.iOS.create3DMatrix();
+	var t = Titanium.UI.create3DMatrix();
 	t = t.rotate(200,0,1,1);
 	t = t.scale(3);
 	t = t.translate(20,50,170);

--- a/demos/KitchenSink/Resources/examples/window_animation.js
+++ b/demos/KitchenSink/Resources/examples/window_animation.js
@@ -70,7 +70,7 @@ var button3 = Titanium.UI.createButton({
 
 button3.addEventListener('click', function()
 {
-	var t1 = Ti.UI.iOS.create3DMatrix();
+	var t1 = Ti.UI.create3DMatrix();
 	t1 = t1.scale(0.00001);
 	t1 = t1.rotate(180,0,0,1);
 	var a1 = Titanium.UI.createAnimation();
@@ -81,7 +81,7 @@ button3.addEventListener('click', function()
 	a1.addEventListener('complete', function()
 	{
 		// simply reset animation
-		var t2 = Ti.UI.iOS.create3DMatrix();
+		var t2 = Ti.UI.create3DMatrix();
 		var a2 = Titanium.UI.createAnimation();
 		a2.transform = t2;
 		a2.duration = 500;

--- a/drillbit/tests/iphone/iPhone.UI.3DMatrix.js
+++ b/drillbit/tests/iphone/iPhone.UI.3DMatrix.js
@@ -1,8 +1,8 @@
-describe("Ti.UI.iOS.3DMatrix Tests", {
+describe("Ti.UI.3DMatrix Tests", {
 
     testInvert: function() {
-	    var matrix1 = Ti.UI.iOS.create3DMatrix();
-	    var matrix2 = Ti.UI.iOS.create3DMatrix();
+	    var matrix1 = Ti.UI.create3DMatrix();
+	    var matrix2 = Ti.UI.create3DMatrix();
 	    valueOf(matrix1.invert()).shouldBeObject();
 	    matrix1 = matrix1.scale(2, 2, 2);
 	    valueOf(matrix1.invert()).shouldBeObject();
@@ -15,14 +15,14 @@ describe("Ti.UI.iOS.3DMatrix Tests", {
     },
     
     testMultiply: function() {
-	    var matrix1 = Ti.UI.iOS.create3DMatrix();
-	    var matrix2 = Ti.UI.iOS.create3DMatrix();
+	    var matrix1 = Ti.UI.create3DMatrix();
+	    var matrix2 = Ti.UI.create3DMatrix();
 	    valueOf(matrix1.multiply(matrix2)).shouldBeObject();
 	    valueOf(matrix1.multiply(matrix1)).shouldBeObject();
     },
 
     testRotate: function() {
-	    var matrix1 = Ti.UI.iOS.create3DMatrix();
+	    var matrix1 = Ti.UI.create3DMatrix();
 	    valueOf(matrix1.rotate(0, 0, 0, 0)).shouldBeObject();
 	    valueOf(matrix1.rotate(90, 1, 0, 0)).shouldBeObject();
 	    valueOf(matrix1.rotate(90, 0, 1, 0)).shouldBeObject();
@@ -38,7 +38,7 @@ describe("Ti.UI.iOS.3DMatrix Tests", {
     },
 
     testTranslate: function() {
-	    var matrix1 = Ti.UI.iOS.create3DMatrix();
+	    var matrix1 = Ti.UI.create3DMatrix();
 	    valueOf(matrix1.translate(-1.0, 0, 0)).shouldBeObject();
 	    valueOf(matrix1.translate(0, -1.0, 0)).shouldBeObject();
 	    valueOf(matrix1.translate(0, 0, -1.0)).shouldBeObject();
@@ -52,7 +52,7 @@ describe("Ti.UI.iOS.3DMatrix Tests", {
     },
     
     testScale: function() {
-	    var matrix1 = Ti.UI.iOS.create3DMatrix();
+	    var matrix1 = Ti.UI.create3DMatrix();
 	    valueOf(matrix1.scale()).shouldBeObject();
 	    valueOf(matrix1.scale(1.0)).shouldBeObject();
 	    valueOf(matrix1.scale(-1.0)).shouldBeObject();
@@ -67,7 +67,7 @@ describe("Ti.UI.iOS.3DMatrix Tests", {
     },
     
     testCreate3DMatrixValue: function() {
-	    var matrix1 = Ti.UI.iOS.create3DMatrix();
+	    var matrix1 = Ti.UI.create3DMatrix();
 	    valueOf(matrix1.m11).shouldBe(1);
 	    valueOf(matrix1.m12).shouldBe(0);
 	    valueOf(matrix1.m13).shouldBe(0);
@@ -87,7 +87,7 @@ describe("Ti.UI.iOS.3DMatrix Tests", {
     },
     
     testInvertValue: function() {
-	    var matrix1 = Ti.UI.iOS.create3DMatrix();
+	    var matrix1 = Ti.UI.create3DMatrix();
 	    matrix1.invert();
 	    valueOf(matrix1.m11).shouldBe(1);
 	    valueOf(matrix1.m12).shouldBe(0);
@@ -108,7 +108,7 @@ describe("Ti.UI.iOS.3DMatrix Tests", {
     },
 
     testRotateValue: function() {
-	    var matrix1 = Ti.UI.iOS.create3DMatrix();
+	    var matrix1 = Ti.UI.create3DMatrix();
 	    matrix1 = matrix1.rotate(-180, 50, 0, 0);
 	    valueOf(matrix1.m11).shouldBe(1);
 	    valueOf(matrix1.m12).shouldBe(0);
@@ -129,7 +129,7 @@ describe("Ti.UI.iOS.3DMatrix Tests", {
     },
 
     testScaleValue: function() {
-	    var matrix1 = Ti.UI.iOS.create3DMatrix();
+	    var matrix1 = Ti.UI.create3DMatrix();
 	    matrix1 = matrix1.scale(5, -5, 0);
 	    valueOf(matrix1.m11).shouldBe(5);
 	    valueOf(matrix1.m12).shouldBe(0);
@@ -150,7 +150,7 @@ describe("Ti.UI.iOS.3DMatrix Tests", {
     },
 
     testTranslateValue: function() {
-	    var matrix1 = Ti.UI.iOS.create3DMatrix();
+	    var matrix1 = Ti.UI.create3DMatrix();
 	    matrix1 = matrix1.translate(5, -10, 5);
 	    valueOf(matrix1.m11).shouldBe(1);
 	    valueOf(matrix1.m12).shouldBe(0);
@@ -171,8 +171,8 @@ describe("Ti.UI.iOS.3DMatrix Tests", {
    },
     
    testMultiplyValue: function() {
-	    var matrix1 = Ti.UI.iOS.create3DMatrix();
-	    var matrix2 = Ti.UI.iOS.create3DMatrix();
+	    var matrix1 = Ti.UI.create3DMatrix();
+	    var matrix2 = Ti.UI.create3DMatrix();
 	    matrix1 = matrix1.multiply(matrix1);
 	    valueOf(matrix1.m11).shouldBe(1);
 	    valueOf(matrix1.m12).shouldBe(0);

--- a/iphone/Classes/Ti3DMatrix.h
+++ b/iphone/Classes/Ti3DMatrix.h
@@ -4,13 +4,13 @@
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
-#import "TiUIiOSProxy.h"
+#import "TiProxy.h"
 
 #if defined(USE_TI_UIIOS3DMATRIX) || defined(USE_TI_UI3DMATRIX)
 
 #import <QuartzCore/QuartzCore.h>
 
-@interface TiUIiOS3DMatrix : TiProxy {
+@interface Ti3DMatrix : TiProxy {
 @protected
 	CATransform3D matrix;
 }
@@ -19,11 +19,11 @@
 -(id)initWithMatrix:(CATransform3D)matrix_;
 
 -(CATransform3D)matrix;
--(TiUIiOS3DMatrix*)translate:(id)args;
--(TiUIiOS3DMatrix*)scale:(id)args;
--(TiUIiOS3DMatrix*)rotate:(id)args;
--(TiUIiOS3DMatrix*)invert:(id)args;
--(TiUIiOS3DMatrix*)multiply:(id)args;
+-(Ti3DMatrix*)translate:(id)args;
+-(Ti3DMatrix*)scale:(id)args;
+-(Ti3DMatrix*)rotate:(id)args;
+-(Ti3DMatrix*)invert:(id)args;
+-(Ti3DMatrix*)multiply:(id)args;
 
 @property(nonatomic,readwrite,retain) NSNumber* m11;
 @property(nonatomic,readwrite,retain) NSNumber* m12;

--- a/iphone/Classes/Ti3DMatrix.m
+++ b/iphone/Classes/Ti3DMatrix.m
@@ -4,11 +4,11 @@
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
-#import "TiUIiOS3DMatrix.h"
+#import "Ti3DMatrix.h"
 
 #if defined(USE_TI_UIIOS3DMATRIX) || defined(USE_TI_UI3DMATRIX)
 
-@implementation TiUIiOS3DMatrix
+@implementation Ti3DMatrix
 
 -(id)init
 {
@@ -46,17 +46,17 @@
 	return matrix;
 }
 
--(TiUIiOS3DMatrix*)translate:(id)args
+-(Ti3DMatrix*)translate:(id)args
 {
 	ENSURE_ARG_COUNT(args,3);
 	CGFloat tx = [[args objectAtIndex:0] floatValue];
 	CGFloat ty = [[args objectAtIndex:1] floatValue];
 	CGFloat tz = [[args objectAtIndex:2] floatValue];
 	CATransform3D newtransform = CATransform3DTranslate(matrix,tx,ty,tz);
-	return [[[TiUIiOS3DMatrix alloc] initWithMatrix:newtransform] autorelease];
+	return [[[Ti3DMatrix alloc] initWithMatrix:newtransform] autorelease];
 }
 
--(TiUIiOS3DMatrix*)scale:(id)args
+-(Ti3DMatrix*)scale:(id)args
 {
 	CGFloat sx = [[args objectAtIndex:0] floatValue];
 	CGFloat sy = [args count] > 1 ? [[args objectAtIndex:1] floatValue] : sx;
@@ -66,10 +66,10 @@
 	if (sy==0) sy = 0.0001;
 	if (sz==0) sz = 0.0001;
 	CATransform3D newtransform = CATransform3DScale(matrix,sx,sy,sz);
-	return [[[TiUIiOS3DMatrix alloc] initWithMatrix:newtransform] autorelease];
+	return [[[Ti3DMatrix alloc] initWithMatrix:newtransform] autorelease];
 }
 
--(TiUIiOS3DMatrix*)rotate:(id)args
+-(Ti3DMatrix*)rotate:(id)args
 {
 	ENSURE_ARG_COUNT(args,4);
 	
@@ -78,21 +78,21 @@
 	CGFloat y = [[args objectAtIndex:2] floatValue];
 	CGFloat z = [[args objectAtIndex:3] floatValue];
 	CATransform3D newtransform = CATransform3DRotate(matrix,degreesToRadians(angle),x,y,z);
-	return [[[TiUIiOS3DMatrix alloc] initWithMatrix:newtransform] autorelease];
+	return [[[Ti3DMatrix alloc] initWithMatrix:newtransform] autorelease];
 }
 
--(TiUIiOS3DMatrix*)invert:(id)args
+-(Ti3DMatrix*)invert:(id)args
 {
-	return [[[TiUIiOS3DMatrix alloc] initWithMatrix:CATransform3DInvert(matrix)] autorelease];
+	return [[[Ti3DMatrix alloc] initWithMatrix:CATransform3DInvert(matrix)] autorelease];
 }
 
--(TiUIiOS3DMatrix*)multiply:(id)args
+-(Ti3DMatrix*)multiply:(id)args
 {
 	ENSURE_ARG_COUNT(args,1);
-	TiUIiOS3DMatrix *othermatrix = [args objectAtIndex:0];
-	ENSURE_TYPE(othermatrix,TiUIiOS3DMatrix);
+	Ti3DMatrix *othermatrix = [args objectAtIndex:0];
+	ENSURE_TYPE(othermatrix,Ti3DMatrix);
 	CATransform3D newtransform = CATransform3DConcat(matrix,[othermatrix matrix]);
-	return [[[TiUIiOS3DMatrix alloc] initWithMatrix:newtransform] autorelease];
+	return [[[Ti3DMatrix alloc] initWithMatrix:newtransform] autorelease];
 }
 
 #define MAKE_PROP(x) \
@@ -127,7 +127,7 @@ MAKE_PROP(44)
 
 -(id)description
 {
-	return @"[object TiUIiOS3DMatrix]";
+	return @"[object Ti3DMatrix]";
 }
 
 @end

--- a/iphone/Classes/TiAnimation.m
+++ b/iphone/Classes/TiAnimation.m
@@ -6,7 +6,7 @@
  */
 #import "TiAnimation.h"
 #import "Ti2DMatrix.h"
-#import "TiUIiOS3DMatrix.h"
+#import "Ti3DMatrix.h"
 #import "TiUtils.h"
 #import "TiViewProxy.h"
 #import "LayoutConstraint.h"

--- a/iphone/Classes/TiUIView.m
+++ b/iphone/Classes/TiUIView.m
@@ -13,8 +13,8 @@
 #ifdef USE_TI_UI2DMATRIX	
 	#import "Ti2DMatrix.h"
 #endif
-#ifdef USE_TI_UIIOS3DMATRIX
-	#import "TiUIiOS3DMatrix.h"
+#ifdef USE_TI_UI3DMATRIX
+	#import "Ti3DMatrix.h"
 #endif
 #import "TiViewProxy.h"
 #import "TiApp.h"
@@ -361,9 +361,9 @@ DEFINE_EXCEPTIONS
 	}
 #endif
 #ifdef USE_TI_UIIOS3DMATRIX	
-	if ([transformMatrix isKindOfClass:[TiUIiOS3DMatrix class]])
+	if ([transformMatrix isKindOfClass:[Ti3DMatrix class]])
 	{
-		self.layer.transform = CATransform3DConcat(CATransform3DMakeAffineTransform(virtualParentTransform),[(TiUIiOS3DMatrix*)transformMatrix matrix]);
+		self.layer.transform = CATransform3DConcat(CATransform3DMakeAffineTransform(virtualParentTransform),[(Ti3DMatrix*)transformMatrix matrix]);
 		return;
 	}
 #endif

--- a/iphone/Classes/TiUIView.m
+++ b/iphone/Classes/TiUIView.m
@@ -360,7 +360,7 @@ DEFINE_EXCEPTIONS
 		return;
 	}
 #endif
-#ifdef USE_TI_UIIOS3DMATRIX	
+#ifdef USE_TI_UI3DMATRIX	
 	if ([transformMatrix isKindOfClass:[Ti3DMatrix class]])
 	{
 		self.layer.transform = CATransform3DConcat(CATransform3DMakeAffineTransform(virtualParentTransform),[(Ti3DMatrix*)transformMatrix matrix]);

--- a/iphone/Classes/TiUIView.m
+++ b/iphone/Classes/TiUIView.m
@@ -13,7 +13,7 @@
 #ifdef USE_TI_UI2DMATRIX	
 	#import "Ti2DMatrix.h"
 #endif
-#ifdef USE_TI_UI3DMATRIX
+#if defined(USE_TI_UIIOS3DMATRIX) || defined(USE_TI_UI3DMATRIX)
 	#import "Ti3DMatrix.h"
 #endif
 #import "TiViewProxy.h"
@@ -360,7 +360,7 @@ DEFINE_EXCEPTIONS
 		return;
 	}
 #endif
-#ifdef USE_TI_UI3DMATRIX	
+#if defined(USE_TI_UIIOS3DMATRIX) || defined(USE_TI_UI3DMATRIX)
 	if ([transformMatrix isKindOfClass:[Ti3DMatrix class]])
 	{
 		self.layer.transform = CATransform3DConcat(CATransform3DMakeAffineTransform(virtualParentTransform),[(Ti3DMatrix*)transformMatrix matrix]);

--- a/iphone/Classes/TiUIiOSProxy.m
+++ b/iphone/Classes/TiUIiOSProxy.m
@@ -17,7 +17,7 @@
 #endif
 
 #ifdef USE_TI_UIIOS3DMATRIX
-	#import "TiUIiOS3DMatrix.h"
+	#import "Ti3DMatrix.h"
 #endif
 #ifdef USE_TI_UIIOSCOVERFLOWVIEW
 	#import "TiUIiOSCoverFlowViewProxy.h"
@@ -53,12 +53,13 @@
 #ifdef USE_TI_UIIOS3DMATRIX
 -(id)create3DMatrix:(id)args
 {
-	if (args==nil || [args count] == 0)
+	DEPRECATED_REPLACED(@"UI.iOS.create3DMatrix()", @"2.1.0", @"Ti.UI.create3DMatrix()");
+    if (args==nil || [args count] == 0)
 	{
-		return [[[TiUIiOS3DMatrix alloc] init] autorelease];
+		return [[[Ti3DMatrix alloc] init] autorelease];
 	}
 	ENSURE_SINGLE_ARG(args,NSDictionary);
-	TiUIiOS3DMatrix *matrix = [[TiUIiOS3DMatrix alloc] initWithProperties:args];
+	Ti3DMatrix *matrix = [[Ti3DMatrix alloc] initWithProperties:args];
 	return [matrix autorelease];
 }
 #endif

--- a/iphone/Classes/UIModule.h
+++ b/iphone/Classes/UIModule.h
@@ -147,6 +147,10 @@
 -(id)create2DMatrix:(id)args;
 #endif
 
+#ifdef USE_TI_UI3DMATRIX
+-(id)create3DMatrix:(id)args;
+#endif
+
 #ifdef USE_TI_UIANIMATION
 -(id)createAnimation:(id)args;
 #endif

--- a/iphone/Classes/UIModule.m
+++ b/iphone/Classes/UIModule.m
@@ -17,7 +17,7 @@
 #endif
 
 #ifdef USE_TI_UI3DMATRIX
-    #import "TiUIiOS3DMatrix.h"
+    #import "Ti3DMatrix.h"
 #endif
 
 #ifdef USE_TI_UIANIMATION
@@ -306,13 +306,12 @@ MAKE_SYSTEM_PROP(FACE_DOWN,UIDeviceOrientationFaceDown);
 #ifdef USE_TI_UI3DMATRIX
  -(id)create3DMatrix:(id)args
 {
-    DEPRECATED_REPLACED(@"UI.create3DMatrix()", @"1.8.0", @"Ti.UI.iOS.create3DMatrix()");
     if (args==nil || [args count] == 0)
 	{
-	    return [[[TiUIiOS3DMatrix alloc] init] autorelease];
+	    return [[[Ti3DMatrix alloc] init] autorelease];
 	}
  	ENSURE_SINGLE_ARG(args,NSDictionary);
- 	TiUIiOS3DMatrix *matrix = [[TiUIiOS3DMatrix alloc] initWithProperties:args];
+ 	Ti3DMatrix *matrix = [[Ti3DMatrix alloc] initWithProperties:args];
  	return [matrix autorelease];
 }
 #endif

--- a/iphone/iphone/Titanium.xcodeproj/project.pbxproj
+++ b/iphone/iphone/Titanium.xcodeproj/project.pbxproj
@@ -483,9 +483,9 @@
 		2B1F65771431031E006C5D37 /* ApplicationDefaults.m in Sources */ = {isa = PBXBuildFile; fileRef = 2B1F65761431031E006C5D37 /* ApplicationDefaults.m */; };
 		2B1F65781431031E006C5D37 /* ApplicationDefaults.m in Sources */ = {isa = PBXBuildFile; fileRef = 2B1F65761431031E006C5D37 /* ApplicationDefaults.m */; };
 		2B1F65791431031E006C5D37 /* ApplicationDefaults.m in Sources */ = {isa = PBXBuildFile; fileRef = 2B1F65761431031E006C5D37 /* ApplicationDefaults.m */; };
-		2B301A8513DA2E290046529F /* TiUIiOS3DMatrix.m in Sources */ = {isa = PBXBuildFile; fileRef = 2B301A8413DA2E290046529F /* TiUIiOS3DMatrix.m */; };
-		2B301A8613DA2E290046529F /* TiUIiOS3DMatrix.m in Sources */ = {isa = PBXBuildFile; fileRef = 2B301A8413DA2E290046529F /* TiUIiOS3DMatrix.m */; };
-		2B301A8713DA2E290046529F /* TiUIiOS3DMatrix.m in Sources */ = {isa = PBXBuildFile; fileRef = 2B301A8413DA2E290046529F /* TiUIiOS3DMatrix.m */; };
+		2B353A8115901D41008FBD84 /* Ti3DMatrix.m in Sources */ = {isa = PBXBuildFile; fileRef = 2B353A8015901D41008FBD84 /* Ti3DMatrix.m */; };
+		2B353A8215901D41008FBD84 /* Ti3DMatrix.m in Sources */ = {isa = PBXBuildFile; fileRef = 2B353A8015901D41008FBD84 /* Ti3DMatrix.m */; };
+		2B353A8315901D41008FBD84 /* Ti3DMatrix.m in Sources */ = {isa = PBXBuildFile; fileRef = 2B353A8015901D41008FBD84 /* Ti3DMatrix.m */; };
 		2B94603613F0A2AE000C5BEA /* TiUIiOSCoverFlowView.m in Sources */ = {isa = PBXBuildFile; fileRef = 2B94603313F0A2AE000C5BEA /* TiUIiOSCoverFlowView.m */; };
 		2B94603713F0A2AE000C5BEA /* TiUIiOSCoverFlowViewProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 2B94603513F0A2AE000C5BEA /* TiUIiOSCoverFlowViewProxy.m */; };
 		2B94603813F0A2AE000C5BEA /* TiUIiOSCoverFlowView.m in Sources */ = {isa = PBXBuildFile; fileRef = 2B94603313F0A2AE000C5BEA /* TiUIiOSCoverFlowView.m */; };
@@ -1383,8 +1383,8 @@
 		29B97316FDCFA39411CA2CEA /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		2B1F65751431031E006C5D37 /* ApplicationDefaults.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ApplicationDefaults.h; path = ../Classes/ApplicationDefaults.h; sourceTree = SOURCE_ROOT; };
 		2B1F65761431031E006C5D37 /* ApplicationDefaults.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ApplicationDefaults.m; path = ../Classes/ApplicationDefaults.m; sourceTree = SOURCE_ROOT; };
-		2B301A8313DA2E290046529F /* TiUIiOS3DMatrix.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TiUIiOS3DMatrix.h; sourceTree = "<group>"; };
-		2B301A8413DA2E290046529F /* TiUIiOS3DMatrix.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TiUIiOS3DMatrix.m; sourceTree = "<group>"; };
+		2B353A7F15901D41008FBD84 /* Ti3DMatrix.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Ti3DMatrix.h; sourceTree = "<group>"; };
+		2B353A8015901D41008FBD84 /* Ti3DMatrix.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Ti3DMatrix.m; sourceTree = "<group>"; };
 		2B94603213F0A2AE000C5BEA /* TiUIiOSCoverFlowView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TiUIiOSCoverFlowView.h; sourceTree = "<group>"; };
 		2B94603313F0A2AE000C5BEA /* TiUIiOSCoverFlowView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TiUIiOSCoverFlowView.m; sourceTree = "<group>"; };
 		2B94603413F0A2AE000C5BEA /* TiUIiOSCoverFlowViewProxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TiUIiOSCoverFlowViewProxy.h; sourceTree = "<group>"; };
@@ -1931,6 +1931,8 @@
 		24CA8A0A111161DC0084E2DE /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				2B353A7F15901D41008FBD84 /* Ti3DMatrix.h */,
+				2B353A8015901D41008FBD84 /* Ti3DMatrix.m */,
 				24CA8A10111161FD0084E2DE /* WebFont.m */,
 				24CA8A11111161FD0084E2DE /* WebFont.h */,
 				2467310611E2549300D39AF7 /* Webcolor.m */,
@@ -2572,8 +2574,6 @@
 				24FB4ECF115C8120001AAF99 /* iPad */,
 				24D0700411D0253D00F615D8 /* TiUIiOSProxy.h */,
 				24D0700511D0253D00F615D8 /* TiUIiOSProxy.m */,
-				2B301A8313DA2E290046529F /* TiUIiOS3DMatrix.h */,
-				2B301A8413DA2E290046529F /* TiUIiOS3DMatrix.m */,
 				24E50E031160661600AF54AF /* Dashboard */,
 			);
 			name = iOS;
@@ -3395,7 +3395,6 @@
 				4D3033A3136239B30034640F /* TiFilesystemFileStreamProxy.m in Sources */,
 				ABD472F413BB73BF00502912 /* KrollCoverage.m in Sources */,
 				DADD76E913CCF4FF00CD03AC /* MGSplitView.m in Sources */,
-				2B301A8513DA2E290046529F /* TiUIiOS3DMatrix.m in Sources */,
 				EF8339D313E3643C001F2A97 /* ASIDownloadCache.m in Sources */,
 				EF03EFF313E3665100BD4FF7 /* ASIDataCompressor.m in Sources */,
 				EF03EFF613E3665100BD4FF7 /* ASIDataDecompressor.m in Sources */,
@@ -3420,6 +3419,7 @@
 				2BDEA4F31448FFB7004EC750 /* TiUIiOSTabbedBarProxy.m in Sources */,
 				844E1F7E14883A3700F5424C /* TiDOMValidator.m in Sources */,
 				DAA72343156D642400757987 /* TiConsole.m in Sources */,
+				2B353A8115901D41008FBD84 /* Ti3DMatrix.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3677,7 +3677,6 @@
 				B415067A136745E20084074A /* TiFilesystemFileStreamProxy.m in Sources */,
 				ABD472F513BB73BF00502912 /* KrollCoverage.m in Sources */,
 				DADD76EA13CCF4FF00CD03AC /* MGSplitView.m in Sources */,
-				2B301A8613DA2E290046529F /* TiUIiOS3DMatrix.m in Sources */,
 				EF8339D413E3643C001F2A97 /* ASIDownloadCache.m in Sources */,
 				EF03EFF413E3665100BD4FF7 /* ASIDataCompressor.m in Sources */,
 				EF03EFF713E3665100BD4FF7 /* ASIDataDecompressor.m in Sources */,
@@ -3700,6 +3699,7 @@
 				2BDEA4F514490546004EC750 /* TiUIiOSTabbedBarProxy.m in Sources */,
 				844E1F7F14883A3700F5424C /* TiDOMValidator.m in Sources */,
 				DAA72344156D642400757987 /* TiConsole.m in Sources */,
+				2B353A8215901D41008FBD84 /* Ti3DMatrix.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3957,7 +3957,6 @@
 				B415067D136745FE0084074A /* TiFilesystemFileStreamProxy.m in Sources */,
 				ABD472F613BB73BF00502912 /* KrollCoverage.m in Sources */,
 				DADD76EB13CCF4FF00CD03AC /* MGSplitView.m in Sources */,
-				2B301A8713DA2E290046529F /* TiUIiOS3DMatrix.m in Sources */,
 				EF8339D513E3643C001F2A97 /* ASIDownloadCache.m in Sources */,
 				EF03EFF513E3665100BD4FF7 /* ASIDataCompressor.m in Sources */,
 				EF03EFF813E3665100BD4FF7 /* ASIDataDecompressor.m in Sources */,
@@ -3980,6 +3979,7 @@
 				2BDEA4F614490547004EC750 /* TiUIiOSTabbedBarProxy.m in Sources */,
 				844E1F8014883A3700F5424C /* TiDOMValidator.m in Sources */,
 				DAA72345156D642400757987 /* TiConsole.m in Sources */,
+				2B353A8315901D41008FBD84 /* Ti3DMatrix.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
The functional test would be to use the updated kitchensink from the demo and try the following

Basic UI-> Animation-> 3danimation
Basic Ui-> Animation-> Windows -> Animate(custom) [button]
Basic Ui-> Animation-> Controls->Animate me [button]

Run drillbit to ensure that 3DMatrix passes.
