### PR TITLE
Tableview improvements

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUITabGroup.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUITabGroup.java
@@ -167,7 +167,9 @@ public class TiUITabGroup extends TiUIView
 
 		KrollDict tabChangeEventData = tabGroupProxy.buildFocusEvent(currentTabID, previousTabID);
 		if (prevTab != null) {
-			prevTab.fireEvent(TiC.EVENT_BLUR, tabChangeEventData, true);
+			// Create a clone of the event data since the 'source' needs to be
+			// correctly set for the proxy firing the event.
+			prevTab.fireEvent(TiC.EVENT_BLUR, tabChangeEventData.clone(), true);
 		}
 		currentTab.fireEvent(TiC.EVENT_FOCUS, tabChangeEventData, true);
 

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiUIHelper.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiUIHelper.java
@@ -537,17 +537,17 @@ public class TiUIHelper
 	{
 		StateListDrawable sld = new StateListDrawable();
 
-		Drawable bgSelectedDrawable = buildBackgroundDrawable(selectedColor, selectedImage, false, gradientDrawable);
+		Drawable bgSelectedDrawable = buildBackgroundDrawable(selectedColor, selectedImage, tileImage, gradientDrawable);
 		if (bgSelectedDrawable != null) {
 			sld.addState(BACKGROUND_SELECTED_STATE, bgSelectedDrawable);
 		}
 
-		Drawable bgFocusedDrawable = buildBackgroundDrawable(focusedColor, focusedImage, false, gradientDrawable);
+		Drawable bgFocusedDrawable = buildBackgroundDrawable(focusedColor, focusedImage, tileImage, gradientDrawable);
 		if (bgFocusedDrawable != null) {
 			sld.addState(BACKGROUND_FOCUSED_STATE, bgFocusedDrawable);
 		}
 
-		Drawable bgDisabledDrawable = buildBackgroundDrawable(disabledColor, disabledImage, false, gradientDrawable);
+		Drawable bgDisabledDrawable = buildBackgroundDrawable(disabledColor, disabledImage, tileImage, gradientDrawable);
 		if (bgDisabledDrawable != null) {
 			sld.addState(BACKGROUND_DISABLED_STATE, bgDisabledDrawable);
 		}

--- a/apidoc/Titanium/UI/ActivityIndicator.yml
+++ b/apidoc/Titanium/UI/ActivityIndicator.yml
@@ -128,7 +128,7 @@ properties:
         See also: [indicatorColor](Titanium.UI.ActivityIndicator.indicatorColor),
         [indicatorDiameter](Titanium.UI.ActivityIndicator.indicatorDiameter)
     type: Number
-    default: <Titanium.UI.iPhone.ActivityIndicatorStyle.PLAIN> (iOS), <Titanium.UI.MobileWeb.ActivityIndicatorStyle.PLAIN> (Mobile Web)
+    default: <Titanium.UI.iPhone.ActivityIndicatorStyle.PLAIN> (iOS), <Titanium.UI.ActivityIndicatorStyle.PLAIN> (Mobile Web)
     platforms: [iphone, ipad, mobileweb]
 
   - name: indicatorColor

--- a/apidoc/Titanium/UI/OptionDialog.yml
+++ b/apidoc/Titanium/UI/OptionDialog.yml
@@ -34,6 +34,9 @@ description: |
     
     On iPad, this dialog is shown in the middle of the display, or as a popover-like dialog if 
     another view or control is specified via an argument.
+
+    Note that on iPad, the cancel button is not displayed -- users can cancel the dialog
+    by clicking outside of the dialog.
     
     #### Caveats
     
@@ -116,9 +119,14 @@ properties:
     description: |
         On iOS, set to `-1` to disable the cancel option.
         
-        On iPad, when the cancel option is enabled by having a valid option index, it must be 
-        the last option, otherwise the last entry in [options](Titanium.UI.OptionDialog.options) 
-        will not be displayed.
+        On iPad, the `cancel` option must be set to either `-1` or the index of the last 
+        option. For example, if there are 3 options and one of them is a cancel button,
+        the cancel button must be the last option (index 2).  If `cancel` is set to a 
+        different value, _the last entry in the [options](Titanium.UI.OptionDialog.options) 
+        array **is not displayed**._
+
+        Note that the cancel button is never shown on iPad, since the user can cancel the 
+        dialog by clicking outside of the dialog. 
     type: Number
     default: undefined (Android), -1 (iOS, Mobile Web)
 
@@ -161,9 +169,9 @@ examples:
         });
         
         var opts = {
-          cancel: 1,
-          options: ['Confirm', 'Cancel', 'Help'],
-          selectedIndex: 1,
+          cancel: 2,
+          options: ['Confirm', 'Help', 'Cancel'],
+          selectedIndex: 2,
           destructive: 0,
           title: 'Delete File?'
         };
