### PR TITLE
timob-9846: Android: Views like Label and Label on Button remain on the screen even after window is closed

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/ActivityWindowProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/ActivityWindowProxy.java
@@ -153,8 +153,6 @@ public class ActivityWindowProxy extends TiWindowProxy
 		if (window != null) {
 			window.close(options);
 		}
-
-		releaseViews();
 	}
 
 	@Kroll.getProperty @Kroll.method


### PR DESCRIPTION
https://jira.appcelerator.org/browse/TIMOB-9846
Don't release views in ActivityWindowProxy.handleClose() because at this point the window activity is still in finishing (not finished yet). Since window.closeFromActivity() is called in TiBaseActivity.onDestroy() which releases all the views, just removed releaseViews() from ActivityWindowProxy.handleClose().
Test case in JIRA.
