### PR TITLE
[TIMOB-8358]IOS: Implementing Localization of Splash Screen.

### DIFF
--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -1540,47 +1540,42 @@ build.prototype = {
 	},
 	
 	copyLocalizedSplashScreens: function (callback) {
-		 
-		var data = ti.i18n.splashScreens(this.projectDir, this.logger);
-		var	i = 0,
-			copyOpts = {
+		
+		var copyOpts = {
 				logger: this.logger.debug
 			};
-		
-		for (; i < data.length; i++) {
-				
-			var token = data[i].split('/'),
+		ti.i18n.splashScreens(this.projectDir, this.logger).forEach(function (splashImage) {
+			var token = splashImage.split('/'),
 				lang = token[token.length-2],
 				lprojDir = path.join(this.xcodeAppDir, lang + '.lproj'),
 				file = token[token.length-1],
-				globalFile = path.join(this.xcodeAppDir,file)
-				resourcesDir = path.join(this.buildDir,'Resources');
+				globalFile = path.join(this.xcodeAppDir, file),
+				resourcesDir = path.join(this.buildDir, 'Resources'),
+				projFile = path.join(resourcesDir, file);
 			
 			//This would never need to run. But just to be safe.
 			if (!afs.exists(lprojDir)) {
 				this.logger.debug(__('Creating lproj folder %s', lprojDir.cyan));
 				wrench.mkdirSyncRecursive(lprojDir);
 			}
-			this.logger.debug(__('Copying file %s to %s', data[i], lprojDir));
-			afs.copyFileSync(data[i], lprojDir, copyOpts);
 			
-			// Delete the old file
-			var projFile = path.join(resourcesDir, file);
+			afs.copyFileSync(splashImage, lprojDir, copyOpts);
+			
 			this.logger.debug(__('Checking if %s exists in global space', file.cyan));
 			
 			// Check for it in the root of the xcode build folder.
-			if(afs.exists(globalFile)) {
+			if (afs.exists(globalFile)) {
 				this.logger.debug(__('Removing File %s, as it is being localized', globalFile.cyan));
 				fs.unlinkSync(globalFile);
 			}
 			
 			// Check in the Resources of Ti-build folder.
-			if(afs.exists(projFile)) {
+			if (afs.exists(projFile)) {
 				this.logger.debug(__('Removing File %s, as it is being localized', projFile.cyan));
 				fs.unlinkSync(projFile);
 			}
-				
-		}
+			
+		}, this);
 		
 		callback();
 	},

--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -764,6 +764,7 @@ function build(logger, config, cli, finished) {
 				'copyCommonJSModules',
 				'copyItunesArtwork',
 				'copyGraphics',
+				'copyLocalizedSplashScreens',
 				'writeBuildManifest'
 			], function () {
 				var xcodeArgs = [
@@ -1536,6 +1537,52 @@ build.prototype = {
 			}, this),
 			callback
 		);
+	},
+	
+	copyLocalizedSplashScreens: function (callback) {
+		 
+		var data = ti.i18n.splashScreens(this.projectDir, this.logger);
+		var	i = 0,
+			copyOpts = {
+				logger: this.logger.debug
+			};
+		
+		for (; i < data.length; i++) {
+				
+			var token = data[i].split('/'),
+				lang = token[token.length-2],
+				lprojDir = path.join(this.xcodeAppDir, lang + '.lproj'),
+				file = token[token.length-1],
+				globalFile = path.join(this.xcodeAppDir,file)
+				resourcesDir = path.join(this.buildDir,'Resources');
+			
+			//This would never need to run. But just to be safe.
+			if (!afs.exists(lprojDir)) {
+				this.logger.debug(__('Creating lproj folder %s', lprojDir.cyan));
+				wrench.mkdirSyncRecursive(lprojDir);
+			}
+			this.logger.debug(__('Copying file %s to %s', data[i], lprojDir));
+			afs.copyFileSync(data[i], lprojDir, copyOpts);
+			
+			// Delete the old file
+			var projFile = path.join(resourcesDir, file);
+			this.logger.debug(__('Checking if %s exists in global space', file.cyan));
+			
+			// Check for it in the root of the xcode build folder.
+			if(afs.exists(globalFile)) {
+				this.logger.debug(__('Removing File %s, as it is being localized', globalFile.cyan));
+				fs.unlinkSync(globalFile);
+			}
+			
+			// Check in the Resources of Ti-build folder.
+			if(afs.exists(projFile)) {
+				this.logger.debug(__('Removing File %s, as it is being localized', projFile.cyan));
+				fs.unlinkSync(projFile);
+			}
+				
+		}
+		
+		callback();
 	},
 	
 	injectModulesIntoXcodeProject: function (callback) {

--- a/iphone/iphone/Titanium.xcodeproj/project.pbxproj
+++ b/iphone/iphone/Titanium.xcodeproj/project.pbxproj
@@ -221,7 +221,6 @@
 		24CA8CED1111689B0084E2DE /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 24CA8CEC1111689B0084E2DE /* AudioToolbox.framework */; };
 		24CA8CF4111168AE0084E2DE /* MediaPlayer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 24CA8CF3111168AE0084E2DE /* MediaPlayer.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		24CA8CFB111168C30084E2DE /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 24CA8CFA111168C30084E2DE /* AVFoundation.framework */; };
-		24CA9183111170820084E2DE /* Default.png in Resources */ = {isa = PBXBuildFile; fileRef = 24CA9182111170820084E2DE /* Default.png */; };
 		24D06FE111D0211100F615D8 /* TiUIiOSAdViewProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 24D06FE011D0211100F615D8 /* TiUIiOSAdViewProxy.m */; };
 		24D06FE211D0211200F615D8 /* TiUIiOSAdViewProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 24D06FE011D0211100F615D8 /* TiUIiOSAdViewProxy.m */; };
 		24D06FE811D0219B00F615D8 /* TiUIiOSAdView.m in Sources */ = {isa = PBXBuildFile; fileRef = 24D06FE711D0219B00F615D8 /* TiUIiOSAdView.m */; };
