### PR TITLE
[TIMOB-11691] (3_0_X) Ensure row data when bubbling events

### DIFF
--- a/iphone/Classes/TiBindingEvent.m
+++ b/iphone/Classes/TiBindingEvent.m
@@ -108,6 +108,14 @@ TiProxy * TiBindingEventNextBubbleTargetProxy(TiBindingEvent event, TiProxy * cu
 		}
 		parentOnly = false;
 		currentTarget = [currentTarget parentForBubbling];
+        
+        //TIMOB-11691. Ensure that tableviewrowproxy modifies the event object before passing it along.
+        if ([currentTarget respondsToSelector:@selector(createEventObject:)]) {
+            NSDictionary *curPayload = event->payloadDictionary;
+            NSDictionary *modifiedPayload = [currentTarget createEventObject:curPayload];
+            [event->payloadDictionary release];
+            event->payloadDictionary = [modifiedPayload copy];
+        }
 	}
 	return currentTarget;
 }


### PR DESCRIPTION
Backport of PR #3455

Test is in [JIRA](https://jira.appcelerator.org/browse/TIMOB-11691)
