### PR TITLE
Timob 9285 2 0 x- Android: new "finishfalseroot" property backport to 2.0.X

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
@@ -727,6 +727,9 @@ public abstract class TiBaseActivity extends Activity
 	protected void onResume()
 	{
 		super.onResume();
+		if (isFinishing()) {
+			return;
+		}
 
 		if (DBG) {
 			Log.d(TAG, "Activity " + this + " onResume");
@@ -770,6 +773,9 @@ public abstract class TiBaseActivity extends Activity
 	protected void onStart()
 	{
 		super.onStart();
+		if (isFinishing()) {
+			return;
+		}
 
 		if (DBG) {
 			Log.d(TAG, "Activity " + this + " onStart");

--- a/android/titanium/src/java/org/appcelerator/titanium/TiLaunchActivity.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiLaunchActivity.java
@@ -217,11 +217,16 @@ public abstract class TiLaunchActivity extends TiBaseActivity
 				// FLAG_ACTIVITY_RESET_TASK_IF_NEEDED from the flags, which still causes the problem.
 				// 0x4 is the flag that occurs when we restart because of the missing category/flag, so
 				// that one is okay as well.
+				// (addendum re timob-9285) Launching from history (FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY)
+				// also appears to be okay, so if that flag is there then don't consider this an invalid
+				// launch.
 				if (Build.VERSION.SDK_INT >= TiC.API_LEVEL_HONEYCOMB && intent.getFlags() != 0x4) {
-					int desiredFlags = Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED;
-					if ((intent.getFlags() & desiredFlags) != desiredFlags) {
-						invalidLaunchDetected = true;
-					}
+					int flags = intent.getFlags();
+					invalidLaunchDetected = (
+						((flags & Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED) != Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED)
+						&&
+						((flags & Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY) != Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY)
+						);
 				}
 			}
 

--- a/android/titanium/src/java/org/appcelerator/titanium/TiLaunchActivity.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiLaunchActivity.java
@@ -459,6 +459,23 @@ public abstract class TiLaunchActivity extends TiBaseActivity
 			return finishing2373;
 		}
 
+		Intent intent = getIntent();
+		if (intent == null) {
+			// We need it. No other checks to make.
+			return finishing2373;
+		}
+
+		String action = intent.getAction();
+		if (action == null || !action.equals(Intent.ACTION_MAIN)) {
+			// No ACTION_MAIN, which means this activity wasn't started
+			// as a launch activity anyway, so there is no reason to shut
+			// it down.  For example, it could be that the app developer
+			// has designated (using intent filters) that this activity
+			// can be used for more things beyond being the launch activity,
+			// and we should allow that.
+			return finishing2373;
+		}
+
 		TiApplication tiApp = TiApplication.getInstance();
 		TiProperties systemProperties = null;
 
@@ -471,7 +488,7 @@ public abstract class TiLaunchActivity extends TiBaseActivity
 			finishing2373 = true;
 		} else if (Build.MODEL.toLowerCase().contains(KINDLE_MODEL)
 				&& creationCounter.getAndIncrement() > 0
-				&& getIntent().getFlags() == KINDLE_FIRE_RESTART_FLAGS) {
+				&& intent.getFlags() == KINDLE_FIRE_RESTART_FLAGS) {
 			finishing2373 = true;
 		}
 

--- a/android/titanium/src/java/org/appcelerator/titanium/TiLaunchActivity.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiLaunchActivity.java
@@ -58,7 +58,12 @@ public abstract class TiLaunchActivity extends TiBaseActivity
 	private PendingIntent restartPendingIntent = null;
 	private AlarmManager restartAlarmManager = null;
 	private int restartDelay = 0;
-	protected boolean invalidKindleFireRelaunch = false;
+	// finishing2373 is a flag indicating we've elected
+	// to finish this instance of the activity because
+	// it's not the task root (i.e., it has come to life
+	// via android bug 2373, while there is another instance
+	// of this same activity "behind it".)
+	protected boolean finishing2373 = false;
 
 	/**
 	 * @return The Javascript URL that this Activity should run
@@ -110,29 +115,44 @@ public abstract class TiLaunchActivity extends TiBaseActivity
 	// activity is coming into existence, so that we can kill it off (finish()) right away.
 	protected boolean checkInvalidKindleFireRelaunch(Bundle savedInstanceState)
 	{
-		invalidKindleFireRelaunch = false;
+		finishing2373 = false;
 		int count = creationCounter.getAndIncrement();
 		if (count > 0 && getIntent().getFlags() == KINDLE_FIRE_RESTART_FLAGS
 			&& Build.MODEL.toLowerCase().contains(KINDLE_MODEL) && !isTaskRoot()) {
-			invalidKindleFireRelaunch = true;
+			finishing2373 = true;
 		}
 
-		if (invalidKindleFireRelaunch) {
+		if (finishing2373) {
 			activityOnCreate(savedInstanceState);
 			finish();
 		}
 
-		return invalidKindleFireRelaunch;
+		return finishing2373;
 	}
 
 	@Override
 	protected void onCreate(Bundle savedInstanceState)
 	{
-		if (invalidKindleFireRelaunch || checkInvalidKindleFireRelaunch(savedInstanceState)) {
-			return;
+		TiApplication tiApp = getTiApp();
+
+		// If not the task root, then this "launch" activity instance is
+		// likely a manifestation of Android bug 2373, and we give
+		// developers an option to simply finish it off right away so that
+		// the running activity stack remains unchanged. We do something similar
+		// below for Kindle Fire, but in that case we do it no matter what if
+		// we detect the condition.
+		if (!isTaskRoot()) {
+			if (tiApp.getSystemProperties().getBool("ti.android.bug2373.finishfalseroot", false)) {
+				finishing2373 = true;
+				activityOnCreate(savedInstanceState);
+				finish();
+				return;
+			}
 		}
 
-		TiApplication tiApp = getTiApp();
+		if (finishing2373 || checkInvalidKindleFireRelaunch(savedInstanceState)) {
+			return;
+		}
 
 		if (!tiApp.isRestartPending()) {
 			// Check for a system application restart that we can't support.
@@ -175,7 +195,8 @@ public abstract class TiLaunchActivity extends TiBaseActivity
 		Intent intent = getIntent();
 		if (intent != null) {
 			TiProperties systemProperties = getTiApp().getSystemProperties();
-			boolean detectionDisabled = systemProperties.getBool("ti.android.bug2373.disableDetection", false);
+			boolean detectionDisabled = systemProperties.getBool("ti.android.bug2373.disableDetection", false) ||
+					systemProperties.getBool("ti.android.bug2373.finishfalseroot", false);
 			if (!detectionDisabled) {
 				return checkInvalidLaunch(intent, savedInstanceState);
 			}
@@ -307,7 +328,7 @@ public abstract class TiLaunchActivity extends TiBaseActivity
 	@Override
 	protected void onRestart()
 	{
-		if (invalidKindleFireRelaunch) {
+		if (finishing2373) {
 			activityOnRestart();
 			return;
 		}
@@ -331,7 +352,7 @@ public abstract class TiLaunchActivity extends TiBaseActivity
 	@Override
 	protected void onPause()
 	{
-		if (invalidKindleFireRelaunch) {
+		if (finishing2373) {
 			activityOnPause();
 			return;
 		}
@@ -357,7 +378,7 @@ public abstract class TiLaunchActivity extends TiBaseActivity
 			return;
 		}
 
-		if (invalidLaunchDetected || invalidKindleFireRelaunch) {
+		if (invalidLaunchDetected || finishing2373) {
 			activityOnStop();
 			return;
 		}
@@ -372,7 +393,7 @@ public abstract class TiLaunchActivity extends TiBaseActivity
 			return;
 		}
 
-		if (invalidLaunchDetected || invalidKindleFireRelaunch) {
+		if (invalidLaunchDetected || finishing2373) {
 			activityOnStart();
 			return;
 		}
@@ -382,11 +403,11 @@ public abstract class TiLaunchActivity extends TiBaseActivity
 	@Override
 	protected void onResume()
 	{
-		if (invalidKindleFireRelaunch) {
+		if (finishing2373) {
 			activityOnResume();
 			return;
 		}
-		if (getTiApp().isRestartPending()) {
+		if (getTiApp().isRestartPending() || isFinishing()) {
 			super.onResume();
 			return;
 		}
@@ -403,7 +424,7 @@ public abstract class TiLaunchActivity extends TiBaseActivity
 	@Override
 	protected void onDestroy()
 	{
-		if (invalidKindleFireRelaunch) {
+		if (finishing2373) {
 			activityOnDestroy();
 			return;
 		}

--- a/android/titanium/src/java/org/appcelerator/titanium/TiLaunchActivity.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiLaunchActivity.java
@@ -58,6 +58,7 @@ public abstract class TiLaunchActivity extends TiBaseActivity
 	private PendingIntent restartPendingIntent = null;
 	private AlarmManager restartAlarmManager = null;
 	private int restartDelay = 0;
+
 	// finishing2373 is a flag indicating we've elected
 	// to finish this instance of the activity because
 	// it's not the task root (i.e., it has come to life
@@ -108,51 +109,14 @@ public abstract class TiLaunchActivity extends TiBaseActivity
 		}
 	}
 
-	// For kindle fire, we want to prevent subsequent instances of the activity from launching if it's following the
-	// restart workaround for android 2373. For whatever reason, the Fire always tries to re-launch the launch activity
-	// (i.e., a new instance of it) whenever the user selects the application from the application drawer (or shelf, whatever
-	// it is) after the app has been restarted because of 2373 detection. We detect here when that new instance of the launch
-	// activity is coming into existence, so that we can kill it off (finish()) right away.
-	protected boolean checkInvalidKindleFireRelaunch(Bundle savedInstanceState)
-	{
-		finishing2373 = false;
-		int count = creationCounter.getAndIncrement();
-		if (count > 0 && getIntent().getFlags() == KINDLE_FIRE_RESTART_FLAGS
-			&& Build.MODEL.toLowerCase().contains(KINDLE_MODEL) && !isTaskRoot()) {
-			finishing2373 = true;
-		}
-
-		if (finishing2373) {
-			activityOnCreate(savedInstanceState);
-			finish();
-		}
-
-		return finishing2373;
-	}
-
 	@Override
 	protected void onCreate(Bundle savedInstanceState)
 	{
-		TiApplication tiApp = getTiApp();
-
-		// If not the task root, then this "launch" activity instance is
-		// likely a manifestation of Android bug 2373, and we give
-		// developers an option to simply finish it off right away so that
-		// the running activity stack remains unchanged. We do something similar
-		// below for Kindle Fire, but in that case we do it no matter what if
-		// we detect the condition.
-		if (!isTaskRoot()) {
-			if (tiApp.getSystemProperties().getBool("ti.android.bug2373.finishfalseroot", false)) {
-				finishing2373 = true;
-				activityOnCreate(savedInstanceState);
-				finish();
-				return;
-			}
-		}
-
-		if (finishing2373 || checkInvalidKindleFireRelaunch(savedInstanceState)) {
+		if (willFinishFalseRootActivity(savedInstanceState)) {
 			return;
 		}
+
+		TiApplication tiApp = getTiApp();
 
 		if (!tiApp.isRestartPending()) {
 			// Check for a system application restart that we can't support.
@@ -361,6 +325,7 @@ public abstract class TiLaunchActivity extends TiBaseActivity
 			activityOnPause();
 			return;
 		}
+
 		if (getTiApp().isRestartPending()) {
 			super.onPause(); // Will take care of finish() if needed.
 			return;
@@ -387,6 +352,7 @@ public abstract class TiLaunchActivity extends TiBaseActivity
 			activityOnStop();
 			return;
 		}
+
 		super.onStop();
 	}
 
@@ -459,4 +425,65 @@ public abstract class TiLaunchActivity extends TiBaseActivity
 		
 		super.onDestroy();
 	}
+
+	/**
+	 * Determines whether to immediately kill of (i.e., finish()) this instance
+	 * of the activity because it is not really the task root activity, and thus
+	 * is likely a byproduct of Android bug 2373. There are two conditions when
+	 * we'll finish it:
+	 *
+	 * <p>(1) The Titanium developer has explicitly said she wants it shut down,
+	 * by setting the "finishfalseroot" property; or
+	 *
+	 * <p>(2) We recognize a specific condition we've seen on Kindle Fires. For whatever
+	 * reason, the Fire always tries to re-launch the launch activity
+	 * (i.e., a new instance of it) whenever the user selects the application
+	 * from the application drawer/shelf after the app has been restarted because
+	 * of our 2373 detection. We detect here when that new instance of the launch
+	 * activity is coming into existence, so that we can finish it immediately.
+	 *
+	 * @param savedInstanceStateThe Bundle passed to onCreate, which we will pass
+	 * on to a superclass onCreate if we decide to finish right away.
+	 *
+	 * @return true if we have detected one of the two conditions and are thus finishing
+	 * the Activity right away.
+	 */
+	protected boolean willFinishFalseRootActivity(Bundle savedInstanceState)
+	{
+		finishing2373 = false;
+
+		if (isTaskRoot()) {
+			// Not a "false root" activity. This activity
+			// instance truly is the root of the task, so
+			// nothing needs to be done.
+			return finishing2373;
+		}
+
+		TiApplication tiApp = TiApplication.getInstance();
+		TiProperties systemProperties = null;
+
+		if (tiApp != null) {
+			systemProperties = tiApp.getSystemProperties();
+		}
+
+		if (systemProperties != null
+				&& systemProperties.getBool("ti.android.bug2373.finishfalseroot", false)) {
+			finishing2373 = true;
+		} else if (Build.MODEL.toLowerCase().contains(KINDLE_MODEL)
+				&& creationCounter.getAndIncrement() > 0
+				&& getIntent().getFlags() == KINDLE_FIRE_RESTART_FLAGS) {
+			finishing2373 = true;
+		}
+
+		if (finishing2373) {
+			// Jumps over TiBaseActivity's onCreate to fulfill directly
+			// the requirement that all Activity-derived classes must
+			// call Activity.onCreate.
+			activityOnCreate(savedInstanceState);
+			finish();
+		}
+
+		return finishing2373;
+	}
+
 }

