### PR TITLE
Fix issue described in TIMOB-12736

### DIFF
--- a/support/iphone/transport.py
+++ b/support/iphone/transport.py
@@ -63,7 +63,7 @@ def main(args):
 			sdk_dir = os.path.abspath(os.path.dirname(template_dir))
 			version = os.path.basename(sdk_dir)			
 		
-		if len(args) == 4:
+		if len(args) > 3:
 			buildMode = args[3]
 
 		tiappxml = os.path.join(project_dir, 'tiapp.xml')

--- a/support/iphone/transport.py
+++ b/support/iphone/transport.py
@@ -54,13 +54,17 @@ def main(args):
 		project_dir = os.path.abspath(args[1])
 		build_dir = os.path.join(project_dir,'build','iphone')
 		titanium_local = os.path.join(build_dir,'titanium')
-		
-		if len(args) == 3:
+		buildMode = 'production'
+
+		if len(args) > 2:
 			version = args[2]
 			sdk_dir = find_sdk(version)
 		else:
 			sdk_dir = os.path.abspath(os.path.dirname(template_dir))
 			version = os.path.basename(sdk_dir)			
+		
+		if len(args) == 4:
+			buildMode = args[3]
 
 		tiappxml = os.path.join(project_dir, 'tiapp.xml')
 		tiapp = TiAppXML(tiappxml)
@@ -68,6 +72,8 @@ def main(args):
 		app_id = tiapp.properties['id']
 		app_name = tiapp.properties['name']
 		
+		info("Creating project in %s mode" % buildMode)
+
 		if app_id is None or app_name is None:
 			info("Your tiapp.xml is malformed - please specify an app name and id")
 			sys.exit(1)
@@ -137,7 +143,7 @@ def main(args):
 		
 		# Run the compiler to autogenerate .m files
 		info("Copying classes, creating generated .m files...")
-		compiler = Compiler(project_dir,app_id,app_name,'export')
+		compiler = Compiler(project_dir,app_id,app_name,buildMode)
 		compiler.compileProject(silent=True)
 		
 		#... But we still have to nuke the stuff that gets built that we don't want
@@ -153,7 +159,7 @@ def main(args):
 		
 		# Get Modules
 		detector = ModuleDetector(project_dir)
-		missing_modules, modules = detector.find_app_modules(tiapp, 'iphone', 'development')
+		missing_modules, modules = detector.find_app_modules(tiapp, 'iphone', buildMode)
 		
 		if len(missing_modules) != 0:
 			for module in missing_modules:
@@ -207,7 +213,7 @@ def main(args):
 		
 		# Process i18n files
 		info("Processing i18n...")
-		locale_compiler = LocaleCompiler(app_name, project_dir, 'ios', 'development', resources_dir)
+		locale_compiler = LocaleCompiler(app_name, project_dir, 'ios', buildMode, resources_dir)
 		locale_compiler.compile()
 		
 		# Migrate compile scripts
@@ -246,4 +252,4 @@ def main(args):
 if __name__ == "__main__":
 		main(sys.argv)
 		sys.exit(0)
-
+		


### PR DESCRIPTION
transport.py currently only builds in development mode. This disables analytics and causes error reporting issues.

This PR adds a parameter to the script that allows the user to set the build mode. By default this build mode is set to production. This mimics behavior of transport.py prior to the 3.0.0GA release.
