### PR TITLE
TIMOB-11820: Android: ScrollableView in ScrollView is not working

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIScrollView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIScrollView.java
@@ -38,7 +38,7 @@ public class TiUIScrollView extends TiUIView
 	private boolean setInitialOffset = false;
 	private boolean mScrollingEnabled = true;
 
-	private class TiScrollViewLayout extends TiCompositeLayout
+	public class TiScrollViewLayout extends TiCompositeLayout
 	{
 		private static final int AUTO = Integer.MAX_VALUE;
 		private int parentWidth = 0;

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIScrollView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIScrollView.java
@@ -21,8 +21,6 @@ import org.appcelerator.titanium.view.TiUIView;
 
 import android.content.Context;
 import android.graphics.Canvas;
-import android.view.GestureDetector;
-import android.view.GestureDetector.SimpleOnGestureListener;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
@@ -46,20 +44,10 @@ public class TiUIScrollView extends TiUIView
 		private int parentWidth = 0;
 		private int parentHeight = 0;
 		private boolean canCancelEvents = true;
-		private GestureDetector gestureDetector;
 
 		public TiScrollViewLayout(Context context, LayoutArrangement arrangement)
 		{
 			super(context, arrangement, proxy);
-			gestureDetector = new GestureDetector(new SimpleOnGestureListener()
-			{
-				@Override
-				public void onLongPress(MotionEvent e)
-				{
-					// Only do this for long presses to match iOS behavior
-					requestDisallowInterceptTouchEvent(true);
-				}
-			});
 		}
 
 		public void setParentWidth(int width)
@@ -81,10 +69,11 @@ public class TiUIScrollView extends TiUIView
 		public boolean dispatchTouchEvent(MotionEvent ev)
 		{
 			// If canCancelEvents is false, then we want to prevent the scroll view from canceling the touch
-			// events of the child view by calling requestDisallowInterceptTouchEvent(true)
+			// events of the child view
 			if (!canCancelEvents) {
-				gestureDetector.onTouchEvent(ev);
+				requestDisallowInterceptTouchEvent(true);
 			}
+
 			return super.dispatchTouchEvent(ev);
 		}
 

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIScrollableView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIScrollableView.java
@@ -21,6 +21,7 @@ import org.appcelerator.titanium.view.TiCompositeLayout.LayoutParams;
 import org.appcelerator.titanium.view.TiUIView;
 
 import ti.modules.titanium.ui.ScrollableViewProxy;
+import ti.modules.titanium.ui.widget.TiUIScrollView.TiScrollViewLayout;
 import android.app.Activity;
 import android.content.Context;
 import android.os.Parcelable;
@@ -536,6 +537,27 @@ public class TiUIScrollableView extends TiUIView
 				showPager();
 			}
 			return super.onTrackballEvent(event);
+		}
+
+		@Override
+		public boolean dispatchTouchEvent(MotionEvent ev)
+		{
+			// If the parent is a scroll view, then we prevent the scroll view from intercepting touch events
+			if (this.getParent() instanceof TiScrollViewLayout) {
+				int action = ev.getAction();
+				switch (action) {
+					case MotionEvent.ACTION_DOWN:
+						requestDisallowInterceptTouchEvent(true);
+						break;
+
+					case MotionEvent.ACTION_UP:
+					case MotionEvent.ACTION_CANCEL:
+						requestDisallowInterceptTouchEvent(false);
+						break;
+
+				}
+			}
+			return super.dispatchTouchEvent(ev);
 		}
 
 		@Override

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIScrollableView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIScrollableView.java
@@ -543,7 +543,7 @@ public class TiUIScrollableView extends TiUIView
 		public boolean dispatchTouchEvent(MotionEvent ev)
 		{
 			// If the parent is a scroll view, then we prevent the scroll view from intercepting touch events
-			if (this.getParent() instanceof TiScrollViewLayout) {
+			if (getParent() instanceof TiScrollViewLayout) {
 				int action = ev.getAction();
 				switch (action) {
 					case MotionEvent.ACTION_DOWN:

--- a/apidoc/Titanium/UI/ScrollView.yml
+++ b/apidoc/Titanium/UI/ScrollView.yml
@@ -170,9 +170,13 @@ events:
 
 properties:
   - name: canCancelEvents
-    summary: |
-        Determines whether this scroll view can cancel subview touches in order to scroll instead.
-    description: Set to `false` to ensure that subview touches always take effect.
+    summary: Determines whether this scroll view can cancel subview touches in order to scroll instead.
+    description: |
+        On iOS, this property maps to the native `canCancelContentTouches` property which controls 
+        whether touches in the content view always lead to tracking. See [UIScrollView](http://developer.apple.com/library/ios/#documentation/uikit/reference/UIScrollView_Class/Reference/UIScrollView.html) for more details.
+
+        On Android, setting this property to false prevents the scroll view from intercepting 
+        any touch events from its subviews. Note that this behavior may be slightly different from iOS.
     type: Boolean
     default: true
     platforms: [android, iphone, ipad]


### PR DESCRIPTION
https://jira.appcelerator.org/browse/TIMOB-11820

Please use the test case in the comments, but set the 'canCancelEvents' property in the scroll view to true.  I have made changes to the scrollable view, so you do not need to set the 'canCancelEvents' on the scrollview.

Please also run the test case in https://jira.appcelerator.org/browse/TIMOB-9955.  Since the user specified 'canCancelEvents' events to be false, the blue view SHOULD be unscrollable.  I have documented that this may be different in iOS in the docs. 
