### PR TITLE
[TIMOB-10041]Ensure trackSignificatLocationUpdate is only used on devices that support it.

### DIFF
--- a/iphone/Classes/GeolocationModule.m
+++ b/iphone/Classes/GeolocationModule.m
@@ -347,11 +347,10 @@ extern BOOL const TI_APPLICATION_ANALYTICS;
 		}
 		if (startLocation && trackingLocation==NO)
 		{
-			if (trackSignificantLocationChange && [CLLocationManager significantLocationChangeMonitoringAvailable]) {
+			if (trackSignificantLocationChange) {
                 [lm startMonitoringSignificantLocationChanges];
             }
             else{
-                trackSignificantLocationChange = NO;
                 [lm startUpdatingLocation];
             }
             trackingLocation = YES;

--- a/iphone/Classes/GeolocationModule.m
+++ b/iphone/Classes/GeolocationModule.m
@@ -617,13 +617,7 @@ extern BOOL const TI_APPLICATION_ANALYTICS;
 
 -(NSNumber*)trackSignificantLocationChange
 {
-    if ([CLLocationManager significantLocationChangeMonitoringAvailable]) {
-        return NUMBOOL(trackSignificantLocationChange);
-    }
-    else{
-        DebugLog(@"[WARN] Ti.Geolocation.setTrackSignificantLocationChange is not supported on this device.");
-        return NO;
-    }
+    return NUMBOOL(trackSignificantLocationChange);
 }
 
 -(void)setTrackSignificantLocationChange:(id)value

--- a/iphone/Classes/GeolocationModule.m
+++ b/iphone/Classes/GeolocationModule.m
@@ -621,7 +621,7 @@ extern BOOL const TI_APPLICATION_ANALYTICS;
         return NUMBOOL(trackSignificantLocationChange);
     }
     else{
-        DebugLog(@"[WARN] The Ti.Geolocation.setTrackSignificantLocationChange is supported on this device.");
+        DebugLog(@"[WARN] Ti.Geolocation.setTrackSignificantLocationChange is not supported on this device.");
         return NO;
     }
 }
@@ -647,7 +647,7 @@ extern BOOL const TI_APPLICATION_ANALYTICS;
     }
     else{
         trackSignificantLocationChange = NO;
-        DebugLog(@"[WARN] The Ti.Geolocation.setTrackSignificantLocationChange is supported on this device.");
+        DebugLog(@"[WARN] Ti.Geolocation.setTrackSignificantLocationChange is not supported on this device.");
     }
 }
 


### PR DESCRIPTION
Test Instruction in [JIRA](https://jira.appcelerator.org/browse/TIMOB-10041)

This PR is just to ensure that this property is only on devices that support the feature. 
