### PR TITLE
[TIMOB-11561]Handle accessory view is on refocus after blur

### DIFF
--- a/iphone/Classes/TiRootViewController.m
+++ b/iphone/Classes/TiRootViewController.m
@@ -1356,7 +1356,7 @@
 {
 	WARN_IF_BACKGROUND_THREAD_OBJ
 
-	if (visibleProxy == keyboardFocusedProxy)
+	if ( (visibleProxy == keyboardFocusedProxy) && (leavingAccessoryView == nil) )
 	{
 		DeveloperLog(@"[WARN] Focused for %@<%X>, despite it already being the focus.",keyboardFocusedProxy,keyboardFocusedProxy);
 		return;


### PR DESCRIPTION
Test is in [JIRA](http://jira.appcelerator.org/browse/TIMOB-11561)

Regress against 
[TIMOB-11023](http://jira.appcelerator.org/browse/TIMOB-11023)
[TIMOB-1902](http://jira.appcelerator.org/browse/TIMOB-1902)
[TIMOB-8720](http://jira.appcelerator.org/browse/TIMOB-8720)
[TIMOB-10356](http://jira.appcelerator.org/browse/TIMOB-10356)
[TIMOB-7839](http://jira.appcelerator.org/browse/TIMOB-7839)
[TIMOB-5100](http://jira.appcelerator.org/browse/TIMOB-5100)
[TIMOB-7998](http://jira.appcelerator.org/browse/TIMOB-7998)
[TIMOB-8363](http://jira.appcelerator.org/browse/TIMOB-8363)
[TIMOB-8368](http://jira.appcelerator.org/browse/TIMOB-8368)

KS keyboard accessory view animations

Please make sure to test on 4.3 device since the ordering of events is different on 4.X and 5.0 and above which is what caused the issue
