### PR TITLE
[TIMOB-10891] (3_0_X) Tabgroup leaks memory

### DIFF
--- a/iphone/Classes/TiUITabController.h
+++ b/iphone/Classes/TiUITabController.h
@@ -13,6 +13,7 @@
 @interface TiUITabController : TiViewController<TiTabController> {
 @private
 //Window is now the superclass's proxy.
+//This is an assign only property. Tabs retain instances of TiTabController.
 	TiUITabProxy *tab;
 }
 

--- a/iphone/Classes/TiUITabController.m
+++ b/iphone/Classes/TiUITabController.m
@@ -17,7 +17,6 @@
 -(void)dealloc
 {
 	[(TiWindowProxy *)[self proxy] _associateTab:nil navBar:nil tab:nil];
-	RELEASE_TO_NIL(tab);
 	[super dealloc];
 }
 
@@ -30,7 +29,7 @@
 {
 	if (self = [self initWithViewProxy:window_])
 	{
-		tab = [tab_ retain];
+		tab = tab_;
 		[window_ _associateTab:self navBar:self.navigationController tab:tab];
 	}
 	return self;

--- a/iphone/Classes/TiUITabGroup.m
+++ b/iphone/Classes/TiUITabGroup.m
@@ -413,7 +413,13 @@ DEFINE_EXCEPTIONS
 		[self tabController].viewControllers = controllers;
 		if (![tabs containsObject:focused])
 		{
-			[self setActiveTab_:thisTab];
+            if ([controllers containsObject:thisTab]) {
+                [self setActiveTab_:thisTab];
+            }
+            else {
+                DebugLog(@"[WARN] ActiveTab property points to tab not in list. Ignoring");
+                RELEASE_TO_NIL(focused);
+            }
 		}
 
 		[controllers release];

--- a/iphone/Classes/TiUITabGroup.m
+++ b/iphone/Classes/TiUITabGroup.m
@@ -177,7 +177,7 @@ DEFINE_EXCEPTIONS
 		UIViewController * rootController = [moreViewControllerStack objectAtIndex:1];
 		if ([rootController respondsToSelector:@selector(tab)])
 		{
-			[(TiUITabProxy *)[(id)rootController tab] handleWillShowViewController:viewController];
+			[(TiUITabProxy *)[(id)rootController tab] handleWillShowViewController:viewController animated:animated];
 		}
 	}
 	else
@@ -223,7 +223,7 @@ DEFINE_EXCEPTIONS
 		}
 	}
 
-	[tabProxy handleDidShowViewController:viewController];
+	[tabProxy handleDidShowViewController:viewController animated:animated];
 }
 
 #pragma mark TabBarController Delegates

--- a/iphone/Classes/TiUITabGroup.m
+++ b/iphone/Classes/TiUITabGroup.m
@@ -459,14 +459,6 @@ DEFINE_EXCEPTIONS
 	[self.proxy setValue:nil forKey:@"activeTab"];
 	if (controller!=nil)
 	{
-        /*
-		for (UIViewController *c in controller.viewControllers)
-		{
-			UINavigationController *navController = (UINavigationController*)c;
-			TiUITabProxy *tab = (TiUITabProxy*)navController.delegate;
-			[tab closeTab];
-		}
-         */
 		controller.viewControllers = nil;
 	}
 	RELEASE_TO_NIL(controller);

--- a/iphone/Classes/TiUITabGroup.m
+++ b/iphone/Classes/TiUITabGroup.m
@@ -456,14 +456,11 @@ DEFINE_EXCEPTIONS
 
 -(void)close:(id)args
 {
-	[self.proxy setValue:nil forKey:@"activeTab"];
 	if (controller!=nil)
 	{
 		controller.viewControllers = nil;
 	}
 	RELEASE_TO_NIL(controller);
-    [focused replaceValue:NUMBOOL(NO) forKey:@"active" notification:NO];
-	RELEASE_TO_NIL(focused);
 }
 
 

