### PR TITLE
tableview new events / TiBlob toImage() / FastDev correction

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiTableView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiTableView.java
@@ -167,11 +167,11 @@ public class TiTableView extends FrameLayout
 		public View getView(int position, View convertView, ViewGroup parent) {
 			Item item = (Item) getItem(position);
 			TiBaseTableViewItem v = null;
-			
+			boolean sameView = false;
 			if (convertView != null) {
 				v = (TiBaseTableViewItem) convertView;
 				// Default creates view for each Item
-				boolean sameView = false;
+				
 				if (item.proxy instanceof TableViewRowProxy) {
 					TableViewRowProxy row = (TableViewRowProxy)item.proxy;
 					if (row.getTableViewRowProxyItem() != null) {
@@ -185,7 +185,7 @@ public class TiTableView extends FrameLayout
 						}
 					} else {
 						// otherwise compare class names
-						if (!v.getClassName().equals(item.className)) {
+						if (!(item.proxy instanceof TableViewRowProxy) || !v.getClassName().equals(item.className)) {
 							Log.w(LCAT, "Handed a view to convert with className " + v.getClassName() + " expected " + item.className);
 							v = null;
 						}
@@ -215,13 +215,13 @@ public class TiTableView extends FrameLayout
 				v.setLayoutParams(new AbsListView.LayoutParams(
 					AbsListView.LayoutParams.FILL_PARENT, AbsListView.LayoutParams.FILL_PARENT));
 			}
-            else
+            else if (!sameView) 
             {
                 //we are reusing a cell
-                TableViewRowProxy row = (TableViewRowProxy)item.proxy;
+                TableViewRowProxy reusedRow = (TableViewRowProxy)v.getRowData().proxy;
                 KrollDict event = new KrollDict();
-                TableViewRowProxy.fillClickEvent(event, viewModel, item);
-                row.fireEvent("reuse", event);
+                TableViewRowProxy.fillClickEvent(event, viewModel, v.getRowData());
+                reusedRow.fireEvent("reuse", event);
             }
 
 			v.setRowData(item);

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiTableView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiTableView.java
@@ -79,9 +79,11 @@ public class TiTableView extends FrameLayout
 		TableViewModel viewModel;
 		ArrayList<Integer> index;
 		private boolean filtered;
+        private TableViewProxy proxy;
 
-		TTVListAdapter(TableViewModel viewModel) {
+		TTVListAdapter(TableViewModel viewModel, TableViewProxy proxy) {
 			this.viewModel = viewModel;
+            this.proxy = proxy;
 			this.index = new ArrayList<Integer>(viewModel.getRowCount());
 			reIndexItems();
 		}
@@ -213,7 +215,21 @@ public class TiTableView extends FrameLayout
 				v.setLayoutParams(new AbsListView.LayoutParams(
 					AbsListView.LayoutParams.FILL_PARENT, AbsListView.LayoutParams.FILL_PARENT));
 			}
+            else
+            {
+                //we are reusing a cell
+                TableViewRowProxy row = (TableViewRowProxy)item.proxy;
+                KrollDict event = new KrollDict();
+                TableViewRowProxy.fillClickEvent(event, viewModel, item);
+                row.fireEvent("reuse", event);
+            }
+
 			v.setRowData(item);
+            //now it means the view will appear
+            KrollDict event = new KrollDict();
+            TableViewRowProxy.fillClickEvent(event, viewModel, item);
+            proxy.fireEvent("rowappear", event);
+
 			return v;
 		}
 
@@ -317,7 +333,7 @@ public class TiTableView extends FrameLayout
 		if (proxy.hasProperty(TiC.PROPERTY_SEPARATOR_COLOR)) {
 			setSeparatorColor(TiConvert.toString(proxy.getProperty(TiC.PROPERTY_SEPARATOR_COLOR)));
 		}
-		adapter = new TTVListAdapter(viewModel);
+		adapter = new TTVListAdapter(viewModel, proxy);
 		if (proxy.hasProperty(TiC.PROPERTY_HEADER_VIEW)) {
 			TiViewProxy view = (TiViewProxy) proxy.getProperty(TiC.PROPERTY_HEADER_VIEW);
 			listView.addHeaderView(layoutHeaderOrFooter(view), null, false);

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiTableView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiTableView.java
@@ -222,13 +222,20 @@ public class TiTableView extends FrameLayout
                 KrollDict event = new KrollDict();
                 TableViewRowProxy.fillClickEvent(event, viewModel, v.getRowData());
                 reusedRow.fireEvent("reuse", event);
-            }
 
-			v.setRowData(item);
-            //now it means the view will appear
-            KrollDict event = new KrollDict();
-            TableViewRowProxy.fillClickEvent(event, viewModel, item);
-            proxy.fireEvent("rowappear", event);
+            }
+            if (v.getRowData() != item)
+            {
+                v.setRowData(item);
+                //now it means the view will appear
+                KrollDict event = new KrollDict();
+                TableViewRowProxy.fillClickEvent(event, viewModel, item);
+                proxy.fireEvent("rowappear", event);
+            }
+            else
+            {
+                Log.w(LCAT, "getView for the same data, no need to set data again");
+            }
 
 			return v;
 		}

