### PR TITLE
[TIMOB-11023] Check focus state before blur and refocus

### DIFF
--- a/iphone/Classes/TiRootViewController.m
+++ b/iphone/Classes/TiRootViewController.m
@@ -451,11 +451,16 @@
     if (forceOrientation || ((newOrientation != oldOrientation) && isCurrentlyVisible))
     {
         TiViewProxy<TiKeyboardFocusableView> *kfvProxy = [keyboardFocusedProxy retain];
-        [kfvProxy blur:nil];
+        BOOL focusAfterBlur = [kfvProxy focused];
+        if (focusAfterBlur) {
+            [kfvProxy blur:nil];
+        }
         forcingStatusBarOrientation = YES;
         [ourApp setStatusBarOrientation:newOrientation animated:(duration > 0.0)];
         forcingStatusBarOrientation = NO;
-        [kfvProxy focus:nil];
+        if (focusAfterBlur) {
+            [kfvProxy focus:nil];
+        }
         [kfvProxy release];
     }
 

--- a/iphone/Classes/TiViewProxy.h
+++ b/iphone/Classes/TiViewProxy.h
@@ -33,6 +33,10 @@
  @param args Unused.
  */
 - (void)blur:(id)args;
+/**
+ Tells if this proxy is currently focused
+ */
+- (BOOL)focused;
 
 #pragma mark Private internal APIs.
 


### PR DESCRIPTION
Fixes regression of TIMOB-7998

Test is in [JIRA](http://jira.appcelerator.org/browse/TIMOB-11023)

regress against 

[TIMOB-1902](http://jira.appcelerator.org/browse/TIMOB-1902)
[TIMOB-8720](http://jira.appcelerator.org/browse/TIMOB-8720)
[TIMOB-10356](http://jira.appcelerator.org/browse/TIMOB-10356)
[TIMOB-7839](http://jira.appcelerator.org/browse/TIMOB-7839)
[TIMOB-5100](http://jira.appcelerator.org/browse/TIMOB-5100)
[TIMOB-7998](http://jira.appcelerator.org/browse/TIMOB-7998)
[TIMOB-8363](http://jira.appcelerator.org/browse/TIMOB-8363)
[TIMOB-8368](http://jira.appcelerator.org/browse/TIMOB-8368)

KS keyboard accessory view animations

Please make sure to test on 4.3 device since the ordering of events is different on 4.X and 5.0 and above which is what caused the issue
