### PR TITLE
[TIMOB-9622] Android: V8 - Clicking a link in the rss xml test causes a runtime error

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/TiViewProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/TiViewProxy.java
@@ -736,7 +736,7 @@ public abstract class TiViewProxy extends KrollProxy implements Handler.Callback
 
 		TiViewProxy parentView = getParent();
 		if (parentView != null) {
-			handled = parentView.fireEvent(eventName, data, bubbles) || handled;
+			handled = parentView.fireEvent(eventName, data) || handled;
 		}
 
 		return handled;


### PR DESCRIPTION
Fixes a regression which prevents some views (ex: table rows) from injecting
extra event data (ex: e.row) into events. Need to bubble parent view events
by using the previous fireEvent method (which is overridden in some views).

To test try running the XML example in KS (see JIRA ticket for details).