--- a/android/titanium/src/java/org/appcelerator/titanium/TiBlob.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiBlob.java
@@ -358,18 +358,21 @@ public class TiBlob extends KrollProxy
         return this;
     }
 
-    private Matrix getScaleMatrix(int orig_w, int orig_h, int w, int h){
-        int scale = Math.min((int)orig_w/w, (int)orig_h/h);
-        Matrix matrix = new Matrix();
-        matrix.postScale(scale, scale);
-        return matrix;
-    }
+    private int sampleSize(int outWidth, int outHeight, int newWidth, int newHeight) {
+        int sample = 1;
 
-    private int sampleSize(BitmapFactory.Options opts, int width, int height){
-        int scaleW = Math.max(1, opts.outWidth / width);
-        int scaleH = Math.max(1, opts.outHeight / height);
-        int sampleSize = (int)Math.min(scaleW, scaleH);
-        return sampleSize;
+        int width = outWidth;
+        int height = outHeight;
+
+        while (true) {
+            if (width / 2 < newWidth || height / 2 < newHeight) {
+                break;
+            }
+            width /= 2;
+            height /= 2;
+            sample *= 2;
+        }
+        return sample;
     }
 
     @Kroll.method
@@ -383,12 +386,12 @@ public class TiBlob extends KrollProxy
 
             BitmapFactory.decodeByteArray(image_data, 0, image_data.length, opts);
 
-            opts.inSampleSize = sampleSize(opts, width, height);
-
+            opts.inSampleSize = sampleSize(opts.outWidth, opts.outHeight, width, height);
             opts.inJustDecodeBounds = false;
+            opts.inScaled = true;
+            opts.inPurgeable = true;
 
             Bitmap image_base = BitmapFactory.decodeByteArray(image_data, 0, image_data.length, opts);
-            // Matrix matrix = getScaleMatrix(opts.outWidth, opts.outHeight, width, height);
             Bitmap scaled_image = Bitmap.createScaledBitmap(image_base, width, height, true);
             TiBlob blob = TiBlob.blobFromImage(scaled_image);
             image_base.recycle();

--- a/android/titanium/src/java/org/appcelerator/titanium/TiBlob.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiBlob.java
@@ -24,6 +24,7 @@ import org.appcelerator.titanium.io.TitaniumBlob;
 import org.appcelerator.titanium.util.TiMimeTypeHelper;
 
 import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
 import android.graphics.Bitmap.CompressFormat;
 
 /** 
@@ -156,6 +157,7 @@ public class TiBlob extends KrollProxy
 		if (mimetype == null || mimetype.length() == 0) {
 			return new TiBlob(TYPE_DATA, data, "application/octet-stream");
 		}
+
 		return new TiBlob(TYPE_DATA, data, mimetype);
 	}
 
@@ -342,6 +344,14 @@ public class TiBlob extends KrollProxy
 	{
 		return height;
 	}
+
+    @Kroll.method
+    public TiBlob toImage()
+    {
+        byte[] bytes = getBytes();
+        Bitmap bitmap= BitmapFactory.decodeByteArray(bytes, 0, bytes.length);
+        return TiBlob.blobFromImage(bitmap);
+    }
 
 	@Kroll.method
 	public String toString()

--- a/android/titanium/src/java/org/appcelerator/titanium/TiBlob.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiBlob.java
@@ -349,8 +349,12 @@ public class TiBlob extends KrollProxy
     public TiBlob toImage()
     {
         byte[] bytes = getBytes();
-        Bitmap bitmap= BitmapFactory.decodeByteArray(bytes, 0, bytes.length);
-        return TiBlob.blobFromImage(bitmap);
+        BitmapFactory.Options options = new BitmapFactory.Options();
+        options.inJustDecodeBounds = true;
+        BitmapFactory.decodeByteArray(bytes, 0, bytes.length, options);
+        this.width = options.outWidth;
+        this.height = options.outHeight;
+        return this;
     }
 
 	@Kroll.method

--- a/iphone/Classes/TiBlob.m
+++ b/iphone/Classes/TiBlob.m
@@ -379,6 +379,12 @@
 	return nil;
 }
 
+-(id)toImage:(id)args
+{
+    [self ensureImageLoaded];
+    return self;
+}
+
 -(id)toString:(id)args
 {
 	id t = [self text];

--- a/iphone/Classes/TiUITableView.m
+++ b/iphone/Classes/TiUITableView.m
@@ -88,6 +88,8 @@
 
 -(void)prepareForReuse
 {
+    //first let s say we gonna disappear!
+    [proxy fireEvent:@"reuse" withObject:[proxy createEventObject:nil] propagate:YES];
 	[self setProxy:nil];
 	[super prepareForReuse];
 	
@@ -1973,6 +1975,7 @@ return result;	\
 	}
 	UIColor * cellColor = [Webcolor webColorNamed:color];
 	cell.backgroundColor = (cellColor != nil)?cellColor:[UIColor whiteColor];
+    [self triggerActionForIndexPath:index fromPath:nil tableView:ourTableView wasAccessory:NO search:NO name:@"rowappear"];
 }
 
 - (NSString *)tableView:(UITableView *)ourTableView titleForDeleteConfirmationButtonForRowAtIndexPath:(NSIndexPath *)indexPath

--- a/support/android/fastdev.py
+++ b/support/android/fastdev.py
@@ -140,8 +140,8 @@ class FastDevHandler(SocketServer.BaseRequestHandler):
 				serving = False
 				if sys.version_info < (2, 6):
 					serving = server.is_serving()
-				elif sys.version_info < (2, 7):
-					serving = server._BaseServer__serving
+				# elif sys.version_info < (2, 7):
+				# 	serving = server._BaseServer__serving
 				else:
 					serving = not server._BaseServer__is_shut_down.isSet()
 				if not serving:


### PR DESCRIPTION
Hi,
This is my first pull request so i might have a lot of things to correct :s

1- FastDev correction: FastDev doesnt work on OSX leopard because python is 2.6

2- I needed to get the "image" width and height of a blob. I didnt want the hassle of creating an ImageView and doing toBlob, so i added a toImage method on TiBlob (just like to string).

3- I added "reuse" and "rowappear" events in the tableview. This allows huge improvements in tableview loading and scrolling. For exemple if you download async  images, you can start the download only when the row appears and stop it on reuse. Also you can "create" the row content only on "rowappear".
When you have a lot of complex rows it can drastically improve table loading. So the idea is that you create the rowData only with empty rows. Then on "rowappear" you create your custom view and add it to the row.
It works amazingly well. I still have to figure out why on android when loading the tableview, displayed cells first appear empty then fill themselves.
I add to fire the "reuse" event on the row itself, because of the ios implementation.
The "rowappear" event is fired on the tableview

I am willing to improve anything necessary to make this go through. But i think it can help people a lot! especially with tableviews.

Thanks
