### PR TITLE
[TIMOB-11866](dbl)click now fired on touchesEnded/UITouchPhaseEnded

### DIFF
--- a/iphone/Classes/TiUIButton.m
+++ b/iphone/Classes/TiUIButton.m
@@ -117,7 +117,7 @@
             touchStarted = NO;
             fireEvent = @"touchend";
             if (button.highlighted) {
-                fireActionEvent = [touch tapCount] < 2 ? @"click" : @"dblclick";
+                fireActionEvent = [touch tapCount] == 1 ? @"click" : ([touch tapCount] == 2 ? @"dblclick" : nil);
             }
             break;
         case UITouchPhaseCancelled:

--- a/iphone/Classes/TiUIView.m
+++ b/iphone/Classes/TiUIView.m
@@ -1131,19 +1131,6 @@ DEFINE_EXCEPTIONS
 			[proxy fireEvent:@"touchstart" withObject:evt propagate:YES];
 			[self handleControlEvents:UIControlEventTouchDown];
 		}
-        // Click handling is special; don't propagate if we have a delegate,
-        // but DO invoke the touch delegate.
-		// clicks should also be handled by any control the view is embedded in.
-		if ([touch tapCount] == 1 && [proxy _hasListeners:@"click"])
-		{
-			if (touchDelegate == nil) {
-				[proxy fireEvent:@"click" withObject:evt propagate:YES];
-				return;
-			} 
-		} else if ([touch tapCount] == 2 && [proxy _hasListeners:@"dblclick"]) {
-			[proxy fireEvent:@"dblclick" withObject:evt propagate:YES];
-			return;
-		}
 	}
 }
 
@@ -1188,6 +1175,20 @@ DEFINE_EXCEPTIONS
 		{
 			[proxy fireEvent:@"touchend" withObject:evt propagate:YES];
 			[self handleControlEvents:UIControlEventTouchCancel];
+		}
+        
+		// Click handling is special; don't propagate if we have a delegate,
+		// but DO invoke the touch delegate.
+		// clicks should also be handled by any control the view is embedded in.
+		if ([touch tapCount] == 1 && [proxy _hasListeners:@"click"])
+		{
+			if (touchDelegate == nil) {
+				[proxy fireEvent:@"click" withObject:evt propagate:YES];
+				return;
+			}
+		} else if ([touch tapCount] == 2 && [proxy _hasListeners:@"dblclick"]) {
+			[proxy fireEvent:@"dblclick" withObject:evt propagate:YES];
+			return;
 		}
 	}
 }


### PR DESCRIPTION
For [TIMOB-11866](https://jira.appcelerator.org/browse/TIMOB-11866)

Fixes a couple of issues.
1. Now we have parity as to when click/dblclick fires between buttons and regular views (touchend).
2. The Button kept firing the dblclick event repeatedly even when tapCount > 2 while regular views did not. Fixes that as well.

This of course means we do not track clicks past the second click on buttons (but that was incorrect anyways)
