### PR TITLE
[TIMOB-13360] Exporting mediaURL for later cleanup

### DIFF
--- a/iphone/Classes/MediaModule.m
+++ b/iphone/Classes/MediaModule.m
@@ -1404,7 +1404,7 @@ MAKE_SYSTEM_PROP(VIDEO_FINISH_REASON_USER_EXITED,MPMovieFinishReasonUserExited);
 	}
 
 	NSMutableDictionary *dictionary = [NSMutableDictionary dictionaryWithObjectsAndKeys:
-			mediaType,@"mediaType",media,@"media",nil];
+			mediaType,@"mediaType",media,@"media",mediaURL,@"mediaURL",nil];
 
 	if (thumbnail!=nil)
 	{


### PR DESCRIPTION
Some privacy-caring apps (as ours) may want to remove temp files after processing. This patch returns the temp mediaURL.

The temp can't be removed in the module as the blob won't be read properly.
