### PR TITLE
[TIMOB-1510] (2.1.X) Clean up temporary files and avoid saving to SD card if possible.

### DIFF
--- a/android/modules/media/src/java/ti/modules/titanium/media/MediaModule.java
+++ b/android/modules/media/src/java/ti/modules/titanium/media/MediaModule.java
@@ -10,7 +10,6 @@ import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -26,7 +25,6 @@ import org.appcelerator.kroll.KrollObject;
 import org.appcelerator.kroll.KrollRuntime;
 import org.appcelerator.kroll.annotations.Kroll;
 import org.appcelerator.kroll.common.Log;
-import org.appcelerator.kroll.common.TiConfig;
 import org.appcelerator.titanium.ContextSpecific;
 import org.appcelerator.titanium.TiApplication;
 import org.appcelerator.titanium.TiBaseActivity;
@@ -41,6 +39,7 @@ import org.appcelerator.titanium.util.TiConvert;
 import org.appcelerator.titanium.util.TiFileHelper;
 import org.appcelerator.titanium.util.TiIntentWrapper;
 import org.appcelerator.titanium.util.TiUIHelper;
+import org.appcelerator.titanium.util.TiConfig;
 
 import ti.modules.titanium.media.android.AndroidModule.MediaScannerClient;
 import android.app.Activity;
@@ -54,6 +53,7 @@ import android.database.Cursor;
 import android.graphics.BitmapFactory;
 import android.hardware.Camera;
 import android.net.Uri;
+import android.os.Environment;
 import android.os.Handler;
 import android.os.Message;
 import android.os.Vibrator;
