### PR TITLE
[TIMOB-9924] Android: Support vertical align on Labels

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/LabelProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/LabelProxy.java
@@ -26,7 +26,8 @@ import android.app.Activity;
 	TiC.PROPERTY_TEXT,
 	TiC.PROPERTY_TEXT_ALIGN,
 	TiC.PROPERTY_TEXTID,
-	TiC.PROPERTY_WORD_WRAP
+	TiC.PROPERTY_WORD_WRAP,
+	TiC.PROPERTY_VERTICAL_ALIGN
 })
 public class LabelProxy extends TiViewProxy
 {

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUILabel.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUILabel.java
@@ -69,13 +69,10 @@ public class TiUILabel extends TiUIView
 		if (d.containsKey(TiC.PROPERTY_FONT)) {
 			TiUIHelper.styleText(tv, d.getKrollDict(TiC.PROPERTY_FONT));
 		}
-		if (d.containsKey(TiC.PROPERTY_TEXT_ALIGN)) {
-			String textAlign = d.getString(TiC.PROPERTY_TEXT_ALIGN);
-			TiUIHelper.setAlignment(tv, textAlign, null);
-		}
-		if (d.containsKey(TiC.PROPERTY_VERTICAL_ALIGN)) {
-			String verticalAlign = d.getString(TiC.PROPERTY_VERTICAL_ALIGN);
-			TiUIHelper.setAlignment(tv, null, verticalAlign);
+		if (d.containsKey(TiC.PROPERTY_TEXT_ALIGN) || d.containsKey(TiC.PROPERTY_VERTICAL_ALIGN)) {
+			String textAlign = d.optString(TiC.PROPERTY_TEXT_ALIGN, "left");
+			String verticalAlign = d.optString(TiC.PROPERTY_VERTICAL_ALIGN, "center");
+			TiUIHelper.setAlignment(tv, textAlign, verticalAlign);
 		}
 		if (d.containsKey(TiC.PROPERTY_ELLIPSIZE)) {
 			if (TiConvert.toBoolean(d, TiC.PROPERTY_ELLIPSIZE)) {

--- a/apidoc/Titanium/UI/Label.yml
+++ b/apidoc/Titanium/UI/Label.yml
@@ -145,8 +145,8 @@ properties:
         [TEXT_VERTICAL_ALIGNMENT_TOP](Titanium.UI.TEXT_VERTICAL_ALIGNMENT_TOP).
     type: [Number,String]
     default: Titanium.UI.TEXT_VERTICAL_ALIGNMENT_CENTER on mobileweb.  Titanium.UI.TEXT_VERTICAL_ALIGNMENT_TOP on iphone and ipad. 
-    platforms: [mobileweb, iphone, ipad]
-    since: { iphone: "2.2", ipad: "2.2", mobileweb: "2.0" }
+    platforms: [mobileweb, iphone, ipad, android]
+    since: { iphone: "2.2", ipad: "2.2", mobileweb: "2.0", android: "2.2" }
     
 examples:
   - title: Basic Label


### PR DESCRIPTION
Enable and fix the 'verticalAlign' property for Labels.
See the JIRA ticket for a test case and information.
