### PR TITLE
[TIMOB-11340] Android: Can't add menu items to ActionBar-style tab group

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TabContentViewProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TabContentViewProxy.java
@@ -1,0 +1,19 @@
+package ti.modules.titanium.ui;
+
+import org.appcelerator.kroll.annotations.Kroll;
+import org.appcelerator.titanium.proxy.ActivityProxy;
+
+import ti.modules.titanium.ui.widget.tabgroup.TiUIAbstractTab;
+
+/**
+ * A special view for the content of a tab.
+ * @see {@link TiUIAbstractTab#getContentView()}
+ */
+@Kroll.proxy(parentModule=UIModule.class)
+public class TabContentViewProxy extends ViewProxy {
+	@Kroll.getProperty(name="_internalActivity")
+	@Override
+	public ActivityProxy getActivityProxy() {
+		return super.getActivityProxy();
+	}
+}

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TabGroupProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TabGroupProxy.java
@@ -271,6 +271,7 @@ public class TabGroupProxy extends TiWindowProxy implements TiActivityWindow
 	public void windowCreated(TiBaseActivity activity) {
 		tabGroupActivity = new WeakReference<Activity>(activity);
 		activity.setWindowProxy(this);
+		setActivity(activity);
 
 		// Use the navigation tabs if this platform supports the action bar.
 		// Otherwise we will fall back to using the TabHost implementation.

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIAbstractTab.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIAbstractTab.java
@@ -57,7 +57,7 @@ public abstract class TiUIAbstractTab extends TiUIView {
 			contentView.setActivity(tabGroupActivity);
 
 			// Assign parent so events bubble up correctly.
-			contentViewProxy.setParent(proxy);
+			contentView.setParent(proxy);
 
 			// Allow the window to fill the content view with its children.
 			windowProxy.getKrollObject().setWindow(contentView);

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIAbstractTab.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIAbstractTab.java
@@ -11,14 +11,15 @@ import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.proxy.TiWindowProxy;
 import org.appcelerator.titanium.view.TiUIView;
 
+import ti.modules.titanium.ui.TabContentViewProxy;
 import ti.modules.titanium.ui.TabProxy;
-import ti.modules.titanium.ui.ViewProxy;
+import android.app.Activity;
 import android.graphics.Color;
 import android.view.View;
 
 
 public abstract class TiUIAbstractTab extends TiUIView {
-	private TiUIView contentView;
+	private TabContentViewProxy contentView;
 
 	public TiUIAbstractTab(TabProxy proxy) {
 		super(proxy);
@@ -47,15 +48,19 @@ public abstract class TiUIAbstractTab extends TiUIView {
 				return emptyContent;
 			}
 
-			ViewProxy contentViewProxy = new ViewProxy();
-			contentViewProxy.setActivity(windowProxy.getActivity());
-			contentView = contentViewProxy.getOrCreateView();
+			contentView = new TabContentViewProxy();
+
+			// A tab's window should be bound to the tab group's activity.
+			// In order for the 'activity' property to work correctly
+			// we need to set the content view's activity to that of the group.
+			Activity tabGroupActivity = ((TabProxy) proxy).getTabGroup().getActivity();
+			contentView.setActivity(tabGroupActivity);
 
 			// Allow the window to fill the content view with its children.
-			windowProxy.getKrollObject().setWindow(contentViewProxy);
+			windowProxy.getKrollObject().setWindow(contentView);
 		}
 
-		return contentView.getNativeView();
+		return contentView.getOrCreateView().getNativeView();
 	}
 
 	private TiWindowProxy getWindowProxy() {


### PR DESCRIPTION
This fixes the broken `window.activity` property for tab windows.
With this fix each property should now reference the activity
hosting the tab group.

See JIRA ticket for test case.
