### PR TITLE
Timob 10712

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiTableView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiTableView.java
@@ -23,6 +23,8 @@ import org.appcelerator.titanium.view.TiUIView;
 
 import ti.modules.titanium.ui.TableViewProxy;
 import ti.modules.titanium.ui.TableViewRowProxy;
+import ti.modules.titanium.ui.widget.TiUILabel;
+import ti.modules.titanium.ui.widget.TiView;
 import ti.modules.titanium.ui.widget.searchbar.TiUISearchBar.OnSearchChangeListener;
 import ti.modules.titanium.ui.widget.tableview.TableViewModel.Item;
 import android.graphics.Color;
@@ -190,10 +192,9 @@ public class TiTableView extends FrameLayout
 			if (v == null) {
 				if (item.className.equals(TableViewProxy.CLASSNAME_HEADERVIEW)) {
 					TiViewProxy vproxy = item.proxy;
-					View headerView = layoutHeaderOrFooter(vproxy);
+					TiUIView headerView = layoutHeaderOrFooter(vproxy);
 					v = new TiTableViewHeaderItem(proxy.getActivity(), headerView);
 					v.setClassName(TableViewProxy.CLASSNAME_HEADERVIEW);
-					return v;
 				} else if (item.className.equals(TableViewProxy.CLASSNAME_HEADER)) {
 					v = new TiTableViewHeaderItem(proxy.getActivity());
 					v.setClassName(TableViewProxy.CLASSNAME_HEADER);
@@ -319,11 +320,11 @@ public class TiTableView extends FrameLayout
 		adapter = new TTVListAdapter(viewModel);
 		if (proxy.hasProperty(TiC.PROPERTY_HEADER_VIEW)) {
 			TiViewProxy view = (TiViewProxy) proxy.getProperty(TiC.PROPERTY_HEADER_VIEW);
-			listView.addHeaderView(layoutHeaderOrFooter(view), null, false);
+			listView.addHeaderView(layoutHeaderOrFooter(view).getNativeView(), null, false);
 		}
 		if (proxy.hasProperty(TiC.PROPERTY_FOOTER_VIEW)) {
 			TiViewProxy view = (TiViewProxy) proxy.getProperty(TiC.PROPERTY_FOOTER_VIEW);
-			listView.addFooterView(layoutHeaderOrFooter(view), null, false);
+			listView.addFooterView(layoutHeaderOrFooter(view).getNativeView(), null, false);
 		}
 
 		listView.setAdapter(adapter);
@@ -429,7 +430,7 @@ public class TiTableView extends FrameLayout
 		}
 	}
 
-	private View layoutHeaderOrFooter(TiViewProxy viewProxy)
+	private TiUIView layoutHeaderOrFooter(TiViewProxy viewProxy)
 	{
 		TiUIView tiView = viewProxy.getOrCreateView();
 		View nativeView = tiView.getNativeView();
@@ -453,7 +454,7 @@ public class TiTableView extends FrameLayout
 		}
 		AbsListView.LayoutParams p = new AbsListView.LayoutParams(width, height);
 		nativeView.setLayoutParams(p);
-		return nativeView;
+		return tiView;
 	}
 
 	public void dataSetChanged() {

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiTableViewHeaderItem.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiTableViewHeaderItem.java
@@ -6,8 +6,11 @@
  */
 package ti.modules.titanium.ui.widget.tableview;
 
+
 import org.appcelerator.titanium.TiContext;
+import org.appcelerator.titanium.proxy.TiViewProxy;
 import org.appcelerator.titanium.util.TiUIHelper;
+import org.appcelerator.titanium.view.TiUIView;
 
 import ti.modules.titanium.ui.widget.tableview.TableViewModel.Item;
 import android.app.Activity;
@@ -15,14 +18,13 @@ import android.content.Context;
 import android.graphics.Color;
 import android.os.Handler;
 import android.view.Gravity;
-import android.view.View;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 
 public class TiTableViewHeaderItem extends TiBaseTableViewItem
 {
 	private RowView rowView;
-	private View headerView;
+	private TiUIView headerView;
 	private boolean isHeaderView = false;
 
 	class RowView extends RelativeLayout
@@ -75,11 +77,11 @@ public class TiTableViewHeaderItem extends TiBaseTableViewItem
 		setMinimumHeight((int)TiUIHelper.getRawDIPSize(18, activity));
 	}
 
-	public TiTableViewHeaderItem(Activity activity, View headerView) {
+	public TiTableViewHeaderItem(Activity activity, TiUIView headerView) {
 		super(activity);
 		
 		this.handler = new Handler(this);
-		this.addView(headerView, headerView.getLayoutParams());
+		this.addView(headerView.getNativeView(), headerView.getLayoutParams());
 		this.setLayoutParams(headerView.getLayoutParams());
 		setMinimumHeight((int)TiUIHelper.getRawDIPSize(18, activity));
 		this.headerView = headerView;
@@ -89,9 +91,24 @@ public class TiTableViewHeaderItem extends TiBaseTableViewItem
 	{
 		this(activity);
 	}
+
 	public void setRowData(Item item) {
 		if (!isHeaderView) {
 			rowView.setRowData(item);
+		}
+		else
+		{
+			setHeaderData(item);
+		}
+	}
+	
+	private void setHeaderData(Item item)
+	{
+		TiUIView labelView = headerView.getChildren().get(0);
+		TiViewProxy labelProxy = item.proxy.getChildren()[0];
+		if (labelView != null && labelProxy != null)
+		{
+			labelView.processProperties(labelProxy.getProperties());
 		}
 	}
 
@@ -113,7 +130,7 @@ public class TiTableViewHeaderItem extends TiBaseTableViewItem
 		if (!isHeaderView) {
 			rowView.layout(left, 0, right, bottom - top);
 		} else {
-			headerView.layout(left, 0, right, bottom - top);
+			headerView.getNativeView().layout(left, 0, right, bottom - top);
 		}
 	}
 }


### PR DESCRIPTION
TIMOB-10712
Android: label 'opacity' property won't change for TableViewRows outside the visible screen on touch event

Factor out view-proxy association code so it only gets called on layout, but not on measurement
passes.
