### PR TITLE
[TIMOB-13127] iOS: Ti.App.Properties.setList cannot save arrays that contain null, undefined, or empty values

### DIFF
--- a/iphone/Classes/TiAppPropertiesProxy.m
+++ b/iphone/Classes/TiAppPropertiesProxy.m
@@ -9,7 +9,9 @@
 #import "TiAppPropertiesProxy.h"
 #import "TiUtils.h"
 
-@implementation TiAppPropertiesProxy
+@implementation TiAppPropertiesProxy {
+	NSData *_defaultsNull;
+}
 
 -(void)dealloc
 {
@@ -17,6 +19,7 @@
 		[[NSNotificationCenter defaultCenter] removeObserver:self];
 	}, YES);
 	RELEASE_TO_NIL(defaultsObject);
+	RELEASE_TO_NIL(_defaultsNull);
 	[super dealloc];
 }
 
@@ -43,6 +46,7 @@
 -(void)_configure
 {
 	defaultsObject = [[NSUserDefaults standardUserDefaults] retain];
+	_defaultsNull = [[NSData alloc] initWithBytes:"NULL" length:4];
 	[super _configure];
 }
 
@@ -86,7 +90,15 @@ if (![self propertyExists:key]) return defaultValue; \
 -(id)getList:(id)args
 {
 	GETPROP
-	return [defaultsObject arrayForKey:key];
+	NSArray *value = [defaultsObject arrayForKey:key];
+	NSMutableArray *array = [[[NSMutableArray alloc] initWithCapacity:[value count]] autorelease];
+	[(NSArray *)value enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
+		if ([obj isKindOfClass:[NSData class]] && [_defaultsNull isEqualToData:obj]) {
+			obj = [NSNull null];
+		}
+		[array addObject:obj];
+	}];
+	return array;
 }
 
 -(id)getObject:(id)args
@@ -147,6 +159,16 @@ if ([self propertyExists:key] && [ [defaultsObject objectForKey:key] isEqual:val
 -(void)setList:(id)args
 {
 	SETPROP
+	if ([value isKindOfClass:[NSArray class]]) {
+		NSMutableArray *array = [[[NSMutableArray alloc] initWithCapacity:[value count]] autorelease];
+		[(NSArray *)value enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
+			if ([obj isKindOfClass:[NSNull class]]) {
+				obj = _defaultsNull;
+			}
+			[array addObject:obj];
+		}];
+		value = array;
+	}
 	[defaultsObject setObject:value forKey:key];
 	[defaultsObject synchronize];
 }


### PR DESCRIPTION
[TIMOB-13127](https://jira.appcelerator.org/browse/TIMOB-13127)

Test case in JIRA
