### PR TITLE
[TIMOB-9799] Support varargs in jsduck generator

### DIFF
--- a/apidoc/Global/String/String.yml
+++ b/apidoc/Global/String/String.yml
@@ -13,8 +13,8 @@ methods:
         The format string follows the 
         [IEEE printf specification](http://www.opengroup.org/onlinepubs/009695399/functions/printf.html).
         
-        For each "conversion specification" (ie. `%s` for a string or `%d` for a number) used inside 
-        the string, `formatString` argument, the respective value is substituted from the second 
+        For each "conversion specification" (ie. `%s` for a string or `%d` for a number) used inside
+        the string, `formatString` argument, the respective value is substituted from the
         argument list. For example:
         
             var forename = 'Paul';
@@ -30,9 +30,11 @@ methods:
         type: String
         
       - name: value
+        repeatable: true
         summary: |
-            Comma-separated list of one or more values to substitute into the `formatString`. 
-            Optional on Android.
+            Values to substitute into the `formatString`.  The method expects a variable number
+            of `value` arugments, one for each `%` conversion specification in the format
+            string. Optional on Android.
         type: [ String, Number ]
         
   - name: formatCurrency

--- a/apidoc/generators/jsduck_generator.py
+++ b/apidoc/generators/jsduck_generator.py
@@ -359,9 +359,13 @@ def generate(raw_apis, annotated_apis, options):
 
 				if obj.has_key("parameters"):
 					for param in obj["parameters"]:
-						if 'summary' in param:
-							summary = param['summary']
-						type = "{" + transform_type(param["type"]) + "}" if param.has_key('type') else ""
+						if "summary" in param:
+							summary = param["summary"]
+							if "repeatable" in param and param["repeatable"]:
+								repeatable = "..."
+							else:
+								repeatable = ""
+						type = "{" + transform_type(param["type"]) + repeatable + "}" if param.has_key("type") else ""
 						optional = "(optional)" if param.has_key('optional') and param["optional"] == True else ""
 						if param.has_key('default'):
 							output.write("\t * @param %s [%s=%s] %s\n\t * %s\n" % (type, param['name'], param['default'], optional, markdown_to_html(summary)))


### PR DESCRIPTION
Also updated String.yml to use the new format.

Test case in [JIRA](https://jira.appcelerator.org/browse/TIMOB-9799)
