### PR TITLE
[TC-1349] Audio Route Override

### DIFF
--- a/iphone/Classes/MediaModule.h
+++ b/iphone/Classes/MediaModule.h
@@ -137,6 +137,9 @@
 @property(nonatomic,readonly) NSNumber* AUDIO_SESSION_MODE_RECORD;
 @property(nonatomic,readonly) NSNumber* AUDIO_SESSION_MODE_PLAY_AND_RECORD;
 
+@property(nonatomic,readonly) NSNumber* AUDIO_SESSION_OVERRIDE_ROUTE_NONE;
+@property(nonatomic,readonly) NSNumber* AUDIO_SESSION_OVERRIDE_ROUTE_SPEAKER;
+
 @property(nonatomic,readonly) NSNumber* MUSIC_MEDIA_TYPE_MUSIC;
 @property(nonatomic,readonly) NSNumber* MUSIC_MEDIA_TYPE_PODCAST;
 @property(nonatomic,readonly) NSNumber* MUSIC_MEDIA_TYPE_AUDIOBOOK;

--- a/iphone/Classes/MediaModule.m
+++ b/iphone/Classes/MediaModule.m
@@ -606,6 +606,9 @@ MAKE_SYSTEM_UINT(AUDIO_SESSION_MODE_PLAYBACK, kAudioSessionCategory_MediaPlaybac
 MAKE_SYSTEM_UINT(AUDIO_SESSION_MODE_RECORD, kAudioSessionCategory_RecordAudio);
 MAKE_SYSTEM_UINT(AUDIO_SESSION_MODE_PLAY_AND_RECORD, kAudioSessionCategory_PlayAndRecord);
 
+MAKE_SYSTEM_UINT(AUDIO_SESSION_OVERRIDE_ROUTE_NONE, kAudioSessionOverrideAudioRoute_None);
+MAKE_SYSTEM_UINT(AUDIO_SESSION_OVERRIDE_ROUTE_SPEAKER, kAudioSessionOverrideAudioRoute_Speaker);
+
 MAKE_SYSTEM_PROP(MUSIC_MEDIA_TYPE_MUSIC, MPMediaTypeMusic);
 MAKE_SYSTEM_PROP(MUSIC_MEDIA_TYPE_PODCAST, MPMediaTypePodcast);
 MAKE_SYSTEM_PROP(MUSIC_MEDIA_TYPE_AUDIOBOOK, MPMediaTypeAudioBook);
@@ -1280,6 +1283,11 @@ MAKE_SYSTEM_PROP(VIDEO_FINISH_REASON_USER_EXITED,MPMovieFinishReasonUserExited);
 -(void)setAudioSessionMode:(NSNumber*)mode
 {
     [[TiMediaAudioSession sharedSession] setSessionMode:[mode unsignedIntValue]];
+} 
+
+-(void)setOverrideAudioRoute:(NSNumber*)mode
+{
+    [[TiMediaAudioSession sharedSession] setRouteOverride:[mode unsignedIntValue]];
 } 
 
 -(NSNumber*)audioSessionMode

--- a/iphone/Classes/TiMediaAudioSession.m
+++ b/iphone/Classes/TiMediaAudioSession.m
@@ -281,6 +281,14 @@ void TiAudioSessionInputAvailableCallback(void* inUserData, AudioSessionProperty
 	AudioSessionSetProperty(kAudioSessionProperty_AudioCategory, sizeof(mode), &mode);
 }
 
+-(void)setRouteOverride:(UInt32)mode
+{
+	if ([self isActive]) {
+		DebugLog(@"[WARN] Overriding audio route while playing audio... changes will not take effect until audio is restarted.");
+	}
+	AudioSessionSetProperty(kAudioSessionProperty_OverrideAudioRoute, sizeof(mode), &mode);
+}
+
 -(UInt32)sessionMode
 {
 	UInt32 mode;


### PR DESCRIPTION
Added support in iOS for changing audio route with kAudioSessionProperty_OverrideAudioRoute, when using Titanium.Media.AUDIO_SESSION_MODE_PLAY_AND_RECORD.
