### PR TITLE
[TIMOB-10015] Android: Gradient colors offset property, when unspecified, crashes app

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiConvert.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiConvert.java
@@ -432,7 +432,7 @@ public class TiConvert
 			return Float.parseFloat((String) value);
 
 		} else {
-			throw new NumberFormatException("Unable to convert " + value.getClass().getName());
+			throw new NumberFormatException("Unable to convert value to float.");
 		}
 	}
 

--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiGradientDrawable.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiGradientDrawable.java
@@ -103,14 +103,18 @@ public class TiGradientDrawable extends ShapeDrawable {
 				if (offsets == null) {
 					offsets = new float[colors.length];
 				}
-				offsets[offsetCount++] = TiConvert.toFloat(colorRefObject, "offset");
+
+				float offset = TiConvert.toFloat(colorRefObject, "offset", -1);
+				if (offset >= 0.0f && offset <= 1.0f) {
+					offsets[offsetCount++] = offset;
+				}
 
 			} else {
 				this.colors[i] = TiConvert.toColor(color.toString());
 			}
 		}
 
-		// If the number of offsets doesn't not match the number of colors,
+		// If the number of offsets doesn't match the number of colors,
 		// just distribute the colors evenly along the gradient line.
 		if (offsetCount != this.colors.length) {
 			offsets = null;


### PR DESCRIPTION
Fixes an exception that was thrown when a gradient color
object was provided that didn't have an offset value.
