### PR TITLE
TIMOB-13688_3_1_X: Bitmap.getByteCount() wasn't added to Android until API Level 12.

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiImageLruCache.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiImageLruCache.java
@@ -41,7 +41,7 @@ public class TiImageLruCache extends LruCache<Integer, Bitmap>
 	{
 		// The cache size will be measured in kilobytes rather than
 		// number of items.
-		if (android.os.Build.VERSION.SDK_INT >= TiC.API_LEVEL_HONEYCOMB) {
+		if (android.os.Build.VERSION.SDK_INT > TiC.API_LEVEL_HONEYCOMB) {
 			return bitmap.getByteCount() / 1024;
 		} else {
 			return bitmap.getRowBytes() * bitmap.getHeight() / 1024;


### PR DESCRIPTION
https://jira.appcelerator.org/browse/TIMOB-13688

Test case will be in JIRA.
