### PR TITLE
TIMOB-13506 3_1_X: Android: Including a borderColor or borderWidth in a tableRow data description causes the title to not show

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiTableViewRowProxyItem.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiTableViewRowProxyItem.java
@@ -306,7 +306,7 @@ public class TiTableViewRowProxyItem extends TiBaseTableViewItem
 		TiUILabel t = (TiUILabel) views.get(0);
 		t.setProxy(rp);
 		t.processProperties(filterProperties(rp.getProperties()));
-		View v = t.getNativeView();
+		View v = t.getOuterView();
 		if (v.getParent() == null) {
 			TiCompositeLayout.LayoutParams params = (TiCompositeLayout.LayoutParams) t.getLayoutParams();
 			params.optionLeft = new TiDimension(5, TiDimension.TYPE_LEFT);


### PR DESCRIPTION
https://jira.appcelerator.org/browse/TIMOB-13506
