### PR TITLE
TIMOB-12558 Reduce warnings, move GetKrollContext out of inline for GC.

### DIFF
--- a/iphone/Classes/KrollContext.h
+++ b/iphone/Classes/KrollContext.h
@@ -148,19 +148,7 @@
 -(void)setExecutionContext:(id<KrollDelegate>)delegate;
 @end
 
-//Todo: Move out of being inline and refactor out constantly creating and removing the Kroll string. --BTH
-TI_INLINE KrollContext* GetKrollContext(TiContextRef context)
-{
-	static const char *krollNS = "Kroll";
-	TiGlobalContextRef globalContext = TiContextGetGlobalContext(context);
-	TiObjectRef global = TiContextGetGlobalObject(globalContext); 
-	TiStringRef string = TiStringCreateWithUTF8CString(krollNS);
-	TiValueRef value = TiObjectGetProperty(globalContext, global, string, NULL);
-//Yes, the __bridge gives a warning when not in ARC. This is why this should not be inline anymore.
-	KrollContext *ctx = (__bridge KrollContext*)TiObjectGetPrivate(TiValueToObject(globalContext, value, NULL));
-	TiStringRelease(string);
-	return ctx;
-}
+KrollContext* GetKrollContext(TiContextRef context);
 
 //TODO: After 1.7, move to individual file and convert KrollInvocation and Callbacks to ExpandedInvocationOperation.
 @interface ExpandedInvocationOperation : NSOperation {

--- a/iphone/Classes/KrollObject.m
+++ b/iphone/Classes/KrollObject.m
@@ -1164,7 +1164,7 @@ TI_INLINE TiStringRef TiStringCreateWithPointerValue(int value)
 	TiStringRelease(nameRef);
 }
 
