### PR TITLE
[TIMOB-11178]Implementation for Autopause API.

### DIFF
--- a/apidoc/Titanium/Geolocation/Geolocation.yml
+++ b/apidoc/Titanium/Geolocation/Geolocation.yml
@@ -47,7 +47,9 @@ description: |
     *   [ACCURACY_KILOMETER](Titanium.Geolocation.ACCURACY_KILOMETER) 
     *   [ACCURACY_LOW](Titanium.Geolocation.ACCURACY_LOW)
     *   [ACCURACY_THREE_KILOMETERS](Titanium.Geolocation.ACCURACY_THREE_KILOMETERS) (lowest
-        accuracy and power consumption). 
+        accuracy and power consumption).
+    *   [ACCURACY_BEST_FOR_NAVIGATION](Titanium.Geolocation.ACCURACY_BEST_FOR_NAVIGATION)
+        (Available in iOS 6.0 and above)
 
     Based on the accuracy you choose, iOS uses its own logic to select location providers
     and filter location updates to provide location updates that meet your accuracy
@@ -281,6 +283,25 @@ events:
         summary: If `success` is false, a string describing the error.
         type: String
 
+ - name: locationupdatepaused
+    summary: Fired when location updates are paused by the OS. Available in iOS 6.0 and later.
+    description: |
+        This event is fired when [pauseLocationUpdateAutomatically](Titanium.Geolocation.pauseLocationUpdateAutomatically) 
+        is set to `true` and if the OS detects that the device’s location is not changing, 
+        causing it to pause the delivery of updates in order to shut down the appropriate 
+        hardware and save power.
+    platforms: [iphone, ipad]
+    since: "3.1.0"
+
+  - name: locationupdateresumed
+    summary: Fired when location manager is resumed by the OS. Available in iOS 6.0 and later.
+    description: |
+        When location updates are paused and need to be resumed (perhaps because the user 
+        is moving again), this event is fired to let the app know that it is about to 
+        begin the delivery of those updates again.
+    platforms: [iphone, ipad]
+    since: "3.1.0"
+
 properties:
 
   - name: ACCURACY_BEST
@@ -351,6 +372,20 @@ properties:
     permission: read-only
     platforms: [android, iphone, ipad, mobileweb]
     since: "2.0.0"
+    
+  - name: ACCURACY_BEST_FOR_NAVIGATION
+    summary: |
+        Use with [accuracy](Titanium.Geolocation.accuracy) to request highest possible 
+        accuracy and combine it with additional sensor data.
+    description: |
+        Using this value is intended for use in navigation applications that require 
+        precise position information at all times and are intended to be used only while 
+        the device is plugged in.
+    type: Number
+    permission: read-only
+    platforms: [iphone, ipad]
+    since: "3.1.0"
+
 
   - name: ACCURACY_LOW
     summary: |
@@ -499,6 +534,53 @@ properties:
     type: String
     permission: read-only
     platforms: [android]
+
+  - name: ACTIVITYTYPE_OTHER
+    summary: The location data is being used for an unknown activity.
+    description: |
+        Used with [activityType](Titanium.Geolocation.activityType). Available in iOS 6.0 and later.
+    type: String
+    permission: read-only
+    platforms: [iphone,ipad]
+    since: "3.1.0"
+    
+  - name: ACTIVITYTYPE_AUTOMOTIVE_NAVIGATION
+    summary: The location data is used for tracking location changes to the automobile specifically during vehicular navigation.
+    description: |
+        Used with [activityType](Titanium.Geolocation.activityType). This activity might 
+        cause location updates to be paused only when the vehicle does not move for an 
+        extended period of time. Available in iOS 6.0 and later.
+    type: String
+    permission: read-only
+    platforms: [iphone,ipad]
+    since: "3.1.0"
+
+  - name: ACTIVITYTYPE_FITNESS
+    summary: The location data is used for tracking any pedestrian-related activity.
+    description: |
+        Used with [activityType](Titanium.Geolocation.activityType). This activity might 
+        cause location updates to be paused only when the user does not move a significant 
+        distance over a period of time.Available in iOS 6.0 and later.
+    type: String
+    permission: read-only
+    platforms: [iphone,ipad]
+    since: "3.1.0"
+
+  - name: ACTIVITYTYPE_OTHER_NAVIGATION
+    summary: |
+        The location data is used for tracking movements of other types of vehicular 
+        navigation that are not automobile related.
+    description: |
+        Used with [activityType](Titanium.Geolocation.activityType). You would use this 
+        to track navigation by boat, train, or plane. Do not use this type for pedestrian 
+        navigation tracking. This activity might cause location updates to be paused only 
+        when the vehicle does not move a significant distance over a period of time. 
+        Available in iOS 6.0 and later.
+    type: String
+    permission: read-only
+    platforms: [iphone,ipad]
+    since: "3.1.0"
+
 
   - name: accuracy
     summary: Specifies the requested accuracy for location updates.
