### PR TITLE
[TIMOB-10750] escape spaces for iPhone Simulator path

### DIFF
--- a/support/iphone/builder.py
+++ b/support/iphone/builder.py
@@ -465,7 +465,7 @@ def copy_tiapp_properties(project_dir):
 def cleanup_app_logfiles(tiapp, log_id, iphone_version):
 	print "[DEBUG] finding old log files"
 	sys.stdout.flush()
-	simulator_dir = os.path.expanduser('~/Library/Application Support/iPhone Simulator/%s' % iphone_version)
+	simulator_dir = os.path.expanduser('~/Library/Application\ Support/iPhone\ Simulator/%s' % iphone_version)
 
 	# No need to clean if the directory doesn't exist
 	if not os.path.exists(simulator_dir):


### PR DESCRIPTION
[TIMOB-10750](https://jira.appcelerator.org/browse/TIMOB-10750)

I was able to reproduce this with anvil iOS  simulator run.
http://developer.appcelerator.com/question/131296/crash-every-2nd-time-i-launch
