### PR TITLE
TIDOC-1081 Add new platforms and remove duplicated code.

### DIFF
--- a/apidoc/common.py
+++ b/apidoc/common.py
@@ -9,6 +9,10 @@
 import os, sys, re
 simple_tag_pattern = re.compile(r"<[^>]*?>")
 not_real_titanium_types = ("Titanium.Proxy", "Titanium.Module", "Titanium.Event")
+DEFAULT_PLATFORMS = ["android", "blackberry", "iphone", "ipad", "mobileweb", "tizen"]
+platform_names = { "android": "Android", "blackberry": "BlackBerry", 
+				"iphone": "iPhone", "ipad": "iPad", "mobileweb": "Mobile Web", "tizen": "Tizen" }
+initial_platform_version = { "blackberry": "3.1", "mobileweb" : "1.8", "tizen": "3.1" }
 
 # odict source is in docgen folder (parent of this folder).
 # Newer versions of Python also have OrderedDict.
@@ -55,3 +59,17 @@ def to_ordered_dict(orig_dict, key_order):
 		if not key in already_added:
 			odict[key] = orig_dict[key]
 	return odict
+
+def pretty_platform_name(platform):
+	name = platform.lower()
+	if name in platform_names:
+		return platform_names[name]
+	else:
+		return name
+
+def first_version_for_platform(platform):
+	name = platform.lower()
+	if name in initial_platform_version:
+		return initial_platform_version[name]
+	else:
+		return None

--- a/apidoc/generators/jsduck_generator.py
+++ b/apidoc/generators/jsduck_generator.py
@@ -298,27 +298,6 @@ def transform_type(type):
 		type = "Callback<%s>" % (type)
 	return type
 
-def has_ancestor(one_type, ancestor_name):
-	if one_type["name"] == ancestor_name:
-		return True
-	if "extends" in one_type and one_type["extends"] == ancestor_name:
-		return True
-	elif "extends" not in one_type:
-		if ancestor_name in special_toplevel_types:
-			# special case for "Global" and "Modules" types - they do not have @extends statement
-			return one_type["name"].find(ancestor_name) == 0
-		return False
-	else:
-		parent_type_name = one_type["extends"]
-		if (parent_type_name is None or not isinstance(parent_type_name, basestring) or
-			parent_type_name.lower() == "object"):
-			return False
-		if not parent_type_name in apis:
-			log.warn("%s extends %s but %s type information not found" % (one_type["name"],
-																		  parent_type_name, parent_type_name))
-			return False
-		return has_ancestor(apis[parent_type_name], ancestor_name)
-
 def is_special_toplevel_type(one_type):
 	for special_type in special_toplevel_types:
 		if one_type["name"].find(special_type) == 0:
@@ -419,7 +398,7 @@ def generate(raw_apis, annotated_apis, options):
 				else:
 					write_utf8(output, '\t * @typestr %s\n' % (typestr))
 			
-			if not (has_ancestor(raw_apis[name], "Titanium.Proxy") or is_special_toplevel_type(raw_apis[name])):
+			if annotated_obj.is_pseudotype and not is_special_toplevel_type(annotated_obj.api_obj):
 				write_utf8(output, "\t * @pseudo\n")
 			write_utf8(output, output_properties_for_obj(annotated_obj))
 			write_utf8(output, get_summary_and_description(annotated_obj.api_obj))

--- a/apidoc/generators/parity_generator.py
+++ b/apidoc/generators/parity_generator.py
@@ -4,6 +4,7 @@
 # Licensed under the Apache Public License (version 2)
 
 import os, sys, re
+from common import DEFAULT_PLATFORMS, pretty_platform_name
 
 this_dir = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(os.path.abspath(os.path.join(this_dir, "..")))
@@ -23,30 +24,9 @@ def is_special_toplevel_type(one_type):
 			return True
 	return False
 
-def has_ancestor(one_type, ancestor_name):
-	if one_type["name"] == ancestor_name:
-		return True
-	if "extends" in one_type and one_type["extends"] == ancestor_name:
-		return True
-	elif "extends" not in one_type:
-		if ancestor_name in special_toplevel_types:
-			# special case for "Global" and "Modules" types - they do not have @extends statement
-			return one_type["name"].find(ancestor_name) == 0
-		return False
-	else:
-		parent_type_name = one_type["extends"]
-		if (parent_type_name is None or not isinstance(parent_type_name, basestring) or
-			parent_type_name.lower() == "object"):
-			return False
-		if not parent_type_name in apis:
-			log.warn("%s extends %s but %s type information not found" % (one_type["name"],
-																		  parent_type_name, parent_type_name))
-			return False
-		return has_ancestor(apis[parent_type_name], ancestor_name)
-
 def get_platforms_available(platforms):
 	res = ""
-	for platform in ( "android", "iphone", "ipad", "mobileweb" ):
+	for platform in DEFAULT_PLATFORMS:
 		if any(platform == p["name"] for p in platforms):
 			res = res + "\t<td class=\"yes\">YES</td>\n"
 		else:
@@ -85,9 +65,8 @@ def generate(raw_apis, annotated_apis, options):
 		output.write("<tr>\n")
 		output.write("<th></th>\n")
 		
-		platform_names = { "android": "Android", "iphone": "iPhone", "ipad": "iPad", "mobileweb": "Mobile Web" }
-		for platform in ( "android", "iphone", "ipad", "mobileweb" ):
-			output.write("\t<th>%s</th>\n" % platform_names[platform])	
+		for platform in DEFAULT_PLATFORMS:
+			output.write("\t<th>%s</th>\n" % pretty_platform_name(platform))	
 		output.write("</tr>\n")
 
 		api_names = annotated_apis.keys()
@@ -97,7 +76,7 @@ def generate(raw_apis, annotated_apis, options):
 			
 			pseudo_text = ""
 			class_type = "normal_type"
-			if not (has_ancestor(raw_apis[name], "Titanium.Proxy") or is_special_toplevel_type(raw_apis[name])):
+			if annotated_obj.is_pseudotype and not is_special_toplevel_type(raw_apis[name]):
 				pseudo_text = "(<i>pseudotype</i>)"
 				class_type = "pseudo_type"
 			


### PR DESCRIPTION
- Centralize list of platforms, platform names.
- Added tizen and blackberry platforms.
- Add "is_pseudotype" field to annotated objects to remove duplicated code in various generators.
- Make docgen fail fast if a generator script has a syntax error (i.e., exit before parsing YAML).

Should test all affected generators.

Note that the new platforms will break JSDuck unless this is tested with the corresponding pulls for JSDuck and doctools:

JSDuck: https://github.com/appcelerator/jsduck/pull/21
Doctools: https://github.com/appcelerator/doctools/pull/13
