### PR TITLE
[TIMOB-10065] Android: TabGroup - Tab bar does not animate on Android

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TabGroupProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TabGroupProxy.java
@@ -372,6 +372,7 @@ public class TabGroupProxy extends TiWindowProxy implements TiActivityWindow
 		if (selectedTab == null) {
 			// If no tab is selected fall back to the default behavior.
 			super.onWindowFocusChange(focused);
+			return;
 		}
 
 		// When the tab group gains focus we need to re-focus

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIActionBarTabGroup.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIActionBarTabGroup.java
@@ -8,6 +8,7 @@ package ti.modules.titanium.ui.widget.tabgroup;
 
 import org.appcelerator.titanium.TiBaseActivity;
 import org.appcelerator.titanium.TiLifecycle.OnLifecycleEvent;
+import org.appcelerator.titanium.view.TiCompositeLayout;
 
 import ti.modules.titanium.ui.TabGroupProxy;
 import ti.modules.titanium.ui.TabProxy;
@@ -16,6 +17,8 @@ import android.app.ActionBar.Tab;
 import android.app.ActionBar.TabListener;
 import android.app.Activity;
 import android.app.FragmentTransaction;
+import android.view.ViewGroup;
+import android.widget.FrameLayout;
 
 /**
  * Tab group implementation using the Action Bar navigation tabs.
@@ -44,6 +47,19 @@ public class TiUIActionBarTabGroup extends TiUIAbstractTabGroup implements TabLi
 		actionBar = activity.getActionBar();
 		actionBar.setNavigationMode(ActionBar.NAVIGATION_MODE_TABS);
 		actionBar.setDisplayShowTitleEnabled(false);
+
+		// Create a view to present the contents of the currently selected tab.
+		FrameLayout tabContent = new FrameLayout(activity);
+		tabContent.setId(android.R.id.tabcontent);
+		TiCompositeLayout.LayoutParams params = new TiCompositeLayout.LayoutParams();
+		params.autoFillsHeight = true;
+		params.autoFillsWidth = true;
+		((ViewGroup) activity.getLayout()).addView(tabContent, params);
+
+		// The tab content view will act as the "native" view for the group.
+		// Note: since the tab bar is NOT part of the content, animations
+		// will not transform it along with the rest of the group.
+		setNativeView(tabContent);
 	}
 
 	@Override
@@ -105,7 +121,7 @@ public class TiUIActionBarTabGroup extends TiUIAbstractTabGroup implements TabLi
 			// If not we will create it here then attach it
 			// to the tab group activity inside the "content" container.
 			tabView.initializeFragment();
-			ft.add(android.R.id.content, tabView.fragment);
+			ft.add(android.R.id.tabcontent, tabView.fragment);
 
 		} else {
 			// If the fragment is already attached just make it visible.

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUITabHostGroup.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUITabHostGroup.java
@@ -85,6 +85,10 @@ public class TiUITabHostGroup extends TiUIAbstractTabGroup
 		container.addView(tabcontent, params);
 
 		tabHost.setup();
+
+		// For view properties (backgroundColor) and methods (animate())
+		// to work correctly we will use the TabHost as the "native" view.
+		setNativeView(tabHost);
 	}
 
 	@Override


### PR DESCRIPTION
Fixes a bug seen when trying to animate a tab group. Prior
to the fix no animation would occur at all. This fixes the issue
by properly setting the "native view" of the tab group.

See JIRA ticket for testing details. Note this also fixes TIMOB-11393.
Please verify it is fixed and resolve it once this fix is merged.
Also test both tab groups types (action bar and tab host) by setting
the target API.
