### PR TITLE
(3_0_X)[TIMOB-11409] move event names to iOS

### DIFF
--- a/iphone/Classes/AppModule.m
+++ b/iphone/Classes/AppModule.m
@@ -424,9 +424,9 @@ extern BOOL const TI_APPLICATION_ANALYTICS;
 		notification = UIAccessibilityAnnouncementNotification;
 		ENSURE_ARG_COUNT(args, 2);
 		ENSURE_ARG_AT_INDEX(argument, args, 1, NSString);
-	} else if ([eventName isEqualToString:self.EVENT_ACCESSIBILITY_LAYOUT_CHANGED]) {
+	} else if ([eventName isEqualToString:@"accessibilitylayoutchanged"]) {
 		notification = UIAccessibilityLayoutChangedNotification;
-	} else if ([eventName isEqualToString:self.EVENT_ACCESSIBILITY_SCREEN_CHANGED]) {
+	} else if ([eventName isEqualToString:@"accessibilityscreenchanged"]) {
 		notification = UIAccessibilityScreenChangedNotification;
 	} else {
 		NSLog(@"[WARN] unknown system event: %@",eventName);
@@ -545,8 +545,6 @@ extern BOOL const TI_APPLICATION_ANALYTICS;
 #endif
 
 MAKE_SYSTEM_STR(EVENT_ACCESSIBILITY_ANNOUNCEMENT,@"accessibilityannouncement");
-MAKE_SYSTEM_STR(EVENT_ACCESSIBILITY_LAYOUT_CHANGED,@"accessibilitylayoutchanged");
-MAKE_SYSTEM_STR(EVENT_ACCESSIBILITY_SCREEN_CHANGED,@"accessibilityscreenchanged");
 MAKE_SYSTEM_STR(EVENT_ACCESSIBILITY_CHANGED,@"accessibilitychanged");
 
 @end

--- a/iphone/Classes/TiAppiOSProxy.m
+++ b/iphone/Classes/TiAppiOSProxy.m
@@ -188,6 +188,9 @@
 	[self fireEvent:@"notification" withObject:notification];
 }
 
+MAKE_SYSTEM_STR(EVENT_ACCESSIBILITY_LAYOUT_CHANGED,@"accessibilitylayoutchanged");
+MAKE_SYSTEM_STR(EVENT_ACCESSIBILITY_SCREEN_CHANGED,@"accessibilityscreenchanged");
+
 
 @end
 


### PR DESCRIPTION
Backport of #3216
