### PR TITLE
[TIMOB-11285] (3_0_X) Opening a new window must always dismiss keyboard

### DIFF
--- a/iphone/Classes/TiUITabProxy.m
+++ b/iphone/Classes/TiUITabProxy.m
@@ -14,6 +14,7 @@
 #import "TiUITabGroupProxy.h"
 #import "TiUtils.h"
 #import "ImageLoader.h"
+#import "TiApp.h"
 
 
 //NOTE: this proxy is a little different than normal Proxy/View pattern
@@ -279,7 +280,7 @@
 	[window setParentOrientationController:self];
 	// TODO: Slap patch.  Views, when opening/added, should check parent visibility (and parent/parent visibility, if possible)
 	[window parentWillShow];
-
+	[[[TiApp app] controller] dismissKeyboard];
 	TiThreadPerformOnMainThread(^{
 		[self openOnUIThread:args];
 	}, YES);

--- a/iphone/Classes/TiUIiPhoneNavigationGroupProxy.m
+++ b/iphone/Classes/TiUIiPhoneNavigationGroupProxy.m
@@ -10,6 +10,7 @@
 #import "TiUtils.h"
 #import "TiWindowProxy.h"
 #import "TiUIiPhoneNavigationGroup.h"
+#import "TiApp.h"
 
 @implementation TiUIiPhoneNavigationGroupProxy
 
@@ -31,6 +32,7 @@
 	[self rememberProxy:window];
 
 	ENSURE_UI_THREAD(open, args);
+	[[[TiApp app] controller] dismissKeyboard];
 	NSDictionary *properties = [args count] > 1 ? [args objectAtIndex:1] : [NSDictionary dictionary];
 	[[self view] performSelector:@selector(open:withObject:) withObject:window withObject:properties];
 }


### PR DESCRIPTION
Cherry Pick PR #3285 into 3_0_X

Test is in [JIRA](http://jira.appcelerator.org/browse/TIMOB-11285)

Case showing behavior difference is in [comments](http://jira.appcelerator.org/browse/TIMOB-11285?focusedCommentId=224208&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-224208)
