### PR TITLE
[TIMOB-10093] Android: HTTPClient leaks function callbacks (ex: onload, ondatastream)

### DIFF
--- a/android/modules/network/src/java/ti/modules/titanium/network/HTTPClientProxy.java
+++ b/android/modules/network/src/java/ti/modules/titanium/network/HTTPClientProxy.java
@@ -1,6 +1,6 @@
 /**
  * Appcelerator Titanium Mobile
- * Copyright (c) 2009-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2009-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
@@ -14,11 +14,7 @@ import org.appcelerator.titanium.TiContext;
 
 import ti.modules.titanium.xml.DocumentProxy;
 
-@Kroll.proxy(creatableInModule=NetworkModule.class, propertyAccessors = {
-	"ondatastream", "onerror", "onload",
-	"onreadystatechange", "onsendstream"
-})
-
+@Kroll.proxy(creatableInModule=NetworkModule.class)
 public class HTTPClientProxy extends KrollProxy
 {
 	@Kroll.constant public static final int UNSENT = TiHTTPClient.READY_STATE_UNSENT;
@@ -27,9 +23,7 @@ public class HTTPClientProxy extends KrollProxy
 	@Kroll.constant public static final int LOADING = TiHTTPClient.READY_STATE_LOADING;
 	@Kroll.constant public static final int DONE = TiHTTPClient.READY_STATE_DONE;
 
-
 	private TiHTTPClient client;
-
 
 	public HTTPClientProxy()
 	{
@@ -176,8 +170,9 @@ public class HTTPClientProxy extends KrollProxy
 	}
 
 	@Kroll.setProperty @Kroll.method
-	void setValidatesSecureCertificate(boolean value)
+	public void setValidatesSecureCertificate(boolean value)
 	{
 		this.setProperty("validatesSecureCertificate", value);
 	}
+
 }

--- a/android/modules/network/src/java/ti/modules/titanium/network/TiHTTPClient.java
+++ b/android/modules/network/src/java/ti/modules/titanium/network/TiHTTPClient.java
@@ -78,7 +78,6 @@ import org.apache.http.protocol.HTTP;
 import org.apache.http.protocol.HttpContext;
 import org.apache.http.util.EntityUtils;
 import org.appcelerator.kroll.KrollDict;
-import org.appcelerator.kroll.KrollFunction;
 import org.appcelerator.kroll.KrollProxy;
 import org.appcelerator.kroll.common.Log;
 import org.appcelerator.kroll.util.TiTempFileHelper;
@@ -102,11 +101,6 @@ public class TiHTTPClient
 	private static final int DEFAULT_MAX_BUFFER_SIZE = 512 * 1024;
 	private static final String PROPERTY_MAX_BUFFER_SIZE = "ti.android.httpclient.maxbuffersize";
 	private static final int PROTOCOL_DEFAULT_PORT = -1;
-	private static final String ON_READY_STATE_CHANGE = "onreadystatechange";
-	private static final String ON_LOAD = "onload";
-	private static final String ON_ERROR = "onerror";
-	private static final String ON_DATA_STREAM = "ondatastream";
-	private static final String ON_SEND_STREAM = "onsendstream";
 
 	private static final String[] FALLBACK_CHARSETS = {HTTP.UTF_8, HTTP.ISO_8859_1};
 
@@ -332,22 +326,20 @@ public class TiHTTPClient
 			}
 			
 			responseOut.write(data, 0, size);
-			KrollFunction onDataStreamCallback = getCallback(ON_DATA_STREAM);
-			if (onDataStreamCallback != null) {
-				KrollDict o = new KrollDict();
-				o.put("totalCount", contentLength);
-				o.put("totalSize", totalSize);
-				o.put("size", size);
-				
-				byte[] blobData = new byte[size];
-				System.arraycopy(data, 0, blobData, 0, size);
 
-				TiBlob blob = TiBlob.blobFromData(blobData, contentType);
-				o.put("blob", blob);
-				o.put("progress", ((double)totalSize)/((double)contentLength));
+			KrollDict callbackData = new KrollDict();
+			callbackData.put("totalCount", contentLength);
+			callbackData.put("totalSize", totalSize);
+			callbackData.put("size", size);
 
-				onDataStreamCallback.callAsync(proxy.getKrollObject(), o);
-			}
+			byte[] blobData = new byte[size];
+			System.arraycopy(data, 0, blobData, 0, size);
+
+			TiBlob blob = TiBlob.blobFromData(blobData, contentType);
+			callbackData.put("blob", blob);
+			callbackData.put("progress", ((double)totalSize)/((double)contentLength));
+
+			dispatchCallback("ondatastream", callbackData);
 		}
 		
 		private void finishedReceivingEntityData(long contentLength) throws IOException
@@ -485,40 +477,6 @@ public class TiHTTPClient
 		return readyState;
 	}
 
-	public KrollFunction getCallback(String name)
-	{
-		Object value = proxy.getProperty(name);
-		if (value != null && value instanceof KrollFunction)
-		{
-			return (KrollFunction) value;
-		}
-		return null;
-	}
-
-	public void fireCallback(String name)
-	{
-		KrollDict eventProperties = new KrollDict();
-		eventProperties.put("source", proxy);
-
-		fireCallback(name, new Object [] {eventProperties});
-	}
-
-	public void fireCallback(String name, Object[] args)
-	{
-		KrollFunction cb = getCallback(name);
-		if (cb != null)
-		{
-			// TODO - implement converter method for array to hashmap?
-			cb.callAsync(proxy.getKrollObject(), args);
-		} else {
-			// It's particularly interesting if an error wants to be reported
-			// but no one is listening, so log that.
-			if (ON_ERROR.equals(name)) {
-				Log.w(TAG, "No onerror callback specified; it would be called if it were.", Log.DEBUG_MODE);
-			}
-		}
-	}
-
 	public boolean validatesSecureCertificate()
 	{
 		if (proxy.hasProperty("validatesSecureCertificate")) {
@@ -538,20 +496,11 @@ public class TiHTTPClient
 		Log.d(TAG, "Setting ready state to " + readyState, Log.DEBUG_MODE);
 		this.readyState = readyState;
 
-		fireCallback(ON_READY_STATE_CHANGE);
-		if (readyState == READY_STATE_DONE) {
-			// Fire onload callback
-			fireCallback(ON_LOAD);
-		}
-	}
+		dispatchCallback("onreadystatechanged", null);
 
-	public void sendError(String error)
-	{
-		Log.i(TAG, "Sending error " + error);
-		KrollDict event = new KrollDict();
-		event.put("error", error);
-		event.put("source", proxy);
-		fireCallback(ON_ERROR, new Object[] {event});
+		if (readyState == READY_STATE_DONE) {
+			dispatchCallback("onload", null);
+		}
 	}
 
 	private String decodeResponseData(String charsetName) {
@@ -752,7 +701,7 @@ public class TiHTTPClient
 
 	public void clearCookies(String url)
 	{
-		List<Cookie> cookies = new ArrayList(client.getCookieStore().getCookies());
+		List<Cookie> cookies = new ArrayList<Cookie>(client.getCookieStore().getCookies());
 		client.getCookieStore().clear();
 		String lower_url = url.toLowerCase();
 
@@ -922,6 +871,16 @@ public class TiHTTPClient
 		}
 	}
 
+	private void dispatchCallback(String name, KrollDict data) {
+		if (data == null) {
+			data = new KrollDict();
+		}
+
+		data.put("source", proxy);
+
+		proxy.callPropertyAsync(name, new Object[] { data });
+	}
+
 	private int addTitaniumFileAsPostData(String name, Object value)
 	{
 		try {
@@ -1040,7 +999,7 @@ public class TiHTTPClient
 		aborted = false;
 
 		// TODO consider using task manager
-		double totalLength = 0;
+		int totalLength = 0;
 		needMultipart = false;
 		
 		if (userData != null)
@@ -1127,9 +1086,9 @@ public class TiHTTPClient
 	
 	private class ClientRunnable implements Runnable
 	{
-		private double totalLength;
+		private final int totalLength;
 
-		public ClientRunnable(double totalLength)
+		public ClientRunnable(int totalLength)
 		{
 			this.totalLength = totalLength;
 		}
@@ -1190,13 +1149,9 @@ public class TiHTTPClient
 
 						ProgressEntity progressEntity = new ProgressEntity(mpe, new ProgressListener() {
 							public void progress(int progress) {
-								KrollFunction cb = getCallback(ON_SEND_STREAM);
-								if (cb != null) {
-									KrollDict data = new KrollDict();
-									data.put("progress", ((double)progress)/totalLength);
-									data.put("source", proxy);
-									cb.callAsync(proxy.getKrollObject(), data);
-								}
+								KrollDict data = new KrollDict();
+								data.put("progress", ((double)progress)/totalLength);
+								dispatchCallback("onsendstream", data);
 							}
 						});
 						e.setEntity(progressEntity);
@@ -1257,7 +1212,10 @@ public class TiHTTPClient
 					msg = t.getClass().getName();
 				}
 				Log.e(TAG, "HTTP Error (" + t.getClass().getName() + "): " + msg, t);
-				sendError(msg);
+
+				KrollDict data = new KrollDict();
+				data.put("error", msg);
+				dispatchCallback("onerror", data);
 			}
 
 			deleteTmpFiles();

--- a/android/runtime/common/src/java/org/appcelerator/kroll/KrollObject.java
+++ b/android/runtime/common/src/java/org/appcelerator/kroll/KrollObject.java
@@ -84,6 +84,32 @@ public abstract class KrollObject implements Handler.Callback
 	}
 
 	/**
+	 * Call a function referenced by a property on this object.
+	 *
+	 * <p>
+	 * For example if we have the following JavaScript:
+	 *   <pre>
+	 *   math.add = function(x, y) { return a + b; }
+	 *   </pre>
+	 *
+	 * To call the "add" function on the "math" object from Java:
+	 *   <pre>
+	 *   Number sum = (Number) krollObject.callProperty("add", new Object[] { 1, 2});
+	 *   </pre>
+	 * </p>
+	 *
+	 * <p>
+	 * If the property does not reference a function this method
+	 * will return the {@link KrollRuntime.UNDEFINED} value.
+	 * </p>
+	 *
+	 * @param propertyName name of the property that references the function to call
+	 * @param args the arguments to pass when calling function
+	 * @return the value returned by the function call
+	 */
+	public abstract Object callProperty(String propertyName, Object[] args);
+
+	/**
 	 * Releases this KrollObject, that is, removes event listeners and any associated native views or content.	
 	 */
 	protected void release()

