### PR TITLE
added defaultImage into mobileweb ImageView

### DIFF
--- a/mobileweb/titanium/Ti/UI/ImageView.js
+++ b/mobileweb/titanium/Ti/UI/ImageView.js
@@ -224,6 +224,27 @@ define(["Ti/_/declare", "Ti/_/event", "Ti/_/lang", "Ti/_/style", "Ti/_/UI/Widget
 				}
 			},
 
+			defaultImage: {
+				set: function(value) {
+					if (this._children.length == 0) {
+						this._images = void 0;						
+						this._add(this._createImage(
+							value, 
+							function() {
+								this.fireEvent("load", {
+									state: "image"
+								});
+							}, 
+							function(e) {
+								this.fireEvent("error", e);
+							}
+						));
+						
+						return value;
+					}
+				}
+			},
+
 			images: {
 				set: function(value) {
 					var imgs = void 0,


### PR DESCRIPTION
really it is feature request: on mobile and mobileweb ImageView behave in different way: iPod/Android allow specify default image. On handsets it make sence because default image may be local and loads quickly. But for mobileWeb the feature is very usefull too. Because images may be on different domains and default may be on same domain with the application. But remote image is loaded from other domain and it may take much more time.
[TC-1749] Add defaultImage property to ImageView on MobileWeb
