### PR TITLE
TIMOB-13443-3_1_X: Deprecate serviceRefCount methods.

### DIFF
--- a/android/runtime/common/src/java/org/appcelerator/kroll/KrollRuntime.java
+++ b/android/runtime/common/src/java/org/appcelerator/kroll/KrollRuntime.java
@@ -1,6 +1,6 @@
 /**
  * Appcelerator Titanium Mobile
- * Copyright (c) 2011-2012 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2011-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
@@ -380,6 +380,30 @@ public abstract class KrollRuntime implements Handler.Callback
 	public static int getServiceReceiverRefCount()
 	{
 		return serviceReceiverRefCount;
+	}
+
+	// For backwards compatibility
+	@Deprecated
+	public static void incrementServiceRefCount()
+	{
+		Log.w(TAG, "incrementServiceRefCount() is deprecated.  Please use incrementServiceReceiverRefCount() instead.",
+			Log.DEBUG_MODE);
+		incrementServiceReceiverRefCount();
+	}
+
+	@Deprecated
+	public static void decrementServiceRefCount()
+	{
+		Log.w(TAG, "decrementServiceRefCount() is deprecated.  Please use decrementServiceReceiverRefCount() instead.",
+			Log.DEBUG_MODE);
+		decrementServiceReceiverRefCount();
+	}
+
+	@Deprecated
+	public static int getServiceRefCount()
+	{
+		Log.w(TAG, "getServiceRefCount() is deprecated.  Please use getServiceReceiverRefCount() instead.", Log.DEBUG_MODE);
+		return getServiceReceiverRefCount();
 	}
 
 	private void internalDispose()

--- a/android/titanium/src/java/org/appcelerator/kroll/KrollProxy.java
+++ b/android/titanium/src/java/org/appcelerator/kroll/KrollProxy.java
@@ -1,6 +1,6 @@
 /**
  * Appcelerator Titanium Mobile
- * Copyright (c) 2009-2012 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2009-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */


### PR DESCRIPTION
Backport of https://github.com/appcelerator/titanium_mobile/pull/4125

https://jira.appcelerator.org/browse/TIMOB-13443