--- a/android/runtime/rhino/src/java/org/appcelerator/kroll/runtime/rhino/RhinoObject.java
+++ b/android/runtime/rhino/src/java/org/appcelerator/kroll/runtime/rhino/RhinoObject.java
@@ -37,6 +37,24 @@ public class RhinoObject extends KrollObject
 	}
 
 	@Override
+	public Object callProperty(String propertyName, Object[] args) {
+		((RhinoRuntime) KrollRuntime.getInstance()).enterContext();
+
+		try {
+			Object returnValue = ScriptableObject.callMethod(proxy, propertyName, args);
+			return TypeConverter.jsObjectToJavaObject(returnValue, proxy);
+
+		} catch (Exception e) {
+			Log.d(TAG, "Exception thrown while calling JS function: " + e, Log.DEBUG_MODE);
+
+		} finally {
+			Context.exit();
+		}
+
+		return KrollRuntime.UNDEFINED;
+	}
+
+	@Override
 	protected void setProperty(String name, Object value)
 	{
 		((RhinoRuntime) KrollRuntime.getInstance()).enterContext();

--- a/android/runtime/v8/src/java/org/appcelerator/kroll/runtime/v8/V8Object.java
+++ b/android/runtime/v8/src/java/org/appcelerator/kroll/runtime/v8/V8Object.java
@@ -17,7 +17,6 @@ public class V8Object extends KrollObject
 
 	private volatile long ptr;
 
-
 	public V8Object(long ptr)
 	{
 		this.ptr = ptr;
@@ -60,6 +59,11 @@ public class V8Object extends KrollObject
 	}
 
 	@Override
+	public Object callProperty(String propertyName, Object[] args) {
+		return nativeCallProperty(ptr, propertyName, args);
+	}
+
+	@Override
 	public void doRelease()
 	{
 		if (ptr == 0) {
@@ -90,6 +94,7 @@ public class V8Object extends KrollObject
 
 	// JNI method prototypes
 	protected static native void nativeInitObject(Class<?> proxyClass, Object proxyObject);
+	private static native Object nativeCallProperty(long ptr, String propertyName, Object[] args);
 	private static native boolean nativeRelease(long ptr);
 
 	private native void nativeSetProperty(long ptr, String name, Object value);

--- a/android/runtime/v8/src/native/V8Object.cpp
+++ b/android/runtime/v8/src/native/V8Object.cpp
@@ -120,7 +120,6 @@ Java_org_appcelerator_kroll_runtime_v8_V8Object_nativeCallProperty
 	Persistent<Object> object = Persistent<Object>((Object*) ptr);
 	Local<Value> property = object->Get(jsPropertyName);
 	if (!property->IsFunction()) {
-		LOGE(TAG, "Not a function!");
 		return JNIUtil::undefinedObject;
 	}
 

--- a/android/runtime/v8/src/native/V8Object.cpp
+++ b/android/runtime/v8/src/native/V8Object.cpp
@@ -109,6 +109,38 @@ Java_org_appcelerator_kroll_runtime_v8_V8Object_nativeFireEvent
 	return JNI_FALSE;
 }
 
+JNIEXPORT jobject JNICALL
+Java_org_appcelerator_kroll_runtime_v8_V8Object_nativeCallProperty
+	(JNIEnv* env, jclass clazz, jlong ptr, jstring propertyName, jobjectArray args)
+{
+	ENTER_V8(V8Runtime::globalContext);
+	JNIScope jniScope(env);
+
+	Handle<Value> jsPropertyName = TypeConverter::javaStringToJsString(propertyName);
+	Persistent<Object> object = Persistent<Object>((Object*) ptr);
+	Local<Value> property = object->Get(jsPropertyName);
+	if (!property->IsFunction()) {
+		LOGE(TAG, "Not a function!");
+		return JNIUtil::undefinedObject;
+	}
+
+	int argc = 0;
+	Handle<Value>* argv = NULL;
+	if (args) {
+		argv = TypeConverter::javaObjectArrayToJsArguments(args, &argc);
+	}
+
+	Local<Function> function = Local<Function>::Cast(property);
+	Local<Value> returnValue = function->Call(object, argc, argv);
+
+	if (argv) {
+		delete[] argv;
+	}
+
+	bool isNew;
+	return TypeConverter::jsValueToJavaObject(returnValue, &isNew);
+}
+
 JNIEXPORT jboolean JNICALL
 Java_org_appcelerator_kroll_runtime_v8_V8Object_nativeRelease
 	(JNIEnv *env, jclass clazz, jlong refPointer)

--- a/android/titanium/src/java/org/appcelerator/kroll/KrollProxy.java
+++ b/android/titanium/src/java/org/appcelerator/kroll/KrollProxy.java
@@ -56,7 +56,8 @@ public class KrollProxy implements Handler.Callback, KrollProxySupport
 	protected static final int MSG_SET_PROPERTY = KrollObject.MSG_LAST_ID + 106;
 	protected static final int MSG_FIRE_EVENT = KrollObject.MSG_LAST_ID + 107;
 	protected static final int MSG_FIRE_SYNC_EVENT = KrollObject.MSG_LAST_ID + 108;
-	protected static final int MSG_LAST_ID = MSG_FIRE_SYNC_EVENT;
+	protected static final int MSG_CALL_PROPERTY = KrollObject.MSG_LAST_ID + 109;
+	protected static final int MSG_LAST_ID = MSG_CALL_PROPERTY;
 	protected static final String PROPERTY_NAME = "name";
 	protected static final String PROPERTY_HAS_JAVA_LISTENER = "_hasJavaListener";
 
@@ -569,6 +570,20 @@ public class KrollProxy implements Handler.Callback, KrollProxySupport
 		}
 	}
 
