### PR TITLE
[TIMOB-10351] Android: Timers (setTimeout, setInterval) leak memory.

### DIFF
--- a/android/runtime/common/src/java/org/appcelerator/kroll/KrollApplication.java
+++ b/android/runtime/common/src/java/org/appcelerator/kroll/KrollApplication.java
@@ -39,5 +39,5 @@ public interface KrollApplication
 
 	public String getDefaultUnit();
 
-	public void cancelTimers(Thread thread);
+	public void cancelTimers();
 }

--- a/android/runtime/common/src/java/org/appcelerator/kroll/KrollRuntime.java
+++ b/android/runtime/common/src/java/org/appcelerator/kroll/KrollRuntime.java
@@ -189,7 +189,7 @@ public abstract class KrollRuntime implements Handler.Callback
 		// Cancel all timers associated with the app
 		KrollApplication app = krollApplication.get();
 		if (app != null) {
-			app.cancelTimers(thread);
+			app.cancelTimers();
 		}
 
 		if (isRuntimeThread()) {

--- a/android/runtime/v8/src/java/org/appcelerator/kroll/runtime/v8/V8Function.java
+++ b/android/runtime/v8/src/java/org/appcelerator/kroll/runtime/v8/V8Function.java
@@ -21,18 +21,14 @@ import android.util.Log;
 
 public class V8Function extends V8Object implements KrollFunction, Handler.Callback
 {
-	private Handler handler;
+	private static final String TAG = "V8Function";
 
 	protected static final int MSG_CALL_SYNC = V8Object.MSG_LAST_ID + 100;
 	protected static final int MSG_LAST_ID = MSG_CALL_SYNC;
 
-	private static final String TAG = "V8Function";
-
-
 	public V8Function(long pointer)
 	{
 		super(pointer);
-		handler = new Handler(TiMessenger.getRuntimeMessenger().getLooper(), this);
 	}
 
 	public Object call(KrollObject krollObject, HashMap args)
@@ -76,6 +72,7 @@ public class V8Function extends V8Object implements KrollFunction, Handler.Callb
 		});
 	}
 
+	@Override
 	public boolean handleMessage(Message message)
 	{
 		switch (message.what) {
@@ -88,10 +85,27 @@ public class V8Function extends V8Object implements KrollFunction, Handler.Callb
 			}
 		}
 
-		return false;
+		return super.handleMessage(message);
+	}
+
+	@Override
+	public void doRelease() {
+		long functionPointer = getPointer();
+		if (functionPointer == 0) {
+			return;
+		}
+
+		nativeRelease(functionPointer);
+		KrollRuntime.suggestGC();
+	}
+
+	@Override
+	protected void finalize() throws Throwable {
+		super.finalize();
 	}
 
 	// JNI method prototypes
 	private native Object nativeInvoke(long thisPointer, long functionPointer, Object[] functionArgs);
+	private static native void nativeRelease(long functionPointer);
 }
 

--- a/android/runtime/v8/src/native/TypeConverter.cpp
+++ b/android/runtime/v8/src/native/TypeConverter.cpp
@@ -165,8 +165,11 @@ jobject TypeConverter::jsObjectToJavaFunction(v8::Handle<v8::Object> jsObject)
 		return NULL;
 	}
 
-	jlong pointer = (jlong) *Persistent<Function>::New(Handle<Function>::Cast(jsObject));
-	return env->NewObject(JNIUtil::v8FunctionClass, JNIUtil::v8FunctionInitMethod, pointer);
+	Persistent<Function> jsFunction = Persistent<Function>::New(Handle<Function>::Cast(jsObject));
+	jsFunction.MarkIndependent();
+
+	jlong ptr = (jlong) *jsFunction;
+	return env->NewObject(JNIUtil::v8FunctionClass, JNIUtil::v8FunctionInitMethod, ptr);
 }
 
 v8::Handle<v8::Function> TypeConverter::javaObjectToJsFunction(jobject javaObject)