--(void)noteObject:(TiObjectRef)storedJSObject forTiString:(TiStringRef) keyString context:(TiContextRef) jsContext
+-(void)noteObject:(TiObjectRef)storedJSObject forTiString:(TiStringRef) keyString context:(TiContextRef) jsContextRef
 {
 	if ((propsObject == NULL) || (storedJSObject == NULL) || finalized)
 	{
@@ -1172,20 +1172,20 @@ TI_INLINE TiStringRef TiStringCreateWithPointerValue(int value)
 	}
 	TiValueRef exception=NULL;
 
-	TiObjectRef jsProxyHash = (TiObjectRef)TiObjectGetProperty(jsContext, propsObject, kTiStringPropertyKey, &exception);
+	TiObjectRef jsProxyHash = (TiObjectRef)TiObjectGetProperty(jsContextRef, propsObject, kTiStringPropertyKey, &exception);
 
-	if ((jsProxyHash == NULL) || (TiValueGetType(jsContext,jsProxyHash) != kTITypeObject))
+	if ((jsProxyHash == NULL) || (TiValueGetType(jsContextRef,jsProxyHash) != kTITypeObject))
 	{
-		jsProxyHash = TiObjectMake(jsContext, NULL, &exception);
-		TiObjectSetProperty(jsContext, propsObject, kTiStringPropertyKey, jsProxyHash,
+		jsProxyHash = TiObjectMake(jsContextRef, NULL, &exception);
+		TiObjectSetProperty(jsContextRef, propsObject, kTiStringPropertyKey, jsProxyHash,
 				kTiPropertyAttributeDontEnum , &exception);
 	}
 
-	TiObjectSetProperty(jsContext, jsProxyHash, keyString, storedJSObject,
+	TiObjectSetProperty(jsContextRef, jsProxyHash, keyString, storedJSObject,
 			kTiPropertyAttributeDontEnum , &exception);
 }
 
--(void)forgetObjectForTiString:(TiStringRef) keyString context:(TiContextRef) jsContext
+-(void)forgetObjectForTiString:(TiStringRef) keyString context:(TiContextRef) jsContextRef
 {
 	if ((propsObject == NULL) || finalized)
 	{
@@ -1193,17 +1193,17 @@ TI_INLINE TiStringRef TiStringCreateWithPointerValue(int value)
 	}
 	TiValueRef exception=NULL;
 
-	TiObjectRef jsProxyHash = (TiObjectRef)TiObjectGetProperty(jsContext, propsObject, kTiStringPropertyKey, &exception);
+	TiObjectRef jsProxyHash = (TiObjectRef)TiObjectGetProperty(jsContextRef, propsObject, kTiStringPropertyKey, &exception);
 
-	if ((jsProxyHash == NULL) || (TiValueGetType(jsContext,jsProxyHash) != kTITypeObject))
+	if ((jsProxyHash == NULL) || (TiValueGetType(jsContextRef,jsProxyHash) != kTITypeObject))
 	{
 		return;
 	}
 
-	TiObjectDeleteProperty(jsContext, jsProxyHash, keyString, &exception);
+	TiObjectDeleteProperty(jsContextRef, jsProxyHash, keyString, &exception);
 }
 
--(TiObjectRef)objectForTiString:(TiStringRef) keyString context:(TiContextRef) jsContext
+-(TiObjectRef)objectForTiString:(TiStringRef) keyString context:(TiContextRef) jsContextRef
 {
 	if(finalized){
 		return NULL;
@@ -1211,15 +1211,15 @@ TI_INLINE TiStringRef TiStringCreateWithPointerValue(int value)
 
 	TiValueRef exception=NULL;
 
-	TiObjectRef jsProxyHash = (TiObjectRef)TiObjectGetProperty(jsContext, propsObject, kTiStringPropertyKey, &exception);
+	TiObjectRef jsProxyHash = (TiObjectRef)TiObjectGetProperty(jsContextRef, propsObject, kTiStringPropertyKey, &exception);
 
-	if ((jsProxyHash == NULL) || (TiValueGetType(jsContext,jsProxyHash) != kTITypeObject))
+	if ((jsProxyHash == NULL) || (TiValueGetType(jsContextRef,jsProxyHash) != kTITypeObject))
 	{
 		return NULL;
 	}
 	
-	TiObjectRef result = (TiObjectRef)TiObjectGetProperty(jsContext, jsProxyHash, keyString, NULL);
-	if ((result == NULL) || (TiValueGetType(jsContext,result) != kTITypeObject))
+	TiObjectRef result = (TiObjectRef)TiObjectGetProperty(jsContextRef, jsProxyHash, keyString, NULL);
+	if ((result == NULL) || (TiValueGetType(jsContextRef,result) != kTITypeObject))
 	{
 		return NULL;
 	}

--- a/iphone/Classes/LauncherView.m
+++ b/iphone/Classes/LauncherView.m
@@ -37,6 +37,7 @@
 #import "LauncherView.h"
 #import "LauncherItem.h"
 #import "LauncherButton.h"
+#import "TiBase.h"
 
 static const CGFloat kLauncherViewMargin = 0;
 static const CGFloat kLauncherViewPadding = 0;

--- a/iphone/Classes/TiMediaMusicPlayer.m
+++ b/iphone/Classes/TiMediaMusicPlayer.m
@@ -73,7 +73,7 @@
 		}
 	}
 	else if ([arg isKindOfClass:[TiMediaItem class]]) {
-		[items addObject:[arg item]];
+		[items addObject:[(TiMediaItem*)arg item]];
 	}
 	else {
 		[self throwException:[NSString stringWithFormat:@"Invalid object type %@ for player queue",[arg class]]

--- a/iphone/Classes/TiUIButtonProxy.m
+++ b/iphone/Classes/TiUIButtonProxy.m
@@ -59,7 +59,7 @@
 
 -(CGFloat) verifyWidth:(CGFloat)suggestedWidth
 {
-	switch(styleCache)
+	switch((int)styleCache)
 	{
 		case UITitaniumNativeItemInfoLight:
 		case UITitaniumNativeItemInfoDark:
@@ -75,7 +75,7 @@
 
 -(CGFloat) verifyHeight:(CGFloat)suggestedHeight
 {
-	switch(styleCache)
+	switch((int)styleCache)
 	{
 		case UITitaniumNativeItemInfoLight:
 		case UITitaniumNativeItemInfoDark:
@@ -92,7 +92,7 @@
 
 -(UIViewAutoresizing) verifyAutoresizing:(UIViewAutoresizing)suggestedResizing
 {
-	switch (styleCache)
+	switch ((int)styleCache)
 	{
 		case UITitaniumNativeItemInfoLight:
 		case UITitaniumNativeItemInfoDark:

--- a/iphone/Classes/TiWindowProxy.m
+++ b/iphone/Classes/TiWindowProxy.m
@@ -23,7 +23,7 @@ TiOrientationFlags TiOrientationFlagsFromObject(id args)
 	for (id mode in args)
 	{
 		UIInterfaceOrientation orientation = (UIInterfaceOrientation)[TiUtils orientationValue:mode def:-1];
-		switch (orientation)
+		switch ((int)orientation)
 		{
 			case UIDeviceOrientationPortrait:
 			case UIDeviceOrientationPortraitUpsideDown:


### PR DESCRIPTION
User should get notably less warnings when building now.
