### PR TITLE
timob-11761: Anvil: Android: jsUrlActivity test fails due to timeout

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/ActionBarProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/ActionBarProxy.java
@@ -87,6 +87,9 @@ public class ActionBarProxy extends KrollProxy
 	@Kroll.method @Kroll.getProperty
 	public String getTitle()
 	{
+		if (actionBar == null) {
+			return null;
+		}
 		return (String) actionBar.getTitle();
 	}
 


### PR DESCRIPTION
http://jira.appcelerator.org/browse/TIMOB-11761
Test steps in JIRA.
