### PR TITLE
TIMOB-10003-2_1_X: Android: Ti.UI.SIZE does not work well with nested views

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiCompositeLayout.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiCompositeLayout.java
@@ -283,7 +283,7 @@ public class TiCompositeLayout extends ViewGroup
 		int maxWidth = 0;
 		int maxHeight = 0;
 
-		// Used for horizontal layout with wrap only
+		// Used for horizontal layout only
 		int horizontalRowWidth = 0;
 		int horizontalRowHeight = 0;
 
@@ -312,16 +312,17 @@ public class TiCompositeLayout extends ViewGroup
 						horizontalRowWidth += childWidth;
 						maxWidth = Math.max(maxWidth, horizontalRowWidth);
 					}
-					horizontalRowHeight = Math.max(horizontalRowHeight, childHeight);
 
 				} else {
 					// For horizontal layout without wrap, just keep on adding the widths since it doesn't wrap
 					maxWidth += childWidth;
 				}
+				horizontalRowHeight = Math.max(horizontalRowHeight, childHeight);
+
 			} else {
 				maxWidth = Math.max(maxWidth, childWidth);
 
-				if(isVerticalArrangement()) {
+				if (isVerticalArrangement()) {
 					maxHeight += childHeight;
 				} else {
 					maxHeight = Math.max(maxHeight, childHeight);
@@ -330,7 +331,7 @@ public class TiCompositeLayout extends ViewGroup
 		}
 
 		// Add height for last row in horizontal layout
-		if (isHorizontalArrangement() && enableHorizontalWrap) {
+		if (isHorizontalArrangement()) {
 			maxHeight += horizontalRowHeight;
 		}
 


### PR DESCRIPTION
The original PR to master was https://github.com/appcelerator/titanium_mobile/pull/2663.

The PR for 2_1_X was https://github.com/appcelerator/titanium_mobile/pull/2741, but it left out some of the changes that was in PR for master.

This PR adds back the change that was left out in the 2_1_X PR.

One of the tickets that broke as a result of this was https://jira.appcelerator.org/browse/TIMOB-10858

For testing you will want to use the test case in TIMOB-10858.
