### PR TITLE
[TIMOB-8358] Splash Screen Localization Fix.

### DIFF
--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -1813,7 +1813,8 @@ build.prototype = {
 				file = token.pop(),
 				lang = token.pop(),
 				lprojDir = path.join(this.xcodeAppDir, lang + '.lproj'),
-				globalFile = path.join(this.xcodeAppDir, file);
+				globalFile = path.join(this.xcodeAppDir, file),
+				resourcesFile = path.join(this.projectDir, 'Resources', 'iphone', file);
 			
 			// this would never need to run. But just to be safe
 			if (!afs.exists(lprojDir)) {
@@ -1825,6 +1826,12 @@ build.prototype = {
 			if (afs.exists(globalFile)) {
 				this.logger.debug(__('Removing File %s, as it is being localized', globalFile.cyan));
 				fs.unlinkSync(globalFile);
+			}
+			
+			// Remove the same file from resources/iphone folder, if their exists one.
+			if (afs.exists(resourcesFile)) {
+				this.logger.debug(__('Removing File %s from project folder as it is being localized', resourcesFile.cyan));
+				fs.unlinkSync(resourcesFile);
 			}
 			
 			afs.copyFileSync(splashImage, lprojDir, {


### PR DESCRIPTION
I forgot the fact that if we have a Default.png in the Resources/iphone folder it should also be removed otherwise, the app will always default to that splash screen.

**TESTING INSTRUCTION**
- Import the following [app](https://www.dropbox.com/s/93ry07ymymgvhru/splashtest.zip) into Studio.
- build for device. 
- Assuming your default language on your phone is english , your app should start with the following splash screen. 
  ![Default](https://f.cloud.github.com/assets/847863/91658/b03e1a5a-65a8-11e2-8824-99a81f9b53bc.png)
- If you check your project after the build, you can also confirm that Default.png will also be removed from Resources/iphone folder. 
