### PR TITLE
[TIMOB-10684] iOS: Ti.App.getArguments() fails when opening the app from a local notification; post local notification to app on boot

### DIFF
--- a/iphone/Classes/TiApp.h
+++ b/iphone/Classes/TiApp.h
@@ -59,7 +59,7 @@ TI_INLINE void waitForMemoryPanicCleared()   //WARNING: This must never be run o
 	UIBackgroundTaskIdentifier bgTask;
 	NSMutableArray *backgroundServices;
 	NSMutableArray *runningServices;
-	UILocalNotification *localNotification;
+	NSDictionary *localNotification;
 }
 
 /**
@@ -77,6 +77,14 @@ TI_INLINE void waitForMemoryPanicCleared()   //WARNING: This must never be run o
  Dictionary containing details about remote notification, or _nil_.
  */
 @property (nonatomic, readonly) NSDictionary* remoteNotification;
+
+/**
+ Returns local notification that has bees sent on the application.
+ 
+ @return Dictionary containing details about local notification, or _nil_.
+ */
+
+@property (nonatomic, readonly) NSDictionary* localNotification;
 
 /**
  Returns the application's root view controller.
@@ -185,13 +193,6 @@ TI_INLINE void waitForMemoryPanicCleared()   //WARNING: This must never be run o
 -(void)registerBackgroundService:(TiProxy*)proxy;
 -(void)unregisterBackgroundService:(TiProxy*)proxy;
 -(void)stopBackgroundService:(TiProxy*)proxy;
-
-/**
- Returns local notification that has bees sent on the application.
- 
- @return The last local notification
- */
--(UILocalNotification*)localNotification;
 
 @end
 

--- a/iphone/Classes/TiAppiOSProxy.m
+++ b/iphone/Classes/TiAppiOSProxy.m
@@ -13,8 +13,6 @@
 #import "TiAppiOSBackgroundServiceProxy.h"
 #import "TiAppiOSLocalNotificationProxy.h"
 
-#define NOTNULL(v) ((v==nil) ? (id)[NSNull null] : v)
-
 @implementation TiAppiOSProxy
 
 -(void)dealloc
@@ -186,20 +184,8 @@
 
 -(void)didReceiveLocalNotification:(NSNotification*)note
 {
-	UILocalNotification *notification = [note object];
-	NSMutableDictionary* event = [NSMutableDictionary dictionary];
-	if (notification!=nil)
-	{
-		[event setObject:NOTNULL([notification fireDate]) forKey:@"date"];
-		[event setObject:NOTNULL([[notification timeZone] name]) forKey:@"timezone"];
-		[event setObject:NOTNULL([notification alertBody]) forKey:@"alertBody"];
-		[event setObject:NOTNULL([notification alertAction]) forKey:@"alertAction"];
-		[event setObject:NOTNULL([notification alertLaunchImage]) forKey:@"alertLaunchImage"];
-		[event setObject:NOTNULL([notification soundName]) forKey:@"sound"];
-		[event setObject:NUMINT([notification applicationIconBadgeNumber]) forKey:@"badge"];
-		[event setObject:NOTNULL([notification userInfo]) forKey:@"userInfo"];
-	}
-	[self fireEvent:@"notification" withObject:event];
+	NSDictionary *notification = [note object];
+	[self fireEvent:@"notification" withObject:notification];
 }
 
 


### PR DESCRIPTION
[TIMOB-10684](https://jira.appcelerator.org/browse/TIMOB-10684)

Test case in JIRA
