### PR TITLE
timob-6891_3_0_X: Android: Tab's window property is null if set via creation arguments

### DIFF
--- a/android/modules/ui/src/js/tab.js
+++ b/android/modules/ui/src/js/tab.js
@@ -11,7 +11,7 @@ exports.bootstrap = function(Titanium) {
 	function createTab(scopeVars, options) {
 		var tab = new Tab(options);
 		if (options) {
-			this._window = options.window;
+			tab._window = options.window;
 		}
 		return tab;
   }


### PR DESCRIPTION
http://jira.appcelerator.org/browse/TIMOB-6891
For FR, please run the test case in JIRA on both rhino and v8, and run anvil-> ui/ui_rhino-> tabWindowNull.
