### PR TITLE
[TIMOB-10486]iOS: Popover orientation changes when camera is opened from a window which has fixed orientation

### DIFF
--- a/iphone/Classes/TiRootViewController.m
+++ b/iphone/Classes/TiRootViewController.m
@@ -649,6 +649,7 @@
         if ([modalvc isKindOfClass:[UINavigationController class]] && 
             ![modalvc isKindOfClass:[MFMailComposeViewController class]] &&
             ![modalvc isKindOfClass:[ABPeoplePickerNavigationController class]] &&
+            ![modalvc isKindOfClass:[UIImagePickerController class]] &&
             modalFlag == YES )
         {
             //Since this is a window opened from inside a modalviewcontroller we need


### PR DESCRIPTION
**Testing Instructions**
- Copy the [code](http://jira.appcelerator.org/secure/attachment/30571/app.js) into app.js
- Run on iPad device running 5.1
- Open the app in landscape.
- Click on show Camera.
- Rotate the device to portrait.
- Rotate the device to upsidedown portrait.( **this step is important, make sure you do it fast**)
- Click on cancel button while in the same orientation.
- Click on show popover.
- Check if the popover is displayed in the correct orientation 
