### PR TITLE
TIMOB-6053 - Android: fontStyle support added

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/picker/TiUISpinnerColumn.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/picker/TiUISpinnerColumn.java
@@ -114,7 +114,7 @@ public class TiUISpinnerColumn extends TiUIView implements WheelView.OnItemSelec
 		}
 		Integer typefaceWeight = null;
 		if (fontWeight != null) {
-			typefaceWeight = new Integer(TiUIHelper.toTypefaceStyle(fontWeight));
+			typefaceWeight = new Integer(TiUIHelper.toTypefaceStyle(fontWeight,null));
 		}
 		
 		boolean dirty = false;

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/picker/TiUISpinnerColumn.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/picker/TiUISpinnerColumn.java
@@ -114,7 +114,7 @@ public class TiUISpinnerColumn extends TiUIView implements WheelView.OnItemSelec
 		}
 		Integer typefaceWeight = null;
 		if (fontWeight != null) {
-			typefaceWeight = new Integer(TiUIHelper.toTypefaceStyle(fontWeight,null));
+			typefaceWeight = new Integer(TiUIHelper.toTypefaceStyle(fontWeight, null));
 		}
 		
 		boolean dirty = false;

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiUIHelper.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiUIHelper.java
@@ -217,11 +217,20 @@ public class TiUIHelper
 		});
 	}
 
-	public static int toTypefaceStyle(String fontWeight) {
+	public static int toTypefaceStyle(String fontWeight, String fontStyle) {
 		int style = Typeface.NORMAL;
+
 		if (fontWeight != null) {
 			if(fontWeight.equals("bold")) {
-				style = Typeface.BOLD;
+				if (fontStyle != null && fontStyle.equals("italic")){
+					style = Typeface.BOLD_ITALIC;
+				}else{
+					style = Typeface.BOLD;
+				}
+			}else if(fontWeight.equals("normal")) {
+				if (fontStyle != null && fontStyle.equals("italic")){
+					style = Typeface.ITALIC;
+				}
 			}
 		}
 		return style;
@@ -301,6 +310,7 @@ public class TiUIHelper
 		String fontSize = null;
 		String fontWeight = null;
 		String fontFamily = null;
+		String fontStyle = null;
 
 		if (d.containsKey("fontSize")) {
 			fontSize = TiConvert.toString(d, "fontSize");
@@ -311,13 +321,20 @@ public class TiUIHelper
 		if (d.containsKey("fontFamily")) {
 			fontFamily = TiConvert.toString(d, "fontFamily");
 		}
-		TiUIHelper.styleText(tv, fontFamily, fontSize, fontWeight);
+		if (d.containsKey("fontStyle")) {
+			fontStyle = TiConvert.toString(d, "fontStyle");
+		}
+		TiUIHelper.styleText(tv, fontFamily, fontSize, fontWeight, fontStyle);
 	}
 
 	public static void styleText(TextView tv, String fontFamily, String fontSize, String fontWeight) {
+		styleText(tv, fontFamily, fontSize, fontWeight, null);
+	}
+
+	public static void styleText(TextView tv, String fontFamily, String fontSize, String fontWeight, String fontStyle) {
 		Typeface tf = tv.getTypeface();
 		tf = toTypeface(tv.getContext(), fontFamily);
-		tv.setTypeface(tf, toTypefaceStyle(fontWeight));
+		tv.setTypeface(tf, toTypefaceStyle(fontWeight, fontStyle));
 		tv.setTextSize(getSizeUnits(fontSize), getSize(fontSize));
 	}
 

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiUIHelper.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiUIHelper.java
@@ -217,18 +217,19 @@ public class TiUIHelper
 		});
 	}
 
-	public static int toTypefaceStyle(String fontWeight, String fontStyle) {
+	public static int toTypefaceStyle(String fontWeight, String fontStyle)
+	{
 		int style = Typeface.NORMAL;
 
 		if (fontWeight != null) {
-			if(fontWeight.equals("bold")) {
-				if (fontStyle != null && fontStyle.equals("italic")){
+			if (fontWeight.equals("bold")) {
+				if (fontStyle != null && fontStyle.equals("italic")) {
 					style = Typeface.BOLD_ITALIC;
-				}else{
+				} else {
 					style = Typeface.BOLD;
 				}
-			}else if(fontWeight.equals("normal")) {
-				if (fontStyle != null && fontStyle.equals("italic")){
+			} else if (fontWeight.equals("normal")) {
+				if (fontStyle != null && fontStyle.equals("italic")) {
 					style = Typeface.ITALIC;
 				}
 			}
@@ -327,11 +328,13 @@ public class TiUIHelper
 		TiUIHelper.styleText(tv, fontFamily, fontSize, fontWeight, fontStyle);
 	}
 
-	public static void styleText(TextView tv, String fontFamily, String fontSize, String fontWeight) {
+	public static void styleText(TextView tv, String fontFamily, String fontSize, String fontWeight)
+	{
 		styleText(tv, fontFamily, fontSize, fontWeight, null);
 	}
 
-	public static void styleText(TextView tv, String fontFamily, String fontSize, String fontWeight, String fontStyle) {
+	public static void styleText(TextView tv, String fontFamily, String fontSize, String fontWeight, String fontStyle)
+	{
 		Typeface tf = tv.getTypeface();
 		tf = toTypeface(tv.getContext(), fontFamily);
 		tv.setTypeface(tf, toTypefaceStyle(fontWeight, fontStyle));


### PR DESCRIPTION
Fixed bug TIMOB-6053 - Android: fontStyle not supported on Android 

Modified TiUIHelper.styleText to read fontStyle and use it in TiUIHelper.styleText.
An overloaded styleText is added to handle the additional fontStyle parameter. 
Existing styleText is modifed to call the new method so that existing code that doesn't pass styleText doesn't break.
