### PR TITLE
[TIMOB-7313] Android: Date Picker getValue throws an error, custom picker returns undefined

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/PickerProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/PickerProxy.java
@@ -41,7 +41,9 @@ import android.util.Log;
 import android.widget.DatePicker;
 import android.widget.TimePicker;
 
-@Kroll.proxy(creatableInModule=UIModule.class, propertyAccessors={"locale", "visibleItems"})
+@Kroll.proxy(creatableInModule=UIModule.class, propertyAccessors={
+	"locale", "visibleItems", "value"
+})
 public class PickerProxy extends TiViewProxy implements PickerColumnListener
 {
 	private int type = UIModule.PICKER_TYPE_PLAIN;


### PR DESCRIPTION
Fixes the 'value' property for the Picker proxy.
See the JIRA ticket for a test case and instructions.
