### PR TITLE
[TIMOB-11320] Android: ScrollView - App crashes on launch

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/TiViewProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/TiViewProxy.java
@@ -459,6 +459,14 @@ public abstract class TiViewProxy extends KrollProxy implements Handler.Callback
 		{
 			setModelListener(view);
 		}
+		else
+		{
+			// Just call processProperties() to set them on this view.
+			// Note that this is done in setModelListener() when it is
+			// called.
+			view.processProperties(getProperties());
+		}
+
 
 		// Use a copy so bundle can be modified as it passes up the inheritance
 		// tree. Allows defaults to be added and keys removed.


### PR DESCRIPTION
This bug got introduced with some recent changes to TableView.  The call to setModelListener() is bypassed for measurement passes through getView().  However, setModelListener() calls processProperties() to set the properties from a proxy on a newly created view.

With the fix here, processProperties() is now called for measurement passes at the time that views are created.
