### PR TITLE
(3_0_X)[TIMOB-12189] iOS: imageWithRoundedCorner() makes opaque corners instead of transparent corners

### DIFF
--- a/iphone/Classes/TiBlob.m
+++ b/iphone/Classes/TiBlob.m
@@ -382,7 +382,6 @@ static NSString *const MIMETYPE_JPEG = @"image/jpeg";
 		bounds.origin.x = [TiUtils floatValue:@"x" properties:args def:(imageSize.width - bounds.size.width) / 2.0];
 		bounds.origin.y = [TiUtils floatValue:@"y" properties:args def:(imageSize.height - bounds.size.height) / 2.0];
 		TiBlob *blob = [[TiBlob alloc] initWithImage:[UIImageResize croppedImage:bounds image:image]];
-		[blob setMimeType:self.mimeType type:self.type];
 		return [blob autorelease];
 	}
 	return nil;

--- a/iphone/Classes/TiBlob.m
+++ b/iphone/Classes/TiBlob.m
@@ -15,6 +15,9 @@
 //NOTE:FilesystemFile is conditionally compiled based on the filesystem module.
 #import "TiFilesystemFileProxy.h"
 
+static NSString *const MIMETYPE_PNG = @"image/png";
+static NSString *const MIMETYPE_JPEG = @"image/jpeg";
+
 @implementation TiBlob
 
 -(void)dealloc
@@ -106,7 +109,7 @@
 	{
 		image = [image_ retain];
 		type = TiBlobTypeImage;
-		mimetype = [@"image/jpeg" retain];
+		mimetype = [MIMETYPE_JPEG copy];
 	}
 	return self;
 }
@@ -117,7 +120,7 @@
 	{
 		data = [data_ retain];
 		type = TiBlobTypeData;
-		mimetype = [mimetype_ retain];
+		mimetype = [mimetype_ copy];
 	}
 	return self;
 }
@@ -128,7 +131,7 @@
 	{
 		type = TiBlobTypeFile;
 		path = [path_ retain];
-		mimetype = [[Mimetypes mimeTypeForExtension:path] retain];
+		mimetype = [[Mimetypes mimeTypeForExtension:path] copy];
 	}
 	return self;
 }
@@ -175,7 +178,7 @@
 		}
 		case TiBlobTypeImage:
 		{
-            if ([@"image/png" isEqualToString:mimetype]) {
+            if ([mimetype isEqualToString:MIMETYPE_PNG]) {
                 return UIImagePNGRepresentation(image);
             }
             return UIImageJPEGRepresentation(image,1.0);
@@ -217,7 +220,7 @@
 {
 	RELEASE_TO_NIL(image);
 	image = [image_ retain];
-    [self setMimeType:@"image/jpeg" type:TiBlobTypeImage];
+    [self setMimeType:MIMETYPE_JPEG type:TiBlobTypeImage];
 }
 
 -(NSString*)path
@@ -263,7 +266,7 @@
 -(void)setMimeType:(NSString*)mime type:(TiBlobType)type_
 {
 	RELEASE_TO_NIL(mimetype);
-	mimetype = [mime retain];
+	mimetype = [mime copy];
 	type = type_;
 }
 
@@ -302,7 +305,9 @@
 	[self ensureImageLoaded];
 	if (image!=nil)
 	{
-		return [[[TiBlob alloc] initWithImage:[UIImageAlpha imageWithAlpha:image]] autorelease];
+		TiBlob *blob = [[TiBlob alloc] initWithImage:[UIImageAlpha imageWithAlpha:image]];
+		[blob setMimeType:MIMETYPE_PNG type:TiBlobTypeImage];
+		return [blob autorelease];
 	}
 	return nil;
 }
@@ -314,7 +319,9 @@
 	{
 		ENSURE_SINGLE_ARG(args,NSObject);
 		NSUInteger size = [TiUtils intValue:args];
-		return [[[TiBlob alloc] initWithImage:[UIImageAlpha transparentBorderImage:size image:image]] autorelease];
+		TiBlob *blob = [[TiBlob alloc] initWithImage:[UIImageAlpha transparentBorderImage:size image:image]];
+		[blob setMimeType:MIMETYPE_PNG type:TiBlobTypeImage];
+		return [blob autorelease];
 	}
 	return nil;
 }
@@ -326,7 +333,9 @@
 	{
 		NSUInteger cornerSize = [TiUtils intValue:[args objectAtIndex:0]];
 		NSUInteger borderSize = [args count] > 1 ? [TiUtils intValue:[args objectAtIndex:1]] : 1;
-		return [[[TiBlob alloc] initWithImage:[UIImageRoundedCorner roundedCornerImage:cornerSize borderSize:borderSize image:image]] autorelease];
+		TiBlob *blob =  [[TiBlob alloc] initWithImage:[UIImageRoundedCorner roundedCornerImage:cornerSize borderSize:borderSize image:image]];
+		[blob setMimeType:MIMETYPE_PNG type:TiBlobTypeImage];
+		return [blob autorelease];
 	}
 	return nil;
 }
@@ -339,12 +348,13 @@
 		NSUInteger size = [TiUtils intValue:[args objectAtIndex:0]];
 		NSUInteger borderSize = [args count] > 1 ? [TiUtils intValue:[args objectAtIndex:1]] : 1;
 		NSUInteger cornerRadius = [args count] > 2 ? [TiUtils intValue:[args objectAtIndex:2]] : 0;
