### PR TITLE
fix [TC-1704] Crash in Kitchen Sink-> Base UI->Views-> Scroll Views->Basic->Scroll to Top

### DIFF
--- a/mobileweb/titanium/Ti/UI/ScrollView.js
+++ b/mobileweb/titanium/Ti/UI/ScrollView.js
@@ -67,7 +67,7 @@ define(["Ti/_/declare", "Ti/_/UI/KineticScrollView", "Ti/_/style", "Ti/_/lang", 
 		},
 
 		scrollTo: function(x, y) {
-			self._setTranslation(x !== null ? -x : this._currentTranslationX, y !== null ? -y : this._currentTranslationX);
+			this._setTranslation(x !== null ? -x : this._currentTranslationX, y !== null ? -y : this._currentTranslationX);
 		},
 
 		_defaultWidth: UI.FILL,


### PR DESCRIPTION
there is misprint in scrollTo functions, should be "this" instead of "self" (or define self)
