### PR TITLE
[TIMOB-10493] iOS: DashboardView rowCount and columnCount properties

### DIFF
--- a/apidoc/Titanium/UI/DashboardView.yml
+++ b/apidoc/Titanium/UI/DashboardView.yml
@@ -168,6 +168,16 @@ methods:
     description: This method causes the <Titanium.UI.DashboardView.commit> event to fire.
 
 properties:
+  - name: columnCount
+    availability: creation
+    summary: The number of columns of items in the view.
+    type: Number
+
+  - name: rowCount
+    availability: creation
+    summary: The number of rows of items in the view.
+    type: Number
+
   - name: data
     summary: Items to display in this view.
     type: Array<Titanium.UI.DashboardItem>

--- a/apidoc/Titanium/UI/DashboardView.yml
+++ b/apidoc/Titanium/UI/DashboardView.yml
@@ -172,11 +172,15 @@ properties:
     availability: creation
     summary: The number of columns of items in the view.
     type: Number
+    since: "3.0"
+    default: 3
 
   - name: rowCount
     availability: creation
     summary: The number of rows of items in the view.
     type: Number
+    since: "3.0"
+    default: 3
 
   - name: data
     summary: Items to display in this view.

--- a/iphone/Classes/LauncherView.m
+++ b/iphone/Classes/LauncherView.m
@@ -66,12 +66,12 @@ static const NSTimeInterval kLauncherViewFastTransitionDuration = 0.2;
 
 @synthesize columnCount, rowCount, delegate, editable;
 
-- (id)initWithFrame:(CGRect)frame 
+- (id)initWithFrame:(CGRect)frame withRowCount:(int)newRowCount withColumnCount:(int)newColumnCount
 {
     if ((self = [super initWithFrame:frame])) 
 	{
-		self.columnCount = kLauncherViewDefaultColumnCount;
-		self.rowCount = 0;
+        self.rowCount = newRowCount;
+        self.columnCount = newColumnCount;
 		self.currentPageIndex = 0;
         self.editable = YES;
         
@@ -125,7 +125,7 @@ static const NSTimeInterval kLauncherViewFastTransitionDuration = 0.2;
 
 -(NSInteger)rowHeight
 {
-	return MAX(33,(scrollView.frame.size.height /3));
+	return MAX(33,(scrollView.frame.size.height / rowCount));
 }
 
 - (NSMutableArray*)pageWithFreeSpace:(NSInteger)pageIndex 
@@ -142,15 +142,6 @@ static const NSTimeInterval kLauncherViewFastTransitionDuration = 0.2;
 	NSMutableArray* page = [NSMutableArray array];
 	[pages addObject:page];
 	return page;
-}
-
-- (NSInteger)rowCount 
-{
-	if (!rowCount) 
-	{
-		rowCount = floor(self.frame.size.height / [self rowHeight]);
-	}
-	return rowCount;
 }
 
 - (NSInteger)currentPageIndex 

--- a/iphone/Classes/TiUIDashboardView.m
+++ b/iphone/Classes/TiUIDashboardView.m
@@ -15,6 +15,9 @@
 #import "LauncherItem.h"
 #import "LauncherButton.h"
 
+static const NSInteger kDashboardViewDefaultRowCount = 3;
+static const NSInteger kDashboardViewDefaultColumnCount = 3;
+
 @implementation TiUIDashboardView
 
 -(void)dealloc
@@ -32,8 +35,8 @@
 {
 	if (launcher==nil)
 	{
-        int rowCount = [TiUtils intValue:[self.proxy valueForKey:@"rowCount"] def:3];
-        int columnCount = [TiUtils intValue:[self.proxy valueForKey:@"columnCount"] def:3];
+		int rowCount = [TiUtils intValue:[self.proxy valueForKey:@"rowCount"] def:kDashboardViewDefaultRowCount];
+		int columnCount = [TiUtils intValue:[self.proxy valueForKey:@"columnCount"] def:kDashboardViewDefaultColumnCount];
 		launcher = [[LauncherView alloc] initWithFrame:CGRectMake(0, 0, 320, 400) 
                                           withRowCount:rowCount 
                                        withColumnCount:columnCount];

--- a/iphone/Classes/TiUIDashboardView.m
+++ b/iphone/Classes/TiUIDashboardView.m
@@ -32,7 +32,11 @@
 {
 	if (launcher==nil)
 	{
-		launcher = [[LauncherView alloc] initWithFrame:CGRectMake(0, 0, 320, 400)];
+        int rowCount = [TiUtils intValue:[self.proxy valueForKey:@"rowCount"] def:3];
+        int columnCount = [TiUtils intValue:[self.proxy valueForKey:@"columnCount"] def:3];
+		launcher = [[LauncherView alloc] initWithFrame:CGRectMake(0, 0, 320, 400) 
+                                          withRowCount:rowCount 
+                                       withColumnCount:columnCount];
 		launcher.delegate = self;
         [launcher setEditable:[[[self proxy] valueForUndefinedKey:@"editable"] boolValue]];
 		[self addSubview:launcher];


### PR DESCRIPTION
JIRA: [TIMOB-10493 iOS: DashboardView rowCount and columnCount properties](https://jira.appcelerator.org/browse/TIMOB-10493)

Hi! I've had to continue using this code despite my wishes to move away from it, and as such I've added the ability to specify the row count and column count on creation.

I realize this might not be the direction y'all want to go with this. This changes the behavior; previously, if the frame was made small enough, the view would reduce the number of rows. Now, if a reduced number of rows is desired, it must be explicitly specified upon creation.

If you'd rather allow the `rowHeight` to be specified, I can do that too, though I think this makes more sense.

Here is a test case that creates a couple of views with different row/col counts:

``` javascript
Titanium.UI.setBackgroundColor('#000');
var tabGroup = Titanium.UI.createTabGroup();
var win1 = Titanium.UI.createWindow({
    title:'Tab 1',
    backgroundColor:'#fff'
});
var tab1 = Titanium.UI.createTab({
    icon:'KS_nav_views.png',
    title:'Tab 1',
    window:win1
});

var win2 = Titanium.UI.createWindow({
    title:'Tab 2',
    backgroundColor:'#fff'
});
var tab2 = Titanium.UI.createTab({
    icon:'KS_nav_ui.png',
    title:'Tab 2',
    window:win2
});

var win3 = Titanium.UI.createWindow({
    title:'Tab 2',
    backgroundColor:'#fff'
});
var tab3 = Titanium.UI.createTab({
    icon:'KS_nav_ui.png',
    title:'Tab 2',
    window:win3
});

tabGroup.addTab(tab1);
tabGroup.addTab(tab2);
tabGroup.addTab(tab3);
tabGroup.open();

var dash1 = Ti.UI.createDashboardView({
  columnCount: 2,
  rowCount: 2
});

// columnCount and rowCount should default to 3
var dash2 = Ti.UI.createDashboardView();

var dash3 = Ti.UI.createDashboardView({
  columnCount: 4,
  rowCount: 4
});

var items = [[], [], []];

for (var j = 0; j < 3; j++) {
  for (var i = 0; i < 20; i++) {
    var item = Ti.UI.createDashboardItem();
    item.add(Ti.UI.createLabel({
      text: "item numba " + i,
      borderColor: '#'+i+'0'+i+'000',
      borderWidth: 3,
      height: 'fill', width: 'fill'
    }));
    items[j][i] = item;
  }
}

dash1.setData(items[0]);
dash2.setData(items[1]);
dash3.setData(items[2]);

win1.add(dash1);
win2.add(dash2);
win3.add(dash3);
```
