### PR TITLE
TIMOB-10397: Android: Ti namespace does not work in webview after reload

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
@@ -46,6 +46,7 @@ public class TiUIWebView extends TiUIView
 	private static final String TAG = "TiUIWebView";
 	private TiWebViewClient client;
 	private boolean changingUrl = false;
+	private boolean injectBindingCode;
 
 	private static Enum<?> enumPluginStateOff;
 	private static Enum<?> enumPluginStateOn;
@@ -282,6 +283,7 @@ public class TiUIWebView extends TiUIView
 		String finalUrl = url;
 		Uri uri = Uri.parse(finalUrl);
 		boolean originalUrlHasScheme = (uri.getScheme() != null);
+		injectBindingCode = false;
 
 		if (!originalUrlHasScheme) {
 			finalUrl = getProxy().resolveUrl(null, finalUrl);
@@ -296,26 +298,9 @@ public class TiUIWebView extends TiUIView
 					fis = tiFile.getInputStream();
 					InputStreamReader reader = new InputStreamReader(fis, "utf-8");
 					BufferedReader breader = new BufferedReader(reader);
-					boolean injected = false;
 					String line = breader.readLine();
 					while (line != null) {
-						if (!injected) {
-							int pos = line.indexOf("<html");
-							if (pos >= 0) {
-								int posEnd = line.indexOf(">", pos);
-								if (posEnd > pos) {
-									out.append(line.substring(pos, posEnd + 1));
-									out.append(TiWebViewBinding.INJECTION_CODE);
-									if ((posEnd + 1) < line.length()) {
-										out.append(line.substring(posEnd + 1));
-									}
-									out.append("\n");
-									injected = true;
-									line = breader.readLine();
-									continue;
-								}
-							}
-						}
+						injectBindingCode = true;
 						out.append(line);
 						out.append("\n");
 						line = breader.readLine();
@@ -421,24 +406,13 @@ public class TiUIWebView extends TiUIView
 			webView.getSettings().setLoadWithOverviewMode(false);
 		}
 
-		if (html.contains(TiWebViewBinding.SCRIPT_INJECTION_ID)) {
-			// Our injection code is in there already, go ahead and show.
-			webView.loadDataWithBaseURL(baseUrl, html, mimeType, "utf-8", baseUrl);
-			return;
-		}
-
 		int tagStart = html.indexOf("<html");
 		int tagEnd = -1;
 		if (tagStart >= 0) {
 			tagEnd = html.indexOf(">", tagStart + 1);
 
 			if (tagEnd > tagStart) {
-				StringBuilder sb = new StringBuilder(html.length() + 2500);
-				sb.append(html.substring(0, tagEnd + 1));
-				sb.append(TiWebViewBinding.INJECTION_CODE);
-				sb.append(html.substring(tagEnd + 1));
-				webView.loadDataWithBaseURL(baseUrl, sb.toString(), mimeType, "utf-8", baseUrl);
-				return;
+				injectBindingCode = true;
 			}
 		}
 
@@ -588,5 +562,10 @@ public class TiUIWebView extends TiUIView
 	public void stopLoading()
 	{
 		getWebView().stopLoading();
+	}
+
+	public boolean shouldInjectBindingCode()
+	{
+		return injectBindingCode;
 	}
 }

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiWebViewBinding.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiWebViewBinding.java
@@ -35,7 +35,6 @@ public class TiWebViewBinding
 	// This is based on binding.min.js. If you have to change anything...
 	// - change binding.js
 	// - minify binding.js to create binding.min.js
-	protected final static String SCRIPT_INJECTION_ID = "__ti_injection";
 	protected final static String INJECTION_CODE;
 
 	// This is based on polling.min.js. If you have to change anything...
@@ -54,7 +53,6 @@ public class TiWebViewBinding
 		}
 
 		StringBuilder allCode = new StringBuilder();
-		allCode.append("\n<script id=\"" + SCRIPT_INJECTION_ID + "\">\n");
 		if (jsonCode == null) {
 			Log.w(TAG, "Unable to read JSON code for injection");
 		} else {
@@ -67,7 +65,6 @@ public class TiWebViewBinding
 			allCode.append("\n");
 			allCode.append(tiCode.toString());
 		}
-		allCode.append("\n</script>\n");
 		jsonCode = null;
 		tiCode = null;
 		INJECTION_CODE = allCode.toString();
@@ -77,14 +74,14 @@ public class TiWebViewBinding
 	private Stack<String> codeSnippets;
 	private boolean destroyed;
 
-	private KrollLogging apiBinding;
+	private ApiBinding apiBinding;
 	private AppBinding appBinding;
 
 	public TiWebViewBinding(WebView webView)
 	{
 		codeSnippets = new Stack<String>();
 
-		apiBinding = KrollLogging.getDefault();
+		apiBinding = new ApiBinding();
 		appBinding = new AppBinding();
 		webView.addJavascriptInterface(appBinding, "TiApp");
 		webView.addJavascriptInterface(apiBinding, "TiAPI");
@@ -254,6 +251,47 @@ public class TiWebViewBinding
 				code = codeSnippets.empty() ? "" : codeSnippets.pop();
 			}
 			return code;
+		}
+	}
+
+	@SuppressWarnings("unused")
+	private class ApiBinding
+	{
+		private KrollLogging logging;
+
+		public ApiBinding()
+		{
+			logging = KrollLogging.getDefault();
+		}
+
+		public void log(String level, String arg)
+		{
+			logging.log(level, arg);
+		}
+
+		public void info(String arg)
+		{
+			logging.info(arg);
+		}
+
+		public void debug(String arg)
+		{
+			logging.debug(arg);
+		}
+
+		public void error(String arg)
+		{
+			logging.error(arg);
+		}
+
+		public void trace(String arg)
+		{
+			logging.trace(arg);
+		}
+
+		public void warn(String arg)
+		{
+			logging.warn(arg);
 		}
 	}
 }

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiWebViewClient.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiWebViewClient.java
@@ -47,6 +47,9 @@ public class TiWebViewClient extends WebViewClient
 		WebView nativeWebView = webView.getWebView();
 
 		if (nativeWebView != null) {
+			if (webView.shouldInjectBindingCode()) {
+				webView.getWebView().loadUrl("javascript:" + TiWebViewBinding.INJECTION_CODE);
+			}
 			webView.getWebView().loadUrl("javascript:" + TiWebViewBinding.POLLING_CODE);
 		}
 	}

--- a/android/runtime/common/src/java/org/appcelerator/kroll/KrollLogging.java
+++ b/android/runtime/common/src/java/org/appcelerator/kroll/KrollLogging.java
@@ -88,11 +88,6 @@ public class KrollLogging
 	{
 		internalLog(FATAL, combineLogMessages(args));
 	}
-	
-	public void log(String... args)
-	{
-		internalLog(INFO, combineLogMessages(args));
-	}
 
 	public void log(String level, String... args)
 	{


### PR DESCRIPTION
https://jira.appcelerator.org/browse/TIMOB-10397

In this PR, I also had to fix another bug where Ti.API.info() was not working at all in webviews.  This was broken as a part of the fix for TIMOB-7624.  I have created a wrapper for our TiAPI bindings in order to deal with this.

The test case is in the Jira ticket.  

@joshthecoder may be a good person to review this since he's familiar with webview issue that I worked on before.
