### PR TITLE
[TIMOB-8648] Android: android:back listener reacts when using "back" to dismiss keyboard

### DIFF
--- a/android/modules/ui/src/js/window.js
+++ b/android/modules/ui/src/js/window.js
@@ -18,7 +18,7 @@ exports.bootstrapWindow = function(Titanium) {
 	var newActivityRequiredKeys = ["fullscreen", "navBarHidden", "modal", "windowSoftInputMode"];
 	
 	//list of TiBaseWindow event listeners
-	var windowEventListeners = ["open", "close", "focus", "blur"];
+	var windowEventListeners = ["open", "close", "focus", "blur", "androidback"];
 
 	// Backward compatibility for lightweight windows
 	var UI = Titanium.UI;

--- a/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
@@ -106,6 +106,15 @@ public abstract class TiBaseActivity extends Activity
 		}
 	}
 
+	/**
+	 * Returns the window at the top of the stack.
+	 * @return the top window or null if the stack is empty.
+	 */
+	public TiBaseWindowProxy topWindowOnStack()
+	{
+		return (windowStack.isEmpty()) ? null : windowStack.peek();
+	}
+
 	// could use a normal ConfigurationChangedListener but since only orientation changes are
 	// forwarded, create a separate interface in order to limit scope and maintain clarity 
 	public static interface OrientationChangedListener
@@ -521,6 +530,21 @@ public abstract class TiBaseActivity extends Activity
 	}
 
 	@Override
+	public void onBackPressed()
+	{
+		// Prevent default Android behavior for "back" press
+		// if the top window has a listener to handle the event.
+		TiWindowProxy topWindow = topWindowOnStack();
+		if (topWindow != null && topWindow.hasListeners(TiC.EVENT_ANDROID_BACK)) {
+			topWindow.fireEvent(TiC.EVENT_ANDROID_BACK, null);
+
+		} else {
+			// If event is not handled by any listeners allow default behavior.
+			super.onBackPressed();
+		}
+	}
+
+	@Override
 	public boolean dispatchKeyEvent(KeyEvent event) 
 	{
 		boolean handled = false;
@@ -538,13 +562,7 @@ public abstract class TiBaseActivity extends Activity
 
 		switch(event.getKeyCode()) {
 			case KeyEvent.KEYCODE_BACK : {
-				if (window.hasListeners(TiC.EVENT_ANDROID_BACK)) {
-					if (event.getAction() == KeyEvent.ACTION_UP) {
-						window.fireEvent(TiC.EVENT_ANDROID_BACK, null);
-					}
-					handled = true;
-				}
-				// TODO: Deprecate old event
+				// Deprecated and replaced by "androidback" event.
 				if (window.hasListeners("android:back")) {
 					if (event.getAction() == KeyEvent.ACTION_UP) {
 						window.fireEvent("android:back", null);

--- a/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
@@ -532,11 +532,17 @@ public abstract class TiBaseActivity extends Activity
 	@Override
 	public void onBackPressed()
 	{
+		TiViewProxy window;
+		if (this.window != null) {
+			window = this.window;
+		} else {
+			window = this.view;
+		}
+
 		// Prevent default Android behavior for "back" press
 		// if the top window has a listener to handle the event.
-		TiWindowProxy topWindow = topWindowOnStack();
-		if (topWindow != null && topWindow.hasListeners(TiC.EVENT_ANDROID_BACK)) {
-			topWindow.fireEvent(TiC.EVENT_ANDROID_BACK, null);
+		if (window.hasListeners(TiC.EVENT_ANDROID_BACK)) {
+			window.fireEvent(TiC.EVENT_ANDROID_BACK, null);
 
 		} else {
 			// If event is not handled by any listeners allow default behavior.

--- a/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
@@ -532,17 +532,12 @@ public abstract class TiBaseActivity extends Activity
 	@Override
 	public void onBackPressed()
 	{
-		TiViewProxy window;
-		if (this.window != null) {
-			window = this.window;
-		} else {
-			window = this.view;
-		}
+		TiBaseWindowProxy topWindow = topWindowOnStack();
 
 		// Prevent default Android behavior for "back" press
 		// if the top window has a listener to handle the event.
-		if (window.hasListeners(TiC.EVENT_ANDROID_BACK)) {
-			window.fireEvent(TiC.EVENT_ANDROID_BACK, null);
+		if (topWindow.hasListeners(TiC.EVENT_ANDROID_BACK)) {
+			topWindow.fireEvent(TiC.EVENT_ANDROID_BACK, null);
 
 		} else {
 			// If event is not handled by any listeners allow default behavior.

--- a/apidoc/Titanium/UI/Window.yml
+++ b/apidoc/Titanium/UI/Window.yml
@@ -34,7 +34,7 @@ events:
     platforms: [android]
     summary: Fired when the Back button is released.
     description: |
-        This event has been deprecated and renamed androidback (without colon).
+        This event has been deprecated and replaced by androidback (without colon).
         
         Setting a listener disables the default key handling for the Back button.
         To restore default behavior, remove the listener. It is recommended that you only
@@ -104,11 +104,20 @@ events:
 
   - name: androidback
     platforms: [android]
-    summary: Fired when the Back button is released.
+    summary: Fired when the back button is pressed by the user.
     description: |
-        Setting a listener disables the default key handling for the Back button.
-        To restore default behavior, remove the listener. It is recommended that you only
-        have one handler per heavyweight window.
+        This event is fired when the current window's activity detects
+        a back button press by the user to navigate back.
+
+        By default this event would trigger the current activity to be finished
+        and removed from the task stack. Subscribing to this event with a listener
+        will prevent the default behavior. To finish the activity from your listener
+        just call the *close* method of the window.
+
+        This event replaces the android:back event. Some behavior
+        changes way exist such as the event no longer firing when the
+        user dismisses the keyboard with the back button.
+
     since: '2.2.0'
 
   - name: androidcamera


### PR DESCRIPTION
Modify the new "androidback" event to use the Activity.onBackPressed() hook.
This fixes some undesired behaviors such as the event firing when the keyboard is dismissed.

See JIRA ticket for a simple test case to verify the keyboard effect has gone away.

Updated documentation to provide more details on the event.