--- a/android/runtime/v8/src/native/V8Function.cpp
+++ b/android/runtime/v8/src/native/V8Function.cpp
@@ -63,6 +63,18 @@ JNIEXPORT jobject JNICALL Java_org_appcelerator_kroll_runtime_v8_V8Function_nati
 	return TypeConverter::jsValueToJavaObject(object, &isNew);
 }
 
+JNIEXPORT void JNICALL
+Java_org_appcelerator_kroll_runtime_v8_V8Function_nativeRelease
+	(JNIEnv *env, jclass clazz, jlong ptr)
+{
+	ASSERT(ptr != 0);
+	Persistent<Function> function = Persistent<Function>((Function*) ptr);
+
+	// Release the JS function so it can be collected.
+	function.Dispose();
+	function.Clear();
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/android/titanium/src/java/org/appcelerator/titanium/TiApplication.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiApplication.java
@@ -866,9 +866,9 @@ public abstract class TiApplication extends Application implements Handler.Callb
 		TiFileHelper.getInstance().destroyTempFiles();
 	}
 
-	public void cancelTimers(Thread thread)
+	public void cancelTimers()
 	{
-		TitaniumModule.cancelTimers(thread);
+		TitaniumModule.cancelTimers();
 	}
 
 	/**

--- a/android/titanium/src/java/ti/modules/titanium/TitaniumModule.java
+++ b/android/titanium/src/java/ti/modules/titanium/TitaniumModule.java
@@ -14,7 +14,6 @@ import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Stack;
 
@@ -23,7 +22,6 @@ import org.appcelerator.kroll.KrollModule;
 import org.appcelerator.kroll.KrollRuntime;
 import org.appcelerator.kroll.annotations.Kroll;
 import org.appcelerator.kroll.common.Log;
-import org.appcelerator.kroll.common.TiConfig;
 import org.appcelerator.titanium.TiApplication;
 import org.appcelerator.titanium.util.TiConvert;
 import org.appcelerator.titanium.util.TiPlatformHelper;
@@ -33,6 +31,7 @@ import org.appcelerator.titanium.util.TiUIHelper;
 import android.app.Activity;
 import android.os.Environment;
 import android.os.Handler;
+import android.util.SparseArray;
 
 @Kroll.module @Kroll.topLevel({"Ti", "Titanium"})
 public class TitaniumModule extends KrollModule
@@ -42,6 +41,9 @@ public class TitaniumModule extends KrollModule
 	private Stack<String> basePath;
 	private Map<String, NumberFormat> numberFormats = java.util.Collections.synchronizedMap(
 		new HashMap<String, NumberFormat>());
+
+	private static final SparseArray<Timer> activeTimers = new SparseArray<TitaniumModule.Timer>();
+	private static int lastTimerId = 1;
 
 	public TitaniumModule()
 	{
@@ -101,10 +103,7 @@ public class TitaniumModule extends KrollModule
 	@Kroll.method
 	public void testThrow(){ throw new Error("Testing throwing throwables"); }
 
-	private static HashMap<Thread, HashMap<Integer, Timer>> timers = new HashMap<Thread, HashMap<Integer, Timer>>();
-	private int currentTimerId;
-
-	protected class Timer implements Runnable
+	private class Timer implements Runnable
 	{
 		protected long timeout;
 		protected boolean interval;
@@ -148,8 +147,14 @@ public class TitaniumModule extends KrollModule
 
 			long start = System.currentTimeMillis();
 			callback.call(getKrollObject(), args);
+
+			// If this timer is repeating schedule it for another round.
+			// Otherwise remove the timer from the active list and quit.
 			if (interval && !canceled) {
 				handler.postDelayed(this, timeout - (System.currentTimeMillis() - start));
+
+			} else {
+				activeTimers.remove(id);
 			}
 		}
 
@@ -161,56 +166,61 @@ public class TitaniumModule extends KrollModule
 	}
 
 	private int createTimer(KrollFunction callback, long timeout, Object[] args, boolean interval)
-		throws IllegalArgumentException
 	{
-		int timerId = currentTimerId++;
-		Handler handler = getRuntimeHandler();
+		// Generate an unique identifier for this timer.
+		// This will later be used by the developer to cancel a timer.
+		final int timerId = lastTimerId++;
 
-		Timer timer = new Timer(timerId, handler, callback, timeout, args, interval);
-		Thread thread = handler.getLooper().getThread();
-		HashMap<Integer, Timer> threadTimers = timers.get(thread);
-		if (threadTimers == null) {
-			threadTimers = new HashMap<Integer, Timer>();
-			timers.put(thread, threadTimers);
-		}
-		threadTimers.put(timerId, timer);
+		Timer timer = new Timer(timerId, getRuntimeHandler(), callback, timeout, args, interval);
+		activeTimers.append(timerId, timer);
+
 		timer.schedule();
 
 		return timerId;
 	}
 
+	private void cancelTimer(int timerId)
+	{
+		Timer timer = activeTimers.get(timerId);
+		if (timer != null) {
+			timer.cancel();
+			activeTimers.remove(timerId);
+		}
+	}
+
+	public static void cancelTimers(Thread thread)
+	{
+		final int timerCount = activeTimers.size();
+		for (int i = 0; i < timerCount; i++) {
+			Timer timer = activeTimers.valueAt(i);
+			timer.cancel();
+		}
+
+		activeTimers.clear();
+	}
+
 	@Kroll.method @Kroll.topLevel
 	public int setTimeout(KrollFunction krollFunction, long timeout, final Object[] args)
-		throws IllegalArgumentException
 	{
 		return createTimer(krollFunction, timeout, args, false);
 	}
 
 	@Kroll.method @Kroll.topLevel
-	public void clearTimeout(int timerId)
-	{
-		for (Thread thread : timers.keySet()) {
-			HashMap<Integer, Timer> threadTimers = timers.get(thread);
-			if (threadTimers.containsKey(timerId)) {
-				Timer timer = threadTimers.remove(timerId);
-				timer.cancel();
-
-				break;
-			}
-		}
-	}
-
-	@Kroll.method @Kroll.topLevel
 	public int setInterval(KrollFunction krollFunction, long timeout, final Object[] args)
-		throws IllegalArgumentException
 	{
 		return createTimer(krollFunction, timeout, args, true);
 	}
 
 	@Kroll.method @Kroll.topLevel
+	public void clearTimeout(int timerId)
+	{
+		cancelTimer(timerId);
+	}
+
+	@Kroll.method @Kroll.topLevel
 	public void clearInterval(int timerId)
 	{
-		clearTimeout(timerId);
+		cancelTimer(timerId);
 	}
 
 	@Kroll.method @Kroll.topLevel
@@ -227,25 +237,6 @@ public class TitaniumModule extends KrollModule
 		*/
 
 		TiUIHelper.doOkDialog("Alert", msg, null);
