### PR TITLE
[TIMOB-3528] Including extra argument in remote event for Push Notification

### DIFF
--- a/apidoc/Titanium/Network/Network.yml
+++ b/apidoc/Titanium/Network/Network.yml
@@ -468,6 +468,6 @@ properties:
         [application:didReceiveRemoteNotification in the UIApplicationDelegate Protocol
         Reference](http://developer.apple.com/library/ios/#DOCUMENTATION/UIKit/Reference/UIApplicationDelegate_Protocol/Reference/Reference.html#//apple_ref/occ/intfm/UIApplicationDelegate/application:didReceiveRemoteNotification:)
     type: Dictionary
-  - name: firedFromRegister
+  - name: inBackground
     summary: Boolean indicating if notification was received while app was in background.
     type: Boolean

--- a/apidoc/Titanium/Network/Network.yml
+++ b/apidoc/Titanium/Network/Network.yml
@@ -468,3 +468,6 @@ properties:
         [application:didReceiveRemoteNotification in the UIApplicationDelegate Protocol
         Reference](http://developer.apple.com/library/ios/#DOCUMENTATION/UIKit/Reference/UIApplicationDelegate_Protocol/Reference/Reference.html#//apple_ref/occ/intfm/UIApplicationDelegate/application:didReceiveRemoteNotification:)
     type: Dictionary
+  - name: firedFromRegister
+    summary: Boolean indicating if notification was received while app was in background.
+    type: Boolean

--- a/apidoc/Titanium/Network/Network.yml
+++ b/apidoc/Titanium/Network/Network.yml
@@ -469,5 +469,7 @@ properties:
         Reference](http://developer.apple.com/library/ios/#DOCUMENTATION/UIKit/Reference/UIApplicationDelegate_Protocol/Reference/Reference.html#//apple_ref/occ/intfm/UIApplicationDelegate/application:didReceiveRemoteNotification:)
     type: Dictionary
   - name: inBackground
-    summary: Boolean indicating if notification was received while app was in background.
+    summary: |
+        Boolean indicating if notification was received while app was in background. 
+        This property became available in Titanium Mobile 3.1.0 for iOS.
     type: Boolean

--- a/iphone/Classes/NetworkModule.m
+++ b/iphone/Classes/NetworkModule.m
@@ -331,7 +331,7 @@ MAKE_SYSTEM_PROP(TLS_VERSION_1_2, TLS_VERSION_1_2);
 	// called by TiApp
 	if (pushNotificationCallback!=nil)
 	{
-		BOOL inBackground = (application.applicationState == UIApplicationStateBackground);
+		BOOL inBackground = (application.applicationState != UIApplicationStateActive);
 		id event = [NSDictionary dictionaryWithObjectsAndKeys:userInfo, @"data", NUMBOOL(inBackground), @"inBackground", nil];
 		[self _fireEventToListener:@"remote" withObject:event listener:pushNotificationCallback thisObject:nil];
 	}

--- a/iphone/Classes/NetworkModule.m
+++ b/iphone/Classes/NetworkModule.m
@@ -295,12 +295,12 @@ MAKE_SYSTEM_PROP(TLS_VERSION_1_2, TLS_VERSION_1_2);
 	
 	// check to see upon registration if we were started with a push 
 	// notification and if so, go ahead and trigger our callback
-	id currentNotification = [[TiApp app] remoteNotification];
-	if (currentNotification!=nil && pushNotificationCallback!=nil)
-	{
-		id event = [NSDictionary dictionaryWithObject:currentNotification forKey:@"data"];
-		[self _fireEventToListener:@"remote" withObject:event listener:pushNotificationCallback thisObject:nil];
-	}
+    id currentNotification = [[TiApp app] remoteNotification];
+    if (currentNotification!=nil && pushNotificationCallback!=nil)
+    {
+        id event = [NSDictionary dictionaryWithObjectsAndKeys:currentNotification, @"data", NUMBOOL(YES), @"firedFromRegister", nil];
+        [self _fireEventToListener:@"remote" withObject:event listener:pushNotificationCallback thisObject:nil];
+    }
 }
 
 -(void)unregisterForPushNotifications:(id)args
@@ -331,8 +331,15 @@ MAKE_SYSTEM_PROP(TLS_VERSION_1_2, TLS_VERSION_1_2);
 	// called by TiApp
 	if (pushNotificationCallback!=nil)
 	{
-		id event = [NSDictionary dictionaryWithObject:userInfo forKey:@"data"];
-		[self _fireEventToListener:@"remote" withObject:event listener:pushNotificationCallback thisObject:nil];
+		id event = nil;
+		if ( application.applicationState == UIApplicationStateActive )
+		{
+			event = [NSDictionary dictionaryWithObject:userInfo forKey:@"data"];
+		}
+		else
+		{
+        	event = [NSDictionary dictionaryWithObjectsAndKeys:userInfo, @"data", NUMBOOL(YES), @"firedFromRegister", nil];
+    	}
 	}
 }
 

