### PR TITLE
TIMOB-12658: Android: TableView row labels disappear, related to className property

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiTableViewRowProxyItem.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiTableViewRowProxyItem.java
@@ -1,6 +1,6 @@
 /**
  * Appcelerator Titanium Mobile
- * Copyright (c) 2009-2012 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2009-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
@@ -347,24 +347,26 @@ public class TiTableViewRowProxyItem extends TiBaseTableViewItem
 		}
 
 		int adjustedWidth = w - leftImageWidth - rightImageWidth - imageHMargin;
-		//int adjustedWidth = w;
+		// int adjustedWidth = w;
 
 		if (content != null) {
-			
+
 			// If there is a child view, we don't set a minimum height for the row.
 			// Otherwise, we set a minimum height.
-			if (((TableViewRowProxy)item.proxy).hasControls()) {
+			if (((TableViewRowProxy) item.proxy).hasControls()) {
 				content.setMinimumHeight(0);
 			} else {
 				content.setMinimumHeight(48);
 			}
-			
+
 			measureChild(content, MeasureSpec.makeMeasureSpec(adjustedWidth, wMode), heightMeasureSpec);
-			if(hMode == MeasureSpec.UNSPECIFIED) {
-				TableViewProxy table = ((TableViewRowProxy)item.proxy).getTable();
+			if (hMode == MeasureSpec.UNSPECIFIED) {
+				TableViewProxy table = ((TableViewRowProxy) item.proxy).getTable();
 				int minRowHeight = -1;
 				if (table != null && table.hasProperty(TiC.PROPERTY_MIN_ROW_HEIGHT)) {
-					minRowHeight = TiConvert.toTiDimension(TiConvert.toString(table.getProperty(TiC.PROPERTY_MIN_ROW_HEIGHT)), TiDimension.TYPE_HEIGHT).getAsPixels(this);
+					minRowHeight = TiConvert.toTiDimension(
+						TiConvert.toString(table.getProperty(TiC.PROPERTY_MIN_ROW_HEIGHT)), TiDimension.TYPE_HEIGHT)
+						.getAsPixels(this);
 				}
 
 				if (height == null) {
@@ -373,13 +375,16 @@ public class TiTableViewRowProxyItem extends TiBaseTableViewItem
 				} else {
 					h = Math.max(minRowHeight, height.getAsPixels(this));
 				}
+				content.getLayoutParams().height = h;
+
 				if (Log.isDebugModeEnabled()) {
 					Log.d(TAG, "Row content measure (" + adjustedWidth + "x" + h + ")", Log.DEBUG_MODE);
 				}
-				measureChild(content, MeasureSpec.makeMeasureSpec(adjustedWidth, wMode), MeasureSpec.makeMeasureSpec(h, hMode));
+				measureChild(content, MeasureSpec.makeMeasureSpec(adjustedWidth, wMode),
+					MeasureSpec.makeMeasureSpec(h, hMode));
 			}
 		}
-		
+
 		setMeasuredDimension(w, Math.max(h, Math.max(leftImageHeight, rightImageHeight)));
 	}
 


### PR DESCRIPTION
https://jira.appcelerator.org/browse/TIMOB-12658

I had to manually set the height parameter in layout params.  Before it was MATCH_PARENT, and since the parent was MeasureSpec.UNSPECIFIED, it defaulted to 0 when it got passed into onMeasure for the children.

Test case in Jira.  Please also make sure to run KS.