@@ -194,7 +202,7 @@ examples:
           opts.options = ['Confirm', 'Cancel'];
           opts.buttonNames = ['Confirm'];
         } else {
-          opts.options = ['Confirm', 'Cancel', 'Help'];
+          opts.options = ['Confirm', 'Help', 'Cancel'];
         }
         
         win.addEventListener('click', function(e){

--- a/apidoc/Titanium/UI/View.yml
+++ b/apidoc/Titanium/UI/View.yml
@@ -657,6 +657,7 @@ methods:
     returns:
         type: Point
     platforms: [android, iphone, ipad, mobileweb]
+    since: { android: "1.8", iphone: "1.8", ipad: "1.8", mobileweb: "2.0" }
     parameters:
       - name: point
         summary: |

--- a/iphone/Classes/TiUITabGroup.m
+++ b/iphone/Classes/TiUITabGroup.m
@@ -339,15 +339,14 @@ DEFINE_EXCEPTIONS
 		}
 	}
 	if (active == nil)  {
-        active = [self tabController].selectedViewController;
+		active = [self tabController].selectedViewController;
 	}
 	if (active != nil)  {
-        [self tabController].selectedViewController = active;
-        [self tabBarController:[self tabController] didSelectViewController:active];
-    }
-    else {
+		[self tabController].selectedViewController = active;
+		[self tabBarController:[self tabController] didSelectViewController:active];
+	} else {
 		DebugLog(@"setActiveTab called but active view controller could not be determined");
-    }
+	}
 }
 
 -(void)setAllowUserCustomization_:(id)value

--- a/iphone/Classes/TiUITabGroup.m
+++ b/iphone/Classes/TiUITabGroup.m
@@ -339,14 +339,10 @@ DEFINE_EXCEPTIONS
 		}
 	}
 	if (active == nil)  {
-		active = [self tabController].selectedViewController;
-	}
-	if (active != nil)  {
-		[self tabController].selectedViewController = active;
-		[self tabBarController:[self tabController] didSelectViewController:active];
-	} else {
 		DebugLog(@"setActiveTab called but active view controller could not be determined");
 	}
+	[self tabController].selectedViewController = active;
+	[self tabBarController:[self tabController] didSelectViewController:active];
 }
 
 -(void)setAllowUserCustomization_:(id)value

--- a/iphone/Classes/TiUITabGroup.m
+++ b/iphone/Classes/TiUITabGroup.m
@@ -338,10 +338,8 @@ DEFINE_EXCEPTIONS
 			active = [[self tabController].viewControllers objectAtIndex:index];
 		}
 	}
-    if (active != nil) {
-        [self tabController].selectedViewController = active;
-        [self tabBarController:[self tabController] didSelectViewController:active];
-    }
+	[self tabController].selectedViewController = active;
+	[self tabBarController:[self tabController] didSelectViewController:active];
 }
 
 -(void)setAllowUserCustomization_:(id)value

