### PR TITLE
(3_0_X)[TIMOB-11422] ensure all elements with accessibility properties are accessible

### DIFF
--- a/iphone/Classes/TiViewProxy.m
+++ b/iphone/Classes/TiViewProxy.m
@@ -2729,6 +2729,7 @@ if(OSAtomicTestAndSetBarrier(flagBit, &dirtyflags))	\
 	ENSURE_UI_THREAD(setAccessibilityLabel, accessibilityLabel);
 	id accessibilityElement = [self view].accessibilityElement;
 	if (accessibilityElement != nil) {
+		[accessibilityElement setIsAccessibilityElement:YES];
 		[accessibilityElement setAccessibilityLabel:accessibilityLabel];
 	}
 	[self setValue:accessibilityLabel forUndefinedKey:@"accessibilityLabel"];
@@ -2739,6 +2740,7 @@ if(OSAtomicTestAndSetBarrier(flagBit, &dirtyflags))	\
 	ENSURE_UI_THREAD(setAccessibilityValue, accessibilityValue);
 	id accessibilityElement = [self view].accessibilityElement;
 	if (accessibilityElement != nil) {
+		[accessibilityElement setIsAccessibilityElement:YES];
 		[accessibilityElement setAccessibilityValue:accessibilityValue];
 	}
 	[self setValue:accessibilityValue forUndefinedKey:@"accessibilityValue"];
@@ -2749,6 +2751,7 @@ if(OSAtomicTestAndSetBarrier(flagBit, &dirtyflags))	\
 	ENSURE_UI_THREAD(setAccessibilityHint, accessibilityHint);
 	id accessibilityElement = [self view].accessibilityElement;
 	if (accessibilityElement != nil) {
+		[accessibilityElement setIsAccessibilityElement:YES];
 		[accessibilityElement setAccessibilityHint:accessibilityHint];
 	}
 	[self setValue:accessibilityHint forUndefinedKey:@"accessibilityHint"];


### PR DESCRIPTION
Backport of #3212
