### PR TITLE
[TIMOB-10039] Restore default IOS behavior if vertical align is not set

### DIFF
--- a/apidoc/Titanium/UI/Label.yml
+++ b/apidoc/Titanium/UI/Label.yml
@@ -143,8 +143,12 @@ properties:
         [TEXT_VERTICAL_ALIGNMENT_BOTTOM](Titanium.UI.TEXT_VERTICAL_ALIGNMENT_BOTTOM), 
         [TEXT_VERTICAL_ALIGNMENT_CENTER](Titanium.UI.TEXT_VERTICAL_ALIGNMENT_CENTER), or 
         [TEXT_VERTICAL_ALIGNMENT_TOP](Titanium.UI.TEXT_VERTICAL_ALIGNMENT_TOP).
+    description: |
+    	On iphone and ipad the default value of the property is undefined. The behavior of the label
+    	depends on the actual content height. If the actual content height is larger than the available 
+    	height the text is truncated at the end and the content is center aligned.
     type: [Number,String]
-    default: Titanium.UI.TEXT_VERTICAL_ALIGNMENT_CENTER on mobileweb.  Titanium.UI.TEXT_VERTICAL_ALIGNMENT_TOP on iphone and ipad. 
+    default: Titanium.UI.TEXT_VERTICAL_ALIGNMENT_CENTER on mobileweb.  Undefined on iphone and ipad. 
     platforms: [mobileweb, iphone, ipad, android]
     since: { iphone: "2.2", ipad: "2.2", mobileweb: "2.0", android: "2.2" }
     

--- a/iphone/Classes/TiUILabel.m
+++ b/iphone/Classes/TiUILabel.m
@@ -19,7 +19,8 @@
 {
     if (self = [super init]) {
         padding = CGRectZero;
-		initialLabelFrame = CGRectZero;
+        initialLabelFrame = CGRectZero;
+        verticalAlign = -1;
     }
     return self;
 }
@@ -72,30 +73,46 @@
 
 -(void)padLabel
 {
-    CGSize actualLabelSize = [self sizeForFont:initialLabelFrame.size.width];
-    CGFloat originX = (initialLabelFrame.size.width - actualLabelSize.width)/2.0;
-    if (originX < 0) {
-        originX = 0;
-    }
-    CGRect labelRect = CGRectMake(originX, 0, actualLabelSize.width, actualLabelSize.height);
-    switch (verticalAlign) {
-        case UIControlContentVerticalAlignmentBottom:
-            labelRect.origin.y = initialLabelFrame.size.height - actualLabelSize.height;
-            break;
-        case UIControlContentVerticalAlignmentCenter:
-            labelRect.origin.y = (initialLabelFrame.size.height - actualLabelSize.height)/2;
-            if (labelRect.origin.y < 0) {
-                labelRect.size.height = (initialLabelFrame.size.height - labelRect.origin.y);
-            }
-            break;
-        default:
-            if (initialLabelFrame.size.height < actualLabelSize.height) {
-                labelRect.size.height = initialLabelFrame.size.height;
-            }
-            break;
-    }
+    if (verticalAlign != -1) {
+        CGSize actualLabelSize = [self sizeForFont:initialLabelFrame.size.width];
+        CGFloat originX = 0;
+        switch (label.textAlignment) {
+            case UITextAlignmentRight:
+                originX = (initialLabelFrame.size.width - actualLabelSize.width);
+                break;
+            case UITextAlignmentCenter:
+                originX = (initialLabelFrame.size.width - actualLabelSize.width)/2.0;
+                break;
+            default:
+                break;
+        }
+        
+        if (originX < 0) {
+            originX = 0;
+        }
+        CGRect labelRect = CGRectMake(originX, 0, actualLabelSize.width, actualLabelSize.height);
+        switch (verticalAlign) {
+            case UIControlContentVerticalAlignmentBottom:
+                labelRect.origin.y = initialLabelFrame.size.height - actualLabelSize.height;
+                break;
+            case UIControlContentVerticalAlignmentCenter:
+                labelRect.origin.y = (initialLabelFrame.size.height - actualLabelSize.height)/2;
+                if (labelRect.origin.y < 0) {
+                    labelRect.size.height = (initialLabelFrame.size.height - labelRect.origin.y);
+                }
+                break;
+            default:
+                if (initialLabelFrame.size.height < actualLabelSize.height) {
+                    labelRect.size.height = initialLabelFrame.size.height;
+                }
+                break;
+        }
     
-    [label setFrame:CGRectIntegral(labelRect)];
+        [label setFrame:CGRectIntegral(labelRect)];
+    }
+    else {
+        [label setFrame:initialLabelFrame];
+    }
 
     if (repad &&
         backgroundView != nil && 
@@ -167,7 +184,10 @@
 
 -(void)setVerticalAlign_:(id)value
 {
-    verticalAlign = [TiUtils intValue:value def:1];
+    verticalAlign = [TiUtils intValue:value def:-1];
+    if (verticalAlign < UIControlContentVerticalAlignmentCenter || verticalAlign > UIControlContentVerticalAlignmentBottom) {
+        verticalAlign = -1;
+    }
     if (label != nil) {
         [self padLabel];
     }
@@ -175,6 +195,7 @@
 -(void)setText_:(id)text
 {
 	[[self label] setText:[TiUtils stringValue:text]];
+    [self padLabel];
 	[(TiViewProxy *)[self proxy] contentsWillChange];
 }
 
@@ -272,6 +293,7 @@
 -(void)setTextAlign_:(id)alignment
 {
 	[[self label] setTextAlignment:[TiUtils textAlignmentValue:alignment]];
+    [self padLabel];
 }
 
 -(void)setShadowColor_:(id)color

--- a/iphone/Classes/TiUILabelProxy.m
+++ b/iphone/Classes/TiUILabelProxy.m
@@ -16,7 +16,6 @@ USE_VIEW_FOR_CONTENT_WIDTH
 
 -(void)_initWithProperties:(NSDictionary *)properties
 {
-    [self initializeProperty:@"verticalAlign" defaultValue:NUMINT(1)];
     [super _initWithProperties:properties];
 }
 


### PR DESCRIPTION
Test is in [JIRA](https://jira.appcelerator.org/browse/TIMOB-10039)

Notes on testing:
A new test case has been added to JIRA. (slightly modified from the one in TIMOB-2574)
Please run various configurations without setting the vertical align property to ensure that the default behavior has not changed (should match behavior on 2.1.0 GA)
