### PR TITLE
[TIMOB-10707] iOS: Expose runtime errors to module developers

### DIFF
--- a/iphone/Classes/KrollBridge.m
+++ b/iphone/Classes/KrollBridge.m
@@ -17,12 +17,14 @@
 #import "KrollContext.h"
 #import "TiDebugger.h"
 #import "TiConsole.h"
+#import "TiExceptionHandler.h"
 
 #ifdef KROLL_COVERAGE
 # include "KrollCoverage.h"
 #endif
 
 extern BOOL const TI_APPLICATION_ANALYTICS;
+extern NSString * const TI_APPLICATION_DEPLOYTYPE;
 
 NSString * TitaniumModuleRequireFormat = @"(function(exports){"
 		"var __OXP=exports;var module={'exports':exports};%@;\n"
@@ -367,12 +369,6 @@ CFMutableSetRef	krollBridgeRegistry = nil;
 	return [context evalJSAndWait:code];
 }
 
-- (void)scriptError:(NSString*)message
-{
-    evaluationError = YES;
-	[[TiApp app] showModalError:message];
-}
-
 -(BOOL)evaluationError
 {
     return evaluationError;
@@ -417,15 +413,15 @@ CFMutableSetRef	krollBridgeRegistry = nil;
 	{
 		NSLog(@"[ERROR] Error loading path: %@, %@",path,error);
 		
+		evaluationError = YES;
+		TiScriptError *scriptError = nil;
 		// check for file not found a give a friendlier message
-		if ([error code]==260 && [error domain]==NSCocoaErrorDomain)
-		{
-			[self scriptError:[NSString stringWithFormat:@"Could not find the file %@",[path lastPathComponent]]];
+		if ([error code]==260 && [error domain]==NSCocoaErrorDomain) {
+			scriptError = [[TiScriptError alloc] initWithMessage:[NSString stringWithFormat:@"Could not find the file %@",[path lastPathComponent]] sourceURL:nil lineNo:0];
+		} else {
+			scriptError = [[TiScriptError alloc] initWithMessage:[NSString stringWithFormat:@"Error loading script %@. %@",[path lastPathComponent],[error description]] sourceURL:nil lineNo:0];
 		}
-		else 
-		{
-			[self scriptError:[NSString stringWithFormat:@"Error loading script %@. %@",[path lastPathComponent],[error description]]];
-		}
+		[[TiExceptionHandler defaultExceptionHandler] reportScriptError:scriptError];
 		return;
 	}
 	
@@ -435,17 +431,12 @@ CFMutableSetRef	krollBridgeRegistry = nil;
 	TiStringRef jsURL = TiStringCreateWithUTF8CString(urlCString);
 	
 	// validate script
-	// TODO: we do not need to do this in production app
-	if (!TiCheckScriptSyntax(jsContext,jsCode,jsURL,1,&exception))
-	{
-		id excm = [KrollObject toID:context value:exception];
-		DebugLog(@"[ERROR] Syntax Error = %@",[TiUtils exceptionMessage:excm]);
-		[self scriptError:[TiUtils exceptionMessage:excm]];
+	if (![TI_APPLICATION_DEPLOYTYPE isEqualToString:@"production"]) {
+		TiCheckScriptSyntax(jsContext,jsCode,jsURL,1,&exception);
 	}
 	
 	// only continue if we don't have any exceptions from above
-	if (exception == NULL)
-	{
+	if (exception == NULL) {
         if ([[self host] debugMode]) {
             TiDebuggerBeginScript(context_,urlCString);
         }
@@ -455,16 +446,20 @@ CFMutableSetRef	krollBridgeRegistry = nil;
         if ([[self host] debugMode]) {
             TiDebuggerEndScript(context_);
         }
-
-		if (exception!=NULL)
-		{
-			id excm = [KrollObject toID:context value:exception];
-			DebugLog(@"[ERROR] Script Error = %@.",[TiUtils exceptionMessage:excm]);
-			[self scriptError:[TiUtils exceptionMessage:excm]];
-		}
-        else {
+		if (exception == NULL) {
             evaluationError = NO;
         }
+	}
+	if (exception != NULL) {
+		id excm = [KrollObject toID:context value:exception];
+		TiScriptError *scriptError = nil;
+		if ([excm isKindOfClass:[NSDictionary class]]) {
+			scriptError = [[TiScriptError alloc] initWithDictionary:excm];
+		} else {
+			scriptError = [[TiScriptError alloc] initWithMessage:[excm description] sourceURL:nil lineNo:0];
+		}
+		evaluationError = YES;
+		[[TiExceptionHandler defaultExceptionHandler] reportScriptError:scriptError];
 	}
 	
 	TiStringRelease(jsCode);

--- a/iphone/Classes/TiApp.m
+++ b/iphone/Classes/TiApp.m
@@ -5,7 +5,6 @@
  * Please see the LICENSE included with this distribution for details.
  */
 #include <stdio.h>
-#include <execinfo.h>
 
 #import "TiApp.h"
 #import "Webcolor.h"
@@ -18,6 +17,7 @@
 #import <AVFoundation/AVFoundation.h>
 #import "ApplicationDefaults.h"
 #import <libkern/OSAtomic.h>
+#import "TiExceptionHandler.h"
 
 #ifdef KROLL_COVERAGE
 # import "KrollCoverage.h"
@@ -37,58 +37,6 @@ extern void UIColorFlushCache();
 
 #define SHUTDOWN_TIMEOUT_IN_SEC	3
 #define TIV @"TiVerify"
-
-//
-// thanks to: http://www.restoroot.com/Blog/2008/10/18/crash-reporter-for-iphone-applications/
-//
-void MyUncaughtExceptionHandler(NSException *exception) 
-{
-	static BOOL insideException = NO;
-	
-	// prevent recursive exceptions
-	if (insideException==YES)
-	{
-		exit(1);
-		return;
-	}
-	
-	insideException = YES;
-    NSArray *callStackArray = [exception callStackReturnAddresses];
-    int frameCount = [callStackArray count];
-    void *backtraceFrames[frameCount];
-	
-    for (int i=0; i<frameCount; i++) 
-	{
-        backtraceFrames[i] = (void *)[[callStackArray objectAtIndex:i] unsignedIntegerValue];
-    }
-	
-	char **frameStrings = backtrace_symbols(&backtraceFrames[0], frameCount);
-	
-	NSMutableString *stack = [[NSMutableString alloc] init];
-	
-	[stack appendString:@"[ERROR] The application has crashed with an unhandled exception. Stack trace:\n\n"];
-	
-	if(frameStrings != NULL) 
-	{
-		for(int x = 0; x < frameCount; x++) 
-		{
-			if(frameStrings[x] == NULL) 
-			{ 
-				break; 
-			}
-			[stack appendFormat:@"%s\n",frameStrings[x]];
-		}
-		free(frameStrings);
-	}
-	[stack appendString:@"\n"];
-			 
-	NSLog(@"%@",stack);
-		
-	[stack release];
-	
-	//TODO - attempt to report the exception
-	insideException=NO;
-}
 
 BOOL applicationInMemoryPanic = NO;
 
@@ -279,7 +227,7 @@ TI_INLINE void waitForMemoryPanicCleared();   //WARNING: This must never be run 
 
 - (void)applicationDidFinishLaunching:(UIApplication *)application 
 {
-	NSSetUncaughtExceptionHandler(&MyUncaughtExceptionHandler);
+	[TiExceptionHandler defaultExceptionHandler];
 	[self initController];
 	[self loadUserDefaults];
 	[self boot];
@@ -305,7 +253,7 @@ TI_INLINE void waitForMemoryPanicCleared();   //WARNING: This must never be run 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions_
 {
 	started = [NSDate timeIntervalSinceReferenceDate];
-	NSSetUncaughtExceptionHandler(&MyUncaughtExceptionHandler);
+	[TiExceptionHandler defaultExceptionHandler];
 
 	// nibless window
 	window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];

--- a/iphone/Classes/TiExceptionHandler.h
+++ b/iphone/Classes/TiExceptionHandler.h
@@ -1,0 +1,82 @@
+/**
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2009-2012 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+
+#import <Foundation/Foundation.h>
+
+#pragma mark - TiScriptError
+
+/**
+ * Script Error class
+ */
+@interface TiScriptError : NSObject
+
+/**
+ * Returns source URL where error happenned.
+ */
+@property (nonatomic, readonly) NSString *sourceURL;
+
+/**
+ * Returns line number where error happenned.
+ */
+@property (nonatomic, readonly) NSInteger lineNo;
+
+/**
+ * Returns error related message
+ */
+@property (nonatomic, readonly) NSString *message;
+
+- (id)initWithMessage:(NSString *)message sourceURL:(NSString *)sourceURL lineNo:(NSInteger)lineNo;
+- (id)initWithDictionary:(NSDictionary *)dictionary;
+
+@end
+
+#pragma mark - TiExceptionHandlerDelegate
+
+/**
+ * Exception handler delegate protocol. 
+ */
+@protocol TiExceptionHandlerDelegate <NSObject>
+
+/**
+ * Called when Objective-C exception is thrown.
+ * @param exception An original NSException object
+ * @param stackTrace An array of strings containing stack trace description
+ */
+- (void)handleUncaughtException:(NSException *)exception withStackTrace:(NSArray *)stackTrace;
+- (void)handleScriptError:(TiScriptError *)error;
+
+@end
+
+#pragma mark - TiExceptionHandler
+
+/**
+ * The Exception Handler class. Singleton instance accessed via <defaultExceptionHandler>
+ */
+@interface TiExceptionHandler : NSObject < TiExceptionHandlerDelegate >
+
+/**
+ * Delegate for error/exception handling
+ * @see TiExceptionHandlerDelegate
+ */
+@property (nonatomic, assign) id<TiExceptionHandlerDelegate> delegate;
+
+/**
+ * Presents provided script error to user. Default behavior in development mode.
+ * @param error The script error object/
+ */
+- (void)showScriptError:(TiScriptError *)error;
+
+/**
+ * Returns singleton instance of TiExceptionHandler.
+ * @return singleton instance
+ */
++ (TiExceptionHandler *)defaultExceptionHandler;
+
+- (void)reportScriptError:(TiScriptError *)error;
+
+@end
+

--- a/iphone/Classes/TiExceptionHandler.m
+++ b/iphone/Classes/TiExceptionHandler.m
@@ -1,0 +1,150 @@
+/**
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2009-2012 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+
+#include <execinfo.h>
+#import "TiExceptionHandler.h"
+#import "TiBase.h"
+#import "TiApp.h"
+
+static void TiUncaughtExceptionHandler(NSException *exception);
+
+static NSUncaughtExceptionHandler *prevUncaughtExceptionHandler = NULL;
+
+@implementation TiExceptionHandler
+
+@synthesize delegate = _delegate;
+
++ (TiExceptionHandler *)defaultExceptionHandler
+{
+	static TiExceptionHandler *defaultExceptionHandler;
+	static dispatch_once_t onceToken;
+	dispatch_once(&onceToken, ^{
+		defaultExceptionHandler = [[self alloc] init];
+		defaultExceptionHandler.delegate = defaultExceptionHandler;
+		prevUncaughtExceptionHandler = NSGetUncaughtExceptionHandler();
+		NSSetUncaughtExceptionHandler(&TiUncaughtExceptionHandler);
+	});
+	return defaultExceptionHandler;
+}
+
+- (void)reportException:(NSException *)exception withStackTrace:(NSArray *)stackTrace
+{
+	NSString *message = [NSString stringWithFormat:
+				@"[ERROR] The application has crashed with an uncaught exception '%@'.\nReason:\n%@\nStack trace:\n\n%@\n",
+				exception.name, exception.reason, [stackTrace componentsJoinedByString:@"\n"]];
+	NSLog(@"%@",message);
+	
+	[_delegate handleUncaughtException:exception withStackTrace:stackTrace];
+}
+
+- (void)reportScriptError:(TiScriptError *)scriptError
+{
+	DebugLog(@"[ERROR] Script Error = %@.", scriptError);
+	
+	[_delegate handleScriptError:scriptError];
+}
+
+- (void)showScriptError:(TiScriptError *)error
+{
+	[[TiApp app] showModalError:[error description]];
+}
+
+#pragma mark - TiExceptionHandlerDelegate
+
+- (void)handleUncaughtException:(NSException *)exception withStackTrace:(NSArray *)stackTrace
+{
+}
+
+- (void)handleScriptError:(TiScriptError *)error
+{
+	[self showScriptError:error];
+}
+
+@end
+
+@implementation TiScriptError
+
+@synthesize message = _message;
+@synthesize sourceURL = _sourceURL;
+@synthesize lineNo = _lineNo;
+
+- (id)initWithMessage:(NSString *)message sourceURL:(NSString *)sourceURL lineNo:(NSInteger)lineNo
+{
+    self = [super init];
+    if (self) {
+		_message = [message copy];
+		_sourceURL = [sourceURL copy];
+		_lineNo = lineNo;
+    }
+    return self;
+}
+
+- (id)initWithDictionary:(NSDictionary *)dictionary
+{
+	NSString *message = [[dictionary objectForKey:@"message"] description];
+	NSString *sourceURL = [[dictionary objectForKey:@"sourceURL"] description];
+	NSInteger lineNo = [[dictionary objectForKey:@"line"] integerValue];
+    return [self initWithMessage:message sourceURL:sourceURL lineNo:lineNo];
+}
+
+- (void)dealloc
+{
+	RELEASE_TO_NIL(_message);
+	RELEASE_TO_NIL(_sourceURL);
+    [super dealloc];
+}
+
+- (NSString *)description
+{
+	if (self.sourceURL != nil) {
+		return [NSString stringWithFormat:@"%@ at %@ (line %d)", self.message,[self.sourceURL lastPathComponent], self.lineNo];
+	} else {
+		return [NSString stringWithFormat:@"%@", self.message];
+	}
+}
+
+@end
+
+//
+// thanks to: http://www.restoroot.com/Blog/2008/10/18/crash-reporter-for-iphone-applications/
+//
+static void TiUncaughtExceptionHandler(NSException *exception)
+{
+	static BOOL insideException = NO;
+	
+	// prevent recursive exceptions
+	if (insideException==YES) {
+		exit(1);
+		return;
+	}
+	insideException = YES;
+	
+    NSArray *callStackArray = [exception callStackReturnAddresses];
+    int frameCount = [callStackArray count];
+    void *backtraceFrames[frameCount];
+	
+    for (int i = 0; i < frameCount; ++i) {
+        backtraceFrames[i] = (void *)[[callStackArray objectAtIndex:i] unsignedIntegerValue];
+    }
+	char **frameStrings = backtrace_symbols(&backtraceFrames[0], frameCount);
+	
+	NSMutableArray *stack = [[NSMutableArray alloc] initWithCapacity:frameCount];
+	if (frameStrings != NULL) {
+		for (int i = 0; (i < frameCount) && (frameStrings[i] != NULL); ++i) {
+			[stack addObject:[NSString stringWithCString:frameStrings[i] encoding:NSASCIIStringEncoding]];
+		}
+		free(frameStrings);
+	}
+	
+	[[TiExceptionHandler defaultExceptionHandler] reportException:exception withStackTrace:[stack copy]];
+	[stack release];
+	
+	insideException=NO;
+	if (prevUncaughtExceptionHandler != NULL) {
+		prevUncaughtExceptionHandler(exception);
+	}
+}

--- a/iphone/Classes/TiExceptionHandler.m
+++ b/iphone/Classes/TiExceptionHandler.m
@@ -24,7 +24,6 @@ static NSUncaughtExceptionHandler *prevUncaughtExceptionHandler = NULL;
 	static dispatch_once_t onceToken;
 	dispatch_once(&onceToken, ^{
 		defaultExceptionHandler = [[self alloc] init];
-		defaultExceptionHandler.delegate = defaultExceptionHandler;
 		prevUncaughtExceptionHandler = NSGetUncaughtExceptionHandler();
 		NSSetUncaughtExceptionHandler(&TiUncaughtExceptionHandler);
 	});
@@ -37,15 +36,22 @@ static NSUncaughtExceptionHandler *prevUncaughtExceptionHandler = NULL;
 				@"[ERROR] The application has crashed with an uncaught exception '%@'.\nReason:\n%@\nStack trace:\n\n%@\n",
 				exception.name, exception.reason, [stackTrace componentsJoinedByString:@"\n"]];
 	NSLog(@"%@",message);
-	
-	[_delegate handleUncaughtException:exception withStackTrace:stackTrace];
+	id <TiExceptionHandlerDelegate> currentDelegate = _delegate;
+	if (currentDelegate == nil) {
+		currentDelegate = self;
+	}
+	[currentDelegate handleUncaughtException:exception withStackTrace:stackTrace];
 }
 
 - (void)reportScriptError:(TiScriptError *)scriptError
 {
 	DebugLog(@"[ERROR] Script Error = %@.", scriptError);
 	
-	[_delegate handleScriptError:scriptError];
+	id <TiExceptionHandlerDelegate> currentDelegate = _delegate;
+	if (currentDelegate == nil) {
+		currentDelegate = self;
+	}
+	[currentDelegate handleScriptError:scriptError];
 }
 
 - (void)showScriptError:(TiScriptError *)error

--- a/iphone/Classes/TiUtils.m
+++ b/iphone/Classes/TiUtils.m
@@ -1075,27 +1075,6 @@ If the new path starts with / and the base url is app://..., we have to massage 
 	return align;
 }
 
-+(NSString*)exceptionMessage:(id)arg
-{
-	if ([arg isKindOfClass:[NSDictionary class]])
-	{
-		// check to see if the object past is a JS Error object and if so attempt
-		// to construct a string that is more readable to the developer
-		id message = [arg objectForKey:@"message"];
-		if (message!=nil)
-		{
-			id source = [arg objectForKey:@"sourceURL"];
-			if (source!=nil)
-			{
-				id lineNumber = [arg objectForKey:@"line"];
-				return [NSString stringWithFormat:@"%@ at %@ (line %@)",message,[source lastPathComponent],lineNumber];
-			}
-            return [NSString stringWithFormat:@"%@ (unknown file)", message];
-		}
-	}
-	return arg;
-}
-
 #define RETURN_IF_ORIENTATION_STRING(str,orientation) \
 if ([str isEqualToString:@#orientation]) return (UIDeviceOrientation)orientation;
 

--- a/iphone/iphone/Titanium.xcodeproj/project.pbxproj
+++ b/iphone/iphone/Titanium.xcodeproj/project.pbxproj
@@ -505,6 +505,9 @@
 		4688700815E39A9D008FA326 /* TiUIiPhoneAlertDialogStyleProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 4688700615E39A9D008FA326 /* TiUIiPhoneAlertDialogStyleProxy.m */; };
 		4688700915E39A9D008FA326 /* TiUIiPhoneAlertDialogStyleProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 4688700615E39A9D008FA326 /* TiUIiPhoneAlertDialogStyleProxy.m */; };
 		4D3033A3136239B30034640F /* TiFilesystemFileStreamProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D3033A2136239B30034640F /* TiFilesystemFileStreamProxy.m */; };
+		5081CEF815F8100E00C881D8 /* TiExceptionHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 5081CEF715F8100E00C881D8 /* TiExceptionHandler.m */; };
+		5081CEF915F8100E00C881D8 /* TiExceptionHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 5081CEF715F8100E00C881D8 /* TiExceptionHandler.m */; };
+		5081CEFA15F8100E00C881D8 /* TiExceptionHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 5081CEF715F8100E00C881D8 /* TiExceptionHandler.m */; };
 		844E1F7E14883A3700F5424C /* TiDOMValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = 844E1F7D14883A3700F5424C /* TiDOMValidator.m */; };
 		844E1F7F14883A3700F5424C /* TiDOMValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = 844E1F7D14883A3700F5424C /* TiDOMValidator.m */; };
 		844E1F8014883A3700F5424C /* TiDOMValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = 844E1F7D14883A3700F5424C /* TiDOMValidator.m */; };