@@ -651,6 +733,48 @@ properties:
     default: false
     platforms: [iphone, ipad]
     since: "2.1.2"
+
+  - name: activityType
+    summary: |
+        The type of user activity to be associated with the location updates. Available in iOS 6.0 and later.
+    description: |
+        Set the activiyType of location updates to either:
+
+        *   [ACTIVITYTYPE_OTHER](Titanium.Geolocation.ACTIVITYTYPE_OTHER) for an unknown activity
+        *   [ACTIVITYTYPE_AUTOMOTIVE_NAVIGATION](Titanium.Geolocation.ACTIVITYTYPE_AUTOMOTIVE_NAVIGATION) 
+            for tracking location changes to the automobile specifically during vehicular navigation.
+        *   [ACTIVITYTYPE_FITNESS](Titanium.Geolocation.ACTIVITYTYPE_FITNESS) for tracking 
+            any pedestrian-related activity.
+        *   [ACTIVITYTYPE_OTHER_NAVIGATION](Titanium.Geolocation.ACTIVITYTYPE_OTHER_NAVIGATION) 
+            for tracking movements of other types of vehicular navigation that are not 
+            automobile related.
+
+        The information in this property is used as a cue to determine when location 
+        updates may be automatically paused. Pausing updates gives the system the 
+        opportunity to save power in situations where the user's location is not likely 
+        to be changing. For example, if the activity type is 
+        [ACTIVITYTYPE_AUTOMOTIVE_NAVIGATION](Titanium.Geolocation.ACTIVITYTYPE_AUTOMOTIVE_NAVIGATION) 
+        and no location changes have occurred recently, the radios might be powered down 
+        until movement is detected again. 
+    type: Number
+    default: <Titanium.Geolocation.ACTIVITYTYPE_OTHER>
+    since: "3.1.0"
+    platforms: [iphone,ipad]
+
+  - name: pauseLocationUpdateAutomatically
+    summary: Indicates whether the location updates may be paused. Available in iOS 6.0 and later.
+    description: |
+        Allowing the location updates to be paused can improve battery life on the 
+        target device without sacrificing location data. When this property is set to YES, 
+        the location updates are paused (and powers down the appropriate hardware) at 
+        times when the location data is unlikely to change. For example, if the user stops 
+        for food while using a navigation app, the location manager might pause updates for 
+        a period of time. You can help the determination of when to pause location updates 
+        by assigning a value to the [activityType](Titanium.Geolocation.activityType) property.
+    type: Boolean
+    default: false
+    platforms: [iphone,ipad]
+    since: "3.1.0"
 
 ---
 name: LocationResults

--- a/apidoc/Titanium/Geolocation/Geolocation.yml
+++ b/apidoc/Titanium/Geolocation/Geolocation.yml
@@ -283,11 +283,11 @@ events:
         summary: If `success` is false, a string describing the error.
         type: String
 
- - name: locationupdatepaused
+  - name: locationupdatepaused
     summary: Fired when location updates are paused by the OS. Available in iOS 6.0 and later.
     description: |
         This event is fired when [pauseLocationUpdateAutomatically](Titanium.Geolocation.pauseLocationUpdateAutomatically) 
-        is set to `true` and if the OS detects that the device’s location is not changing, 
+        is set to `true` and if the OS detects that the device's location is not changing, 
         causing it to pause the delivery of updates in order to shut down the appropriate 
         hardware and save power.
     platforms: [iphone, ipad]

--- a/iphone/Classes/GeolocationModule.h
+++ b/iphone/Classes/GeolocationModule.h
@@ -24,6 +24,10 @@
 	BOOL trackingHeading;
 	BOOL trackingLocation;
     BOOL trackSignificantLocationChange;
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_6_0
+    CLActivityType activityType;
+    BOOL pauseLocationUpdateAutomatically;
+#endif
 	
 	NSRecursiveLock* lock;
 }
@@ -36,6 +40,10 @@
 @property(nonatomic,readwrite,assign) NSNumber *headingFilter;
 @property(nonatomic,readonly) NSNumber *locationServicesEnabled;
 @property(nonatomic,readonly) NSNumber* locationServicesAuthorization;
+
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_6_0
+@property(nonatomic,readwrite,assign) NSNumber *activityType;
+#endif
 
 // Error codes
 @property(nonatomic, readonly) NSNumber* ERROR_LOCATION_UNKNOWN;
@@ -57,6 +65,7 @@
 @property(nonatomic,readonly) NSNumber *ACCURACY_KILOMETER;
 @property(nonatomic,readonly) NSNumber *ACCURACY_LOW;
 @property(nonatomic,readonly) NSNumber *ACCURACY_THREE_KILOMETERS;
