### PR TITLE
[TIMOB-11030] (2_1_X) Warn when using group tableView background as a color

### DIFF
--- a/apidoc/Titanium/UI/iOS/iOS.yml
+++ b/apidoc/Titanium/UI/iOS/iOS.yml
@@ -340,7 +340,7 @@ properties:
         
         This constant has been deprecated in iOS 6. Group style table views still default to using the standard iOS group table 
         view background texture if no background color is specified. However, specifying this constant explicitly on iOS 6 and 
-        above results in a black background color
+        above results in a black background color.
         
         Can be used anywhere a color value is required. See also "Colors" in <Titanium.UI>.
     type: String

--- a/apidoc/Titanium/UI/iOS/iOS.yml
+++ b/apidoc/Titanium/UI/iOS/iOS.yml
@@ -337,8 +337,11 @@ properties:
     summary: Returns the iOS system texture used to render the background on a group table view. 
     description: |
         Corresponds to iOS `UIColor` groupTableViewBackgroundColor`.
-        This constant has been deprecated in iOS6. Group style table view backgrounds can no longer be represented by a simple color.
-        Using this constant on a device running iOS6 or above will set the color to 'black'.
+        
+        This constant has been deprecated in iOS 6. Group style table views still default to using the standard iOS group table 
+        view background texture if no background color is specified. However, specifying this constant explicitly on iOS 6 and 
+        above results in a black background color
+        
         Can be used anywhere a color value is required. See also "Colors" in <Titanium.UI>.
     type: String
     permission: read-only

--- a/apidoc/Titanium/UI/iOS/iOS.yml
+++ b/apidoc/Titanium/UI/iOS/iOS.yml
@@ -337,7 +337,8 @@ properties:
     summary: Returns the iOS system texture used to render the background on a group table view. 
     description: |
         Corresponds to iOS `UIColor` groupTableViewBackgroundColor`.
-
+        This constant has been deprecated in iOS6. Group style table view backgrounds can no longer be represented by a simple color.
+        Using this constant on a device running iOS6 or above will set the color to 'black'.
         Can be used anywhere a color value is required. See also "Colors" in <Titanium.UI>.
     type: String
     permission: read-only

--- a/iphone/Classes/TiColor.m
+++ b/iphone/Classes/TiColor.m
@@ -7,6 +7,8 @@
 
 #import "TiColor.h"
 #import "Webcolor.h"
+#import "TiBase.h"
+#import "TiUtils.h"
 //TODO: Move all of Webcolor into TiColor.
 
 @implementation TiColor
@@ -26,7 +28,10 @@
 			return nil;
 		}
 	}
-
+    if ([TiUtils isIOS6OrGreater] && (translatedColor == [UIColor groupTableViewBackgroundColor])) {
+        DebugLog(@"[WARN]Group style table view backgrounds can no longer be represented by a simple color. Reverting to black");
+        translatedColor = [UIColor blackColor];
+    }
 	result = [[self alloc] initWithColor:translatedColor name:name];
 	return [result autorelease];
 }


### PR DESCRIPTION
Cherry pick PR #3016 into 2_1_X
Associated [ticket](https://jira.appcelerator.org/browse/TIMOB-11030)
