### PR TITLE
Timob 10355  Fix issue with access properties on 2_0_X branch

### DIFF
--- a/anvil/driver/common.js
+++ b/anvil/driver/common.js
@@ -392,7 +392,7 @@ module.exports = new function() {
 							make sure to only inject if the value doesn't already exist in the 
 							config tiapp.xml so we avoid duplicates
 							*/
-							newTiappXmlContents += "\t<property name=\"" + key + "\">" + self.customTiappXmlProperties[key] + "</property>\n";
+							newTiappXmlContents += "\t<property name=\"" + key + "\" type=\"" + self.customTiappXmlProperties[key].type + "\">" + self.customTiappXmlProperties[key].value + "</property>\n";
 						}
 					}
 				}

--- a/anvil/driver/platforms/android.js
+++ b/anvil/driver/platforms/android.js
@@ -64,7 +64,7 @@ module.exports = new function() {
 		make sure the harness has access to what port number it should listen on for a connection 
 		from the driver
 		*/
-		common.customTiappXmlProperties["driver.socketPort"] = driverGlobal.config.androidSocketPort;
+		common.customTiappXmlProperties["driver.socketPort"] = {value: driverGlobal.config.androidSocketPort, type: "string"};
 
 		// due to python behavior on windows, we need to escape the slashes in the argument string
 		if (os.platform().substr(0 ,3) === "win") {

--- a/anvil/driver/platforms/android.js
+++ b/anvil/driver/platforms/android.js
@@ -64,7 +64,7 @@ module.exports = new function() {
 		make sure the harness has access to what port number it should listen on for a connection 
 		from the driver
 		*/
-		common.customTiappXmlProperties["driver.socketPort"] = {value: driverGlobal.config.androidSocketPort, type: "string"};
+		common.customTiappXmlProperties["driver.socketPort"] = {value: driverGlobal.config.androidSocketPort, type: "int"};
 
 		// due to python behavior on windows, we need to escape the slashes in the argument string
 		if (os.platform().substr(0 ,3) === "win") {

--- a/anvil/driver/platforms/ios.js
+++ b/anvil/driver/platforms/ios.js
@@ -84,7 +84,7 @@ module.exports = new function() {
 		make sure the harness has access to what port number it should listen on for a connection 
 		from the driver
 		*/
-		common.customTiappXmlProperties["driver.socketPort"] = driverGlobal.config.iosSocketPort;
+		common.customTiappXmlProperties["driver.socketPort"] = {value: driverGlobal.config.iosSocketPort, type: "int"};
 
 		common.createHarness(
 			"ios",

--- a/anvil/driver/platforms/mobileweb.js
+++ b/anvil/driver/platforms/mobileweb.js
@@ -135,7 +135,7 @@ module.exports = new function() {
 		};
 
 		// this is the same whether browser only mode is enabled or not
-		common.customTiappXmlProperties["driver.httpPort"] = driverGlobal.config.httpPort;
+		common.customTiappXmlProperties["driver.httpPort"] = {value: driverGlobal.config.httpPort, type: "int"};
 
 		/*
 		check for browser only mode.  When in browser only mode, we are gonna skip invoking the 
@@ -151,7 +151,7 @@ module.exports = new function() {
 			since we are running in browser only mode, the harness should use the loopback address
 			when making requests to the driver
 			*/
-			common.customTiappXmlProperties["driver.httpHost"] = "http://127.0.0.1";
+			common.customTiappXmlProperties["driver.httpHost"] = {value: "http://127.0.0.1", type: "string"};
 
 			// skip the normal logic of launching the browser on device
 			serverCallback = function() {
@@ -182,7 +182,7 @@ module.exports = new function() {
 				make sure that the harness has the correct wifi address to use when making requests to 
 				the driver
 				*/
-				common.customTiappXmlProperties["driver.httpHost"] = driverGlobal.httpHost;
+				common.customTiappXmlProperties["driver.httpHost"] = {value: driverGlobal.httpHost, type: "string"};
 
 			} else {
 				driverUtils.log("unable to get IP address", driverGlobal.logLevels.quiet);

--- a/support/anvil/configSet/configs/default_rhino/tiapp.xml
+++ b/support/anvil/configSet/configs/default_rhino/tiapp.xml
@@ -18,7 +18,7 @@
 	<analytics>false</analytics>
 	<guid></guid>
 	<property name="ti.ui.defaultunit">system</property>
-	<property name="ti.android.threadstacksize" type="int">32768</property>
+	<property name="ti.android.threadstacksize" type="int">49152</property>
 	<iphone>
 		<orientations device="iphone">
 			<orientation>Ti.UI.PORTRAIT</orientation>


### PR DESCRIPTION
https://jira.appcelerator.org/browse/TIMOB-10355

Testing steps are to run TIMOB-10355 version of Anvil against 2_0_X branch.

1)  Checkout 2_0_X branch, build via scons and unpack the sdk within the "dist" directory
2)  Checkout TIMOB-10355 branch, point the Titanium SDK location in the driver config.js(anvil/driver/config.js) to the "dist/mobilesdk/osx" directory
3)  Run Anvil pass against Android, iOS and Mobile Web

PR should not be closed until I have updated the driver machines running in remote mode.  I will note the PR once the driver machines are updated.
