### PR TITLE
[TIMOB-11023] Fix up keyboard focus/blur handling

### DIFF
--- a/iphone/Classes/TiRootViewController.m
+++ b/iphone/Classes/TiRootViewController.m
@@ -1222,7 +1222,7 @@
 	leaveDuration = [[userInfo valueForKey:UIKeyboardAnimationDurationUserInfoKey] floatValue];
 	[self extractKeyboardInfo:userInfo];
 	keyboardVisible = NO;
-    
+
 	if(!updatingAccessoryView)
 	{
 		updatingAccessoryView = YES;
@@ -1251,6 +1251,9 @@
     if ( (updatingAccessoryView == NO) && ([TiUtils boolValue:_keyboardVisible] == keyboardVisible) ) {
         updatingAccessoryView = YES;
         [self performSelector:@selector(handleNewKeyboardStatus) withObject:nil afterDelay:0.0];
+        if (!keyboardVisible) {
+            RELEASE_TO_NIL_AUTORELEASE(keyboardFocusedProxy);
+        }
     }
 }
 
@@ -1299,7 +1302,6 @@
 -(void)didKeyboardBlurOnProxy:(TiViewProxy<TiKeyboardFocusableView> *)blurredProxy;
 {
 	WARN_IF_BACKGROUND_THREAD_OBJ
-    
 	if (blurredProxy != keyboardFocusedProxy)
 	{
 		DeveloperLog(@"[WARN] Blurred for %@<%X>, despite %@<%X> being the focus.",blurredProxy,blurredProxy,keyboardFocusedProxy,keyboardFocusedProxy);
@@ -1318,26 +1320,6 @@
 		return;
 	}
 
-	if(scrolledView != nil)	//If this isn't IN the toolbar, then we update the scrollviews to compensate.
-	{
-		UIView * ourView = [self viewForKeyboardAccessory];
-        CGRect rect = [ourView convertRect:endFrame fromView:nil];
-		CGFloat keyboardHeight = rect.origin.y;
-        if (keyboardHeight > 0) {
-            UIView * possibleScrollView = [scrolledView superview];
-            UIView<TiScrolling> * confirmedScrollView = nil;
-            while (possibleScrollView != nil)
-            {
-                if ([possibleScrollView conformsToProtocol:@protocol(TiScrolling)])
-                {
-                    confirmedScrollView = (UIView<TiScrolling>*)possibleScrollView;
-                }
-                possibleScrollView = [possibleScrollView superview];
-            }
-            [confirmedScrollView keyboardDidShowAtHeight:keyboardHeight];
-        }
-	}
-    RELEASE_TO_NIL_AUTORELEASE(keyboardFocusedProxy);
 	if((doomedView == nil) || (leavingAccessoryView == doomedView)){
 		//Nothing to worry about. No toolbar or it's on its way out.
 		return;
@@ -1364,7 +1346,7 @@
 -(void)didKeyboardFocusOnProxy:(TiViewProxy<TiKeyboardFocusableView> *)visibleProxy;
 {
 	WARN_IF_BACKGROUND_THREAD_OBJ
-    
+
 	if (visibleProxy == keyboardFocusedProxy)
 	{
 		DeveloperLog(@"[WARN] Focused for %@<%X>, despite it already being the focus.",keyboardFocusedProxy,keyboardFocusedProxy);
@@ -1374,6 +1356,7 @@
 	{
 		DeveloperLog(@"[WARN] Focused for %@<%X>, despite %@<%X> already being the focus.",visibleProxy,visibleProxy,keyboardFocusedProxy,keyboardFocusedProxy);
 		[self didKeyboardBlurOnProxy:keyboardFocusedProxy];
+		RELEASE_TO_NIL_AUTORELEASE(keyboardFocusedProxy);
 	}
 	
 	keyboardFocusedProxy = [visibleProxy retain];


### PR DESCRIPTION
Test is in [JIRA](http://jira.appcelerator.org/browse/TIMOB-11023)

regress against 

[TIMOB-1902](http://jira.appcelerator.org/browse/TIMOB-1902)
[TIMOB-8720](http://jira.appcelerator.org/browse/TIMOB-8720)
[TIMOB-10356](http://jira.appcelerator.org/browse/TIMOB-10356)
[TIMOB-7839](http://jira.appcelerator.org/browse/TIMOB-7839)
[TIMOB-5100](http://jira.appcelerator.org/browse/TIMOB-5100)
[TIMOB-7998](http://jira.appcelerator.org/browse/TIMOB-7998)
[TIMOB-8363](http://jira.appcelerator.org/browse/TIMOB-8363)
[TIMOB-8368](http://jira.appcelerator.org/browse/TIMOB-8368)

KS keyboard accessory view animations

Please make sure to test on 4.3 device since the ordering of events is different on 4.X and 5.0 and above which is what caused the issue
