### PR TITLE
[TIMOB-11388] Commented out the iOS build command's --retina flag. Also ...

### DIFF
--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -95,9 +95,10 @@ exports.config = function (logger, config, cli) {
 			
 			callback(conf = {
 				flags: {
+					/* commented out until the ios-sim tool support launching a retina iOS Simulator instance...
 					retina: {
 						desc: __('use the retina version of the iOS Simulator')
-					},
+					},*/
 					xcode: {
 						// secret flag to perform Xcode pre-compile build step
 						hidden: true

--- a/support/cli/commands/build.js
+++ b/support/cli/commands/build.js
@@ -72,6 +72,7 @@ exports.config = function (logger, config, cli) {
 							}
 						},
 						required: true,
+						skipValueCheck: true,
 						values: ti.availablePlatforms
 					},
 					'project-dir': {


### PR DESCRIPTION
...made it so the --platform option's values were not automatically validated, but rather validated by the build command itself.