--- a/iphone/Classes/TiUITabGroup.m
+++ b/iphone/Classes/TiUITabGroup.m
@@ -458,13 +458,15 @@ DEFINE_EXCEPTIONS
 {
 	[self.proxy setValue:nil forKey:@"activeTab"];
 	if (controller!=nil)
-	{ 
+	{
+        /*
 		for (UIViewController *c in controller.viewControllers)
 		{
 			UINavigationController *navController = (UINavigationController*)c;
 			TiUITabProxy *tab = (TiUITabProxy*)navController.delegate;
 			[tab closeTab];
 		}
+         */
 		controller.viewControllers = nil;
 	}
 	RELEASE_TO_NIL(controller);

--- a/iphone/Classes/TiUITabGroup.m
+++ b/iphone/Classes/TiUITabGroup.m
@@ -367,7 +367,9 @@ DEFINE_EXCEPTIONS
 	if (active == nil)  {
 		DebugLog(@"setActiveTab called but active view controller could not be determined");
 	}
-	[self tabController].selectedViewController = active;
+	else {
+		[self tabController].selectedViewController = active;
+	}
 	[self tabBarController:[self tabController] didSelectViewController:active];
 }
 

--- a/iphone/Classes/TiUITabGroupProxy.m
+++ b/iphone/Classes/TiUITabGroupProxy.m
@@ -26,8 +26,10 @@
 {
 	for (id thisTab in tabs)
 	{
+        [thisTab removeFromTabGroup];
 		[thisTab setParentOrientationController:nil];
 		[thisTab setTabGroup:nil];
+        [self forgetProxy:thisTab];
 	}
 	RELEASE_TO_NIL(tabs);
 	[super dealloc];

--- a/iphone/Classes/TiUITabProxy.h
+++ b/iphone/Classes/TiUITabProxy.h
@@ -18,7 +18,7 @@
 @private
 	UINavigationController *controller;
 	TiUITabController *rootController;
-	
+	//This is an assign only property. TabGroup retains instances of tab.
 	TiUITabGroupProxy *tabGroup;
 	TiUITabController *current;
     

--- a/iphone/Classes/TiUITabProxy.h
+++ b/iphone/Classes/TiUITabProxy.h
@@ -56,8 +56,8 @@
 - (void)handleDidBlur:(NSDictionary *)event;
 - (void)handleWillFocus;
 - (void)handleDidFocus:(NSDictionary *)event;
-- (void)handleWillShowViewController:(UIViewController *)viewController;
-- (void)handleDidShowViewController:(UIViewController *)viewController;
+- (void)handleWillShowViewController:(UIViewController *)viewController animated:(BOOL)animated;
+- (void)handleDidShowViewController:(UIViewController *)viewController animated:(BOOL)animated;
 
 @end
 

--- a/iphone/Classes/TiUITabProxy.h
+++ b/iphone/Classes/TiUITabProxy.h
@@ -39,7 +39,7 @@
 -(void)setTabGroup:(TiUITabGroupProxy*)proxy;
 -(void)removeFromTabGroup;
 - (void)closeTab;
--(void)closeWindow:(TiWindowProxy *)window animated:(BOOL)animated removeTab:(BOOL)removeTab;
+-(void)closeWindow:(TiWindowProxy *)window animated:(BOOL)animated;
 -(void)windowClosing:(TiWindowProxy*)window animated:(BOOL)animated;
 
 #pragma mark Public APIs

--- a/iphone/Classes/TiUITabProxy.h
+++ b/iphone/Classes/TiUITabProxy.h
@@ -38,7 +38,6 @@
 -(UINavigationController*)controller;
 -(void)setTabGroup:(TiUITabGroupProxy*)proxy;
 -(void)removeFromTabGroup;
-- (void)closeTab;
 -(void)closeWindow:(TiWindowProxy *)window animated:(BOOL)animated;
 -(void)windowClosing:(TiWindowProxy*)window animated:(BOOL)animated;
 

--- a/iphone/Classes/TiUITabProxy.m
+++ b/iphone/Classes/TiUITabProxy.m
@@ -90,7 +90,6 @@
 		}
 		[(TiWindowProxy *)[thisController proxy] _associateTab:nil navBar:nil tab:nil];
 	}
-	RELEASE_TO_NIL(tabGroup);
 	tabGroup = proxy;
 }
 

--- a/iphone/Classes/TiUITabProxy.m
+++ b/iphone/Classes/TiUITabProxy.m
@@ -126,10 +126,6 @@
     [self cleanNavStack:YES];
 }
 
