### PR TITLE
[TIMOB-12401] ImageView not showing remote images that can not be cached

### DIFF
--- a/iphone/Classes/TiUIImageView.m
+++ b/iphone/Classes/TiUIImageView.m
@@ -758,9 +758,7 @@ DEFINE_EXCEPTIONS
 
 -(void)imageLoadSuccess:(ImageLoaderRequest*)request image:(UIImage*)image
 {
-    UIImage* theImage = [[ImageLoader sharedLoader] loadImmediateImage:[request url]];
-    
-    UIImage *imageToUse = [self rotatedImage:theImage];
+    UIImage *imageToUse = [self rotatedImage:image];
 
     autoWidth = imageToUse.size.width;
     autoHeight = imageToUse.size.height;


### PR DESCRIPTION
[JIRA TICKET](https://jira.appcelerator.org/browse/TIMOB-12401)

To test will probably need a server that sets either max-age to 0 or sends a no-cache header

Smoke test against KS.
