### PR TITLE
timob-10895: Android: Ti.UI.Picker crashes when PickerColumns passed to add() via array

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/PickerProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/PickerProxy.java
@@ -230,17 +230,39 @@ public class PickerProxy extends TiViewProxy implements PickerColumnListener
 	{
 		if (child instanceof PickerColumnProxy) {
 			PickerColumnProxy column = (PickerColumnProxy)child;
-			prepareColumn(column);
-			super.add(column);
-			if (peekView() instanceof TiUIPicker) {
-				((TiUIPicker)peekView()).onColumnAdded(children.indexOf(column));
-			}
+			addColumn(column);
 		} else if (child instanceof PickerRowProxy) {
 			getFirstColumn(true).add((PickerRowProxy)child);
 		} else if (child.getClass().isArray()) {
-			getFirstColumn(true).addRows((Object[])child);
+			Object[] obj = (Object[])child;
+			Object firstObj = obj[0];
+			if (firstObj instanceof PickerRowProxy) {
+				getFirstColumn(true).addRows(obj);
+			} else if (firstObj instanceof PickerColumnProxy) {
+				addColumns(obj);
+			}
 		} else {
 			Log.w(TAG, "Unexpected type not added to picker: " + child.getClass().getName());
+		}
+	}
+
+	private void addColumns(Object[] columns)
+	{
+		for (Object obj :columns) {
+			if (obj instanceof PickerColumnProxy) {
+				addColumn((PickerColumnProxy)obj);
+			} else {
+				Log.w(TAG, "Unexpected type not added to picker: " + obj.getClass().getName());
+			}
+		}
+	}
+
+	private void addColumn(PickerColumnProxy column)
+	{
+		prepareColumn(column);
+		super.add(column);
+		if (peekView() instanceof TiUIPicker) {
+			((TiUIPicker)peekView()).onColumnAdded(children.indexOf(column));
 		}
 	}
 

--- a/apidoc/Titanium/UI/Picker.yml
+++ b/apidoc/Titanium/UI/Picker.yml
@@ -20,7 +20,7 @@ methods:
             A row, set of rows, a column of rows or a set of columns of rows. When this method is 
             used to add a row or set of rows, a single-column picker is created.
         type: [Array<Titanium.UI.PickerRow>, Titanium.UI.PickerRow, Array<Titanium.UI.PickerColumn>, Titanium.UI.PickerColumn]
-    platforms: [iphone, ipad]
+    platforms: [android, iphone, ipad]
 
   - name: getSelectedRow
     summary: Gets the selected row for a column, or `null` if none exists.


### PR DESCRIPTION
https://jira.appcelerator.org/browse/TIMOB-10895
Test case in JIRA.
