### PR TITLE
TIMOB-13276: Remove references to js.jar since rhino runtime is gone.

### DIFF
--- a/support/android/compiler.py
+++ b/support/android/compiler.py
@@ -43,7 +43,6 @@ class Compiler(object):
 		self.gen_dir = gen_dir
 		self.template_dir = os.path.abspath(os.path.dirname(sys._getframe(0).f_code.co_filename))
 		self.root_dir = root_dir
-		self.use_bytecode = False
 		if project_dir:
 			self.project_dir = os.path.abspath(os.path.expanduser(project_dir))
 		self.modules = set()
@@ -156,24 +155,18 @@ class Compiler(object):
 		escape_chars = ['\\', '/', ' ', '.','-']
 		for escape_char in escape_chars:
 			js_class_name = js_class_name.replace(escape_char, '_')
-		
-		if self.use_bytecode:
-			jsc_args = [self.java, '-classpath', js_jar, 'org.mozilla.javascript.tools.jsc.Main',
-				'-main-method-class', 'org.appcelerator.titanium.TiScriptRunner',
-				'-nosource', '-package', self.appid + '.js', '-encoding', 'utf8',
-				'-o', js_class_name, '-d', self.classes_dir, fullpath]
-		else:
-			jsc_args = [
-				self.java,
-				'-jar',
-				os.path.join(self.template_dir, 'lib/closure-compiler.jar'),
-				'--js',
-				fullpath,
-				'--js_output_file',
-				fullpath + '-compiled',
-				'--jscomp_off=internetExplorerChecks',
-				'--accept_const_keyword'
-				]
+
+		jsc_args = [
+			self.java,
+			'-jar',
+			os.path.join(self.template_dir, 'lib/closure-compiler.jar'),
+			'--js',
+			fullpath,
+			'--js_output_file',
+			fullpath + '-compiled',
+			'--jscomp_off=internetExplorerChecks',
+			'--accept_const_keyword'
+			]
 
 		print "[INFO] Compiling javascript: %s" % resource_relative_path
 		sys.stdout.flush()

--- a/support/module/android/android.py
+++ b/support/module/android/android.py
@@ -34,7 +34,6 @@ class android(module.ModulePlatform):
 			self.sdk.get_android_jar(),
 			self.sdk.get_maps_jar(),
 			'/'.join([sdk_android_dir, 'titanium.jar']),
-			'/'.join([sdk_android_dir, 'js.jar']),
 			'/'.join([sdk_android_dir, 'kroll-common.jar']),
 			'/'.join([sdk_android_dir, 'kroll-apt.jar'])
 		]


### PR DESCRIPTION
https://jira.appcelerator.org/browse/TIMOB-13276

Test case in Jira.
