### PR TITLE
added setCurrentPlaybackTime

### DIFF
--- a/iphone/Classes/TiMediaVideoPlayerProxy.m
+++ b/iphone/Classes/TiMediaVideoPlayerProxy.m
@@ -591,6 +591,13 @@ NSArray* moviePlayerKeys = nil;
 	}
 }
 
+-(void)setCurrentPlaybackTime:(id)value
+{
+    if (movie != nil) {
+      movie.currentPlaybackTime=[TiUtils doubleValue:value];   
+    }
+}
+
 -(NSNumber*)endPlaybackTime
 {
 	if (movie != nil) {


### PR DESCRIPTION
This fixes TC-1251 for iOS devices. Verified with iOS 5.1.1 against 2.1.2.GA.
