### PR TITLE
[TIMOB-12433] reset top/left layout properties due to their higher precedence when center animation is used

### DIFF
--- a/iphone/Classes/TiAnimation.m
+++ b/iphone/Classes/TiAnimation.m
@@ -506,6 +506,8 @@ doReposition = YES;\
 
                     layoutProperties->centerX = [center xDimension];
                     layoutProperties->centerY = [center yDimension];
+					layoutProperties->left = TiDimensionUndefined;
+					layoutProperties->top = TiDimensionUndefined;
                     doReposition = YES;
                 }
                 


### PR DESCRIPTION
[TIMOB-12533](https://jira.appcelerator.org/browse/TIMOB-12533)
