### PR TITLE
[TIMOB-3370][TIMOB-9593] webview fixes

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
@@ -421,7 +421,7 @@ public class TiUIWebView extends TiUIView
 		
 		reloadMethod = reloadTypes.HTML;
 		reloadData = d;
-		String baseUrl = "TiC.URL_ANDROID_ASSET_RESOURCES";
+		String baseUrl = TiC.URL_ANDROID_ASSET_RESOURCES;
 		String mimeType = "text/html";
 		if (d.containsKey(TiC.PROPERTY_BASE_URL_WEBVIEW)) {
 			baseUrl = TiConvert.toString(d.get(TiC.PROPERTY_BASE_URL_WEBVIEW));
@@ -500,7 +500,7 @@ public class TiUIWebView extends TiUIView
 		if (blob.getType() == TiBlob.TYPE_FILE) {
 			String fullPath = blob.getNativePath();
 			if (fullPath != null) {
-				getWebView().loadUrl(fullPath);
+				setUrl(fullPath);
 				return;
 			}
 		}

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
@@ -489,12 +489,22 @@ public class TiUIWebView extends TiUIView
 		reloadMethod = reloadTypes.DATA;
 		reloadData = blob;
 		String mimeType = "text/html";
+		
 		// iOS parity: for whatever reason, in setData, the iOS implementation
 		// explicitly sets the native webview's setScalesPageToFit to YES if the
 		// Ti scalesPageToFit property has _not_ been set.
 		if (!proxy.hasProperty(TiC.PROPERTY_SCALES_PAGE_TO_FIT)) {
 			getWebView().getSettings().setLoadWithOverviewMode(true);
 		}
+		
+		if (blob.getType() == TiBlob.TYPE_FILE) {
+			String fullPath = blob.getNativePath();
+			if (fullPath != null) {
+				getWebView().loadUrl(fullPath);
+				return;
+			}
+		}
+		
 		if (blob.getMimeType() != null) {
 			mimeType = blob.getMimeType();
 		}

--- a/iphone/Classes/TiUIWebView.h
+++ b/iphone/Classes/TiUIWebView.h
@@ -26,6 +26,8 @@
 	SEL reloadMethod;
     
     BOOL willHandleTouches;
+    
+    NSString* lastValidLoad;
 }
 
 @property(nonatomic,readonly) id url;

--- a/iphone/Classes/TiUIWebView.m
+++ b/iphone/Classes/TiUIWebView.m
@@ -324,6 +324,7 @@ NSString *HTMLTextEncodingNameForStringEncoding(NSStringEncoding encoding)
 
 - (void)reload
 {
+    RELEASE_TO_NIL(lastValidLoad);
 	if (webview == nil)
 	{
 		return;

--- a/iphone/Classes/TiUIWebView.m
+++ b/iphone/Classes/TiUIWebView.m
@@ -393,6 +393,7 @@ NSString *HTMLTextEncodingNameForStringEncoding(NSStringEncoding encoding)
 	[self setReloadData:content];
 	[self setReloadDataProperties:property];
 	reloadMethod = @selector(setHtml_:withObject:);
+	RELEASE_TO_NIL(lastValidLoad);
 	[self loadHTML:content encoding:NSUTF8StringEncoding textEncodingName:@"utf-8" mimeType:mimeType baseURL:baseURL];
 }
 
@@ -403,6 +404,7 @@ NSString *HTMLTextEncodingNameForStringEncoding(NSStringEncoding encoding)
 	[self setReloadDataProperties:nil];
 	reloadMethod = @selector(setData_:);
 	RELEASE_TO_NIL(url);
+	RELEASE_TO_NIL(lastValidLoad);
 	ENSURE_SINGLE_ARG(args,NSObject);
 	
 	[self stopLoading];
@@ -474,6 +476,7 @@ NSString *HTMLTextEncodingNameForStringEncoding(NSStringEncoding encoding)
 	reloadMethod = @selector(setUrl_:);
 
 	RELEASE_TO_NIL(url);
+	RELEASE_TO_NIL(lastValidLoad);
 	ENSURE_SINGLE_ARG(args,NSString);
 	
 	url = [[TiUtils toURL:args proxy:(TiProxy*)self.proxy] retain];

--- a/iphone/Classes/TiUIWebView.m
+++ b/iphone/Classes/TiUIWebView.m
@@ -166,7 +166,6 @@ NSString *HTMLTextEncodingNameForStringEncoding(NSStringEncoding encoding)
 			[spinner sizeToFit];
 			[spinner startAnimating];
 		}
-		lastValidLoad = nil;
 	}
 	return webview;
 }
@@ -706,7 +705,7 @@ NSString *HTMLTextEncodingNameForStringEncoding(NSStringEncoding encoding)
         if (![urlAbs isEqualToString:lastValidLoad]) {
             NSDictionary *event = url == nil ? nil : [NSDictionary dictionaryWithObject:[self url] forKey:@"url"];
             [self.proxy fireEvent:@"load" withObject:event];
-            RELEASE_TO_NIL(lastValidLoad);
+            [lastValidLoad release];
             lastValidLoad = [urlAbs retain];
         }
     }


### PR DESCRIPTION
iOS fixes:
Load will fire only for unique urls
Test case is in [TIMOB-3370](https://jira.appcelerator.org/browse/TIMOB-3370)

Android Fixes:
refactor of reload method to properly fix TIMOB-9593 and do setHtml with baseURL pointing to resources dir.
setData now checks for type file and loads from there to get correct baseUrl for relative paths in files
changeProxyUrl now does not fire property change for url.

Note that setting HTML still sets the wrong URL in history and so goBack() will always fail once you navigate away from page(existing behavior)

Test case attached to [TIMOB-9593](https://jira.appcelerator.org/browse/TIMOB-9593)
Regress against KS Webview
