### PR TITLE
[TIMOB-7624] vararg API.* log support for android.

### DIFF
--- a/android/runtime/common/src/java/org/appcelerator/kroll/KrollLogging.java
+++ b/android/runtime/common/src/java/org/appcelerator/kroll/KrollLogging.java
@@ -49,54 +49,55 @@ public class KrollLogging
 		this.listener = listener;
 	}
 	
-	public void debug(String msg)
+	public void debug(String... args)
 	{
-		internalLog(DEBUG, msg);
+		internalLog(DEBUG, condenseMessage(args));
 	}
 
-	public void info(String msg)
+	public void info(String... args)
 	{
-		internalLog(INFO, msg);
+		internalLog(INFO, condenseMessage(args));
 	}
 
-	public void warn(String msg)
+	public void warn(String... args)
 	{
-		internalLog(WARN, msg);
+		internalLog(WARN, condenseMessage(args));
 	}
 
-	public void error(String msg)
+	public void error(String... args)
 	{
-		internalLog(ERROR, msg);
+		internalLog(ERROR, condenseMessage(args));
 	}
 
-	public void trace(String msg)
+	public void trace(String... args)
 	{
-		internalLog(TRACE, msg);
+		internalLog(TRACE, condenseMessage(args));
 	}
 
-	public void notice(String msg)
+	public void notice(String... args)
 	{
-		internalLog(NOTICE, msg);
+		internalLog(NOTICE, condenseMessage(args));
 	}
 
-	public void critical(String msg)
+	public void critical(String... args)
 	{
-		internalLog(CRITICAL, msg);
+		internalLog(CRITICAL, condenseMessage(args));
 	}
 
-	public void fatal(String msg)
+	public void fatal(String... args)
 	{
-		internalLog(FATAL, msg);
+		internalLog(FATAL, condenseMessage(args));
 	}
 	
-	public void log(String msg)
+	public void log(String... args)
 	{
-		internalLog(INFO, msg);
+		internalLog(INFO, condenseMessage(args));
 	}
 
-	public void log(String level, String msg)
+	public void log(String level, String... args)
 	{
 		String ulevel = level.toUpperCase();
+		String msg = condenseMessage(args);
 		int severity = INFO;
 
 		if ("TRACE".equals(ulevel)) {
@@ -120,6 +121,21 @@ public class KrollLogging
 		}
 
 		internalLog(severity, msg);
+	}
+	
+	private String condenseMessage(String... args)
+	{
+		String msg;
+		if (args.length > 0) {
+			msg = args[0];
+		}
+		else {
+			msg = new String();
+		}
+		for (int i=1; i < args.length; i++ ) {
+			msg = msg.concat(String.format(" %s", args[i]));
+		}
+		return msg;
 	}
 
 	private void internalLog(int severity, String msg)

--- a/android/runtime/common/src/java/org/appcelerator/kroll/KrollLogging.java
+++ b/android/runtime/common/src/java/org/appcelerator/kroll/KrollLogging.java
@@ -51,53 +51,53 @@ public class KrollLogging
 	
 	public void debug(String... args)
 	{
-		internalLog(DEBUG, condenseMessage(args));
+		internalLog(DEBUG, combineLogMessages(args));
 	}
 
 	public void info(String... args)
 	{
-		internalLog(INFO, condenseMessage(args));
+		internalLog(INFO, combineLogMessages(args));
 	}
 
 	public void warn(String... args)
 	{
-		internalLog(WARN, condenseMessage(args));
+		internalLog(WARN, combineLogMessages(args));
 	}
 
 	public void error(String... args)
 	{
-		internalLog(ERROR, condenseMessage(args));
+		internalLog(ERROR, combineLogMessages(args));
 	}
 
 	public void trace(String... args)
 	{
-		internalLog(TRACE, condenseMessage(args));
+		internalLog(TRACE, combineLogMessages(args));
 	}
 
 	public void notice(String... args)
 	{
-		internalLog(NOTICE, condenseMessage(args));
+		internalLog(NOTICE, combineLogMessages(args));
 	}
 
 	public void critical(String... args)
 	{
-		internalLog(CRITICAL, condenseMessage(args));
+		internalLog(CRITICAL, combineLogMessages(args));
 	}
 
 	public void fatal(String... args)
 	{
-		internalLog(FATAL, condenseMessage(args));
+		internalLog(FATAL, combineLogMessages(args));
 	}
 	
 	public void log(String... args)
 	{
-		internalLog(INFO, condenseMessage(args));
+		internalLog(INFO, combineLogMessages(args));
 	}
 
 	public void log(String level, String... args)
 	{
 		String ulevel = level.toUpperCase();
-		String msg = condenseMessage(args);
+		String msg = combineLogMessages(args);
 		int severity = INFO;
 
 		if ("TRACE".equals(ulevel)) {
@@ -123,7 +123,7 @@ public class KrollLogging
 		internalLog(severity, msg);
 	}
 	
-	private String condenseMessage(String... args)
+	private String combineLogMessages(String... args)
 	{
 		String msg;
 		if (args.length > 0) {

--- a/android/runtime/v8/src/native/modules/APIModule.h
+++ b/android/runtime/v8/src/native/modules/APIModule.h
@@ -38,6 +38,7 @@ public:
 private:
 	static void logInternal(int logLevel, const char *messageTag, const char *message);
 	static Persistent<FunctionTemplate> constructorTemplate;
+    static Handle<Value> combineLogMessages(const Arguments& args, int startIndex=0);
 };
 }
 


### PR DESCRIPTION
Does not include a doc update; this feature is going to have to be undocumented until we have a good way of saying that methods can take varargs (but NOT an array).

Be sure and test both v8 and Android. A simple test is available on [the ticket](https://jira.appcelerator.org/browse/TIMOB-7624).
