### PR TITLE
[TIMOB-8443] Android: setting orientationModes on a Ti.UI.TabGroup does not work

### DIFF
--- a/android/modules/android/src/java/org/appcelerator/titanium/proxy/TiActivityWindowProxy.java
+++ b/android/modules/android/src/java/org/appcelerator/titanium/proxy/TiActivityWindowProxy.java
@@ -64,7 +64,7 @@ public class TiActivityWindowProxy extends TiWindowProxy
 	}
 
 	@Override
-	protected Activity handleGetActivity()
+	protected Activity getWindowActivity()
 	{
 		if (view == null) return null;
 		return ((TiUIActivityWindow)view).getActivity();

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/ActivityWindowProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/ActivityWindowProxy.java
@@ -210,8 +210,13 @@ public class ActivityWindowProxy extends TiWindowProxy
 	*/
 
 	@Override
-	protected Activity handleGetActivity() 
+	protected Activity getWindowActivity() 
 	{
-		return getActivity();
+		TiUIActivityWindow window = getWindow();
+		if (window != null) {
+			return window.getActivity();
+		}
+
+		return null;
 	}
 }

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TabGroupProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TabGroupProxy.java
@@ -233,6 +233,23 @@ public class TabGroupProxy extends TiWindowProxy
 		}
 	}
 
+	@Override
+	public void handleCreationDict(KrollDict options) {
+		super.handleCreationDict(options);
+
+		// Support setting orientation modes at creation.
+		Object orientationModes = options.get(TiC.PROPERTY_ORIENTATION_MODES);
+		if (orientationModes != null && orientationModes instanceof Object[]) {
+			try {
+				int[] modes = TiConvert.toIntArray((Object[]) orientationModes);
+				setOrientationModes(modes);
+
+			} catch (ClassCastException e) {
+				Log.e(LCAT, "Invalid orientationMode array. Must only contain orientation mode constants.");
+			}
+		}
+	}
+
 	@Kroll.getProperty @Kroll.method
 	public TabProxy getActiveTab()
 	{
@@ -298,6 +315,9 @@ public class TabGroupProxy extends TiWindowProxy
 				addTabToGroup(tg, tab);
 			}
 		}
+
+		// Setup the new tab activity like setting orientation modes.
+		onWindowActivityCreated();
 		
 		tg.changeActiveTab(initialActiveTab);
 		// Make sure the tab indicator is selected. We need to force it to be selected due to TIMOB-7832.
@@ -434,8 +454,20 @@ public class TabGroupProxy extends TiWindowProxy
 	}
 
 	@Override
-	protected Activity handleGetActivity()
+	protected Activity getWindowActivity()
 	{
-		return weakActivity.get();
+		if (weakActivity != null) {
+			return weakActivity.get();
+		}
+
+		return null;
+	}
+
+	@Kroll.method @Kroll.setProperty
+	@Override
+	public void setOrientationModes(int[] modes) {
+		// Unlike Windows this setter is not defined in JavaScript.
+		// We need to expose it here with an annotation.
+		super.setOrientationModes(modes);
 	}
 }

--- a/android/titanium/src/java/org/appcelerator/titanium/TiC.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiC.java
@@ -1368,6 +1368,11 @@ public class TiC
 	 * @module.api
 	 */
 	public static final String PROPERTY_ORGANIZATION = "organization";
+
+	/**
+	 * @module.api
+	 */
+	public static final String PROPERTY_ORIENTATION_MODES = "orientationModes";
 	
 	/**
 	 * @module.api

--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/TiBaseWindowProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/TiBaseWindowProxy.java
@@ -76,7 +76,7 @@ public class TiBaseWindowProxy extends TiWindowProxy
 	}
 
 	@Override
-	protected Activity handleGetActivity()
+	protected Activity getWindowActivity()
 	{
 		return null;
 	}

--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/TiWindowProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/TiWindowProxy.java
@@ -338,7 +338,7 @@ public abstract class TiWindowProxy extends TiViewProxy
 				activityOrientationMode = 8;
 			}
 
-			Activity activity = getActivity();
+			Activity activity = getWindowActivity();
 
 			// Wait until the window activity is created before setting orientation modes.
 			if (activity != null && windowActivityCreated)
@@ -382,7 +382,7 @@ public abstract class TiWindowProxy extends TiViewProxy
 
 	protected abstract void handleOpen(KrollDict options);
 	protected abstract void handleClose(KrollDict options);
-	protected abstract Activity handleGetActivity();
+	protected abstract Activity getWindowActivity();
 
 	/**
 	 * Sub-classes will need to call handlePostOpen after their window is visible

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiConvert.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiConvert.java
@@ -573,14 +573,14 @@ public class TiConvert
 
 	/**
 	 * Converts an array of boxed objects into a primitive int array.
-	 * @param inArray array that contains Integer objects
+	 * @param inArray array that contains Number objects
 	 * @return a primitive int array
 	 * @throws ClassCastException if a non-Integer object is found in the array.
 	 */
 	public static int[] toIntArray(Object[] inArray) {
 		int[] outArray = new int[inArray.length];
 		for (int i = 0; i < inArray.length; i++) {
-			outArray[i] = (Integer) inArray[i];
+			outArray[i] = ((Number) inArray[i]).intValue();
 		}
 		return outArray;
 	}

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiConvert.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiConvert.java
@@ -572,6 +572,20 @@ public class TiConvert
 	}
 
 	/**
+	 * Converts an array of boxed objects into a primitive int array.
+	 * @param inArray array that contains Integer objects
+	 * @return a primitive int array
+	 * @throws ClassCastException if a non-Integer object is found in the array.
+	 */
+	public static int[] toIntArray(Object[] inArray) {
+		int[] outArray = new int[inArray.length];
+		for (int i = 0; i < inArray.length; i++) {
+			outArray[i] = (Integer) inArray[i];
+		}
+		return outArray;
+	}
+
+	/**
 	 * Returns a new TiDimension object given a String value and type.
 	 * Refer to {@link TiDimension#TiDimension(String, int)} for more details.
 	 * @param value the dimension value.


### PR DESCRIPTION
Fixes a regression with setting orientation modes on a tab group.
See the JIRA ticket for a test case and directions. Please also test for regressions
to window orientation modes since this could affect them as well.
