### PR TITLE
(2_1_X)[TIMOB-10854] ios-sim uses default Xcode.app location ignoring location specified by xcode-select

### DIFF
--- a/support/iphone/builder.py
+++ b/support/iphone/builder.py
@@ -1363,7 +1363,7 @@ def main(args):
 					# set the DYLD_FRAMEWORK_PATH environment variable for the following Popen iphonesim command
 					# this allows the XCode developer folder to be arbitrarily named
 					xcodeselectpath = os.popen("/usr/bin/xcode-select -print-path").readline().rstrip('\n')
-					iphoneprivateframeworkspath = xcodeselectpath + '/Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks'
+					iphoneprivateframeworkspath = xcodeselectpath + '/Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks:' + xcodeselectpath + '/../OtherFrameworks'
 					os.putenv('DYLD_FRAMEWORK_PATH', iphoneprivateframeworkspath)
 
 					# launch the simulator


### PR DESCRIPTION
Backport of #2913
