### PR TITLE
timob-9845: Android: Camera with overlay does not auto focus

### DIFF
--- a/android/modules/media/src/java/ti/modules/titanium/media/MediaModule.java
+++ b/android/modules/media/src/java/ti/modules/titanium/media/MediaModule.java
@@ -73,6 +73,9 @@ public class MediaModule extends KrollModule
 	protected static final int MSG_INVOKE_CALLBACK = KrollModule.MSG_LAST_ID + 100;
 	protected static final int MSG_LAST_ID = MSG_INVOKE_CALLBACK;
 
+	// The mode FOCUS_MODE_CONTINUOUS_PICTURE is added in API 14
+	public static final String FOCUS_MODE_CONTINUOUS_PICTURE = "continuous-picture";
+
 	@Kroll.constant public static final int UNKNOWN_ERROR = 0;
 	@Kroll.constant public static final int DEVICE_BUSY = 1;
 	@Kroll.constant public static final int NO_CAMERA = 2;

--- a/android/modules/media/src/java/ti/modules/titanium/media/TiCameraActivity.java
+++ b/android/modules/media/src/java/ti/modules/titanium/media/TiCameraActivity.java
@@ -28,6 +28,7 @@ import android.content.Intent;
 import android.content.pm.ActivityInfo;
 import android.graphics.Color;
 import android.hardware.Camera;
+import android.hardware.Camera.AutoFocusCallback;
 import android.hardware.Camera.Parameters;
 import android.hardware.Camera.PictureCallback;
 import android.hardware.Camera.Size;
@@ -119,6 +120,17 @@ public class TiCameraActivity extends TiBaseActivity implements SurfaceHolder.Ca
 			previewLayout.setAspectRatio(aspectRatio);
 			List<Size> supportedPreviewSizes = param.getSupportedPreviewSizes();
 			Size previewSize = getOptimalPreviewSize(supportedPreviewSizes, width, height, aspectRatio);
+
+			// Set appropriate focus mode if supported.
+			List<String> supportedFocusModes = param.getSupportedFocusModes();
+			if (supportedFocusModes.contains(MediaModule.FOCUS_MODE_CONTINUOUS_PICTURE)) {
+				param.setFocusMode(MediaModule.FOCUS_MODE_CONTINUOUS_PICTURE);
+			} else if (supportedFocusModes.contains(Parameters.FOCUS_MODE_AUTO)) {
+				param.setFocusMode(Parameters.FOCUS_MODE_AUTO);
+			} else if (supportedFocusModes.contains(Parameters.FOCUS_MODE_MACRO)) {
+				param.setFocusMode(Parameters.FOCUS_MODE_MACRO);
+			}
+
 			if (previewSize != null) {
 				param.setPreviewSize(previewSize.width, previewSize.height);
 				camera.setParameters(param);
@@ -268,8 +280,23 @@ public class TiCameraActivity extends TiBaseActivity implements SurfaceHolder.Ca
 		activity.sendBroadcast(mediaScanIntent);
 	}
 
-	static public void takePicture() {
-		camera.takePicture(null, null, jpegCallback);
+	static public void takePicture()
+	{
+		String focusMode = camera.getParameters().getFocusMode();
+		if (!(focusMode.equals(Parameters.FOCUS_MODE_EDOF) || focusMode.equals(Parameters.FOCUS_MODE_FIXED) 
+				|| focusMode.equals(Parameters.FOCUS_MODE_INFINITY))) {
+			AutoFocusCallback focusCallback = new AutoFocusCallback()
+			{
+				public void onAutoFocus(boolean success, Camera camera)
+				{
+					// Take the picture when the camera auto focus completes.
+					camera.takePicture(null, null, jpegCallback);
+				}
+			};
+			camera.autoFocus(focusCallback);
+		} else {
+			camera.takePicture(null, null, jpegCallback);
+		}
 	}
 
 	static PictureCallback jpegCallback = new PictureCallback() {


### PR DESCRIPTION
https://jira.appcelerator.org/browse/TIMOB-9845
In this PR, we call autoFocus() before the picture is captured if the focus mode is supported. For Android API level > 14, we set the focus mode to FOCUS_MODE_CONTINUOUS_PICTURE, so the camera continuously tries to focus when the preview is active.
Test steps in JIRA.
