### PR TITLE
[TIMOB-11055] Android: WebView event JSON object conversion bug causing crash.

### DIFF
--- a/android/titanium/src/java/org/appcelerator/kroll/KrollDict.java
+++ b/android/titanium/src/java/org/appcelerator/kroll/KrollDict.java
@@ -49,6 +49,7 @@ public class KrollDict
 		try {
 			if (value instanceof JSONObject) {
 				return new KrollDict((JSONObject)value);
+
 			} else if (value instanceof JSONArray) {
 				JSONArray array = (JSONArray)value;
 				Object[] values = new Object[array.length()];
@@ -56,10 +57,15 @@ public class KrollDict
 					values[i] = fromJSON(array.get(i));
 				}
 				return values;
+
+			} else if (value == JSONObject.NULL) {
+				return null;
+
 			}
 		} catch (JSONException e) {
 			Log.e(TAG, "Error parsing JSON", e);
 		}
+
 		return value;
 	}
 

--- a/support/anvil/configSet/Resources/suites/ui/test-fire-event.html
+++ b/support/anvil/configSet/Resources/suites/ui/test-fire-event.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html>
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+        <title>test</title>
+    </head>
+    <body>
+      <script>
+        setTimeout(function() {
+            Ti.App.fireEvent('webViewEvent', {
+                object: {
+                    string: "string",
+                    number: 1,
+                    nullObject: null,
+                    array: [{}, "a", 1, null]
+                }
+            });
+        }, 250);
+      </script>
+    </body>
+</html>

--- a/support/anvil/configSet/Resources/suites/ui/ui.js
+++ b/support/anvil/configSet/Resources/suites/ui/ui.js
@@ -19,6 +19,7 @@ module.exports = new function() {
 		{name: "webviewBindingUnavailable", timeout: 15000},
 		{name: "webviewBindingAvailable", timeout: 10000},
 		{name: "webviewBindingAvailableAfterSetHtml", timeout: 10000},
+		{name: "webviewFireEvent", timeout: 10000},
 		{name: "dotslashWindow"},
 		{name: "absoluteAndRelativeWinURLs", timeout: 10000},
 		{name: "appendRowWithHeader"},
@@ -91,6 +92,33 @@ module.exports = new function() {
 		wv.addEventListener('load', listener);
 		w.add(wv);
 		wv.html = "<html><body>x</body></html>";
+	}
+
+	this.webviewFireEvent = function(testRun) {
+		var w = Ti.UI.createWindow();
+		w.open();
+
+		function onEventFired(e) {
+			valueOf(testRun, e.object).shouldBeObject();
+			valueOf(testRun, e.object.string).shouldBeString();
+			valueOf(testRun, e.object.number).shouldBeNumber();
+			valueOf(testRun, e.object.nullObject).shouldBeNull();
+			valueOf(testRun, e.object.array).shouldBeArray();
+
+			valueOf(testRun, e.object.array.length).shouldBe(4);
+			valueOf(testRun, e.object.array[0]).shouldBeObject();
+			valueOf(testRun, e.object.array[1]).shouldBeString();
+			valueOf(testRun, e.object.array[2]).shouldBeNumber();
+			valueOf(testRun, e.object.array[3]).shouldBeNull();
+
+			Ti.App.removeEventListener('webViewEvent', onEventFired);
+			finish(testRun);
+		}
+
+		Ti.App.addEventListener('webViewEvent', onEventFired);
+
+		var wv = Ti.UI.createWebView({url: 'test-fire-event.html'});
+		w.add(wv);
 	}
 
 	//https://appcelerator.lighthouseapp.com/projects/32238/tickets/2443-android-paths-beginning-with-are-not-recognised


### PR DESCRIPTION
Resolves a crash seen when firing an event that contains an object
having a null value in it. This causes a conversion error which leads to a native crash.

See JIRA ticket for a test case and instructions.
I have also added a new ui test (webviewFireEvent) for automated testing.
Please run Anvil during the functional review.
