### PR TITLE
[TIMOB-9811] Android:Tabgroup:Focus event for a tab is showing wrong source name. (2_1_X)

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUITabGroup.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUITabGroup.java
@@ -167,7 +167,9 @@ public class TiUITabGroup extends TiUIView
 
 		KrollDict tabChangeEventData = tabGroupProxy.buildFocusEvent(currentTabID, previousTabID);
 		if (prevTab != null) {
-			prevTab.fireEvent(TiC.EVENT_BLUR, tabChangeEventData, true);
+			// Create a clone of the event data since the 'source' needs to be
+			// correctly set for the proxy firing the event.
+			prevTab.fireEvent(TiC.EVENT_BLUR, tabChangeEventData.clone(), true);
 		}
 		currentTab.fireEvent(TiC.EVENT_FOCUS, tabChangeEventData, true);
 


### PR DESCRIPTION
Backport fix into the 2_1_X branch.
