### PR TITLE
Timob 13561: Android: Move Ti.Android.Calendar to Ti.Calendar and deprecate Ti.Android.Calendar

### DIFF
--- a/android/dependency.json
+++ b/android/dependency.json
@@ -6,7 +6,7 @@
 		"analytics":[],
 		"android":[],
 		"app":[],
-		"calendar":["android"],
+		"calendar":[],
 		"contacts":[],
 		"database":[],
 		"filesystem":[],

--- a/android/modules/android/src/java/ti/modules/titanium/android/calendar/AlarmReceiver.java
+++ b/android/modules/android/src/java/ti/modules/titanium/android/calendar/AlarmReceiver.java
@@ -1,0 +1,37 @@
+/**
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2011-2013 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+
+package ti.modules.titanium.android.calendar;
+
+import android.app.Notification;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+
+@Deprecated
+public class AlarmReceiver extends BroadcastReceiver
+{
+	@Override
+	public void onReceive(Context context, Intent intent)
+	{
+	    NotificationManager manger = (NotificationManager) context
+	            .getSystemService(context.NOTIFICATION_SERVICE);
+
+		Intent mainIntent = new Intent("ti.intent.action.calendar.ALARM");
+
+	    Notification notification = new Notification(0x7f020000,
+	            "", System.currentTimeMillis());
+	    PendingIntent contentIntent = PendingIntent.getActivity(context, 0,
+	            mainIntent, 0);
+	//TEST
+		notification.setLatestEventInfo(context,"Payment Reminder","Send me to jhaynie@appcelerator.com",contentIntent);
+	    manger.notify(1, notification);
+	}
+}
+

--- a/android/modules/android/src/java/ti/modules/titanium/android/calendar/AlertProxy.java
+++ b/android/modules/android/src/java/ti/modules/titanium/android/calendar/AlertProxy.java
@@ -1,3 +1,10 @@
+/**
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2011-2013 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+
 package ti.modules.titanium.android.calendar;
 
 import java.util.ArrayList;
@@ -18,13 +25,14 @@ import android.content.Intent;
 import android.database.Cursor;
 import android.net.Uri;
 
+@Deprecated
 @Kroll.proxy(parentModule=CalendarModule.class)
 public class AlertProxy extends KrollProxy {
 
 	public static final int STATE_SCHEDULED = 0;
 	public static final int STATE_FIRED = 1;
 	public static final int STATE_DISMISSED = 2;
-	
+
 	protected String id, eventId;
 	protected Date begin, end;
 	protected Date alarmTime;
@@ -39,7 +47,7 @@ public class AlertProxy extends KrollProxy {
 	{
 		this();
 	}
-	
+
 	public static String getAlertsUri() {
 		return CalendarProxy.getBaseCalendarUri() + "/calendar_alerts";
 	}
@@ -48,16 +56,15 @@ public class AlertProxy extends KrollProxy {
 		return CalendarProxy.getBaseCalendarUri() + "/calendar_alerts/by_instance";
 	}
 
-	public static ArrayList<AlertProxy> queryAlerts(String query, String queryArgs[], String orderBy) {
+	public static ArrayList<AlertProxy> queryAlerts(String query, String queryArgs[], String orderBy)
+	{
 		ArrayList<AlertProxy> alerts = new ArrayList<AlertProxy>();
 		ContentResolver contentResolver = TiApplication.getInstance().getContentResolver();
-		
-		Cursor cursor = contentResolver.query(Uri.parse(getAlertsUri()),
-			new String[] { "_id", "event_id", "begin", "end", "alarmTime", "state", "minutes"},
-			query, queryArgs, orderBy);
-		
-		if (cursor!=null)
-		{
+
+		Cursor cursor = contentResolver.query(Uri.parse(getAlertsUri()), new String[] { "_id", "event_id", "begin", "end",
+			"alarmTime", "state", "minutes" }, query, queryArgs, orderBy);
+
+		if (cursor != null) {
 			while (cursor.moveToNext()) {
 				AlertProxy alert = new AlertProxy();
 				alert.id = cursor.getString(0);
@@ -72,7 +79,7 @@ public class AlertProxy extends KrollProxy {
 
 			cursor.close();
 		}
-		
+
 		return alerts;
 	}
 
@@ -89,14 +96,15 @@ public class AlertProxy extends KrollProxy {
 		return AlertProxy.getAlertsForEvent(event);
 	}
 
-	public static AlertProxy createAlert(EventProxy event, int minutes) {
+	public static AlertProxy createAlert(EventProxy event, int minutes)
+	{
 		ContentResolver contentResolver = TiApplication.getInstance().getContentResolver();
 		ContentValues values = new ContentValues();
-		
+
 		Calendar alarmTime = Calendar.getInstance();
 		alarmTime.setTime(event.getBegin());
 		alarmTime.add(Calendar.MINUTE, -minutes);
-		
+
 		values.put("event_id", event.getId());
 		values.put("begin", event.getBegin().getTime());
 		values.put("end", event.getEnd().getTime());
@@ -106,10 +114,10 @@ public class AlertProxy extends KrollProxy {
 		values.put("creationTime", System.currentTimeMillis());
 		values.put("receivedTime", 0);
 		values.put("notifyTime", 0);
-		
+
 		Uri alertUri = contentResolver.insert(Uri.parse(getAlertsUri()), values);
 		String alertId = alertUri.getLastPathSegment();
-		
+
 		AlertProxy alert = new AlertProxy();
 		alert.id = alertId;
 		alert.begin = event.getBegin();
@@ -150,12 +158,12 @@ public class AlertProxy extends KrollProxy {
 	public String getId() {
 		return id;
 	}
-	
+
 	@Kroll.getProperty @Kroll.method
 	public String getEventId() {
 		return eventId;
 	}
-	
+
 	@Kroll.getProperty @Kroll.method
 	public Date getBegin() {
 		return begin;

--- a/android/modules/android/src/java/ti/modules/titanium/android/calendar/CalendarModule.java
+++ b/android/modules/android/src/java/ti/modules/titanium/android/calendar/CalendarModule.java
@@ -1,0 +1,102 @@
+/**
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2011-2013 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+
+package ti.modules.titanium.android.calendar;
+
+import java.util.ArrayList;
+
+import org.appcelerator.kroll.KrollModule;
+import org.appcelerator.kroll.annotations.Kroll;
+import org.appcelerator.titanium.TiContext;
+import org.appcelerator.kroll.common.Log;
+
+import android.os.Build;
+
+import ti.modules.titanium.android.AndroidModule;
+
+@Deprecated
+@Kroll.module(parentModule=AndroidModule.class)
+public class CalendarModule extends KrollModule
+{
+	private static final String TAG = "CalendarModule";
+
+	@Kroll.constant public static final int STATUS_TENTATIVE = EventProxy.STATUS_TENTATIVE;
+	@Kroll.constant public static final int STATUS_CONFIRMED = EventProxy.STATUS_CONFIRMED;
+	@Kroll.constant public static final int STATUS_CANCELED = EventProxy.STATUS_CANCELED;
+
+	@Kroll.constant public static final int VISIBILITY_DEFAULT = EventProxy.VISIBILITY_DEFAULT;
+	@Kroll.constant public static final int VISIBILITY_CONFIDENTIAL = EventProxy.VISIBILITY_CONFIDENTIAL;
+	@Kroll.constant public static final int VISIBILITY_PRIVATE = EventProxy.VISIBILITY_PRIVATE;
+	@Kroll.constant public static final int VISIBILITY_PUBLIC = EventProxy.VISIBILITY_PUBLIC;
+
+	@Kroll.constant public static final int METHOD_ALERT = ReminderProxy.METHOD_ALERT;
+	@Kroll.constant public static final int METHOD_DEFAULT = ReminderProxy.METHOD_DEFAULT;
+	@Kroll.constant public static final int METHOD_EMAIL = ReminderProxy.METHOD_EMAIL;
+	@Kroll.constant public static final int METHOD_SMS = ReminderProxy.METHOD_SMS;
+
+	@Kroll.constant public static final int STATE_DISMISSED = AlertProxy.STATE_DISMISSED;
+	@Kroll.constant public static final int STATE_FIRED = AlertProxy.STATE_FIRED;
+	@Kroll.constant public static final int STATE_SCHEDULED = AlertProxy.STATE_SCHEDULED;
+
+	public static final String EVENT_LOCATION = "eventLocation";
+
+	public CalendarModule()
+	{
+		super();
+		Log.w(TAG, "The Titanium.Android.Calendar module is deprecated. Use Titanium.Calendar instead.");
+	}
+
+	public CalendarModule(TiContext context)
+	{
+		this();
+	}
+
+	@Kroll.getProperty @Kroll.method
+	public CalendarProxy[] getAllCalendars() {
+		ArrayList<CalendarProxy> calendars = CalendarProxy.queryCalendars(null, null);
+		return calendars.toArray(new CalendarProxy[calendars.size()]);
+	}
+
+	@Kroll.getProperty @Kroll.method
+	public CalendarProxy[] getSelectableCalendars() {
+		ArrayList<CalendarProxy> calendars;
+		// selectable calendars are "visible"
+		if (Build.VERSION.SDK_INT >= 14) { // ICE_CREAM_SANDWICH, 4.0
+			calendars = CalendarProxy.queryCalendars(
+				"Calendars.visible = ?", new String[] {"1"});
+		}
+		// selectable calendars are "selected"
+		else if (Build.VERSION.SDK_INT >= 11) { // HONEYCOMB, 3.0
+			calendars = CalendarProxy.queryCalendars(
+				"Calendars.selected = ?", new String[] {"1"});
+		}
+		// selectable calendars are "selected" && !"hidden"
+		else {
+			calendars = CalendarProxy.queryCalendars(
+				"Calendars.selected = ? AND Calendars.hidden = ?", new String[] { "1", "0" });
+		}
+		return calendars.toArray(new CalendarProxy[calendars.size()]);
+	}
+
+	@Kroll.method
+	public CalendarProxy getCalendarById(int id) {
+		ArrayList<CalendarProxy> calendars = CalendarProxy.queryCalendars(
+			"Calendars._id = ?", new String[] { ""+id });
+
+		if (calendars.size() > 0) {
+			return calendars.get(0);
+		} else {
+			return null;
+		}
+	}
+
+	@Kroll.getProperty @Kroll.method
+	public AlertProxy[] getAllAlerts() {
+		ArrayList<AlertProxy> alerts = AlertProxy.queryAlerts(null, null, null);
+		return alerts.toArray(new AlertProxy[alerts.size()]);
+	}
+}

--- a/android/modules/android/src/java/ti/modules/titanium/android/calendar/CalendarProxy.java
+++ b/android/modules/android/src/java/ti/modules/titanium/android/calendar/CalendarProxy.java
@@ -1,0 +1,209 @@
+/**
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2011-2013 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+
+package ti.modules.titanium.android.calendar;
+
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Date;
+
+import org.appcelerator.kroll.KrollDict;
+import org.appcelerator.kroll.KrollProxy;
+import org.appcelerator.kroll.annotations.Kroll;
+import org.appcelerator.titanium.TiApplication;
+import org.appcelerator.titanium.TiContext;
+
+import android.content.ContentResolver;
+import android.database.Cursor;
+import android.net.Uri;
+import android.os.Build;
+import android.text.format.DateUtils;
+
+@Deprecated
+@Kroll.proxy(parentModule=CalendarModule.class)
+public class CalendarProxy extends KrollProxy {
+
+	protected String id, name;
+	protected boolean selected, hidden;
+	private static final long MAX_DATE_RANGE = 2 * DateUtils.YEAR_IN_MILLIS - 3 * DateUtils.DAY_IN_MILLIS;
+
+	public CalendarProxy(String id, String name, boolean selected, boolean hidden)
+	{
+		super();
+
+		this.id = id;
+		this.name = name;
+		this.selected = selected;
+		this.hidden = hidden;
+	}
+
+	public CalendarProxy(TiContext context, String id, String name, boolean selected, boolean hidden)
+	{
+		this(id, name, selected, hidden);
+	}
+
+	public static String getBaseCalendarUri()
+	{
+		if (Build.VERSION.SDK_INT >= 8) { // FROYO, 2.2
+			return "content://com.android.calendar";
+		}
+
+		return "content://calendar";
+	}
+
+	public static ArrayList<CalendarProxy> queryCalendars(String query, String[] queryArgs)
+	{
+		ArrayList<CalendarProxy> calendars = new ArrayList<CalendarProxy>();
+		ContentResolver contentResolver = TiApplication.getInstance().getContentResolver();
+
+		Cursor cursor = null;
+		if (Build.VERSION.SDK_INT >= 14) { // ICE_CREAM_SANDWICH, 4.0
+			cursor = contentResolver.query(Uri.parse(getBaseCalendarUri() + "/calendars"),
+				new String[] { "_id", "calendar_displayName", "visible"}, query, queryArgs, null);
+		}
+		else if (Build.VERSION.SDK_INT >= 11) { // HONEYCOMB, 3.0
+			cursor = contentResolver.query(Uri.parse(getBaseCalendarUri() + "/calendars"),
+				new String[] { "_id", "displayName", "selected"}, query, queryArgs, null);
+		}
+		else {
+			cursor = contentResolver.query(Uri.parse(getBaseCalendarUri() + "/calendars"),
+				new String[] { "_id", "displayName", "selected", "hidden" }, query, queryArgs, null);
+		}
+
+		// calendars can be null
+		if (cursor!=null)
+		{
+			while (cursor.moveToNext()) {
+				String id = cursor.getString(0);
+				String name = cursor.getString(1);
+				boolean selected = !cursor.getString(2).equals("0");
+				// For API level >= 11 (3.0), there is no column "hidden".
+				boolean hidden = false;
+				if (Build.VERSION.SDK_INT < 11) {
+					hidden = !cursor.getString(3).equals("0");
+				}
+
+				calendars.add(new CalendarProxy(id, name, selected, hidden));
+			}
+		}
+
+		return calendars;
+	}
+
+	public static ArrayList<CalendarProxy> queryCalendars(TiContext context, String query, String[] queryArgs)
+	{
+		return queryCalendars(query, queryArgs);
+	}
+
+	@Kroll.method
+	public EventProxy[] getEventsInYear(int year)
+	{
+		Calendar jan1 = Calendar.getInstance();
+		jan1.clear();
+		jan1.set(year, 0, 1);
+
+		long date1 = jan1.getTimeInMillis();
+		long date2 = date1 + DateUtils.YEAR_IN_MILLIS;
+		ArrayList<EventProxy> events = EventProxy.queryEventsBetweenDates(date1, date2, this);
+		return events.toArray(new EventProxy[events.size()]);
+	}
+
+	@Kroll.method
+	public EventProxy[] getEventsInMonth(int year, int month)
+	{
+		Calendar firstOfTheMonth = Calendar.getInstance();
+		firstOfTheMonth.clear();
+		firstOfTheMonth.set(year, month, 1);
+		Calendar lastOfTheMonth = Calendar.getInstance();
+		lastOfTheMonth.clear();
+		lastOfTheMonth.set(year, month, 1, 23, 59, 59);
+
+		int lastDay = lastOfTheMonth.getActualMaximum(Calendar.DAY_OF_MONTH);
+		lastOfTheMonth.set(Calendar.DAY_OF_MONTH, lastDay);
+
+		long date1 = firstOfTheMonth.getTimeInMillis();
+		long date2 = lastOfTheMonth.getTimeInMillis();
+
+		ArrayList<EventProxy> events = EventProxy.queryEventsBetweenDates(date1, date2, this);
+		return events.toArray(new EventProxy[events.size()]);
+	}
+
+	@Kroll.method
+	public EventProxy[] getEventsInDate(int year, int month, int day)
+	{
+		Calendar beginningOfDay = Calendar.getInstance();
+		beginningOfDay.clear();
+		beginningOfDay.set(year, month, day, 0, 0, 0);
+		Calendar endOfDay = Calendar.getInstance();
+		endOfDay.clear();
+		endOfDay.set(year, month, day, 23, 59, 59);
+
+		long date1 = beginningOfDay.getTimeInMillis();
+		long date2 = endOfDay.getTimeInMillis();
+
+		ArrayList<EventProxy> events = EventProxy.queryEventsBetweenDates(date1, date2, this);
+		return events.toArray(new EventProxy[events.size()]);
+	}
+
+	@Kroll.method
+	public EventProxy[] getEventsBetweenDates(Date date1, Date date2)
+	{
+		long start = date1.getTime();
+		long end = date2.getTime();
+		ArrayList<EventProxy> events = new ArrayList<EventProxy>();
+
+		// A workaround for TIMOB-8439
+		while (end - start > MAX_DATE_RANGE) {
+			events.addAll(EventProxy.queryEventsBetweenDates(start, start + MAX_DATE_RANGE, this));
+			start += MAX_DATE_RANGE;
+		}
+
+		events.addAll(EventProxy.queryEventsBetweenDates(start, end, this));
+
+		return events.toArray(new EventProxy[events.size()]);
+	}
+
+	@Kroll.method
+	public EventProxy getEventById(int id)
+	{
+		ArrayList<EventProxy> events = EventProxy.queryEvents("_id = ?", new String[] { ""+id });
+		if (events.size() > 0) {
+			return events.get(0);
+		} else return null;
+	}
+
+	@Kroll.method
+	public EventProxy createEvent(KrollDict data)
+	{
+		return EventProxy.createEvent(this, data);
+	}
+
+	@Kroll.getProperty @Kroll.method
+	public String getName()
+	{
+		return name;
+	}
+
+	@Kroll.getProperty @Kroll.method
+	public String getId()
+	{
+		return id;
+	}
+
+	@Kroll.getProperty @Kroll.method
+	public boolean getSelected()
+	{
+		return selected;
+	}
+
+	@Kroll.getProperty @Kroll.method
+	public boolean getHidden()
+	{
+		return hidden;
+	}
+}
+

--- a/android/modules/android/src/java/ti/modules/titanium/android/calendar/EventProxy.java
+++ b/android/modules/android/src/java/ti/modules/titanium/android/calendar/EventProxy.java
@@ -1,6 +1,6 @@
 /**
  * Appcelerator Titanium Mobile
- * Copyright (c) 2011-2012 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2011-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
@@ -28,25 +28,26 @@ import android.provider.CalendarContract.Events;
 import android.provider.CalendarContract.Instances;
 
 // Columns and value constants taken from android.provider.Calendar in the android source base
+@Deprecated
 @Kroll.proxy(parentModule=CalendarModule.class)
 public class EventProxy extends KrollProxy {
 	public static final String TAG = "TiEvent";
-	
+
 	public static final int STATUS_TENTATIVE = 0;
 	public static final int STATUS_CONFIRMED = 1;
 	public static final int STATUS_CANCELED = 2;
-	
+
 	public static final int VISIBILITY_DEFAULT = 0;
 	public static final int VISIBILITY_CONFIDENTIAL = 1;
 	public static final int VISIBILITY_PRIVATE = 2;
 	public static final int VISIBILITY_PUBLIC = 3;
-	
+
 	protected String id, title, description, location;
 	protected Date begin, end;
 	protected boolean allDay, hasAlarm = true, hasExtendedProperties = true;
 	protected int status, visibility;
 	protected KrollDict extendedProperties = new KrollDict();
-	
+
 	protected String recurrenceRule, recurrenceDate, recurrenceExceptionRule, recurrenceExceptionDate;
 	protected Date lastDate;
 
@@ -55,40 +56,46 @@ public class EventProxy extends KrollProxy {
 		super();
 	}
 
-	public EventProxy(TiContext context) {
+	public EventProxy(TiContext context)
+	{
 		this();
 	}
 
-	public static String getEventsUri() {
+	public static String getEventsUri()
+	{
 		return CalendarProxy.getBaseCalendarUri() + "/events";
 	}
-	
-	public static String getInstancesWhenUri() {
+
+	public static String getInstancesWhenUri()
+	{
 		return CalendarProxy.getBaseCalendarUri() + "/instances/when";
 	}
-	
-	public static String getExtendedPropertiesUri() {
+
+	public static String getExtendedPropertiesUri()
+	{
 		return CalendarProxy.getBaseCalendarUri() + "/extendedproperties";
 	}
 
-	public static ArrayList<EventProxy> queryEvents(String query, String[] queryArgs) {
+	public static ArrayList<EventProxy> queryEvents(String query, String[] queryArgs)
+	{
 		return queryEvents(Uri.parse(getEventsUri()), query, queryArgs, "dtstart ASC");
 	}
-	
+
 	public static ArrayList<EventProxy> queryEvents(TiContext context, String query, String[] queryArgs)
 	{
 		return queryEvents(query, queryArgs);
 	}
 
-	public static ArrayList<EventProxy> queryEventsBetweenDates(long date1, long date2, String query, String[] queryArgs) {
+	public static ArrayList<EventProxy> queryEventsBetweenDates(long date1, long date2, String query, String[] queryArgs)
+	{
 		ArrayList<EventProxy> events = new ArrayList<EventProxy>();
 		ContentResolver contentResolver = TiApplication.getInstance().getContentResolver();
-		
+
 		Uri.Builder builder = Uri.parse(getInstancesWhenUri()).buildUpon();
-		
+
 		ContentUris.appendId(builder, date1);
 		ContentUris.appendId(builder, date2);
-		
+
 		String visibility = "";
 		if (Build.VERSION.SDK_INT >= 14) {
 			visibility = Instances.ACCESS_LEVEL;
@@ -96,11 +103,11 @@ public class EventProxy extends KrollProxy {
 			visibility = "visibility";
 		}
 
-		Cursor eventCursor = contentResolver.query(builder.build(),
-			new String[] { "event_id", "title", "description", "eventLocation", "begin", "end", "allDay", "hasAlarm", "eventStatus", visibility},
-			query, queryArgs, "startDay ASC, startMinute ASC");
+		Cursor eventCursor = contentResolver.query(builder.build(), new String[] { "event_id", "title", "description",
+			"eventLocation", "begin", "end", "allDay", "hasAlarm", "eventStatus", visibility }, query, queryArgs,
+			"startDay ASC, startMinute ASC");
 
-		if(eventCursor == null) {
+		if (eventCursor == null) {
 			Log.w(TAG, "Unable to get any results when pulling events by date range");
 
 			return events;
@@ -118,36 +125,37 @@ public class EventProxy extends KrollProxy {
 			event.hasAlarm = !eventCursor.getString(7).equals("0");
 			event.status = eventCursor.getInt(8);
 			event.visibility = eventCursor.getInt(9);
-			
+
 			events.add(event);
 		}
-		
+
 		eventCursor.close();
-		
+
 		return events;
 	}
 
-	public static ArrayList<EventProxy> queryEventsBetweenDates(TiContext context, long date1, long date2, String query, String[] queryArgs)
+	public static ArrayList<EventProxy> queryEventsBetweenDates(TiContext context, long date1, long date2, String query,
+		String[] queryArgs)
 	{
 		return queryEventsBetweenDates(date1, date2, query, queryArgs);
 	}
-	
+
 	public static ArrayList<EventProxy> queryEvents(Uri uri, String query, String[] queryArgs, String orderBy)
 	{
 		ArrayList<EventProxy> events = new ArrayList<EventProxy>();
 		ContentResolver contentResolver = TiApplication.getInstance().getContentResolver();
-		
+
 		String visibility = "";
 		if (Build.VERSION.SDK_INT >= 14) {
 			visibility = Instances.ACCESS_LEVEL;
 		} else {
 			visibility = "visibility";
 		}
-		
-		Cursor eventCursor = contentResolver.query(uri,
-			new String[] { "_id", "title", "description", "eventLocation", "dtstart", "dtend", "allDay", "hasAlarm", "eventStatus", visibility, "hasExtendedProperties"},
-			query, queryArgs, orderBy);
-		
+
+		Cursor eventCursor = contentResolver.query(uri, new String[] { "_id", "title", "description", "eventLocation",
+			"dtstart", "dtend", "allDay", "hasAlarm", "eventStatus", visibility, "hasExtendedProperties" }, query,
+			queryArgs, orderBy);
+
 		while (eventCursor.moveToNext()) {
 			EventProxy event = new EventProxy();
 			event.id = eventCursor.getString(0);
@@ -161,36 +169,38 @@ public class EventProxy extends KrollProxy {
 			event.status = eventCursor.getInt(8);
 			event.visibility = eventCursor.getInt(9);
 			event.hasExtendedProperties = !eventCursor.getString(10).equals("0");
-			
+
 			events.add(event);
 		}
 		eventCursor.close();
 		return events;
 	}
 
-	public static ArrayList<EventProxy> queryEvents(TiContext context, Uri uri, String query, String[] queryArgs, String orderBy)
+	public static ArrayList<EventProxy> queryEvents(TiContext context, Uri uri, String query, String[] queryArgs,
+		String orderBy)
 	{
 		return queryEvents(uri, query, queryArgs, orderBy);
 	}
-	
-	public static EventProxy createEvent(CalendarProxy calendar, KrollDict data) {
+
+	public static EventProxy createEvent(CalendarProxy calendar, KrollDict data)
+	{
 		ContentResolver contentResolver = TiApplication.getInstance().getContentResolver();
 		EventProxy event = new EventProxy();
-		
+
 		ContentValues eventValues = new ContentValues();
 		eventValues.put("hasAlarm", 1);
 		eventValues.put("hasExtendedProperties", 1);
-		
+
 		if (!data.containsKey("title")) {
 			Log.e(TAG, "Title was not created, no title found for event");
 			return null;
 		}
-		
+
 		event.title = TiConvert.toString(data, "title");
 		eventValues.put("title", event.title);
 		eventValues.put("calendar_id", calendar.getId());
-		
-		//ICS requires eventTimeZone field when inserting new event
+
+		// ICS requires eventTimeZone field when inserting new event
 		if (Build.VERSION.SDK_INT >= 14) {
 			eventValues.put(Events.EVENT_TIMEZONE, new Date().toString());
 		}
@@ -205,13 +215,13 @@ public class EventProxy extends KrollProxy {
 		}
 		if (data.containsKey("begin")) {
 			event.begin = TiConvert.toDate(data, "begin");
-			if (event.begin !=  null) {
+			if (event.begin != null) {
 				eventValues.put("dtstart", event.begin.getTime());
 			}
 		}
 		if (data.containsKey("end")) {
 			event.end = TiConvert.toDate(data, "end");
-			if (event.end !=  null) {
+			if (event.end != null) {
 				eventValues.put("dtend", event.end.getTime());
 			}
 		}
@@ -219,23 +229,23 @@ public class EventProxy extends KrollProxy {
 			event.allDay = TiConvert.toBoolean(data, "allDay");
 			eventValues.put("allDay", event.allDay ? 1 : 0);
 		}
-		
+
 		if (data.containsKey("hasExtendedProperties")) {
 			event.hasExtendedProperties = TiConvert.toBoolean(data, "hasExtendedProperties");
 			eventValues.put("hasExtendedProperties", event.hasExtendedProperties ? 1 : 0);
 		}
-		
+
 		if (data.containsKey("hasAlarm")) {
 			event.hasAlarm = TiConvert.toBoolean(data, "hasAlarm");
 			eventValues.put("hasAlarm", event.hasAlarm ? 1 : 0);
 		}
-		
-		Uri eventUri = contentResolver.insert(Uri.parse(CalendarProxy.getBaseCalendarUri()+"/events"), eventValues);
+
+		Uri eventUri = contentResolver.insert(Uri.parse(CalendarProxy.getBaseCalendarUri() + "/events"), eventValues);
 		Log.d("TiEvents", "created event with uri: " + eventUri, Log.DEBUG_MODE);
-		
+
 		String eventId = eventUri.getLastPathSegment();
 		event.id = eventId;
-		
+
 		return event;
 	}
 
@@ -244,14 +254,12 @@ public class EventProxy extends KrollProxy {
 		return createEvent(calendar, data);
 	}
 
-	public static ArrayList<EventProxy> queryEventsBetweenDates(long date1, long date2, CalendarProxy calendar) {
-		if (Build.VERSION.SDK_INT >= 11)
-		{
+	public static ArrayList<EventProxy> queryEventsBetweenDates(long date1, long date2, CalendarProxy calendar)
+	{
+		if (Build.VERSION.SDK_INT >= 11) {
 			return queryEventsBetweenDates(date1, date2, null, null);
-		}
-		else
-		{
-			return queryEventsBetweenDates(date1, date2, "Calendars._id="+calendar.getId(), null);
+		} else {
+			return queryEventsBetweenDates(date1, date2, "Calendars._id=" + calendar.getId(), null);
 		}
 	}
 
@@ -265,52 +273,60 @@ public class EventProxy extends KrollProxy {
 		ArrayList<ReminderProxy> reminders = ReminderProxy.getRemindersForEvent(this);
 		return reminders.toArray(new ReminderProxy[reminders.size()]);
 	}
-	
+
 	@Kroll.method
-	public ReminderProxy createReminder(KrollDict data) {
+	public ReminderProxy createReminder(KrollDict data)
+	{
 		int minutes = TiConvert.toInt(data, "minutes");
 		int method = ReminderProxy.METHOD_DEFAULT;
 		if (data.containsKey("method")) {
 			method = TiConvert.toInt(data, "method");
 		}
-		
+
 		return ReminderProxy.createReminder(this, minutes, method);
 	}
-	
+
 	@Kroll.method @Kroll.getProperty
-	public AlertProxy[] getAlerts() {
+	public AlertProxy[] getAlerts()
+	{
 		ArrayList<AlertProxy> alerts = AlertProxy.getAlertsForEvent(this);
 		return alerts.toArray(new AlertProxy[alerts.size()]);
 	}
-	
+
 	@Kroll.method
-	public AlertProxy createAlert(KrollDict data) {
+	public AlertProxy createAlert(KrollDict data)
+	{
 		int minutes = TiConvert.toInt(data, "minutes");
 		return AlertProxy.createAlert(this, minutes);
 	}
-	
+
 	@Kroll.getProperty @Kroll.method
-	public String getId() {
+	public String getId()
+	{
 		return id;
 	}
 
 	@Kroll.getProperty @Kroll.method
-	public String getTitle() {
+	public String getTitle()
+	{
 		return title;
 	}
 
 	@Kroll.getProperty @Kroll.method
-	public String getDescription() {
+	public String getDescription()
+	{
 		return description;
 	}
 
 	@Kroll.getProperty @Kroll.method
-	public String getLocation() {
+	public String getLocation()
+	{
 		return location;
 	}
 
 	@Kroll.getProperty @Kroll.method
-	public Date getBegin() {
+	public Date getBegin()
+	{
 		return begin;
 	}
 
@@ -368,7 +384,7 @@ public class EventProxy extends KrollProxy {
 	public Date getLastDate() {
 		return lastDate;
 	}
-	
+
 	@Kroll.getProperty @Kroll.method
 	public KrollDict getExtendedProperties() {
 		KrollDict extendedProperties = new KrollDict();
@@ -385,52 +401,55 @@ public class EventProxy extends KrollProxy {
 		extPropsCursor.close();
 		return extendedProperties;
 	}
-	
+
 	@Kroll.method
-	public String getExtendedProperty(String name) {
+	public String getExtendedProperty(String name)
+	{
 		ContentResolver contentResolver = TiApplication.getInstance().getContentResolver();
-		Cursor extPropsCursor = contentResolver.query(
-			Uri.parse(getExtendedPropertiesUri()),
-			new String[] { "value" }, "event_id = ? and name = ?", new String[] { getId(), name }, null);
-		
+		Cursor extPropsCursor = contentResolver.query(Uri.parse(getExtendedPropertiesUri()), new String[] { "value" },
+			"event_id = ? and name = ?", new String[] { getId(), name }, null);
+
 		if (extPropsCursor != null && extPropsCursor.getCount() > 0) {
 			extPropsCursor.moveToNext();
 			String value = extPropsCursor.getString(0);
 			extPropsCursor.close();
 			return value;
 		}
-	
+
 		return null;
 	}
-	
+
 	@Kroll.method
-	public void setExtendedProperty(String name, String value) {
+	public void setExtendedProperty(String name, String value)
+	{
 		if (!hasExtendedProperties) {
 			hasExtendedProperties = true;
 		}
 		Log.d("TiEvent", "set extended property: " + name + " = " + value, Log.DEBUG_MODE);
-		
+
 		// we need to update the DB
 		ContentResolver contentResolver = TiApplication.getInstance().getContentResolver();
-		/*ContentValues eventValues = new ContentValues();
-		eventValues.put("hasExtendedProperties", hasExtendedProperties);
-		contentResolver.update(Uri.parse(getEventsUri()), eventValues, "_id = ?", new String[] { getId() });*/
-		
-		Uri extPropsUri = Uri.parse(getExtendedPropertiesUri()); 
-		Cursor results = contentResolver.query(
-			extPropsUri, new String[] { "name" }, "name = ? AND event_id = ?", new String[] { name, getId() }, null);
-		
-		ContentValues values =  new ContentValues();
+		/*
+		 * ContentValues eventValues = new ContentValues();
+		 * eventValues.put("hasExtendedProperties", hasExtendedProperties);
+		 * contentResolver.update(Uri.parse(getEventsUri()), eventValues, "_id = ?", new String[] { getId() });
+		 */
+
+		Uri extPropsUri = Uri.parse(getExtendedPropertiesUri());
+		Cursor results = contentResolver.query(extPropsUri, new String[] { "name" }, "name = ? AND event_id = ?",
+			new String[] { name, getId() }, null);
+
+		ContentValues values = new ContentValues();
 		values.put("name", name);
 		values.put("value", value);
 		int count = results.getCount();
 		results.close();