@@ -1409,6 +1412,8 @@
 		4D3033A1136239B30034640F /* TiFilesystemFileStreamProxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = TiFilesystemFileStreamProxy.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		4D3033A2136239B30034640F /* TiFilesystemFileStreamProxy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = TiFilesystemFileStreamProxy.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		50115A9315D5DE0500122055 /* ThirdpartyNS.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ThirdpartyNS.h; path = ../Classes/ThirdpartyNS.h; sourceTree = SOURCE_ROOT; };
+		5081CEF615F8100E00C881D8 /* TiExceptionHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TiExceptionHandler.h; sourceTree = "<group>"; };
+		5081CEF715F8100E00C881D8 /* TiExceptionHandler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TiExceptionHandler.m; sourceTree = "<group>"; };
 		844E1F7C14883A3700F5424C /* TiDOMValidator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TiDOMValidator.h; sourceTree = "<group>"; };
 		844E1F7D14883A3700F5424C /* TiDOMValidator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TiDOMValidator.m; sourceTree = "<group>"; };
 		848C2592145F37A200E1B0F1 /* TiDOMCDATANodeProxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TiDOMCDATANodeProxy.h; sourceTree = "<group>"; };
@@ -2045,6 +2050,8 @@
 				DABF3EDB134D2E4300836137 /* TiStreamProxy.m */,
 				DAE541E113577BEC00A65123 /* TiDataStream.h */,
 				DAE541E213577BEC00A65123 /* TiDataStream.m */,