-	}
-
-	public static void cancelTimers(Thread thread)
-	{
-		HashMap<Integer, Timer> threadTimers = timers.get(thread);
-		if (threadTimers == null) {
-			return;
-		}
-
-		Iterator<Timer> timerIter = threadTimers.values().iterator();
-		while (timerIter.hasNext()) {
-			Timer timer = timerIter.next();
-			if (timer != null) {
-				timer.cancel();
-				timerIter.remove();
-			}
-		}
-
-		threadTimers.clear();
 	}
 
 	@Kroll.method @Kroll.topLevel("String.format")

--- a/android/titanium/src/java/ti/modules/titanium/TitaniumModule.java
+++ b/android/titanium/src/java/ti/modules/titanium/TitaniumModule.java
@@ -188,7 +188,7 @@ public class TitaniumModule extends KrollModule
 		}
 	}
 
-	public static void cancelTimers(Thread thread)
+	public static void cancelTimers()
 	{
 		final int timerCount = activeTimers.size();
 		for (int i = 0; i < timerCount; i++) {


### PR DESCRIPTION
Resolves a memory leak seen when a timer callback
retains a proxy. Timers would never get cleared out after
they fired or get cancelled. On top of this V8Function wouldn't
release the V8 handle properly.

See JIRA ticket for test case and instructions.
Please test on both runtimes.