@@ -135,6 +135,10 @@ public class MediaModule extends KrollModule
 	@Kroll.method
 	public void showCamera(HashMap options)
 	{
+		Activity activity = TiApplication.getInstance().getCurrentActivity();
+
+		Log.d(LCAT, "showCamera called");
+
 		KrollFunction successCallback = null;
 		KrollFunction cancelCallback = null;
 		KrollFunction errorCallback = null;
@@ -148,13 +152,27 @@ public class MediaModule extends KrollModule
 		if (options.containsKey("error")) {
 			errorCallback = (KrollFunction) options.get("error");
 		}
-		if (options.containsKey("overlay")) {
-			TiCameraActivity.overlayProxy = (TiViewProxy) options.get("overlay");
+
+		boolean saveToPhotoGallery = false;
+		if (options.containsKey("saveToPhotoGallery")) {
+			saveToPhotoGallery = TiConvert.toBoolean(options.get("saveToPhotoGallery"));
 		}
 
-		if (DBG) {
-			Log.d(LCAT, "showCamera called");
+		// Use our own custom camera activity when an overlay is provided.
+		if (options.containsKey("overlay")) {
+			TiCameraActivity.overlayProxy = (TiViewProxy) options.get("overlay");
+
+			TiCameraActivity.callbackContext = getKrollObject();
+			TiCameraActivity.successCallback = successCallback;
+			TiCameraActivity.errorCallback = errorCallback;
+			TiCameraActivity.cancelCallback	= cancelCallback;
+			TiCameraActivity.saveToPhotoGallery = saveToPhotoGallery;
+
+			Intent intent = new Intent(activity, TiCameraActivity.class);
+			activity.startActivity(intent);
+			return;
 		}
+
 		Camera camera = null;
 		try {
 			camera = Camera.open();
@@ -175,23 +193,43 @@ public class MediaModule extends KrollModule
 			return;
 		}
 
-		boolean saveToPhotoGallery = false;
-		if (options.containsKey("saveToPhotoGallery")) {
-			saveToPhotoGallery = TiConvert.toBoolean(options.get("saveToPhotoGallery"));
-		}
-
-		Activity activity = TiApplication.getInstance().getCurrentActivity();
 		TiActivitySupport activitySupport = (TiActivitySupport) activity;
 		TiFileHelper tfh = TiFileHelper.getInstance();
+
+		TiIntentWrapper cameraIntent = new TiIntentWrapper(new Intent());
+		if(TiCameraActivity.overlayProxy == null) {
+			cameraIntent.getIntent().setAction(MediaStore.ACTION_IMAGE_CAPTURE);
+			cameraIntent.getIntent().addCategory(Intent.CATEGORY_DEFAULT);
+		} else {
+			cameraIntent.getIntent().setClass(TiApplication.getInstance().getBaseContext(), TiCameraActivity.class);
+		}
+
+		cameraIntent.setWindowId(TiIntentWrapper.createActivityName("CAMERA"));
+		PackageManager pm = (PackageManager) activity.getPackageManager();
+		List<ResolveInfo> activities = pm.queryIntentActivities(cameraIntent.getIntent(), PackageManager.MATCH_DEFAULT_ONLY);
+
+		// See if it's the HTC camera app
+		boolean isHTCCameraApp = false;
+
+		for (ResolveInfo rs : activities) {
+			try {
+				if (rs.activityInfo.applicationInfo.sourceDir.contains("HTC")) {
+					isHTCCameraApp = true;
+					break;
+				}
+			} catch (NullPointerException e) {
+				//Ignore
+			}
+		}
 
 		File imageDir = null;
 		File imageFile = null;
 
 		try {
 			if (saveToPhotoGallery) {
-				imageDir = new File(PHOTO_DCIM_CAMERA);
-				if (!imageDir.exists()) {
-					imageDir.mkdirs();
+				// HTC camera application will create its own gallery image file.
+				if (!isHTCCameraApp) {
+					imageFile = createGalleryImageFile();
 				}
 
 			} else {
@@ -208,9 +246,9 @@ public class MediaModule extends KrollModule
 				} else {
 					imageDir = tfh.getDataDirectory(false);
 				}
-			}
 
-			imageFile = tfh.getTempFile(imageDir, ".jpg");
+				imageFile = tfh.getTempFile(imageDir, ".jpg", true);
+			}
 
 		} catch (IOException e) {
 			Log.e(LCAT, "Unable to create temp file", e);
@@ -221,48 +259,21 @@ public class MediaModule extends KrollModule
 			return;
 		}
 
-		String imageUrl = "file://" + imageFile.getAbsolutePath();
-		TiIntentWrapper cameraIntent = new TiIntentWrapper(new Intent());
-
-		if(TiCameraActivity.overlayProxy == null) {
-			cameraIntent.getIntent().setAction(MediaStore.ACTION_IMAGE_CAPTURE);
-			cameraIntent.getIntent().addCategory(Intent.CATEGORY_DEFAULT);
-		} else {
-			cameraIntent.getIntent().setClass(TiApplication.getInstance().getBaseContext(), TiCameraActivity.class);
-		}
-
-		cameraIntent.setWindowId(TiIntentWrapper.createActivityName("CAMERA"));
-
-		PackageManager pm = (PackageManager) activity.getPackageManager();
-		List<ResolveInfo> activities = pm.queryIntentActivities(cameraIntent.getIntent(), PackageManager.MATCH_DEFAULT_ONLY);
-		
-		// See if it's the HTC camera app
-		boolean isHTCCameraApp = false;
-		
-		for (ResolveInfo rs : activities) {
-			try {
-				if (rs.activityInfo.applicationInfo.sourceDir.contains("HTC")) {
-					isHTCCameraApp = true;
-					break;
-				}
-			} catch (NullPointerException e) {
-				//Ignore
-			}
-		}
-
-		if (!isHTCCameraApp) {
-			cameraIntent.getIntent().putExtra(MediaStore.EXTRA_OUTPUT, Uri.parse(imageUrl));
-		}
-
 		CameraResultHandler resultHandler = new CameraResultHandler();
 		resultHandler.imageFile = imageFile;
-		resultHandler.imageUrl = imageUrl;
 		resultHandler.saveToPhotoGallery = saveToPhotoGallery;
 		resultHandler.successCallback = successCallback;
 		resultHandler.cancelCallback = cancelCallback;
 		resultHandler.errorCallback = errorCallback;
 		resultHandler.activitySupport = activitySupport;
 		resultHandler.cameraIntent = cameraIntent.getIntent();
+
+		if (imageFile != null) {
+			String imageUrl = "file://" + imageFile.getAbsolutePath();
+			cameraIntent.getIntent().putExtra(MediaStore.EXTRA_OUTPUT, Uri.parse(imageUrl));
+			resultHandler.imageUrl = imageUrl;
+		}
+
 		activity.runOnUiThread(resultHandler);
 	}
 
@@ -302,6 +313,28 @@ public class MediaModule extends KrollModule
 		}
 
 		return super.handleMessage(message);
