### PR TITLE
[TIDOC-773] Fixes to remove 'duplicate' warnings from doctools

### DIFF
--- a/apidoc/Titanium/UI/ScrollableView.yml
+++ b/apidoc/Titanium/UI/ScrollableView.yml
@@ -20,7 +20,7 @@ description: |
     the equivalent functionality may be obtained by adding a `ScrollView` to `ScrollableView`. See 
     the "Simple Scrollable View with 2 Zoomable Images" example for a demonstration.
 excludes: { 
-    events: [ 'click', 'longclick', 'pinch', 'scrollEnd', 'swipe', 'touchend', 'touchmove' ]
+    events: [ 'click', 'longclick', 'pinch', 'swipe', 'touchend', 'touchmove' ]
 }
 extends: Titanium.UI.View
 platforms: [android, iphone, ipad, mobileweb]

--- a/apidoc/Titanium/UI/TableView.yml
+++ b/apidoc/Titanium/UI/TableView.yml
@@ -95,7 +95,6 @@ description: |
 extends: Titanium.UI.View
 since: "0.8"
 excludes: {
-    events: [delete],
     properties: [backgroundSelectedColor, backgroundSelectedImage]
 }
 

--- a/apidoc/Titanium/UI/TableViewRow.yml
+++ b/apidoc/Titanium/UI/TableViewRow.yml
@@ -68,7 +68,7 @@ description: |
 extends: Titanium.UI.View
 since: "0.9"
 excludes:
-    events: [dblclick, doubletap, longpress, pinch, singletap, touchend, touchmove, twofingertap]
+    events: [dblclick, doubletap, longpress, pinch, singletap, touchmove, twofingertap]
     methods: [animate]
     properties: []
 


### PR DESCRIPTION
Remove documented events from excludes section. Events are still firing.
