### PR TITLE
[TIMOB-9672] Android: app crashes when Slider object it's inside a tableViewRow and has the 'value' property (backport)

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiConvert.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiConvert.java
@@ -419,7 +419,10 @@ public class TiConvert
 	 */
 	public static float toFloat(Object value)
 	{
-		if (value instanceof Double) {
+		if (value instanceof Float) {
+			return (Float) value;
+
+		} else if (value instanceof Double) {
 			return ((Double) value).floatValue();
 
 		} else if (value instanceof Integer) {


### PR DESCRIPTION
Backport the fix into the 2_1_X branch. See JIRA ticket for a test case and instructions.
