### PR TITLE
[TIMOB-9868] setScrollIndicatorInsets in UITableView

### DIFF
--- a/iphone/Classes/TiUITableView.m
+++ b/iphone/Classes/TiUITableView.m
@@ -1645,6 +1645,24 @@
     }
 }
 
+-(void)setScrollViewInsets_:(id)value withObject:(id)props
+{
+	UIEdgeInsets insets = [TiUtils contentInsets:value];
+	BOOL animated = [TiUtils boolValue:@"animated" properties:props def:NO];
+	
+	void (^setInset)(void) = ^{
+		[tableview setScrollIndicatorInsets:insets];
+	};
+	
+	if (animated) {
+	
+		double duration = [TiUtils doubleValue:@"duration" properties:props def:300]/1000;
+		[UIView animateWithDuration:duration animations:setInset];
+	} else {
+		setInset();
+	}
+}
+
 #pragma mark Datasource 
 
 

--- a/iphone/Classes/TiUITableView.m
+++ b/iphone/Classes/TiUITableView.m
@@ -1645,7 +1645,7 @@
     }
 }
 
--(void)setScrollViewInsets_:(id)value withObject:(id)props
+-(void)setScrollIndicatorInsets_:(id)value withObject:(id)props
 {
 	UIEdgeInsets insets = [TiUtils contentInsets:value];
 	BOOL animated = [TiUtils boolValue:@"animated" properties:props def:NO];

--- a/iphone/Classes/TiUITableViewProxy.m
+++ b/iphone/Classes/TiUITableViewProxy.m
@@ -756,6 +756,26 @@ USE_VIEW_FOR_CONTENT_HEIGHT
 	[[self view] performSelector:@selector(setContentInsets_:withObject:) withObject:arg1 withObject:arg2];
 }
 
+-(void)setScrollViewInsets:(id)args
+{
+	ENSURE_UI_THREAD(setScrollViewInsets,args);
+	id arg1;
+	id arg2;
+	
+	if ([args isKindOfClass:[NSDictionary class]])
+	{
+		arg1 = args;
+		arg2 = [NSDictionary dictionary];
+	}
+	else
+	{
+		arg1 = [args objectAtIndex:0];
+		arg2 = [args count] > 1 ? [args objectAtIndex:1] : [NSDictionary dictionary];
+	}
+	
+	[[self view] performSelector:@selector(setScrollViewInsets_:withObject:) withObject:arg1 withObject:arg2];
+}
+
 
 @end 
 

--- a/iphone/Classes/TiUITableViewProxy.m
+++ b/iphone/Classes/TiUITableViewProxy.m
@@ -756,9 +756,9 @@ USE_VIEW_FOR_CONTENT_HEIGHT
 	[[self view] performSelector:@selector(setContentInsets_:withObject:) withObject:arg1 withObject:arg2];
 }
 
--(void)setScrollViewInsets:(id)args
+-(void)setScrollIndicatorInsets:(id)args
 {
-	ENSURE_UI_THREAD(setScrollViewInsets,args);
+	ENSURE_UI_THREAD(setScrollIndicatorInsets,args);
 	id arg1;
 	id arg2;
 	
@@ -773,7 +773,7 @@ USE_VIEW_FOR_CONTENT_HEIGHT
 		arg2 = [args count] > 1 ? [args objectAtIndex:1] : [NSDictionary dictionary];
 	}
 	
-	[[self view] performSelector:@selector(setScrollViewInsets_:withObject:) withObject:arg1 withObject:arg2];
+	[[self view] performSelector:@selector(setScrollIndicatorInsets_:withObject:) withObject:arg1 withObject:arg2];
 }
 
 


### PR DESCRIPTION
TIMOB-9868: https://jira.appcelerator.org/browse/TIMOB-9868

Create a new method in _TiUITableView_ to set the insets of ScrollIndicator.

Usage:

``` javascript
var tableView = Ti.UI.createTableView();

// This example simulate with Keyboard opened
tableView.addEventListener("scroll", function() {
  if (keyboardIsOpened) {

    // Set content inset of TableView
    tableView.setContentInsets({ bottom : 216 });

    // Set inset of ScrollIndicator of TableView
    tableView.setScrollIndicatorInsets({ bottom : 216 });

  }
});
```