-		
+
 		if (count == 1) {
 			// android won't let us update, so we have to delete+insert
 			contentResolver.delete(extPropsUri, "name = ? and event_id = ?", new String[] { name, getId() });
 		}
-		
+
 		// insert the record
 		values.put("event_id", getId());
 		contentResolver.insert(extPropsUri, values);

--- a/android/modules/android/src/java/ti/modules/titanium/android/calendar/ReminderProxy.java
+++ b/android/modules/android/src/java/ti/modules/titanium/android/calendar/ReminderProxy.java
@@ -1,0 +1,118 @@
+/**
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2011-2013 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+package ti.modules.titanium.android.calendar;
+
+import java.util.ArrayList;
+
+import org.appcelerator.kroll.KrollProxy;
+import org.appcelerator.kroll.annotations.Kroll;
+import org.appcelerator.kroll.common.Log;
+import org.appcelerator.titanium.TiApplication;
+import org.appcelerator.titanium.TiContext;
+
+import android.content.ContentResolver;
+import android.content.ContentValues;
+import android.database.Cursor;
+import android.net.Uri;
+
+@Deprecated
+@Kroll.proxy(parentModule=CalendarModule.class)
+public class ReminderProxy extends KrollProxy {
+
+	public static final int METHOD_DEFAULT = 0;
+	public static final int METHOD_ALERT = 1;
+	public static final int METHOD_EMAIL = 2;
+	public static final int METHOD_SMS = 3;
+
+	protected String id;
+	protected int minutes, method;
+
+	public ReminderProxy()
+	{
+		super();
+	}
+
+	public ReminderProxy(TiContext context)
+	{
+		this();
+	}
+
+	public static String getRemindersUri()
+	{
+		return CalendarProxy.getBaseCalendarUri() + "/reminders";
+	}
+
+	public static ArrayList<ReminderProxy> getRemindersForEvent(EventProxy event)
+	{
+		ArrayList<ReminderProxy> reminders = new ArrayList<ReminderProxy>();
+		ContentResolver contentResolver = TiApplication.getInstance().getContentResolver();
+		Uri uri = Uri.parse(getRemindersUri());
+
+		Cursor reminderCursor = contentResolver.query(uri, new String[] { "_id", "minutes", "method" }, "event_id = ?",
+			new String[] { event.getId() }, null);
+
+		while (reminderCursor.moveToNext()) {
+			ReminderProxy reminder = new ReminderProxy();
+			reminder.id = reminderCursor.getString(0);
+			reminder.minutes = reminderCursor.getInt(1);
+			reminder.method = reminderCursor.getInt(2);
+
+			reminders.add(reminder);
+		}
+
+		reminderCursor.close();
+
+		return reminders;
+	}
+
+	public static ArrayList<ReminderProxy> getRemindersForEvent(TiContext context, EventProxy event)
+	{
+		return getRemindersForEvent(event);
+	}
+
+	public static ReminderProxy createReminder(EventProxy event, int minutes, int method)
+	{
+		ContentResolver contentResolver = TiApplication.getInstance().getContentResolver();
+		ContentValues eventValues = new ContentValues();
+
+		eventValues.put("minutes", minutes);
+		eventValues.put("method", method);
+		eventValues.put("event_id", event.getId());
+
+		Uri reminderUri = contentResolver.insert(Uri.parse(getRemindersUri()), eventValues);
+		Log.d("TiEvents", "created reminder with uri: " + reminderUri + ", minutes: " + minutes + ", method: " + method
+			+ ", event_id: " + event.getId(), Log.DEBUG_MODE);
+
+		String eventId = reminderUri.getLastPathSegment();
+		ReminderProxy reminder = new ReminderProxy();
+		reminder.id = eventId;
+		reminder.minutes = minutes;
+		reminder.method = method;
+
+		return reminder;
+	}
+
+	public static ReminderProxy createReminder(TiContext context, EventProxy event, int minutes, int method)
+	{
+		return createReminder(event, minutes, method);
+	}
+
+	@Kroll.getProperty @Kroll.method
+	public String getId() {
+		return id;
+	}
+
+	@Kroll.getProperty @Kroll.method
+	public int getMinutes() {
+		return minutes;
+	}
+
+	@Kroll.getProperty @Kroll.method
+	public int getMethod() {
+		return method;
+	}
+}

--- a/android/modules/calendar/project.properties
+++ b/android/modules/calendar/project.properties
@@ -11,5 +11,4 @@ android.library=true
 # Project target.
 target=Google Inc.:Google APIs:14
 android.library.reference.1=../../runtime/common
-android.library.reference.2=../android
-android.library.reference.3=../../titanium
+android.library.reference.2=../../titanium

--- a/android/modules/calendar/src/java/ti/modules/titanium/calendar/AlarmReceiver.java
+++ b/android/modules/calendar/src/java/ti/modules/titanium/calendar/AlarmReceiver.java
@@ -1,4 +1,11 @@
-package ti.modules.titanium.android.calendar;
+/**
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2011-2013 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+
+package ti.modules.titanium.calendar;
 
 import android.app.Notification;
 import android.app.NotificationManager;
@@ -7,10 +14,10 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 
-public class AlarmReceiver extends BroadcastReceiver 
+public class AlarmReceiver extends BroadcastReceiver
 {
 	@Override
-	public void onReceive(Context context, Intent intent) 
+	public void onReceive(Context context, Intent intent)
 	{
 	    NotificationManager manger = (NotificationManager) context
 	            .getSystemService(context.NOTIFICATION_SERVICE);
@@ -24,6 +31,6 @@ public class AlarmReceiver extends BroadcastReceiver
 	//TEST
 		notification.setLatestEventInfo(context,"Payment Reminder","Send me to jhaynie@appcelerator.com",contentIntent);
 	    manger.notify(1, notification);
-	}           
+	}
 }
 

--- a/android/modules/calendar/src/java/ti/modules/titanium/calendar/AlertProxy.java
+++ b/android/modules/calendar/src/java/ti/modules/titanium/calendar/AlertProxy.java
@@ -1,0 +1,204 @@
+/**
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2011-2013 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+
+package ti.modules.titanium.calendar;
+
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Date;
+
+import org.appcelerator.kroll.KrollProxy;
+import org.appcelerator.kroll.annotations.Kroll;
+import org.appcelerator.titanium.TiApplication;
+import org.appcelerator.titanium.TiContext;
+
+import android.app.AlarmManager;
+import android.app.PendingIntent;
+import android.content.ContentResolver;
+import android.content.ContentValues;
+import android.content.Context;
+import android.content.Intent;
+import android.database.Cursor;
+import android.net.Uri;
+
+@Kroll.proxy(parentModule=CalendarModule.class)
+public class AlertProxy extends KrollProxy
+{
+
+	public static final int STATE_SCHEDULED = 0;
+	public static final int STATE_FIRED = 1;
+	public static final int STATE_DISMISSED = 2;
+
+	protected String id, eventId;
+	protected Date begin, end;
+	protected Date alarmTime;
+	protected int state, minutes;
+
+	public AlertProxy()
+	{
+		super();
+	}
+
+	public AlertProxy(TiContext context)
+	{
+		this();
+	}
+
+	public static String getAlertsUri()
+	{
+		return CalendarProxy.getBaseCalendarUri() + "/calendar_alerts";
+	}
+
+	public static String getAlertsInstanceUri()
+	{
+		return CalendarProxy.getBaseCalendarUri() + "/calendar_alerts/by_instance";
+	}
+
+	public static ArrayList<AlertProxy> queryAlerts(String query, String queryArgs[], String orderBy)
+	{
+		ArrayList<AlertProxy> alerts = new ArrayList<AlertProxy>();
+		ContentResolver contentResolver = TiApplication.getInstance().getContentResolver();
+
+		Cursor cursor = contentResolver.query(Uri.parse(getAlertsUri()), new String[] { "_id", "event_id", "begin", "end",
+			"alarmTime", "state", "minutes" }, query, queryArgs, orderBy);
+
+		if (cursor != null) {
+			while (cursor.moveToNext()) {
+				AlertProxy alert = new AlertProxy();
+				alert.id = cursor.getString(0);
+				alert.eventId = cursor.getString(1);
+				alert.begin = new Date(cursor.getLong(2));
+				alert.end = new Date(cursor.getLong(3));
+				alert.alarmTime = new Date(cursor.getLong(4));
+				alert.state = cursor.getInt(5);
+				alert.minutes = cursor.getInt(6);
+				alerts.add(alert);
+			}
+
+			cursor.close();
+		}
+
+		return alerts;
+	}
+
+	public static ArrayList<AlertProxy> queryAlerts(TiContext context, String query, String queryArgs[], String orderBy)
+	{
+		return AlertProxy.queryAlerts(query, queryArgs, orderBy);
+	}
+
+	public static ArrayList<AlertProxy> getAlertsForEvent(EventProxy event)
+	{
+		return queryAlerts("event_id = ?", new String[] { event.getId() }, "alarmTime ASC,begin ASC,title ASC");
+	}
+
+	public static ArrayList<AlertProxy> getAlertsForEvent(TiContext context, EventProxy event)
+	{
+		return AlertProxy.getAlertsForEvent(event);
+	}
+
+	public static AlertProxy createAlert(EventProxy event, int minutes)
+	{
+		ContentResolver contentResolver = TiApplication.getInstance().getContentResolver();
+		ContentValues values = new ContentValues();
+
+		Calendar alarmTime = Calendar.getInstance();
+		alarmTime.setTime(event.getBegin());
+		alarmTime.add(Calendar.MINUTE, -minutes);
+
+		values.put("event_id", event.getId());
+		values.put("begin", event.getBegin().getTime());
+		values.put("end", event.getEnd().getTime());
+		values.put("alarmTime", alarmTime.getTimeInMillis());
+		values.put("state", STATE_SCHEDULED);
+		values.put("minutes", minutes);
+		values.put("creationTime", System.currentTimeMillis());
+		values.put("receivedTime", 0);
+		values.put("notifyTime", 0);
+
+		Uri alertUri = contentResolver.insert(Uri.parse(getAlertsUri()), values);
+		String alertId = alertUri.getLastPathSegment();
+
+		AlertProxy alert = new AlertProxy();
+		alert.id = alertId;
+		alert.begin = event.getBegin();
+		alert.end = event.getEnd();
+		alert.alarmTime = alarmTime.getTime();
+		alert.state = STATE_SCHEDULED;
+		alert.minutes = minutes;
+		// FIXME this needs to be implemented alert.registerAlertIntent();
+		return alert;
+	}
+
+	public static AlertProxy createAlert(TiContext context, EventProxy event, int minutes)
+	{
+		return AlertProxy.createAlert(event, minutes);
+	}
+
+	protected static final String EVENT_REMINDER_ACTION = "android.intent.action.EVENT_REMINDER";
+
+	protected void registerAlertIntent(TiContext context)
+	{
+		// Uri uri = ContentUris.withAppendedId(Uri.parse(getAlertsUri()), Long.parseLong(id));
+		// Intent intent = new Intent(EVENT_REMINDER_ACTION);
+		Intent intent = new Intent(context.getActivity(), AlarmReceiver.class);
+		// intent.setAction("" + Math.random());
+		// intent.setData(uri);
+		// intent.putExtra("beginTime", begin.getTime());
+		// intent.putExtra("endTime", end.getTime());
+		PendingIntent sender = PendingIntent.getBroadcast(context.getActivity(), 0, intent,
+			PendingIntent.FLAG_CANCEL_CURRENT);
+		// PendingIntent sender = PendingIntent.getActivity(context.getActivity(), 0, intent,
+		// PendingIntent.FLAG_CANCEL_CURRENT);
+
+		AlarmManager manager = (AlarmManager) getTiContext().getActivity().getSystemService(Context.ALARM_SERVICE);
+
+		// manager.set(AlarmManager.RTC_WAKEUP, alarmTime.getTime()+2000, sender);
+		manager.set(AlarmManager.RTC_WAKEUP, System.currentTimeMillis(), sender);
+	}
+
+	@Kroll.getProperty @Kroll.method
+	public String getId()
+	{
+		return id;
+	}
+
+	@Kroll.getProperty @Kroll.method
+	public String getEventId()
+	{
+		return eventId;
+	}
+
+	@Kroll.getProperty @Kroll.method
+	public Date getBegin()
+	{
+		return begin;
+	}
+
+	@Kroll.getProperty @Kroll.method
+	public Date getEnd()
+	{
+		return end;
+	}
+
+	@Kroll.getProperty @Kroll.method
+	public Date getAlarmTime()
+	{
+		return alarmTime;
+	}
+
+	@Kroll.getProperty @Kroll.method
+	public int getState()
+	{
+		return state;
+	}
+
+	@Kroll.getProperty @Kroll.method
+	public int getMinutes()
+	{
+		return minutes;
+	}
+}

--- a/android/modules/calendar/src/java/ti/modules/titanium/calendar/CalendarModule.java
+++ b/android/modules/calendar/src/java/ti/modules/titanium/calendar/CalendarModule.java
@@ -1,4 +1,11 @@
-package ti.modules.titanium.android.calendar;
+/**
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2011-2013 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+
+package ti.modules.titanium.calendar;
 
 import java.util.ArrayList;
 
@@ -8,25 +15,23 @@ import org.appcelerator.titanium.TiContext;
 
 import android.os.Build;
 
-import ti.modules.titanium.android.AndroidModule;
-
-@Kroll.module(parentModule=AndroidModule.class)
+@Kroll.module
 public class CalendarModule extends KrollModule
 {
 	@Kroll.constant public static final int STATUS_TENTATIVE = EventProxy.STATUS_TENTATIVE;
 	@Kroll.constant public static final int STATUS_CONFIRMED = EventProxy.STATUS_CONFIRMED;
 	@Kroll.constant public static final int STATUS_CANCELED = EventProxy.STATUS_CANCELED;
-	
+
 	@Kroll.constant public static final int VISIBILITY_DEFAULT = EventProxy.VISIBILITY_DEFAULT;
 	@Kroll.constant public static final int VISIBILITY_CONFIDENTIAL = EventProxy.VISIBILITY_CONFIDENTIAL;
 	@Kroll.constant public static final int VISIBILITY_PRIVATE = EventProxy.VISIBILITY_PRIVATE;
 	@Kroll.constant public static final int VISIBILITY_PUBLIC = EventProxy.VISIBILITY_PUBLIC;
-	
+
 	@Kroll.constant public static final int METHOD_ALERT = ReminderProxy.METHOD_ALERT;
 	@Kroll.constant public static final int METHOD_DEFAULT = ReminderProxy.METHOD_DEFAULT;
 	@Kroll.constant public static final int METHOD_EMAIL = ReminderProxy.METHOD_EMAIL;
 	@Kroll.constant public static final int METHOD_SMS = ReminderProxy.METHOD_SMS;
-	
+
 	@Kroll.constant public static final int STATE_DISMISSED = AlertProxy.STATE_DISMISSED;
 	@Kroll.constant public static final int STATE_FIRED = AlertProxy.STATE_FIRED;
 	@Kroll.constant public static final int STATE_SCHEDULED = AlertProxy.STATE_SCHEDULED;
@@ -42,48 +47,49 @@ public class CalendarModule extends KrollModule
 	{
 		this();
 	}
-	
+
 	@Kroll.getProperty @Kroll.method
-	public CalendarProxy[] getAllCalendars() {
+	public CalendarProxy[] getAllCalendars()
+	{
 		ArrayList<CalendarProxy> calendars = CalendarProxy.queryCalendars(null, null);
 		return calendars.toArray(new CalendarProxy[calendars.size()]);
 	}
-	
+
 	@Kroll.getProperty @Kroll.method
-	public CalendarProxy[] getSelectableCalendars() {
+	public CalendarProxy[] getSelectableCalendars()
+	{
 		ArrayList<CalendarProxy> calendars;
 		// selectable calendars are "visible"
 		if (Build.VERSION.SDK_INT >= 14) { // ICE_CREAM_SANDWICH, 4.0
-			calendars = CalendarProxy.queryCalendars(
-				"Calendars.visible = ?", new String[] {"1"});
+			calendars = CalendarProxy.queryCalendars("Calendars.visible = ?", new String[] { "1" });
 		}
 		// selectable calendars are "selected"
 		else if (Build.VERSION.SDK_INT >= 11) { // HONEYCOMB, 3.0
-			calendars = CalendarProxy.queryCalendars(
-				"Calendars.selected = ?", new String[] {"1"});
+			calendars = CalendarProxy.queryCalendars("Calendars.selected = ?", new String[] { "1" });
 		}
 		// selectable calendars are "selected" && !"hidden"
 		else {
-			calendars = CalendarProxy.queryCalendars(
-				"Calendars.selected = ? AND Calendars.hidden = ?", new String[] { "1", "0" });
+			calendars = CalendarProxy.queryCalendars("Calendars.selected = ? AND Calendars.hidden = ?", new String[] { "1",
+				"0" });
 		}
 		return calendars.toArray(new CalendarProxy[calendars.size()]);
 	}
-	
+
 	@Kroll.method
-	public CalendarProxy getCalendarById(int id) {
-		ArrayList<CalendarProxy> calendars = CalendarProxy.queryCalendars(
-			"Calendars._id = ?", new String[] { ""+id });
-		
+	public CalendarProxy getCalendarById(int id)
+	{
+		ArrayList<CalendarProxy> calendars = CalendarProxy.queryCalendars("Calendars._id = ?", new String[] { "" + id });
+
 		if (calendars.size() > 0) {
 			return calendars.get(0);
 		} else {
 			return null;
 		}
 	}
-	
+
 	@Kroll.getProperty @Kroll.method
-	public AlertProxy[] getAllAlerts() {
+	public AlertProxy[] getAllAlerts()
+	{
 		ArrayList<AlertProxy> alerts = AlertProxy.queryAlerts(null, null, null);
 		return alerts.toArray(new AlertProxy[alerts.size()]);
 	}

--- a/android/modules/calendar/src/java/ti/modules/titanium/calendar/CalendarProxy.java
+++ b/android/modules/calendar/src/java/ti/modules/titanium/calendar/CalendarProxy.java
@@ -1,4 +1,11 @@
-package ti.modules.titanium.android.calendar;
+/**
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2011-2013 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+
+package ti.modules.titanium.calendar;
 
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -26,7 +33,7 @@ public class CalendarProxy extends KrollProxy {
 	public CalendarProxy(String id, String name, boolean selected, boolean hidden)
 	{
 		super();
-		
+
 		this.id = id;
 		this.name = name;
 		this.selected = selected;
@@ -43,7 +50,7 @@ public class CalendarProxy extends KrollProxy {
 		if (Build.VERSION.SDK_INT >= 8) { // FROYO, 2.2
 			return "content://com.android.calendar";
 		}
-		
+
 		return "content://calendar";
 	}
 
@@ -51,7 +58,7 @@ public class CalendarProxy extends KrollProxy {
 	{
 		ArrayList<CalendarProxy> calendars = new ArrayList<CalendarProxy>();
 		ContentResolver contentResolver = TiApplication.getInstance().getContentResolver();
-		
+
 		Cursor cursor = null;
 		if (Build.VERSION.SDK_INT >= 14) { // ICE_CREAM_SANDWICH, 4.0
 			cursor = contentResolver.query(Uri.parse(getBaseCalendarUri() + "/calendars"),
@@ -65,7 +72,7 @@ public class CalendarProxy extends KrollProxy {
 			cursor = contentResolver.query(Uri.parse(getBaseCalendarUri() + "/calendars"),
 				new String[] { "_id", "displayName", "selected", "hidden" }, query, queryArgs, null);
 		}
-		
+
 		// calendars can be null
 		if (cursor!=null)
 		{
@@ -82,7 +89,7 @@ public class CalendarProxy extends KrollProxy {
 				calendars.add(new CalendarProxy(id, name, selected, hidden));
 			}
 		}
-		
+
 		return calendars;
 	}
 
@@ -97,13 +104,13 @@ public class CalendarProxy extends KrollProxy {
 		Calendar jan1 = Calendar.getInstance();
 		jan1.clear();
 		jan1.set(year, 0, 1);
-		
+
 		long date1 = jan1.getTimeInMillis();
 		long date2 = date1 + DateUtils.YEAR_IN_MILLIS;
 		ArrayList<EventProxy> events = EventProxy.queryEventsBetweenDates(date1, date2, this);
 		return events.toArray(new EventProxy[events.size()]);
 	}
-	
+
 	@Kroll.method
 	public EventProxy[] getEventsInMonth(int year, int month)
 	{
@@ -113,17 +120,17 @@ public class CalendarProxy extends KrollProxy {
 		Calendar lastOfTheMonth = Calendar.getInstance();
 		lastOfTheMonth.clear();
 		lastOfTheMonth.set(year, month, 1, 23, 59, 59);
-		
+
 		int lastDay = lastOfTheMonth.getActualMaximum(Calendar.DAY_OF_MONTH);
 		lastOfTheMonth.set(Calendar.DAY_OF_MONTH, lastDay);
-		
+
 		long date1 = firstOfTheMonth.getTimeInMillis();
 		long date2 = lastOfTheMonth.getTimeInMillis();
-		
+
 		ArrayList<EventProxy> events = EventProxy.queryEventsBetweenDates(date1, date2, this);
 		return events.toArray(new EventProxy[events.size()]);
 	}
-	
+
 	@Kroll.method
 	public EventProxy[] getEventsInDate(int year, int month, int day)
 	{
@@ -133,14 +140,14 @@ public class CalendarProxy extends KrollProxy {
 		Calendar endOfDay = Calendar.getInstance();
 		endOfDay.clear();
 		endOfDay.set(year, month, day, 23, 59, 59);
-		
+
 		long date1 = beginningOfDay.getTimeInMillis();
 		long date2 = endOfDay.getTimeInMillis();
-		
+
 		ArrayList<EventProxy> events = EventProxy.queryEventsBetweenDates(date1, date2, this);
 		return events.toArray(new EventProxy[events.size()]);
 	}
-	
+
 	@Kroll.method
 	public EventProxy[] getEventsBetweenDates(Date date1, Date date2)
 	{
@@ -158,7 +165,7 @@ public class CalendarProxy extends KrollProxy {
 
 		return events.toArray(new EventProxy[events.size()]);
 	}
-	
+
 	@Kroll.method
 	public EventProxy getEventById(int id)
 	{
@@ -167,31 +174,31 @@ public class CalendarProxy extends KrollProxy {
 			return events.get(0);
 		} else return null;
 	}
-	
+
 	@Kroll.method
 	public EventProxy createEvent(KrollDict data)
 	{
 		return EventProxy.createEvent(this, data);
 	}
-	
+
 	@Kroll.getProperty @Kroll.method
 	public String getName()
 	{
 		return name;
 	}
-	
+
 	@Kroll.getProperty @Kroll.method
 	public String getId()
 	{
 		return id;
 	}
-	
+
 	@Kroll.getProperty @Kroll.method
 	public boolean getSelected()
 	{
 		return selected;
 	}
-	
+
 	@Kroll.getProperty @Kroll.method
 	public boolean getHidden()
 	{

--- a/android/modules/calendar/src/java/ti/modules/titanium/calendar/EventProxy.java
+++ b/android/modules/calendar/src/java/ti/modules/titanium/calendar/EventProxy.java
@@ -1,0 +1,468 @@
+/**
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2011-2013 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+package ti.modules.titanium.calendar;
+
+import java.util.ArrayList;
+import java.util.Date;
+
+import org.appcelerator.kroll.KrollDict;
+import org.appcelerator.kroll.KrollProxy;
+import org.appcelerator.kroll.annotations.Kroll;
+import org.appcelerator.kroll.common.Log;
+import org.appcelerator.titanium.TiApplication;
+import org.appcelerator.titanium.TiC;
+import org.appcelerator.titanium.TiContext;
+import org.appcelerator.titanium.util.TiConvert;
+
+import android.content.ContentResolver;
+import android.content.ContentUris;
+import android.content.ContentValues;
+import android.database.Cursor;
+import android.net.Uri;
+import android.os.Build;
+import android.provider.CalendarContract.Events;
+import android.provider.CalendarContract.Instances;
+
+// Columns and value constants taken from android.provider.Calendar in the android source base
+@Kroll.proxy(parentModule=CalendarModule.class)
+public class EventProxy extends KrollProxy {
+	public static final String TAG = "EventProxy";
+
+	public static final int STATUS_TENTATIVE = 0;
+	public static final int STATUS_CONFIRMED = 1;
+	public static final int STATUS_CANCELED = 2;
+
+	public static final int VISIBILITY_DEFAULT = 0;
+	public static final int VISIBILITY_CONFIDENTIAL = 1;
+	public static final int VISIBILITY_PRIVATE = 2;
+	public static final int VISIBILITY_PUBLIC = 3;
+
+	protected String id, title, description, location;
+	protected Date begin, end;
+	protected boolean allDay, hasAlarm = true, hasExtendedProperties = true;
+	protected int status, visibility;
+	protected KrollDict extendedProperties = new KrollDict();
+
+	protected String recurrenceRule, recurrenceDate, recurrenceExceptionRule, recurrenceExceptionDate;
+	protected Date lastDate;
+
+	public EventProxy()
+	{
+		super();
+	}
+
+	public EventProxy(TiContext context)
+	{
+		this();
+	}
+
+	public static String getEventsUri()
+	{
+		return CalendarProxy.getBaseCalendarUri() + "/events";
+	}
+
+	public static String getInstancesWhenUri()
+	{
+		return CalendarProxy.getBaseCalendarUri() + "/instances/when";
+	}
+
+	public static String getExtendedPropertiesUri()
+	{
+		return CalendarProxy.getBaseCalendarUri() + "/extendedproperties";
+	}
+
+	public static ArrayList<EventProxy> queryEvents(String query, String[] queryArgs)
+	{
+		return queryEvents(Uri.parse(getEventsUri()), query, queryArgs, "dtstart ASC");
+	}
+
+	public static ArrayList<EventProxy> queryEvents(TiContext context, String query, String[] queryArgs)
+	{
+		return queryEvents(query, queryArgs);
+	}
+
+	public static ArrayList<EventProxy> queryEventsBetweenDates(long date1, long date2, String query, String[] queryArgs)
+	{
+		ArrayList<EventProxy> events = new ArrayList<EventProxy>();
+		ContentResolver contentResolver = TiApplication.getInstance().getContentResolver();
+
+		Uri.Builder builder = Uri.parse(getInstancesWhenUri()).buildUpon();
+
+		ContentUris.appendId(builder, date1);
+		ContentUris.appendId(builder, date2);
+
+		String visibility = "";
+		if (Build.VERSION.SDK_INT >= 14) {
+			visibility = Instances.ACCESS_LEVEL;
+		} else {
+			visibility = "visibility";
+		}
+
+		Cursor eventCursor = contentResolver.query(builder.build(), new String[] { "event_id", "title", "description",
+			"eventLocation", "begin", "end", "allDay", "hasAlarm", "eventStatus", visibility }, query, queryArgs,
+			"startDay ASC, startMinute ASC");
+
+		if (eventCursor == null) {
+			Log.w(TAG, "Unable to get any results when pulling events by date range");
+
+			return events;
+		}
+
+		while (eventCursor.moveToNext()) {
+			EventProxy event = new EventProxy();
+			event.id = eventCursor.getString(0);
+			event.title = eventCursor.getString(1);
+			event.description = eventCursor.getString(2);
+			event.location = eventCursor.getString(3);
+			event.begin = new Date(eventCursor.getLong(4));
+			event.end = new Date(eventCursor.getLong(5));
+			event.allDay = !eventCursor.getString(6).equals("0");
+			event.hasAlarm = !eventCursor.getString(7).equals("0");
+			event.status = eventCursor.getInt(8);
+			event.visibility = eventCursor.getInt(9);
+
+			events.add(event);
+		}
+
+		eventCursor.close();
+
+		return events;
+	}
+
+	public static ArrayList<EventProxy> queryEventsBetweenDates(TiContext context, long date1, long date2, String query,
+		String[] queryArgs)
+	{
+		return queryEventsBetweenDates(date1, date2, query, queryArgs);
+	}
+
+	public static ArrayList<EventProxy> queryEvents(Uri uri, String query, String[] queryArgs, String orderBy)
+	{
+		ArrayList<EventProxy> events = new ArrayList<EventProxy>();
+		ContentResolver contentResolver = TiApplication.getInstance().getContentResolver();
+
+		String visibility = "";
+		if (Build.VERSION.SDK_INT >= 14) {
+			visibility = Instances.ACCESS_LEVEL;
+		} else {
+			visibility = "visibility";
+		}
+
+		Cursor eventCursor = contentResolver.query(uri, new String[] { "_id", "title", "description", "eventLocation",
+			"dtstart", "dtend", "allDay", "hasAlarm", "eventStatus", visibility, "hasExtendedProperties" }, query,
+			queryArgs, orderBy);
+
+		while (eventCursor.moveToNext()) {
+			EventProxy event = new EventProxy();
+			event.id = eventCursor.getString(0);
+			event.title = eventCursor.getString(1);
+			event.description = eventCursor.getString(2);
+			event.location = eventCursor.getString(3);
+			event.begin = new Date(eventCursor.getLong(4));
+			event.end = new Date(eventCursor.getLong(5));
+			event.allDay = !eventCursor.getString(6).equals("0");
+			event.hasAlarm = !eventCursor.getString(7).equals("0");
+			event.status = eventCursor.getInt(8);
+			event.visibility = eventCursor.getInt(9);
+			event.hasExtendedProperties = !eventCursor.getString(10).equals("0");
+
+			events.add(event);
+		}
+		eventCursor.close();
+		return events;
+	}
+
+	public static ArrayList<EventProxy> queryEvents(TiContext context, Uri uri, String query, String[] queryArgs,
+		String orderBy)
+	{
+		return queryEvents(uri, query, queryArgs, orderBy);
+	}
+
+	public static EventProxy createEvent(CalendarProxy calendar, KrollDict data)
+	{
+		ContentResolver contentResolver = TiApplication.getInstance().getContentResolver();
+		EventProxy event = new EventProxy();
+
+		ContentValues eventValues = new ContentValues();
+		eventValues.put("hasAlarm", 1);
+		eventValues.put("hasExtendedProperties", 1);
+
+		if (!data.containsKey("title")) {
+			Log.e(TAG, "Title was not created, no title found for event");
+			return null;
+		}
+
+		event.title = TiConvert.toString(data, "title");
+		eventValues.put("title", event.title);
+		eventValues.put("calendar_id", calendar.getId());
+
+		// ICS requires eventTimeZone field when inserting new event
+		if (Build.VERSION.SDK_INT >= 14) {
+			eventValues.put(Events.EVENT_TIMEZONE, new Date().toString());
+		}
+
+		if (data.containsKey(TiC.PROPERTY_LOCATION)) {
+			event.location = TiConvert.toString(data, TiC.PROPERTY_LOCATION);
+			eventValues.put(CalendarModule.EVENT_LOCATION, event.location);
+		}
+		if (data.containsKey("description")) {
+			event.description = TiConvert.toString(data, "description");
+			eventValues.put("description", event.description);
+		}
+		if (data.containsKey("begin")) {
+			event.begin = TiConvert.toDate(data, "begin");
+			if (event.begin != null) {
+				eventValues.put("dtstart", event.begin.getTime());
+			}
+		}
+		if (data.containsKey("end")) {
+			event.end = TiConvert.toDate(data, "end");
+			if (event.end != null) {
+				eventValues.put("dtend", event.end.getTime());
+			}
+		}
+		if (data.containsKey("allDay")) {
+			event.allDay = TiConvert.toBoolean(data, "allDay");
+			eventValues.put("allDay", event.allDay ? 1 : 0);
+		}
+
+		if (data.containsKey("hasExtendedProperties")) {
+			event.hasExtendedProperties = TiConvert.toBoolean(data, "hasExtendedProperties");
+			eventValues.put("hasExtendedProperties", event.hasExtendedProperties ? 1 : 0);
+		}
+
+		if (data.containsKey("hasAlarm")) {
+			event.hasAlarm = TiConvert.toBoolean(data, "hasAlarm");
+			eventValues.put("hasAlarm", event.hasAlarm ? 1 : 0);
+		}
+
+		Uri eventUri = contentResolver.insert(Uri.parse(CalendarProxy.getBaseCalendarUri() + "/events"), eventValues);
+		Log.d("TiEvents", "created event with uri: " + eventUri, Log.DEBUG_MODE);
+
+		String eventId = eventUri.getLastPathSegment();
+		event.id = eventId;
+
+		return event;
+	}
+
+	public static EventProxy createEvent(TiContext context, CalendarProxy calendar, KrollDict data)
+	{
+		return createEvent(calendar, data);
+	}
+
+	public static ArrayList<EventProxy> queryEventsBetweenDates(long date1, long date2, CalendarProxy calendar)
+	{
+		if (Build.VERSION.SDK_INT >= 11) {
+			return queryEventsBetweenDates(date1, date2, null, null);
+		} else {
+			return queryEventsBetweenDates(date1, date2, "Calendars._id=" + calendar.getId(), null);
+		}
+	}
+
+	public static ArrayList<EventProxy> queryEventsBetweenDates(TiContext context, long date1, long date2, CalendarProxy calendar)
+	{
+		return queryEventsBetweenDates(date1, date2, calendar);
+	}
+
+	@Kroll.method @Kroll.getProperty
+	public ReminderProxy[] getReminders()
+	{
+		ArrayList<ReminderProxy> reminders = ReminderProxy.getRemindersForEvent(this);
+		return reminders.toArray(new ReminderProxy[reminders.size()]);
+	}
+
+	@Kroll.method
+	public ReminderProxy createReminder(KrollDict data)
+	{
+		int minutes = TiConvert.toInt(data, "minutes");
+		int method = ReminderProxy.METHOD_DEFAULT;
+		if (data.containsKey("method")) {
+			method = TiConvert.toInt(data, "method");
+		}
+
+		return ReminderProxy.createReminder(this, minutes, method);
+	}
+
+	@Kroll.method @Kroll.getProperty
+	public AlertProxy[] getAlerts()
+	{
+		ArrayList<AlertProxy> alerts = AlertProxy.getAlertsForEvent(this);
+		return alerts.toArray(new AlertProxy[alerts.size()]);
+	}
+
+	@Kroll.method
+	public AlertProxy createAlert(KrollDict data)
+	{
+		int minutes = TiConvert.toInt(data, "minutes");
+		return AlertProxy.createAlert(this, minutes);
+	}
+
+	@Kroll.getProperty @Kroll.method
+	public String getId()
+	{
+		return id;
+	}
+
+	@Kroll.getProperty @Kroll.method
+	public String getTitle()
+	{
+		return title;
+	}
+
+	@Kroll.getProperty @Kroll.method
+	public String getDescription()
+	{
+		return description;
+	}
+
+	@Kroll.getProperty @Kroll.method
+	public String getLocation()
+	{
+		return location;
+	}
+
+	@Kroll.getProperty @Kroll.method
+	public Date getBegin()
+	{
+		return begin;
+	}
+
+	@Kroll.getProperty @Kroll.method
+	public Date getEnd()
+	{
+		return end;
+	}
+
+	@Kroll.getProperty @Kroll.method
+	public boolean getAllDay()
+	{
+		return allDay;
+	}
+
+	@Kroll.getProperty @Kroll.method
+	public boolean getHasAlarm()
+	{
+		return hasAlarm;
+	}
+
+	@Kroll.getProperty @Kroll.method
+	public boolean getHasExtendedProperties()
+	{
+		return hasExtendedProperties;
+	}
+
+	@Kroll.getProperty @Kroll.method
+	public int getStatus()
+	{
+		return status;
+	}
+
+	@Kroll.getProperty @Kroll.method
+	public int getVisibility()
+	{
+		return visibility;
+	}
+
+	@Kroll.getProperty @Kroll.method
+	public String getRecurrenceRule()
+	{
+		return recurrenceRule;
+	}
+
+	@Kroll.getProperty @Kroll.method
+	public String getRecurrenceDate()
+	{
+		return recurrenceDate;
+	}
+
+	@Kroll.getProperty @Kroll.method
+	public String getRecurrenceExceptionRule()
+	{
+		return recurrenceExceptionRule;
+	}
+
+	@Kroll.getProperty @Kroll.method
+	public String getRecurrenceExceptionDate()
+	{
+		return recurrenceExceptionDate;
+	}
+
+	@Kroll.getProperty @Kroll.method
+	public Date getLastDate()
+	{
+		return lastDate;
+	}
+
+	@Kroll.getProperty @Kroll.method
+	public KrollDict getExtendedProperties()
+	{
+		KrollDict extendedProperties = new KrollDict();
+		ContentResolver contentResolver = TiApplication.getInstance().getContentResolver();
+		Cursor extPropsCursor = contentResolver.query(Uri.parse(getExtendedPropertiesUri()),
+			new String[] { "name", "value" }, "event_id = ?", new String[] { getId() }, null);
+
+		while (extPropsCursor.moveToNext()) {
+			String name = extPropsCursor.getString(0);
+			String value = extPropsCursor.getString(1);
+			extendedProperties.put(name, value);
+		}
+		extPropsCursor.close();
+		return extendedProperties;
+	}
+
+	@Kroll.method
+	public String getExtendedProperty(String name)
+	{
+		ContentResolver contentResolver = TiApplication.getInstance().getContentResolver();
+		Cursor extPropsCursor = contentResolver.query(Uri.parse(getExtendedPropertiesUri()), new String[] { "value" },
+			"event_id = ? and name = ?", new String[] { getId(), name }, null);
+
+		if (extPropsCursor != null && extPropsCursor.getCount() > 0) {
+			extPropsCursor.moveToNext();
+			String value = extPropsCursor.getString(0);
+			extPropsCursor.close();
+			return value;
+		}
+
+		return null;
+	}
+
+	@Kroll.method
+	public void setExtendedProperty(String name, String value)
+	{
+		if (!hasExtendedProperties) {
+			hasExtendedProperties = true;
+		}
+		Log.d("TiEvent", "set extended property: " + name + " = " + value, Log.DEBUG_MODE);
+
+		// we need to update the DB
+		ContentResolver contentResolver = TiApplication.getInstance().getContentResolver();
+		/*
+		 * ContentValues eventValues = new ContentValues();
+		 * eventValues.put("hasExtendedProperties", hasExtendedProperties);
+		 * contentResolver.update(Uri.parse(getEventsUri()), eventValues, "_id = ?", new String[] { getId() });
+		 */
+
+		Uri extPropsUri = Uri.parse(getExtendedPropertiesUri());
+		Cursor results = contentResolver.query(extPropsUri, new String[] { "name" }, "name = ? AND event_id = ?",
+			new String[] { name, getId() }, null);
+
+		ContentValues values = new ContentValues();
+		values.put("name", name);
+		values.put("value", value);
+		int count = results.getCount();
+		results.close();
+
+		if (count == 1) {
+			// android won't let us update, so we have to delete+insert
+			contentResolver.delete(extPropsUri, "name = ? and event_id = ?", new String[] { name, getId() });
+		}
+
+		// insert the record
+		values.put("event_id", getId());
+		contentResolver.insert(extPropsUri, values);
+	}
+}