--- a/iphone/Classes/NetworkModule.m
+++ b/iphone/Classes/NetworkModule.m
@@ -331,15 +331,9 @@ MAKE_SYSTEM_PROP(TLS_VERSION_1_2, TLS_VERSION_1_2);
 	// called by TiApp
 	if (pushNotificationCallback!=nil)
 	{
-		id event = nil;
-		if ( application.applicationState == UIApplicationStateActive )
-		{
-			event = [NSDictionary dictionaryWithObject:userInfo forKey:@"data"];
-		}
-		else
-		{
-        	event = [NSDictionary dictionaryWithObjectsAndKeys:userInfo, @"data", NUMBOOL(YES), @"firedFromRegister", nil];
-    	}
+		BOOL firedFromRegister = (application.applicationState != UIApplicationStateActive);
+		id event = [NSDictionary dictionaryWithObjectsAndKeys:userInfo, @"data", NUMBOOL(firedFromRegister), @"firedFromRegister", nil];
+		[self _fireEventToListener:@"remote" withObject:event listener:pushNotificationCallback thisObject:nil];
 	}
 }
 

--- a/iphone/Classes/NetworkModule.m
+++ b/iphone/Classes/NetworkModule.m
@@ -298,7 +298,7 @@ MAKE_SYSTEM_PROP(TLS_VERSION_1_2, TLS_VERSION_1_2);
     id currentNotification = [[TiApp app] remoteNotification];
     if (currentNotification!=nil && pushNotificationCallback!=nil)
     {
-        id event = [NSDictionary dictionaryWithObjectsAndKeys:currentNotification, @"data", NUMBOOL(YES), @"firedFromRegister", nil];
+        id event = [NSDictionary dictionaryWithObjectsAndKeys:currentNotification, @"data", NUMBOOL(YES), @"inBackground", nil];
         [self _fireEventToListener:@"remote" withObject:event listener:pushNotificationCallback thisObject:nil];
     }
 }
@@ -331,8 +331,8 @@ MAKE_SYSTEM_PROP(TLS_VERSION_1_2, TLS_VERSION_1_2);
 	// called by TiApp
 	if (pushNotificationCallback!=nil)
 	{
-		BOOL firedFromRegister = (application.applicationState != UIApplicationStateActive);
-		id event = [NSDictionary dictionaryWithObjectsAndKeys:userInfo, @"data", NUMBOOL(firedFromRegister), @"firedFromRegister", nil];
+		BOOL inBackground = (application.applicationState == UIApplicationStateBackground);
+		id event = [NSDictionary dictionaryWithObjectsAndKeys:userInfo, @"data", NUMBOOL(inBackground), @"inBackground", nil];
 		[self _fireEventToListener:@"remote" withObject:event listener:pushNotificationCallback thisObject:nil];
 	}
 }


### PR DESCRIPTION
**TESTING INSTRUCTION** 
- Use the same code in ti.cloud 
- Receive notification and launch app. In the alert message verify there is an extra argument `inbackground`. - if launched while app was backgrounded / inactive it will return true.and return false when running in foreground. 

Includes commits from @sreuter @srijs PR #3666
