### PR TITLE
(3_0_X)[TIMOB-11620] iOS 6: 'className' property is returned as TiUIObjectProxy

### DIFF
--- a/iphone/Classes/KrollObject.m
+++ b/iphone/Classes/KrollObject.m
@@ -707,6 +707,9 @@ bool KrollHasInstance(TiContextRef ctx, TiObjectRef constructor, TiValueRef poss
 					argcount:1 type:KrollMethodInvoke name:nil context:[self context]] autorelease];
 #endif
 			}
+			if ([key isEqualToString:@"className"]) {
+				return [target valueForUndefinedKey:key];
+			}
 			// attempt a function that has no args (basically a non-property property)
 			selector = NSSelectorFromString([NSString stringWithFormat:@"%@",key]);
 			if ([target respondsToSelector:selector])

--- a/iphone/Classes/KrollObject.m
+++ b/iphone/Classes/KrollObject.m
@@ -707,6 +707,7 @@ bool KrollHasInstance(TiContextRef ctx, TiObjectRef constructor, TiValueRef poss
 					argcount:1 type:KrollMethodInvoke name:nil context:[self context]] autorelease];
 #endif
 			}
+			// Special handling for className due to conflict with NSObject private API
 			if ([key isEqualToString:@"className"]) {
 				return [target valueForUndefinedKey:key];
 			}

--- a/iphone/Classes/TiProxy.m
+++ b/iphone/Classes/TiProxy.m
@@ -958,11 +958,6 @@ void DoProxyDelegateReadValuesWithKeysFromProxy(UIView<TiProxyDelegate> * target
 		[self setValue:thisValue forKey:thisKey];
 	}
 }
-
-- (id)className
-{
-	return [self valueForUndefinedKey:NSStringFromSelector(_cmd)];
-}
  
 DEFINE_EXCEPTIONS
 

--- a/iphone/Classes/TiProxy.m
+++ b/iphone/Classes/TiProxy.m
@@ -958,6 +958,11 @@ void DoProxyDelegateReadValuesWithKeysFromProxy(UIView<TiProxyDelegate> * target
 		[self setValue:thisValue forKey:thisKey];
 	}
 }
+
+- (id)className
+{
+	return [self valueForUndefinedKey:NSStringFromSelector(_cmd)];
+}
  
 DEFINE_EXCEPTIONS
 

--- a/iphone/Classes/TiUITableViewRowProxy.m
+++ b/iphone/Classes/TiUITableViewRowProxy.m
@@ -256,11 +256,6 @@ TiProxy * DeepScanForProxyOfViewContainingPoint(UIView * targetView, CGPoint poi
 
 @synthesize tableClass, table, section, row, callbackCell;
 
--(NSString *)className
-{
-	return [self tableClass];
-}
-
 -(void)_destroy
 {
 	RELEASE_TO_NIL(tableClass);


### PR DESCRIPTION
Backport of #3375
