### PR TITLE
[TIMOB-10320] iOS: improved JS exception logging when thrown from Objective-C

### DIFF
--- a/iphone/Classes/TiBase.h
+++ b/iphone/Classes/TiBase.h
@@ -89,7 +89,7 @@ void TiLogMessage(NSString* str, ...);
 #define RELEASE_TO_NIL_AUTORELEASE(x) { if (x!=nil) { [x autorelease]; x = nil; } }
 #define RELEASE_AND_REPLACE(x,y) { [x release]; x = [y retain]; }
 
-#define CODELOCATION	[NSString stringWithFormat:@" in %s (%@:%d)",__FUNCTION__,[[NSString stringWithFormat:@"%s",__FILE__] lastPathComponent],__LINE__]
+#define CODELOCATION	[NSString stringWithFormat:@"%s (%@:%d)",__FUNCTION__,[[NSString stringWithFormat:@"%s",__FILE__] lastPathComponent],__LINE__]
 
 #define NULL_IF_NIL(x)	({ id xx = (x); (xx==nil)?[NSNull null]:xx; })
 
@@ -289,21 +289,19 @@ if ((__x<__minX) || (__x>__maxX)) \
 #define ENSURE_ARRAY(x) ENSURE_TYPE(x,NSArray)
 #define ENSURE_STRING(x) ENSURE_TYPE(x,NSString)
 
-void TiExceptionThrowWithNameAndReason(NSString * exceptionName, NSString * message);
+void TiExceptionThrowWithNameAndReason(NSString *exceptionName, NSString *reason, NSString *subreason, NSString *location);
 	
 #define DEFINE_EXCEPTIONS \
 - (void) throwException:(NSString *) reason subreason:(NSString*)subreason location:(NSString *)location\
 {\
 	NSString * exceptionName = [@"org.appcelerator." stringByAppendingString:NSStringFromClass([self class])];\
-	NSString * message = [NSString stringWithFormat:@"%@. %@ %@",reason,(subreason!=nil?subreason:@""),(location!=nil?location:@"")];\
-	TiExceptionThrowWithNameAndReason(exceptionName,message);\
+	TiExceptionThrowWithNameAndReason(exceptionName,reason,subreason,location);\
 }\
 \
 + (void) throwException:(NSString *) reason subreason:(NSString*)subreason location:(NSString *)location\
 {\
 	NSString * exceptionName = @"org.appcelerator";\
-	NSString * message = [NSString stringWithFormat:@"%@. %@ %@",reason,(subreason!=nil?subreason:@""),(location!=nil?location:@"")];\
-	TiExceptionThrowWithNameAndReason(exceptionName,message);\
+	TiExceptionThrowWithNameAndReason(exceptionName,reason,subreason,location);\
 }\
 
 
@@ -570,7 +568,9 @@ extern NSString* const kTiUnitDip;
 extern NSString* const kTiUnitDipAlternate;
 extern NSString* const kTiUnitSystem;
 extern NSString* const kTiUnitPercent;
-    
+
+extern NSString* const kTiExceptionSubreason;
+extern NSString* const kTiExceptionLocation;
 
 
 #ifndef ASI_AUTOUPDATE_NETWORK_INDICATOR

--- a/iphone/Classes/TiBase.h
+++ b/iphone/Classes/TiBase.h
@@ -81,10 +81,9 @@ CGPoint midpointBetweenPoints(CGPoint a, CGPoint b);
 void TiLogMessage(NSString* str, ...);
 
 NSString *convertClassToJS(Class c);
-NSString *convertTypeToJS(id obj);
 
 #define CLASS2JS(x)		convertClassToJS(x)
-#define OBJTYPE2JS(x)	convertTypeToJS(x)
+#define OBJTYPE2JS(x)	convertClassToJS([x class])
 
 #define degreesToRadians(x) (M_PI * x / 180.0)
 #define radiansToDegrees(x) (x * (180.0 / M_PI))

--- a/iphone/Classes/TiBase.h
+++ b/iphone/Classes/TiBase.h
@@ -80,10 +80,18 @@ NSMutableDictionary* TiCreateNonRetainingDictionary();
 CGPoint midpointBetweenPoints(CGPoint a, CGPoint b);
 void TiLogMessage(NSString* str, ...);
 
-NSString *convertClassToJS(Class c);
+/**
+ * Protocol for classes to provide their JavaScript details (class name, in particular).
+ */
+@protocol JavascriptClass <NSObject>
+@required
++ (NSString *)javascriptClassName;
+@end
 
