### PR TITLE
fixes for TIMOB-11216 and TIMOB-11217 related to crash handling missing certain scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="http://www.appcelerator.com/wp-content/themes/app/images/ti-logo.png"> Appcelerator Titanium Mobile  
+Appcelerator Titanium Mobile  
 ============================
 
 Welcome to the Appcelerator Titanium Mobile open source project.  Titanium provides

--- a/iphone/Classes/KrollBridge.m
+++ b/iphone/Classes/KrollBridge.m
@@ -456,7 +456,7 @@ CFMutableSetRef	krollBridgeRegistry = nil;
 		if ([excm isKindOfClass:[NSDictionary class]]) {
 			scriptError = [[TiScriptError alloc] initWithDictionary:excm];
 		} else {
-			scriptError = [[TiScriptError alloc] initWithMessage:[excm description] sourceURL:nil lineNo:0];
+			scriptError = [[TiScriptError alloc] initWithMessage:[excm description] sourceURL:path lineNo:0];
 		}
 		evaluationError = YES;
 		[[TiExceptionHandler defaultExceptionHandler] reportScriptError:scriptError];
@@ -732,9 +732,14 @@ CFMutableSetRef	krollBridgeRegistry = nil;
 	
 	if (exception != NULL) {
 		id excm = [KrollObject toID:context value:exception];
-		DebugLog(@"[ERROR] Script Error = %@",[TiUtils exceptionMessage:excm]);
-		fflush(stderr);
-		@throw excm;
+		TiScriptError *scriptError = nil;
+		if ([excm isKindOfClass:[NSDictionary class]]) {
+			scriptError = [[TiScriptError alloc] initWithDictionary:excm];
+		} else {
+			scriptError = [[TiScriptError alloc] initWithMessage:[excm description] sourceURL:[sourceURL absoluteString] lineNo:0];
+		}
+		[[TiExceptionHandler defaultExceptionHandler] reportScriptError:scriptError];
+		return nil;
 	}
 	/*
 	 *	In order to work around the underlying issue of TIMOB-2392, we must

--- a/iphone/Classes/TiExceptionHandler.h
+++ b/iphone/Classes/TiExceptionHandler.h
@@ -57,7 +57,9 @@
  * The Exception Handler class. Singleton instance accessed via <defaultExceptionHandler>
  */
 @interface TiExceptionHandler : NSObject < TiExceptionHandlerDelegate >
-
+{
+    BOOL dismissed;
+}
 /**
  * Delegate for error/exception handling
  * @see TiExceptionHandlerDelegate
@@ -77,6 +79,11 @@
 + (TiExceptionHandler *)defaultExceptionHandler;
 
 - (void)reportScriptError:(TiScriptError *)error;
+
+/**
+ * returns current stack trace as array
+ */
++ (NSArray *)backtrace;
 
 @end
 


### PR DESCRIPTION
This pull request fixes the following related JIRA errors.

http://jira.appcelerator.org/browse/TIMOB-11216 -- fix for areas of code that don't call proper TiExceptionHandler reportScriptError method.

http://jira.appcelerator.org/browse/TIMOB-11217 -- fix for signal crashes (such as SIGABRT).

To test the first, you can create a module that raises an exception.
To test the second, call abort() in a method of a module.

These fixes are necessary to have any reasonable external crash handling.
