### PR TITLE
[Tc-1247] label backgroundImage always use caps

### DIFF
--- a/iphone/Classes/TiUILabel.h
+++ b/iphone/Classes/TiUILabel.h
@@ -11,10 +11,10 @@
 @interface TiUILabel : TiUIView<LayoutAutosizing> {
 @private
 	UILabel *label;
-    TiUIView* backgroundView;
+    CALayer* bgdLayer;
 	BOOL requiresLayout;
     CGRect padding;
-    BOOL repad;
+    CGRect textPadding;
     UIControlContentVerticalAlignment verticalAlign;
     CGRect initialLabelFrame;
 }

--- a/iphone/Classes/TiUILabel.h
+++ b/iphone/Classes/TiUILabel.h
@@ -11,7 +11,7 @@
 @interface TiUILabel : TiUIView<LayoutAutosizing> {
 @private
 	UILabel *label;
-    UIImageView* backgroundView;
+    TiUIView* backgroundView;
 	BOOL requiresLayout;
     CGRect padding;
     BOOL repad;

--- a/iphone/Classes/TiUILabel.m
+++ b/iphone/Classes/TiUILabel.m
@@ -18,9 +18,7 @@
 -(id)init
 {
     if (self = [super init]) {
-        backgroundView = [[TiUIView alloc] init];
-        backgroundView.userInteractionEnabled = NO;
-        [self insertSubview:backgroundView atIndex:0];
+        bgdLayer = nil;
         padding = CGRectZero;
         initialLabelFrame = CGRectZero;
         verticalAlign = -1;
@@ -31,7 +29,7 @@
 -(void)dealloc
 {
     RELEASE_TO_NIL(label);
-    RELEASE_TO_NIL(backgroundView);
+    RELEASE_TO_NIL(bgdLayer);
     [super dealloc];
 }
 
@@ -117,14 +115,9 @@
         [label setFrame:initialLabelFrame];
     }
 
-    if (repad &&
-        !CGRectIsEmpty(initialLabelFrame))
+    if (bgdLayer != nil && !CGRectIsEmpty(initialLabelFrame))
     {
-        [backgroundView setFrame:CGRectMake(initialLabelFrame.origin.x - padding.origin.x,
-                                            initialLabelFrame.origin.y - padding.origin.y,
-                                            initialLabelFrame.size.width + padding.origin.x + padding.size.width,
-                                            initialLabelFrame.size.height + padding.origin.y + padding.size.height)];
-        repad = NO;
+        [self updateBackgroundImageFrameWithPadding];
     }
 	return;
 }
@@ -140,8 +133,7 @@
 -(void)frameSizeChanged:(CGRect)frame bounds:(CGRect)bounds
 {
 	initialLabelFrame = bounds;
-
-    repad = YES;
+    
     [self padLabel];
 
     [super frameSizeChanged:frame bounds:bounds];
@@ -155,7 +147,7 @@
         label.backgroundColor = [UIColor clearColor];
         label.numberOfLines = 0;
         [self addSubview:label];
-        self.clipsToBounds = YES;
+//        self.clipsToBounds = YES;
 	}
 	return label;
 }
@@ -235,48 +227,55 @@
 
 }
 
+-(CALayer *)backgroundImageLayer
+{
+    if (bgdLayer == nil)
+    {
+        bgdLayer = [[CALayer alloc]init];
+        bgdLayer.frame = self.layer.bounds;
+        [self.layer insertSublayer:bgdLayer atIndex:0];
+    }
+	return bgdLayer;
+}
+-(void) updateBackgroundImageFrameWithPadding
+{
+    CGRect backgroundFrame = CGRectMake(self.bounds.origin.x - padding.origin.x,
+               self.bounds.origin.y - padding.origin.y,
+               self.bounds.size.width + padding.origin.x + padding.size.width,
+                                        self.bounds.size.height + padding.origin.y + padding.size.height);
+    [self backgroundImageLayer].frame = backgroundFrame;
+}
+
 -(void)setBackgroundImage_:(id)url
 {
-    [backgroundView setBackgroundImage_:url];
-    self.backgroundImage = url;
-}
-
--(void)setBackgroundLeftCap_:(id)value
-{
-    [backgroundView setBackgroundLeftCap_:value];
-}
-
--(void)setBackgroundTopCap_:(id)value
-{
-    [backgroundView setBackgroundTopCap_:value];
+    [super setBackgroundImage_:url];
+    //setBackgroundimage puts masksToBounds to FALSE if bgdImage!=nil
+    //but it goes against the meaning of backgroundPadding
+    self.layer.masksToBounds = NO;
 }
 
 -(void)setBackgroundPaddingLeft_:(id)left
 {
     padding.origin.x = [TiUtils floatValue:left];
-    repad = YES;
-    [self padLabel];
+    [self updateBackgroundImageFrameWithPadding];
 }
 
 -(void)setBackgroundPaddingRight_:(id)right
 {
     padding.size.width = [TiUtils floatValue:right];
-    repad = YES;
-    [self padLabel];
+    [self updateBackgroundImageFrameWithPadding];
 }
 
 -(void)setBackgroundPaddingTop_:(id)top
 {
     padding.origin.y = [TiUtils floatValue:top];
-    repad = YES;
-    [self padLabel];
+    [self updateBackgroundImageFrameWithPadding];
 }
 
 -(void)setBackgroundPaddingBottom_:(id)bottom
 {
     padding.size.height = [TiUtils floatValue:bottom];
-    repad = YES;
-    [self padLabel];
+    [self updateBackgroundImageFrameWithPadding];
 }
 
 -(void)setTextAlign_:(id)alignment

