### PR TITLE
TIMOB-10524 Blackberry: Titanium.UI.Window zIndex property bug

### DIFF
--- a/apidoc/Titanium/UI/Window.yml
+++ b/apidoc/Titanium/UI/Window.yml
@@ -797,6 +797,12 @@ description: |
           exitOnClose: true
         });
 
+    #### BlackBerry
+
+    On BlackBerry the windows always cover the whole screen.  For this reason setting dimensions 
+    on a window is discouraged as it likely won't give the expected result.  Also as a window
+    hides everything underneath it, the zIndex of windows is ignored.  The last opened window is
+    always shown.
 
 examples:
   - title: Full Screen Window example


### PR DESCRIPTION
TIMOB-10961 Blackberry: KS: Window Properties > Layout/Dimension is broken

Updated the Window docs to state that windows on BB are always full screen and can't be ordered using zIndex