@@ -230,7 +229,6 @@
 		24D0700711D0253D00F615D8 /* TiUIiOSProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 24D0700511D0253D00F615D8 /* TiUIiOSProxy.m */; };
 		24D5C75911E6364F00F097E2 /* libtiverify.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 24D5C75811E6364F00F097E2 /* libtiverify.a */; };
 		24D5C75A11E6364F00F097E2 /* libtiverify.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 24D5C75811E6364F00F097E2 /* libtiverify.a */; };
-		24D8E3B7119B9D8A00F8CAA6 /* Default.png in Resources */ = {isa = PBXBuildFile; fileRef = 24CA9182111170820084E2DE /* Default.png */; };
 		24D8E3BB119B9D8A00F8CAA6 /* TiUITableViewAction.m in Sources */ = {isa = PBXBuildFile; fileRef = 243EC7D6112634AF00639DF4 /* TiUITableViewAction.m */; };
 		24D8E3BC119B9D8A00F8CAA6 /* TiFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 24F5AEB3111F9DE9005C9199 /* TiFile.m */; };
 		24D8E3BD119B9D8A00F8CAA6 /* TiMapPinAnnotationView.m in Sources */ = {isa = PBXBuildFile; fileRef = 24EB0BA9111F7959001DC2D1 /* TiMapPinAnnotationView.m */; };
@@ -467,8 +465,6 @@
 		24F1584711D72A23000DD736 /* TiMapImageAnnotationView.m in Sources */ = {isa = PBXBuildFile; fileRef = 24F1584511D72A23000DD736 /* TiMapImageAnnotationView.m */; };
 		24F29E2E12209C920099351D /* TiStylesheet.m in Sources */ = {isa = PBXBuildFile; fileRef = 24F29E2D12209C920099351D /* TiStylesheet.m */; };
 		24F29E2F12209C920099351D /* TiStylesheet.m in Sources */ = {isa = PBXBuildFile; fileRef = 24F29E2D12209C920099351D /* TiStylesheet.m */; };
