### PR TITLE
[TIMOB-11771] Android: WebView crashes with basic HTML on emulator

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -112,7 +112,7 @@ if build_type in ['full', 'android'] and not only_package:
 	d = os.getcwd()
 	os.chdir('android')
 	try:
-		sdk = AndroidSDK(ARGUMENTS.get("android_sdk", None), 14)
+		sdk = AndroidSDK(ARGUMENTS.get("android_sdk", None), 17)
 		build_x86 = int(ARGUMENTS.get('build_x86', 1))
 
 		# TODO re-enable javadoc targets = ["full.build", "build.titanium.javadoc"]

--- a/android/modules/ui/project.properties
+++ b/android/modules/ui/project.properties
@@ -9,7 +9,7 @@
 
 android.library=true
 # Project target.
-target=Google Inc.:Google APIs:17
+target=android-17
 android.library.reference.1=../../runtime/common
 android.library.reference.3=../filesystem
 android.library.reference.4=../media

--- a/android/modules/ui/project.properties
+++ b/android/modules/ui/project.properties
@@ -9,7 +9,7 @@
 
 android.library=true
 # Project target.
-target=android-14
+target=Google Inc.:Google APIs:17
 android.library.reference.1=../../runtime/common
 android.library.reference.3=../filesystem
 android.library.reference.4=../media

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiWebViewBinding.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiWebViewBinding.java
@@ -26,6 +26,7 @@ import org.appcelerator.titanium.util.TiConvert;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import android.webkit.JavascriptInterface;
 import android.webkit.WebView;
 
 public class TiWebViewBinding
@@ -47,13 +48,13 @@ public class TiWebViewBinding
 		StringBuilder jsonCode = readResourceFile("json2.js");
 		StringBuilder tiCode = readResourceFile("binding.min.js");
 		StringBuilder pollingCode = readResourceFile("polling.min.js");
-
+		
 		if (pollingCode == null) {
 			Log.w(TAG, "Unable to read polling code");
 		} else {
 			POLLING_CODE = pollingCode.toString();
 		}
-
+		
 		StringBuilder scriptCode = new StringBuilder();
 		StringBuilder injectionCode = new StringBuilder();
 		scriptCode.append("\n<script id=\"" + SCRIPT_INJECTION_ID + "\">\n");
@@ -208,12 +209,13 @@ public class TiWebViewBinding
 	{
 		private KrollModule module;
 		private HashMap<String, Integer> appListeners = new HashMap<String, Integer>();
-
+		private int counter = 0;
+		private String code = null;
 		public AppBinding()
 		{
 			module = TiApplication.getInstance().getModuleByName("App");
 		}
-
+		@JavascriptInterface
 		public void fireEvent(String event, String json)
 		{
 			try {
@@ -226,7 +228,7 @@ public class TiWebViewBinding
 				Log.e(TAG, "Error parsing event JSON", e);
 			}
 		}
-
+		@JavascriptInterface
 		public int addEventListener(String event, int id)
 		{
 			WebViewCallback callback = new WebViewCallback(id);
@@ -236,30 +238,43 @@ public class TiWebViewBinding
 
 			return result;
 		}
-
+		@JavascriptInterface
 		public void removeEventListener(String event, int id)
 		{
 			module.removeEventListener(event, id);
 		}
-
+		@JavascriptInterface
 		public void clearEventListeners()
 		{
 			for (String event : appListeners.keySet()) {
 				removeEventListener(event, appListeners.get(event));
 			}
 		}
-
+		@JavascriptInterface
 		public String getJSCode()
 		{
 			if (destroyed) {
 				return null;
 			}
-
-			String code;
-			synchronized (codeSnippets) {
-				code = codeSnippets.empty() ? "" : codeSnippets.pop();
-			}
 			return code;
+		}
+		@JavascriptInterface
+		public int hasResult()
+		{
+			if (destroyed) {
+				return -1;
+			}
+			int result = 0;
+			synchronized (codeSnippets) {
+				if(codeSnippets.empty()) {
+					code = "";
+				} else {
+					result = 1;
+					code = codeSnippets.pop().toString();
+				}
+			}
+			return result;
+			
 		}
 	}
 
@@ -272,32 +287,38 @@ public class TiWebViewBinding
 		{
 			logging = KrollLogging.getDefault();
 		}
-
+		
+		@JavascriptInterface
 		public void log(String level, String arg)
 		{
 			logging.log(level, arg);
 		}
-
+		
+		@JavascriptInterface
 		public void info(String arg)
 		{
 			logging.info(arg);
 		}
-
+		
+		@JavascriptInterface
 		public void debug(String arg)
 		{
 			logging.debug(arg);
 		}
-
+		
+		@JavascriptInterface
 		public void error(String arg)
 		{
 			logging.error(arg);
 		}
-
+		
+		@JavascriptInterface
 		public void trace(String arg)
 		{
 			logging.trace(arg);
 		}
 
