### PR TITLE
Allow to compile modules using ARC.

### DIFF
--- a/iphone/Classes/KrollContext.h
+++ b/iphone/Classes/KrollContext.h
@@ -153,7 +153,7 @@ TI_INLINE KrollContext* GetKrollContext(TiContextRef context)
 	TiObjectRef global = TiContextGetGlobalObject(globalContext); 
 	TiStringRef string = TiStringCreateWithUTF8CString(krollNS);
 	TiValueRef value = TiObjectGetProperty(globalContext, global, string, NULL);
-	KrollContext *ctx = (KrollContext*)TiObjectGetPrivate(TiValueToObject(globalContext, value, NULL));
+	KrollContext *ctx = (__bridge KrollContext*)TiObjectGetPrivate(TiValueToObject(globalContext, value, NULL));
 	TiStringRelease(string);
 	return ctx;
 }


### PR DESCRIPTION
This fixes the "Cast to C pointer type 'void *' to Objective-C pointer requires a bridged cast error that current customers of PSPDFKit (https://marketplace.appcelerator.com/apps/1072) are getting unless they manually edit this source file. The even better way to fix this would be to not add method bodies in a header.

Please merge this for 3.0.1, this is a major show-stopper for me and my customers