+	}
+
+	public static File createGalleryImageFile() {
+		File pictureDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES);
+		File appPictureDir = new File(pictureDir, TiApplication.getInstance().getAppInfo().getName());
+		if (!appPictureDir.exists()) {
+			if (!appPictureDir.mkdirs()) {
+				Log.e(LCAT, "Failed to create application gallery directory.");
+				return null;
+			}
+		}
+
+		File imageFile;
+		try {
+			imageFile = TiFileHelper.getInstance().getTempFile(appPictureDir, ".jpg", false);
+
+		} catch (IOException e) {
+			Log.e(LCAT, "Failed to create gallery image file: " + e.getMessage());
+			return null;
+		}
+
+		return imageFile;
 	}
 
 	private void invokeCallback(TiBaseActivity callbackActivity, KrollFunction callback, KrollObject krollObject, KrollDict callbackArgs)
@@ -373,7 +406,7 @@ public class MediaModule extends KrollModule
 					}
 					values.put("_data", imageFile.getAbsolutePath());
 
-					Uri imageUri = activity.getContentResolver().insert(Images.Media.EXTERNAL_CONTENT_URI, values);
+					activity.getContentResolver().insert(Images.Media.EXTERNAL_CONTENT_URI, values);
 
 					// puts newly captured photo into the gallery
 					MediaScannerClient mediaScanner = new MediaScannerClient(activity, new String[] {imageUrl}, null, null);
@@ -381,7 +414,7 @@ public class MediaModule extends KrollModule
 
 					try {
 						if (successCallback != null) {
-							invokeCallback((TiBaseActivity) activity, successCallback, getKrollObject(), createDictForImage(imageUri.toString(), "image/jpeg"));
+							invokeCallback((TiBaseActivity) activity, successCallback, getKrollObject(), createDictForImage(imageFile.getAbsolutePath(), "image/jpeg"));
 						}
 
 					} catch (OutOfMemoryError e) {
@@ -611,31 +644,27 @@ public class MediaModule extends KrollModule
 			});
 	}
 