+		@JavascriptInterface
 		public void warn(String arg)
 		{
 			logging.warn(arg);

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiWebViewBinding.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiWebViewBinding.java
@@ -276,7 +276,7 @@ public class TiWebViewBinding
 					code = "";
 				} else {
 					result = 1;
-					code = codeSnippets.pop().toString();
+					code = codeSnippets.pop();
 				}
 			}
 			return result;

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiWebViewBinding.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiWebViewBinding.java
@@ -215,6 +215,7 @@ public class TiWebViewBinding
 		{
 			module = TiApplication.getInstance().getModuleByName("App");
 		}
+		
 		@JavascriptInterface
 		public void fireEvent(String event, String json)
 		{
@@ -228,6 +229,7 @@ public class TiWebViewBinding
 				Log.e(TAG, "Error parsing event JSON", e);
 			}
 		}
+		
 		@JavascriptInterface
 		public int addEventListener(String event, int id)
 		{
@@ -238,11 +240,13 @@ public class TiWebViewBinding
 
 			return result;
 		}
+		
 		@JavascriptInterface
 		public void removeEventListener(String event, int id)
 		{
 			module.removeEventListener(event, id);
 		}
+		
 		@JavascriptInterface
 		public void clearEventListeners()
 		{
@@ -250,6 +254,7 @@ public class TiWebViewBinding
 				removeEventListener(event, appListeners.get(event));
 			}
 		}
+		
 		@JavascriptInterface
 		public String getJSCode()
 		{
@@ -258,6 +263,7 @@ public class TiWebViewBinding
 			}
 			return code;
 		}
+		
 		@JavascriptInterface
 		public int hasResult()
 		{

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/polling.js
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/polling.js
@@ -4,7 +4,7 @@ function checkForJSCode() {
 		if (result == 1) {
 			var code = TiApp.getJSCode();
 			if (code != undefined) {
-				eval(code);
+				eval(code+"");
 			}
 			else {
 				clearInterval(refreshIntervalId);

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/polling.js
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/polling.js
@@ -4,6 +4,7 @@ function checkForJSCode() {
 		if (result == 1) {
 			var code = TiApp.getJSCode();
 			if (code != undefined) {
+				// Force this to be a string, since this does not evaluate in the 2.2 emulator correctly.
 				eval(code+"");
 			}
 			else {

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/polling.js
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/polling.js
@@ -1,11 +1,21 @@
 function checkForJSCode() {
-	var code = TiApp.getJSCode();
-	if ( code != undefined) {
-		// Force this to be a string, since this does not evaluate in the 2.2 emulator correctly.
-		eval(code + "");
-	} else {
+	var result = TiApp.hasResult();
+	if ( result != -1) {
+		if (result == 1) {
+			var code = TiApp.getJSCode();
+			if (code != undefined) {
+				eval(code);
+			}
+			else {
+				clearInterval(refreshIntervalId);
+			}
+			code = null;
+		}
+	}
+	else {
 		clearInterval(refreshIntervalId);
 	}
+	result = null;
 }
 
 var refreshIntervalId = setInterval(checkForJSCode, 250);

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/polling.min.js
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/polling.min.js
@@ -1,1 +1,1 @@
-function checkForJSCode(){var a=TiApp.getJSCode();void 0!=a?eval(a+""):clearInterval(refreshIntervalId)}var refreshIntervalId=setInterval(checkForJSCode,250);
+function checkForJSCode(){var a=TiApp.hasResult();-1!=a?1==a&&(a=TiApp.getJSCode(),void 0!=a?eval(a):clearInterval(refreshIntervalId)):clearInterval(refreshIntervalId)}var refreshIntervalId=setInterval(checkForJSCode,250);

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/polling.min.js
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/polling.min.js
@@ -1,1 +1,1 @@
-function checkForJSCode(){var a=TiApp.hasResult();-1!=a?1==a&&(a=TiApp.getJSCode(),void 0!=a?eval(a):clearInterval(refreshIntervalId)):clearInterval(refreshIntervalId)}var refreshIntervalId=setInterval(checkForJSCode,250);
+function checkForJSCode(){var a=TiApp.hasResult();-1!=a?1==a&&(a=TiApp.getJSCode(),void 0!=a?eval(a+""):clearInterval(refreshIntervalId)):clearInterval(refreshIntervalId)}var refreshIntervalId=setInterval(checkForJSCode,250);


### PR DESCRIPTION
Test is in [JIRA](https://jira.appcelerator.org/browse/TIMOB-11771)

The basic crash is due to incrementing GREF count which is tied into our polling code.

What this PR does is wrap the eval code inside a function that returns a primitive (int) which does not increment the GREF count. Does not change any existing functionality

So basically for simple webviews the developers should be ok. The crash will however occur once the getJSCode returns enough valid string values (basically GREF goes up by 2 on every valid return). So essentially this PR puts off the crash for some time but does not really fix it.

Also added the annotation @JavascriptInterface and had to update the build files for that. See documentation [here](http://developer.android.com/reference/android/webkit/JavascriptInterface.html)

This is a problem on emulators only. It is up to the reviewer whether the ticket should be marked as resolved or HOLD.
