### PR TITLE
[TIMOB-13874] BlackBerry : Orientation change does not work in sdk 3.1.1

### DIFF
--- a/support/node_modules/titanium-sdk/lib/tiappxml.js
+++ b/support/node_modules/titanium-sdk/lib/tiappxml.js
@@ -326,6 +326,29 @@ function toJS(obj, doc) {
 						}
 					});
 					break;
+
+				case 'blackberry':
+					var blackberry = obj.blackberry = {};
+					xml.forEachElement(node, function (elem) {
+						switch (elem.tagName) {
+							case 'permissions':
+								var permissions = blackberry.permissions = {};
+								xml.forEachElement(elem, function (elem) {
+									permissions[xml.getValue(elem)] = true;
+								});
+								break;
+
+							case 'build-id':
+								blackberry[elem.tagName] = xml.getValue(elem);
+								break;
+
+							case 'orientation':
+								blackberry[elem.tagName] = xml.getValue(elem);
+								break;
+						}
+					});
+					break;
+
 				
 				case 'iphone':
 					var iphone = obj.iphone = {},


### PR DESCRIPTION
This is a backport of the BlackBerry specific parsing
code for tiapp.xml. This fixes an issue with orientations not working.

For testing see the JIRA ticket which includes a test case for BlackBerry app.
After building and running the application the UI should rotate properly as you
turn the device.
