### PR TITLE
[TIMOB-11510] reproxy subviews of tableview rows when className specified

### DIFF
--- a/iphone/Classes/TiUIView.h
+++ b/iphone/Classes/TiUIView.h
@@ -175,8 +175,9 @@ void ModifyScrollViewForKeyboardHeightAndContentHeightWithResponderRect(UIScroll
 /*
  Tells the view to change its proxy to the new one provided.
  @param newProxy The new proxy to set on the view.
+ @param deep true for deep transfer
  */
--(void)transferProxy:(TiViewProxy*)newProxy;
+-(void)transferProxy:(TiViewProxy*)newProxy deep:(BOOL)deep;
 
 /**
  Tells the view to update its touch handling state.

--- a/iphone/Classes/TiUIView.h
+++ b/iphone/Classes/TiUIView.h
@@ -179,6 +179,13 @@ void ModifyScrollViewForKeyboardHeightAndContentHeightWithResponderRect(UIScroll
  */
 -(void)transferProxy:(TiViewProxy*)newProxy deep:(BOOL)deep;
 
+/*
+ Returns whether the view tree matches proxy tree for later transfer.
+ @param proxy The proxy to validate view tree with.
+ @param deep true for deep validation
+ */
+-(BOOL)validateTransferToProxy:(TiViewProxy*)proxy deep:(BOOL)deep;
+
 /**
  Tells the view to update its touch handling state.
  @see touchEnabled

--- a/iphone/Classes/TiUIView.m
+++ b/iphone/Classes/TiUIView.m
@@ -782,7 +782,7 @@ DEFINE_EXCEPTIONS
 		NSArray *subProxies = [newProxy children];
 		NSArray *oldSubProxies = [oldProxy children];
 		if ([subProxies count] != [oldSubProxies count]) {
-			return YES;
+			return NO;
 		}
 		[oldSubProxies enumerateObjectsUsingBlock:^(TiViewProxy *oldSubProxy, NSUInteger idx, BOOL *stop) {
 			TiViewProxy *newSubProxy = [subProxies objectAtIndex:idx];

--- a/iphone/Classes/TiUIView.m
+++ b/iphone/Classes/TiUIView.m
@@ -766,6 +766,34 @@ DEFINE_EXCEPTIONS
 	}
 }
 
+-(BOOL)validateTransferToProxy:(TiViewProxy*)newProxy deep:(BOOL)deep
+{
+	TiViewProxy * oldProxy = (TiViewProxy *)[self proxy];
+	
+	if (oldProxy == newProxy) {
+		return YES;
+	}
+	if (![newProxy isMemberOfClass:[oldProxy class]]) {
+		return NO;
+	}
+	
+	__block BOOL result = YES;
+	if (deep) {
+		NSArray *subProxies = [newProxy children];
+		NSArray *oldSubProxies = [oldProxy children];
+		if ([subProxies count] != [oldSubProxies count]) {
+			return YES;
+		}
+		[oldSubProxies enumerateObjectsUsingBlock:^(TiViewProxy *oldSubProxy, NSUInteger idx, BOOL *stop) {
+			TiViewProxy *newSubProxy = [subProxies objectAtIndex:idx];
+			result = [[oldSubProxy view] validateTransferToProxy:newSubProxy deep:YES];
+			if (!result) {
+				*stop = YES;
+			}
+		}];
+	}
+	return result;
+}
 
 -(id)proxyValueForKey:(NSString *)key
 {

--- a/iphone/Classes/TiUIView.m
+++ b/iphone/Classes/TiUIView.m
@@ -704,7 +704,7 @@ DEFINE_EXCEPTIONS
 	}	
 }
 
--(void)transferProxy:(TiViewProxy*)newProxy
+-(void)transferProxy:(TiViewProxy*)newProxy deep:(BOOL)deep
 {
 	TiViewProxy * oldProxy = (TiViewProxy *)[self proxy];
 	
@@ -752,6 +752,13 @@ DEFINE_EXCEPTIONS
 			[self setKrollValue:newValue forKey:thisKey withObject:nil];
 		}
 		
+		if (deep) {
+			NSArray *subProxies = [newProxy children];
+			[[oldProxy children] enumerateObjectsUsingBlock:^(TiViewProxy *oldSubProxy, NSUInteger idx, BOOL *stop) {
+				TiViewProxy *newSubProxy = idx < [subProxies count] ? [subProxies objectAtIndex:idx] : nil;
+				[[oldSubProxy view] transferProxy:newSubProxy deep:YES];
+			}];
+		}
 		[oldProxy release];
 		
 		[newProxy setReproxying:NO];


### PR DESCRIPTION
[TIMOB-11510](http://jira.appcelerator.org/browse/TIMOB-11510)

Test instructions:
1. use example project attached to the JIRA.
2. ensure smooth scrolling performance comparing to before the fix.
3. use Instruments/Core Animation to measure FPS during scrolling for comparison.
4. use Instruments/Allocations to ensure number of allocated TiUILabel, UILabel, TiUITableViewRowContainer is not increasing as table scrolls.

Test another example in JIRA comments. Ensure ERROR messages printed to console.

Test for regressions with [TIMOB-9500](https://jira.appcelerator.org/browse/TIMOB-9500) and [TIMOB-5429](https://jira.appcelerator.org/browse/TIMOB-5429) 
