### PR TITLE
[TIMOB-11058] (2_1_X) Contacts picker fails to update orientation on device rotate

### DIFF
--- a/iphone/Classes/TiRootViewController.m
+++ b/iphone/Classes/TiRootViewController.m
@@ -13,6 +13,7 @@
 #import "TiTab.h"
 #import "TiApp.h"
 #import <MessageUI/MessageUI.h>
+#import <AddressBookUI/AddressBookUI.h>
 
 @interface TiRootView : UIView
 @end
@@ -326,10 +327,41 @@
     return YES;
 }
 
+-(id)topmostViewController
+{
+    id topmostController = self;
+    id presentedViewController = nil;
+    while ( topmostController != nil && [topmostController respondsToSelector:@selector(presentedViewController)] ) {
+        presentedViewController = [topmostController presentedViewController];
+        if (presentedViewController != nil) {
+            topmostController = presentedViewController;
+            presentedViewController = nil;
+        }
+        else {
+            break;
+        }
+    }
+    return topmostController;
+}
+
 - (NSUInteger)supportedInterfaceOrientations{
     //IOS6. If forcing status bar orientation, this must return 0.
     if (forcingStatusBarOrientation) {
         return 0;
+    }
+    //IOS6. If we are presenting a modal view controller, get the supported
+    //orientations from the modal view controller
+    id topmostController = [self topmostViewController];
+    if (topmostController != self) {
+        //If I am a modal window then send out orientationFlags property
+        if ([topmostController isKindOfClass:[UINavigationController class]]) {
+            UIViewController* topVC = [topmostController topViewController];
+            if ( topVC != nil && ([topVC respondsToSelector:@selector(orientationFlags)]) ) {
+                return [self orientationFlags];
+            }
+        }
+        //Send out whatever the View Controller supports
+        return [topmostController supportedInterfaceOrientations];
     }
     return [self orientationFlags];
 }
@@ -599,7 +631,8 @@
     if(modalvc != nil){
         if ([modalvc isKindOfClass:[UINavigationController class]] && 
             ![modalvc isKindOfClass:[MFMailComposeViewController class]] &&
-            modalFlag == YES ) 
+            ![modalvc isKindOfClass:[ABPeoplePickerNavigationController class]] &&
+            modalFlag == YES )
         {
             //Since this is a window opened from inside a modalviewcontroller we need
             //to let this be oriented by ourselves.

--- a/iphone/Classes/TiRootViewController.m
+++ b/iphone/Classes/TiRootViewController.m
@@ -356,7 +356,7 @@
         //If I am a modal window then send out orientationFlags property
         if ([topmostController isKindOfClass:[UINavigationController class]]) {
             UIViewController* topVC = [topmostController topViewController];
-            if ( topVC != nil && ([topVC respondsToSelector:@selector(orientationFlags)]) ) {
+            if ( topVC != nil && ([topVC isKindOfClass:[TiViewController class]]) ) {
                 return [self orientationFlags];
             }
         }


### PR DESCRIPTION
Cheery Pick PR #3036 into 2_1_X

Fixes [TIMOB-11058](http://jira.appcelerator.org/browse/TIMOB-11058) and [TIMOB-11059](http://jira.appcelerator.org/browse/TIMOB-11059)

Regression test againts [TIMOB-10973](http://jira.appcelerator.org/browse/TIMOB-10973) and [TIMOB-10972](http://jira.appcelerator.org/browse/TIMOB-10972)
