### PR TITLE
[TIMOB-11352] Android: TableViewSection header title does not change if ...

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiTableView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiTableView.java
@@ -454,7 +454,7 @@ public class TiTableView extends FrameLayout
 
 	private TiUIView layoutHeaderOrFooter(TiViewProxy viewProxy)
 	{
-		TiUIView tiView = viewProxy.getOrCreateView();
+		TiUIView tiView = viewProxy.getOrCreateView(false);		// false means don't set model listener
 		View nativeView = tiView.getOuterView();
 		TiCompositeLayout.LayoutParams params = tiView.getLayoutParams();
 

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiTableViewHeaderItem.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiTableViewHeaderItem.java
@@ -6,7 +6,6 @@
  */
 package ti.modules.titanium.ui.widget.tableview;
 
-import org.appcelerator.kroll.common.Log;
 import org.appcelerator.titanium.TiContext;
 import org.appcelerator.titanium.proxy.TiViewProxy;
 import org.appcelerator.titanium.util.TiUIHelper;

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiTableViewHeaderItem.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiTableViewHeaderItem.java
@@ -112,6 +112,7 @@ public class TiTableViewHeaderItem extends TiBaseTableViewItem
 	private void setHeaderData(Item item)
 	{
 		this.item = item;
+		headerView.processProperties(item.proxy.getProperties());
 		if (headerView != null && headerView.getChildren() != null && headerView.getChildren().size() > 0 && item != null
 			&& item.proxy != null && item.proxy.getChildren() != null && item.proxy.getChildren().length > 0) {
 			TiUIView labelView = headerView.getChildren().get(0);

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiTableViewHeaderItem.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiTableViewHeaderItem.java
@@ -6,6 +6,7 @@
  */
 package ti.modules.titanium.ui.widget.tableview;
 
+import org.appcelerator.kroll.common.Log;
 import org.appcelerator.titanium.TiContext;
 import org.appcelerator.titanium.proxy.TiViewProxy;
 import org.appcelerator.titanium.util.TiUIHelper;
@@ -27,6 +28,7 @@ public class TiTableViewHeaderItem extends TiBaseTableViewItem
 	private RowView rowView;
 	private TiUIView headerView;
 	private boolean isHeaderView = false;
+	private Item item;
 
 	class RowView extends RelativeLayout
 	{
@@ -110,6 +112,7 @@ public class TiTableViewHeaderItem extends TiBaseTableViewItem
 
 	private void setHeaderData(Item item)
 	{
+		this.item = item;
 		if (headerView != null && headerView.getChildren() != null && headerView.getChildren().size() > 0 && item != null
 			&& item.proxy != null && item.proxy.getChildren() != null && item.proxy.getChildren().length > 0) {
 			TiUIView labelView = headerView.getChildren().get(0);
@@ -142,6 +145,15 @@ public class TiTableViewHeaderItem extends TiBaseTableViewItem
 		if (!isHeaderView) {
 			rowView.layout(left, 0, right, bottom - top);
 		} else {
+			//
+			// Do this association here, and NOT in getView().
+			//
+			TiViewProxy proxy = this.item.proxy;
+			proxy.setView(headerView);
+			headerView.setProxy(proxy);
+			proxy.setModelListener(headerView);
+			
+			
 			View view = headerView.getOuterView();
 			view.layout(left, 0, right, bottom - top);
 			// Also layout the inner native view when we have borders


### PR DESCRIPTION
...sections have many rows

The change here is to not drive the proxy to view association through getView() -- instead it is initiated in onLayout().   The views returned by getView() could be for measurement or layout passes, and it's not possible in the code to know which is happening for a given call.
