### PR TITLE
[TIMOB-11219] Restore fullscreen before closing window and rotating

### DIFF
--- a/iphone/Classes/TiUITabProxy.m
+++ b/iphone/Classes/TiUITabProxy.m
@@ -111,6 +111,7 @@
 
 - (void)handleWillShowViewController:(UIViewController *)viewController
 {
+	BOOL safeToTransition = YES;
 	if (current!=nil)
 	{ 
 		TiWindowProxy *currentWindow = [current window];
@@ -135,6 +136,8 @@
                         continue;
                     }
                     [closingWindows addObject:window];
+                    safeToTransition = safeToTransition & ![window restoreFullScreen];
+
                     [window windowWillClose];
                 }
                 else {
@@ -160,7 +163,9 @@
 	
 	[newWindow _tabFocus];
 	WARN_IF_BACKGROUND_THREAD_OBJ;
-	[self childOrientationControllerChangedFlags:newWindow];
+	if (safeToTransition) {
+		[self childOrientationControllerChangedFlags:newWindow];
+	}
 
 	opening = NO; 
 }
@@ -176,6 +181,7 @@
 	}
     RELEASE_TO_NIL(controllerStack);
     controllerStack = [[[rootController navigationController] viewControllers] copy];
+    [self childOrientationControllerChangedFlags:[current window]];
 }
 
 #pragma mark Delegates

--- a/iphone/Classes/TiUITabProxy.m
+++ b/iphone/Classes/TiUITabProxy.m
@@ -136,7 +136,7 @@
                         continue;
                     }
                     [closingWindows addObject:window];
-                    safeToTransition = safeToTransition & ![window restoreFullScreen];
+                    safeToTransition = safeToTransition && ![window restoreFullScreen];
 
                     [window windowWillClose];
                 }

--- a/iphone/Classes/TiWindowProxy.h
+++ b/iphone/Classes/TiWindowProxy.h
@@ -180,7 +180,7 @@ TiOrientationFlags TiOrientationFlagsFromObject(id args);
 -(void)prepareForNavView:(UINavigationController*)navController;
 
 -(BOOL)modalFlagValue;
-
+-(BOOL)restoreFullScreen;
 /**
  Returns view controller for the window's view.
  */

--- a/iphone/Classes/TiWindowProxy.m
+++ b/iphone/Classes/TiWindowProxy.m
@@ -575,6 +575,17 @@ TiOrientationFlags TiOrientationFlagsFromObject(id args)
     }, YES);
 }
 
+-(BOOL)restoreFullScreen
+{
+    if (fullscreenFlag && !restoreFullscreen)
+    {
+        [[UIApplication sharedApplication] setStatusBarHidden:restoreFullscreen withAnimation:UIStatusBarAnimationNone];
+        [[[TiApp app] controller] resizeViewForStatusBarHidden];
+        return YES;
+    } 
+    return NO;
+}
+
 -(void)closeOnUIThread:(id)args
 {
 	[self windowWillClose];
@@ -645,10 +656,10 @@ TiOrientationFlags TiOrientationFlagsFromObject(id args)
 			[closeAnimation animate:self];
 		}
 		  
-		if (fullscreenFlag)
+		if (fullscreenFlag && !restoreFullscreen)
 		{
-			[[UIApplication sharedApplication] setStatusBarHidden:restoreFullscreen];
-			self.view.frame = [[[TiApp app] controller] resizeView];
+			[[UIApplication sharedApplication] setStatusBarHidden:restoreFullscreen withAnimation:UIStatusBarAnimationNone];
+			self.view.frame = [[[TiApp app] controller] resizeViewForStatusBarHidden];
 		} 
  
 		if (closeAnimation!=nil)


### PR DESCRIPTION
Test is in [JIRA](http://jira.appcelerator.org/browse/TIMOB-11219)

It does change app behavior minimally when closing windows in tabs and switching statusBar hidden property but that is the only way to avoid the race condition.
