### PR TITLE
[TIMOB-10584] Android: WebView click event is not being fired

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
@@ -81,6 +81,8 @@ public class TiUIWebView extends TiUIView
 		@Override
 		public boolean onTouchEvent(MotionEvent ev)
 		{
+
+			
 			boolean handled = false;
 
 			// In Android WebView, all the click events are directly sent to WebKit. As a result, OnClickListener() is
@@ -91,13 +93,10 @@ public class TiUIWebView extends TiUIView
 					handled = proxy.fireEvent(TiC.EVENT_CLICK, dictFromEvent(ev));
 				}
 			}
-
-			if (handled) {
-				return true;
-			}
-
-			// If performClick() can not handle the event, we pass it to WebKit.
-			return super.onTouchEvent(ev);
+			
+			boolean superHandled = super.onTouchEvent(ev);
+			
+			return (superHandled || handled);
 		}
 
 		@SuppressWarnings("deprecation")


### PR DESCRIPTION
In order for all events to be fired here, the onclick event handler and the super method
must both be called -- if not, one blocks the other.   The change here is to always call
both, and to not allow one to block the other.
