### PR TITLE
[TC-1237] iOS: DashboardView: don't recreate items on frame change

### DIFF
--- a/iphone/Classes/LauncherView.h
+++ b/iphone/Classes/LauncherView.h
@@ -71,6 +71,7 @@
 - (void)beginEditing;
 - (void)endEditing;
 - (void)recreateButtons;
+- (void)layoutButtons;
 
 - (LauncherItem*)itemForIndex:(NSInteger)index;
 - (NSArray*)items;

--- a/iphone/Classes/TiUIDashboardView.m
+++ b/iphone/Classes/TiUIDashboardView.m
@@ -52,10 +52,7 @@ static const NSInteger kDashboardViewDefaultColumnCount = 3;
 	if (!CGRectIsEmpty(bounds))
 	{
 		[TiUtils setView:launcher positionRect:bounds];
-		if(launcher.editing == NO)
-		{
-			[launcher recreateButtons];
-		}
+		[launcher layoutButtons];
 	}
     [super frameSizeChanged:frame bounds:bounds];
 }


### PR DESCRIPTION
JIRA: [[TC-1237] iOS: DashboardView: don't recreate items on frame change](https://jira.appcelerator.org/browse/TC-1237)

Formerly, whenever the frame was changed we would recreate every button; this would cause them to be animated from the upper left corner of the parent view. By simply calling `layoutButtons`, we can smoothly animate the buttons to their new calculated position on orientation / frame change.

Test case:

``` javascript
Titanium.UI.setBackgroundColor('#000');
var win1 = Titanium.UI.createWindow({  
    title:'Tab 1',
    backgroundColor:'#fff'
});

var dash1 = Ti.UI.createDashboardView({
  columnCount: 4,
  rowCount: 4
});

var items = [[], [], []];

for (var j = 0; j < 3; j++) {
  for (var i = 0; i < 20; i++) {
    var item = Ti.UI.createDashboardItem();
    item.add(Ti.UI.createLabel({
      text: "item numba " + i,
      borderColor: '#'+i+'0'+i+'000',
      borderWidth: 3,
      left: 0, right: 0,
      height: 50, width: 50
    }));
    items[j][i] = item;
  }
}

dash1.setData(items[0]);

win1.add(dash1);

win1.open();

win1.addEventListener('click', function (event) {
  dash1.stopEditing();
});
```
