### PR TITLE
[TIMOB-12218]iOS: Implementing `significanttimechange` event.

### DIFF
--- a/apidoc/Titanium/App/App.yml
+++ b/apidoc/Titanium/App/App.yml
@@ -270,7 +270,17 @@ events:
         is being dissmissed.
     platforms: [iphone, ipad]
     since: '3.0.0'
-    
+
+  - name: significanttimechange
+    summary: Fired when there is a significant change in the time.
+    description: |
+        Examples of significant time changes include the arrival of midnight, an update to the time by a carrier, 
+        and the change to daylight savings time. If your application is currently in `paused` state, this message 
+        will be is queued until your application returns to the foreground, at which point it is delievered. If multiple 
+        changes occur, only the most recent one is delievered.
+    platforms: [iphone, ipad]
+    since: '3.1.0'
+
 methods:
   - name: fireSystemEvent
     summary: Fire a system-level event such as <Titanium.App.EVENT_ACCESSIBILITY_ANNOUNCEMENT>.

--- a/iphone/Classes/AppModule.m
+++ b/iphone/Classes/AppModule.m
@@ -260,6 +260,12 @@ extern BOOL const TI_APPLICATION_ANALYTICS;
     [self fireEvent:@"keyboardframechanged" withObject:event];     
 }
 
+- (void)timeChanged:(NSNotification*)notiication
+{
+    if ([self _hasListeners:@"significanttimechange"]) {
+        [self fireEvent:@"significanttimechange" withObject:nil];
+    }
+}
 
 #pragma mark Internal Memory Management
 
@@ -339,7 +345,7 @@ extern BOOL const TI_APPLICATION_ANALYTICS;
     
     [nc addObserver:self selector:@selector(keyboardFrameChanged:) name:UIKeyboardDidShowNotification object:nil];
     [nc addObserver:self selector:@selector(keyboardFrameChanged:) name:UIKeyboardDidHideNotification object:nil];
-
+    [nc addObserver:self selector:@selector(timeChanged:) name:UIApplicationSignificantTimeChangeNotification object:nil];
 #endif	
     
     [super startup];


### PR DESCRIPTION
Testing instruction in [KITCHENSINK PR](https://github.com/appcelerator-developer-relations/KitchenSink/pull/88)
