### PR TITLE
Timob 9813 2_1_X Android: Animation anomaly: backgrounds bleed through

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/TiViewProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/TiViewProxy.java
@@ -34,6 +34,7 @@ import org.appcelerator.titanium.view.TiAnimation;
 import org.appcelerator.titanium.view.TiUIView;
 
 import android.app.Activity;
+import android.os.Build;
 import android.os.Handler;
 import android.os.Message;
 import android.view.View;
@@ -644,7 +645,14 @@ public abstract class TiViewProxy extends KrollProxy implements Handler.Callback
 	{
 		if (pendingAnimation != null && peekView() != null) {
 			if (forceQueue || !(TiApplication.isUIThread())) {
-				getMainHandler().obtainMessage(MSG_ANIMATE).sendToTarget();
+				if (Build.VERSION.SDK_INT < TiC.API_LEVEL_HONEYCOMB) {
+					// Even this very small delay can help eliminate the bug
+					// whereby the animated view's parent suddenly becomes
+					// transparent (pre-honeycomb). cf. TIMOB-9813.
+					getMainHandler().sendEmptyMessageDelayed(MSG_ANIMATE, 10);
+				} else {
+					getMainHandler().sendEmptyMessage(MSG_ANIMATE);
+				}
 			} else {
 				handleAnimate();
 			}

--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiUIView.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiUIView.java
@@ -295,7 +295,7 @@ public abstract class TiUIView
 				// Could be animating from nothing to something
 				invalidateParent = true;
 			} else {
-				Rect r = new Rect(0, 0, nativeView.getWidth(), nativeView.getHeight());
+				Rect r = new Rect(0, 0, width, height);
 				Point p = new Point(0, 0);
 				invalidateParent = !(viewParent.getChildVisibleRect(nativeView, r, p));
 			}

--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiUIView.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiUIView.java
@@ -38,8 +38,6 @@ import android.graphics.Point;
 import android.graphics.Rect;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
-import android.os.Looper;
-import android.os.MessageQueue.IdleHandler;
 import android.util.Pair;
 import android.view.GestureDetector;
 import android.view.GestureDetector.SimpleOnGestureListener;
@@ -252,32 +250,34 @@ public abstract class TiUIView
 	 */
 	public void animate()
 	{
-		TiAnimationBuilder builder = proxy.getPendingAnimation();
-		proxy.clearAnimation(builder);
-
-		if (builder != null && nativeView != null) {
-			final AnimationSet as = builder.render(proxy, nativeView);
-			if (Build.VERSION.SDK_INT > TiC.API_LEVEL_HONEYCOMB) {
-				startAnimation(as);
-			} else {
-				// Waiting for the UI looper's queue to get idle
-				// seems to help avoid TIMOB-9813, a condition whereby
-				// parts of the parent of the animated view might suddenly become
-				// transparent during the animation on devices < Honeycomb.
-				Looper.myQueue().addIdleHandler(new IdleHandler() {
-
-					public boolean queueIdle()
-					{
-						startAnimation(as);
-						return false;
-					}
-				});
-			}
+		if (nativeView == null) {
+			return;
 		}
-	}
 
-	private void startAnimation(Animation animation)
-	{
+		// Pre-honeycomb, if one animation clobbers another you get a problem whereby the background of the
+		// animated view's parent (or the grandparent) bleeds through.  It seems to improve if you cancel and clear
+		// the older animation.  So here we cancel and clear, then re-queue the desired animation.
+		if (Build.VERSION.SDK_INT < TiC.API_LEVEL_HONEYCOMB) {
+			Animation currentAnimation = nativeView.getAnimation();
+			if (currentAnimation != null && currentAnimation.hasStarted() && !currentAnimation.hasEnded()) {
+				// Cancel existing animation and
+				// re-queue desired animation.
+				currentAnimation.cancel();
+				nativeView.clearAnimation();
+				proxy.handlePendingAnimation(true);
+				return;
+			}
+
+		}
+
+		TiAnimationBuilder builder = proxy.getPendingAnimation();
+		if (builder == null) {
+			return;
+		}
+
+		proxy.clearAnimation(builder);
+		AnimationSet as = builder.render(proxy, nativeView);
+
 		// If a view is "visible" but not currently seen (such as because it's covered or
 		// its position is currently set to be fully outside its parent's region),
 		// then Android might not animate it immediately because by default it animates
@@ -302,14 +302,13 @@ public abstract class TiUIView
 		}
 
 		if (DBG) {
-			Log.d(LCAT, "starting animation: " + animation);
+			Log.d(LCAT, "starting animation: " + as);
 		}
-		nativeView.startAnimation(animation);
+		nativeView.startAnimation(as);
 
 		if (invalidateParent) {
 			((View) viewParent).postInvalidate();
 		}
-
 	}
 
 	public void listenerAdded(String type, int count, KrollProxy proxy) {


### PR DESCRIPTION
**ONLY DO IF https://github.com/appcelerator/titanium_mobile/pull/2585 IS APPROVED**

This is the 2_1_X version of #2585.

See [Testing Notes](https://jira.appcelerator.org/browse/TIMOB-9813?focusedCommentId=208101&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-208101).

Important to test on 2.2/2.3 (not necessarily both, IMO, but feel free), 3.x and 4.x.
