### PR TITLE
TIMOB-13395: Android: native modules broken with android-ndk-r8e

### DIFF
--- a/support/module/android/generated/Android.mk
+++ b/support/module/android/generated/Android.mk
@@ -6,7 +6,7 @@ include $(CLEAR_VARS)
 
 THIS_DIR = $(LOCAL_PATH)
 LOCAL_MODULE := @MODULE_ID@
-LOCAL_CFLAGS := -g "-I$(TI_MOBILE_SDK)/android/native/include" -I$(SYSROOT)/usr/include
+LOCAL_CFLAGS := -g "-I$(TI_MOBILE_SDK)/android/native/include"
 
 # Several places in generated code we set some jvalues to NULL and
 # since NDK r8b we'd get warnings about each one.


### PR DESCRIPTION
Backport to 3_1_X for https://jira.appcelerator.org/browse/TIMOB-13395