+@property(nonatomic,readonly) NSNumber *ACCURACY_BEST_FOR_NAVIGATION; //Since 3.1.0
 
 // Authorization to use location, 4.2+ only
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_4_2
@@ -65,6 +74,16 @@
 @property(nonatomic,readonly) NSNumber* AUTHORIZATION_RESTRICTED;
 #endif
 @property(nonatomic,readonly) NSNumber* AUTHORIZATION_UNKNOWN; // We still need the 'authorization unknown' constant, though.
+
+
+// To specify the geolocation activity type
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_6_0
+@property(nonatomic,readonly) NSNumber* ACTIVITYTYPE_OTHER;// default
+@property(nonatomic,readonly) NSNumber* ACTIVITYTYPE_AUTOMOTIVE_NAVIGATION;// for automotive navigation
+@property(nonatomic,readonly) NSNumber* ACTIVITYTYPE_FITNESS;// includes any pedestrian activities
+@property(nonatomic,readonly) NSNumber* ACTIVITYTYPE_OTHER_NAVIGATION;// for other navigation cases (excluding pedestrian navigation), e.g. navigation for boats, trains or planes.
+#endif
+
 
 @end
 

--- a/iphone/Classes/GeolocationModule.m
+++ b/iphone/Classes/GeolocationModule.m
@@ -254,6 +254,17 @@ extern BOOL const TI_APPLICATION_ANALYTICS;
     
     // track all location changes by default 
 	trackSignificantLocationChange = NO;
+
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_6_0
+    if ([TiUtils isIOS6OrGreater]) {
+        // activity Type by default
+        activityType = CLActivityTypeOther;
+        
+        // pauseLocationupdateAutomatically by default NO
+        pauseLocationUpdateAutomatically  = NO;
+        
+    }
+#endif
     
 	lock = [[NSRecursiveLock alloc] init];
 	
@@ -288,6 +299,14 @@ extern BOOL const TI_APPLICATION_ANALYTICS;
 		{
 			[locationManager setPurpose:purpose];
 		}
