### PR TITLE
TIMOB-7474 2_1_X: Support selecting what ABI to target when using V8 runtime.

### DIFF
--- a/support/tiapp.py
+++ b/support/tiapp.py
@@ -238,9 +238,12 @@ class TiAppXML(object):
 		def parse_tool_api_level(node):
 			lazy_init('tool-api-level', get_text(node))
 
+		def parse_abi(node):
+			lazy_init('abi', get_text(node))
+
 
 		local_objects = locals()
-		parse_tags = ['services', 'activities', 'manifest', 'tool-api-level']
+		parse_tags = ['services', 'activities', 'manifest', 'tool-api-level', 'abi']
 		for child in node.childNodes:
 			if child.nodeName in parse_tags:
 				local_objects['parse_'+child.nodeName.replace('-', '_')](child)


### PR DESCRIPTION
This is the 2_1_X cherry-pick of #2848.

**Do not merge until 2.1.2 is released and build/titanium_version.py shows 2.1.3.**

See [JIRA](https://jira.appcelerator.org/browse/TIMOB-7474?focusedCommentId=216641&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-216641) for testing notes.
