### PR TITLE
[TIMOB-9666] Android: Application doesn't work with Fastdev enabled

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiDrawableReference.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiDrawableReference.java
@@ -154,6 +154,9 @@ public class TiDrawableReference
 	 */
 	public static TiDrawableReference fromUrl(KrollProxy proxy, String url)
 	{
+		if (url == null || url.length() == 0 || url.trim().length() == 0) {
+			return new TiDrawableReference(proxy.getActivity(), DrawableReferenceType.NULL);
+		}
 		return fromUrl(proxy.getActivity(), proxy.resolveUrl(null, url));
 	}
 

--- a/support/android/fastdev.py
+++ b/support/android/fastdev.py
@@ -221,12 +221,18 @@ class FastDevHandler(SocketServer.BaseRequestHandler):
 
 	def handle_get(self, relative_path):
 		path = self.get_resource_path(relative_path)
-		if path != None:
-			logging.info("get %s: %s" % (relative_path, path))
-			self.send_file(path)
-		else:
+
+		if path is None:
 			logging.warn("get %s: path not found" % relative_path)
 			self.send_tokens("NOT_FOUND")
+			return
+		if os.path.isfile(path) is False:
+			logging.warn("get %s: path is a directory" % relative_path)
+			self.send_tokens("NOT_FOUND")
+			return
+
+		logging.info("get %s: %s" % (relative_path, path))
+		self.send_file(path)
 
 	def send_tokens(self, *tokens):
 		send_tokens(self.request, *tokens)


### PR DESCRIPTION
This fixes a bug in FastDev and also one in platform which would result in a crash
if an empty or directory path is set for the "image" property of an ImageView.
See the JIRA ticket for a test case and instructions.
