### PR TITLE
[TIMOB-11861] ensure rowContainer frame to match row contentView.

### DIFF
--- a/iphone/Classes/TiUITableViewRowProxy.m
+++ b/iphone/Classes/TiUITableViewRowProxy.m
@@ -712,7 +712,7 @@ TiProxy * DeepScanForProxyOfViewContainingPoint(UIView * targetView, CGPoint poi
 	if ([[self children] count] > 0)
 	{
 		UIView *contentView = cell.contentView;
-		CGRect rect = [contentView frame];
+		CGRect rect = [contentView bounds];
         CGSize cellSize = [(TiUITableViewCell*)cell computeCellSize];
 		CGFloat rowWidth = cellSize.width;
 		CGFloat rowHeight = cellSize.height;
@@ -763,6 +763,8 @@ TiProxy * DeepScanForProxyOfViewContainingPoint(UIView * targetView, CGPoint poi
 			if (rowContainerView == nil) {
 				rowContainerView = [[TiUITableViewRowContainer alloc] initWithFrame:rect];
 				[contentView addSubview:rowContainerView];
+			} else {
+				[rowContainerView setFrame:rect];
 			}
 			[rowContainerView setBackgroundColor:[UIColor clearColor]];
 			[rowContainerView setAutoresizingMask:UIViewAutoresizingFlexibleWidth|UIViewAutoresizingFlexibleHeight];
@@ -783,6 +785,7 @@ TiProxy * DeepScanForProxyOfViewContainingPoint(UIView * targetView, CGPoint poi
 				[proxy setReproxying:NO];
 			}];
 		} else {
+			[rowContainerView setFrame:rect];
 			[contentView addSubview:rowContainerView];
 		}
 	}


### PR DESCRIPTION
Backport of #3489

[TIMOB-11861](https://jira.appcelerator.org/browse/TIMOB-11861)

**FT note**: run _ALL_ KitchenSink TableView tests.
