### PR TITLE
TIMOB-10473 Tooling apidoc validate.py: failure to parse should be fatal...

### DIFF
--- a/apidoc/validate.py
+++ b/apidoc/validate.py
@@ -471,12 +471,19 @@ def loadTypesFromDocgen():
 
 def validateTDoc(tdocPath):
 	global typesFromDocgen
-	if not typesFromDocgen:
-		loadTypesFromDocgen()
 
 	tdocTypes = [type for type in yaml.load_all(codecs.open(tdocPath, 'r', 'utf8').read())]
+
 	if options.parseOnly:
 		return
+
+	if not typesFromDocgen:
+		try:
+			loadTypesFromDocgen()
+		except Exception, e:
+			# This should be fatal
+			print >> sys.stderr, e
+			sys.exit(1)
 
 	for type in tdocTypes:
 		validateType(type)


### PR DESCRIPTION
... and end validate.py.

https://jira.appcelerator.org/browse/TIMOB-10473  includes testing notes.
