### PR TITLE
[TIMOB-11941] relayout before showing view

### DIFF
--- a/iphone/Classes/TiViewProxy.m
+++ b/iphone/Classes/TiViewProxy.m
@@ -650,7 +650,7 @@ LAYOUTFLAGS_SETTER(setHorizontalWrap,horizontalWrap,horizontalWrap,[self willCha
 
 -(void)setHidden:(BOOL)newHidden withArgs:(id)args
 {
-	if(hidden == newHidden)
+	if([self view].hidden == newHidden)
 	{
 		return;
 	}
@@ -1718,7 +1718,7 @@ if(OSAtomicTestAndSetBarrier(flagBit, &dirtyflags))	\
 {
 	if(dirtyflags)
 	{//If we have any need for changes, let's enroll ourselves.
-		[self willEnqueue];
+		[self refreshView:nil];
 	}
 
 	SET_AND_PERFORM(TiRefreshViewZIndex,);

--- a/iphone/Classes/TiViewProxy.m
+++ b/iphone/Classes/TiViewProxy.m
@@ -1718,7 +1718,9 @@ if(OSAtomicTestAndSetBarrier(flagBit, &dirtyflags))	\
 {
 	if(dirtyflags)
 	{//If we have any need for changes, let's enroll ourselves.
-		[self refreshView:nil];
+        [self willEnqueue];
+        [self relayout];
+		[self layoutChildren:NO];
 	}
 
 	SET_AND_PERFORM(TiRefreshViewZIndex,);


### PR DESCRIPTION
[jira ticket](http://jira.appcelerator.org/browse/TC-1417)

First `setHidden` method was incorrectly checking if the view was currently hidden. In fact if you create a view with visible:false, then when showing the view, setHidden would not call willShow.

Now in `willShow` the relayout was enqueued. It should be done immediately to make sure the view has the correct layout right away.
I called `refreshView` but may be that s not the right call to make. It works but i was not sure of the "level" of refreshView.