-		24F29E3712209E6F0099351D /* stylesheet.plist in Resources */ = {isa = PBXBuildFile; fileRef = 24F29E3612209E6F0099351D /* stylesheet.plist */; };
-		24F29E3812209E6F0099351D /* stylesheet.plist in Resources */ = {isa = PBXBuildFile; fileRef = 24F29E3612209E6F0099351D /* stylesheet.plist */; };
 		24F29E701220CE0A0099351D /* TiLocale.m in Sources */ = {isa = PBXBuildFile; fileRef = 24F29E6F1220CE0A0099351D /* TiLocale.m */; };
 		24F29E711220CE0A0099351D /* TiLocale.m in Sources */ = {isa = PBXBuildFile; fileRef = 24F29E6F1220CE0A0099351D /* TiLocale.m */; };
 		24F29F82122105C70099351D /* LocaleModule.m in Sources */ = {isa = PBXBuildFile; fileRef = 24F29F80122105C70099351D /* LocaleModule.m */; };
@@ -628,8 +624,6 @@
 		DABA10C812E676A1007DD791 /* FBLoginButton.m in Sources */ = {isa = PBXBuildFile; fileRef = DABA10BC12E676A1007DD791 /* FBLoginButton.m */; };
 		DABA10C912E676A1007DD791 /* FBLoginDialog.m in Sources */ = {isa = PBXBuildFile; fileRef = DABA10BE12E676A1007DD791 /* FBLoginDialog.m */; };
 		DABA10CA12E676A1007DD791 /* FBRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = DABA10C012E676A1007DD791 /* FBRequest.m */; };
-		DABB369C12E8CB280026A6EA /* Default.png in Resources */ = {isa = PBXBuildFile; fileRef = 24CA9182111170820084E2DE /* Default.png */; };
-		DABB369E12E8CB280026A6EA /* stylesheet.plist in Resources */ = {isa = PBXBuildFile; fileRef = 24F29E3612209E6F0099351D /* stylesheet.plist */; };
 		DABB36A112E8CB280026A6EA /* TiUITableViewAction.m in Sources */ = {isa = PBXBuildFile; fileRef = 243EC7D6112634AF00639DF4 /* TiUITableViewAction.m */; };
 		DABB36A212E8CB280026A6EA /* TiFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 24F5AEB3111F9DE9005C9199 /* TiFile.m */; };
 		DABB36A312E8CB280026A6EA /* TiMapPinAnnotationView.m in Sources */ = {isa = PBXBuildFile; fileRef = 24EB0BA9111F7959001DC2D1 /* TiMapPinAnnotationView.m */; };
@@ -899,9 +893,6 @@
 		DABF3EDC134D2E4400836137 /* TiStreamProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = DABF3EDB134D2E4300836137 /* TiStreamProxy.m */; };
 		DABF3EDD134D2E4400836137 /* TiStreamProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = DABF3EDB134D2E4300836137 /* TiStreamProxy.m */; };
 		DABF3EDE134D2E4400836137 /* TiStreamProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = DABF3EDB134D2E4300836137 /* TiStreamProxy.m */; };
-		DAC9D36C138DB65C004917F8 /* debugger.plist in Resources */ = {isa = PBXBuildFile; fileRef = DAC9D36B138DB65C004917F8 /* debugger.plist */; };
-		DAC9D36D138DB678004917F8 /* debugger.plist in Resources */ = {isa = PBXBuildFile; fileRef = DAC9D36B138DB65C004917F8 /* debugger.plist */; };
-		DAC9D36E138DB67F004917F8 /* debugger.plist in Resources */ = {isa = PBXBuildFile; fileRef = DAC9D36B138DB65C004917F8 /* debugger.plist */; };
 		DADD76E913CCF4FF00CD03AC /* MGSplitView.m in Sources */ = {isa = PBXBuildFile; fileRef = DADD76E813CCF4FF00CD03AC /* MGSplitView.m */; };
 		DADD76EA13CCF4FF00CD03AC /* MGSplitView.m in Sources */ = {isa = PBXBuildFile; fileRef = DADD76E813CCF4FF00CD03AC /* MGSplitView.m */; };
 		DADD76EB13CCF4FF00CD03AC /* MGSplitView.m in Sources */ = {isa = PBXBuildFile; fileRef = DADD76E813CCF4FF00CD03AC /* MGSplitView.m */; };
