### PR TITLE
[TIMOB-11578] (3_0_X) ensure correctness of activeTab

### DIFF
--- a/iphone/Classes/TiUITabGroup.m
+++ b/iphone/Classes/TiUITabGroup.m
@@ -415,7 +415,13 @@ DEFINE_EXCEPTIONS
 		[self tabController].viewControllers = controllers;
 		if (![tabs containsObject:focused])
 		{
-            if ([controllers containsObject:thisTab]) {
+            if ( (thisTab != nil) && (![thisTab isKindOfClass:[TiUITabProxy class]]) ) {
+                int index = [TiUtils intValue:thisTab];
+                if (index < [tabs count]) {
+                    thisTab = [tabs objectAtIndex:index];
+                }
+            }
+            if ([tabs containsObject:thisTab]) {
                 [self setActiveTab_:thisTab];
             }
             else {


### PR DESCRIPTION
Cherry-pick PR #3327 into 3_0_X

Test is in [JIRA](http://jira.appcelerator.org/browse/TIMOB-11578)
