### PR TITLE
[TIMOB-10965] Implementing launchOptions for location Updates.

### DIFF
--- a/iphone/Classes/TiApp.m
+++ b/iphone/Classes/TiApp.m
@@ -283,7 +283,7 @@ TI_INLINE void waitForMemoryPanicCleared();   //WARNING: This must never be run 
 	NSString *sourceBundleId = [launchOptions objectForKey:UIApplicationLaunchOptionsSourceApplicationKey];
 	NSDictionary *notification = [launchOptions objectForKey:UIApplicationLaunchOptionsRemoteNotificationKey];
 	
-    BOOL locationUpdateRecieved = [[launchOptions objectForKey:UIApplicationLaunchOptionsLocationKey] boolValue];
+    [launchOptions setObject:NUMBOOL([[launchOptions objectForKey:UIApplicationLaunchOptionsLocationKey] boolValue]) forKey:@"launchOptionsLocationKey"];
     [launchOptions removeObjectForKey:UIApplicationLaunchOptionsLocationKey];
     
 	localNotification = [[[self class] dictionaryWithLocalNotification:[launchOptions objectForKey:UIApplicationLaunchOptionsLocalNotificationKey]] retain];
@@ -304,9 +304,7 @@ TI_INLINE void waitForMemoryPanicCleared();   //WARNING: This must never be run 
 	{
 		[self generateNotification:notification];
 	}
-    if (locationUpdateRecieved) {
-        [launchOptions setObject:NUMBOOL(locationUpdateRecieved) forKey:@"location"];
-    }
+    
 	[self loadUserDefaults];
 	[self boot];
 	

--- a/iphone/Classes/TiApp.m
+++ b/iphone/Classes/TiApp.m
@@ -283,6 +283,9 @@ TI_INLINE void waitForMemoryPanicCleared();   //WARNING: This must never be run 
 	NSString *sourceBundleId = [launchOptions objectForKey:UIApplicationLaunchOptionsSourceApplicationKey];
 	NSDictionary *notification = [launchOptions objectForKey:UIApplicationLaunchOptionsRemoteNotificationKey];
 	
+    BOOL locationUpdateRecieved = [[launchOptions objectForKey:UIApplicationLaunchOptionsLocationKey] boolValue];
+    [launchOptions removeObjectForKey:UIApplicationLaunchOptionsLocationKey];
+    
 	localNotification = [[[self class] dictionaryWithLocalNotification:[launchOptions objectForKey:UIApplicationLaunchOptionsLocalNotificationKey]] retain];
 	[launchOptions removeObjectForKey:UIApplicationLaunchOptionsLocalNotificationKey];
 	
@@ -301,6 +304,9 @@ TI_INLINE void waitForMemoryPanicCleared();   //WARNING: This must never be run 
 	{
 		[self generateNotification:notification];
 	}
+    if (locationUpdateRecieved) {
+        [launchOptions setObject:NUMBOOL(locationUpdateRecieved) forKey:@"location"];
+    }
 	[self loadUserDefaults];
 	[self boot];
 	


### PR DESCRIPTION
Implementing a launchOption `location` to see if the app was restarted by the OS after it was killed from the background. 

backport #3334

Test case in [JIRA](http://jira.appcelerator.org/browse/TIMOB-10965?focusedCommentId=225129&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-225129)

Testing Instruction in [Jira Comment](http://jira.appcelerator.org/browse/TIMOB-10965?focusedCommentId=225132&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-225132)
