### PR TITLE
[TIMOB-13142] fix ListItem layout to absolute to prevent crashes with unsupported values

### DIFF
--- a/iphone/Classes/TiUIListItem.m
+++ b/iphone/Classes/TiUIListItem.m
@@ -86,6 +86,8 @@
 {
 	[super layoutSubviews];
 	if (_templateStyle == TiUIListItemTemplateStyleCustom) {
+		// prevent any crashes that could be caused by unsupported layouts
+		_proxy.layoutProperties->layoutStyle = TiLayoutRuleAbsolute;
 		[_proxy layoutChildren:NO];
 	}
 }


### PR DESCRIPTION
[TIMOB-13142](https://jira.appcelerator.org/browse/TIMOB-13142)
