### PR TITLE
Add buildID and simplified object access for blackberry tiapp.xml

### DIFF
--- a/support/node_modules/titanium-sdk/lib/tiappxml.js
+++ b/support/node_modules/titanium-sdk/lib/tiappxml.js
@@ -338,7 +338,7 @@ function toJS(obj, doc) {
 								});
 								break;
 
-							case 'buildID':
+							case 'build-id':
 								blackberry[elem.tagName] = xml.getValue(elem);
 								break;	
 	

--- a/support/node_modules/titanium-sdk/lib/tiappxml.js
+++ b/support/node_modules/titanium-sdk/lib/tiappxml.js
@@ -66,7 +66,7 @@ function toXml(dom, parent, name, value) {
 				plNode.appendChild(dom.createTextNode('\r\n\t\t'));
 			}
 			break;
-		
+
 		case 'iphone':
 			value.orientations && Object.keys(value.orientations).forEach(function (o) {
 				dom.create('orientations', { device: o }, node, function (orientations) {
@@ -337,10 +337,13 @@ function toJS(obj, doc) {
 									permissions[xml.getValue(elem)] = true;
 								});
 								break;
+
+							case 'buildID':
+								blackberry[elem.tagName] = xml.getValue(elem);
+								break;	
 	
 							case 'orientation':
-								var orientation = blackberry.orientation = {};
-								orientation[elem.tagName] = xml.getValue(elem);
+								blackberry[elem.tagName] = xml.getValue(elem);
 								break;	
 						}	
 					});

--- a/support/node_modules/titanium-sdk/tests/resources/tiapp2.xml
+++ b/support/node_modules/titanium-sdk/tests/resources/tiapp2.xml
@@ -130,6 +130,20 @@
 			</type>
 		</types>
 	</iphone>
+	<blackberry>
+        <orientation>auto</orientation>
+        <buildID>1</buildID>
+        <permissions>
+            <permission>access_shared</permission>
+            <permission>record_audio</permission>
+            <permission>use_camera</permission>
+            <permission>access_internet</permission>
+            <permission>play_audio</permission>
+            <permission>post_notification</permission>          
+            <permission>set_audio_volume</permission>
+            <permission>read_device_identifying_information</permission>
+        </permissions>
+    </blackberry>
 	<android xmlns:android="http://schemas.android.com/apk/res/android">
 		<manifest>
 			<supports-screens android:anyDensity="false"/>

--- a/support/node_modules/titanium-sdk/tests/resources/tiapp2.xml
+++ b/support/node_modules/titanium-sdk/tests/resources/tiapp2.xml
@@ -131,19 +131,19 @@
 		</types>
 	</iphone>
 	<blackberry>
-        <orientation>auto</orientation>
-        <buildID>1</buildID>
-        <permissions>
-            <permission>access_shared</permission>
-            <permission>record_audio</permission>
-            <permission>use_camera</permission>
-            <permission>access_internet</permission>
-            <permission>play_audio</permission>
-            <permission>post_notification</permission>          
-            <permission>set_audio_volume</permission>
-            <permission>read_device_identifying_information</permission>
-        </permissions>
-    </blackberry>
+		<orientation>auto</orientation>
+		<build-id>1</build-id>
+		<permissions>
+			<permission>access_shared</permission>
+			<permission>record_audio</permission>
+			<permission>use_camera</permission>
+			<permission>access_internet</permission>
+			<permission>play_audio</permission>
+			<permission>post_notification</permission>          
+			<permission>set_audio_volume</permission>
+			<permission>read_device_identifying_information</permission>
+		</permissions>
+	</blackberry>
 	<android xmlns:android="http://schemas.android.com/apk/res/android">
 		<manifest>
 			<supports-screens android:anyDensity="false"/>


### PR DESCRIPTION
<blackberry>
        <orientation>auto</orientation>
        <buildID>auto</buildID>
...

Access was done using

 console.log(cli.tiapp.blackberry.orientation['orientation']);

Now done using

console.log(cli.tiapp.blackberry['orientation']);
console.log(cli.tiapp.blackberry['buildID']);
