### PR TITLE
[TIMOB-11483] (3_0_X) Check for oldSize as well for postLayout

### DIFF
--- a/iphone/Classes/TiUIView.h
+++ b/iphone/Classes/TiUIView.h
@@ -120,6 +120,7 @@ void ModifyScrollViewForKeyboardHeightAndContentHeightWithResponderRect(UIScroll
  @see updateTouchHandling
  */
 @property(nonatomic,readonly) BOOL touchEnabled;
+@property(nonatomic,readonly) CGSize oldSize;
 
 @property(nonatomic,readonly)	UITapGestureRecognizer*			singleTapRecognizer;
 @property(nonatomic,readonly)	UITapGestureRecognizer*			doubleTapRecognizer;

--- a/iphone/Classes/TiUIView.m
+++ b/iphone/Classes/TiUIView.m
@@ -160,7 +160,7 @@ NSArray* listenerArray = nil;
 
 DEFINE_EXCEPTIONS
 
-@synthesize proxy,touchDelegate,backgroundImage;
+@synthesize proxy,touchDelegate,backgroundImage,oldSize;
 
 #pragma mark Internal Methods
 

--- a/iphone/Classes/TiViewProxy.m
+++ b/iphone/Classes/TiViewProxy.m
@@ -2143,6 +2143,12 @@ if(OSAtomicTestAndSetBarrier(flagBit, &dirtyflags))	\
 		positionCache.y += sizeCache.origin.y + sandboxBounds.origin.y;
         
         BOOL layoutChanged = (!CGRectEqualToRect([view bounds], sizeCache) || !CGPointEqualToPoint([view center], positionCache));
+        if (!layoutChanged && [view isKindOfClass:[TiUIView class]]) {
+            //Views with flexible margins might have already resized when the parent resized.
+            //So we need to explicitly check for oldSize here which triggers frameSizeChanged
+            CGSize oldSize = [(TiUIView*) view oldSize];
+            layoutChanged = layoutChanged || !(CGSizeEqualToSize(oldSize,sizeCache.size));
+        }
         
 		[view setAutoresizingMask:autoresizeCache];
 		[view setCenter:positionCache];


### PR DESCRIPTION
Cherry Pick PR #3238 into 3_0_X

Test is in [JIRA](http://jira.appcelerator.org/browse/TIMOB-11483)

Regress against http://jira.appcelerator.org/browse/TIMOB-10005
