### PR TITLE
TIMOB-10306 When starting app on emulator, send intent flags for a normal launcher launch

### DIFF
--- a/support/android/builder.py
+++ b/support/android/builder.py
@@ -1628,7 +1628,8 @@ class Builder(object):
 		output = self.run_adb('shell', 'am', 'start',
 			'-a', 'android.intent.action.MAIN',
 			'-c','android.intent.category.LAUNCHER',
-			'-n', '%s/.%sActivity' % (self.app_id , self.classname))
+			'-n', '%s/.%sActivity' % (self.app_id , self.classname),
+			'-f', '0x10200000')
 		trace("Launch output: %s" % output)
 
 	def wait_for_sdcard(self):


### PR DESCRIPTION
See JIRA: https://jira.appcelerator.org/browse/TIMOB-10306.  **Should be tested on all three desktop platforms: win, osx, linux.**
