### PR TITLE
TIMOB-10553 Lower Analytics' dependency on Platform module.

### DIFF
--- a/iphone/Classes/AnalyticsModule.m
+++ b/iphone/Classes/AnalyticsModule.m
@@ -499,11 +499,16 @@ NSString * const TI_DB_VERSION = @"1";
 	
 	id platform = [self platform];
 	id network = [self network];
+	UIDevice * device = [UIDevice currentDevice];
 	
 	NSString * version = [NSString stringWithCString:TI_VERSION_STR encoding:NSUTF8StringEncoding];
-	NSString * os = [platform valueForKey:@"version"];
-	NSString * username = [platform valueForKey:@"username"];
-	NSString * mmodel = [platform valueForKey:@"model"];
+	NSString * os = [device systemVersion];
+	NSString * username = [device name];
+	NSString * mmodel = nil;
+	//TIMOB 10553: Platform module might not be included.
+	if ([platform isKindOfClass:[TiModule class]]) {
+		mmodel = [platform valueForKey:@"model"];
+	}
 	NSString * nettype = [network valueForKey:@"networkTypeName"];
 	
 	NSDictionary * data = [NSDictionary dictionaryWithObjectsAndKeys:


### PR DESCRIPTION
Test: Build an app that does NOT use platform module for device with analytics on.

Given how this was very hard to reproduce, it might be wiser just to make sure there's no regression?