--- a/iphone/Classes/TiUILabel.m
+++ b/iphone/Classes/TiUILabel.m
@@ -18,6 +18,9 @@
 -(id)init
 {
     if (self = [super init]) {
+        backgroundView = [[TiUIView alloc] init];
+        backgroundView.userInteractionEnabled = NO;
+        [self insertSubview:backgroundView atIndex:0];
         padding = CGRectZero;
         initialLabelFrame = CGRectZero;
         verticalAlign = -1;
@@ -115,7 +118,6 @@
     }
 
     if (repad &&
-        backgroundView != nil &&
         !CGRectIsEmpty(initialLabelFrame))
     {
         [backgroundView setFrame:CGRectMake(initialLabelFrame.origin.x - padding.origin.x,
@@ -235,31 +237,18 @@
 
 -(void)setBackgroundImage_:(id)url
 {
-    if (url != nil) {
-        UIImage* bgImage = [self loadImage:url];
-        if (backgroundView == nil) {
-            backgroundView = [[UIImageView alloc] initWithImage:bgImage];
-            backgroundView.userInteractionEnabled = NO;
-            [self insertSubview:backgroundView atIndex:0];
-            repad = YES;
-            [self padLabel];
-        }
-        else {
-            backgroundView.image = bgImage;
-            [backgroundView setNeedsDisplay];
-
-            repad = YES;
-            [self padLabel];
-        }
-    }
-    else {
-        if (backgroundView) {
-            [backgroundView removeFromSuperview];
-            RELEASE_TO_NIL(backgroundView);
-        }
-    }
-
+    [backgroundView setBackgroundImage_:url];
     self.backgroundImage = url;
+}
+
+-(void)setBackgroundLeftCap_:(id)value
+{
+    [backgroundView setBackgroundLeftCap_:value];
+}
+
+-(void)setBackgroundTopCap_:(id)value
+{
+    [backgroundView setBackgroundTopCap_:value];
 }
 
 -(void)setBackgroundPaddingLeft_:(id)left

--- a/iphone/Classes/TiUILabel.m
+++ b/iphone/Classes/TiUILabel.m
@@ -249,9 +249,6 @@
 -(void)setBackgroundImage_:(id)url
 {
     [super setBackgroundImage_:url];
-    //setBackgroundimage puts masksToBounds to FALSE if bgdImage!=nil
-    //but it goes against the meaning of backgroundPadding
-    self.layer.masksToBounds = NO;
 }
 
 -(void)setBackgroundPaddingLeft_:(id)left

--- a/iphone/Classes/TiUIView.h
+++ b/iphone/Classes/TiUIView.h
@@ -229,8 +229,6 @@ void ModifyScrollViewForKeyboardHeightAndContentHeightWithResponderRect(UIScroll
 -(void)setVisible_:(id)visible;
 
 -(void)setBackgroundImage_:(id)value;
--(void)setBackgroundLeftCap_:(id)value;
--(void)setBackgroundTopCap_:(id)value;
 
 -(UIView *)gradientWrapperView;
 -(void)checkBounds;

--- a/iphone/Classes/TiUIView.h
+++ b/iphone/Classes/TiUIView.h
@@ -228,6 +228,10 @@ void ModifyScrollViewForKeyboardHeightAndContentHeightWithResponderRect(UIScroll
 
 -(void)setVisible_:(id)visible;
 
+-(void)setBackgroundImage_:(id)value;
+-(void)setBackgroundLeftCap_:(id)value;
+-(void)setBackgroundTopCap_:(id)value;
+
 -(UIView *)gradientWrapperView;
 -(void)checkBounds;
 


### PR DESCRIPTION
[jira ticket](https://jira.appcelerator.org/browse/TC-1247)

This fix uses a layer to render backgroundImage for label instead of an UIImage. It just uses the backgroundImageLayer method of TiUIView

One note about this. in the setBackgroundImage_ of TiUIView there is a 
self.clipsToBounds = bgdImage != nil;

I dont really get it and it kinds of break the backgroundPadding property of label. So in the setBackgroundImage_ of TiUILabel i do
self.layer.masksToBounds = NO;

i need feedback on this.
