### PR TITLE
TIMOB-12840 Added exception reporting for invokeCallbackForKey

### DIFF
--- a/iphone/Classes/KrollObject.m
+++ b/iphone/Classes/KrollObject.m
@@ -1125,6 +1125,11 @@ TI_INLINE TiStringRef TiStringCreateWithPointerValue(int value)
 
 	TiValueRef jsEventData = ConvertIdTiValue(context, eventData);
 	TiObjectCallAsFunction(jsContext, jsCallback, [thisObject jsobject], 1, &jsEventData,&exception);
+	if (exception!=NULL)
+	{
+		id excm = [KrollObject toID:context value:exception];
+		[[TiExceptionHandler defaultExceptionHandler] reportScriptError:[TiUtils scriptErrorValue:excm]];
+	}
 }
 
 -(void)noteKrollObject:(KrollObject *)value forKey:(NSString *)key


### PR DESCRIPTION
Test is to make an httpClient request or camera call where the onSuccess or onError throws an uncaught exception.
