### PR TITLE
[TIMOB-10017] added null check for windowActivity

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TiUIActivityWindow.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TiUIActivityWindow.java
@@ -323,7 +323,9 @@ public class TiUIActivityWindow extends TiUIView
 			});
 
 		} else {
-			windowActivity.getWindow().setBackgroundDrawable(drawable);
+			if (windowActivity != null) {
+				windowActivity.getWindow().setBackgroundDrawable(drawable);
+			}
 		}
 	}
 


### PR DESCRIPTION
TIMOB-10017 - Made sure that windowActivity is not null before calling setBackgroundDrawable.
Test case is running without crash after the change
