### PR TITLE
[TIMOB-10238] Android: Wrong row index when using TableView with Ti.UI.S...

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiBaseTableViewItem.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiBaseTableViewItem.java
@@ -75,7 +75,7 @@ public abstract class TiBaseTableViewItem extends ViewGroup implements Handler.C
 		this(activity);
 	}
 
-	public abstract void setRowData(Item item);
+	public abstract void setRowData(Item item, boolean isLayoutPass);
 	public abstract Item getRowData();
 	
 	public boolean handleMessage(Message msg) {

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiTableView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiTableView.java
@@ -64,6 +64,8 @@ public class TiTableView extends FrameLayout
 	private TableViewProxy proxy;
 	private boolean filterCaseInsensitive = true;
 	private TiTableViewSelector selector;
+	
+	private boolean isLayoutPass = false;
 
 	public interface OnItemClickedListener {
 		public void onClick(KrollDict item);
@@ -210,7 +212,7 @@ public class TiTableView extends FrameLayout
 				v.setLayoutParams(new AbsListView.LayoutParams(
 					AbsListView.LayoutParams.FILL_PARENT, AbsListView.LayoutParams.FILL_PARENT));
 			}
-			v.setRowData(item);
+			v.setRowData(item, isLayoutPass);
 			return v;
 		}
 
@@ -518,9 +520,20 @@ public class TiTableView extends FrameLayout
 		viewModel = null;
 		itemClickListener = null;
 	}
+	
+	@Override
+	protected void onMeasure(int width, int height) {
+		isLayoutPass = false;
+		super.onMeasure(width, height);
+		return;
+	}
+	
 
 	@Override
 	protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
+		
+		isLayoutPass = true;
+		
 		// To prevent undesired "focus" and "blur" events during layout caused
 		// by ListView temporarily taking focus, we will disable focus events until
 		// layout has finished.
@@ -555,4 +568,5 @@ public class TiTableView extends FrameLayout
 			}
 		}
 	}
+	
 }

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiTableViewHeaderItem.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiTableViewHeaderItem.java
@@ -52,7 +52,7 @@ public class TiTableViewHeaderItem extends TiBaseTableViewItem
 			TiUIHelper.setTextViewDIPPadding(textView, 4, 2);
 		}
 
-		public void setRowData(Item item) {
+		public void setRowData(Item item, boolean isLayoutPass) {
 			this.item = item;
 			if (item.headerText != null) {
 				textView.setText(item.headerText, TextView.BufferType.NORMAL);
@@ -89,9 +89,9 @@ public class TiTableViewHeaderItem extends TiBaseTableViewItem
 	{
 		this(activity);
 	}
-	public void setRowData(Item item) {
+	public void setRowData(Item item, boolean isLayoutPass) {
 		if (!isHeaderView) {
-			rowView.setRowData(item);
+			rowView.setRowData(item, isLayoutPass);
 		}
 	}
 

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiTableViewRowProxyItem.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiTableViewRowProxyItem.java
@@ -74,10 +74,14 @@ public class TiTableViewRowProxyItem extends TiBaseTableViewItem
 		return (TableViewRowProxy)item.proxy;
 	}
 
-	public void setRowData(Item item) {
+	public void setRowData(Item item, boolean isLayoutPass) {
 		this.item = item;
 		TableViewRowProxy rp = getRowProxy();
-		rp.setTableViewItem(this);
+		if (isLayoutPass)
+		{
+			// Only make this association during the actual layout pass
+			rp.setTableViewItem(this);
+		}
 		setRowData(rp);
 	}
 


### PR DESCRIPTION
...IZE and specifying row className

The change here is to only associate TiTableViewRowProxyItem's with 
TableViewRowProxy's when the layout pass is done, and not to do it when
any measurement passes are done.

This needs review by Opie Cyrus.
