### PR TITLE
TIMOB-10215 If JSCA file creation contains runtime errors, fail it immed...

### DIFF
--- a/apidoc/docgen.py
+++ b/apidoc/docgen.py
@@ -140,11 +140,8 @@ def load_one_yaml(filepath):
 	except KeyboardInterrupt:
 		raise
 	except:
-		e = traceback.format_exc()
-		log.error("Exception occured while processing %s:" % filepath)
-		for line in e.splitlines():
-			log.error(line)
-		return None
+		log.error("Exception occurred while processing %s:" % filepath)
+		raise
 	finally:
 		if f is not None:
 			try:


### PR DESCRIPTION
...iately so that our scons build will also failed.  This avoids accidentally creating releases which contain bad or partial api.jsca files.

See JIRA:

https://jira.appcelerator.org/browse/TIMOB-10215
