### PR TITLE
[TIMOB-13056] Android: correctly handle timeout in evalJS by removing enqueued code snippet and drain permits before next snippet enqueue 

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiWebViewBinding.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiWebViewBinding.java
@@ -149,11 +149,15 @@ public class TiWebViewBinding
 			String code = "_TiReturn.setValue((function(){try{return " + expression
 				+ "+\"\";}catch(ti_eval_err){return '';}})());";
 			Log.d(TAG, "getJSValue:" + code, Log.DEBUG_MODE);
+			returnSemaphore.drainPermits();
 			synchronized (codeSnippets) {
 				codeSnippets.push(code);
 			}
 			try {
 				if (!returnSemaphore.tryAcquire(3500, TimeUnit.MILLISECONDS)) {
+					synchronized (codeSnippets) {
+						codeSnippets.removeElement(code);
+					}
 					Log.w(TAG, "Timeout waiting to evaluate JS");
 				}
 				return returnValue;


### PR DESCRIPTION
[TIMOB-13056](https://jira.appcelerator.org/browse/TIMOB-13056)

Test case attached to JIRA.
