### PR TITLE
[TIMOB-3749]Do not scale images. Update content mode for imageView

### DIFF
--- a/iphone/Classes/TiUIImageView.m
+++ b/iphone/Classes/TiUIImageView.m
@@ -482,7 +482,7 @@ DEFINE_EXCEPTIONS
         }
         
         
-		UIImage *image = [[ImageLoader sharedLoader] loadImmediateImage:url_ withSize:imageSize];
+		UIImage *image = [[ImageLoader sharedLoader] loadImmediateImage:url_];
 		if (image==nil)
 		{
             [self loadDefaultImage:imageSize];
@@ -497,7 +497,10 @@ DEFINE_EXCEPTIONS
 			CGSize fullSize = [[ImageLoader sharedLoader] fullImageSize:img];
 			autoWidth = fullSize.width;
 			autoHeight = fullSize.height;
-			
+			if ([TiUtils boolValue:[[self proxy] valueForKey:@"hires"]]) {
+				autoWidth = autoWidth/2;
+				autoHeight = autoHeight/2;
+			}
 			[self imageView].image = image;
 			[self fireLoadEventWithState:@"image"];
 		}

--- a/iphone/Classes/TiUIImageView.m
+++ b/iphone/Classes/TiUIImageView.m
@@ -740,26 +740,20 @@ DEFINE_EXCEPTIONS
 
 -(void)imageLoadSuccess:(ImageLoaderRequest*)request image:(UIImage*)image
 {
-	CGFloat computedWidth = TiDimensionCalculateValue(width, autoWidth);
-	CGFloat computedHeight = TiDimensionCalculateValue(height, autoHeight);
-	if ([TiUtils boolValue:[[self proxy] valueForKey:@"hires"]])
-	{
-		computedWidth *= 2;
-		computedHeight *= 2;
-	}
-	
-	UIImage * bestImage = [[ImageLoader sharedLoader] loadImmediateImage:[request url] withSize:CGSizeMake(computedWidth, computedHeight)];
-	if (bestImage != nil)
-	{
-		image = bestImage;
-	}
-    
+    UIImage* theImage = [[ImageLoader sharedLoader] loadImmediateImage:[request url]];
+
     autoWidth = image.size.width;
     autoHeight = image.size.height;
     
-	TiThreadPerformOnMainThread(^{
-		[self setURLImageOnUIThread:image];
-	}, NO);
+    //Setting hires to true causes image to de displayed at 50%
+    if ([TiUtils boolValue:[[self proxy] valueForKey:@"hires"]]) {
+        autoWidth = autoWidth/2;
+        autoHeight = autoHeight/2;
+    }
+        
+    TiThreadPerformOnMainThread(^{
+        [self setURLImageOnUIThread:theImage];
+    }, NO);
 }
 
 -(void)imageLoadFailed:(ImageLoaderRequest*)request error:(NSError*)error


### PR DESCRIPTION
Fixes a few issues with the imageView implementation on IOS.

imageView contentMode is now dependent on the width and height definitions.

If both the properties are set to override image dimensions(Percent,FILL,DIP) the contentMode is UIViewContentModeScaleToFill otherwise the contentMode is UIViewContentModeScaleAspectFit.

Test is in [JIRA](https://jira.appcelerator.org/browse/TIMOB-3749).
Please test the original issue and also the additional test case in the comments. (which will show the current problems with the implementation)

Must regress against KS->BaseUI->ImageViews
