### PR TITLE
Fix appid validation regression.

### DIFF
--- a/support/node_modules/titanium-sdk/lib/titanium.js
+++ b/support/node_modules/titanium-sdk/lib/titanium.js
@@ -153,7 +153,7 @@ exports.validateTiappXml = function (logger, tiapp) {
 		process.exit(1);
 	}
 	
-	if (!/^([a-zA-Z_]{1}[a-zA-Z0-9_]*(\.[a-zA-Z0-9_]*)*)$/.test(tiapp.id)) {
+	if (!/^([a-zA-Z_]{1}[a-zA-Z0-9_\-]*(\.[a-zA-Z0-9_\-]*)*)$/.test(tiapp.id)) {
 		logger.error(__('tiapp.xml contains an invalid app id "%s"', tiapp.id) + '\n');
 		logger.log(__('The app id must consist of letters, numbers, and underscores.'));
 		logger.log(__('The first character must be a letter or underscore.'));


### PR DESCRIPTION
When building, the app id is validated, and, according to the rules
previously in place, may not contain hyphens.

However, this was allowed in the 2.\* SDK and there are now existing
apps using hyphens for their IDs which cannot be changed due to
Apple AppStore restrictions.

This is a regression!
Please pull this in asap, as it is mandatory for upgrading existing apps to use the 3.\* SDKs.
