### PR TITLE
[TIMOB-10846]iOS 6, reloading webview after reloading data.

### DIFF
--- a/iphone/Classes/TiUIWebView.m
+++ b/iphone/Classes/TiUIWebView.m
@@ -290,7 +290,10 @@ static NSString * const kTitaniumJavascript = @"Ti.App={};Ti.API={};Ti.App._list
 	if (reloadData != nil)
 	{
 		[self performSelector:reloadMethod withObject:reloadData withObject:reloadDataProperties];
-		return;
+		//[timob-10846] On iOS 6 we have to reload the webview otherwise views seems to be misplaced.
+        if (![TiUtils isIOS6OrGreater]) {
+            return;
+        }
 	}
 	[webview reload];
 }


### PR DESCRIPTION
Turns out in iOS 6 after reloading the data on webview we need explicitly reload the webview otherwise some views might end up misaligned. 

**Testing Instruction**
**should be tested after merging KS PR [35](https://github.com/appcelerator-developer-relations/KitchenSink/pull/35)**
*_Go to (newKS from appcelerator-developer-relation) BaseUI > Views > Web Views> Youtube Video.
*_Hit reload video. 
