### PR TITLE
TIMOB-11530 Android: Check for HashMap instead of KrollDict in fireEvent, since it could be c...

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TableViewProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TableViewProxy.java
@@ -1,6 +1,6 @@
 /**
  * Appcelerator Titanium Mobile
- * Copyright (c) 2009-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2009-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
@@ -140,7 +140,8 @@ public class TableViewProxy extends TiViewProxy
 		if (eventName.equals(TiC.EVENT_LONGPRESS) && (data instanceof HashMap)) {
 			// The data object may already be in use by the runtime thread
 			// due to a child view's event fire. Create a copy to be thread safe.
-			KrollDict dataCopy = new KrollDict((HashMap)data);
+			@SuppressWarnings("unchecked")
+			KrollDict dataCopy = new KrollDict((HashMap<String, Object>) data);
 			double x = dataCopy.getDouble(TiC.PROPERTY_X);
 			double y = dataCopy.getDouble(TiC.PROPERTY_Y);
 			int index = getTableView().getTableView().getIndexFromXY(x, y);
@@ -626,6 +627,7 @@ public class TableViewProxy extends TiViewProxy
 		return new Object[0];
 	}
 
+	@SuppressWarnings("unchecked")
 	private TableViewRowProxy rowProxyFor(Object row)
 	{
 		TableViewRowProxy rowProxy = null;
@@ -639,7 +641,7 @@ public class TableViewProxy extends TiViewProxy
 				rowDict = (KrollDict) row;
 
 			} else if (row instanceof HashMap) {
-				rowDict = new KrollDict((HashMap) row);
+				rowDict = new KrollDict((HashMap<String, Object>) row);
 			}
 
 			if (rowDict != null) {
@@ -663,6 +665,7 @@ public class TableViewProxy extends TiViewProxy
 		return rowProxy;
 	}
 
+	@SuppressWarnings("unchecked")
 	private TableViewSectionProxy sectionProxyFor(Object section)
 	{
 		TableViewSectionProxy sectionProxy = null;
@@ -674,7 +677,7 @@ public class TableViewProxy extends TiViewProxy
 			if (section instanceof KrollDict) {
 				sectionDict = (KrollDict) section;
 			} else if (section instanceof HashMap) {
-				sectionDict = new KrollDict((HashMap) section);
+				sectionDict = new KrollDict((HashMap<String, Object>) section);
 			}
 			if (sectionDict != null) {
 				sectionProxy = new TableViewSectionProxy();

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TableViewRowProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TableViewRowProxy.java
@@ -7,6 +7,7 @@
 package ti.modules.titanium.ui;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 
 import org.appcelerator.kroll.KrollDict;
 import org.appcelerator.kroll.annotations.Kroll;
@@ -175,7 +176,7 @@ public class TableViewRowProxy extends TiViewProxy
 		return super.handleMessage(msg);
 	}
 
-	public static void fillClickEvent(KrollDict data, TableViewModel model, Item item) {
+	public static void fillClickEvent(HashMap<String, Object> data, TableViewModel model, Item item) {
 		
 		//Don't include rowData if we click on a section
 		if (!(item.proxy instanceof TableViewSectionProxy)) {
@@ -194,10 +195,11 @@ public class TableViewRowProxy extends TiViewProxy
 			// Inject row click data for events coming from row children.
 			TableViewProxy table = getTable();
 			Item item = tableViewItem.getRowData();
-			if (table != null && item != null && data instanceof KrollDict) {
+			if (table != null && item != null && data instanceof HashMap) {
 				// The data object may already be in use by the runtime thread
 				// due to a child view's event fire. Create a copy to be thread safe.
-				KrollDict dataCopy = new KrollDict((KrollDict)data);
+				@SuppressWarnings("unchecked")
+				KrollDict dataCopy = new KrollDict((HashMap<String, Object>) data);
 				fillClickEvent(dataCopy, table.getTableView().getModel(), item);
 				data = dataCopy;
 			}

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiTableView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiTableView.java
@@ -23,8 +23,6 @@ import org.appcelerator.titanium.view.TiUIView;
 
 import ti.modules.titanium.ui.TableViewProxy;
 import ti.modules.titanium.ui.TableViewRowProxy;
-import ti.modules.titanium.ui.widget.TiUILabel;
-import ti.modules.titanium.ui.widget.TiView;
 import ti.modules.titanium.ui.widget.searchbar.TiUISearchBar.OnSearchChangeListener;
 import ti.modules.titanium.ui.widget.tableview.TableViewModel.Item;
 import android.graphics.Color;

--- a/android/titanium/src/java/org/appcelerator/kroll/KrollDict.java
+++ b/android/titanium/src/java/org/appcelerator/kroll/KrollDict.java
@@ -147,12 +147,13 @@ public class KrollDict
 		return TiConvert.toStringArray((Object[])get(key));
 	}
 
+	@SuppressWarnings("unchecked")
 	public KrollDict getKrollDict(String key) {
 		Object value = get(key);
 		if (value instanceof KrollDict) {
 			return (KrollDict) value;
 		} else if (value instanceof HashMap) {
-			return new KrollDict((HashMap)value);
+			return new KrollDict((HashMap<String, Object>) value);
 		} else {
 			return null;
 		}


### PR DESCRIPTION
...alled from native code (via JavaScript) when bubbling up and there is no "KrollDict" in JS.

Also suppress warnings we can't get around, namely the "unchecked" warning when casting from Object to HashMap.

Fix a few other warnings as well.

Test case is fail case in item:

http://jira.appcelerator.org/browse/TIMOB-11530
