### PR TITLE
[TIMOB-11408] Android: Runtime error is thrown for require method when called from window opened via URL

### DIFF
--- a/android/modules/ui/src/js/window.js
+++ b/android/modules/ui/src/js/window.js
@@ -355,6 +355,12 @@ exports.bootstrapWindow = function(Titanium) {
 		var scriptSource = assets.readAsset(scriptPath);
 		var filename = 'app:///'+scriptPath.replace("Resources/", "");
 
+		// Setup require for the new window context.
+		var module = new kroll.Module(filename, this._module || kroll.Module.main, context);
+		context.require = function(request, context) {
+			return module.require(request, context);
+		};
+
 		if (kroll.runtime == "v8") {
 			Script.runInContext(scriptSource, context, filename, true);
 


### PR DESCRIPTION
This was broken during an earlier refactor.
Fixed bug by properly setting up the require function
in the new context we run the window URL script.

See JIRA ticket for testing details.
