### PR TITLE
[TIMOB-11755][TIMOB-11756] (3_0_X) HTTPClient: add properties username, password and domain

### DIFF
--- a/android/modules/network/src/java/ti/modules/titanium/network/HTTPClientProxy.java
+++ b/android/modules/network/src/java/ti/modules/titanium/network/HTTPClientProxy.java
@@ -175,4 +175,39 @@ public class HTTPClientProxy extends KrollProxy
 		this.setProperty("validatesSecureCertificate", value);
 	}
 
+	@Kroll.setProperty @Kroll.method
+	public void setUsername(String value)
+	{
+		this.setProperty("username", value);
+	}
+
+	@Kroll.setProperty @Kroll.method
+	public String getUsername()
+	{
+		return client.getUsername();
+	}
+
+	@Kroll.setProperty @Kroll.method
+	public void setPassword(String value)
+	{
+		this.setProperty("password", value);
+	}
+
+	@Kroll.setProperty @Kroll.method
+	public String getPassword()
+	{
+		return client.getPassword();
+	}
+
+	@Kroll.setProperty @Kroll.method
+	public void setDomain(String value)
+	{
+		this.setProperty("domain", value);
+	}
+
+	@Kroll.setProperty @Kroll.method
+	public String getDomain()
+	{
+		return client.getDomain();
+	}
 }

--- a/android/modules/network/src/java/ti/modules/titanium/network/HTTPClientProxy.java
+++ b/android/modules/network/src/java/ti/modules/titanium/network/HTTPClientProxy.java
@@ -180,7 +180,7 @@ public class HTTPClientProxy extends KrollProxy
 	@Kroll.setProperty @Kroll.method
 	public void setUsername(String value)
 	{
-		this.setProperty("username", value);
+		this.setProperty(TiC.PROPERTY_USERNAME, value);
 	}
 
 	@Kroll.getProperty @Kroll.method
@@ -192,7 +192,7 @@ public class HTTPClientProxy extends KrollProxy
 	@Kroll.setProperty @Kroll.method
 	public void setPassword(String value)
 	{
-		this.setProperty("password", value);
+		this.setProperty(TiC.PROPERTY_PASSWORD, value);
 	}
 
 	@Kroll.getProperty @Kroll.method
@@ -204,7 +204,7 @@ public class HTTPClientProxy extends KrollProxy
 	@Kroll.setProperty @Kroll.method
 	public void setDomain(String value)
 	{
-		this.setProperty("domain", value);
+		this.setProperty(TiC.PROPERTY_DOMAIN, value);
 	}
 
 	@Kroll.getProperty @Kroll.method

--- a/android/modules/network/src/java/ti/modules/titanium/network/HTTPClientProxy.java
+++ b/android/modules/network/src/java/ti/modules/titanium/network/HTTPClientProxy.java
@@ -186,7 +186,10 @@ public class HTTPClientProxy extends KrollProxy
 	@Kroll.getProperty @Kroll.method
 	public String getUsername()
 	{
-		return client.getUsername();
+		if (this.hasProperty(TiC.PROPERTY_USERNAME)) {
+			return TiConvert.toString(this.getProperty(TiC.PROPERTY_USERNAME));
+		}
+		return null;
 	}
 
 	@Kroll.setProperty @Kroll.method
@@ -198,7 +201,10 @@ public class HTTPClientProxy extends KrollProxy
 	@Kroll.getProperty @Kroll.method
 	public String getPassword()
 	{
-		return client.getPassword();
+		if (this.hasProperty(TiC.PROPERTY_PASSWORD)) {
+			return TiConvert.toString(this.getProperty(TiC.PROPERTY_PASSWORD));
+		}
+		return null;
 	}
 
 	@Kroll.setProperty @Kroll.method
@@ -210,7 +216,10 @@ public class HTTPClientProxy extends KrollProxy
 	@Kroll.getProperty @Kroll.method
 	public String getDomain()
 	{
-		return client.getDomain();
+		if (this.hasProperty(TiC.PROPERTY_DOMAIN)) {
+			return TiConvert.toString(this.getProperty(TiC.PROPERTY_DOMAIN));
+		}
+		return null;
 	}
 	
 	@Kroll.method

--- a/android/modules/network/src/java/ti/modules/titanium/network/HTTPClientProxy.java
+++ b/android/modules/network/src/java/ti/modules/titanium/network/HTTPClientProxy.java
@@ -12,7 +12,9 @@ import org.appcelerator.kroll.KrollDict;
 import org.appcelerator.kroll.KrollProxy;
 import org.appcelerator.kroll.annotations.Kroll;
 import org.appcelerator.titanium.TiBlob;
+import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.TiContext;
+import org.appcelerator.titanium.util.TiConvert;
 
 import ti.modules.titanium.xml.DocumentProxy;
 

