### PR TITLE
TIMOB-4333-Implemented playing event

### DIFF
--- a/android/modules/media/src/java/android/widget/TiVideoView8.java
+++ b/android/modules/media/src/java/android/widget/TiVideoView8.java
@@ -746,10 +746,15 @@ public class TiVideoView8 extends SurfaceView implements MediaPlayerControl
 	{
 		if (isInPlaybackState()) {
 			mMediaPlayer.start();
+			int oldState = mCurrentState;
 			mCurrentState = STATE_PLAYING;
 			// TITANIUM
 			if (mPlaybackListener != null) {
 				mPlaybackListener.onStartPlayback();
+				// Fired after a stop or play is called after a after url change.
+				if (oldState == STATE_PREPARED || oldState == STATE_PREPARING) {
+					mPlaybackListener.onPlayingPlayback();
+				}
 			}
 		}
 		mTargetState = STATE_PLAYING;

--- a/android/modules/media/src/java/ti/modules/titanium/media/TiPlaybackListener.java
+++ b/android/modules/media/src/java/ti/modules/titanium/media/TiPlaybackListener.java
@@ -10,6 +10,10 @@ package ti.modules.titanium.media;
 public interface TiPlaybackListener
 {
 	public void onStartPlayback();
+
 	public void onPausePlayback();
+
 	public void onStopPlayback();
+
+	public void onPlayingPlayback();
 }

--- a/android/modules/media/src/java/ti/modules/titanium/media/TiUIVideoView.java
+++ b/android/modules/media/src/java/ti/modules/titanium/media/TiUIVideoView.java
@@ -341,6 +341,12 @@ public class TiUIVideoView extends TiUIView
 		getPlayerProxy().onPlaybackStopped();
 	}
 
+	@Override
+	public void onPlayingPlayback()
+	{
+		getPlayerProxy().onPlaying();
+	}
+	
 	private VideoPlayerProxy getPlayerProxy()
 	{
 		return ((VideoPlayerProxy) proxy);

--- a/android/modules/media/src/java/ti/modules/titanium/media/VideoPlayerProxy.java
+++ b/android/modules/media/src/java/ti/modules/titanium/media/VideoPlayerProxy.java
@@ -544,6 +544,13 @@ public class VideoPlayerProxy extends TiViewProxy implements TiLifecycle.OnLifec
 		args.put(TiC.EVENT_PROPERTY_REASON, reason);
 		fireEvent(TiC.EVENT_COMPLETE, args);
 	}
+	
+	public void firePlaying()
+	{
+		KrollDict args = new KrollDict();
+		args.put(TiC.EVENT_PROPERTY_URL, getProperty(TiC.PROPERTY_URL));
+		fireEvent(TiC.EVENT_PLAYING, args);
+	}
 
 	public void onPlaybackReady(int duration)
 	{
@@ -571,6 +578,11 @@ public class VideoPlayerProxy extends TiViewProxy implements TiLifecycle.OnLifec
 	public void onPlaybackStarted()
 	{
 		firePlaybackState(MediaModule.VIDEO_PLAYBACK_STATE_PLAYING);
+	}
+	
+	public void onPlaying()
+	{
+		firePlaying();
 	}
 
 	public void onPlaybackPaused()

--- a/android/titanium/src/java/org/appcelerator/titanium/TiC.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiC.java
@@ -208,6 +208,11 @@ public class TiC
 	 * @module.api
 	 */
 	public static final String EVENT_POST_LAYOUT = "postlayout";
+	
+	/**
+	 * @module.api
+	 */
+	public static final String EVENT_PLAYING = "playing";
 
 	/**
 	 * @module.api
@@ -448,6 +453,12 @@ public class TiC
 	 * @module.api
 	 */
 	public static final String EVENT_TWOFINGERTAP = "twofingertap";
+	
+	/**
+	 * @module.api
+	 */
+	public static final String EVENT_PROPERTY_URL = "url";
+	
 
 	/**
 	 * @module.api

--- a/apidoc/Titanium/Media/VideoPlayer.yml
+++ b/apidoc/Titanium/Media/VideoPlayer.yml
@@ -409,7 +409,7 @@ events:
 
   - name: playing
     summary: Fired when the currently playing movie changes.
-    platforms: [iphone, ipad, mobileweb]
+    platforms: [android, iphone, ipad, mobileweb]
     properties:
       - name: url
         summary: URL of the media.


### PR DESCRIPTION
Mimic the IOS behavior.
Event fired when video starts playing except pause->start and completed->start.

Since this event was not there in Android, we may need to change the documentation, if so, let me know.
