### PR TITLE
timob-12825: Anvil: Android: update android_resources since the Facebook module is removed from SDK

### DIFF
--- a/anvil/driver/harnessResourcesTemplate/testUtil.js
+++ b/anvil/driver/harnessResourcesTemplate/testUtil.js
@@ -115,7 +115,7 @@ module.exports = new function() {
 			return;
 		}
 
-		if (this.obj !== expected) {
+		if (!(this.obj === expected)) {
 			self.reportError(this.testRun, "should be exactly: " + expected + ", was: " + this.obj);
 		}
 	};
@@ -205,7 +205,7 @@ module.exports = new function() {
 			return;
 		}
 
-		if (this.obj !== true) {
+		if (!(this.obj === true)) {
 			self.reportError(this.testRun, "should be true, was: " + this.obj);
 		}
 	};
@@ -215,7 +215,7 @@ module.exports = new function() {
 			return;
 		}
 
-		if (this.obj !== false) {
+		if (!(this.obj === false)) {
 			self.reportError(this.testRun, "should be false, was: " + this.obj);
 		}
 	};
@@ -283,7 +283,7 @@ module.exports = new function() {
 			return;
 		}
 
-		if (this.obj <= expected) {
+		if (!(this.obj > expected)) {
 			self.reportError(this.testRun, "should be greater than, was " + this.obj + " <= " + expected);
 		}
 	};
@@ -293,7 +293,7 @@ module.exports = new function() {
 			return;
 		}
 
-		if (this.obj >= expected) {
+		if (!(this.obj < expected)) {
 			self.reportError(this.testRun, "should be less than, was " + this.obj + " >= " + expected);
 		}
 	};
@@ -303,7 +303,7 @@ module.exports = new function() {
 			return;
 		}
 
-		if (this.obj < expected) {
+		if (!(this.obj >= expected)) {
 			self.reportError(this.testRun, "should be greater than equal, was " + this.obj + " < " + expected);
 		}
 	};
@@ -313,7 +313,7 @@ module.exports = new function() {
 			return;
 		}
 
-		if (this.obj > expected) {
+		if (!(this.obj <= expected)) {
 			self.reportError(this.testRun, "should be greater than, was " + this.obj + " > " + expected);
 		}
 	};

--- a/support/anvil/configSet/Resources/suites/android/android_resources/android_resources.js
+++ b/support/anvil/configSet/Resources/suites/android/android_resources/android_resources.js
@@ -21,9 +21,8 @@ module.exports = new function() {
 
 	// https://appcelerator.lighthouseapp.com/projects/32238-titanium-mobile/tickets/3163
 	this.packagedResources = function(testRun) {
-		Ti.Facebook.appid=1;//forces inclusion of facebook module.
 		valueOf(testRun,  function() {
-			var resid=Ti.App.Android.R.drawable.facebook_login;
+			var resid=Ti.App.Android.R.string.app_name;
 			valueOf(testRun, resid).shouldBeGreaterThan(0);
 		}).shouldNotThrowException();
 


### PR DESCRIPTION
https://jira.appcelerator.org/browse/TIMOB-12825
This PR also fixes some comparison methods in testUtil.js. Please run anvil on android and ios to make sure nothing is broken.
