### PR TITLE
[TIMOB-13253] (3_1_X) Check for listeners before firing events

### DIFF
--- a/android/titanium/src/java/org/appcelerator/kroll/KrollProxy.java
+++ b/android/titanium/src/java/org/appcelerator/kroll/KrollProxy.java
@@ -695,11 +695,14 @@ public class KrollProxy implements Handler.Callback, KrollProxySupport
 	 */
 	public boolean fireEvent(String event, Object data)
 	{
-		Message message = getRuntimeHandler().obtainMessage(MSG_FIRE_EVENT, data);
-		message.getData().putString(PROPERTY_NAME, event);
-		message.sendToTarget();
+		if (hierarchyHasListener(event)) {
+			Message message = getRuntimeHandler().obtainMessage(MSG_FIRE_EVENT, data);
+			message.getData().putString(PROPERTY_NAME, event);
+			message.sendToTarget();
+			return true;
+		}
 
-		return hierarchyHasListener(event);
+		return false;
 	}
 
 	/**
@@ -730,15 +733,18 @@ public class KrollProxy implements Handler.Callback, KrollProxySupport
 	 */
 	public boolean fireSyncEvent(String event, Object data)
 	{
-		if (KrollRuntime.getInstance().isRuntimeThread()) {
-			return doFireEvent(event, data);
+		if (hierarchyHasListener(event)) {
+			if (KrollRuntime.getInstance().isRuntimeThread()) {
+				return doFireEvent(event, data);
 
-		} else {
-			Message message = getRuntimeHandler().obtainMessage(MSG_FIRE_SYNC_EVENT);
-			message.getData().putString(PROPERTY_NAME, event);
+			} else {
+				Message message = getRuntimeHandler().obtainMessage(MSG_FIRE_SYNC_EVENT);
+				message.getData().putString(PROPERTY_NAME, event);
 
-			return (Boolean) TiMessenger.sendBlockingRuntimeMessage(message, data);
+				return (Boolean) TiMessenger.sendBlockingRuntimeMessage(message, data);
+			}
 		}
+		return false;
 	}
 
 	@SuppressWarnings({ "rawtypes", "unchecked" })
@@ -875,9 +881,8 @@ public class KrollProxy implements Handler.Callback, KrollProxySupport
 		// Checks whether the parent has the listener or not
 		if (!hasListener) {
 			KrollProxy parentProxy = getParentForBubbling();
-			if (parentProxy != null) {
-				boolean parentHasListener = parentProxy.hierarchyHasListener(event);
-				hasListener = hasListener || parentHasListener;
+			if (parentProxy != null && bubbleParent) {
+				return parentProxy.hierarchyHasListener(event);
 			}
 		}
 


### PR DESCRIPTION
Cherry Pick PR #4240 into 3_1_X

Resolves [TIMOB-13253](https://jira.appcelerator.org/browse/TIMOB-13253)

This is a basic fix which I am comfortable backporting to 3_1_X. A more detailed PR which cleans up the eventing system will follow later. Will be attached to the eventing experiment ticket.
