### PR TITLE
[TIMOB-6903]- iOS: Media - openPhotoGallery opens popover in wrong position.

### DIFF
--- a/iphone/Classes/MediaModule.m
+++ b/iphone/Classes/MediaModule.m
@@ -223,7 +223,7 @@ static NSDictionary* TI_filterableItemProperties;
 		if (popoverViewProxy!=nil)
 		{
 			poView = [popoverViewProxy view];
-			poFrame = [poView frame];
+			poFrame = [poView bounds];
 		}
 		else
 		{


### PR DESCRIPTION
Back-porting PR 2502 to 2_1_X branch

Test case in [JIRA](https://jira.appcelerator.org/browse/TIMOB-6903)
