### PR TITLE
TIMOB-10136: Android: Postlayout event should not bubble up to parent

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiCompositeLayout.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiCompositeLayout.java
@@ -574,7 +574,7 @@ public class TiCompositeLayout extends ViewGroup
 		TiViewProxy viewProxy = (proxy == null ? null : proxy.get());
 
 		if (viewProxy != null && viewProxy.hasListeners(TiC.EVENT_POST_LAYOUT)) {
-			viewProxy.fireEvent(TiC.EVENT_POST_LAYOUT, null);
+			viewProxy.fireEvent(TiC.EVENT_POST_LAYOUT, null, false);
 		}
 	}
 


### PR DESCRIPTION
https://jira.appcelerator.org/browse/TIMOB-10136

Test case in Jira.
