### PR TITLE
[TIMOB-9580] Android: Images captured using Ti.Media.showCamera() are written to SD card on Android

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/TiApplication.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiApplication.java
@@ -37,6 +37,7 @@ import org.appcelerator.titanium.analytics.TiAnalyticsEvent;
 import org.appcelerator.titanium.analytics.TiAnalyticsEventFactory;
 import org.appcelerator.titanium.analytics.TiAnalyticsModel;
 import org.appcelerator.titanium.analytics.TiAnalyticsService;
+import org.appcelerator.titanium.util.TiFileHelper;
 import org.appcelerator.titanium.util.TiPlatformHelper;
 import org.appcelerator.titanium.util.TiResponseCache;
 import org.appcelerator.titanium.util.TiUIHelper;
@@ -869,6 +870,7 @@ public abstract class TiApplication extends Application implements Handler.Callb
 	public void dispose()
 	{
 		TiActivityWindows.dispose();
+		TiFileHelper.getInstance().destroyTempFiles();
 	}
 
 	/**

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiFileHelper.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiFileHelper.java
@@ -60,6 +60,8 @@ public class TiFileHelper
 
 	private SoftReference<Context> softContext;
 	private TiNinePatchHelper nph;
+
+	private ArrayList<File> tempFiles = new ArrayList<File>();
 	
 	private static HashSet<String> resourcePathCache;
 	private static HashSet<String> foundResourcePathCache;
@@ -563,19 +565,19 @@ public class TiFileHelper
 		}
 	}
 
-	public File getTempFile(String suffix)
+	public File getTempFile(String suffix, boolean destroyOnExit)
 		throws IOException
 	{
 		File result = null;
 		Context context = softContext.get();
 
 		if(context != null) {
-			result = getTempFile(context.getCacheDir(), suffix);
+			result = getTempFile(context.getCacheDir(), suffix, destroyOnExit);
 		}
 		return result;
 	}
 
-	public File getTempFile(File dir, String suffix)
+	public File getTempFile(File dir, String suffix, boolean destroyOnExit)
 		throws IOException
 	{
 		File result = null;
@@ -585,8 +587,23 @@ public class TiFileHelper
 				Log.w(LCAT, "getTempFile: Directory '" + dir.getAbsolutePath() + "' does not exist. Call to File.createTempFile() will fail." );
 			}
 			result = File.createTempFile("tia", suffix, dir);
+
+			if (destroyOnExit) {
+				tempFiles.add(result);
+			}
 		}
 		return result;
+	}
+
+	// Destroys all temporary files that have been created.
+	// This is called when the application is exited/destroyed.
+	public void destroyTempFiles()
+	{
+		for (File tempFile : tempFiles) {
+			tempFile.delete();
+		}
+
+		tempFiles.clear();
 	}
 
 	/**

--- a/demos/KitchenSink-Nook/Resources/examples/camera.js
+++ b/demos/KitchenSink-Nook/Resources/examples/camera.js
@@ -1,14 +1,14 @@
 // create table view data object
 var data = [
-	{title:'Camera Basic', hasChild:true, test:'../examples/camera_basic.js'}
+	{title:'Camera Basic', hasChild:true, test:'../examples/camera_basic.js'},
+	{title:'Camera Custom Overlay', hasChild:true, test:'../examples/camera_overlay.js'},
+	{title:'Camera Overlay Webview', hasChild:true, test:'../examples/camera_overlay_webview.js'},
+	{title:'Save to Gallery (Auto)', hasChild:true, test:'../examples/camera_gallery.js'},
+	{title:'Save to File', hasChild:true, test:'../examples/camera_file.js'}
 ];
 
 if (Ti.Platform.osname == "iphone") {
-	data.push({title:'Camera Custom Overlay', hasChild:true, test:'../examples/camera_overlay.js'});
-	data.push({title:'Camera Overlay Webview', hasChild:true, test:'../examples/camera_overlay_webview.js'});
 	data.push({title:'Camera Augmented Reality', hasChild:true, test:'../examples/camera_ar.js'});
-	data.push({title:'Save to Gallery (Auto)', hasChild:true, test:'../examples/camera_gallery.js'});
-	data.push({title:'Save to File', hasChild:true, test:'../examples/camera_file.js'});	
 
 	Ti.include('version.js');
 	

--- a/demos/KitchenSink-Nook/Resources/examples/camera_overlay.js
+++ b/demos/KitchenSink-Nook/Resources/examples/camera_overlay.js
@@ -78,7 +78,9 @@ Titanium.Media.showCamera({
 		win.add(imageView);
 		
 		// programatically hide the camera
-		Ti.Media.hideCamera();
+		if (Ti.Platform.osname != "android") {
+			Ti.Media.hideCamera();
+		}
 	},
 	cancel:function()
 	{

--- a/demos/KitchenSink-Nook/Resources/examples/camera_overlay_webview.js
+++ b/demos/KitchenSink-Nook/Resources/examples/camera_overlay_webview.js
@@ -32,7 +32,9 @@ Titanium.Media.showCamera({
 		win.add(imageView);
 		
 		// programatically hide the camera
-		Ti.Media.hideCamera();
+		if (Ti.Platform.osname != "android") {
+			Ti.Media.hideCamera();
+		}
 	},
 	cancel:function()
 	{

--- a/demos/KitchenSink/Resources/examples/camera.js
+++ b/demos/KitchenSink/Resources/examples/camera.js
@@ -1,14 +1,14 @@
 // create table view data object
 var data = [
-	{title:'Camera Basic', hasChild:true, test:'../examples/camera_basic.js'}
+	{title:'Camera Basic', hasChild:true, test:'../examples/camera_basic.js'},
+	{title:'Camera Custom Overlay', hasChild:true, test:'../examples/camera_overlay.js'},
+	{title:'Camera Overlay Webview', hasChild:true, test:'../examples/camera_overlay_webview.js'},
+	{title:'Save to Gallery (Auto)', hasChild:true, test:'../examples/camera_gallery.js'},
+	{title:'Save to File', hasChild:true, test:'../examples/camera_file.js'}
 ];
 
 if (Ti.Platform.osname == "iphone") {
-	data.push({title:'Camera Custom Overlay', hasChild:true, test:'../examples/camera_overlay.js'});
-	data.push({title:'Camera Overlay Webview', hasChild:true, test:'../examples/camera_overlay_webview.js'});
 	data.push({title:'Camera Augmented Reality', hasChild:true, test:'../examples/camera_ar.js'});
-	data.push({title:'Save to Gallery (Auto)', hasChild:true, test:'../examples/camera_gallery.js'});
-	data.push({title:'Save to File', hasChild:true, test:'../examples/camera_file.js'});	
 
 	Ti.include('version.js');
 	

--- a/demos/KitchenSink/Resources/examples/camera_overlay.js
+++ b/demos/KitchenSink/Resources/examples/camera_overlay.js
@@ -78,7 +78,9 @@ Titanium.Media.showCamera({
 		win.add(imageView);
 		
 		// programatically hide the camera
-		Ti.Media.hideCamera();
+		if (Ti.Platform.osname != "android") {
+			Ti.Media.hideCamera();
+		}
 	},
 	cancel:function()
 	{

--- a/demos/KitchenSink/Resources/examples/camera_overlay_webview.js
+++ b/demos/KitchenSink/Resources/examples/camera_overlay_webview.js
@@ -32,7 +32,9 @@ Titanium.Media.showCamera({
 		win.add(imageView);
 		
 		// programatically hide the camera
-		Ti.Media.hideCamera();
+		if (Ti.Platform.osname != "android") {
+			Ti.Media.hideCamera();
+		}
 	},
 	cancel:function()
 	{


### PR DESCRIPTION
This fixes bugs with the camera saving images to the SD card. It is not always necessary to
write the image data to the SD card (presents security concerns for some apps) and when we do
create a temporary file, we never clean them up.

See the JIRA ticket for further details about testing. It is important we test on a wide range of
devices for multiple vendors (ex: HTC, Samsung, LG). Please also run all Camera examples in KS,
this PR enables more examples that where previously iOS only.
