### PR TITLE
[TIMOB-6903] - iOS: Media - openPhotoGallery opens popover in wrong position.

### DIFF
--- a/iphone/Classes/MediaModule.m
+++ b/iphone/Classes/MediaModule.m
@@ -223,7 +223,7 @@ static NSDictionary* TI_filterableItemProperties;
 		if (popoverViewProxy!=nil)
 		{
 			poView = [popoverViewProxy view];
-			poFrame = [poView frame];
+			poFrame = [poView bounds];
 		}
 		else
 		{


### PR DESCRIPTION
Testing Instruction in [JIRA](https://jira.appcelerator.org/browse/TIMOB-6903)
