### PR TITLE
TIMOB-11119 Android Tooling: Use Studio's python in Windows when building modules from Studio

### DIFF
--- a/support/module/android/build.xml
+++ b/support/module/android/build.xml
@@ -92,6 +92,7 @@ timodule.xml.
 	<property file="${ti.module.root}/build.properties"/>
 	<property name="android.jar" location="${android.platform}/android.jar"/>
 	<property name="ti.module.support.dir" location="${titanium.platform}/../module"/>
+	<property name="titanium.py" location="${titanium.platform}/../titanium.py"/>
 
 	<!-- the manifest format seems to be compatible w/ the properties format -->
 	<property file="${ti.module.root}/manifest" prefix="manifest"/>
@@ -484,22 +485,15 @@ timodule.xml.
 		</delete>
 	</target>
 	
-	<property name="titanium.py" location="${titanium.platform}/../titanium.py"/>
-	<property name="titanium.bat" location="${titanium.platform}/../titanium.bat"/>
 
 	<macrodef name="titanium">
 		<attribute name="command"/>
 		<element name="args" implicit="true" optional="true"/>
 		<sequential>
-			<!-- Python needs to be on the path in OSX / Linux -->
-			<condition property="titanium.exec" value="${titanium.bat}" else="${titanium.py}">
-				<os family="windows"/>
-			</condition>
-			<exec executable="${titanium.exec}" dir="${basedir}">
-				<env key="ANT_HOME" file="${ant.home}"/>
+			<python file="${titanium.py}">
 				<arg value="@{command}"/>
 				<args/>
-			</exec>
+			</python>
 		</sequential>
 	</macrodef>
 
@@ -508,6 +502,7 @@ timodule.xml.
 		<element name="args" implicit="true" optional="true"/>
 		<sequential>
 			<exec executable="${python.exec}" dir="${basedir}">
+				<env key="ANT_HOME" file="${ant.home}"/>
 				<arg value="@{file}"/>
 				<args/>
 			</exec>
@@ -529,7 +524,7 @@ timodule.xml.
 	<target name="pre.docgen">
 	</target>
 
-	<target name="docgen" depends="pre.docgen" description="Generate HTML documentation from Markdown">
+	<target name="docgen" depends="init,pre.docgen" description="Generate HTML documentation from Markdown">
 		<titanium command="docgen"/>
 		<antcall target="post.docgen"/>
 	</target>

--- a/support/module/android/build.xml
+++ b/support/module/android/build.xml
@@ -133,6 +133,10 @@ timodule.xml.
 	</path>
 
 	<target name="init">
+		<echo>Testing for Python</echo>
+		<exec failonerror="true" executable="python">
+			<arg line="--version"/>
+		</exec>
 		<mkdir dir="${classes}"/>
 		<mkdir dir="${gen}"/>
 		<mkdir dir="${dist}"/>

--- a/support/module/android/build.xml
+++ b/support/module/android/build.xml
@@ -132,16 +132,25 @@ timodule.xml.
 		<pathelement path="${google.apis}/libs/maps.jar"/>
 	</path>
 
-	<target name="init">
+	<target name="python.set.exec">
+		<property name="python.bat" location="${titanium.platform}/../python.bat"/>
+		<condition property="python.exec" value="${python.bat}" else="python">
+			<os family="windows"/>
+		</condition>
+	</target>
+
+	<target name="python.check" depends="python.set.exec">
 		<echo>Testing for Python</echo>
-		<exec failonerror="true" executable="python">
+		<exec failonerror="true" executable="${python.exec}">
 			<arg line="--version"/>
 		</exec>
+	</target>
+
+	<target name="init" depends="python.check">
 		<mkdir dir="${classes}"/>
 		<mkdir dir="${gen}"/>
 		<mkdir dir="${dist}"/>
 	</target>
-
 
 	<target name="process.annotations" depends="init"
 		description="Processes @Kroll.proxy and @Kroll.module annotations">
@@ -493,11 +502,6 @@ timodule.xml.
 			</exec>
 		</sequential>
 	</macrodef>
-
-	<property name="python.bat" location="${titanium.platform}/../python.bat"/>
-	<condition property="python.exec" value="${python.bat}" else="python">
-		<os family="windows"/>
-	</condition>
 
 	<macrodef name="python">
 		<attribute name="file"/>

--- a/support/module/android/generated/Android.mk
+++ b/support/module/android/generated/Android.mk
@@ -7,6 +7,14 @@ include $(CLEAR_VARS)
 THIS_DIR = $(LOCAL_PATH)
 LOCAL_MODULE := @MODULE_ID@
 LOCAL_CFLAGS := -g "-I$(TI_MOBILE_SDK)/android/native/include" -I$(SYSROOT)/usr/include
+
+# Several places in generated code we set some jvalues to NULL and
+# since NDK r8b we'd get warnings about each one.
+LOCAL_CFLAGS += -Wno-conversion-null
+
+# cf https://groups.google.com/forum/?fromgroups=#!topic/android-ndk/Q8ajOD37LR0
+LOCAL_CFLAGS += -Wno-psabi
+
 LOCAL_LDLIBS := -L$(SYSROOT)/usr/lib -ldl -llog -L$(TARGET_OUT) "-L$(TI_MOBILE_SDK)/android/native/libs/$(TARGET_ARCH_ABI)" -lkroll-v8
 
 GEN_DIR := $(realpath .)

--- a/support/win32/findpython.bat
+++ b/support/win32/findpython.bat
@@ -45,7 +45,7 @@ if ()==(%pythonPath%) goto NoPython
 goto Exit
 
 :NoPython
-echo Error: No python executable could found in your system
+echo Error: No python executable could be found on your system
 exit /b 1
 
 :Exit


### PR DESCRIPTION
...else give a useful error message if no other python can be found.

See [Testing Notes](http://jira.appcelerator.org/browse/TIMOB-11119?focusedCommentId=221467&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-221467) in JIRA.
