### PR TITLE
add null check when clearing listItemData

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/ListSectionProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/ListSectionProxy.java
@@ -381,7 +381,9 @@ public class ListSectionProxy extends ViewProxy{
 		if (data instanceof Object[]) {
 			Object[] items = (Object[]) data;
 			itemProperties =  new ArrayList<Object>(Arrays.asList(items));
-			listItemData.clear();
+			if(listItemData){
+				listItemData.clear();
+			}
 			//only process items when listview's properties is processed.
 			if (getListView() == null) {
 				preload = true;


### PR DESCRIPTION
When creating listview and quickly press android back button will, sometimes, cause crash
