### PR TITLE
[TIMOB-9819] added null check to prevent the crash

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiUIView.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiUIView.java
@@ -734,17 +734,17 @@ public abstract class TiUIView
 
 	private void applyCustomBackground(boolean reuseCurrentDrawable)
 	{
-		if (nativeView != null) {
+		if (getNativeView() != null) {
 			if (background == null) {
 				background = new TiBackgroundDrawable();
 	
-				Drawable currentDrawable = nativeView.getBackground();
+				Drawable currentDrawable = getNativeView().getBackground();
 				if (currentDrawable != null) {
 					if (reuseCurrentDrawable) {
 						background.setBackgroundDrawable(currentDrawable);
 						
 					} else {
-						nativeView.setBackgroundDrawable(null);
+						getNativeView().setBackgroundDrawable(null);
 						currentDrawable.setCallback(null);
 						if (currentDrawable instanceof TiBackgroundDrawable) {
 							((TiBackgroundDrawable) currentDrawable).releaseDelegate();
@@ -752,7 +752,7 @@ public abstract class TiUIView
 					}
 				}
 			}
-			nativeView.setBackgroundDrawable(background);
+			getNativeView().setBackgroundDrawable(background);
 		}
 	}
 
@@ -902,7 +902,7 @@ public abstract class TiUIView
 		KrollDict gradientProperties = d.getKrollDict(TiC.PROPERTY_BACKGROUND_GRADIENT);
 		if (gradientProperties != null) {
 			try {
-				gradientDrawable = new TiGradientDrawable(nativeView, gradientProperties);
+				gradientDrawable = new TiGradientDrawable(getNativeView(), gradientProperties);
 				if (gradientDrawable.getGradientType() == GradientType.RADIAL_GRADIENT) {
 					// TODO: Remove this once we support radial gradients.
 					Log.w(TAG, "Android does not support radial gradients.");

--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiUIView.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiUIView.java
@@ -921,19 +921,22 @@ public abstract class TiUIView
 				applyCustomBackground(false);
 			}
 
-			Drawable bgDrawable = TiUIHelper.buildBackgroundDrawable(
-					bg,
-					d.getBoolean(TiC.PROPERTY_BACKGROUND_REPEAT),
-					bgColor,
-					bgSelected,
-					bgSelectedColor,
-					bgDisabled,
-					bgDisabledColor,
-					bgFocused,
-					bgFocusedColor,
-					gradientDrawable);
-
-			background.setBackgroundDrawable(bgDrawable);
+			if (background != null)
+			{
+				Drawable bgDrawable = TiUIHelper.buildBackgroundDrawable(
+						bg,
+						d.getBoolean(TiC.PROPERTY_BACKGROUND_REPEAT),
+						bgColor,
+						bgSelected,
+						bgSelectedColor,
+						bgDisabled,
+						bgDisabledColor,
+						bgFocused,
+						bgFocusedColor,
+						gradientDrawable);
+	
+				background.setBackgroundDrawable(bgDrawable);
+			}
 		}
 	}
 


### PR DESCRIPTION
This fixes the crash but gradient won't be applied. nativeView is never set in TiUIView in the case of heavyweight window.

https://jira.appcelerator.org/browse/TIMOB-9819
