### PR TITLE
[TIMOB-9904] 'SIZE' height for text areas based explictly off of pre-computed width

### DIFF
--- a/iphone/Classes/TiUITextArea.m
+++ b/iphone/Classes/TiUITextArea.m
@@ -179,9 +179,8 @@ Text area constrains the text event though the content offset and edge insets ar
     if (txt.length == 0) {
         txt = @" ";
     }
-    //sizeThatFits does not seem to work properly
-    CGFloat txtHeight = [txt sizeWithFont:ourView.font constrainedToSize:CGSizeMake(constrainedWidth, 1E100) lineBreakMode:UILineBreakModeWordWrap].height;
-    return txtHeight + 2 * self.layer.borderWidth;
+    
+    return [ourView sizeThatFits:CGSizeMake(constrainedWidth, 1E100)].height;
 }
 
 - (void)scrollViewDidScroll:(id)scrollView


### PR DESCRIPTION
There are a couple of notes about this ticket:
- Believe it or not, the "resize as you type" behavior is EXPECTED. This was even explicitly added to iOS for parity with Android, and I double-checked. If this behavior is undesirable, we're going to need another ticket.
- The original offending code was removed (and replaced with the thing it specifically said "did not work") based on the fact that no adequate justification was given and blame did not reveal a specific bug which was fixed by not using `-[UIView sizeThatFits:]`. As a consequence it is recommended that the original committer (@vishalduggal) perform review of this ticket to provide any information about the original decision.

[TICKET](https://jira.appcelerator.org/browse/TIMOB-9904)
