### PR TITLE
TIMOB-12930 The dangers of copy-pasting at the last moment.

### DIFF
--- a/android/runtime/v8/src/native/TypeConverter.h
+++ b/android/runtime/v8/src/native/TypeConverter.h
@@ -64,7 +64,7 @@ public:
 	static v8::Handle<v8::Number> javaDoubleToJsNumber(jdouble javaDouble);
 
 	static inline jdouble jsNumberToJavaDouble(JNIEnv *env, v8::Handle<v8::Number> jsNumber) {
-		return jsNumberToJavaFloat(jsNumber);
+		return jsNumberToJavaDouble(jsNumber);
 	}
 	static inline v8::Handle<v8::Number> javaDoubleToJsNumber(JNIEnv *env, jdouble javaDouble) {
 		return javaDoubleToJsNumber(javaDouble);


### PR DESCRIPTION
9995dc3 had two, two, two regressions for the price of one!

How embarrassing. The two errors found by Anvil were caused by another typo of the same type. 

<Error: should be: '1364098279905', was: '1364098285568'\n    at [object Object].reportError (testUtil.js:25:10)\n    at [object Object].<anonymous> (testUtil.js:77:9)\n    at [object Object].doublePrecision (suites/properties.js:123:27)\n    at [object Objec
<Error: should be: '$555,123.23', was: '$555,123.25'\n    at [object Object].reportError (testUtil.js:25:10)\n    at [object Object].<anonymous> (testUtil.js:77:9)\n    at [object Object].stringFormatCurrency (suites/android/android_string.js:331:30)\n    at 

Anyways, test is in Anvil.
