### PR TITLE
TIMOB-13620: Android: Proxies in modules are not disposed correctly

### DIFF
--- a/android/runtime/v8/src/native/KrollBindings.h
+++ b/android/runtime/v8/src/native/KrollBindings.h
@@ -38,6 +38,7 @@ private:
 	static std::map<std::string, jobject> externalCommonJsModules;
 	static std::map<std::string, jmethodID> commonJsSourceRetrievalMethods;
 	static std::vector<LookupFunction> externalLookups;
+	static std::map<std::string, bindings::BindEntry*> externalLookupBindings;
 
 public:
 	static void initFunctions(v8::Handle<v8::Object> exports);


### PR DESCRIPTION
If we do not dispose the proxy templates, they will now
inherit from a proxy (KrollProxy) that is no longer valid
when the application and runtime restarts. This leads to missing
methods such as "addEventListener", "getProperty", etc.

See JIRA ticket for testing details.
