### PR TITLE
[TIMOB-11031] Android: Fix open and close events for tab group.

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TabGroupProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TabGroupProxy.java
@@ -340,9 +340,21 @@ public class TabGroupProxy extends TiWindowProxy implements TiActivityWindow
 		opened = false;
 
 		Activity activity = tabGroupActivity.get();
-		if (activity != null) {
+		if (activity != null && !activity.isFinishing()) {
 			activity.finish();
 		}
+	}
+
+	@Override
+	public void closeFromActivity() {
+		// Allow each tab to close its window before the tab group closes.
+		for (TabProxy tab : tabs) {
+			tab.close();
+		}
+
+		// Call super to fire the close event on the tab group.
+		// This event must fire after each tab has been closed.
+		super.closeFromActivity();
 	}
 
 	@Override

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TabProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TabProxy.java
@@ -29,8 +29,9 @@ public class TabProxy extends TiViewProxy
 	@SuppressWarnings("unused")
 	private static final String TAG = "TabProxy";
 
-	private TiWindowProxy win;
 	private TabGroupProxy tabGroupProxy;
+	private TiWindowProxy window;
+	private boolean windowOpened = false;
 	private int windowId;
 
 	public TabProxy()
@@ -86,7 +87,7 @@ public class TabProxy extends TiViewProxy
 	@Kroll.method
 	public void setWindow(TiWindowProxy window)
 	{
-		this.win = window;
+		this.window = window;
 
 		// don't call setProperty cause the property is already set on the JS
 		// object and thus we don't need to cross back over the bridge, we just
@@ -97,22 +98,22 @@ public class TabProxy extends TiViewProxy
 			return;
 		}
 
-		this.win.setTabProxy(this);
+		this.window.setTabProxy(this);
 
 		if (tabGroupProxy != null) {
 			// Set window's tab group if this tab has been added to a group.
-			this.win.setTabGroupProxy(tabGroupProxy);
+			this.window.setTabGroupProxy(tabGroupProxy);
 		}
 
 		//Send out a sync event to indicate window is added to tab
-		this.win.fireSyncEvent(TiC.EVENT_ADDED_TO_TAB, null);
+		this.window.fireSyncEvent(TiC.EVENT_ADDED_TO_TAB, null);
 		// TODO: Deprecate old event
-		this.win.fireSyncEvent("addedToTab", null);
+		this.window.fireSyncEvent("addedToTab", null);
 	}
 
 	public TiWindowProxy getWindow()
 	{
-		return this.win;
+		return this.window;
 	}
 
 	@Kroll.method @Kroll.getProperty
@@ -126,11 +127,11 @@ public class TabProxy extends TiViewProxy
 		setParent(tabGroupProxy);
 		this.tabGroupProxy = tabGroupProxy;
 
-		if (win != null) {
+		if (window != null) {
 			// If a window was set before the tab
 			// was added to a group we need to initialize
 			// the window's tab group reference.
-			win.setTabGroupProxy(tabGroupProxy);
+			window.setTabGroupProxy(tabGroupProxy);
 		}
 	}
 
@@ -148,10 +149,10 @@ public class TabProxy extends TiViewProxy
 	public void releaseViews()
 	{
 		super.releaseViews();
-		if (win != null) {
-			win.setTabProxy(null);
-			win.setTabGroupProxy(null);
-			win.releaseViews();
+		if (window != null) {
+			window.setTabProxy(null);
+			window.setTabGroupProxy(null);
+			window.releaseViews();
 		}
 	}
 
@@ -195,12 +196,25 @@ public class TabProxy extends TiViewProxy
 
 	void onFocusChanged(boolean focused, KrollDict eventData)
 	{
+		// Windows are lazily opened when the tab is first focused.
+		if (window != null && !windowOpened) {
+			windowOpened = true;
+			window.fireEvent(TiC.EVENT_OPEN, null, false);
+		}
+
 		// The focus and blur events for tab changes propagate like so:
 		//    window -> tab -> tab group
 		//
 		// The window is optional and will be skipped if it does not exist.
-		TiViewProxy eventEmitter = (win != null) ? win : this;
+		TiViewProxy eventEmitter = (window != null) ? window : this;
 		eventEmitter.fireEvent((focused) ? TiC.EVENT_FOCUS : TiC.EVENT_BLUR, eventData, true);
+	}
+
+	void close() {
+		if (windowOpened && window != null) {
+			windowOpened = false;
+			window.fireSyncEvent(TiC.EVENT_CLOSE, null);
+		}
 	}
 
 	void onSelectionChanged(boolean selected)

--- a/android/modules/ui/src/js/window.js
+++ b/android/modules/ui/src/js/window.js
@@ -271,16 +271,17 @@ exports.bootstrapWindow = function(Titanium) {
 		this.addChildren();
 
 		var self = this;
-		this.window.on("open", function () {
-			self.postOpen();
-			self.fireEvent("open");
+		this.on("open", function () {
+			self.postOpen(true);
 		});
 	}
 
-	Window.prototype.postOpen = function() {
+	Window.prototype.postOpen = function(isTab) {
 		// Set view and model listener after the window opens
 		this.setWindowView(this.view);
-		this.addSelfToStack();
+		if (!isTab) {
+			this.addSelfToStack();
+		}
 
 		if ("url" in this._properties) {
 			this.loadUrl();

--- a/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
@@ -1149,14 +1149,7 @@ public abstract class TiBaseActivity extends Activity
 	{
 		super.finish();
 
-		if (window != null) {
-			KrollDict data = new KrollDict();
-			data.put(TiC.EVENT_PROPERTY_SOURCE, window);
-			window.fireSyncEvent(TiC.EVENT_CLOSE, data);
-		}
-
 		boolean animate = getIntentBoolean(TiC.PROPERTY_ANIMATE, true);
-
 		
 		if (shouldFinishRootActivity()) {
 			TiApplication app = getTiApp();

--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/TiWindowProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/TiWindowProxy.java
@@ -180,9 +180,12 @@ public abstract class TiWindowProxy extends TiViewProxy
 		releaseViews();
 		opened = false;
 
-		// TODO ?
+		// Causes some clean up in our window.js.
 		fireEvent("closeFromActivity", null);
 		activity = null;
+
+		// Once the window's activity is destroyed we will fire the close event.
+		fireSyncEvent(TiC.EVENT_CLOSE, null);
 	}
 
 	@Kroll.method(name="setTab")


### PR DESCRIPTION
This resolves regressions with "open" and "close" events not properly firing.
The side effect of this bug is any UI event listeners (ex: click) also not firing.