--(void)closeTab
-{
-    [self cleanNavStack:NO];
-}
 
 - (void)handleWillShowViewController:(UIViewController *)viewController animated:(BOOL)animated
 {

--- a/iphone/Classes/TiUITabProxy.m
+++ b/iphone/Classes/TiUITabProxy.m
@@ -482,46 +482,6 @@
 
 
 
-- (void)viewWillAppear:(BOOL)animated;    // Called when the view is about to made visible. Default does nothing
-{
-	if ([self viewAttached])
-	{
-//		UITabBarController * tabController = [(TiUITabGroup *)[self view] tabController];
-//		[tabController viewWillAppear:animated];
-	}
-//	[super viewWillAppear:animated];
-}
-
-- (void)viewDidAppear:(BOOL)animated;     // Called when the view has been fully transitioned onto the screen. Default does nothing
-{
-	if ([self viewAttached])
-	{
-//		UITabBarController * tabController = [(TiUITabGroup *)[self view] tabController];
-//		[tabController viewDidAppear:animated];
-	}
-//	[super viewDidAppear:animated];
-}
-
-- (void)viewWillDisappear:(BOOL)animated; // Called when the view is dismissed, covered or otherwise hidden. Default does nothing
-{
-	if ([self viewAttached])
-	{
-//		UITabBarController * tabController = [(TiUITabGroup *)[self view] tabController];
-//		[tabController viewWillDisappear:animated];
-	}
-//	[super viewWillDisappear:animated];
-}
-
-- (void)viewDidDisappear:(BOOL)animated;  // Called after the view was dismissed, covered or otherwise hidden. Default does nothing
-{
-	if ([self viewAttached])
-	{
-//		UITabBarController * tabController = [(TiUITabGroup *)[self view] tabController];
-//		[tabController viewDidDisappear:animated];
-	}
-//	[super viewDidDisappear:animated];
-}
-
 -(void)willChangeSize
 {
 	[super willChangeSize];

--- a/iphone/Classes/TiUITabProxy.m
+++ b/iphone/Classes/TiUITabProxy.m
@@ -102,7 +102,7 @@
         [controller setViewControllers:[NSArray arrayWithObject:rootController]];
         if (current != nil) {
             RELEASE_TO_NIL(current);
-            current = rootController;
+            current = [rootController retain];
         }
         for (TiUITabController* doomedVc in doomedVcs) {
             [self closeWindow:(TiWindowProxy *)[doomedVc proxy] animated:NO];

--- a/iphone/Classes/TiUITabProxy.m
+++ b/iphone/Classes/TiUITabProxy.m
@@ -117,7 +117,9 @@
 
 -(void)closeTab
 {
-    [self cleanNavStack:NO];
+    if (current != nil) {
+        [self cleanNavStack:NO];
+    }
 }
 
 - (void)handleWillShowViewController:(UIViewController *)viewController animated:(BOOL)animated
@@ -133,8 +135,9 @@
 		// check to make sure that we're not actually push a window on the stack
 		if (opening==NO && [rootController window]!=currentWindow && [TiUtils boolValue:currentWindow.opened] && currentWindow.closing==NO && [controllerStack containsObject:viewController])
 		{
-			RELEASE_TO_NIL(closingWindows);
-            closingWindows = [[NSMutableArray alloc] init];
+			if (closingWindows == nil) {
+				closingWindows = [[NSMutableArray alloc] init];
+			}
             // Travel down the stack until the new viewController is reached; these are the windows
             // which must be closed.
             NSEnumerator* enumerator = [controllerStack reverseObjectEnumerator];
@@ -180,11 +183,12 @@
 {
 	if (closingWindows!=nil)
 	{
-        for (TiWindowProxy* closingWindow in closingWindows) {
+        NSMutableArray* closingCopy = [closingWindows copy];
+        for (TiWindowProxy* closingWindow in closingCopy) {
+            [closingWindows removeObject:closingWindow];
             NSArray* args = [NSArray arrayWithObjects:closingWindow,[NSDictionary dictionaryWithObject:NUMBOOL(animated) forKey:@"animated"], nil];
             [self close:args];
         }
-		RELEASE_TO_NIL(closingWindows);
 	}
     RELEASE_TO_NIL(controllerStack);
     controllerStack = [[[rootController navigationController] viewControllers] copy];

--- a/iphone/Classes/TiUITabProxy.m
+++ b/iphone/Classes/TiUITabProxy.m
@@ -32,7 +32,6 @@
 {
     RELEASE_TO_NIL(closingWindows);
     RELEASE_TO_NIL(controllerStack);
-	RELEASE_TO_NIL(tabGroup);
 	RELEASE_TO_NIL(rootController);
     RELEASE_TO_NIL(controller);
 	RELEASE_TO_NIL(current);
@@ -92,7 +91,7 @@
 		[(TiWindowProxy *)[thisController proxy] _associateTab:nil navBar:nil tab:nil];
 	}
 	RELEASE_TO_NIL(tabGroup);
-	tabGroup = [proxy retain];
+	tabGroup = proxy;
 }
 
 -(void)removeFromTabGroup

--- a/iphone/Classes/TiUITabProxy.m
+++ b/iphone/Classes/TiUITabProxy.m
@@ -331,7 +331,6 @@
 
 - (void)closeWindow:(TiWindowProxy *)window animated:(BOOL)animated
 {
-    //This method should never be called for current window or root window
     [window retain];
     UIViewController *windowController = [[window controller] retain];
     if ([windowController isKindOfClass:[TiUITabController class]]) {

--- a/iphone/Classes/TiUITabProxy.m
+++ b/iphone/Classes/TiUITabProxy.m
@@ -93,7 +93,7 @@
 	tabGroup = proxy;
 }
 
--(void)removeFromTabGroup
+-(void) cleanNavStack:(BOOL)removeTab
 {
     NSArray* theStack = [[[rootController navigationController] viewControllers] copy];
     NSInteger stackCount = [theStack count];
@@ -106,16 +106,18 @@
 		}
     }
     TiUITabController * baseController = [theStack objectAtIndex:0];
-    [self closeWindow:[baseController window] animated:NO removeTab:YES];
+    [self closeWindow:[baseController window] animated:NO removeTab:removeTab];
+    
+}
+
+-(void)removeFromTabGroup
+{
+    [self cleanNavStack:YES];
 }
 
 -(void)closeTab
 {
-	if (current!=nil)
-	{
-		TiWindowProxy *currentWindow = [current window];
-		//[self closeWindow:currentWindow animated:YES removeTab:NO];
-	}
+    [self cleanNavStack:NO];
 }
 
 - (void)handleWillShowViewController:(UIViewController *)viewController animated:(BOOL)animated

--- a/iphone/Classes/TiUITabProxy.m
+++ b/iphone/Classes/TiUITabProxy.m
@@ -95,29 +95,31 @@
 
 -(void) cleanNavStack:(BOOL)removeTab
 {
-    [controller setDelegate:nil];
-    if ([[controller viewControllers] count] > 1) {
-        NSMutableArray* doomedVcs = [[NSMutableArray arrayWithArray:[controller viewControllers]] retain];
-        [doomedVcs removeObject:rootController];
-        [controller setViewControllers:[NSArray arrayWithObject:rootController]];
-        if (current != nil) {
+    TiThreadPerformOnMainThread(^{
+        [controller setDelegate:nil];
+        if ([[controller viewControllers] count] > 1) {
+            NSMutableArray* doomedVcs = [[NSMutableArray arrayWithArray:[controller viewControllers]] retain];
+            [doomedVcs removeObject:rootController];
+            [controller setViewControllers:[NSArray arrayWithObject:rootController]];
+            if (current != nil) {
+                RELEASE_TO_NIL(current);
+                current = [rootController retain];
+            }
+            for (TiUITabController* doomedVc in doomedVcs) {
+                [self closeWindow:(TiWindowProxy *)[doomedVc proxy] animated:NO];
+            }
+            RELEASE_TO_NIL(doomedVcs);
+        }
+        if (removeTab) {
+            [self closeWindow:[rootController window] animated:NO];
+            RELEASE_TO_NIL(rootController);
+            RELEASE_TO_NIL(controller);
             RELEASE_TO_NIL(current);
-            current = [rootController retain];
         }
-        for (TiUITabController* doomedVc in doomedVcs) {
-            [self closeWindow:(TiWindowProxy *)[doomedVc proxy] animated:NO];
+        else {
+            [controller setDelegate:self];
         }
-        RELEASE_TO_NIL(doomedVcs);
-    }
-    if (removeTab) {
-        [self closeWindow:[rootController window] animated:NO];
-        RELEASE_TO_NIL(rootController);
-        RELEASE_TO_NIL(controller);
-        RELEASE_TO_NIL(current);
-    }
-    else {
-       [controller setDelegate:self];
-    }
+    },YES);
 }
 
 -(void)removeFromTabGroup


### PR DESCRIPTION
Cherry Pick PR #3203 into 3_0_X

Test is in [JIRA](http://jira.appcelerator.org/browse/TIMOB-10891)
Be sure to test code in [comments](http://jira.appcelerator.org/browse/TIMOB-10891?focusedCommentId=223354&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-223354)

Regress against 
[TIMOB-7858](http://jira.appcelerator.org/browse/TIMOB-7858)
[TIMOB-7714](http://jira.appcelerator.org/browse/TIMOB-7714)
[TIMOB-7644](http://jira.appcelerator.org/browse/TIMOB-7644)
[TIMOB-7152](http://jira.appcelerator.org/browse/TIMOB-7152)
[TIMOB-7791](http://jira.appcelerator.org/browse/TIMOB-7791)
[TIMOB-7820](http://jira.appcelerator.org/browse/TIMOB-7820)

KS smoke test
