### PR TITLE
[TIMOB-11763] 3_0_X Android module with JNI won't build

### DIFF
--- a/support/module/android/build.xml
+++ b/support/module/android/build.xml
@@ -393,7 +393,12 @@ timodule.xml.
 	<target name="ndk.build.local" if="${jni.local}">
 		<check.ndk/>
 		<mkdir dir="${genjni.local}"/>
-		<copy todir="${genjni.local}">
+		<copy todir="${genjni.local}"
+			file="${module.generated.dir}/Application.mk">
+			<filterset refid="ndk.filter"/>
+		</copy>
+		<mkdir dir="${genjni.local}/jni"/>
+		<copy todir="${genjni.local}/jni">
 			<fileset dir="${ti.module.root}/jni">
 				<include name="**"/>
 			</fileset>


### PR DESCRIPTION
[TIMOB-11763](https://jira.appcelerator.org/browse/TIMOB-11763)

Test instructions in JIRA

This is the 3_0_X backport of #3472
