### PR TITLE
[TIMOB-10238] Android: Wrong row index when using TableView with Ti.UI.S...

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiTableViewRowProxyItem.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiTableViewRowProxyItem.java
@@ -77,7 +77,6 @@ public class TiTableViewRowProxyItem extends TiBaseTableViewItem
 	public void setRowData(Item item) {
 		this.item = item;
 		TableViewRowProxy rp = getRowProxy();
-		rp.setTableViewItem(this);
 		setRowData(rp);
 	}
 
@@ -356,6 +355,10 @@ public class TiTableViewRowProxyItem extends TiBaseTableViewItem
 	@Override
 	protected void onLayout(boolean changed, int left, int top, int right, int bottom)
 	{
+		// Make this association here to avoid doing it on measurement passes
+		TableViewRowProxy rp = getRowProxy();
+		rp.setTableViewItem(this);
+		
 		int contentLeft = left;
 		int contentRight = right;
 		bottom = bottom - top;


### PR DESCRIPTION
...IZE and specifying row className

The change ehre is to only associate a TableViewRowProxy with a TiTableViewRowProxyItem when layout is done, but not when measurement is done.

This needs review by Opie Cyrus.
