### PR TITLE
[TC-1072] Fixes after verticalAlign addition

### DIFF
--- a/iphone/Classes/TiUILabel.m
+++ b/iphone/Classes/TiUILabel.m
@@ -77,7 +77,7 @@
     if (originX < 0) {
         originX = 0;
     }
-    CGRect labelRect = CGRectMake(originX, 0, actualLabelSize.width, actualLabelSize.height);
+    CGRect labelRect = CGRectMake(0, 0, initialLabelFrame.size.width, actualLabelSize.height);
     switch (verticalAlign) {
         case UIControlContentVerticalAlignmentBottom:
             labelRect.origin.y = initialLabelFrame.size.height - actualLabelSize.height;
@@ -167,7 +167,7 @@
 
 -(void)setVerticalAlign_:(id)value
 {
-    verticalAlign = [TiUtils intValue:value def:1];
+    verticalAlign = [TiUtils intValue:value def:0];
     if (label != nil) {
         [self padLabel];
     }
@@ -175,6 +175,7 @@
 -(void)setText_:(id)text
 {
 	[[self label] setText:[TiUtils stringValue:text]];
+    [self padLabel];
 	[(TiViewProxy *)[self proxy] contentsWillChange];
 }
 


### PR DESCRIPTION
The new verticalAlign feature broke a few things.
This commit fixes:
- padLabel move the label "horizontally" which breaks textAlign
- padLabel was not called on setText. This was bad when the new text didnt have the same size as the old one.
- The default value for verticalAlign was top
