### PR TITLE
[TIMOB-10146](2_1_X) Ensure view attached before dispatching setSelected

### DIFF
--- a/iphone/Classes/TiUIPickerProxy.m
+++ b/iphone/Classes/TiUIPickerProxy.m
@@ -40,10 +40,21 @@ NSArray* pickerKeySequence;
 
 -(void)viewDidAttach
 {
-	if (selectOnLoad != nil) {
-		[self setSelectedRow:selectOnLoad];
-		RELEASE_TO_NIL(selectOnLoad);
-	}
+    //Window might not have opened yet, so delay till we get windowDidOpen
+    if (selectOnLoad != nil && windowOpened) {
+        [self setSelectedRow:selectOnLoad];
+        RELEASE_TO_NIL(selectOnLoad);
+    }
+    [super viewDidAttach];
+}
+
+-(void)windowDidOpen
+{
+    [super windowDidOpen];
+    if (selectOnLoad != nil) {
+        [self setSelectedRow:selectOnLoad];
+        RELEASE_TO_NIL(selectOnLoad);
+    }
 }
 
 -(BOOL)supportsNavBarPositioning


### PR DESCRIPTION
Cherry pick PR #2671 into 2_1_X
Test is in [JIRA](https://jira.appcelerator.org/browse/TIMOB-10146)