+
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_6_0
+        if ([TiUtils isIOS6OrGreater]) {
+            locationManager.activityType = activityType;
+            locationManager.pausesLocationUpdatesAutomatically = pauseLocationUpdateAutomatically;
+            
+        }
+#endif
 
 		if ([CLLocationManager locationServicesEnabled]== NO) 
 		{
@@ -662,6 +681,47 @@ extern BOOL const TI_APPLICATION_ANALYTICS;
     }
 }
 
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_6_0
+// Activity Type for CLlocationManager.
+-(NSNumber*)activityType
+{
+	return NUMINT(activityType);
+}
+
+-(void)setActivityType:(NSNumber *)value
+{
+    if ([TiUtils isIOS6OrGreater]) {
+        ENSURE_UI_THREAD(setActivityType,value);
+        activityType = [TiUtils intValue:value];
+        if (locationManager!=nil)
+        {
+            [locationManager setActivityType:accuracy];
+        }
+    }
+    
+}
+
+// Flag to decide whether or not the app should continue to send location updates while the app is in background.
+
+-(NSNumber*)pauseLocationUpdateAutomatically
+{
+	return NUMBOOL(pauseLocationUpdateAutomatically);
+}
+
+-(void)setPauseLocationUpdateAutomatically:(id)value
+{
+	if ([TiUtils isIOS6OrGreater]) {
+        ENSURE_UI_THREAD(setPauseLocationUpdateAutomatically,value);
+        pauseLocationUpdateAutomatically = [TiUtils boolValue:value];
+        if (locationManager!=nil)
+        {
+            [locationManager setPausesLocationUpdatesAutomatically:pauseLocationUpdateAutomatically];
+        }
+    }
+}
+#endif
+
+
 -(void)restart:(id)arg
 {
 	[lock lock];
@@ -680,6 +740,7 @@ MAKE_SYSTEM_PROP_DBL(ACCURACY_HUNDRED_METERS,kCLLocationAccuracyHundredMeters);
 MAKE_SYSTEM_PROP_DBL(ACCURACY_KILOMETER,kCLLocationAccuracyKilometer);
 MAKE_SYSTEM_PROP_DBL(ACCURACY_THREE_KILOMETERS,kCLLocationAccuracyThreeKilometers);
 MAKE_SYSTEM_PROP_DBL(ACCURACY_LOW, kCLLocationAccuracyThreeKilometers);
+MAKE_SYSTEM_PROP(ACCURACY_BEST_FOR_NAVIGATION, kCLLocationAccuracyBestForNavigation);//Since 2.1.3
 
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_4_2
 MAKE_SYSTEM_PROP(AUTHORIZATION_UNKNOWN, kCLAuthorizationStatusNotDetermined);
@@ -699,6 +760,13 @@ MAKE_SYSTEM_PROP(ERROR_HEADING_FAILURE, kCLErrorHeadingFailure);
 MAKE_SYSTEM_PROP(ERROR_REGION_MONITORING_DENIED, kCLErrorRegionMonitoringDenied);
 MAKE_SYSTEM_PROP(ERROR_REGION_MONITORING_FAILURE, kCLErrorRegionMonitoringFailure);
 MAKE_SYSTEM_PROP(ERROR_REGION_MONITORING_DELAYED, kCLErrorRegionMonitoringSetupDelayed);
+
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_6_0
+MAKE_SYSTEM_PROP(ACTIVITYTYPE_OTHER, CLActivityTypeOther);
+MAKE_SYSTEM_PROP(ACTIVITYTYPE_AUTOMOTIVE_NAVIGATION, CLActivityTypeAutomotiveNavigation);
+MAKE_SYSTEM_PROP(ACTIVITYTYPE_FITNESS, CLActivityTypeFitness);
+MAKE_SYSTEM_PROP(ACTIVITYTYPE_OTHER_NAVIGATION, CLActivityTypeOtherNavigation);
+#endif
 
 #pragma mark Internal
 
@@ -826,6 +894,27 @@ MAKE_SYSTEM_PROP(ERROR_REGION_MONITORING_DELAYED, kCLErrorRegionMonitoringSetupD
 }
 
 #pragma mark Delegates
+
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_6_0
+
+- (void)locationManagerDidPauseLocationUpdates:(CLLocationManager *)manager
+{
+    if ([self _hasListeners:@"locationupdatepaused"])
+	{
+		[self fireEvent:@"locationupdatepaused" withObject:nil];
+	}
+}
+
+- (void)locationManagerDidResumeLocationUpdates:(CLLocationManager *)manager
+{
+    if ([self _hasListeners:@"locationupdateresumed"])
+	{
+		[self fireEvent:@"locationupdateresumed" withObject:nil];
+	}
+}
+
+#endif
+
 
 //Using new delegate instead of the old deprecated method - (void)locationManager:didUpdateToLocation:fromLocation:
 

--- a/iphone/Classes/GeolocationModule.m
+++ b/iphone/Classes/GeolocationModule.m
@@ -691,12 +691,8 @@ extern BOOL const TI_APPLICATION_ANALYTICS;
 -(void)setActivityType:(NSNumber *)value
 {
     if ([TiUtils isIOS6OrGreater]) {
-        ENSURE_UI_THREAD(setActivityType,value);
         activityType = [TiUtils intValue:value];
-        if (locationManager!=nil)
-        {
-            [locationManager setActivityType:accuracy];
-        }
+        TiThreadPerformOnMainThread(^{[locationManager setActivityType:accuracy];}, NO);
     }
     
 }
@@ -711,12 +707,8 @@ extern BOOL const TI_APPLICATION_ANALYTICS;
 -(void)setPauseLocationUpdateAutomatically:(id)value
 {
 	if ([TiUtils isIOS6OrGreater]) {
-        ENSURE_UI_THREAD(setPauseLocationUpdateAutomatically,value);
         pauseLocationUpdateAutomatically = [TiUtils boolValue:value];
-        if (locationManager!=nil)
-        {
-            [locationManager setPausesLocationUpdatesAutomatically:pauseLocationUpdateAutomatically];
-        }
+        TiThreadPerformOnMainThread(^{[locationManager setPausesLocationUpdatesAutomatically:pauseLocationUpdateAutomatically];}, NO);
     }
 }
 #endif


### PR DESCRIPTION
**Testing Instruction**

 *\* Make an app with the following code [app.js](https://jira.appcelerator.org/browse/TIMOB-11178?focusedCommentId=222599&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-222599)
*\* add location into the backgroundmodes in tiapp.xml

``` javascript
<ios>
<plist>
<dict>
  <key>UIBackgroundModes</key>
  <array>
    <string>location</string>
  </array>
</dict>
</plist>
</ios>
```

*\* By default i have set the autopause to be false.

**TEST 1**
*\* Put the app in background .
*\* Move around for a bit and ensure you receive location update
*\* Now put the phone on the table and leave it for a while(say 20-30 to be sure) 
*\* Verify that location update **paused is not** fired.

**TEST 2**

*\* Open the same app.
*\* Switch the puaseLocationUpdatesAutomatically to true(0N)
*\* Put the app in background.
*\* Move around for a bit and ensure you receive location update
*\* Now put the phone on the table and leave it for a while(say 20-30 to be sure).
*\* Verify that location update **paused** **is**  fired.
*\* Once the location paused event is fired. Now open the app and move around.
*\* Ensure that the location update resumed event is fired and the app continues to receive location updates.

If there is any confusion while testing let me know.
