### PR TITLE
TIMOB-13031-allow setRequestHeader when state is opened and unsent

### DIFF
--- a/android/modules/network/src/java/ti/modules/titanium/network/TiHTTPClient.java
+++ b/android/modules/network/src/java/ti/modules/titanium/network/TiHTTPClient.java
@@ -736,7 +736,7 @@ public class TiHTTPClient
 	
 	public void setRequestHeader(String header, String value)
 	{
-		if (readyState == READY_STATE_OPENED) {
+		if (readyState <= READY_STATE_OPENED) {
 			headers.put(header, value);
 
 		} else {


### PR DESCRIPTION
Allow setRequestHeader when state is READY_STATE_OPENED or READY_STATE_UNSENT.

https://jira.appcelerator.org/browse/TIMOB-13031
