### PR TITLE
[TIMOB-9504] Remove sigalg DSA force in Android APK bundling.

### DIFF
--- a/support/android/builder.py
+++ b/support/android/builder.py
@@ -1560,7 +1560,6 @@ class Builder(object):
 			app_apk = os.path.join(self.project_dir, 'bin', 'app.apk')	
 
 		output = run.run([self.jarsigner,
-			'-sigalg', 'MD5withRSA',
 			'-digestalg', 'SHA1',
 			'-storepass', self.keystore_pass,
 			'-keystore', self.keystore,


### PR DESCRIPTION
This fixes problems with signing APKs with an RSA key.