--- a/android/modules/calendar/src/java/ti/modules/titanium/calendar/ReminderProxy.java
+++ b/android/modules/calendar/src/java/ti/modules/titanium/calendar/ReminderProxy.java
@@ -1,10 +1,10 @@
 /**
  * Appcelerator Titanium Mobile
- * Copyright (c) 2011-2012 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2011-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
-package ti.modules.titanium.android.calendar;
+package ti.modules.titanium.calendar;
 
 import java.util.ArrayList;
 
@@ -26,7 +26,7 @@ public class ReminderProxy extends KrollProxy {
 	public static final int METHOD_ALERT = 1;
 	public static final int METHOD_EMAIL = 2;
 	public static final int METHOD_SMS = 3;
-	
+
 	protected String id;
 	protected int minutes, method;
 
@@ -40,30 +40,31 @@ public class ReminderProxy extends KrollProxy {
 		this();
 	}
 
-	public static String getRemindersUri() {
+	public static String getRemindersUri()
+	{
 		return CalendarProxy.getBaseCalendarUri() + "/reminders";
 	}
-	
-	public static ArrayList<ReminderProxy> getRemindersForEvent(EventProxy event) {
+
+	public static ArrayList<ReminderProxy> getRemindersForEvent(EventProxy event)
+	{
 		ArrayList<ReminderProxy> reminders = new ArrayList<ReminderProxy>();
 		ContentResolver contentResolver = TiApplication.getInstance().getContentResolver();
 		Uri uri = Uri.parse(getRemindersUri());
-		 
-		Cursor reminderCursor = contentResolver.query(uri,
-			new String[] { "_id", "minutes", "method" },
-			"event_id = ?", new String[] { event.getId() }, null);
-		
+
+		Cursor reminderCursor = contentResolver.query(uri, new String[] { "_id", "minutes", "method" }, "event_id = ?",
+			new String[] { event.getId() }, null);
+
 		while (reminderCursor.moveToNext()) {
 			ReminderProxy reminder = new ReminderProxy();
 			reminder.id = reminderCursor.getString(0);
 			reminder.minutes = reminderCursor.getInt(1);
 			reminder.method = reminderCursor.getInt(2);
-			
+
 			reminders.add(reminder);
 		}
-		
+
 		reminderCursor.close();
-		
+
 		return reminders;
 	}
 
@@ -72,24 +73,25 @@ public class ReminderProxy extends KrollProxy {
 		return getRemindersForEvent(event);
 	}
 
-	public static ReminderProxy createReminder(EventProxy event, int minutes, int method) {
+	public static ReminderProxy createReminder(EventProxy event, int minutes, int method)
+	{
 		ContentResolver contentResolver = TiApplication.getInstance().getContentResolver();
 		ContentValues eventValues = new ContentValues();
-		
+
 		eventValues.put("minutes", minutes);
 		eventValues.put("method", method);
 		eventValues.put("event_id", event.getId());
-		
+
 		Uri reminderUri = contentResolver.insert(Uri.parse(getRemindersUri()), eventValues);
 		Log.d("TiEvents", "created reminder with uri: " + reminderUri + ", minutes: " + minutes + ", method: " + method
 			+ ", event_id: " + event.getId(), Log.DEBUG_MODE);
-		
+
 		String eventId = reminderUri.getLastPathSegment();
 		ReminderProxy reminder = new ReminderProxy();
 		reminder.id = eventId;
 		reminder.minutes = minutes;
 		reminder.method = method;
-		
+
 		return reminder;
 	}
 
@@ -99,17 +101,20 @@ public class ReminderProxy extends KrollProxy {
 	}
 
 	@Kroll.getProperty @Kroll.method
-	public String getId() {
+	public String getId()
+	{
 		return id;
 	}
-	
+
 	@Kroll.getProperty @Kroll.method
-	public int getMinutes() {
+	public int getMinutes()
+	{
 		return minutes;
 	}
-	
+
 	@Kroll.getProperty @Kroll.method
-	public int getMethod() {
+	public int getMethod()
+	{
 		return method;
 	}
 }

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/android/SearchViewProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/android/SearchViewProxy.java
@@ -1,11 +1,10 @@
 /**
  * Appcelerator Titanium Mobile
- * Copyright (c) 2009-2013 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
-package ti.modules.titanium.ui;
-
+package ti.modules.titanium.ui.android;
 
 import org.appcelerator.kroll.annotations.Kroll;
 import org.appcelerator.kroll.common.Log;
@@ -13,31 +12,30 @@ import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.proxy.TiViewProxy;
 import org.appcelerator.titanium.view.TiUIView;
 
-import ti.modules.titanium.ui.android.AndroidModule;
 import ti.modules.titanium.ui.widget.searchview.TiUISearchView;
 import android.app.Activity;
 import android.os.Build;
 
 @Kroll.proxy(creatableInModule = AndroidModule.class, propertyAccessors = {
 	TiC.PROPERTY_ICONIFIED, TiC.PROPERTY_ICONIFIED_BY_DEFAULT, TiC.PROPERTY_HINT_TEXT, TiC.PROPERTY_VALUE })
-public class SearchViewProxy extends TiViewProxy {
-
+public class SearchViewProxy extends TiViewProxy
+{
 	private static final String TAG = "SearchProxy";
 
-	public SearchViewProxy() {
+	public SearchViewProxy()
+	{
 		super();
 		defaultValues.put(TiC.PROPERTY_ICONIFIED_BY_DEFAULT, true);
 	}
 
 	@Override
-	public TiUIView createView(Activity activity) {
+	public TiUIView createView(Activity activity)
+	{
 		if (Build.VERSION.SDK_INT >= TiC.API_LEVEL_HONEYCOMB) {
 			return new TiUISearchView(this);
 		}
 
 		Log.e(TAG, "SearchView is only supported on target API 11+");
-		return null;	
+		return null;
 	}
-
-
 }

--- a/apidoc/Titanium/Android/Calendar/Alert.yml
+++ b/apidoc/Titanium/Android/Calendar/Alert.yml
@@ -5,6 +5,7 @@ extends: Titanium.Proxy
 since: "1.5"
 platforms: [android]
 createable: false
+deprecated: {since: "3.2.0"}
 
 properties:
   - name: alarmTime

--- a/apidoc/Titanium/Android/Calendar/Calendar.yml
+++ b/apidoc/Titanium/Android/Calendar/Calendar.yml
@@ -15,6 +15,7 @@ extends: Titanium.Module
 platforms: [android]
 since: "1.5"
 createable: false
+deprecated: {since: "3.2.0"}
 
 methods:
   - name: getCalendarById

--- a/apidoc/Titanium/Android/Calendar/CalendarProxy.yml
+++ b/apidoc/Titanium/Android/Calendar/CalendarProxy.yml
@@ -5,6 +5,7 @@ extends: Titanium.Proxy
 platforms: [android]
 since: "1.5"
 createable: false
+deprecated: {since: "3.2.0"}
 
 methods:
   - name: createEvent

--- a/apidoc/Titanium/Android/Calendar/Event.yml
+++ b/apidoc/Titanium/Android/Calendar/Event.yml
@@ -11,6 +11,7 @@ extends: Titanium.Proxy
 platforms: [android]
 since: "1.5"
 createable: false
+deprecated: {since: "3.2.0"}
 
 methods:
   - name: createAlert

--- a/apidoc/Titanium/Android/Calendar/Reminder.yml
+++ b/apidoc/Titanium/Android/Calendar/Reminder.yml
@@ -12,6 +12,7 @@ extends: Titanium.Proxy
 platforms: [android]
 since: "1.5"
 createable: false
+deprecated: {since: "3.2.0"}
 
 properties:
   - name: id

--- a/apidoc/Titanium/Calendar/Alert.yml
+++ b/apidoc/Titanium/Calendar/Alert.yml
@@ -2,8 +2,8 @@
 name: Titanium.Calendar.Alert
 summary: An object that represents a single alert for an event in an calendar.
 extends: Titanium.Proxy
-since: {iphone: "3.1.0", ipad: "3.1.0", android: "3.2.0"}
-platforms: [iphone, ipad, android]
+since: {android: "3.2.0", iphone: "3.1.0", ipad: "3.1.0"}
+platforms: [android, iphone, ipad]
 createable: false
 
 properties:

--- a/apidoc/Titanium/Calendar/Alert.yml
+++ b/apidoc/Titanium/Calendar/Alert.yml
@@ -2,8 +2,8 @@
 name: Titanium.Calendar.Alert
 summary: An object that represents a single alert for an event in an calendar.
 extends: Titanium.Proxy
-since: "3.1.0"
-platforms: [iphone, ipad]
+since: {iphone: "3.1.0", ipad: "3.1.0", android: "3.2.0"}
+platforms: [iphone, ipad, android]
 createable: false
 
 properties:
@@ -14,7 +14,7 @@ properties:
         the relative offset and becomes an absolute alarm.
     type: Date
     platforms: [iphone, ipad]
-    
+
   - name: relativeOffset
     summary: The offset from the start of an event, at which the alarm fires.
     description: |
@@ -23,3 +23,49 @@ properties:
     type: Number
     platforms: [iphone, ipad]
 
+  - name: alarmTime
+    summary: Date/time at which this alert alarm is set to trigger.
+    type: Date
+    permission: read-only
+    platforms: [android]
+
+  - name: begin
+    summary: Start date/time for the corresponding event.
+    type: Date
+    permission: read-only
+    platforms: [android]
+
+  - name: end
+    summary: End date/time for the corresponding event.
+    type: Date
+    permission: read-only
+    platforms: [android]
+
+  - name: eventId
+    summary: Identifier of the event for which this alert is set.
+    type: Number
+    permission: read-only
+
+  - name: id
+    summary: Identifier of this alert.
+    type: String
+    permission: read-only
+    platforms: [android]
+
+  - name: minutes
+    summary: |
+        Reminder notice period in minutes, that determines how long prior to the event this alert 
+        should trigger.
+    type: Number
+    permission: read-only
+    platforms: [android]
+
+  - name: state
+    summary: The current state of the alert.
+    description: |
+        One of [STATE_DISMISSED](Titanium.Calendar.STATE_DISMISSED),
+        [STATE_FIRED](Titanium.Calendar.STATE_FIRED),
+        or [STATE_SCHEDULED](Titanium.Calendar.STATE_SCHEDULED).
+    type: Number
+    permission: read-only
+    platforms: [android]

--- a/apidoc/Titanium/Calendar/Calendar.yml
+++ b/apidoc/Titanium/Calendar/Calendar.yml
@@ -56,7 +56,7 @@ properties:
   - name: METHOD_ALERT
     summary: Reminder alert delivery method.
     description: |
-        Used with <Titanium.Android.Calendar.Reminder>.
+        Used with <Titanium.Calendar.Reminder>.
 
         One of the group of reminder method constants,
         [METHOD_ALERT](Titanium.Calendar.METHOD_ALERT),

--- a/apidoc/Titanium/Calendar/Calendar.yml
+++ b/apidoc/Titanium/Calendar/Calendar.yml
@@ -11,8 +11,8 @@ description: |
     [tiapp.xml and timodule.xml Reference](http://docs.appcelerator.com/titanium/latest/#!/guide/tiapp.xml_and_timodule.xml_Reference).
 
 extends: Titanium.Module
-platforms: [iphone, ipad, android]
-since: {iphone: "3.1.0", ipad: "3.1.0", android: "3.2.0"}
+platforms: [android, iphone, ipad]
+since: {android: "3.2.0", iphone: "3.1.0", ipad: "3.1.0"}
 createable: false
 
 events:
@@ -38,7 +38,7 @@ methods:
       - name: id
         summary: Integer identifier of the calendar.
         type: Number
-    platforms: [iphone, ipad, android]
+    platforms: [android, iphone, ipad]
 
   - name: requestEventsAuthorization
     summary: If authorization is unknown, will bring up a dialog requesting permission.
@@ -173,7 +173,7 @@ properties:
         and [STATUS_TENTATIVE](Titanium.Calendar.STATUS_TENTATIVE).
     type: Number
     permission: read-only
-    platforms: [iphone, ipad, android]
+    platforms: [android, iphone, ipad]
 
   - name: STATUS_CONFIRMED
     summary:  Event confirmed status.
@@ -187,7 +187,7 @@ properties:
         and [STATUS_TENTATIVE](Titanium.Calendar.STATUS_TENTATIVE).
     type: Number
     permission: read-only
-    platforms: [iphone, ipad, android]
+    platforms: [android, iphone, ipad]
 
   - name: STATUS_TENTATIVE
     summary: Event tentative status.
@@ -201,7 +201,7 @@ properties:
         and [STATUS_TENTATIVE](Titanium.Calendar.STATUS_TENTATIVE).
     type: Number
     permission: read-only
-    platforms: [iphone, ipad]
+    platforms: [android, iphone, ipad]
 
   - name: AVAILABILITY_NOTSUPPORTED
     summary: Availability settings are not supported by the event's calendar.
@@ -459,7 +459,7 @@ properties:
     summary: All calendars known to the native calendar app.
     type: Array<Titanium.Calendar.Calendar>
     permission: read-only
-    platforms: [iphone, ipad, android]
+    platforms: [android, iphone, ipad]
 
   - name: allEditableCalendars
     summary: |

--- a/apidoc/Titanium/Calendar/Calendar.yml
+++ b/apidoc/Titanium/Calendar/Calendar.yml
@@ -4,11 +4,15 @@ summary: |
     The Calendar module provides an API for accessing the native calendar functionality.
 description: |
     This module supports retrieving information about existing events and creating new events. 
-    Modifying or deleting existing events and creating recurring events is also supported. 
+    Modifying or deleting existing events and creating recurring events are only supported on iOS.
+
+    Currently, on Android, calendar permissions must be explicitly configured in `tiapp.xml` in order to access the
+    calendar. See "Common Requirements" in
+    [tiapp.xml and timodule.xml Reference](http://docs.appcelerator.com/titanium/latest/#!/guide/tiapp.xml_and_timodule.xml_Reference).
 
 extends: Titanium.Module
-platforms: [iphone, ipad]
-since: "3.1.0"
+platforms: [iphone, ipad, android]
+since: {iphone: "3.1.0", ipad: "3.1.0", android: "3.2.0"}
 createable: false
 
 events:
@@ -34,7 +38,7 @@ methods:
       - name: id
         summary: Integer identifier of the calendar.
         type: Number
-    platforms: [iphone, ipad]
+    platforms: [iphone, ipad, android]
 
   - name: requestEventsAuthorization
     summary: If authorization is unknown, will bring up a dialog requesting permission.
@@ -46,84 +50,184 @@ methods:
       - name: callback
         summary: Callback function to execute when when authorization is no longer unknown.
         type: Callback<EventsAuthorizationResponse>
+    platforms: [iphone, ipad]
         
 properties:
+  - name: METHOD_ALERT
+    summary: Reminder alert delivery method.
+    description: |
+        Used with <Titanium.Android.Calendar.Reminder>.
+
+        One of the group of reminder method constants,
+        [METHOD_ALERT](Titanium.Calendar.METHOD_ALERT),
+        [METHOD_DEFAULT](Titanium.Calendar.METHOD_DEFAULT),
+        [METHOD_EMAIL](Titanium.Calendar.METHOD_EMAIL),
+        and [METHOD_SMS](Titanium.Calendar.METHOD_SMS).
+    type: Number
+    permission: read-only
+    platforms: [android]
+
+  - name: METHOD_DEFAULT
+    summary: Reminder default delivery method.
+    description: |
+        Used with <Titanium.Calendar.Reminder>.
+
+        One of the group of reminder method constants,
+        [METHOD_ALERT](Titanium.Calendar.METHOD_ALERT),
+        [METHOD_DEFAULT](Titanium.Calendar.METHOD_DEFAULT),
+        [METHOD_EMAIL](Titanium.Calendar.METHOD_EMAIL),
+        and [METHOD_SMS](Titanium.Calendar.METHOD_SMS).
+    type: Number
+    permission: read-only
+    platforms: [android]
+
+  - name: METHOD_EMAIL
+    summary: Reminder email delivery method.
+    description: |
+        Used with <Titanium.Calendar.Reminder>.
+
+        One of the group of reminder method constants,
+        [METHOD_ALERT](Titanium.Calendar.METHOD_ALERT), 
+        [METHOD_DEFAULT](Titanium.Calendar.METHOD_DEFAULT),
+        [METHOD_EMAIL](Titanium.Calendar.METHOD_EMAIL),
+        and [METHOD_SMS](Titanium.Calendar.METHOD_SMS).
+    type: Number
+    permission: read-only
+    platforms: [android]
+
+  - name: METHOD_SMS
+    summary: Reminder SMS delivery method.
+    description: |
+        Used with <Titanium.Calendar.Reminder>.
+
+        One of the group of reminder method constants,
+        [METHOD_ALERT](Titanium.Calendar.METHOD_ALERT),
+        [METHOD_DEFAULT](Titanium.Calendar.METHOD_DEFAULT),
+        [METHOD_EMAIL](Titanium.Calendar.METHOD_EMAIL),
+        and [METHOD_SMS](Titanium.Calendar.METHOD_SMS).
+    type: Number
+    permission: read-only
+    platforms: [android]
+
+  - name: STATE_DISMISSED
+    summary: Alert dismissed state.
+    description: |
+        Used with <Titanium.Calendar.Alert>.
+
+        One of the group of reminder method constants,
+        [STATE_DISMISSED](Titanium.Calendar.STATE_DISMISSED),
+        [STATE_FIRED](Titanium.Calendar.STATE_FIRED),
+        and [STATE_SCHEDULED](Titanium.Calendar.STATE_SCHEDULED).
+    type: Number
+    permission: read-only
+    platforms: [android]
+
+  - name: STATE_FIRED
+    summary: Alert fired state.
+    description: |
+        Used with <Titanium.Calendar.Alert>.
+
+        One of the group of reminder method constants,
+        [STATE_DISMISSED](Titanium.Calendar.STATE_DISMISSED),
+        [STATE_FIRED](Titanium.Calendar.STATE_FIRED),
+        and [STATE_SCHEDULED](Titanium.Calendar.STATE_SCHEDULED).
+    type: Number
+    permission: read-only
+    platforms: [android]
+
+  - name: STATE_SCHEDULED
+    summary: Alert scheduled status.
+    description: |
+        Used with <Titanium.Calendar.Alert>.
+
+        One of the group of reminder method constants,
+        [STATE_DISMISSED](Titanium.Calendar.STATE_DISMISSED),
+        [STATE_FIRED](Titanium.Calendar.STATE_FIRED),
+        and [STATE_SCHEDULED](Titanium.Calendar.STATE_SCHEDULED).
+    type: Number
+    permission: read-only
+    platforms: [android]
+
   - name: STATUS_NONE
     summary: Event has no status.
     description: |
         A [event status]<Titanium.Calendar.Event.status> value.
-        
-        One of the group of event "status" constants, 
-        [STATUS_CANCELED](Titanium.Calendar.STATUS_CANCELED), 
-        [STATUS_CONFIRMED](Titanium.Calendar.STATUS_CONFIRMED), 
+
+        One of the group of event "status" constants,
+        [STATUS_CANCELED](Titanium.Calendar.STATUS_CANCELED),
+        [STATUS_CONFIRMED](Titanium.Calendar.STATUS_CONFIRMED),
         and [STATUS_TENTATIVE](Titanium.Calendar.STATUS_TENTATIVE).
     type: Number
     permission: read-only
+    platforms: [iphone, ipad]
 
   - name: STATUS_CANCELED
     summary: Event canceled status.
     description: |
         A [event status]<Titanium.Calendar.Event.status> value.
-        
-        One of the group of event "status" constants, 
-        [STATUS_NONE](Titanium.Calendar.STATUS_NONE), 
-        [STATUS_CANCELED](Titanium.Calendar.STATUS_CANCELED), 
-        [STATUS_CONFIRMED](Titanium.Calendar.STATUS_CONFIRMED), 
+
+        One of the group of event "status" constants,
+        [STATUS_NONE](Titanium.Calendar.STATUS_NONE),
+        [STATUS_CANCELED](Titanium.Calendar.STATUS_CANCELED),
+        [STATUS_CONFIRMED](Titanium.Calendar.STATUS_CONFIRMED),
         and [STATUS_TENTATIVE](Titanium.Calendar.STATUS_TENTATIVE).
     type: Number
     permission: read-only
-    
+    platforms: [iphone, ipad, android]
+
   - name: STATUS_CONFIRMED
     summary:  Event confirmed status.
     description: |
         A [event status]<Titanium.Calendar.Event.status> value.
-        
-        One of the group of event "status" constants, 
+
+        One of the group of event "status" constants,
         [STATUS_NONE](Titanium.Calendar.STATUS_NONE),
-        [STATUS_CANCELED](Titanium.Calendar.STATUS_CANCELED), 
-        [STATUS_CONFIRMED](Titanium.Calendar.STATUS_CONFIRMED), 
+        [STATUS_CANCELED](Titanium.Calendar.STATUS_CANCELED),
+        [STATUS_CONFIRMED](Titanium.Calendar.STATUS_CONFIRMED),
         and [STATUS_TENTATIVE](Titanium.Calendar.STATUS_TENTATIVE).
     type: Number
     permission: read-only
-    
+    platforms: [iphone, ipad, android]
+
   - name: STATUS_TENTATIVE
     summary: Event tentative status.
     description: |
         A [event status]<Titanium.Calendar.Event.status> value.
-        
+
         One of the group of event "status" constants,
-        [STATUS_NONE](Titanium.Calendar.STATUS_NONE), 
-        [STATUS_CANCELED](Titanium.Calendar.STATUS_CANCELED), 
-        [STATUS_CONFIRMED](Titanium.Calendar.STATUS_CONFIRMED), 
+        [STATUS_NONE](Titanium.Calendar.STATUS_NONE),
+        [STATUS_CANCELED](Titanium.Calendar.STATUS_CANCELED),
+        [STATUS_CONFIRMED](Titanium.Calendar.STATUS_CONFIRMED),
         and [STATUS_TENTATIVE](Titanium.Calendar.STATUS_TENTATIVE).
     type: Number
     permission: read-only
+    platforms: [iphone, ipad]
 
   - name: AVAILABILITY_NOTSUPPORTED
     summary: Availability settings are not supported by the event's calendar.
     description: |
         A [event availability](Titanium.Calendar.Event.availability) value.
-        
-        One of the group of event method constants, 
-        [AVAILABILITY_NOTSUPPORTED](Titanium.Calendar.AVAILABILITY_NOTSUPPORTED), 
-        [AVAILABILITY_BUSY](Titanium.Calendar.AVAILABILITY_BUSY), 
-        [AVAILABILITY_FREE](Titanium.Calendar.AVAILABILITY_FREE), 
-        [AVAILABILITY_TENTATIVE](Titanium.Calendar.AVAILABILITY_TENTATIVE), 
+
+        One of the group of event method constants,
+        [AVAILABILITY_NOTSUPPORTED](Titanium.Calendar.AVAILABILITY_NOTSUPPORTED),
+        [AVAILABILITY_BUSY](Titanium.Calendar.AVAILABILITY_BUSY),
+        [AVAILABILITY_FREE](Titanium.Calendar.AVAILABILITY_FREE),
+        [AVAILABILITY_TENTATIVE](Titanium.Calendar.AVAILABILITY_TENTATIVE),
         and [AVAILABILITY_UNAVAILABLE](Titanium.Calendar.AVAILABILITY_UNAVAILABLE).
     type: Number
     permission: read-only
     platforms: [iphone, ipad]
-    
+
   - name: AVAILABILITY_BUSY
     summary: Event has a busy availability setting.
     description: |
         A [event availability](Titanium.Calendar.Event.availability) value.
-        
-        One of the group of event method constants, 
-        [AVAILABILITY_NOTSUPPORTED](Titanium.Calendar.AVAILABILITY_NOTSUPPORTED), 
-        [AVAILABILITY_BUSY](Titanium.Calendar.AVAILABILITY_BUSY), 
-        [AVAILABILITY_FREE](Titanium.Calendar.AVAILABILITY_FREE), 
-        [AVAILABILITY_TENTATIVE](Titanium.Calendar.AVAILABILITY_TENTATIVE), 
+
+        One of the group of event method constants,
+        [AVAILABILITY_NOTSUPPORTED](Titanium.Calendar.AVAILABILITY_NOTSUPPORTED),
+        [AVAILABILITY_BUSY](Titanium.Calendar.AVAILABILITY_BUSY),
+        [AVAILABILITY_FREE](Titanium.Calendar.AVAILABILITY_FREE),
+        [AVAILABILITY_TENTATIVE](Titanium.Calendar.AVAILABILITY_TENTATIVE),
         and [AVAILABILITY_UNAVAILABLE](Titanium.Calendar.AVAILABILITY_UNAVAILABLE).
     type: Number
     permission: read-only
@@ -133,12 +237,12 @@ properties:
     summary: Event has a free availability setting.
     description: |
         A [event availability](Titanium.Calendar.Event.availability) value.
-        
-        One of the group of event method constants, 
-        [AVAILABILITY_NOTSUPPORTED](Titanium.Calendar.AVAILABILITY_NOTSUPPORTED), 
-        [AVAILABILITY_BUSY](Titanium.Calendar.AVAILABILITY_BUSY), 
-        [AVAILABILITY_FREE](Titanium.Calendar.AVAILABILITY_FREE), 
-        [AVAILABILITY_TENTATIVE](Titanium.Calendar.AVAILABILITY_TENTATIVE), 
+
+        One of the group of event method constants,
+        [AVAILABILITY_NOTSUPPORTED](Titanium.Calendar.AVAILABILITY_NOTSUPPORTED),
+        [AVAILABILITY_BUSY](Titanium.Calendar.AVAILABILITY_BUSY),
+        [AVAILABILITY_FREE](Titanium.Calendar.AVAILABILITY_FREE),
+        [AVAILABILITY_TENTATIVE](Titanium.Calendar.AVAILABILITY_TENTATIVE),
         and [AVAILABILITY_UNAVAILABLE](Titanium.Calendar.AVAILABILITY_UNAVAILABLE).
     type: Number
     permission: read-only
@@ -148,12 +252,12 @@ properties:
     summary: Event has a tentative availability setting.
     description: |
         A [event availability](Titanium.Calendar.Event.availability) value.
-        
-        One of the group of event method constants, 
-        [AVAILABILITY_NOTSUPPORTED](Titanium.Calendar.AVAILABILITY_NOTSUPPORTED), 
-        [AVAILABILITY_BUSY](Titanium.Calendar.AVAILABILITY_BUSY), 
-        [AVAILABILITY_FREE](Titanium.Calendar.AVAILABILITY_FREE), 
-        [AVAILABILITY_TENTATIVE](Titanium.Calendar.AVAILABILITY_TENTATIVE), 
+
+        One of the group of event method constants,
+        [AVAILABILITY_NOTSUPPORTED](Titanium.Calendar.AVAILABILITY_NOTSUPPORTED),
+        [AVAILABILITY_BUSY](Titanium.Calendar.AVAILABILITY_BUSY),
+        [AVAILABILITY_FREE](Titanium.Calendar.AVAILABILITY_FREE),
+        [AVAILABILITY_TENTATIVE](Titanium.Calendar.AVAILABILITY_TENTATIVE),
         and [AVAILABILITY_UNAVAILABLE](Titanium.Calendar.AVAILABILITY_UNAVAILABLE).
     type: Number
     permission: read-only
@@ -163,12 +267,12 @@ properties:
     summary: Event has a tentative availability setting.
     description: |
         A [event availability](Titanium.Calendar.Event.availability) value.
-        
-        One of the group of event method constants, 
-        [AVAILABILITY_NOTSUPPORTED](Titanium.Calendar.AVAILABILITY_NOTSUPPORTED), 
-        [AVAILABILITY_BUSY](Titanium.Calendar.AVAILABILITY_BUSY), 
-        [AVAILABILITY_FREE](Titanium.Calendar.AVAILABILITY_FREE), 
-        [AVAILABILITY_TENTATIVE](Titanium.Calendar.AVAILABILITY_TENTATIVE), 
+
+        One of the group of event method constants,
+        [AVAILABILITY_NOTSUPPORTED](Titanium.Calendar.AVAILABILITY_NOTSUPPORTED),
+        [AVAILABILITY_BUSY](Titanium.Calendar.AVAILABILITY_BUSY),
+        [AVAILABILITY_FREE](Titanium.Calendar.AVAILABILITY_FREE),
+        [AVAILABILITY_TENTATIVE](Titanium.Calendar.AVAILABILITY_TENTATIVE),
         and [AVAILABILITY_UNAVAILABLE](Titanium.Calendar.AVAILABILITY_UNAVAILABLE).
     type: Number
     permission: read-only
@@ -237,6 +341,7 @@ properties:
         and [RECURRENCEFREQUENCY_YEARLY](Titanium.Calendar.RECURRENCEFREQUENCY_YEARLY).
     type: Number
     permission: read-only
+    platforms: [iphone, ipad]
 
   - name: RECURRENCEFREQUENCY_WEEKLY
     summary: Indicates a weekly recurrence rule for a events reccurance frequency.
@@ -250,6 +355,7 @@ properties:
         and [RECURRENCEFREQUENCY_YEARLY](Titanium.Calendar.RECURRENCEFREQUENCY_YEARLY).
     type: Number
     permission: read-only
+    platforms: [iphone, ipad]
 
   - name: RECURRENCEFREQUENCY_MONTHLY
     summary: Indicates a monthly recurrence rule for a events reccurance frequency.
@@ -263,6 +369,7 @@ properties:
         and [RECURRENCEFREQUENCY_YEARLY](Titanium.Calendar.RECURRENCEFREQUENCY_YEARLY).
     type: Number
     permission: read-only
+    platforms: [iphone, ipad]
 
   - name: RECURRENCEFREQUENCY_YEARLY
     summary: Indicates a yearly recurrence rule for a events reccurance frequency.
@@ -276,6 +383,63 @@ properties:
         and [RECURRENCEFREQUENCY_YEARLY](Titanium.Calendar.RECURRENCEFREQUENCY_YEARLY).
     type: Number
     permission: read-only
+    platforms: [iphone, ipad]
+
+  - name: VISIBILITY_CONFIDENTIAL
+    summary: Event confidential visibility.
+    description: |
+        Used with <Titanium.Calendar.Event>.
+
+        One of the group of reminder method constants,
+        [VISIBILITY_CONFIDENTIAL](Titanium.Calendar.VISIBILITY_CONFIDENTIAL),
+        [VISIBILITY_DEFAULT](Titanium.Calendar.VISIBILITY_DEFAULT),
+        [VISIBILITY_PRIVATE](Titanium.Calendar.VISIBILITY_PRIVATE),
+        and [VISIBILITY_PUBLIC](Titanium.Calendar.VISIBILITY_PUBLIC).
+    type: Number
+    permission: read-only
+    platforms: [android]
+
+  - name: VISIBILITY_DEFAULT
+    summary: Event default visibility.
+    description: |
+        Used with <Titanium.Calendar.Event>.
+
+        One of the group of reminder method constants,
+        [VISIBILITY_CONFIDENTIAL](Titanium.Calendar.VISIBILITY_CONFIDENTIAL),
+        [VISIBILITY_DEFAULT](Titanium.Calendar.VISIBILITY_DEFAULT),
+        [VISIBILITY_PRIVATE](Titanium.Calendar.VISIBILITY_PRIVATE),
+        and [VISIBILITY_PUBLIC](Titanium.Calendar.VISIBILITY_PUBLIC).
+    type: Number
+    permission: read-only
+    platforms: [android]
+
+  - name: VISIBILITY_PRIVATE
+    summary: Event private visibility.
+    description: |
+        Used with <Titanium.Calendar.Event>.
+
+        One of the group of reminder method constants,
+        [VISIBILITY_CONFIDENTIAL](Titanium.Calendar.VISIBILITY_CONFIDENTIAL),
+        [VISIBILITY_DEFAULT](Titanium.Calendar.VISIBILITY_DEFAULT),
+        [VISIBILITY_PRIVATE](Titanium.Calendar.VISIBILITY_PRIVATE),
+        and [VISIBILITY_PUBLIC](Titanium.Calendar.VISIBILITY_PUBLIC).
+    type: Number
+    permission: read-only
+    platforms: [android]
+
+  - name: VISIBILITY_PUBLIC
+    summary: Event public visibility.
+    description: |
+        Used with <Titanium.Calendar.Event>.
+
+        One of the group of reminder method constants, 
+        [VISIBILITY_CONFIDENTIAL](Titanium.Calendar.VISIBILITY_CONFIDENTIAL),
+        [VISIBILITY_DEFAULT](Titanium.Calendar.VISIBILITY_DEFAULT),
+        [VISIBILITY_PRIVATE](Titanium.Calendar.VISIBILITY_PRIVATE),
+        and [VISIBILITY_PUBLIC](Titanium.Calendar.VISIBILITY_PUBLIC).
+    type: Number
+    permission: read-only
+    platforms: [android]
 
   - name: eventsAuthorization
     summary: Returns an authorization constant indicating if the application has access to the events in the EventKit.
@@ -285,10 +449,17 @@ properties:
     permission: read-only
     platforms: [iphone, ipad]
 
+  - name: allAlerts
+    summary: All alerts in selected calendars.
+    type: Array<Titanium.Calendar.Alert>
+    permission: read-only
+    platforms: [android]
+
   - name: allCalendars
     summary: All calendars known to the native calendar app.
     type: Array<Titanium.Calendar.Calendar>
     permission: read-only
+    platforms: [iphone, ipad, android]
 
   - name: allEditableCalendars
     summary: |
@@ -296,15 +467,72 @@ properties:
         delete items in the calendar.
     type: Array<Titanium.Calendar.Calendar>
     permission: read-only
+    platforms: [iphone, ipad]
+
+  - name: selectableCalendars
+    summary: |
+        All calendars selected within the native calendar app, which may be a subset of `allCalendars`. 
+    description: |
+        The native calendar application may know via the registered webservices, such as Gooogle or 
+        Facebook accounts about calendars that it has access to but have not been selected to be 
+        displayed in the native calendar app.
+    type: Array<Titanium.Calendar.Calendar>
+    permission: read-only
+    platforms: [android]
 
   - name: defaultCalendar
     summary: |
         Calendar that events are added to by default, as specified by user settings.
     type: Titanium.Calendar.Calendar
     permission: read-only
+    platforms: [iphone, ipad]
 
 examples:
+  - title: All Calendars vs Selectable Calendars
+    example: |
+        Print the names of all calendars, and the names of calendars that 
+        have been selected in the native Android calendar application.
+
+            function showCalendars(calendars) {
+                for (var i = 0; i < calendars.length; i++) {
+                    Ti.API.info(calendars[i].name);
+                }
+            }
+
+            Ti.API.info('ALL CALENDARS:');
+            showCalendars(Ti.Calendar.allCalendars);
+            if (Ti.Platform.osname === 'android') {
+                Ti.API.info('SELECTABLE CALENDARS:');
+                showCalendars(Ti.Calendar.selectableCalendars);
+            }
+
+  - title: Create an Event and Reminder on Android
+    example: |
+        Creates an event and adds an e-mail reminder for 10 minutes before the event.
         
+            var CALENDAR_TO_USE = 3;
+            var calendar = Ti.Calendar.getCalendarById(CALENDAR_TO_USE);
+
+            // Create the event
+            var eventBegins = new Date(2010, 11, 26, 12, 0, 0);
+            var eventEnds = new Date(2010, 11, 26, 14, 0, 0);
+            var details = {
+                title: 'Do some stuff',
+                description: "I'm going to do some stuff at this time.",
+                begin: eventBegins,
+                end: eventEnds
+            };
+
+            var event = calendar.createEvent(details);
+
+            // Now add a reminder via e-mail for 10 minutes before the event.
+            var reminderDetails = {
+                minutes: 10,
+                method: Ti.Calendar.METHOD_EMAIL
+            };
+
+            event.createReminder(reminderDetails);
+
   - title: Events in a year
     example: |
         Create a picker to allow an existing calendar to be selected and, when a button is clicked, 
@@ -314,7 +542,7 @@ examples:
             var selectedCalendarName;
             var selectedid;
             var pickerData = [];
-            
+            var osname = Ti.Platform.osname;
             
             //**read events from calendar*******
             function performCalendarReadFunctions(){
@@ -388,8 +616,28 @@ examples:
                     Ti.API.info('Calendar was of type' + calendar);
                     Ti.API.info('calendar that we are going to fetch is :: '+ calendar.id + ' name:' + calendar.name);
                     
+                    function printReminder(r) {
+                    	if (osname === 'android') {
+                    		var typetext = '[method unknown]';
+                    		if (r.method == Ti.Calendar.METHOD_EMAIL) {
+                    			typetext = 'Email';
+                    		} else if (r.method == Ti.Calendar.METHOD_SMS) {
+                    			typetext = 'SMS';
+                    		} else if (r.method == Ti.Calendar.METHOD_ALERT) {
+                    			typetext = 'Alert';
+                    		} else if (r.method == Ti.Calendar.METHOD_DEFAULT) {
+                    			typetext = '[default reminder method]';
+                    		}
+                    		print(typetext + ' reminder to be sent ' + r.minutes + ' minutes before the event');
+                    	}
+                	}
+                    
                     function printAlert(a) {
-                      print('Alert id ' + a.id + ' begin ' + a.begin + '; end ' + a.end + '; alarmTime ' + a.alarmTime + '; minutes ' + a.minutes);
+                    	if (osname === 'android') {
+                      		print('Alert id ' + a.id + ' begin ' + a.begin + '; end ' + a.end + '; alarmTime ' + a.alarmTime + '; minutes ' + a.minutes);
+                    	} else if (osname === 'iphone' || osname === 'ipad') {
+                    		print('Alert absoluteDate ' + a.absoluteDate + ' relativeOffset ' + a.relativeOffset);
+                    	}
                     }
                     
                     function printEvent(event) {
@@ -399,6 +647,13 @@ examples:
                         print('Event: ' + event.title + '; ' + event.begin + ' ' + event.begin+ '-' + event.end);
                       }
                       
+                      var reminders = event.reminders;
+                      if (reminders && reminders.length) {
+                      	print('There is/are ' + reminders.length + ' reminder(s)');
+                      	for (var i = 0; i < reminders.length; i++) {
+                      		printReminder(reminders[i]);
+                      	}
+                      }
                       print('hasAlarm? ' + event.hasAlarm);
                       var alerts = event.alerts;
                       if (alerts && alerts.length) {
@@ -447,23 +702,25 @@ examples:
               title: 'Calendar Demo'
             });
             
-            if(Ti.Calendar.eventsAuthorization == Ti.Calendar.AUTHORIZATION_AUTHORIZED) {
-                performCalendarReadFunctions();
-            } else {
-                Ti.Calendar.requestEventsAuthorization(function(e){
-                    if (e.success) {
-                        performCalendarReadFunctions();
-                    } else {
-                        alert('Access to calendar is not allowed');
-                    }
-                });
-            
+            if (osname === 'android') {
+            	performCalendarReadFunctions();
+            } else if (osname === 'iphone' || osname === 'ipad') {
+            	if (Ti.Calendar.eventsAuthorization == Ti.Calendar.AUTHORIZATION_AUTHORIZED) {
+                	performCalendarReadFunctions();
+            	} else {
+                	Ti.Calendar.requestEventsAuthorization(function(e){
+                    	if (e.success) {
+                        	performCalendarReadFunctions();
+                    	} else {
+                        	alert('Access to calendar is not allowed');
+                    	}
+                	});
+            	}
             }
-            
             
             win.open();
 
-  - title: Create a Recurring Event with Alerts 
+  - title: Create a Recurring Event with Alerts on iOS
     example: |
         Create a recurring event with alerts.
         

--- a/apidoc/Titanium/Calendar/CalendarProxy.yml
+++ b/apidoc/Titanium/Calendar/CalendarProxy.yml
@@ -2,8 +2,8 @@
 name: Titanium.Calendar.Calendar
 summary: An object that represents a single calendar.
 extends: Titanium.Proxy
-platforms: [iphone, ipad, android]
-since: {iphone: "3.1.0", ipad: "3.1.0", android: "3.2.0"}
+platforms: [android, iphone, ipad]
+since: {android: "3.2.0", iphone: "3.1.0", ipad: "3.1.0"}
 createable: false
 
 methods:
@@ -15,7 +15,7 @@ methods:
       - name: properties
         summary: Properties of the event
         type: Dictionary<Titanium.Calendar.Event>
-    platforms: [iphone, ipad, android]
+    platforms: [android, iphone, ipad]
         
   - name: getEventById
     summary: Gets the event with the specified identifier.
@@ -25,7 +25,7 @@ methods:
       - name: id
         summary: Identifier of the event.
         type: Number
-    platforms: [iphone, ipad, android]
+    platforms: [android, iphone, ipad]
         
   - name: getEventsBetweenDates
     summary: Gets events that occur between two dates.
@@ -39,7 +39,7 @@ methods:
       - name: date2
         summary: End date.
         type: Date
-    platforms: [iphone, ipad, android]
+    platforms: [android, iphone, ipad]
         
   - name: getEventsInDate
     summary: Gets events that occur on a specified date.
@@ -57,7 +57,7 @@ methods:
       - name: day
         summary: Day of the month of the events.
         type: Number
-    platforms: [iphone, ipad, android]
+    platforms: [android, iphone, ipad]
         
   - name: getEventsInMonth
     summary: Gets events that occur during a specified month.
@@ -71,7 +71,7 @@ methods:
       - name: month
         summary: Month of the events, as a zero-based integer with January at 0 and December at 11.
         type: Number
-    platforms: [iphone, ipad, android]
+    platforms: [android, iphone, ipad]
         
   - name: getEventsInYear
     summary: Gets all events that occur during a specified year.
@@ -81,7 +81,7 @@ methods:
       - name: year
         summary: Year of the events.
         type: Number
-    platforms: [iphone, ipad, android]
+    platforms: [android, iphone, ipad]
         
 properties:
   - name: hidden
@@ -89,20 +89,20 @@ properties:
     description: This property is `true` when this calendar is editable.
     type: Boolean
     permission: read-only
-    platforms: [iphone, ipad, android]
+    platforms: [android, iphone, ipad]
     
   - name: id
     summary: Identifier of this calendar. Available only in iOS 5.0 and above.
     type: String
     permission: read-only
     osver: {ios: {min: "5.0"}}
-    platforms: [iphone, ipad, android]
+    platforms: [android, iphone, ipad]
     
   - name: name
     summary: Display name of this calendar.
     type: String
     permission: read-only
-    platforms: [iphone, ipad, android]
+    platforms: [android, iphone, ipad]
 
   - name: selected
     summary: Indicates whether the calendar is selected.

--- a/apidoc/Titanium/Calendar/CalendarProxy.yml
+++ b/apidoc/Titanium/Calendar/CalendarProxy.yml
@@ -2,8 +2,8 @@
 name: Titanium.Calendar.Calendar
 summary: An object that represents a single calendar.
 extends: Titanium.Proxy
-platforms: [iphone, ipad]
-since: "3.1.0"
+platforms: [iphone, ipad, android]
+since: {iphone: "3.1.0", ipad: "3.1.0", android: "3.2.0"}
 createable: false
 
 methods:
@@ -15,6 +15,7 @@ methods:
       - name: properties
         summary: Properties of the event
         type: Dictionary<Titanium.Calendar.Event>
+    platforms: [iphone, ipad, android]
         
   - name: getEventById
     summary: Gets the event with the specified identifier.
@@ -24,6 +25,7 @@ methods:
       - name: id
         summary: Identifier of the event.
         type: Number
+    platforms: [iphone, ipad, android]
         
   - name: getEventsBetweenDates
     summary: Gets events that occur between two dates.
@@ -37,6 +39,7 @@ methods:
       - name: date2
         summary: End date.
         type: Date
+    platforms: [iphone, ipad, android]
         
   - name: getEventsInDate
     summary: Gets events that occur on a specified date.
@@ -54,6 +57,7 @@ methods:
       - name: day
         summary: Day of the month of the events.
         type: Number
+    platforms: [iphone, ipad, android]
         
   - name: getEventsInMonth
     summary: Gets events that occur during a specified month.
@@ -67,6 +71,7 @@ methods:
       - name: month
         summary: Month of the events, as a zero-based integer with January at 0 and December at 11.
         type: Number
+    platforms: [iphone, ipad, android]
         
   - name: getEventsInYear
     summary: Gets all events that occur during a specified year.
@@ -76,6 +81,7 @@ methods:
       - name: year
         summary: Year of the events.
         type: Number
+    platforms: [iphone, ipad, android]
         
 properties:
   - name: hidden
@@ -83,15 +89,27 @@ properties:
     description: This property is `true` when this calendar is editable.
     type: Boolean
     permission: read-only
+    platforms: [iphone, ipad, android]
     
   - name: id
     summary: Identifier of this calendar. Available only in iOS 5.0 and above.
     type: String
     permission: read-only
     osver: {ios: {min: "5.0"}}
+    platforms: [iphone, ipad, android]
     
   - name: name
     summary: Display name of this calendar.
     type: String
     permission: read-only
-    
+    platforms: [iphone, ipad, android]
+
+  - name: selected
+    summary: Indicates whether the calendar is selected.
+    description: |
+        Set to `true` when this calendar is selected.
+
+        See <Titanium.Calendar> for examples.
+    type: Boolean
+    permission: read-only
+    platforms: [android]

--- a/apidoc/Titanium/Calendar/Event.yml
+++ b/apidoc/Titanium/Calendar/Event.yml
@@ -3,13 +3,13 @@ name: Titanium.Calendar.Event
 summary: An object that represents a single event in a calendar.
 description: |
     The API supports retrieving information about existing events and creating new events.  
-    Additionally, modifying or deleting existing events and creating recurring rules for events 
-    is also supported.
+    Be aware that modifying or deleting existing events and creating recurring rules for events 
+    are only supported on iOS.
     
     See <Titanium.Calendar> for examples of retrieving event information and creating events.
 extends: Titanium.Proxy
-platforms: [iphone, ipad]
-since: "3.1.0"
+platforms: [iphone, ipad, android]
+since: {iphone: "3.1.0", ipad: "3.1.0", android: "3.2.0"}
 createable: false
 
 methods:
@@ -21,6 +21,39 @@ methods:
       - name: data
         summary: Properties for the alert.
         type: Dictionary<Titanium.Calendar.Alert>
+    platforms: [iphone, ipad, android]
+
+  - name: createReminder
+    summary: Creates a reminder for this event.
+    returns:
+        type: Titanium.Calendar.Reminder
+    parameters:
+      - name: data
+        summary: Properties for the reminder.
+        type: Dictionary<Titanium.Calendar.Reminder>
+    platforms: [android]
+
+  - name: getExtendedProperty
+    summary: Gets the value of the specified extended property.
+    returns:
+        type: String
+    parameters:
+      - name: name
+        summary: Name of an existing extended property.
+        type: String
+    platforms: [android]
+
+  - name: setExtendedProperty
+    summary: Sets the value of the specified extended property.
+    parameters:
+      - name: name
+        summary: Property name.
+        type: String
+
+      - name: value
+        summary: Property value.
+        type: String
+    platforms: [android]
 
   - name: createRecurenceRule
     summary: |
@@ -33,6 +66,7 @@ methods:
       - name: data
         summary: Properties for the recurrence rule.
         type: Dictionary<Titanium.Calendar.RecurrenceRule>
+    platforms: [iphone, ipad]
 
   - name: save
     summary: Saves changes to an event permanently.
@@ -53,6 +87,7 @@ methods:
             [SPAN_FUTUREEVENTS](Titanium.Calendar.SPAN_FUTUREEVENTS).
         type: Number
         default: <Titanium.Calendar.SPAN_THISEVENT>
+    platforms: [iphone, ipad]
 
   - name: remove
     summary: Removes an event from the event store.
@@ -69,6 +104,7 @@ methods:
             [SPAN_FUTUREEVENTS](Titanium.Calendar.SPAN_FUTUREEVENTS).
         type: Number
         default: <Titanium.Calendar.SPAN_THISEVENT>
+    platforms: [iphone, ipad]
 
   - name: refresh
     summary: Updates the event's data with the current information in the Calendar database.
@@ -79,6 +115,7 @@ methods:
         and you should not continue to use it. 
     returns:
         type: Boolean
+    platforms: [iphone, ipad]
 
   - name: addRecurrenceRule
     summary: Adds a recurrence rule to the recurrence rule array.
@@ -87,6 +124,7 @@ methods:
         summary: The recurrence rule to be added.
         type: Titanium.Calendar.RecurrenceRule
     osver: {ios: {min: "5.0"}}
+    platforms: [iphone, ipad]
 
   - name: removeRecurenceRule
     summary: Removes a recurrence rule to the recurrence rule array.
@@ -95,43 +133,80 @@ methods:
         summary: The recurrence rule to be removed.
         type: Titanium.Calendar.RecurrenceRule
     osver: {ios: {min: "5.0"}}
+    platforms: [iphone, ipad]
 
 properties:
   - name: alerts
-    summary: Existing alerts for this event.
+    summary: Alarms associated with the calendar item, as an array of <Titanium.Calendar.Alert> objects.
+    description: |
+        This property is read-only on Android.
     type: Array<Titanium.Calendar.Alert>
-    
+    platforms: [iphone, ipad, android]
+
   - name: allDay
     summary: Indicates whether this event is all day.
+    description: |
+        This property is read-only on Android.
     type: Boolean
     default: false
+    platforms: [iphone, ipad, android]
 
   - name: begin
     summary: Start date/time of this event.
+    description: |
+        This property is read-only on Android.
     type: Date
-    
+    platforms: [iphone, ipad, android]
+
   - name: notes
     summary: Notes for this event.
     type: String
-    
+    platforms: [iphone, ipad]
+
+  - name: description
+    summary: Description of this event.
+    type: String
+    permission: read-only
+    platforms: [android]
+
   - name: end
     summary: End date/time of this event.
+    description: |
+        This property is read-only on Android.
     type: Date
-    
+    platforms: [iphone, ipad, android]
+
+  - name: extendedProperties
+    summary: Extended properties of this event.
+    type: Dictionary
+    permission: read-only
+    platforms: [android]
+
   - name: hasAlarm
     summary: Indicates whether an alarm is scheduled for this event.
     type: Boolean
     permission: read-only
+    platforms: [iphone, ipad, android]
 
   - name: id
     summary: Identifier of this event.
     type: String
     permission: read-only
-    
+    platforms: [iphone, ipad, android]
+
   - name: location
     summary: Location of this event.
+    description: |
+        This property is read-only on Android.
     type: String
-        
+    platforms: [iphone, ipad, android]
+    
+  - name: reminders
+    summary: Existing reminders for this event.
+    type: Array<Titanium.Calendar.Reminder>
+    permission: read-only
+    platforms: [android]
+
   - name: status
     summary: Status of this event.
     description: |
@@ -141,6 +216,7 @@ properties:
         and [STATUS_TENTATIVE](Titanium.Calendar.STATUS_TENTATIVE).
     type: Number
     permission: read-only
+    platforms: [iphone, ipad, android]
 
   - name: availability
     summary: Availability of this event.
@@ -152,6 +228,7 @@ properties:
         and [AVAILABILITY_UNAVAILABLE](Titanium.Calendar.AVAILABILITY_UNAVAILABLE).
     type: Number
     permission: read-only
+    platforms: [iphone, ipad]
 
   - name: isDetached
     summary: |
@@ -163,21 +240,34 @@ properties:
         default attributes.
     type: Boolean
     permission: read-only
+    platforms: [iphone, ipad]
     
   - name: title
     summary: Title of this event.
+    description: |
+        This property is read-only on Android.
     type: String
+    platforms: [iphone, ipad, android]
     
   - name: recurenceRule
     summary: Recurrence rule associated with the event. (Available in iOS 4.0 through iOS 5.1.)
     type: Titanium.Calendar.RecurrenceRule
     osver: {ios: {max: "5.0"}}
+    platforms: [iphone, ipad]
+
   - name: recurenceRules
     summary: The recurrence rules for the calendar item. (Available in iOS 5.1 and above.)
     type: Array<Titanium.Calendar.RecurrenceRule>
     osver: {ios: {min: "5.0"}}
+    platforms: [iphone, ipad]
 
-  - name: alerts
-    summary: Alarms associated with the calendar item, as an array of <Titanium.Calendar.Alert> objects.
-    type: Array<Titanium.Calendar.Alert>
-    
+  - name: visibility
+    summary: Visibility of this event.
+    description: |
+        One of [VISIBILITY_CONFIDENTIAL](Titanium.Calendar.VISIBILITY_CONFIDENTIAL),
+        [VISIBILITY_DEFAULT](Titanium.Calendar.VISIBILITY_DEFAULT),
+        [VISIBILITY_PRIVATE](Titanium.Calendar.VISIBILITY_PRIVATE),
+        and [VISIBILITY_PUBLIC](Titanium.Calendar.VISIBILITY_PUBLIC).
+    type: Number
+    permission: read-only
+    platforms: [android]

--- a/apidoc/Titanium/Calendar/Event.yml
+++ b/apidoc/Titanium/Calendar/Event.yml
@@ -8,8 +8,8 @@ description: |
     
     See <Titanium.Calendar> for examples of retrieving event information and creating events.
 extends: Titanium.Proxy
-platforms: [iphone, ipad, android]
-since: {iphone: "3.1.0", ipad: "3.1.0", android: "3.2.0"}
+platforms: [android, iphone, ipad]
+since: {android: "3.2.0", iphone: "3.1.0", ipad: "3.1.0"}
 createable: false
 
 methods:
@@ -21,7 +21,7 @@ methods:
       - name: data
         summary: Properties for the alert.
         type: Dictionary<Titanium.Calendar.Alert>
-    platforms: [iphone, ipad, android]
+    platforms: [android, iphone, ipad]
 
   - name: createReminder
     summary: Creates a reminder for this event.
@@ -141,7 +141,7 @@ properties:
     description: |
         This property is read-only on Android.
     type: Array<Titanium.Calendar.Alert>
-    platforms: [iphone, ipad, android]
+    platforms: [android, iphone, ipad]
 
   - name: allDay
     summary: Indicates whether this event is all day.
@@ -149,14 +149,14 @@ properties:
         This property is read-only on Android.
     type: Boolean
     default: false
-    platforms: [iphone, ipad, android]
+    platforms: [android, iphone, ipad]
 
   - name: begin
     summary: Start date/time of this event.
     description: |
         This property is read-only on Android.
     type: Date
-    platforms: [iphone, ipad, android]
+    platforms: [android, iphone, ipad]
 
   - name: notes
     summary: Notes for this event.
@@ -174,7 +174,7 @@ properties:
     description: |
         This property is read-only on Android.
     type: Date
-    platforms: [iphone, ipad, android]
+    platforms: [android, iphone, ipad]
 
   - name: extendedProperties
     summary: Extended properties of this event.
@@ -186,20 +186,20 @@ properties:
     summary: Indicates whether an alarm is scheduled for this event.
     type: Boolean
     permission: read-only
-    platforms: [iphone, ipad, android]
+    platforms: [android, iphone, ipad]
 
   - name: id
     summary: Identifier of this event.
     type: String
     permission: read-only
-    platforms: [iphone, ipad, android]
+    platforms: [android, iphone, ipad]
 
   - name: location
     summary: Location of this event.
     description: |
         This property is read-only on Android.
     type: String
-    platforms: [iphone, ipad, android]
+    platforms: [android, iphone, ipad]
     
   - name: reminders
     summary: Existing reminders for this event.
@@ -216,7 +216,7 @@ properties:
         and [STATUS_TENTATIVE](Titanium.Calendar.STATUS_TENTATIVE).
     type: Number
     permission: read-only
-    platforms: [iphone, ipad, android]
+    platforms: [android, iphone, ipad]
 
   - name: availability
     summary: Availability of this event.
@@ -247,7 +247,7 @@ properties:
     description: |
         This property is read-only on Android.
     type: String
-    platforms: [iphone, ipad, android]
+    platforms: [android, iphone, ipad]
     
   - name: recurenceRule
     summary: Recurrence rule associated with the event. (Available in iOS 4.0 through iOS 5.1.)

--- a/apidoc/Titanium/Calendar/Reminder.yml
+++ b/apidoc/Titanium/Calendar/Reminder.yml
@@ -1,0 +1,37 @@
+---
+name: Titanium.Calendar.Reminder
+summary: An object that represents a single reminder for an event in a calendar.
+description: |
+    Reminders should be created using the <Titanium.Calendar.Event.createReminder> method 
+    rather than directly.
+
+    See <Titanium.Calendar> for examples of retrieving reminder information and creating 
+    reminders for events.
+
+extends: Titanium.Proxy
+platforms: [android]
+since: "3.2.0"
+createable: false
+
+properties:
+  - name: id
+    summary: Identifier of this reminder.
+    type: String
+    permission: read-only
+
+  - name: method
+    summary: Method by which this reminder will be delivered.
+    description: |
+        One of [METHOD_ALERT](Titanium.Calendar.METHOD_ALERT),
+        [METHOD_DEFAULT](Titanium.Calendar.METHOD_DEFAULT),
+        [METHOD_EMAIL](Titanium.Calendar.METHOD_EMAIL),
+        or [METHOD_SMS](Titanium.Calendar.METHOD_SMS).
+    type: Number
+    permission: read-only
+
+  - name: minutes
+    summary: |
+        Reminder notice period in minutes, that determines how long prior to the event this reminder 
+        should trigger.
+    type: Number
+    permission: read-only

--- a/support/android/builder.py
+++ b/support/android/builder.py
@@ -983,11 +983,17 @@ class Builder(object):
 			'Contacts.getAllGroups' : CONTACTS_READ_PERMISSION,
 			'Contacts.getGroupByID' : CONTACTS_READ_PERMISSION,
 			
-			# CALENDAR
+			# Old CALENDAR
 			'Android.Calendar.getAllAlerts' : CALENDAR_PERMISSION,
 			'Android.Calendar.getAllCalendars' : CALENDAR_PERMISSION,
 			'Android.Calendar.getCalendarById' : CALENDAR_PERMISSION,
 			'Android.Calendar.getSelectableCalendars' : CALENDAR_PERMISSION,
+
+			# CALENDAR
+			'Calendar.getAllAlerts' : CALENDAR_PERMISSION,
+			'Calendar.getAllCalendars' : CALENDAR_PERMISSION,
+			'Calendar.getCalendarById' : CALENDAR_PERMISSION,
+			'Calendar.getSelectableCalendars' : CALENDAR_PERMISSION,
 
 			# WALLPAPER
 			'Media.Android.setSystemWallpaper' : WALLPAPER_PERMISSION,


### PR DESCRIPTION
https://jira.appcelerator.org/browse/TIMOB-13561
For FR, please run scons and docgen. Then run all the test cases in apidoc/Titanium/Android/Calendar/Calendar.yml and the first three test cases in apidoc/Titanium/Calendar/Calendar.yml .
This PR also moves SearchViewProxy.java to the correct package. So please also run the test case in TIMOB-11604.
