### PR TITLE
fixes [TIMOB-10998] iOS 6 only - tableView - On a tableview using iOS TableViewStyle.GROUPED, you can't set the tableview background to a color or an image

### DIFF
--- a/iphone/Classes/TiUITableView.m
+++ b/iphone/Classes/TiUITableView.m
@@ -381,7 +381,8 @@
 		tableview.delegate = self;
 		tableview.dataSource = self;
 		tableview.autoresizingMask = UIViewAutoresizingFlexibleWidth|UIViewAutoresizingFlexibleHeight;
-		
+    // WORKAROUND: for Apple iOS6 Bug not setting TableView BackgroundColor
+    tableview.backgroundView = nil;
 		
 		if (TiDimensionIsDip(rowHeight))
 		{


### PR DESCRIPTION
fixes [TIMOB-10998] iOS 6 only - tableView - On a tableview using iOS TableViewStyle.GROUPED, you can't set the tableview background to a color or an image.
