### PR TITLE
TIMOB-11119 Android Tooling: Fail early in module build if python cannot be located.

### DIFF
--- a/support/module/android/build.xml
+++ b/support/module/android/build.xml
@@ -133,6 +133,10 @@ timodule.xml.
 	</path>
 
 	<target name="init">
+		<echo>Testing for Python</echo>
+		<exec failonerror="true" executable="python">
+			<arg line="--version"/>
+		</exec>
 		<mkdir dir="${classes}"/>
 		<mkdir dir="${gen}"/>
 		<mkdir dir="${dist}"/>


### PR DESCRIPTION
Failing at the right time also has the benefit of stderr containing the relevant error message, rather than failing later because something a python script was supposed to do didn't get done.

See [testing notes](http://jira.appcelerator.org/browse/TIMOB-11119?focusedCommentId=221467&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-221467).