@@ -3087,9 +3078,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				24CA9183111170820084E2DE /* Default.png in Resources */,
-				24F29E3812209E6F0099351D /* stylesheet.plist in Resources */,
-				DAC9D36E138DB67F004917F8 /* debugger.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3097,9 +3085,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				24D8E3B7119B9D8A00F8CAA6 /* Default.png in Resources */,
-				24F29E3712209E6F0099351D /* stylesheet.plist in Resources */,
-				DAC9D36D138DB678004917F8 /* debugger.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3107,9 +3092,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DABB369C12E8CB280026A6EA /* Default.png in Resources */,
-				DABB369E12E8CB280026A6EA /* stylesheet.plist in Resources */,
-				DAC9D36C138DB65C004917F8 /* debugger.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/support/node_modules/titanium-sdk/lib/i18n.js
+++ b/support/node_modules/titanium-sdk/lib/i18n.js
@@ -62,7 +62,7 @@ exports.splashScreens = function (projectDir, logger) {
 			
 			if (fs.lstatSync(langDir).isDirectory()) {
 				fs.readdirSync(langDir).forEach(function (file) {
-					if(/^(Default(2x|-568h@2x|-Landscape|-Landscape@2x|-Portrait|-Portriat@2x)?)\.png$/.test(file)) {
+					if(/^(Default(@2x|-568h@2x|-Landscape|-Landscape@2x|-Portrait|-Portriat@2x)?)\.png$/.test(file)) {
 						data.push(path.join(langDir, file));
 					}
 				});

--- a/support/node_modules/titanium-sdk/lib/i18n.js
+++ b/support/node_modules/titanium-sdk/lib/i18n.js
@@ -49,3 +49,26 @@ exports.load = function (projectDir, logger) {
 	
 	return data;
 };
+
+exports.splashScreens = function (projectDir, logger) {
+
+	var i18nDir = path.join(projectDir, 'i18n'),
+		data = [];
+	
+	if (afs.exists(i18nDir)) {
+		logger.info(__('Checking for Splash Screen localization'));
+		fs.readdirSync(i18nDir).forEach(function (lang) {
+			var langDir = path.join(i18nDir, lang);
+			
+			if (fs.lstatSync(langDir).isDirectory()) {
+				fs.readdirSync(langDir).forEach(function (file) {
+					if(/^(Default(2x|-568h@2x|-Landscape|-Landscape@2x|-Portrait|-Portriat@2x)?)\.png$/.test(file)) {
+						data.push(path.join(langDir, file));
+					}
+				});
+			}
+		});
+	}
+	
+	return data;
+};


### PR DESCRIPTION
**Changes that needs to be reviewed to the build process**
- If an Localized Splash Screen exists in the i18n folder, the corresponding splash screen from the global space would be removed. 
- I have removed all items under  > build phase > **Copy Bundle Resources**  for the titanium xcode project as it would always try to copy default.png , along with 'debugger.plist' and 'stylesheet.plist' from app/build/iphone/Resources folder which is not always correct. It would also help in resolving a subsequent ticket [TC-1660](https://jira.appcelerator.org/browse/TC-1660)
  ![ Copy bundle Resources](https://f.cloud.github.com/assets/847863/51287/3b1b3590-59c9-11e2-9514-9c3caef87d6e.png) 

**TESTING INSTRUCTIONS**
- Import Code from (here)[https://jira.appcelerator.org/secure/attachment/34607/splashtest.zip] into TiStudio.
- Build app for device. 
- Install app on to device.
- Open the app.
- Check if the default appcelerator splash screen shows (assuming your default language is english)
- Kill the app, remove it from background.
- Go to Settings > General > International >  Language , Change language to French.
- Restart the app. Verify that the splash screen has changed.
- Kill the app, remove it from background.
- Go to Settings > General > International >  Language , Change language to any other language.
- Restart the app. Verify that the splash screen defaults back to the english one.(appcelerator splash screen).
- I have also included another .png image `Copy of Default.png` inside the i18n folder which should not be copied during the build (Just to sanity check that the regex actually works and does not copy over any thing other than the required splash screen images.)
