### PR TITLE
TIMOB-10227-2_1_X: Kitchensink: Kitchensink crashes on relaunch after opening ...

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TiTabActivity.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TiTabActivity.java
@@ -279,16 +279,18 @@ public class TiTabActivity extends TabActivity
 			finish();
 			return;
 		}
-		
-		//Remove activityWindows reference from tabs. ActivityWindow reference is only removed when a tab is created (but is added when a tab is added to a tabGroup).
-		//Furthermore, when a tabGroup opens, only the current tab is created (the rest won't create until clicked on). This introduces a memory leak when we have multiple tabs,
-		//and attempt to open/close tabGroup without navigating through all the tabs.
-		TabProxy[] tabs = proxy.getTabs();
-		for (int i = 0; i < tabs.length; ++i) {
-			TiActivityWindows.removeWindow(tabs[i].getWindowId());
-		}
-		
+
 		if (proxy != null) {
+			//Remove activityWindows reference from tabs. ActivityWindow reference is only removed when a tab is created (but is added when a tab is added to a tabGroup).
+			//Furthermore, when a tabGroup opens, only the current tab is created (the rest won't create until clicked on). This introduces a memory leak when we have multiple tabs,
+			//and attempt to open/close tabGroup without navigating through all the tabs.
+			TabProxy[] tabs = proxy.getTabs();
+			if (tabs != null) {
+				for (int i = 0; i < tabs.length; ++i) {
+					TiActivityWindows.removeWindow(tabs[i].getWindowId());
+				}
+			}
+
 			proxy.closeFromActivity();
 			proxy = null;
 		}


### PR DESCRIPTION
...a tab and leave the device idle for sometime.

https://jira.appcelerator.org/browse/TIMOB-10227

Test case in Jira.  Josh may want to review this since he was able to reproduce the issue.