-	KrollDict createDictForImage(String path, String mimeType) {
+	public static KrollDict createDictForImage(String path, String mimeType) {
+		String[] parts = { path };
+		TiBlob imageData = TiBlob.blobFromFile(TiFileFactory.createTitaniumFile(parts, false), mimeType);
+		return createDictForImage(imageData, mimeType);
+	}
+
+	public static KrollDict createDictForImage(TiBlob imageData, String mimeType) {
 		KrollDict d = new KrollDict();
 
 		int width = -1;
 		int height = -1;
 
-		try {
-			String fpath = path;
-			if (!fpath.startsWith("file://") && !fpath.startsWith("content://")) {
-				fpath = "file://" + path;
-			}
-			BitmapFactory.Options opts = new BitmapFactory.Options();
-			opts.inJustDecodeBounds = true;
+		BitmapFactory.Options opts = new BitmapFactory.Options();
+		opts.inJustDecodeBounds = true;
 
-			// We only need the ContentResolver so it doesn't matter if the root or current activity is used for
-			// accessing it
-			BitmapFactory.decodeStream(
-				TiApplication.getAppRootOrCurrentActivity().getContentResolver().openInputStream(Uri.parse(fpath)), null,
-				opts);
+		// We only need the ContentResolver so it doesn't matter if the root or current activity is used for
+		// accessing it
+		BitmapFactory.decodeStream(imageData.getInputStream(), null, opts);
 
-			width = opts.outWidth;
-			height = opts.outHeight;
-		} catch (FileNotFoundException e) {
-			Log.w(LCAT, "bitmap not found: " + path);
-		}
+		width = opts.outWidth;
+		height = opts.outHeight;
 
 		d.put("x", 0);
 		d.put("y", 0);
@@ -649,9 +678,8 @@ public class MediaModule extends KrollModule
 		cropRect.put("height", height);
 		d.put("cropRect", cropRect);
 
-		String[] parts = { path };
 		d.put("mediaType", MEDIA_TYPE_PHOTO);
-		d.put("media", TiBlob.blobFromFile(TiFileFactory.createTitaniumFile(parts, false), mimeType));
+		d.put("media", imageData);
 
 		return d;
 	}
@@ -785,7 +813,7 @@ public class MediaModule extends KrollModule
 		if (TiCameraActivity.cameraActivity != null) {
 			TiCameraActivity.takePicture();
 		} else {
-			Log.e(LCAT, "camera preview is not open, unable to take photo");
+			Log.e(LCAT, "Camera preview is not open, unable to take photo");
 		}
 	}
 

--- a/android/modules/media/src/java/ti/modules/titanium/media/TiCameraActivity.java
+++ b/android/modules/media/src/java/ti/modules/titanium/media/TiCameraActivity.java
@@ -1,45 +1,88 @@
 package ti.modules.titanium.media;
 
+import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.util.List;
 
+import org.appcelerator.kroll.KrollDict;
+import org.appcelerator.kroll.KrollFunction;
+import org.appcelerator.kroll.KrollObject;
+import org.appcelerator.kroll.common.Log;
+import org.appcelerator.titanium.TiApplication;
 import org.appcelerator.titanium.TiBaseActivity;
+import org.appcelerator.titanium.TiBlob;
+import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.proxy.TiViewProxy;
 
 import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
 import android.content.pm.ActivityInfo;
+import android.graphics.Color;
 import android.hardware.Camera;
 import android.hardware.Camera.Parameters;
 import android.hardware.Camera.PictureCallback;
-import android.hardware.Camera.ShutterCallback;
+import android.hardware.Camera.Size;
 import android.net.Uri;
 import android.os.Bundle;
-import android.provider.MediaStore;
-import android.util.Log;
+import android.view.Gravity;
 import android.view.SurfaceHolder;
 import android.view.SurfaceView;
 import android.view.ViewGroup.LayoutParams;
 import android.widget.FrameLayout;
 
 public class TiCameraActivity extends TiBaseActivity implements SurfaceHolder.Callback {
-	private static final String LCAT = "TiCameraActivity";
+	private static final String TAG = "TiCameraActivity";
 	private static Camera camera;
 
 	private TiViewProxy localOverlayProxy = null;
-	private Uri storageUri;
 	private SurfaceView preview;
-	private FrameLayout previewLayout;
+	private PreviewLayout previewLayout;
+	private FrameLayout cameraLayout;
+	private boolean previewRunning = false;
 
 	public static TiViewProxy overlayProxy = null;
 	public static TiCameraActivity cameraActivity = null;
 
+	public static KrollObject callbackContext;
+	public static KrollFunction successCallback, errorCallback, cancelCallback;
+	public static boolean saveToPhotoGallery = false;
+
+	private static class PreviewLayout extends FrameLayout {
+		private double aspectRatio;
+
+		public PreviewLayout(Context context) {
+			super(context);
+			setAspectRatio(4.0/3.0);
+		}
+
+		public void setAspectRatio(double aspectRatio) {
+			this.aspectRatio = aspectRatio;
+		}
+
+		@Override
+		protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+			int previewWidth = MeasureSpec.getSize(widthMeasureSpec);
+			int previewHeight = MeasureSpec.getSize(heightMeasureSpec);
+
+			// Resize the preview frame with correct aspect ratio.
+			if (previewWidth > previewHeight * aspectRatio) {
+				previewWidth = (int) (previewHeight * aspectRatio + .5);
+
+			} else {
+				previewHeight = (int) (previewWidth / aspectRatio + .5);
+			}
+
+			super.onMeasure(MeasureSpec.makeMeasureSpec(previewWidth, MeasureSpec.EXACTLY),
+					MeasureSpec.makeMeasureSpec(previewHeight, MeasureSpec.EXACTLY));
+		}
+	}
+
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
-
-		// set picture location
-		storageUri = (Uri)getIntent().getParcelableExtra(MediaStore.EXTRA_OUTPUT);
 
 		// create camera preview
 		preview = new SurfaceView(this);
