### PR TITLE
[TIMOB-10584] Android: WebView click event is not being fired

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
@@ -81,6 +81,8 @@ public class TiUIWebView extends TiUIView
 		@Override
 		public boolean onTouchEvent(MotionEvent ev)
 		{
+
+			
 			boolean handled = false;
 
 			// In Android WebView, all the click events are directly sent to WebKit. As a result, OnClickListener() is
@@ -91,13 +93,10 @@ public class TiUIWebView extends TiUIView
 					handled = proxy.fireEvent(TiC.EVENT_CLICK, dictFromEvent(ev));
 				}
 			}
-
-			if (handled) {
-				return true;
-			}
-
-			// If performClick() can not handle the event, we pass it to WebKit.
-			return super.onTouchEvent(ev);
+			
+			boolean superHandled = super.onTouchEvent(ev);
+			
+			return (superHandled || handled);
 		}
 
 		@SuppressWarnings("deprecation")

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
@@ -81,18 +81,24 @@ public class TiUIWebView extends TiUIView
 		@Override
 		public boolean onTouchEvent(MotionEvent ev)
 		{
-
 			
 			boolean handled = false;
 
 			// In Android WebView, all the click events are directly sent to WebKit. As a result, OnClickListener() is
 			// never called. Therefore, we have to manually call performClick() when a click event is detected.
+			//
+			// In native Android and in the Ti world, it's possible to to have a touchEvent click on a link in a webview and
+			// also to be detected as a click on the webview.  So we cannot let handling of the event one way block
+			// the handling the other way -- it must be passed to both in all cases for everything to work correctly.
+			//
 			if (ev.getAction() == MotionEvent.ACTION_UP) {
 				Rect r = new Rect(0, 0, getWidth(), getHeight());
 				if (r.contains((int) ev.getX(), (int) ev.getY())) {
 					handled = proxy.fireEvent(TiC.EVENT_CLICK, dictFromEvent(ev));
 				}
 			}
+			
+			// Don't return here -- must call super.onTouchEvent()
 			
 			boolean superHandled = super.onTouchEvent(ev);
 			


### PR DESCRIPTION
With this change, the call to super.onTouchEvent() gets made regardless of whether the event needs to cause a click to get fired.  Both things must happen each time this method is called in order for events not to be dropped.