-#define CLASS2JS(x)		convertClassToJS(x)
-#define OBJTYPE2JS(x)	convertClassToJS([x class])
+NSString *JavascriptNameForClass(Class c);
+
+#define CLASS2JS(x)		JavascriptNameForClass(x)
+#define OBJTYPE2JS(x)	JavascriptNameForClass([x class])
 
 #define degreesToRadians(x) (M_PI * x / 180.0)
 #define radiansToDegrees(x) (x * (180.0 / M_PI))

--- a/iphone/Classes/TiBase.h
+++ b/iphone/Classes/TiBase.h
@@ -79,7 +79,13 @@ NSMutableDictionary* TiCreateNonRetainingDictionary();
 
 CGPoint midpointBetweenPoints(CGPoint a, CGPoint b);
 void TiLogMessage(NSString* str, ...);
-    
+
+NSString *convertClassToJS(Class c);
+NSString *convertTypeToJS(id obj);
+
+#define CLASS2JS(x)		convertClassToJS(x)
+#define OBJTYPE2JS(x)	convertTypeToJS(x)
+
 #define degreesToRadians(x) (M_PI * x / 180.0)
 #define radiansToDegrees(x) (x * (180.0 / M_PI))
 
@@ -116,7 +122,7 @@ x = (t*)[x objectAtIndex:0]; \
 } \
 if (![x isKindOfClass:[t class]]) \
 {\
-[self throwException:TiExceptionInvalidType subreason:[NSString stringWithFormat:@"expected: %@, was: %@",[t class],[x class]] location:CODELOCATION]; \
+[self throwException:TiExceptionInvalidType subreason:[NSString stringWithFormat:@"expected: %@, was: %@",CLASS2JS([t class]),OBJTYPE2JS(x)] location:CODELOCATION]; \
 }\
 
 #define ENSURE_SINGLE_ARG_OR_NIL(x,t) \
@@ -128,7 +134,7 @@ x = (t*)[x objectAtIndex:0]; \
 } \
 if (![x isKindOfClass:[t class]]) \
 {\
-[self throwException:TiExceptionInvalidType subreason:[NSString stringWithFormat:@"expected: %@, was: %@",[t class],[x class]] location:CODELOCATION]; \
+[self throwException:TiExceptionInvalidType subreason:[NSString stringWithFormat:@"expected: %@, was: %@",CLASS2JS([t class]),OBJTYPE2JS(x)] location:CODELOCATION]; \
 }\
 }\
 
@@ -139,7 +145,7 @@ out = (type*)[args objectAtIndex:index]; \
 } \
 if (![out isKindOfClass:[type class]]) \
 { \
-[self throwException:TiExceptionInvalidType subreason:[NSString stringWithFormat:@"expected: %@, was: %@",[type class],[out class]] location:CODELOCATION]; \
+[self throwException:TiExceptionInvalidType subreason:[NSString stringWithFormat:@"expected: %@, was: %@",CLASS2JS([type class]),OBJTYPE2JS(out)] location:CODELOCATION]; \
 } \
 
 
@@ -156,13 +162,13 @@ else { \
 out = nil; \
 } \
 if (out && ![out isKindOfClass:[type class]]) { \
-[self throwException:TiExceptionInvalidType subreason:[NSString stringWithFormat:@"expected: %@, was: %@",[type class],[out class]] location:CODELOCATION]; \
+[self throwException:TiExceptionInvalidType subreason:[NSString stringWithFormat:@"expected: %@, was: %@",CLASS2JS([type class]),OBJTYPE2JS(out)] location:CODELOCATION]; \
 } \
 } \
 
 #define COERCE_TO_INT(out,in) \
 if (![in respondsToSelector:@selector(intValue)]) {\
-[self throwException:TiExceptionInvalidType subreason:[NSString stringWithFormat:@"cannot coerce type %@ to int",[in class]] location:CODELOCATION]; \
+[self throwException:TiExceptionInvalidType subreason:[NSString stringWithFormat:@"cannot coerce type %@ to int",OBJTYPE2JS(in)] location:CODELOCATION]; \
 }\
 out = [in intValue]; \
 
@@ -221,7 +227,7 @@ COERCE_TO_INT(out,tmp);\
 #define ENSURE_CLASS(x,t) \
 if (![x isKindOfClass:t]) \
 { \
-[self throwException:TiExceptionInvalidType subreason:[NSString stringWithFormat:@"expected: %@, was: %@",t,[x class]] location:CODELOCATION]; \
+[self throwException:TiExceptionInvalidType subreason:[NSString stringWithFormat:@"expected: %@, was: %@",CLASS2JS(t),OBJTYPE2JS(x)] location:CODELOCATION]; \
 }\
 
 #define ENSURE_TYPE(x,t) ENSURE_CLASS(x,[t class])
