### PR TITLE
[TIMOB-10929] IOS6 button bar not behaving correctly as title control

### DIFF
--- a/iphone/Classes/TiUIButtonBar.m
+++ b/iphone/Classes/TiUIButtonBar.m
@@ -53,13 +53,16 @@
 // AND the width of the proxy is undefined, they want magic!
 -(void)frameSizeChanged:(CGRect)frame_ bounds:(CGRect)bounds_
 {
-	// Treat 'undefined' like 'auto' when we have an available width for ALL control segments
-	if (controlSpecifiedWidth && TiDimensionIsUndefined([(TiViewProxy*)[self proxy] layoutProperties]->width)) {
-		UISegmentedControl* ourControl = [self segmentedControl];
-		CGRect controlBounds = bounds_;
-		controlBounds.size = [ourControl sizeThatFits:CGSizeZero];
-		[ourControl setBounds:controlBounds];
-	}
+    // Treat 'undefined' like 'auto' when we have an available width for ALL control segments
+    UISegmentedControl* ourControl = [self segmentedControl];
+    if (controlSpecifiedWidth && TiDimensionIsUndefined([(TiViewProxy*)[self proxy] layoutProperties]->width)) {
+        CGRect controlBounds = bounds_;
+        controlBounds.size = [ourControl sizeThatFits:CGSizeZero];
+        [ourControl setBounds:controlBounds];
+    }
+    else {
+        [ourControl setFrame:bounds_];
+    }
     [super frameSizeChanged:frame_ bounds:bounds_];
 }
 

--- a/iphone/Classes/TiUIWindowProxy.m
+++ b/iphone/Classes/TiUIWindowProxy.m
@@ -582,12 +582,12 @@
     if ([oldView isKindOfClass:[TiUIView class]]) {
         TiViewProxy * oldProxy = (TiViewProxy *)[(TiUIView *)oldView proxy];
         if (oldProxy == titleControl) {
-            //resize titleControl
+            //relayout titleControl
             CGRect barBounds;
             barBounds.origin = CGPointZero;
             barBounds.size = SizeConstraintViewWithSizeAddingResizing(titleControl.layoutProperties, titleControl, availableTitleSize, NULL);
             
-            [oldView setBounds:barBounds];
+            [TiUtils setView:oldView positionRect:[TiUtils centerRect:barBounds inRect:barFrame]];
             [oldView setAutoresizingMask:UIViewAutoresizingNone];
             
             //layout the titleControl children

--- a/iphone/Classes/TiUIiOSTabbedBarProxy.m
+++ b/iphone/Classes/TiUIiOSTabbedBarProxy.m
@@ -30,5 +30,14 @@ NSArray* tabbedKeySequence;
 USE_VIEW_FOR_CONTENT_WIDTH
 USE_VIEW_FOR_CONTENT_HEIGHT
 
+-(TiDimension)defaultAutoWidthBehavior:(id)unused
+{
+    return TiDimensionAutoSize;
+}
+-(TiDimension)defaultAutoHeightBehavior:(id)unused
+{
+    return TiDimensionAutoSize;
+}
+
 @end
 #endif


### PR DESCRIPTION
Test is in [JIRA](https://jira.appcelerator.org/browse/TIMOB-10929)

Regression tickets
[TIMOB-8613](https://jira.appcelerator.org/browse/TIMOB-8613)
[TIMOB-8968](https://jira.appcelerator.org/browse/TIMOB-8968)

KS->BaseUI->Window NavBar
KS->Controls->Tabbed Bar
KS->Controls->ButtonBar