@@ -52,42 +95,52 @@ public class TiCameraActivity extends TiBaseActivity implements SurfaceHolder.Ca
 		overlayProxy = null; // clear the static object once we have a local reference
 
 		// set overall layout - will populate in onResume
-		previewLayout = new FrameLayout(this);
+		previewLayout = new PreviewLayout(this);
+		cameraLayout = new FrameLayout(this);
+		cameraLayout.setBackgroundColor(Color.BLACK);
+		cameraLayout.addView(previewLayout, new FrameLayout.LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT, Gravity.CENTER));
 
 		setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
-		setContentView(previewLayout);
+		setContentView(cameraLayout);
 	}
 
 	public void surfaceChanged(SurfaceHolder previewHolder, int format, int width, int height) {
-		camera.startPreview();  // make sure setPreviewDisplay is called before this
+		if (!previewRunning) {
+			// Set the preview size to the most optimal given the target size and aspect ratio.
+			Parameters param = camera.getParameters();
+			Size pictureSize = param.getPictureSize();
+			double aspectRatio = (double) pictureSize.width / pictureSize.height;
+			previewLayout.setAspectRatio(aspectRatio);
+			List<Size> supportedPreviewSizes = param.getSupportedPreviewSizes();
+			Size previewSize = getOptimalPreviewSize(supportedPreviewSizes, width, height, aspectRatio);
+			if (previewSize != null) {
+				param.setPreviewSize(previewSize.width, previewSize.height);
+				camera.setParameters(param);
+			}
+
+			previewRunning = true;
+			camera.startPreview();
+		}
 	}
 
 	public void surfaceCreated(SurfaceHolder previewHolder) {
 		camera = Camera.open();
 
-		/*
-		 * Disabling this since it can end up picking a bad preview
-		 * size which can create stretching issues (TIMOB-8151).
-		 * Original words of wisdom left by some unknown person:
-		 * "using default preview size may be causing problem on some devices, setting dimensions manually"
-		 * We may want to expose camera parameters to the developer for extra control.
-		Parameters cameraParams = camera.getParameters();
-		Camera.Size previewSize = cameraParams.getSupportedPreviewSizes().get((cameraParams.getSupportedPreviewSizes().size()) - 1);
-		cameraParams.setPreviewSize(previewSize.width, previewSize.height );
-		camera.setParameters(cameraParams);
-		*/
-
 		try {
-			Log.i(LCAT, "setting preview display");
 			camera.setPreviewDisplay(previewHolder);
+
 		} catch(IOException e) {
-			e.printStackTrace();
+			onError(MediaModule.UNKNOWN_ERROR, "Unable to setup preview surface: " + e.getMessage());
+			cancelCallback = null;
+			finish();
+			return;
 		}
 	}
 
 	// make sure to call release() otherwise you will have to force kill the app before 
 	// the built in camera will open
 	public void surfaceDestroyed(SurfaceHolder previewHolder) {
+		stopPreview();
 		camera.release();
 		camera = null;
 	}
