### PR TITLE
Added support for the ANDROID_SDK_HOME environment variable.

### DIFF
--- a/support/android/builder.py
+++ b/support/android/builder.py
@@ -252,8 +252,12 @@ class Builder(object):
 			self.force_rebuild = True
 			sys.stdout.flush()
 		
+		# favor the ANDROID_SDK_HOME environment variable if used
+		if os.environ.has_key('ANDROID_SDK_HOME') and os.path.exists(os.environ['ANDROID_SDK_HOME']):
+			self.home_dir = os.path.join(os.environ['ANDROID_SDK_HOME'], '.titanium')
+			self.android_home_dir = os.path.join(os.environ['ANDROID_SDK_HOME'], '.android')
 		# we place some files in the users home
-		if platform.system() == "Windows":
+		elif platform.system() == "Windows":
 			self.home_dir = os.path.join(os.environ['USERPROFILE'], '.titanium')
 			self.android_home_dir = os.path.join(os.environ['USERPROFILE'], '.android')
 		else:


### PR DESCRIPTION
Supports Android devs who changed the location of their .android folder and properly set the ANDROID_SDK_HOME variable to reflect.

Typically, the .android folder is stored in the users home directory, but in some cases this might need to be changed. The Android SDK provides the aforementioned environment variable as a means to specify an alternate parent folder.

In the case of TitaniumStudio, I believe setting this variable makes sense to also affect the .titanium folder.

Ex:
Windows (D:\myDevHome\.android)
set %ANDROID_SDK_HOME%=D:\myDevHome

Linux/Mac (/usr/opt/devHome/.android)
ANDROID_SDK_HOME="/usr/opt/devHome"
