### PR TITLE
timob-11515: Anvil Android: filesystem/filesystem:emptyFile failed on Droid 1 

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/TiBlob.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiBlob.java
@@ -186,7 +186,7 @@ public class TiBlob extends KrollProxy
 		if (is != null) {
 			try {
 				mt = URLConnection.guessContentTypeFromStream(is);
-			} catch (IOException e) {
+			} catch (Exception e) {
 				Log.e(TAG, e.getMessage(), e, Log.DEBUG_MODE);
 			}
 		}


### PR DESCRIPTION
http://jira.appcelerator.org/browse/TIMOB-11515
