### PR TITLE
TIMOB-11628: Correct spacing and grammar in Android NDK console warning.

### DIFF
--- a/support/module/android/build.xml
+++ b/support/module/android/build.xml
@@ -289,7 +289,7 @@ timodule.xml.
 	<macrodef name="check.ndk">
 		<sequential>
 			<property environment="env"/>
-			<fail message="Neither the ANDROID_NDK environment variable, or the android.ndk property is not set to an existing Android NDK installation (check your module's build.properties)">
+			<fail message="Neither the ANDROID_NDK environment variable, or the android.ndk property is not set to an existing Android NDK installation (check your module's build.properties). ">
 				<condition>
 					<not>
 						<or>


### PR DESCRIPTION
https://jira.appcelerator.org/browse/TIMOB-11628

Test case in Jira.
