### PR TITLE
[TIMOB-10280] cleanup dispatch_async calls to prevent possibility of reordered actions

### DIFF
--- a/iphone/Classes/LauncherView.m
+++ b/iphone/Classes/LauncherView.m
@@ -239,9 +239,9 @@ static const NSTimeInterval kLauncherViewFastTransitionDuration = 0.2;
 - (void)recreateButtons 
 {
     if (![NSThread isMainThread]) {
-        dispatch_async(dispatch_get_main_queue(), ^{
+        TiThreadPerformOnMainThread( ^{
             [self recreateButtons];
-        });
+        }, NO);
         return;
     }
     

--- a/iphone/Classes/TiMediaSoundProxy.m
+++ b/iphone/Classes/TiMediaSoundProxy.m
@@ -73,7 +73,7 @@
 -(void)play:(id)args
 {
     [self rememberSelf];
-    dispatch_async(dispatch_get_main_queue(), ^{
+    TiThreadPerformOnMainThread(^{
         // indicate we're going to start playback
         if (![[TiMediaAudioSession sharedSession] canPlayback]) {
             [self throwException:@"Improper audio session mode for playback"
@@ -86,12 +86,12 @@
         }
         [[self player] play];
         paused = NO;
-    });
+    }, NO);
 }
 
 -(void)stop:(id)args
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
+    TiThreadPerformOnMainThread(^{
         if (player != nil) {
             if ([player isPlaying] || paused) {
                 [player stop];
@@ -101,24 +101,24 @@
         }
         resumeTime = 0;
         paused = NO;
-    });
+    }, NO);
 }
 
 -(void)pause:(id)args
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
+    TiThreadPerformOnMainThread(^{
         if (player != nil) {
             if ([player isPlaying]) {
                 [player pause];
                 paused = YES;
             }
         }
-    });
+    }, NO);
 }
 
 -(void)reset:(id)args
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
+    TiThreadPerformOnMainThread(^{
         if (player != nil) {
             if (!([player isPlaying] || paused)) {
                 [[TiMediaAudioSession sharedSession] startAudioSession];
@@ -130,7 +130,7 @@
         }
         resumeTime = 0;
         paused = NO;
-    });
+    }, NO);
 }
 
 -(void)release:(id)args

--- a/iphone/Classes/TiMediaVideoPlayerProxy.m
+++ b/iphone/Classes/TiMediaVideoPlayerProxy.m
@@ -343,9 +343,9 @@ NSArray* moviePlayerKeys = nil;
 -(void)setMediaControlStyle:(NSNumber *)value
 {
 	if (movie != nil) {
-		dispatch_async(dispatch_get_main_queue(), ^{
+		TiThreadPerformOnMainThread(^{
 			[movie setControlStyle:[TiUtils intValue:value def:MPMovieControlStyleDefault]];
-		});
+		}, NO);
 	} else {
 		[loadProperties setValue:value forKey:@"mediaControlStyle"];
 	}

--- a/iphone/Classes/TiUIDashboardItemProxy.m
+++ b/iphone/Classes/TiUIDashboardItemProxy.m
@@ -94,13 +94,13 @@
     // because -[TiViewProxy add:] could exit early if it's not on the main thread.
     // On the other hand, blocking this to execute on the main thread only doesn't appear to work right.
     
-    dispatch_async(dispatch_get_main_queue(), ^{
+	TiThreadPerformOnMainThread(^{
         LauncherItem *item_ = [self  ensureItem];
         if (item_.view==nil)
         {
             [item_ setView:[self view]];
         }
-    });
+	}, NO);
 }
 
 

--- a/iphone/Classes/TiUITableView.m
+++ b/iphone/Classes/TiUITableView.m
@@ -463,14 +463,9 @@
     // way, meaning that we have to explicitly reload the whole visible table to get
     // the "right" behavior.
     if (animation == UITableViewRowAnimationNone) {
-        if (![NSThread isMainThread]) {
-            dispatch_async(dispatch_get_main_queue(), ^{
-                [table reloadData];
-            });
-        }
-        else {
-            [table reloadData];            
-        }
+		TiThreadPerformOnMainThread(^{
+			[table reloadData];
+		}, NO);
         return;
     }
     
@@ -1678,14 +1673,9 @@
 
     // Instead of calling back through our mechanism to reload specific sections, because the entire index of the table
     // has been regenerated, we can assume it's okay to just reload the whole dataset.
-    if ([NSThread isMainThread]) {
-        [[self tableView] reloadData];
-    }
-    else {
-        dispatch_async(dispatch_get_main_queue(), ^{
-            [[self tableView] reloadData];
-        });
-    }
+	TiThreadPerformOnMainThread(^{
+		[[self tableView] reloadData];
+	}, NO);
 }
 
 -(void)setFilterCaseInsensitive_:(id)caseBool

--- a/iphone/Classes/TiUIView.m
+++ b/iphone/Classes/TiUIView.m
@@ -494,9 +494,9 @@ DEFINE_EXCEPTIONS
 -(void)renderRepeatedBackground:(id)image
 {
     if (![NSThread isMainThread]) {
-        dispatch_async(dispatch_get_main_queue(), ^{
+        TiThreadPerformOnMainThread(^{
             [self renderRepeatedBackground:image];
-        });
+        }, NO);
         return;
     }
     

--- a/iphone/Classes/TiViewProxy.m
+++ b/iphone/Classes/TiViewProxy.m
@@ -330,18 +330,18 @@
 
 -(void)show:(id)arg
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
+	TiThreadPerformOnMainThread(^{
         [self setHidden:NO withArgs:arg];
         [self replaceValue:NUMBOOL(YES) forKey:@"visible" notification:YES];
-    });
+    }, NO);
 }
  
 -(void)hide:(id)arg
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
+    TiThreadPerformOnMainThread(^{
         [self setHidden:YES withArgs:arg];
         [self replaceValue:NUMBOOL(NO) forKey:@"visible" notification:YES];
-    });
+    }, NO);
 }
 
 -(void)animate:(id)arg


### PR DESCRIPTION
Possible fix for intermittent issue [TIMOB-10280](https://jira.appcelerator.org/browse/TIMOB-10280) with hide()

FT: run KS
