### PR TITLE
[TIMOB-11599] Fixed issues with building from Xcode not properly interpr...

### DIFF
--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -120,6 +120,9 @@ exports.config = function (logger, config, cli) {
 					retina: {
 						desc: __('use the retina version of the iOS Simulator')
 					},*/
+					legacy: {
+						desc: __('build using the old Python-based builder.py')
+					},
 					xcode: {
 						// secret flag to perform Xcode pre-compile build step
 						hidden: true
@@ -417,8 +420,8 @@ exports.validate = function (logger, config, cli) {
 		
 		try {
 			var buildManifest = JSON.parse(fs.readFileSync(buildManifestFile)) || {};
-			cli.argv.target = buildManifest.target;
-			cli.argv['deploy-type'] = buildManifest.deployType;
+			cli.argv.target = process.env.CURRENT_ARCH === 'i386' ? 'simulator' : (buildManifest.target != 'simulator' ? buildManifest.target : 'device');
+			cli.argv['deploy-type'] = process.env.TITANIUM_CLI_XCODEBUILD ? buildManifest.deployType : (process.env.CURRENT_ARCH === 'i386' ? 'development' : 'test');
 			cli.argv['output-dir'] = buildManifest.outputDir;
 			cli.argv['developer-name'] = buildManifest.developerName;
 			cli.argv['distribution-name'] = buildManifest.distributionName;
@@ -734,7 +737,7 @@ function build(logger, config, cli, finished) {
 	this.keychain = cli.argv.keychain;
 	
 	if (cli.argv.xcode) {
-		this.deployType = process.env.CURRENT_ARCH === 'i386' ? 'development' : process.env.CONFIGURATION === 'Debug' ? (cli.argv['deploy-type'] || 'test') : 'production';
+		this.deployType = cli.argv['deploy-type'];
 	} else {
 		this.deployType = /device|simulator/.test(this.target) && cli.argv['deploy-type'] ? cli.argv['deploy-type'] : deployTypes[this.target];
 	}
@@ -958,7 +961,8 @@ function build(logger, config, cli, finished) {
 						env: {
 							DEVELOPER_DIR: this.xcodeEnv.path,
 							HOME: process.env.HOME,
-							PATH: process.env.PATH
+							PATH: process.env.PATH,
+							TITANIUM_CLI_XCODEBUILD: 'yeah baby'
 						}
 					}),
 					out = [],
@@ -1312,8 +1316,9 @@ build.prototype = {
 		proj = injectCompileShellScript(
 			proj,
 			'Pre-Compile',
+			'if [ \\"x$TITANIUM_CLI_XCODEBUILD\\" == \\"x\\" ]; then NO_COLORS=\\"--no-colors\\"; else NO_COLORS=\\"\\"; fi\\n' +
 			(process.execPath || 'node') + ' \\"' + this.cli.argv.$0.replace(/^node /, '') + '\\" build --platform ' +
-				this.platformName + ' --sdk ' + this.titaniumSdkVersion + ' --no-prompt --no-banner --xcode\\nexit $?'
+				this.platformName + ' --sdk ' + this.titaniumSdkVersion + ' --no-prompt --no-banner $NO_COLORS --xcode\\nexit $?'
 		);
 		proj = injectCompileShellScript(
 			proj,

--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -423,8 +423,8 @@ exports.validate = function (logger, config, cli) {
 			cli.argv.target = process.env.CURRENT_ARCH === 'i386' ? 'simulator' : (buildManifest.target != 'simulator' ? buildManifest.target : 'device');
 			cli.argv['deploy-type'] = process.env.TITANIUM_CLI_XCODEBUILD ? buildManifest.deployType : (process.env.CURRENT_ARCH === 'i386' ? 'development' : 'test');
 			cli.argv['output-dir'] = buildManifest.outputDir;
-			cli.argv['developer-name'] = buildManifest.developerName;
-			cli.argv['distribution-name'] = buildManifest.distributionName;
+			cli.argv['developer-name'] = process.env.CODE_SIGN_IDENTITY ? process.env.CODE_SIGN_IDENTITY.replace(/^iPhone Developer\: /, '') : buildManifest.developerName;
+			cli.argv['distribution-name'] = process.env.CODE_SIGN_IDENTITY ? process.env.CODE_SIGN_IDENTITY.replace(/^iPhone Distribution\: /, '') : buildManifest.distributionName;
 			conf.options['output-dir'].required = false;
 		} catch (e) {}
 	}

--- a/support/node_modules/titanium-sdk/lib/titanium.js
+++ b/support/node_modules/titanium-sdk/lib/titanium.js
@@ -330,7 +330,7 @@ exports.loadPlugins = function (logger, cli, config, projectDir) {
 exports.validateCorrectSDK = function (logger, config, cli, commandName) {
 	// tiapp.xml should exist by the time we get here
 	var sdk = cli.tiapp['sdk-version'];
-	if (!sdk || version.eq(sdk, manifest.version)) return true;
+	if (cli.argv.legacy !== true && (!sdk || version.eq(sdk, manifest.version))) return true;
 	
 	// check the project's preferred sdk is even installed
 	if (sdk == '__global__' || !cli.env.sdks[sdk]) {
@@ -359,11 +359,11 @@ exports.validateCorrectSDK = function (logger, config, cli, commandName) {
 		args.splice(p, 2);
 	}
 	
-	if (version.lt(sdk, '2.2.0')) { // technically, there is no 2.2, it was released as 3.0
+	if (cli.argv.legacy || version.lt(sdk, '2.2.0')) { // technically, there is no 2.2, it was released as 3.0
 		cmdRoot = 'python';
 		exports.legacy.constructLegacyCommand(cli, cli.tiapp, platform, cmd, emulatorCmd);
 	} else {
-		cmdRoot = 'node';
+		cmdRoot = process.execPath || 'node';
 		cmd = [cli.argv.$0.split(' ').slice(1), commandName, '--sdk', sdk];
 		hideBanner = true;
 		
@@ -404,7 +404,7 @@ exports.validateCorrectSDK = function (logger, config, cli, commandName) {
 	
 	if (emulatorCmd.length > 0) {
 		// console.log('Forking correct SDK command: ' + ( cmdRoot + ' ' +  emulatorCmd.join(' ') ).cyan + '\n');
-		spawn(cmdRoot, emulatorCmd,{});
+		spawn(cmdRoot, emulatorCmd, {});
 	}
 	
 	logger.info(__('tiapp.xml <sdk-version> set to %s, but current Titanium SDK set to %s', sdk.cyan, manifest.version.cyan));
@@ -412,6 +412,8 @@ exports.validateCorrectSDK = function (logger, config, cli, commandName) {
 	hideBanner && cmd.push('--no-banner');
 	spawn(cmdRoot, cmd, {
 		stdio: 'inherit'
+	}).on('exit', function (code, signal) {
+		code && process.exit(code);
 	});
 };
 


### PR DESCRIPTION
...eting the device and deploy type. Added the --legacy flag to invoke the old builder.py. Fixed bug when building from Xcode where the PATH might not contain the path where node is installed. Correctly return the legacy build command's exit code in the event of an error. Force the removal of colors when building directly from Xcode to clean up the log output.
