### PR TITLE
[TC-1104] Tableview improvements

### DIFF
--- a/iphone/Classes/TiUITableView.m
+++ b/iphone/Classes/TiUITableView.m
@@ -88,6 +88,8 @@
 
 -(void)prepareForReuse
 {
+    //first let s say we gonna disappear!
+    [proxy fireEvent:@"reuse" withObject:[proxy createEventObject:nil] propagate:YES];
 	[self setProxy:nil];
 	[super prepareForReuse];
 	
@@ -1973,6 +1975,7 @@ return result;	\
 	}
 	UIColor * cellColor = [Webcolor webColorNamed:color];
 	cell.backgroundColor = (cellColor != nil)?cellColor:[UIColor whiteColor];
+    [self triggerActionForIndexPath:index fromPath:nil tableView:ourTableView wasAccessory:NO search:NO name:@"rowappear"];
 }
 
 - (NSString *)tableView:(UITableView *)ourTableView titleForDeleteConfirmationButtonForRowAtIndexPath:(NSIndexPath *)indexPath


### PR DESCRIPTION
The first thing and most important thing in that branch is an optimisation of scrolling on android. the getView() method is called many times on the same row, and every-time the setRowData was called (which is really heavy).
So i changed it to only call setRowData when the data actually changed.

I also added "reuse" and "rowappear" events in the tableview. This allows huge improvements in tableview loading and scrolling. For exemple if you download async images, you can start the download only when the row appears and stop it on reuse. Also you can "create" the row content only on "rowappear".
When you have a lot of complex rows it can drastically improve table loading. So the idea is that you create the rowData only with empty rows. Then on "rowappear" you create your custom view and add it to the row.
It works amazingly well. I still have to figure out why on android when loading the tableview, displayed cells first appear empty then fill themselves.
I add to fire the "reuse" event on the row itself, because of the ios implementation.
The "rowappear" event is fired on the tableview

I am willing to improve anything necessary to make this go through. But i think it can help people a lot! especially with tableviews.