--- a/iphone/Classes/TiUITabGroup.m
+++ b/iphone/Classes/TiUITabGroup.m
@@ -338,6 +338,9 @@ DEFINE_EXCEPTIONS
 			active = [[self tabController].viewControllers objectAtIndex:index];
 		}
 	}
+	if (active == nil && [self tabController].viewControllers.count > 0)  {
+		active = [self tabController].selectedViewController;
+	}
 	if (active == nil)  {
 		DebugLog(@"setActiveTab called but active view controller could not be determined");
 	}

--- a/iphone/Classes/TiUITabGroup.m
+++ b/iphone/Classes/TiUITabGroup.m
@@ -338,8 +338,16 @@ DEFINE_EXCEPTIONS
 			active = [[self tabController].viewControllers objectAtIndex:index];
 		}
 	}
-	[self tabController].selectedViewController = active;
-	[self tabBarController:[self tabController] didSelectViewController:active];
+	if (active == nil)  {
+        active = [self tabController].selectedViewController;
+	}
+	if (active != nil)  {
+        [self tabController].selectedViewController = active;
+        [self tabBarController:[self tabController] didSelectViewController:active];
+    }
+    else {
+		DebugLog(@"setActiveTab called but active view controller could not be determined");
+    }
 }
 
 -(void)setAllowUserCustomization_:(id)value

--- a/iphone/Classes/TiUITableView.m
+++ b/iphone/Classes/TiUITableView.m
@@ -88,6 +88,8 @@
 
 -(void)prepareForReuse
 {
+    //first let s say we gonna disappear!
+    [proxy fireEvent:@"reuse" withObject:[proxy createEventObject:nil] propagate:YES];
 	[self setProxy:nil];
 	[super prepareForReuse];
 	
@@ -1973,6 +1975,7 @@ return result;	\
 	}
 	UIColor * cellColor = [Webcolor webColorNamed:color];
 	cell.backgroundColor = (cellColor != nil)?cellColor:[UIColor whiteColor];
+    [self triggerActionForIndexPath:index fromPath:nil tableView:ourTableView wasAccessory:NO search:NO name:@"rowappear"];
 }
 
 - (NSString *)tableView:(UITableView *)ourTableView titleForDeleteConfirmationButtonForRowAtIndexPath:(NSIndexPath *)indexPath

--- a/mobileweb/titanium/Ti/UI/ScrollableView.js
+++ b/mobileweb/titanium/Ti/UI/ScrollableView.js
@@ -325,7 +325,8 @@ define(["Ti/_/browser", "Ti/_/declare", "Ti/_/UI/KineticScrollView", "Ti/_/lang"
 						return value;
 					}
 					return oldValue;
-				}
+				},
+				value: -1
 			},
 			pagingControlColor: {
 				set: function(value) {
@@ -374,6 +375,7 @@ define(["Ti/_/browser", "Ti/_/declare", "Ti/_/UI/KineticScrollView", "Ti/_/lang"
 						view.height = "100%";
 						contentContainer._add(view);
 					}
+					this.properties.__values__.currentPage = len ? 0 : -1;
 
 					return value;
 				},


### PR DESCRIPTION
The first thing and most important thing in that branch is an optimisation of scrolling on android. the getView() method is called many times on the same row, and every-time the setRowData was called (which is really heavy).
So i changed it to only call setRowData when the data actually changed.

I also added "reuse" and "rowappear" events in the tableview. This allows huge improvements in tableview loading and scrolling. For exemple if you download async images, you can start the download only when the row appears and stop it on reuse. Also you can "create" the row content only on "rowappear".
When you have a lot of complex rows it can drastically improve table loading. So the idea is that you create the rowData only with empty rows. Then on "rowappear" you create your custom view and add it to the row.
It works amazingly well. I still have to figure out why on android when loading the tableview, displayed cells first appear empty then fill themselves.
I add to fire the "reuse" event on the row itself, because of the ios implementation.
The "rowappear" event is fired on the tableview

I am willing to improve anything necessary to make this go through. But i think it can help people a lot! especially with tableviews.
