### PR TITLE
[TIMOB-14090] fix issue where umlauts (ä,ö,ü etc.)

### DIFF
--- a/support/android/builder.py
+++ b/support/android/builder.py
@@ -19,6 +19,9 @@ from xml.dom.minidom import parseString
 from tilogger import *
 from datetime import datetime, timedelta
 
+reload(sys) # this is required to prevent the following error: "AttributeError: 'module' object has no attribute 'setdefaultencoding'"
+sys.setdefaultencoding("utf_8") # Fix umlaut issues
+
 template_dir = os.path.abspath(os.path.dirname(sys._getframe(0).f_code.co_filename))
 top_support_dir = os.path.dirname(template_dir) 
 sys.path.append(top_support_dir)


### PR DESCRIPTION
If the App-Name had umlauts (ä,ö,ü etc.) in it, it caused an error during the android build process, because the Android Manifest couldn't be generated from it's template.
These 2 lines fixed this issue and I had no problems building my app for Android.

Had no issues with this on iOS.
