### PR TITLE
[TIDOC-920] docgen should omit members not allowed by platform

### DIFF
--- a/apidoc/docgen.py
+++ b/apidoc/docgen.py
@@ -425,6 +425,10 @@ class AnnotatedProxy(AnnotatedApi):
 		if "excludes" in self.api_obj and att_list_name in self.api_obj["excludes"]:
 			excluded_names = self.api_obj["excludes"][att_list_name]
 
+		class_platforms = 0
+		if dict_has_non_empty_member(self.api_obj, "platforms"):
+			class_platforms = self.api_obj["platforms"]
+
 		while (super_type_name is not None and len(super_type_name) > 0
 				and super_type_name in apis):
 			super_type = apis[super_type_name]
@@ -432,6 +436,23 @@ class AnnotatedProxy(AnnotatedApi):
 				for new_item in super_type[att_list_name]:
 					if new_item["name"] in existing_names or new_item["name"] in excluded_names:
 						continue
+
+					# TIDOC-920. Crosscheck class with attributes to see if the platforms match
+					# If not, add them to the excludes list
+					if class_platforms and dict_has_non_empty_member(new_item, "platforms"):
+						attr_platforms = new_item["platforms"]
+						platform_match = False;
+						for attr_platform_name in attr_platforms:
+							for class_platform_name in class_platforms:
+								if attr_platform_name == class_platform_name:
+									platform_match = True;
+									break
+							if platform_match:
+								break
+						if not platform_match:
+							excluded_names.append(new_item["name"])
+							continue
+
 					new_instance = class_type(new_item, self)
 					new_instance.inherited_from = super_type_name
 					att_list.append(new_instance)
@@ -441,6 +462,11 @@ class AnnotatedProxy(AnnotatedApi):
 				super_type_name = super_type["extends"]
 			else:
 				super_type_name = None
+
+		if excluded_names:
+			if "excludes" not in self.api_obj:
+				self.api_obj["excludes"] = {};
+			self.api_obj["excludes"][att_list_name] = excluded_names
 
 	def append_inherited_methods(self, methods):
 		self.append_inherited_attributes(methods, "methods")

--- a/apidoc/docgen.py
+++ b/apidoc/docgen.py
@@ -425,7 +425,7 @@ class AnnotatedProxy(AnnotatedApi):
 		if "excludes" in self.api_obj and att_list_name in self.api_obj["excludes"]:
 			excluded_names = self.api_obj["excludes"][att_list_name]
 
-		class_platforms = 0
+		class_platforms = []
 		if dict_has_non_empty_member(self.api_obj, "platforms"):
 			class_platforms = self.api_obj["platforms"]
 
@@ -443,11 +443,8 @@ class AnnotatedProxy(AnnotatedApi):
 						attr_platforms = new_item["platforms"]
 						platform_match = False;
 						for attr_platform_name in attr_platforms:
-							for class_platform_name in class_platforms:
-								if attr_platform_name == class_platform_name:
-									platform_match = True;
-									break
-							if platform_match:
+							if attr_platform_name in class_platforms:
+								platform_match = True;
 								break
 						if not platform_match:
 							excluded_names.append(new_item["name"])

--- a/apidoc/generators/jsduck_generator.py
+++ b/apidoc/generators/jsduck_generator.py
@@ -334,6 +334,41 @@ def get_summary_and_description(api_obj):
 		res = u"\t * " + desc
 	return res
 
+# Side effect of hiding properties is that the accessors do not get hidden
+# Explicitly hide accessors for JSDuck
+def hide_accessors(parent_name, property_name):
+	res = ""
+	parent_obj = all_annotated_apis[parent_name].api_obj
+	if "properties" in parent_obj:
+		parent_properties = parent_obj["properties"]
+		property_dict = dict((p["name"], p) for p in parent_properties)
+		if property_name in property_dict:
+			setter = True;
+			getter = True;
+			if "accessors" in property_dict[property_name] and not property_dict[property_name]["accessors"]:
+				return res
+			if "availability" in property_dict[property_name] and property_dict[property_name]["availability"] == "creation":
+				setter = False;
+			if "permission" in property_dict[property_name]:
+				if property_dict[property_name]["permission"] == "read-only":
+					setter = False;
+				elif property_dict[property_name]["permission"] == "write-only":
+					getter = False;
+
+			upperFirst = property_name[0].upper() + property_name[1:]
+			if getter:
+				getter = "get" + upperFirst
+				res +=  "/**\n\t * @method " + getter + " \n\t * @hide\n*/\n"
+			if setter:
+				setter = "set" + upperFirst
+				res += "/**\n\t * @method " + setter + " \n\t * @hide\n*/\n"
+
+	if "extends" in parent_obj:
+		parent_name = parent_obj["extends"]
+		return res + hide_accessors(parent_name, property_name)
+	else:
+		return res
+
 def generate(raw_apis, annotated_apis, options):
 	global all_annotated_apis, apis
 	all_annotated_apis = annotated_apis
@@ -507,5 +542,12 @@ def generate(raw_apis, annotated_apis, options):
 						excluded_members = api_obj["excludes"][member_type]
 						for one_member in excluded_members:
 							write_utf8(output, "/**\n\t * %s %s \n\t * @hide\n*/\n" % (annotation_string, one_member))
+							# Explicitly hide accessors
+							if member_type == "properties" and "extends" in api_obj:
+								parent_name = api_obj["extends"]
+								hide_methods = hide_accessors(parent_name, one_member)
+								if hide_methods:
+									write_utf8(output, "%s" % (hide_methods))
+
 
 		output.close()


### PR DESCRIPTION
- docgen.py: crosscheck class platform with attribute platform to exclude it
- jsduck_generator.py: side effect of hiding properties is that the accessors are not automatically hidden with jsduck. Explicitly hide accessors.
