### PR TITLE
[TIMOB-9824] Don't display a background gradient on Android if colors ar...

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiGradientDrawable.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiGradientDrawable.java
@@ -9,6 +9,7 @@ package org.appcelerator.titanium.view;
 import java.util.HashMap;
 
 import org.appcelerator.kroll.KrollDict;
+import org.appcelerator.kroll.common.Log;
 import org.appcelerator.titanium.TiDimension;
 import org.appcelerator.titanium.TiPoint;
 import org.appcelerator.titanium.util.TiConvert;
@@ -28,6 +29,7 @@ public class TiGradientDrawable extends ShapeDrawable {
 	private static final TiPoint DEFAULT_START_POINT = new TiPoint(0, 0);
 	private static final TiPoint DEFAULT_END_POINT = new TiPoint(0, 1);
 	private static final TiDimension DEFAULT_RADIUS = new TiDimension(1.0, TiDimension.TYPE_UNDEFINED);
+	private static final String LCAT = "TiGradientDrawable";
 
 	private GradientType gradientType;
 	private TiPoint startPoint = DEFAULT_START_POINT, endPoint = DEFAULT_END_POINT;
@@ -78,6 +80,7 @@ public class TiGradientDrawable extends ShapeDrawable {
 
 		Object colors = properties.get("colors");
 		if (!(colors instanceof Object[])) {
+			Log.w(LCAT, "Android does not support gradients without colors.");
 			throw new IllegalArgumentException("Must provide an array of colors.");
 		}
 		loadColors((Object[])colors);

--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiUIView.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiUIView.java
@@ -821,10 +821,15 @@ public abstract class TiUIView
 		TiGradientDrawable gradientDrawable = null;
 		KrollDict gradientProperties = d.getKrollDict(TiC.PROPERTY_BACKGROUND_GRADIENT);
 		if (gradientProperties != null) {
-			gradientDrawable = new TiGradientDrawable(nativeView, gradientProperties);
-			if (gradientDrawable.getGradientType() == GradientType.RADIAL_GRADIENT) {
-				// TODO: Remove this once we support radial gradients.
-				Log.w(LCAT, "Android does not support radial gradients.");
+			try {
+				gradientDrawable = new TiGradientDrawable(nativeView, gradientProperties);
+				if (gradientDrawable.getGradientType() == GradientType.RADIAL_GRADIENT) {
+					// TODO: Remove this once we support radial gradients.
+					Log.w(LCAT, "Android does not support radial gradients.");
+					gradientDrawable = null;
+				}
+			}
+			catch (IllegalArgumentException e) {
 				gradientDrawable = null;
 			}
 		}


### PR DESCRIPTION
Previously, not specifying colors in a backgroundGradient threw an exception which
caused the app to crash.   Now a warning message is logged, the exception is caught,
and the view with the backgroundGradient is not displayed.   Verified that we now have
parity on Android, IOS, and Mobile web.
