### PR TITLE
[TIMOB-9085] 'this' object should be event firer, not source, for callbacks

### DIFF
--- a/iphone/Classes/KrollBridge.h
+++ b/iphone/Classes/KrollBridge.h
@@ -64,7 +64,7 @@ extern NSString * TitaniumModuleRequireFormat;
 + (BOOL)krollBridgeExists:(KrollBridge *)bridge;
 + (KrollBridge *)krollBridgeForThreadName:(NSString *)threadName;
 
--(void)enqueueEvent:(NSString*)type forProxy:(TiProxy *)proxy withObject:(id)obj withSource:(id)source;
+-(void)enqueueEvent:(NSString*)type forProxy:(TiProxy *)proxy withObject:(id)obj;
 -(void)registerProxy:(id)proxy krollObject:(KrollObject *)ourKrollObject;
 -(int)forceGarbageCollectNow;
 

--- a/iphone/Classes/KrollBridge.m
+++ b/iphone/Classes/KrollBridge.m
@@ -498,14 +498,21 @@ CFMutableSetRef	krollBridgeRegistry = nil;
 
 -(void)enqueueEvent:(NSString*)type forProxy:(TiProxy *)proxy withObject:(id)obj withSource:(id)source
 {
-	KrollObject * eventKrollObject = [self krollObjectForProxy:proxy];
-	KrollObject * sourceObject = [self krollObjectForProxy:source];
-	if (sourceObject == nil)
+	KrollObject* eventKrollObject = [self krollObjectForProxy:proxy];
+	KrollObject* sourceObject = [self krollObjectForProxy:source];
+    KrollObject* thisObject = [self krollObjectForProxy:proxy];
+    
+	if (thisObject == nil)
 	{
-		sourceObject = eventKrollObject;
+		thisObject = eventKrollObject;
 	}
-	KrollEvent * newEvent = [[KrollEvent alloc] initWithType:type ForKrollObject:eventKrollObject
-			 eventObject:obj thisObject:sourceObject];
+    
+	KrollEvent * newEvent = [[KrollEvent alloc] 
+                             initWithType:type 
+                             ForKrollObject:eventKrollObject
+                             eventObject:obj 
+                             thisObject:thisObject];
+    
 	[context enqueue:newEvent];
 	[newEvent release];
 }

--- a/iphone/Classes/KrollBridge.m
+++ b/iphone/Classes/KrollBridge.m
@@ -496,22 +496,15 @@ CFMutableSetRef	krollBridgeRegistry = nil;
 	[event release];
 }
 
--(void)enqueueEvent:(NSString*)type forProxy:(TiProxy *)proxy withObject:(id)obj withSource:(id)source
+-(void)enqueueEvent:(NSString*)type forProxy:(TiProxy *)proxy withObject:(id)obj
 {
 	KrollObject* eventKrollObject = [self krollObjectForProxy:proxy];
-	KrollObject* sourceObject = [self krollObjectForProxy:source];
-    KrollObject* thisObject = [self krollObjectForProxy:proxy];
-    
-	if (thisObject == nil)
-	{
-		thisObject = eventKrollObject;
-	}
     
 	KrollEvent * newEvent = [[KrollEvent alloc] 
                              initWithType:type 
                              ForKrollObject:eventKrollObject
                              eventObject:obj 
-                             thisObject:thisObject];
+                             thisObject:eventKrollObject];
     
 	[context enqueue:newEvent];
 	[newEvent release];

--- a/iphone/Classes/TiProxy.m
+++ b/iphone/Classes/TiProxy.m
@@ -858,7 +858,7 @@ void DoProxyDelegateReadValuesWithKeysFromProxy(UIView<TiProxyDelegate> * target
 
 	if ((bridgeCount == 1) && (pageKrollObject != nil))
 	{
-		[(KrollBridge *)pageContext enqueueEvent:type forProxy:self withObject:eventObject withSource:source];
+		[(KrollBridge *)pageContext enqueueEvent:type forProxy:self withObject:eventObject];
 	}
 	else
 	{
@@ -866,7 +866,7 @@ void DoProxyDelegateReadValuesWithKeysFromProxy(UIView<TiProxyDelegate> * target
 
 		for (KrollBridge * currentBridge in bridges)
 		{
-			[currentBridge enqueueEvent:type forProxy:self withObject:eventObject withSource:source];
+			[currentBridge enqueueEvent:type forProxy:self withObject:eventObject];
 		}
 	}
 }


### PR DESCRIPTION
Note that although this brings parity with Android and Mobile Web, it violates the specification. The callback function's `this` should refer to the function itself.

[TICKET](https://jira.appcelerator.org/browse/TIMOB-9085)
