### PR TITLE
[TIMOB-12988] Delay setContentOffset if scrollRectToVisible called

### DIFF
--- a/iphone/Classes/TiUIScrollView.h
+++ b/iphone/Classes/TiUIScrollView.h
@@ -12,6 +12,11 @@
 @private
     TiUIView * touchHandler;
     UIView * touchedContentView;
+    //TIMOB-12988 Additions
+    BOOL delay;
+    BOOL ignore;
+    BOOL offsetAnimated;
+    CGPoint offsetPoint;
 }
 -(void)setTouchHandler:(TiUIView*)handler;
 @end


### PR DESCRIPTION
Fixes [TIMOB-12988](https://jira.appcelerator.org/browse/TIMOB-12988)

Regress against
[TIMOB-11023](http://jira.appcelerator.org/browse/TIMOB-11023)
[TIMOB-1902](http://jira.appcelerator.org/browse/TIMOB-1902)
[TIMOB-8720](http://jira.appcelerator.org/browse/TIMOB-8720)
[TIMOB-10356](http://jira.appcelerator.org/browse/TIMOB-10356)
[TIMOB-7839](http://jira.appcelerator.org/browse/TIMOB-7839)
[TIMOB-5100](http://jira.appcelerator.org/browse/TIMOB-5100)
[TIMOB-7998](http://jira.appcelerator.org/browse/TIMOB-7998)
[TIMOB-8363](http://jira.appcelerator.org/browse/TIMOB-8363)
[TIMOB-8368](http://jira.appcelerator.org/browse/TIMOB-8368)

KS keyboard accessory view animations
