### PR TITLE
Timob 9285 2 1 x Android: Message "An application restart is required" fires incorrectly.

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/TiApplication.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiApplication.java
@@ -199,7 +199,7 @@ public abstract class TiApplication extends Application implements Handler.Callb
 			activityRef = activityStack.get(i);
 			if (activityRef != null) {
 				currentActivity = activityRef.get();
-				if (currentActivity != null) {
+				if (currentActivity != null && !currentActivity.isFinishing()) {
 					currentActivity.finish();
 				}
 			}

--- a/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
@@ -750,6 +750,9 @@ public abstract class TiBaseActivity extends Activity
 	protected void onResume()
 	{
 		super.onResume();
+		if (isFinishing()) {
+			return;
+		}
 
 		if (DBG) {
 			Log.d(TAG, "Activity " + this + " onResume");
@@ -797,6 +800,9 @@ public abstract class TiBaseActivity extends Activity
 	protected void onStart()
 	{
 		super.onStart();
+		if (isFinishing()) {
+			return;
+		}
 
 		if (DBG) {
 			Log.d(TAG, "Activity " + this + " onStart");

--- a/android/titanium/src/java/org/appcelerator/titanium/TiLaunchActivity.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiLaunchActivity.java
@@ -464,6 +464,23 @@ public abstract class TiLaunchActivity extends TiBaseActivity
 			return finishing2373;
 		}
 
+		Intent intent = getIntent();
+		if (intent == null) {
+			// We need it. No other checks to make.
+			return finishing2373;
+		}
+
+		String action = intent.getAction();
+		if (action == null || !action.equals(Intent.ACTION_MAIN)) {
+			// No ACTION_MAIN, which means this activity wasn't started
+			// as a launch activity anyway, so there is no reason to shut
+			// it down.  For example, it could be that the app developer
+			// has designated (using intent filters) that this activity
+			// can be used for more things beyond being the launch activity,
+			// and we should allow that.
+			return finishing2373;
+		}
+
 		TiApplication tiApp = TiApplication.getInstance();
 		TiProperties systemProperties = null;
 
@@ -476,7 +493,7 @@ public abstract class TiLaunchActivity extends TiBaseActivity
 			finishing2373 = true;
 		} else if (Build.MODEL.toLowerCase().contains(KINDLE_MODEL)
 				&& creationCounter.getAndIncrement() > 0
-				&& getIntent().getFlags() == KINDLE_FIRE_RESTART_FLAGS) {
+				&& intent.getFlags() == KINDLE_FIRE_RESTART_FLAGS) {
 			finishing2373 = true;
 		}
 

--- a/android/titanium/src/java/org/appcelerator/titanium/TiLaunchActivity.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiLaunchActivity.java
@@ -217,11 +217,16 @@ public abstract class TiLaunchActivity extends TiBaseActivity
 				// FLAG_ACTIVITY_RESET_TASK_IF_NEEDED from the flags, which still causes the problem.
 				// 0x4 is the flag that occurs when we restart because of the missing category/flag, so
 				// that one is okay as well.
+				// (addendum re timob-9285) Launching from history (FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY)
+				// also appears to be okay, so if that flag is there then don't consider this an invalid
+				// launch.
 				if (Build.VERSION.SDK_INT >= TiC.API_LEVEL_HONEYCOMB && intent.getFlags() != 0x4) {
-					int desiredFlags = Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED;
-					if ((intent.getFlags() & desiredFlags) != desiredFlags) {
-						invalidLaunchDetected = true;
-					}
+					int flags = intent.getFlags();
+					invalidLaunchDetected = (
+						((flags & Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED) != Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED)
+						&&
+						((flags & Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY) != Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY)
+						);
 				}
 			}
 

--- a/android/titanium/src/java/org/appcelerator/titanium/TiLaunchActivity.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiLaunchActivity.java
@@ -44,13 +44,16 @@ public abstract class TiLaunchActivity extends TiBaseActivity
 	private static final int RESTART_DELAY = 500;
 	private static final int FINISH_DELAY = 500;
 
-	// Constants for Kindle fire fix for android 2373 (TIMOB-7843)
+	// Constants for Kindle fire fix for android bug 2373 (TIMOB-7843)
 	private static final AtomicInteger creationCounter = new AtomicInteger();
 	private static final int KINDLE_FIRE_RESTART_FLAGS = (Intent.FLAG_ACTIVITY_NEW_TASK
 		| Intent.FLAG_ACTIVITY_BROUGHT_TO_FRONT | Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED);
 	private static final String KINDLE_MODEL = "kindle";
 
-	protected TiUrl url;
+	// For general android bug 2373 condition checking.
+	private static final int VALID_LAUNCH_FLAGS = Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED
+			| Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY;
+
 
 	// For restarting due to android bug 2373 detection.
 	private boolean invalidLaunchDetected = false;
@@ -65,6 +68,8 @@ public abstract class TiLaunchActivity extends TiBaseActivity
 	// via android bug 2373, while there is another instance
 	// of this same activity "behind it".)
 	protected boolean finishing2373 = false;
+
+	protected TiUrl url;
 
 	/**
 	 * @return The Javascript URL that this Activity should run
@@ -183,14 +188,9 @@ public abstract class TiLaunchActivity extends TiBaseActivity
 				// that one is okay as well.
 				// (addendum re timob-9285) Launching from history (FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY)
 				// also appears to be okay, so if that flag is there then don't consider this an invalid
-				// launch.
+				// launch. VALID_LAUNCH_FLAGS contains both of these valid flags.
 				if (Build.VERSION.SDK_INT >= TiC.API_LEVEL_HONEYCOMB && intent.getFlags() != 0x4) {
-					int flags = intent.getFlags();
-					invalidLaunchDetected = (
-						((flags & Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED) != Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED)
-						&&
-						((flags & Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY) != Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY)
-						);
+					invalidLaunchDetected = (intent.getFlags() & VALID_LAUNCH_FLAGS) == 0;
 				}
 			}
 

--- a/android/titanium/src/java/org/appcelerator/titanium/TiRootActivity.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiRootActivity.java
@@ -74,31 +74,16 @@ public class TiRootActivity extends TiLaunchActivity
 	@Override
 	protected void onCreate(Bundle savedInstanceState)
 	{
-		TiApplication tiApp = getTiApp();
-
-		// If not the task root, then this "launch" activity instance is
-		// likely a manifestation of Android bug 2373, and we give
-		// developers an option to simply finish it off right away so that
-		// the running activity stack remains unchanged.
-		if (!isTaskRoot()) {
-			TiProperties sysProperties = tiApp.getSystemProperties();
-			if (sysProperties != null && sysProperties.getBool("ti.android.bug2373.finishfalseroot", false)) {
-				finishing2373 = true;
-				activityOnCreate(savedInstanceState);
-				finish();
-				return;
-			}
+		if (willFinishFalseRootActivity(savedInstanceState)) {
+			return;
 		}
-
 
 		if (checkInvalidLaunch(savedInstanceState)) {
 			// Android bug 2373 detected and we're going to restart.
 			return;
 		}
 
-		if (checkInvalidKindleFireRelaunch(savedInstanceState)) {
-			return;
-		}
+		TiApplication tiApp = getTiApp();
 
 		if (tiApp.isRestartPending() || TiBaseActivity.isUnsupportedReLaunch(this, savedInstanceState)) {
 			super.onCreate(savedInstanceState); // Will take care of scheduling restart and finishing.
@@ -156,6 +141,7 @@ public class TiRootActivity extends TiLaunchActivity
 	protected void onDestroy()
 	{
 		super.onDestroy();
+
 		if (finishing2373) {
 			return;
 		}
@@ -173,6 +159,7 @@ public class TiRootActivity extends TiLaunchActivity
 			super.finish();
 			return;
 		}
+
 		// Ensure we only run the finish logic once. We want to avoid an infinite loop since this method can be called
 		// from the finish method inside TiBaseActivity ( which can be triggered by terminateActivityStack() )
 		if (!finishing) {


### PR DESCRIPTION
This is the 2_1_X cherry-pick.

See [Testing Notes](https://jira.appcelerator.org/browse/TIMOB-9285?focusedCommentId=210305#comment-210305).  The comment above the Testing Notes might also be useful for background info.
