### PR TITLE
[TIMOB-13436] Refresh cache for imageloader if the underlaying local file changed.

### DIFF
--- a/iphone/Classes/ImageLoader.m
+++ b/iphone/Classes/ImageLoader.m
@@ -50,7 +50,8 @@
 @property(nonatomic,readwrite) TiDimension leftCap;
 @property(nonatomic,readwrite) TiDimension topCap;
 @property(nonatomic,readwrite) BOOL hires;
-@property(nonatomic,retain) NSDate* lastModified;
+@property(nonatomic,readonly) NSDate* lastModified;
+@property(nonatomic,readonly) BOOL local;
 
 -(ImageCacheEntry*)initWithURL:(NSURL*)url;
 
@@ -59,13 +60,12 @@
 -(void)serialize:(NSData*)data;
 
 +(NSString*)cachePathForURL:(NSURL*)url;
--(BOOL)isLocal;
 
 @end
 
 @implementation ImageCacheEntry
 
-@synthesize fullImage, leftCap, topCap, hires, localPath, stretchableImage, recentlyResizedImage, lastModified;
+@synthesize fullImage, leftCap, topCap, hires, localPath, stretchableImage, recentlyResizedImage, lastModified, local;
 
 - (UIImage *)fullImage {
 	if(fullImage == nil) {
@@ -84,9 +84,6 @@
         }
 	}
 	return fullImage;
-}
-- (BOOL)isLocal {
-    return local;
 }
 
 - (void)setData:(NSData *)data
@@ -508,7 +505,7 @@ DEFINE_EXCEPTIONS
     NSLog(@"[CACHE DEBUG] cache[%@] : %@", urlString, result);
 #endif
     if (result != nil) {
-        if ([result isLocal]) {
+        if ([result local]) {
             NSError* error = nil;
             NSDate* currentTimeStamp = [[[NSFileManager defaultManager] attributesOfItemAtPath:result.localPath  error:&error]  objectForKey:NSFileModificationDate];
             

--- a/iphone/Classes/ImageLoader.m
+++ b/iphone/Classes/ImageLoader.m
@@ -249,6 +249,7 @@
         if ([remoteURL isFileURL]) {
             localPath = [[remoteURL path] retain];
             local = YES;
+            lastModified = [[[NSFileManager defaultManager] attributesOfItemAtPath:localPath error:nil]  objectForKey:NSFileModificationDate];
         }
         else {
             localPath = [[ImageCacheEntry cachePathForURL:url] retain];
@@ -264,7 +265,7 @@
 	RELEASE_TO_NIL(stretchableImage);
 	RELEASE_TO_NIL(fullImage);
     RELEASE_TO_NIL(remoteURL);
-    
+    RELEASE_TO_NIL(lastModified);
 	[super dealloc];
 }
 
@@ -455,7 +456,6 @@ DEFINE_EXCEPTIONS
     
     if ([image isKindOfClass:[UIImage class]]) {
         [newEntry setFullImage:image];
-        [newEntry setLastModified:[[[NSFileManager defaultManager] attributesOfItemAtPath:newEntry.localPath error:nil]  objectForKey:NSFileModificationDate]];
     }
     else if ([image isKindOfClass:[NSData class]]) {
         [newEntry setData:image];

--- a/iphone/Classes/ImageLoader.m
+++ b/iphone/Classes/ImageLoader.m
@@ -59,7 +59,7 @@
 -(void)serialize:(NSData*)data;
 
 +(NSString*)cachePathForURL:(NSURL*)url;
-
+-(BOOL)isLocal;
 
 @end
 
@@ -79,10 +79,14 @@
         RELEASE_TO_NIL(recentlyResizedImage);
         RELEASE_TO_NIL(lastModified);
 		fullImage = [[UIImage alloc] initWithContentsOfFile:localPath];
-       
-        lastModified = [[[[NSFileManager defaultManager] attributesOfItemAtPath:localPath error:nil]  objectForKey:NSFileModificationDate] retain];
+        if (local) {
+            lastModified = [[[[NSFileManager defaultManager] attributesOfItemAtPath:localPath error:nil]  objectForKey:NSFileModificationDate] retain];
+        }
 	}
 	return fullImage;
+}
+- (BOOL)isLocal {
+    return local;
 }
 
 - (void)setData:(NSData *)data
@@ -249,7 +253,7 @@
         if ([remoteURL isFileURL]) {
             localPath = [[remoteURL path] retain];
             local = YES;
-            lastModified = [[[NSFileManager defaultManager] attributesOfItemAtPath:localPath error:nil]  objectForKey:NSFileModificationDate];
+            lastModified = [[[[NSFileManager defaultManager] attributesOfItemAtPath:localPath error:nil]  objectForKey:NSFileModificationDate] retain];
         }
         else {
             localPath = [[ImageCacheEntry cachePathForURL:url] retain];
@@ -504,7 +508,7 @@ DEFINE_EXCEPTIONS
     NSLog(@"[CACHE DEBUG] cache[%@] : %@", urlString, result);
 #endif
     if (result != nil) {
-        if (result.localPath && result.lastModified) {
+        if ([result isLocal]) {
             NSError* error = nil;
             NSDate* currentTimeStamp = [[[NSFileManager defaultManager] attributesOfItemAtPath:result.localPath  error:&error]  objectForKey:NSFileModificationDate];
             

--- a/iphone/Classes/TiBlob.m
+++ b/iphone/Classes/TiBlob.m
@@ -293,7 +293,7 @@ static NSString *const MIMETYPE_JPEG = @"image/jpeg";
 	}
 	if (writeData!=nil)
 	{
-		[writeData writeToFile:destination atomically:YES];
+		return [writeData writeToFile:destination atomically:YES];
 	}
 	return NO;
 }


### PR DESCRIPTION
**TESTING INSTRUCTION**

Use the following [code](https://gist.github.com/srahim/5407896) in your app.js
__Make sure to include image files with `.JPG` extension in the resources folder of your app.

Click on the coverflow image to update the image with the current timestamp. Make sure the image new image does not get cropped.  
