### PR TITLE
[TIMOB-4625] Android: debug on device

### DIFF
--- a/support/android/builder.py
+++ b/support/android/builder.py
@@ -2199,9 +2199,12 @@ if __name__ == "__main__":
 		elif command == 'install':
 			avd_id = dequote(sys.argv[6])
 			device_args = ['-d']
-			if len(sys.argv) >= 8:
+			if len(sys.argv) >= 8 and len(sys.argv[7]) > 0:
 				device_args = ['-s', sys.argv[7]]
-			s.build_and_run(True, avd_id, device_args=device_args)
+			debugger_host = None
+			if len(sys.argv) >= 9 and len(sys.argv[8]) > 0:
+				debugger_host = dequote(sys.argv[8])
+			s.build_and_run(True, avd_id, device_args=device_args, debugger_host=debugger_host)
 		elif command == 'distribute':
 			key = os.path.abspath(os.path.expanduser(dequote(sys.argv[6])))
 			password = dequote(sys.argv[7])


### PR DESCRIPTION
[TIMOB-4625](https://jira.appcelerator.org/browse/TIMOB-4625)

Given that normally we verify debugging via TiStudio, and TiStudio is not yet ready for on-device debugging with Android, I will post different verification instructions in JIRA comments.
