### PR TITLE
TIMOB-13220-3_1_X: Only allow wordwrap to exceed parent if wordwrap is disable...

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUILabel.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUILabel.java
@@ -28,7 +28,7 @@ import android.widget.TextView;
 public class TiUILabel extends TiUIView
 {
 	private static final String TAG = "TiUILabel";
-	
+
 	private int defaultColor;
 	private boolean wordWrap = true;
 
@@ -41,7 +41,8 @@ public class TiUILabel extends TiUIView
 			@Override
 			protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec)
 			{
-				if (!wordWrap) {
+				// Only allow label to exceed the size of parent when it's size behavior with wordwrap disabled
+				if (!wordWrap && layoutParams.optionWidth == null && !layoutParams.autoFillsWidth) {
 					widthMeasureSpec = MeasureSpec.makeMeasureSpec(MeasureSpec.getSize(widthMeasureSpec),
 						MeasureSpec.UNSPECIFIED);
 					heightMeasureSpec = MeasureSpec.makeMeasureSpec(MeasureSpec.getSize(heightMeasureSpec),


### PR DESCRIPTION
...d, and width is size behavior.

https://jira.appcelerator.org/browse/TIMOB-13220

This is backport of https://github.com/appcelerator/titanium_mobile/pull/4159
