### PR TITLE
TIMOB-11307 3_0_X Android: Call runInContext with the the filename argument relatively path'd as re...

### DIFF
--- a/android/modules/ui/src/js/window.js
+++ b/android/modules/ui/src/js/window.js
@@ -352,20 +352,19 @@ exports.bootstrapWindow = function(Titanium) {
 		bootstrap.bootstrapGlobals(context, Titanium);
 
 		var scriptPath = url.toAssetPath(resolvedUrl);
+		var relScriptPath = scriptPath.replace("Resources/", "");
 		var scriptSource = assets.readAsset(scriptPath);
-		var filename = 'app:///'+scriptPath.replace("Resources/", "");
 
 		// Setup require for the new window context.
-		var module = new kroll.Module(filename, this._module || kroll.Module.main, context);
+		var module = new kroll.Module("app:///" + relScriptPath, this._module || kroll.Module.main, context);
 		context.require = function(request, context) {
 			return module.require(request, context);
 		};
 
 		if (kroll.runtime == "v8") {
-			Script.runInContext(scriptSource, context, scriptPath, true);
-
+			Script.runInContext(scriptSource, context, relScriptPath, true);
 		} else {
-			Script.runInThisContext(scriptSource, scriptPath, true, context);
+			Script.runInThisContext(scriptSource, relScriptPath, true, context);
 		}
 	}
 


### PR DESCRIPTION
...quired by debugger.

Test is fail case described in 

http://jira.appcelerator.org/browse/TIMOB-11307

**Test V8/Rhino**

This is the 3_0_X cherry-pick of #3278.