+				5081CEF615F8100E00C881D8 /* TiExceptionHandler.h */,
+				5081CEF715F8100E00C881D8 /* TiExceptionHandler.m */,
 			);
 			name = API;
 			sourceTree = "<group>";
@@ -3446,6 +3453,7 @@
 				2B0B6E0C15951F9400F3170F /* TiUIiOSDocumentViewerProxy.m in Sources */,
 				1D8166DF15A79362007F20A0 /* FBFrictionlessRequestSettings.m in Sources */,
 				4688700715E39A9D008FA326 /* TiUIiPhoneAlertDialogStyleProxy.m in Sources */,
+				5081CEF815F8100E00C881D8 /* TiExceptionHandler.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3728,6 +3736,7 @@
 				2B0B6E0D15951F9400F3170F /* TiUIiOSDocumentViewerProxy.m in Sources */,
 				1D8166E015A79362007F20A0 /* FBFrictionlessRequestSettings.m in Sources */,
 				4688700815E39A9D008FA326 /* TiUIiPhoneAlertDialogStyleProxy.m in Sources */,
+				5081CEF915F8100E00C881D8 /* TiExceptionHandler.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4010,6 +4019,7 @@
 				2B0B6E0E15951F9400F3170F /* TiUIiOSDocumentViewerProxy.m in Sources */,
 				1D8166E115A79362007F20A0 /* FBFrictionlessRequestSettings.m in Sources */,
 				4688700915E39A9D008FA326 /* TiUIiPhoneAlertDialogStyleProxy.m in Sources */,
+				5081CEFA15F8100E00C881D8 /* TiExceptionHandler.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
[TIMOB-10707](https://jira.appcelerator.org/browse/TIMOB-10707)

FT instructions:
Use default KS app with the variations below:
1. add Ti.include("nonexisting.js"); to the top of the app.'s
2. Change win.open(); to win.openX();
3. Add var a = new Array(0x100000000);
4. See test instructions in JIRA comments
5. With Xcode, modify TiWindowProxy.m -(void)windowDidOpen to add [self performSelector:@selector(nonexisting)];

In cases 1-3 a default red screen with error message and line information should appear.
In case 5, see a stack trace in console