@@ -97,60 +150,136 @@ public class TiCameraActivity extends TiBaseActivity implements SurfaceHolder.Ca
 		super.onResume();
 
 		cameraActivity = this;
-		previewLayout.addView(preview);
-		previewLayout.addView(localOverlayProxy.getOrCreateView().getNativeView(), new FrameLayout.LayoutParams(LayoutParams.FILL_PARENT, LayoutParams.FILL_PARENT));
+		previewLayout.addView(preview, new FrameLayout.LayoutParams(LayoutParams.FILL_PARENT, LayoutParams.FILL_PARENT));
+		cameraLayout.addView(localOverlayProxy.getOrCreateView().getNativeView(), new FrameLayout.LayoutParams(LayoutParams.FILL_PARENT, LayoutParams.FILL_PARENT));
 	}
 
 	@Override
 	protected void onPause() {
 		super.onPause();
 
+		stopPreview();
 		previewLayout.removeView(preview);
-		previewLayout.removeView(localOverlayProxy.getOrCreateView().getNativeView());
+		cameraLayout.removeView(localOverlayProxy.getOrCreateView().getNativeView());
 
 		try {
 			camera.release();
 			camera = null;
 		} catch (Throwable t) {
-			Log.i(LCAT, "camera is not open, unable to release");
+			Log.d(TAG, "Camera is not open, unable to release");
 		}
 
 		cameraActivity = null;
 	}
 
