### PR TITLE
TIMOB-12286: Android: Memory leak when backing out and coming back to an app

### DIFF
--- a/android/runtime/common/src/js/titanium.js
+++ b/android/runtime/common/src/js/titanium.js
@@ -207,22 +207,16 @@ function TiInclude(filename, baseUrl, scopeVars) {
 		return require("rhino").include(filename, baseUrl, localSandbox);
 
 	} else {
-		var source = getUrlSource(filename, sourceUrl);
-		var wrappedSource = "with(sandbox) { " + source + "\n }";
-		var contextGlobal = ti.global;
-		var filePath = sourceUrl.href.replace("app://", "");
+		var source = getUrlSource(filename, sourceUrl),
+			wrappedSource = "with(sandbox) { " + source + "\n }",
+			filePath = sourceUrl.href.replace("app://", "");
 
-		if (contextGlobal) {
-			// We're running inside another window or module, so we run against it's context
-			contextGlobal.sandbox = localSandbox;
-			return Script.runInContext(wrappedSource, contextGlobal, filePath, true);
+		// Use the global V8 Context directly, since we don't create a
+		// new context for modules due to TIMOB-11752.
+		// Put sandbox on the global scope
+		sandbox = localSandbox;
+		return Script.runInThisContext(wrappedSource, filePath, true);
 
-		} else {
-			// We're running in the main module (app.js), so we use the global V8 Context directly.
-			// Put sandbox on the global scope
-			sandbox = localSandbox;
-			return Script.runInThisContext(wrappedSource, filePath, true);
-		}
 	}
 }
 TiInclude.prototype = global;

--- a/android/runtime/v8/src/native/NativeObject.h
+++ b/android/runtime/v8/src/native/NativeObject.h
@@ -107,7 +107,7 @@ private:
 		assert(value == obj->handle_);
 		assert(!obj->refs_);
 		assert(value.IsNearDeath());
-		delete obj;
+//		delete obj;
 	}
 
 	friend class ProxyFactory;

--- a/android/runtime/v8/src/native/NativeObject.h
+++ b/android/runtime/v8/src/native/NativeObject.h
@@ -107,7 +107,7 @@ private:
 		assert(value == obj->handle_);
 		assert(!obj->refs_);
 		assert(value.IsNearDeath());
-//		delete obj;
+		delete obj;
 	}
 
 	friend class ProxyFactory;

--- a/android/runtime/v8/src/native/V8Runtime.cpp
+++ b/android/runtime/v8/src/native/V8Runtime.cpp
@@ -164,7 +164,7 @@ JNIEXPORT void JNICALL Java_org_appcelerator_kroll_runtime_v8_V8Runtime_nativeIn
 	V8Runtime::javaInstance = env->NewGlobalRef(self);
 	JNIUtil::initCache();
 
-	Persistent<Context> context = Persistent<Context>::New(Context::New());
+	Persistent<Context> context = Context::New();
 	context->Enter();
 
 	V8Runtime::globalContext = context;


### PR DESCRIPTION
https://jira.appcelerator.org/browse/TIMOB-12286

This pull request makes it so we no longer wrap our global context inside a persistent handle.  This would cause a memory leak since it would never get cleaned up.  Modules also no longer create a new context when they are created.  Instead, they use the existing context and TiInclude was also changed to do the same.

Please run test case in [TIMOB-12286](https://jira.appcelerator.org/browse/TIMOB-12286), [TIMOB-11752](https://jira.appcelerator.org/browse/TIMOB-11752), and also do a pass of KS.
