### PR TITLE
iOS: optimize relayout queue

### DIFF
--- a/iphone/Classes/TiLayoutQueue.m
+++ b/iphone/Classes/TiLayoutQueue.m
@@ -17,6 +17,73 @@ NSMutableArray * layoutArray = nil;
 CFRunLoopTimerRef layoutTimer = NULL;
 pthread_mutex_t layoutMutex;
 
+void allNodes(NSMutableArray** array, TiViewProxy* tivp) {
+    if([tivp.children count] > 0) {
+        for (TiViewProxy* p in tivp.children) {
+            allNodes(array, p);
+        }
+    }
+    return [(NSMutableArray*)(*array) addObject:tivp];
+}
+
+
+NSMutableArray* getAllNodesOfProxy(NSArray* array) {
+    NSMutableArray* all = [[NSMutableArray alloc] init];
+    for (TiViewProxy* proxy in array) {
+        NSMutableArray* allChildrenOfProxy = [[NSMutableArray alloc] init];
+        [allChildrenOfProxy addObject:proxy];
+        allNodes(&allChildrenOfProxy, proxy);
+        [all addObject:allChildrenOfProxy];
+    }
+    
+    return all;
+}
+
+
+NSArray* isInSameTree(NSArray* needs) {
+    NSMutableArray* alltrees = getAllNodesOfProxy(needs);
+    int count = [alltrees count];
+    NSMutableArray* indexes = [[NSMutableArray alloc] initWithCapacity:count];
+    
+    for (int i = 0; i < count; i++) {
+        for (int j = 0; j < count; j++) {
+            if (i != j) {
+                if([[alltrees objectAtIndex:j] containsObject:[[alltrees objectAtIndex:i] objectAtIndex:0]] ) {
+                    [indexes addObject:[NSNumber numberWithInt:i]];
+                    continue;
+                }
+            }
+        }
+    }
+    
+    for(int i = 0; i < [indexes count]; i++) {
+        int tmp = [[indexes objectAtIndex:i] integerValue];
+        for (int j = 0; j < [indexes count]; j++) {
+            if (i != j) {
+                if([[indexes objectAtIndex:j] integerValue] == tmp) {
+                    [indexes removeObjectAtIndex:j];
+                }
+            }
+        }
+    }
+    
+    NSMutableIndexSet* indexSet = [[NSMutableIndexSet alloc] init];
+    for (NSNumber* num in indexes) {
+        [indexSet addIndex:[num integerValue]];
+    }
+    [alltrees removeObjectsAtIndexes:indexSet];
+    [indexes removeAllObjects];
+    
+    for(NSMutableArray* a in alltrees) {
+        //tmp use indexes，avoid alloc new array.
+        [indexes addObject:[a objectAtIndex:0]];
+    }
+    
+    [alltrees release];
+    
+    return indexes;
+}
+
 
 void performLayoutRefresh(CFRunLoopTimerRef timer, void *info)
 {
@@ -36,11 +103,14 @@ void performLayoutRefresh(CFRunLoopTimerRef timer, void *info)
 		layoutTimer = NULL;
 	}
 
+	// add push req for this optimization
+	localLayoutArray = isInSameTree(localLayoutArray);
+	
 	pthread_mutex_unlock(&layoutMutex);
 	
 	for (TiViewProxy *thisProxy in localLayoutArray)
 	{
-        [TiLayoutQueue layoutProxy:thisProxy];
+        	[TiLayoutQueue layoutProxy:thisProxy];
 	}
 		
 	RELEASE_TO_NIL(localLayoutArray);


### PR DESCRIPTION
remove useless relayout in queue, 
all subviews are useless when performing performLayoutRefresh, 
only root views will be relayout.
