### PR TITLE
[TIMOB-13251] remove extra line injected into top of module js files

### DIFF
--- a/android/runtime/common/src/js/kroll.js
+++ b/android/runtime/common/src/js/kroll.js
@@ -117,7 +117,7 @@
 	};
 
 	NativeModule.wrapper = [
-		'(function (exports, require, module, __filename, __dirname, Titanium, Ti, global, kroll) {\n',
+		'(function (exports, require, module, __filename, __dirname, Titanium, Ti, global, kroll) {',
 		'\n});' ];
 
 	NativeModule.prototype.compile = function() {


### PR DESCRIPTION
[TIMOB-13251](https://jira.appcelerator.org/browse/TIMOB-13251)

Fixes regression caused by https://github.com/appcelerator/titanium_mobile/commit/cbffb1b4cc42bdcf201c8782e8955e6b6e387cd4#android/runtime/common/src/js/kroll.js
