### PR TITLE
TIMOB-11567-Default ColumnProxy width to FILL

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/PickerColumnProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/PickerColumnProxy.java
@@ -11,6 +11,7 @@ import org.appcelerator.kroll.annotations.Kroll;
 import org.appcelerator.kroll.common.AsyncResult;
 import org.appcelerator.kroll.common.TiMessenger;
 import org.appcelerator.titanium.TiApplication;
+import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.TiContext;
 import org.appcelerator.titanium.proxy.TiViewProxy;
 import org.appcelerator.titanium.view.TiUIView;
@@ -39,6 +40,7 @@ public class PickerColumnProxy extends TiViewProxy implements PickerRowListener
 	public PickerColumnProxy()
 	{
 		super();
+		defaultValues.put(TiC.PROPERTY_WIDTH, TiC.LAYOUT_FILL);
 	}
 
 	public PickerColumnProxy(TiContext tiContext)

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/PickerProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/PickerProxy.java
@@ -504,6 +504,9 @@ public class PickerProxy extends TiViewProxy implements PickerColumnListener
 		PickerColumnProxy column = getColumn(0);
 		if (column == null && createIfMissing) {
 			column = new PickerColumnProxy();
+			//Force applying default values
+			KrollDict d = new KrollDict();
+			column.handleCreationDict(d);
 			add(column);
 		}
 		return column;


### PR DESCRIPTION
Set the default width property for the columnProxy to be FILL to occupy the entire parent width.

https://jira.appcelerator.org/browse/TIMOB-11567
