### PR TITLE
[TIDOC-819] Change to verbiage rather than code syntax.

### DIFF
--- a/apidoc/Titanium/UI/AlertDialog.yml
+++ b/apidoc/Titanium/UI/AlertDialog.yml
@@ -122,7 +122,7 @@ properties:
         
         A maximum of 3 buttons is supported on Android.
     type: Array<String>
-    default: null (Android), ['OK'] (iOS)
+    default: No buttons (Android), Single "OK" button (iOS, Mobile Web)
     availability: creation
 
   - name: cancel


### PR DESCRIPTION
Cannot accept square brackets due to translation to JSDuck notation and cannot use an HTML character due to code formatting.
