### PR TITLE
respect case-insensitive file systems

### DIFF
--- a/support/iphone/tools.py
+++ b/support/iphone/tools.py
@@ -183,7 +183,7 @@ def install_logo(tiapp, applogo, project_dir, template_dir, dest):
 	install_default(applogo, project_dir, template_dir, dest)
 
 def install_defaults(project_dir, template_dir, dest):
-	for graphic in os.listdir(os.path.join(template_dir, 'resources')):
+	for graphic in os.listdir(os.path.join(template_dir, 'Resources')):
 		install_default(graphic, project_dir, template_dir, dest)
 
 def fix_xcode_script(content,script_name,script_contents):


### PR DESCRIPTION
This commit will fix the following error (which happenend when calling
"titanium run" for my native iOS module):

> [DEBUG] Traceback (most recent call last):
> [DEBUG] File "/Library/Application Support/Titanium/mobilesdk/osx/3.0.2.GA/iphone/builder.py", line 1645, in <module>
> [DEBUG] main(sys.argv)
> [DEBUG] File "/Library/Application Support/Titanium/mobilesdk/osx/3.0.2.GA/iphone/builder.py", line 752, in main
> [DEBUG] find_name_conflicts(project_dir, app_name)
> [DEBUG] File "/Library/Application Support/Titanium/mobilesdk/osx/3.0.2.GA/iphone/builder.py", line 508, in find_name_conflicts
> [DEBUG] for name in os.listdir(os.path.join(project_dir, dir)):
> [DEBUG] OSError: [Errno 2] No such file or directory: '/var/folders/c8/j1mm9_qs3_93c_byn4vclw_m0000gn/T/mZPNuv3ti/appicon-badge/Resources/iphone'
- support/iphone/tools.py: the folder's name begins with a capital
  letter