--- a/android/titanium/src/java/org/appcelerator/titanium/TiRootActivity.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiRootActivity.java
@@ -33,6 +33,21 @@ public class TiRootActivity extends TiLaunchActivity
 	{
 		TiApplication tiApp = getTiApp();
 
+		// If not the task root, then this "launch" activity instance is
+		// likely a manifestation of Android bug 2373, and we give
+		// developers an option to simply finish it off right away so that
+		// the running activity stack remains unchanged.
+		if (!isTaskRoot()) {
+			TiProperties sysProperties = tiApp.getSystemProperties();
+			if (sysProperties != null && sysProperties.getBool("ti.android.bug2373.finishfalseroot", false)) {
+				finishing2373 = true;
+				activityOnCreate(savedInstanceState);
+				finish();
+				return;
+			}
+		}
+
+
 		if (checkInvalidLaunch(savedInstanceState)) {
 			// Android bug 2373 detected and we're going to restart.
 			return;
@@ -68,8 +83,6 @@ public class TiRootActivity extends TiLaunchActivity
 		super.windowCreated();
 	}
 
-	// Lifecyle
-
 	@Override
 	protected void onResume()
 	{
@@ -100,7 +113,7 @@ public class TiRootActivity extends TiLaunchActivity
 	protected void onDestroy()
 	{
 		super.onDestroy();
-		if (invalidKindleFireRelaunch) {
+		if (finishing2373) {
 			return;
 		}
 


### PR DESCRIPTION
This is a backport all the way back to 2_0_X.  Use the same [testing notes](http://jira.appcelerator.org/browse/TIMOB-9285?focusedCommentId=210305&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-210305) in JIRA, except ...
- When testing the fail case, use 2.0.2.GA.
- When testing the new property in Kitchen Sink, be sure to use the Kitchen Sink under demos/ in the 2_0_X branch since the new Kitchen Sink likely has dependencies on newer versions of the SDK.