-		return [[[TiBlob alloc] initWithImage:[UIImageResize thumbnailImage:size 
+		TiBlob *blob = [[TiBlob alloc] initWithImage:[UIImageResize thumbnailImage:size
 												  transparentBorder:borderSize
 													   cornerRadius:cornerRadius
 											   interpolationQuality:kCGInterpolationHigh
-															  image:image]] 
-				autorelease];
+															  image:image]];
+		[blob setMimeType:MIMETYPE_PNG type:TiBlobTypeImage];
+		return [blob autorelease];		
 	}
 	return nil;
 }
@@ -357,7 +367,9 @@
 		ENSURE_ARG_COUNT(args,2);
 		NSUInteger width = [TiUtils intValue:[args objectAtIndex:0]];
 		NSUInteger height = [TiUtils intValue:[args objectAtIndex:1]];
-		return [[[TiBlob alloc] initWithImage:[UIImageResize resizedImage:CGSizeMake(width, height) interpolationQuality:kCGInterpolationHigh image:image hires:NO]] autorelease];
+		TiBlob *blob =  [[TiBlob alloc] initWithImage:[UIImageResize resizedImage:CGSizeMake(width, height) interpolationQuality:kCGInterpolationHigh image:image hires:NO]];
+		[blob setMimeType:self.mimeType type:self.type];
+		return [blob autorelease];
 	}
 	return nil;
 }
@@ -374,7 +386,9 @@
 		bounds.size.height = [TiUtils floatValue:@"height" properties:args def:imageSize.height];
 		bounds.origin.x = [TiUtils floatValue:@"x" properties:args def:(imageSize.width - bounds.size.width) / 2.0];
 		bounds.origin.y = [TiUtils floatValue:@"y" properties:args def:(imageSize.height - bounds.size.height) / 2.0];
-		return [[[TiBlob alloc] initWithImage:[UIImageResize croppedImage:bounds image:image]] autorelease];
+		TiBlob *blob = [[TiBlob alloc] initWithImage:[UIImageResize croppedImage:bounds image:image]];
+		[blob setMimeType:self.mimeType type:self.type];
+		return [blob autorelease];
 	}
 	return nil;
 }

--- a/iphone/Classes/TiBlob.m
+++ b/iphone/Classes/TiBlob.m
@@ -109,7 +109,7 @@ static NSString *const MIMETYPE_JPEG = @"image/jpeg";
 	{
 		image = [image_ retain];
 		type = TiBlobTypeImage;
-		mimetype = [MIMETYPE_JPEG copy];
+		mimetype = [([UIImageAlpha hasAlpha:image_] ? MIMETYPE_PNG : MIMETYPE_JPEG) copy];
 	}
 	return self;
 }
@@ -220,7 +220,7 @@ static NSString *const MIMETYPE_JPEG = @"image/jpeg";
 {
 	RELEASE_TO_NIL(image);
 	image = [image_ retain];
-    [self setMimeType:MIMETYPE_JPEG type:TiBlobTypeImage];
+    [self setMimeType:([UIImageAlpha hasAlpha:image_] ? MIMETYPE_PNG : MIMETYPE_JPEG) type:TiBlobTypeImage];
 }
 
 -(NSString*)path
@@ -306,7 +306,6 @@ static NSString *const MIMETYPE_JPEG = @"image/jpeg";
 	if (image!=nil)
 	{
 		TiBlob *blob = [[TiBlob alloc] initWithImage:[UIImageAlpha imageWithAlpha:image]];
-		[blob setMimeType:MIMETYPE_PNG type:TiBlobTypeImage];
 		return [blob autorelease];
 	}
 	return nil;
@@ -320,7 +319,6 @@ static NSString *const MIMETYPE_JPEG = @"image/jpeg";
 		ENSURE_SINGLE_ARG(args,NSObject);
 		NSUInteger size = [TiUtils intValue:args];
 		TiBlob *blob = [[TiBlob alloc] initWithImage:[UIImageAlpha transparentBorderImage:size image:image]];
-		[blob setMimeType:MIMETYPE_PNG type:TiBlobTypeImage];
 		return [blob autorelease];
 	}
 	return nil;
@@ -334,7 +332,6 @@ static NSString *const MIMETYPE_JPEG = @"image/jpeg";
 		NSUInteger cornerSize = [TiUtils intValue:[args objectAtIndex:0]];
 		NSUInteger borderSize = [args count] > 1 ? [TiUtils intValue:[args objectAtIndex:1]] : 1;
 		TiBlob *blob =  [[TiBlob alloc] initWithImage:[UIImageRoundedCorner roundedCornerImage:cornerSize borderSize:borderSize image:image]];
-		[blob setMimeType:MIMETYPE_PNG type:TiBlobTypeImage];
 		return [blob autorelease];
 	}
 	return nil;
@@ -353,7 +350,6 @@ static NSString *const MIMETYPE_JPEG = @"image/jpeg";
 													   cornerRadius:cornerRadius
 											   interpolationQuality:kCGInterpolationHigh
 															  image:image]];
-		[blob setMimeType:MIMETYPE_PNG type:TiBlobTypeImage];
 		return [blob autorelease];		
 	}
 	return nil;
@@ -368,7 +364,6 @@ static NSString *const MIMETYPE_JPEG = @"image/jpeg";
 		NSUInteger width = [TiUtils intValue:[args objectAtIndex:0]];
 		NSUInteger height = [TiUtils intValue:[args objectAtIndex:1]];
 		TiBlob *blob =  [[TiBlob alloc] initWithImage:[UIImageResize resizedImage:CGSizeMake(width, height) interpolationQuality:kCGInterpolationHigh image:image hires:NO]];
-		[blob setMimeType:self.mimeType type:self.type];
 		return [blob autorelease];
 	}
 	return nil;


### PR DESCRIPTION
Backport of #3678
[TIMOB-12402](https://jira.appcelerator.org/browse/TIMOB-12402)
