### PR TITLE
[TIMOB-13102] Ensure rendering to right region on bounds change

### DIFF
--- a/iphone/Classes/TiMapView.h
+++ b/iphone/Classes/TiMapView.h
@@ -26,6 +26,8 @@
 	BOOL animate;
 	BOOL loaded;
 	BOOL ignoreClicks;
+	BOOL ignoreRegionChanged;
+	BOOL forceRender;
 	MKCoordinateRegion region;
 	
     // routes


### PR DESCRIPTION
Test is in [JIRA](https://jira.appcelerator.org/browse/TIMOB-13102)

Regress against 
[TIMOB-11359](https://jira.appcelerator.org/browse/TIMOB-11359)
[TIMOB-8092](https://jira.appcelerator.org/browse/TIMOB-8092)

Make sure to run this across all versions of iOS (4,5,6)