@@ -230,7 +236,7 @@ if (![x isKindOfClass:t]) \
 #define ENSURE_METHOD(x,t) \
 if (![x respondsToSelector:@selector(t)]) \
 { \
-[self throwException:TiExceptionInvalidType subreason:[NSString stringWithFormat:@"%@ doesn't respond to method: %@",[x class],@#t] location:CODELOCATION]; \
+[self throwException:TiExceptionInvalidType subreason:[NSString stringWithFormat:@"%@ doesn't respond to method: %@",OBJTYPE2JS(x),@#t] location:CODELOCATION]; \
 }\
 
 #define IS_NULL_OR_NIL(x)	((x==nil) || ((id)x==[NSNull null]))
@@ -242,7 +248,7 @@ if (IS_NULL_OR_NIL(x))	\
 }	\
 else if (![x isKindOfClass:t])	\
 { \
-	[self throwException:TiExceptionInvalidType subreason:[NSString stringWithFormat:@"expected: %@ or nil, was: %@",t, [x class]] location:CODELOCATION]; \
+	[self throwException:TiExceptionInvalidType subreason:[NSString stringWithFormat:@"expected: %@ or nil, was: %@",CLASS2JS(t), OBJTYPE2JS(x)] location:CODELOCATION]; \
 }\
 
 #define ENSURE_TYPE_OR_NIL(x,t) ENSURE_CLASS_OR_NIL(x,[t class])

--- a/iphone/Classes/TiBase.m
+++ b/iphone/Classes/TiBase.m
@@ -158,16 +158,21 @@ NSString* const kTiUnitDipAlternate = @"dp";
 NSString* const kTiUnitSystem = @"system";
 NSString* const kTiUnitPercent = @"%";
 
+NSString* const kTiExceptionSubreason = @"TiExceptionSubreason";
+NSString* const kTiExceptionLocation = @"TiExceptionLocation";
 
 
 
 BOOL TiExceptionIsSafeOnMainThread = NO;
 
-void TiExceptionThrowWithNameAndReason(NSString * exceptionName, NSString * message)
+void TiExceptionThrowWithNameAndReason(NSString *exceptionName, NSString *reason, NSString *subreason, NSString *location)
 {
-	NSLog(@"[ERROR] %@",message);
 	if (TiExceptionIsSafeOnMainThread || ![NSThread isMainThread]) {
-		@throw [NSException exceptionWithName:exceptionName reason:message userInfo:nil];
+		NSDictionary *details = [NSDictionary dictionaryWithObjectsAndKeys:subreason, kTiExceptionSubreason, location, kTiExceptionLocation, nil];
+		@throw [NSException exceptionWithName:exceptionName reason:reason userInfo:details];
+	} else {
+		NSString * message = [NSString stringWithFormat:@"%@. %@ %@",reason,(subreason!=nil?subreason:@""),(location!=nil?location:@"")];
+		NSLog(@"[ERROR] %@", message);
 	}
 }
 

--- a/iphone/Classes/TiBase.m
+++ b/iphone/Classes/TiBase.m
@@ -196,21 +196,11 @@ static NSString * knownJSClasses[] = {
 NSString *convertClassToJS(Class c)
 {
 	for (NSUInteger i = 0; i < sizeof(knownNativeClasses)/sizeof(*knownNativeClasses); ++i) {
-		if (c == NSClassFromString(knownNativeClasses[i])) {
+		if ([c isSubclassOfClass:NSClassFromString(knownNativeClasses[i])]) {
 			return knownJSClasses[i];
 		}
 	}
 	return NSStringFromClass(c);
-}
-
-NSString *convertTypeToJS(id obj)
-{
-	for (NSUInteger i = 0; i < sizeof(knownNativeClasses)/sizeof(*knownNativeClasses); ++i) {
-		if ([obj isKindOfClass:NSClassFromString(knownNativeClasses[i])]) {
-			return knownJSClasses[i];
-		}
-	}
-	return NSStringFromClass([obj class]);
 }
 
 void TiThreadReleaseOnMainThread(id releasedObject,BOOL waitForFinish)

--- a/iphone/Classes/TiBase.m
+++ b/iphone/Classes/TiBase.m
@@ -176,6 +176,43 @@ void TiExceptionThrowWithNameAndReason(NSString *exceptionName, NSString *reason
 	}
 }
 
+static NSString * knownNativeClasses[] = {
+	@"NSString",
+	@"NSNumber",
+	@"NSArray",
+	@"NSDictionary",
+	@"KrollCallback",
+	@"KrollWrapper",
+};
+static NSString * knownJSClasses[] = {
+	@"String",
+	@"Number",
+	@"Array",
+	@"Object",
+	@"Function",
+	@"Function",
+};
+
+NSString *convertClassToJS(Class c)
+{
+	for (NSUInteger i = 0; i < sizeof(knownNativeClasses)/sizeof(*knownNativeClasses); ++i) {
+		if (c == NSClassFromString(knownNativeClasses[i])) {
+			return knownJSClasses[i];
+		}
+	}
+	return NSStringFromClass(c);
+}
+
+NSString *convertTypeToJS(id obj)
+{
+	for (NSUInteger i = 0; i < sizeof(knownNativeClasses)/sizeof(*knownNativeClasses); ++i) {
+		if ([obj isKindOfClass:NSClassFromString(knownNativeClasses[i])]) {
+			return knownJSClasses[i];
+		}
+	}
+	return NSStringFromClass([obj class]);
+}
+
 void TiThreadReleaseOnMainThread(id releasedObject,BOOL waitForFinish)
 {
 	if (releasedObject == nil) {

--- a/iphone/Classes/TiBase.m
+++ b/iphone/Classes/TiBase.m
@@ -176,29 +176,16 @@ void TiExceptionThrowWithNameAndReason(NSString *exceptionName, NSString *reason
 	}
 }
 
-static NSString * knownNativeClasses[] = {
-	@"NSString",
-	@"NSNumber",
-	@"NSArray",
-	@"NSDictionary",
-	@"KrollCallback",
-	@"KrollWrapper",
-};
-static NSString * knownJSClasses[] = {
-	@"String",
-	@"Number",
-	@"Array",
-	@"Object",
-	@"Function",
-	@"Function",
-};
-
-NSString *convertClassToJS(Class c)
+NSString *JavascriptNameForClass(Class c)
 {
-	for (NSUInteger i = 0; i < sizeof(knownNativeClasses)/sizeof(*knownNativeClasses); ++i) {
-		if ([c isSubclassOfClass:NSClassFromString(knownNativeClasses[i])]) {
-			return knownJSClasses[i];
-		}
+	if([c isSubclassOfClass:[NSString class]]) return @"String";
+	else if([c isSubclassOfClass:[NSNumber class]]) return @"Number";
+	else if([c isSubclassOfClass:[NSArray class]]) return @"Array";
+	else if([c isSubclassOfClass:[NSDictionary class]]) return @"Object";
+	else if([c isSubclassOfClass:[KrollCallback class]]) return @"Function";
+	else if([c isSubclassOfClass:[KrollWrapper class]]) return @"Function";
+	else if ([c conformsToProtocol:@protocol(JavascriptClass)]) {
+		return [(id<JavascriptClass>)c javascriptClassName];
 	}
 	return NSStringFromClass(c);
 }

--- a/iphone/Classes/TiBindingTiValue.m
+++ b/iphone/Classes/TiBindingTiValue.m
@@ -238,16 +238,18 @@ TiValueRef TiBindingTiValueFromNSObject(TiContextRef jsContext, NSObject * obj)
 		TiStringRelease(jsString);
 		TiObjectRef excObject = TiObjectMakeError(jsContext, 1, &result, NULL);
 		NSDictionary *details = [(NSException *)obj userInfo];
-		if ([details objectForKey:kTiExceptionSubreason] != nil) {
+		NSString *subreason = [details objectForKey:kTiExceptionSubreason];
+		if (subreason != nil) {
 			TiStringRef propertyName = TiStringCreateWithUTF8CString("nativeReason");
-			TiStringRef valueString = TiStringCreateWithCFString((CFStringRef) [details objectForKey:kTiExceptionSubreason]);
+			TiStringRef valueString = TiStringCreateWithCFString((CFStringRef) subreason);
 			TiObjectSetProperty(jsContext, excObject, propertyName, TiValueMakeString(jsContext, valueString), kTiPropertyAttributeReadOnly, NULL);
 			TiStringRelease(propertyName);
 			TiStringRelease(valueString);
 		}
-		if ([details objectForKey:kTiExceptionLocation] != nil) {
+		NSString *location = [details objectForKey:kTiExceptionLocation];
+		if (location != nil) {
 			TiStringRef propertyName = TiStringCreateWithUTF8CString("nativeLocation");
-			TiStringRef valueString = TiStringCreateWithCFString((CFStringRef) [details objectForKey:kTiExceptionLocation]);
+			TiStringRef valueString = TiStringCreateWithCFString((CFStringRef) location);
 			TiObjectSetProperty(jsContext, excObject, propertyName, TiValueMakeString(jsContext, valueString), kTiPropertyAttributeReadOnly, NULL);
 			TiStringRelease(propertyName);
 			TiStringRelease(valueString);

--- a/iphone/Classes/TiBindingTiValue.m
+++ b/iphone/Classes/TiBindingTiValue.m
@@ -236,7 +236,23 @@ TiValueRef TiBindingTiValueFromNSObject(TiContextRef jsContext, NSObject * obj)
 		TiStringRef jsString = TiStringCreateWithCFString((CFStringRef) [(NSException *)obj reason]);
 		TiValueRef result = TiValueMakeString(jsContext,jsString);
 		TiStringRelease(jsString);
-		return TiObjectMakeError(jsContext, 1, &result, NULL);
+		TiObjectRef excObject = TiObjectMakeError(jsContext, 1, &result, NULL);
+		NSDictionary *details = [(NSException *)obj userInfo];
+		if ([details objectForKey:kTiExceptionSubreason] != nil) {
+			TiStringRef propertyName = TiStringCreateWithUTF8CString("nativeReason");
+			TiStringRef valueString = TiStringCreateWithCFString((CFStringRef) [details objectForKey:kTiExceptionSubreason]);
+			TiObjectSetProperty(jsContext, excObject, propertyName, TiValueMakeString(jsContext, valueString), kTiPropertyAttributeReadOnly, NULL);
+			TiStringRelease(propertyName);
+			TiStringRelease(valueString);
+		}
+		if ([details objectForKey:kTiExceptionLocation] != nil) {
+			TiStringRef propertyName = TiStringCreateWithUTF8CString("nativeLocation");
+			TiStringRef valueString = TiStringCreateWithCFString((CFStringRef) [details objectForKey:kTiExceptionLocation]);
+			TiObjectSetProperty(jsContext, excObject, propertyName, TiValueMakeString(jsContext, valueString), kTiPropertyAttributeReadOnly, NULL);
+			TiStringRelease(propertyName);
+			TiStringRelease(valueString);
+		}
+		return excObject;
 	}
 	if ([obj isKindOfClass:[KrollMethod class]])
 	{

--- a/iphone/Classes/TiExceptionHandler.h
+++ b/iphone/Classes/TiExceptionHandler.h
@@ -42,6 +42,11 @@
 - (id)initWithMessage:(NSString *)message sourceURL:(NSString *)sourceURL lineNo:(NSInteger)lineNo;
 - (id)initWithDictionary:(NSDictionary *)dictionary;
 
+/**
+ * Returns detailed description.
+ */
+- (NSString *)detailedDescription;
+
 @end
 
 #pragma mark - TiExceptionHandlerDelegate

--- a/iphone/Classes/TiExceptionHandler.m
+++ b/iphone/Classes/TiExceptionHandler.m
@@ -45,7 +45,7 @@ static NSUncaughtExceptionHandler *prevUncaughtExceptionHandler = NULL;
 
 - (void)reportScriptError:(TiScriptError *)scriptError
 {
-	DebugLog(@"[ERROR] Script Error = %@.", scriptError);
+	DebugLog(@"[ERROR] Script Error %@", [scriptError detailedDescription]);
 	
 	id <TiExceptionHandlerDelegate> currentDelegate = _delegate;
 	if (currentDelegate == nil) {
@@ -121,6 +121,11 @@ static NSUncaughtExceptionHandler *prevUncaughtExceptionHandler = NULL;
 	} else {
 		return [NSString stringWithFormat:@"%@", self.message];
 	}
+}
+
+- (NSString *)detailedDescription
+{
+	return _dictionaryValue != nil ? [_dictionaryValue description] : [self description];
 }
 
 @end


### PR DESCRIPTION
[TIMOB-10320](https://jira.appcelerator.org/browse/TIMOB-10320)

Test instructions in JIRA.

Expected output is like

``` javascript
[ERROR] Script Error {
    backtrace = "#0 () at file://localhost/Users/max/Library/Application%20Support/iPhone%20Simulator/4.3.2/Applications/86EAB896-F4E9-4672-9426-D20F7FAED5F1/Titanium.app/app.js:29";
    line = 13;
    message = "Invalid type passed to function";
    nativeLocation = "-[TiUIEmailDialogProxy open:] (TiUIEmailDialogProxy.m:63)";
    nativeReason = "expected: NSArray or nil, was: NSCFString";
    sourceId = 208722560;
    sourceURL = "file://localhost/Users/max/Library/Application%20Support/iPhone%20Simulator/4.3.2/Applications/86EAB896-F4E9-4672-9426-D20F7FAED5F1/Titanium.app/app.js";
}

```
