### PR TITLE
[TIMOB-12107] [TIMOB-12106] + misc bugs

### DIFF
--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -361,7 +361,7 @@ function sendAnalytics(cli) {
 		name: cli.tiapp.name,
 		publisher: cli.tiapp.publisher,
 		url: cli.tiapp.url,
-		image: cli.tiapp.image,
+		image: cli.tiapp.icon,
 		appid: cli.tiapp.id,
 		description: cli.tiapp.description,
 		type: cli.argv.type,

--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -252,12 +252,14 @@ exports.config = function (logger, config, cli) {
 								
 								var availableUUIDs = [],
 									addUUIDs = function (section, uuids) {
-										availableUUIDs.push(section);
-										for (var i = 0; i < uuids.length; i++) {
-											if (uuids[i].uuid == uuid) {
-												return true;
+										if (uuids.length) {
+											availableUUIDs.push(section);
+											for (var i = 0; i < uuids.length; i++) {
+												if (uuids[i].uuid == uuid) {
+													return true;
+												}
+												availableUUIDs.push('    ' + uuids[i].uuid.cyan + '  ' + uuids[i].appId + ' (' + uuids[i].name + ')');
 											}
-											availableUUIDs.push('    ' + uuids[i].uuid.cyan + '  ' + uuids[i].appId + ' (' + uuids[i].name + ')');
 										}
 									};
 								
@@ -509,14 +511,16 @@ exports.validate = function (logger, config, cli) {
 				allUUIDs = [],
 				addUUIDs = function (section, uuids) {
 					var match = 0;
-					availableUUIDs.push(section);
-					for (var i = 0; i < uuids.length; i++) {
-						if (uuids[i].uuid == cli.argv['pp-uuid']) {
-							match = 1;
+					if (uuids.length) {
+						availableUUIDs.push(section);
+						for (var i = 0; i < uuids.length; i++) {
+							if (uuids[i].uuid == cli.argv['pp-uuid']) {
+								match = 1;
+							}
+							allUUIDs.push(uuids[i].uuid);
+							iosEnv.provisioningProfilesByUUID[uuids[i].uuid] = uuids[i];
+							availableUUIDs.push('    ' + uuids[i].uuid.cyan + '  ' + uuids[i].appId + ' (' + uuids[i].name + ')');
 						}
-						allUUIDs.push(uuids[i].uuid);
-						iosEnv.provisioningProfilesByUUID[uuids[i].uuid] = uuids[i];
-						availableUUIDs.push('    ' + uuids[i].uuid.cyan + '  ' + uuids[i].appId + ' (' + uuids[i].name + ')');
 					}
 					return match;
 				};
@@ -582,8 +586,12 @@ exports.validate = function (logger, config, cli) {
 			deviceFamily = 'ipad';
 		}
 	}
+	if (!deviceFamily) {
+		logger.info(__('No device family specified, defaulting to %s', 'universal'));
+		deviceFamily = 'universal';
+	}
 	
-	if (!deviceFamily || !deviceFamilies[deviceFamily]) {
+	if (!deviceFamilies[deviceFamily]) {
 		logger.error(__('Invalid device family "%s"', deviceFamily) + '\n');
 		appc.string.suggest(deviceFamily, Object.keys(deviceFamilies), logger.log, 3);
 		process.exit(1);
@@ -688,7 +696,7 @@ function sendAnalytics(cli) {
 		name: cli.tiapp.name,
 		publisher: cli.tiapp.publisher,
 		url: cli.tiapp.url,
-		image: cli.tiapp.image,
+		image: cli.tiapp.icon,
 		appid: cli.tiapp.id,
 		description: cli.tiapp.description,
 		type: cli.argv.type,
@@ -799,12 +807,6 @@ function build(logger, config, cli, finished) {
 		this.tiapp.icon = 'appicon.png';
 	}
 	
-	// if installing a non-production build on device, add a timestamp to the version
-	if (this.target != 'simulator' && this.deployType != 'production') {
-		this.tiapp.version = appc.version.format(this.tiapp.version || 1, 2, 3) + '.' + (new Date).getTime();
-		this.logger.info(__('Setting non-production device build version to %s', this.tiapp.version));
-	}
-	
 	Array.isArray(this.tiapp.modules) || (this.tiapp.modules = []);
 	
 	if (cli.argv.xcode) {
@@ -902,29 +904,37 @@ function build(logger, config, cli, finished) {
 				'writeBuildManifest'
 			], function () {
 				var xcodeArgs = [
-					'-target', this.tiapp.name + xcodeTargetSuffixes[this.deviceFamily],
-					'-configuration', this.xcodeTarget,
-					'-sdk', this.xcodeTargetOS,
-					'IPHONEOS_DEPLOYMENT_TARGET=' + this.minIosVer,
-					'TARGETED_DEVICE_FAMILY=' + deviceFamilies[this.deviceFamily],
-					'VALID_ARCHS=' + this.architectures
-				];
+						'-target', this.tiapp.name + xcodeTargetSuffixes[this.deviceFamily],
+						'-configuration', this.xcodeTarget,
+						'-sdk', this.xcodeTargetOS,
+						'IPHONEOS_DEPLOYMENT_TARGET=' + appc.version.format(this.minIosVer, 2),
+						'TARGETED_DEVICE_FAMILY=' + deviceFamilies[this.deviceFamily],
+						'VALID_ARCHS=' + this.architectures
+					],
+					gccDefs = [ 'DEPLOYTYPE=' + this.deployType ];
+				
+				// Note: There is no evidence that TI_DEVELOPMENT, TI_TEST, TI_DEVELOPMENT, or
+				//       DEBUGGER_ENABLED are used anymore.
 				
 				if (this.target == 'simulator') {
-					xcodeArgs.push('GCC_PREPROCESSOR_DEFINITIONS=__LOG__ID__=' + this.tiapp.guid);
-					xcodeArgs.push('DEPLOYTYPE=' + this.deployType);
-					xcodeArgs.push('TI_DEVELOPMENT=1');
-					xcodeArgs.push('DEBUG=1');
-					xcodeArgs.push('TI_VERSION=' + ti.manifest.version);
+					gccDefs.push('__LOG__ID__=' + this.tiapp.guid);
+					gccDefs.push('TI_DEVELOPMENT=1');
+					gccDefs.push('DEBUG=1');
+					gccDefs.push('TI_VERSION=' + this.titaniumSdkVersion);
+				} else if (this.target == 'dist-appstore') {
+					gccDefs.push('TI_PRODUCTION=1');
+				} else if (this.target == 'dist-adhoc' || this.target == 'device') {
+					gccDefs.push('TI_TEST=1');
 				}
 				
 				if (/simulator|device|dist\-adhoc/.test(this.target)) {
-					this.tiapp.ios && this.tiapp.ios.enablecoverage && xcodeArgs.push('KROLL_COVERAGE=1');
-					this.debugHost && xcodeArgs.push('DEBUGGER_ENABLED=1');
+					this.tiapp.ios && this.tiapp.ios.enablecoverage && gccDefs.push('KROLL_COVERAGE=1');
+					this.debugHost && gccDefs.push('DEBUGGER_ENABLED=1');
 				}
 				
+				xcodeArgs.push('GCC_PREPROCESSOR_DEFINITIONS=' + gccDefs.join(' '));
+				
 				if (/device|dist\-appstore|dist\-adhoc/.test(this.target)) {
-					xcodeArgs.push('GCC_PREPROCESSOR_DEFINITIONS=DEPLOYTYPE=' + this.deployType);
 					xcodeArgs.push('PROVISIONING_PROFILE=' + this.provisioningProfileUUID);
 					xcodeArgs.push('DEPLOYMENT_POSTPROCESSING=YES');
 					if (this.keychain) {
@@ -933,20 +943,12 @@ function build(logger, config, cli, finished) {
 					this.codeSignEntitlements && xcodeArgs.push('CODE_SIGN_ENTITLEMENTS=Resources/Entitlements.plist');
 				}
 				
-				if (/device|dist\-adhoc/.test(this.target)) {
-					xcodeArgs.push('TI_TEST=1');
-				}
-				
 				if (this.target == 'device') {
 					xcodeArgs.push('CODE_SIGN_IDENTITY=iPhone Developer: ' + this.certDeveloperName);
 				}
 				
 				if (/dist-appstore|dist\-adhoc/.test(this.target)) {
 					xcodeArgs.push('CODE_SIGN_IDENTITY=iPhone Distribution: ' + this.certDistributionName);
-				}
-				
-				if (this.target == 'dist-appstore') {
-					xcodeArgs.push('TI_PRODUCTION=1');
 				}
 				
 				var p = spawn(this.xcodeEnv.xcodebuild, xcodeArgs, {
@@ -1076,9 +1078,9 @@ build.prototype = {
 			merge(custom, plist);
 		}
 		
-		plist.UIRequiresPersistentWiFi = this.tiapp['persistent-wifi'];
-		plist.UIPrerenderedIcon = this.tiapp['prerendered-icon'];
-		plist.UIStatusBarHidden = this.tiapp['statusbar-hidden'];
+		plist.UIRequiresPersistentWiFi = this.tiapp.hasOwnProperty('persistent-wifi') ? !!this.tiapp['persistent-wifi'] : false;
+		plist.UIPrerenderedIcon = this.tiapp.hasOwnProperty('prerendered-icon') ? !!this.tiapp['prerendered-icon'] : false;
+		plist.UIStatusBarHidden = this.tiapp.hasOwnProperty('statusbar-hidden') ? !!this.tiapp['statusbar-hidden'] : false;
 		
 		plist.UIStatusBarStyle = 'UIStatusBarStyleDefault';
 		if (/opaque_black|opaque|black/.test(this.tiapp['statusbar-style'])) {
@@ -1150,8 +1152,14 @@ build.prototype = {
 		ios && ios.plist && merge(ios.plist, plist);
 		
 		plist.CFBundleIdentifier = this.tiapp.id;
-		plist.CFBundleVersion = appc.version.format(this.tiapp.version || 1, 2);
-		plist.CFBundleShortVersionString = appc.version.format(this.tiapp.version || 1, 2, 3);
+		
+		// device builds require an additional token to ensure uniquiness so that iTunes will detect an updated app to sync
+		if (this.target == 'device') {
+			plist.CFBundleVersion = appc.version.format(this.tiapp.version, 3, 3) + '.' + (new Date).getTime();
+		} else {
+			plist.CFBundleVersion = appc.version.format(this.tiapp.version, 3, 3);
+		}
+		plist.CFBundleShortVersionString = plist.CFBundleVersion;
 		
 		Array.isArray(plist.CFBundleIconFiles) || (plist.CFBundleIconFiles = []);
 		['.png', '@2x.png', '-72.png', '-Small-50.png', '-72@2x.png', '-Small-50@2x.png', '-Small.png', '-Small@2x.png'].forEach(function (name) {
@@ -1416,6 +1424,69 @@ build.prototype = {
 			return true;
 		}
 		
+		// next we check if any tiapp.xml values changed so we know if we need to reconstruct the main.m
+		if (this.tiapp.name != manifest.name) {
+			this.logger.debug(__('Forcing rebuild: tiapp.xml project name changed since last build'));
+			this.logger.debug('  ' + __('Was: %s', manifest.name));
+			this.logger.debug('  ' + __('Now: %s', this.tiapp.name));
+			return true;
+		}
+		
+		if (this.tiapp.id != manifest.id) {
+			this.logger.debug(__('Forcing rebuild: tiapp.xml app id changed since last build'));
+			this.logger.debug('  ' + __('Was: %s', manifest.id));
+			this.logger.debug('  ' + __('Now: %s', this.tiapp.id));
+			return true;
+		}
+		
+		if (!this.tiapp.analytics != !manifest.analytics) {
+			this.logger.debug(__('Forcing rebuild: tiapp.xml analytics flag changed since last build'));
+			this.logger.debug('  ' + __('Was: %s', !!manifest.analytics));
+			this.logger.debug('  ' + __('Now: %s', !!this.tiapp.analytics));
+			return true;
+		}
+		if (this.tiapp.publisher != manifest.publisher) {
+			this.logger.debug(__('Forcing rebuild: tiapp.xml publisher changed since last build'));
+			this.logger.debug('  ' + __('Was: %s', manifest.publisher));
+			this.logger.debug('  ' + __('Now: %s', this.tiapp.publisher));
+			return true;
+		}
+		
+		if (this.tiapp.url != manifest.url) {
+			this.logger.debug(__('Forcing rebuild: tiapp.xml url changed since last build'));
+			this.logger.debug('  ' + __('Was: %s', manifest.url));
+			this.logger.debug('  ' + __('Now: %s', this.tiapp.url));
+			return true;
+		}
+		
+		if (this.tiapp.version != manifest.version) {
+			this.logger.debug(__('Forcing rebuild: tiapp.xml version changed since last build'));
+			this.logger.debug('  ' + __('Was: %s', manifest.version));
+			this.logger.debug('  ' + __('Now: %s', this.tiapp.version));
+			return true;
+		}
+		
+		if (this.tiapp.description != manifest.description) {
+			this.logger.debug(__('Forcing rebuild: tiapp.xml description changed since last build'));
+			this.logger.debug('  ' + __('Was: %s', manifest.description));
+			this.logger.debug('  ' + __('Now: %s', this.tiapp.description));
+			return true;
+		}
+		
+		if (this.tiapp.copyright != manifest.copyright) {
+			this.logger.debug(__('Forcing rebuild: tiapp.xml copyright changed since last build'));
+			this.logger.debug('  ' + __('Was: %s', manifest.copyright));
+			this.logger.debug('  ' + __('Now: %s', this.tiapp.copyright));
+			return true;
+		}
+		
+		if (this.tiapp.guid != manifest.guid) {
+			this.logger.debug(__('Forcing rebuild: tiapp.xml guid changed since last build'));
+			this.logger.debug('  ' + __('Was: %s', manifest.guid));
+			this.logger.debug('  ' + __('Now: %s', this.tiapp.guid));
+			return true;
+		}
+		
 		return false;
 	},
 	
@@ -1663,7 +1734,16 @@ build.prototype = {
 			tiCoreHash: this.libTiCoreHash,
 			modulesHash: this.modulesHash,
 			gitHash: ti.manifest.githash,
-			outputDir: this.cli.argv['output-dir']
+			outputDir: this.cli.argv['output-dir'],
+			name: this.tiapp.name,
+			id: this.tiapp.id,
+			analytics: this.tiapp.analytics,
+			publisher: this.tiapp.publisher,
+			url: this.tiapp.url,
+			version: this.tiapp.version,
+			description: this.tiapp.description,
+			copyright: this.tiapp.copyright,
+			guid: this.tiapp.guid
 		}, null, '\t'), callback);
 	},
 	
@@ -1835,7 +1915,7 @@ build.prototype = {
 				'__APP_PUBLISHER__': this.tiapp.publisher,
 				'__APP_URL__': this.tiapp.url,
 				'__APP_NAME__': this.tiapp.name,
-				'__APP_VERSION__': version.format(this.tiapp.version, 2),
+				'__APP_VERSION__': this.tiapp.version,
 				'__APP_DESCRIPTION__': this.tiapp.description,
 				'__APP_COPYRIGHT__': this.tiapp.copyright,
 				'__APP_GUID__': this.tiapp.guid,
@@ -1867,46 +1947,49 @@ build.prototype = {
 			fs.writeFileSync(dest, mainContents);
 		}
 		
-		this.modules.forEach(function (m) {
-			var moduleId = m.manifest.moduleid.toLowerCase(),
-				moduleName = m.manifest.name.toLowerCase(),
-				prefix = m.manifest.moduleid.toUpperCase().replace(/\./g, '_');
-			
-			[	path.join(m.modulePath, 'module.xcconfig'),
-				path.join(this.projectDir, 'modules', 'iphone', moduleName + '.xcconfig')
-			].forEach(function (file) {
-				if (afs.exists(file)) {
-					var xc = new appc.xcconfig(file);
-					Object.keys(xc).forEach(function (key) {
-						var name = (prefix + '_' + key).replace(/[^\w]/g, '_');
-						variables[key] || (variables[key] = []);
-						variables[key].push(name);
-						xcconfigContents.push((name + '=' + xc[key]).replace(new RegExp('\$\(' + key + '\)', 'g'), '$(' + name + ')'));
-					});
-				}
+		if (this.modules.length) {
+			// if we have modules, write out a new ApplicationMods.m, otherwise use the default one
+			this.modules.forEach(function (m) {
+				var moduleId = m.manifest.moduleid.toLowerCase(),
+					moduleName = m.manifest.name.toLowerCase(),
+					prefix = m.manifest.moduleid.toUpperCase().replace(/\./g, '_');
+				
+				[	path.join(m.modulePath, 'module.xcconfig'),
+					path.join(this.projectDir, 'modules', 'iphone', moduleName + '.xcconfig')
+				].forEach(function (file) {
+					if (afs.exists(file)) {
+						var xc = new appc.xcconfig(file);
+						Object.keys(xc).forEach(function (key) {
+							var name = (prefix + '_' + key).replace(/[^\w]/g, '_');
+							variables[key] || (variables[key] = []);
+							variables[key].push(name);
+							xcconfigContents.push((name + '=' + xc[key]).replace(new RegExp('\$\(' + key + '\)', 'g'), '$(' + name + ')'));
+						});
+					}
+				});
+				
+				applicationModsContents.push('	[modules addObject:[NSDictionary dictionaryWithObjectsAndKeys:@\"' +
+					moduleName + '\",@\"name\",@\"' +
+					moduleId + '\",@\"moduleid\",@\"' +
+					(m.manifest.version || '') + '\",@\"version\",@\"' +
+					(m.manifest.guid || '') + '\",@\"guid\",@\"' +
+					(m.manifest.licensekey || '') + '\",@\"licensekey\",nil]];'
+				);
 			});
 			
-			applicationModsContents.push('	[modules addObject:[NSDictionary dictionaryWithObjectsAndKeys:@\"' +
-				moduleName + '\",@\"name\",@\"' +
-				moduleId + '\",@\"moduleid\",@\"' +
-				(m.manifest.version || '') + '\",@\"version\",@\"' +
-				(m.manifest.guid || '') + '\",@\"guid\",@\"' +
-				(m.manifest.licensekey || '') + '\",@\"licensekey\",nil]];'
-			);
-		});
-		
-		applicationModsContents.push('	return modules;');
-		applicationModsContents.push('}\n');
-		applicationModsContents.push('@end');
-		applicationModsContents = applicationModsContents.join('\n');
-		
-		// write the ApplicationMods.m file
-		dest = path.join(this.buildDir, 'Classes', 'ApplicationMods.m');
-		if (!afs.exists(dest) || fs.readFileSync(dest).toString() != applicationModsContents) {
-			this.logger.debug(__('Writing application modules source file: %s', dest.cyan));
-			fs.writeFileSync(dest, applicationModsContents);
-		} else {
-			this.logger.debug(__('Application modules source file already up-to-date: %s', dest.cyan));
+			applicationModsContents.push('	return modules;');
+			applicationModsContents.push('}\n');
+			applicationModsContents.push('@end');
+			applicationModsContents = applicationModsContents.join('\n');
+			
+			// write the ApplicationMods.m file
+			dest = path.join(this.buildDir, 'Classes', 'ApplicationMods.m');
+			if (!afs.exists(dest) || fs.readFileSync(dest).toString() != applicationModsContents) {
+				this.logger.debug(__('Writing application modules source file: %s', dest.cyan));
+				fs.writeFileSync(dest, applicationModsContents);
+			} else {
+				this.logger.debug(__('Application modules source file already up-to-date: %s', dest.cyan));
+			}
 		}
 		
 		// write the module.xcconfig file

--- a/mobileweb/cli/commands/_build.js
+++ b/mobileweb/cli/commands/_build.js
@@ -77,7 +77,7 @@ exports.run = function (logger, config, cli, finished) {
 					name: cli.tiapp.name,
 					publisher: cli.tiapp.publisher,
 					url: cli.tiapp.url,
-					image: cli.tiapp.image,
+					image: cli.tiapp.icon,
 					appid: cli.tiapp.id,
 					description: cli.tiapp.description,
 					type: cli.argv.type,

--- a/support/cli/commands/create.js
+++ b/support/cli/commands/create.js
@@ -57,7 +57,21 @@ exports.config = function (logger, config, cli) {
 				prompt: {
 					label: __('App ID'),
 					error: __('Invalid App ID'),
-					pattern: /^([a-z_]{1}[a-z0-9_]*(\.[a-z_]{1}[a-z0-9_]*)*)$/
+					validator: function (id) {
+						if (!/^([a-z_]{1}[a-z0-9_]*(\.[a-z_]{1}[a-z0-9_]*)*)$/.test(id)) {
+							throw new appc.exception(__('Invalid app id "%s"', tiapp.id), [
+								__('The app id must consist of letters, numbers, and underscores.'),
+								__('The first character must be a letter or underscore.'),
+								__("Usually the app id is your company's reversed Internet domain name. (i.e. com.example.myapp)")
+							]);
+						}
+						if (!ti.validAppId(id)) {
+							throw new appc.exception(__('Invalid app id "%s"', id), [
+								__('The app id parts must not contain reserved words.')
+							]);
+						}
+						return true;
+					}
 				},
 				required: true
 			},
@@ -74,6 +88,11 @@ exports.config = function (logger, config, cli) {
 					pattern: /^[A-Za-z]+[A-Za-z0-9_-]*$/
 				},
 				required: true
+			},
+			url: {
+				abbr: 'u',
+				default: config.app.url || '',
+				desc: __('your company/personal URL'),
 			},
 			'workspace-dir': {
 				abbr: 'd',
@@ -113,6 +132,29 @@ exports.validate = function (logger, config, cli) {
 		process.exit(1);
 	}
 	
+	cli.argv.id = (cli.argv.id || '').trim();
+	if (!/^([a-z_]{1}[a-z0-9_]*(\.[a-z_]{1}[a-z0-9_]*)*)$/.test(cli.argv.id)) {
+		logger.error(__('Invalid app id "%s"', cli.argv.id) + '\n');
+		logger.log(__('The app id must consist of letters, numbers, and underscores.'));
+		logger.log(__('The first character must be a letter or underscore.'));
+		logger.log(__("Usually the app id is your company's reversed Internet domain name. (i.e. com.example.myapp)") + '\n');
+		process.exit(1);
+	}
+	
+	if (!ti.validAppId(cli.argv.id)) {
+		logger.error(__('Invalid app id "%s"', cli.argv.id) + '\n');
+		logger.log(__('The app id parts must not contain reserved words.') + '\n');
+		process.exit(1);
+	}
+	
+	cli.argv.name = (cli.argv.name || '').trim();
+	if (!/^[A-Za-z]+[A-Za-z0-9_-]*$/.test(cli.argv.name)) {
+		logger.error(__('Invalid project name "%s"', cli.argv.name) + '\n');
+		logger.log(__('The project name must consist of letters, numbers, dashes, and underscores.'));
+		logger.log(__('The first character must be a letter.') + '\n');
+		process.exit(1);
+	}
+	
 	cli.argv['workspace-dir'] = afs.resolvePath(cli.argv['workspace-dir'] || '.');
 	
 	var projectDir = path.join(cli.argv['workspace-dir'], cli.argv.name);
@@ -128,6 +170,7 @@ exports.run = function (logger, config, cli) {
 		platforms = cli.argv.platforms,
 		id = cli.argv.id,
 		type = cli.argv.type,
+		url = cli.argv.url || '',
 		sdk = cli.env.getSDK(cli.argv.sdk),
 		projectDir = afs.resolvePath(cli.argv['workspace-dir'], projectName),
 		templateDir = afs.resolvePath(sdk.path, 'templates', type, cli.argv.template),
@@ -145,6 +188,7 @@ exports.run = function (logger, config, cli) {
 		projectConfig = new ti.tiappxml(projectDir + '/tiapp.xml');
 		projectConfig.id = id;
 		projectConfig.name = projectName;
+		projectConfig.url = url;
 		projectConfig.version = '1.0';
 		projectConfig.guid = uuid.v4();
 		projectConfig['deployment-targets'] = {};

--- a/support/node_modules/titanium-sdk/lib/titanium.js
+++ b/support/node_modules/titanium-sdk/lib/titanium.js
@@ -140,7 +140,124 @@ exports.validateProjectDir = function(logger, cli, argv, name) {
 		process.exit(1);
 	}
 	
-	cli.tiapp = new exports.tiappxml(path.join(projectDir, 'tiapp.xml'));
+	// load the tiapp.xml
+	var tiapp = cli.tiapp = new exports.tiappxml(path.join(projectDir, 'tiapp.xml'));
+	
+	// validate the common tiapp.xml values
+	
+	if (!/^([a-z_]{1}[a-z0-9_]*(\.[a-z_]{1}[a-z0-9_]*)*)$/.test(tiapp.id)) {
+		logger.error(__('tiapp.xml contains an invalid app id "%s"', tiapp.id) + '\n');
+		logger.log(__('The app id must consist of letters, numbers, and underscores.'));
+		logger.log(__('The first character must be a letter or underscore.'));
+		logger.log(__("Usually the app id is your company's reversed Internet domain name. (i.e. com.example.myapp)") + '\n');
+		process.exit(1);
+	}
+	
+	if (!exports.validAppId(tiapp.id)) {
+		logger.error(__('tiapp.xml contains an invalid app id "%s"', tiapp.id) + '\n');
+		logger.log(__('The app id parts must not contain reserved words.') + '\n');
+		process.exit(1);
+	}
+	
+	if (!/^[A-Za-z]+[A-Za-z0-9_-]*$/.test(tiapp.name)) {
+		logger.error(__('tiapp.xml contains an invalid project name "%s"', tiapp.name) + '\n');
+		logger.log(__('The project name must consist of letters, numbers, dashes, and underscores.'));
+		logger.log(__('The first character must be a letter.') + '\n');
+		process.exit(1);
+	}
+
+	if (!/^[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}$/.test(tiapp.guid)) {
+		logger.error(__('tiapp.xml contains an invalid guid "%s"', tiapp.guid) + '\n');
+		logger.log(__('The guid must be in the format XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX and consist of letters and numbers.') + '\n');
+		logger.log(__('If you need a new guid, below are 5 freshly generated new ones that you can choose from:'));
+		for (var i = 0, uuid = require('node-uuid'); i < 5; i++) {
+			logger.log('    ' + uuid.v4().cyan);
+		}
+		logger.log();
+		process.exit(1);
+	}
+	
+	tiapp.version || (tiapp.version = '1.0');
+	
+	if (!/^\d+(\.\d+(\.\d+(\..+)?)?)?$/.test(tiapp.version)) {
+		logger.error(__('tiapp.xml contains an invalid version "%s"', tiapp.version) + '\n');
+		logger.log(__('The version may only contist of letters, numbers, dashes, underscores, pluses, and spaces.') + '\n');
+		process.exit(1);
+	}
+	
+	if ((''+tiapp.version).charAt(0) == '0') {
+		logger.warn(__('tiapp.xml contains an invalid version "%s"', tiapp.version));
+		logger.warn(__('The app version major number must be greater than zero.'));
+	}
+};
+
+exports.validAppId = function (id) {
+	var words = {
+			'abstract': 1,
+			'assert': 1,
+			'boolean': 1,
+			'break': 1,
+			'byte': 1,
+			'case': 1,
+			'catch': 1,
+			'char': 1,
+			'class': 1,
+			'const': 1,
+			'continue': 1,
+			'default': 1,
+			'do': 1,
+			'double': 1,
+			'else': 1,
+			'enum': 1,
+			'extends': 1,
+			'false': 1,
+			'final': 1,
+			'finally': 1,
+			'float': 1,
+			'for': 1,
+			'goto': 1,
+			'if': 1,
+			'implements': 1,
+			'import': 1,
+			'instanceof': 1,
+			'int': 1,
+			'interface': 1,
+			'long': 1,
+			'native': 1,
+			'new': 1,
+			'null': 1,
+			'package': 1,
+			'private': 1,
+			'protected': 1,
+			'public': 1,
+			'return': 1,
+			'short': 1,
+			'static': 1,
+			'strictfp': 1,
+			'super': 1,
+			'switch': 1,
+			'synchronized': 1,
+			'this': 1,
+			'throw': 1,
+			'throws': 1,
+			'transient': 1,
+			'true': 1,
+			'try': 1,
+			'void': 1,
+			'volatile': 1,
+			'while': 1
+		},
+		parts = id.split('.'),
+		i = 0,
+		l = parts.length;
+	
+	for (; i < l; i++) {
+		if (words[parts[i]]) {
+			return false;
+		}
+	}
+	
+	return true;
 };
 
 exports.loadPlugins = function (logger, cli, config, projectDir) {


### PR DESCRIPTION
[TIMOB-12107] Added tiapp.xml validation for id, name, guid, and version

[TIMOB-12106] Fixed app name validation when specified at the command line.

In addition:
- Added better validation of app ids, version numbers
- Fixed analytics where it was sending undefined instead of the icon
- Added more things to check for to see if a full rebuild is necessary
- Added --url to the create command
- No longer modify the ApplicationMods.m if there are no modules
- Forces universal device family if device family was not specified
- Fixed bug with the list of params being set in the GCC_PREPROCESSOR_DEFINITIONS Xcode param
- Cleaned up display of uuids when being prompted