--- a/android/modules/network/src/java/ti/modules/titanium/network/HTTPClientProxy.java
+++ b/android/modules/network/src/java/ti/modules/titanium/network/HTTPClientProxy.java
@@ -181,7 +181,7 @@ public class HTTPClientProxy extends KrollProxy
 		this.setProperty("username", value);
 	}
 
-	@Kroll.setProperty @Kroll.method
+	@Kroll.getProperty @Kroll.method
 	public String getUsername()
 	{
 		return client.getUsername();
@@ -193,7 +193,7 @@ public class HTTPClientProxy extends KrollProxy
 		this.setProperty("password", value);
 	}
 
-	@Kroll.setProperty @Kroll.method
+	@Kroll.getProperty @Kroll.method
 	public String getPassword()
 	{
 		return client.getPassword();
@@ -205,7 +205,7 @@ public class HTTPClientProxy extends KrollProxy
 		this.setProperty("domain", value);
 	}
 
-	@Kroll.setProperty @Kroll.method
+	@Kroll.getProperty @Kroll.method
 	public String getDomain()
 	{
 		return client.getDomain();

--- a/android/modules/network/src/java/ti/modules/titanium/network/HTTPClientProxy.java
+++ b/android/modules/network/src/java/ti/modules/titanium/network/HTTPClientProxy.java
@@ -217,7 +217,7 @@ public class HTTPClientProxy extends KrollProxy
 	public void addAuthFactory(String scheme, Object factory)
 	{
 		//Sanity Checks
-		if ( (scheme == null) || (scheme.length() == 0) || (factory == null) || (! (factory instanceof AuthSchemeFactory) )) {
+		if ( (scheme == null) || (scheme.length() == 0) || (! (factory instanceof AuthSchemeFactory) )) {
 			return;
 		}
 		

--- a/android/modules/network/src/java/ti/modules/titanium/network/HTTPClientProxy.java
+++ b/android/modules/network/src/java/ti/modules/titanium/network/HTTPClientProxy.java
@@ -7,6 +7,8 @@
 package ti.modules.titanium.network;
 
 import org.apache.http.MethodNotSupportedException;
+import org.apache.http.auth.AuthSchemeFactory;
+import org.appcelerator.kroll.KrollDict;
 import org.appcelerator.kroll.KrollProxy;
 import org.appcelerator.kroll.annotations.Kroll;
 import org.appcelerator.titanium.TiBlob;
@@ -209,5 +211,16 @@ public class HTTPClientProxy extends KrollProxy
 	public String getDomain()
 	{
 		return client.getDomain();
+	}
+	
+	@Kroll.method
+	public void addAuthFactory(String scheme, Object factory)
+	{
+		//Sanity Checks
+		if ( (scheme == null) || (scheme.length() == 0) || (factory == null) || (! (factory instanceof AuthSchemeFactory) )) {
+			return;
+		}
+		
+		client.addAuthFactory(scheme, (AuthSchemeFactory)factory);
 	}
 }

--- a/android/modules/network/src/java/ti/modules/titanium/network/TiHTTPClient.java
+++ b/android/modules/network/src/java/ti/modules/titanium/network/TiHTTPClient.java
@@ -511,7 +511,7 @@ public class TiHTTPClient
 
 	public String getDomain()
 	{
-		if (proxy.hasProperty("domin")) {
+		if (proxy.hasProperty("domain")) {
 			return TiConvert.toString(proxy.getProperty("domain"));
 		}
 		return null;

--- a/android/modules/network/src/java/ti/modules/titanium/network/TiHTTPClient.java
+++ b/android/modules/network/src/java/ti/modules/titanium/network/TiHTTPClient.java
@@ -87,6 +87,7 @@ import org.appcelerator.kroll.common.Log;
 import org.appcelerator.kroll.util.TiTempFileHelper;
 import org.appcelerator.titanium.TiApplication;
 import org.appcelerator.titanium.TiBlob;
+import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.TiFileProxy;
 import org.appcelerator.titanium.io.TiBaseFile;
 import org.appcelerator.titanium.io.TiFile;
@@ -500,24 +501,24 @@ public class TiHTTPClient
 	
 	public String getUsername()
 	{
-		if (proxy.hasProperty("username")) {
-			return TiConvert.toString(proxy.getProperty("username"));
+		if (proxy.hasProperty(TiC.PROPERTY_USERNAME)) {
+			return TiConvert.toString(proxy.getProperty(TiC.PROPERTY_USERNAME));
 		}
 		return null;
 	}
 	
 	public String getPassword()
 	{
-		if (proxy.hasProperty("password")) {
-			return TiConvert.toString(proxy.getProperty("password"));
+		if (proxy.hasProperty(TiC.PROPERTY_PASSWORD)) {
+			return TiConvert.toString(proxy.getProperty(TiC.PROPERTY_PASSWORD));
 		}
 		return null;
 	}
 
 	public String getDomain()
 	{
-		if (proxy.hasProperty("domain")) {
-			return TiConvert.toString(proxy.getProperty("domain"));
+		if (proxy.hasProperty(TiC.PROPERTY_DOMAIN)) {
+			return TiConvert.toString(proxy.getProperty(TiC.PROPERTY_DOMAIN));
 		}
 		return null;
 	}

--- a/android/modules/network/src/java/ti/modules/titanium/network/TiHTTPClient.java
+++ b/android/modules/network/src/java/ti/modules/titanium/network/TiHTTPClient.java
@@ -499,30 +499,6 @@ public class TiHTTPClient
 		return false;
 	}
 	
-	public String getUsername()
-	{
-		if (proxy.hasProperty(TiC.PROPERTY_USERNAME)) {
-			return TiConvert.toString(proxy.getProperty(TiC.PROPERTY_USERNAME));
-		}
-		return null;
-	}
-	
-	public String getPassword()
-	{
-		if (proxy.hasProperty(TiC.PROPERTY_PASSWORD)) {
-			return TiConvert.toString(proxy.getProperty(TiC.PROPERTY_PASSWORD));
-		}
-		return null;
-	}
-
-	public String getDomain()
-	{
-		if (proxy.hasProperty(TiC.PROPERTY_DOMAIN)) {
-			return TiConvert.toString(proxy.getProperty(TiC.PROPERTY_DOMAIN));
-		}
-		return null;
-	}
-	
 	public void addAuthFactory(String scheme, AuthSchemeFactory theFactory)
 	{
 		customAuthenticators.put(scheme, theFactory);
@@ -870,9 +846,9 @@ public class TiHTTPClient
 			credentials = new UsernamePasswordCredentials(uri.getUserInfo());
 		}
 		if (credentials == null) {
-			String userName = getUsername();
-			String password = getPassword();
-			String domain = getDomain();
+			String userName = ((HTTPClientProxy)proxy).getUsername();
+			String password = ((HTTPClientProxy)proxy).getPassword();
+			String domain = ((HTTPClientProxy)proxy).getDomain();
 			if (domain != null) {
 				password = (password == null)?"":password;
 				credentials = new NTCredentials(userName, password, TiPlatformHelper.getMobileId(), domain);

--- a/android/titanium/src/java/org/appcelerator/titanium/TiC.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiC.java
@@ -929,6 +929,11 @@ public class TiC
 	/**
 	 * @module.api
 	 */
+	public static final String PROPERTY_DOMAIN = "domain";
+
+	/**
+	 * @module.api
+	 */
 	public static final String PROPERTY_DOMESTIC_PARTNER = "domesticPartner";
 
 	/**
@@ -1502,6 +1507,11 @@ public class TiC
 	/**
 	 * @module.api
 	 */
+	public static final String PROPERTY_PASSWORD = "password";
+
+	/**
+	 * @module.api
+	 */
 	public static final String PROPERTY_PASSWORD_MASK = "passwordMask";
 
 	/**
@@ -1959,6 +1969,11 @@ public class TiC
 	 * @module.api
 	 */
 	public static final String PROPERTY_URL = "url";
+
+	/**
+	 * @module.api
+	 */
+	public static final String PROPERTY_USERNAME = "username";
 
 	/**
 	 * @module.api

--- a/iphone/Classes/TiNetworkHTTPClientProxy.m
+++ b/iphone/Classes/TiNetworkHTTPClientProxy.m
@@ -425,6 +425,12 @@ extern NSString * const TI_APPLICATION_DEPLOYTYPE;
 	[request setShouldAttemptPersistentConnection:keepAlive];
 	//handled in send, as now optional
 	//[request setShouldRedirect:YES];
+    
+	//TIMOB-5435 NTLM support
+	[request setUsername:[TiUtils stringValue:[self valueForKey:@"username"]]];
+	[request setPassword:[TiUtils stringValue:[self valueForKey:@"password"]]];
+	[request setDomain:[TiUtils stringValue:[self valueForKey:@"domain"]]];
+    
 	[self _fireReadyStateChange:NetworkClientStateOpened failed:NO];
 	[self _fireReadyStateChange:NetworkClientStateHeaders failed:NO];
 }


### PR DESCRIPTION
Backport of PR #3422 into 3_0_X

Exposes username, password and domain properties for http client for iOS and Android.

On iOS this will enable NTLM authentication

For Android, have exposed new method addAuthFactory(String,AuthSchemeFactory) to add custom AuthSchemeFactory  to HTTP Client. Developers should be able to extend HTTPClient for android for any auth scheme they choose (including NTLM) with modules.

JIRA Tickets
[iOS](http://jira.appcelerator.org/browse/TIMOB-11755)
[Android](http://jira.appcelerator.org/browse/TIMOB-11756)