+	/**
+	 * Asynchronously calls a function referenced by a property on this object.
+	 * This may be called safely on any thread.
+	 *
+	 * @see KrollObject#callProperty(String, Object[])
+	 * @param name the property that references the function
+	 * @param args the arguments to pass when calling the function.
+	 */
+	public void callPropertyAsync(String name, Object[] args) {
+		Message msg = getRuntimeHandler().obtainMessage(MSG_CALL_PROPERTY, args);
+		msg.getData().putString(PROPERTY_NAME, name);
+		msg.sendToTarget();
+	}
+
 	protected void doSetProperty(String name, Object value)
 	{
 		getKrollObject().setProperty(name, value);
@@ -835,6 +850,11 @@ public class KrollProxy implements Handler.Callback, KrollProxySupport
 				asyncResult.setResult(handled);
 
 				return handled;
+			}
+			case MSG_CALL_PROPERTY: {
+				String propertyName = msg.getData().getString(PROPERTY_NAME);
+				Object[] args = (Object[]) msg.obj;
+				getKrollObject().callProperty(propertyName, args);
 			}
 		}
 


### PR DESCRIPTION
This resolves a memory leak caused by the HTTPClient retaining a reference
to the JavaScript callback functions. The result would be a circular reference
of the HTTPClient (its retained by the callback function's scope).

I introduce a new API that allows calling properties on a proxy
object that are function from Java. This works around the circular reference issue
since it requires no extra referencing since the callbacks are kept alive anyway
since they are properties of the proxy.

See the JIRA ticket for a test case and instructions.