-	static public void takePicture() {
-		Log.i(LCAT, "Taking picture");
-		camera.takePicture(shutterCallback, rawCallback, jpegCallback);
+	private void stopPreview() {
+		if (camera == null || !previewRunning) {
+			return;
+		}
+
+		camera.stopPreview();
+		previewRunning = false;
 	}
 
-	// support user defined callback for this in the future?
-	static ShutterCallback shutterCallback = new ShutterCallback() {
-		public void onShutter() {
-		}
-	};
+	/**
+	 * Computes the optimal preview size given the target display size and aspect ratio.
+	 *
+	 * @param supportPreviewSizes a list of preview sizes the camera supports
+	 * @param targetSize the target display size that will render the preview
+	 * @param aspectRatio the aspect ratio to use for previewing the image
+	 * @return the optimal size of the preview
+	 */
+	private static Size getOptimalPreviewSize(List<Size> supportedPreviewSizes, int width, int height, double aspectRatio) {
+		final double ASPECT_TOLERANCE = 0.001;
+		Size optimalSize = null;
+		double minDiff = Double.MAX_VALUE;
 
-	// support user defined callback for this in the future?
-	static PictureCallback rawCallback = new PictureCallback() {
-		public void onPictureTaken(byte[] data, Camera camera) {
+        int targetHeight = Math.min(height, width);
+        if (targetHeight <= 0) {
+            // We don't know the size of SurfaceView, use screen height
+            targetHeight = height;
+        }
+
+		for (Size size : supportedPreviewSizes) {
+			double ratio = (double) size.width / size.height;
+			if (Math.abs(ratio - aspectRatio) > ASPECT_TOLERANCE) continue;
+
+            if (Math.abs(size.height - targetHeight) < minDiff) {
+                optimalSize = size;
+                minDiff = Math.abs(size.height - targetHeight);
+            }
 		}
-	};
+
+		// If a size cannot be found that matches the aspect ratio, try
+		// again and just ignore the aspect ratio. We will just try to find
+		// the best size that fits best.
+		if (optimalSize == null) {
+			Log.w(TAG, "No preview size found that matches the aspect ratio.");
+			minDiff = Double.MAX_VALUE;
+			for (Size size : supportedPreviewSizes) {
+				if (Math.abs(size.height - targetHeight) < minDiff) {
+					optimalSize = size;
+					minDiff = Math.abs(size.height - targetHeight);
+				}
+			}
+		}
+
+		return optimalSize;
+	}
+
+	private static void onError(int code, String message) {
+		if (errorCallback == null) {
+			Log.e(TAG, message);
+			return;
+		}
+
+		KrollDict dict = new KrollDict();
+		dict.put(TiC.PROPERTY_CODE, code);
+		dict.put(TiC.PROPERTY_MESSAGE, message);
+
+		errorCallback.callAsync(callbackContext, dict);
+	}
+
+	private static void saveToPhotoGallery(byte[] data) {
+		File imageFile = MediaModule.createGalleryImageFile();
+		try {
+			FileOutputStream imageOut = new FileOutputStream(imageFile);
+			imageOut.write(data);
+			imageOut.close();
+
+		} catch (FileNotFoundException e) {
+			Log.e(TAG, "Failed to open gallery image file: " + e.getMessage());
+
+		} catch (IOException e) {
+			Log.e(TAG, "Failed to write image to gallery file: " + e.getMessage());
+		}
+
+		// Notify media scanner to add image to gallery.
+		Intent mediaScanIntent = new Intent(Intent.ACTION_MEDIA_SCANNER_SCAN_FILE);
+		Uri contentUri = Uri.fromFile(imageFile);
+		mediaScanIntent.setData(contentUri);
+		Activity activity = TiApplication.getAppCurrentActivity();
+		activity.sendBroadcast(mediaScanIntent);
+	}
+
+	static public void takePicture() {
+		camera.takePicture(null, null, jpegCallback);
+	}
 
 	static PictureCallback jpegCallback = new PictureCallback() {
 		public void onPictureTaken(byte[] data, Camera camera) {
-			FileOutputStream outputStream = null;
-			try {
-				// write photo to storage
-				outputStream = new FileOutputStream(cameraActivity.storageUri.getPath());
-				outputStream.write(data);
-				outputStream.close();
-
-				cameraActivity.setResult(Activity.RESULT_OK);
-				cameraActivity.finish();
-			} catch (FileNotFoundException e) {
-				e.printStackTrace();
-			} catch (IOException e) {
-				e.printStackTrace();
+			if (saveToPhotoGallery) {
+				saveToPhotoGallery(data);
 			}
+
+			if (successCallback != null) {
+				TiBlob imageData = TiBlob.blobFromData(data);
+				KrollDict dict = MediaModule.createDictForImage(imageData, "image/jpeg");
+				successCallback.callAsync(callbackContext, dict);
+			}
+
+			cancelCallback = null;
+			cameraActivity.finish();
 		}
 	};
 }

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiFileHelper.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiFileHelper.java
@@ -61,6 +61,8 @@ public class TiFileHelper
 	private SoftReference<Context> softContext;
 	private TiNinePatchHelper nph;
 	
+	private ArrayList<File> tempFiles = new ArrayList<File>();
+
 	private static HashSet<String> resourcePathCache;
 	private static HashSet<String> foundResourcePathCache;
 	private static HashSet<String> notFoundResourcePathCache;
@@ -585,6 +587,25 @@ public class TiFileHelper
 				Log.w(LCAT, "getTempFile: Directory '" + dir.getAbsolutePath() + "' does not exist. Call to File.createTempFile() will fail." );
 			}
 			result = File.createTempFile("tia", suffix, dir);
+		}
+		return result;
+	}
+
+	public File getTempFile(File dir, String suffix, boolean destroyOnExit)
+		throws IOException
+	{
+		File result = null;
+		Context context = softContext.get();
+		if (context != null) {
+			if (!dir.exists()) {
+				Log.w(LCAT, "getTempFile: Directory '" + dir.getAbsolutePath()
+					+ "' does not exist. Call to File.createTempFile() will fail.");
+			}
+			result = File.createTempFile("tia", suffix, dir);
+
+			if (destroyOnExit) {
+				tempFiles.add(result);
+			}
 		}
 		return result;
 	}


### PR DESCRIPTION
Backport of 1ab989c to 2.1.X branch.

We don't need to write the image data to the FS if using our
customer overlay activity IF the user does not want it saved
to the photo gallery.
