### PR TITLE
anvil fix to builder.py

### DIFF
--- a/support/iphone/builder.py
+++ b/support/iphone/builder.py
@@ -407,6 +407,9 @@ DEFAULTS_IMPL_HEADER= """#import "TiUtils.h"
 #import "ApplicationDefaults.h"
  
 @implementation ApplicationDefaults
++(NSDictionary*)launchUrl {
+    return nil;
+}
   
 + (NSMutableDictionary*) copyDefaults
 {


### PR DESCRIPTION
due to the implementation of the timob-12431, the old builder.py never recreated the launchUrl it nuked when created the copy defaults in ApplicationDefaults.m 

**Testing instruction**
Run app using the old builder scripts. 
