### PR TITLE
TIMOB-13494-make sure that image doesn't scroll beyond it boundaries

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiImageView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiImageView.java
@@ -102,15 +102,19 @@ public class TiImageView extends ViewGroup implements Handler.Callback, OnClickL
 			@Override
 			public boolean onScroll(MotionEvent e1, MotionEvent e2, float dx, float dy)
 			{
-				if (zoomControls.getVisibility() == View.VISIBLE) {
-					changeMatrix.postTranslate(-dx, -dy);
-					imageView.setImageMatrix(getViewMatrix());
-					requestLayout();
-					scheduleControlTimeout();
-					return true;
-				} else {
-					return false;
+				boolean retValue = false;
+				// Allow scrolling only if the image is zoomed in
+				if (zoomControls.getVisibility() == View.VISIBLE && scaleFactor > 1) {
+					// check if image scroll beyond its borders
+					if (!checkImageScrollBeyondBorders(dx, dy)) {
+						changeMatrix.postTranslate(-dx, -dy);
+						imageView.setImageMatrix(getViewMatrix());
+						requestLayout();
+						scheduleControlTimeout();
+						retValue = true;
+					}
 				}
+				return retValue;
 			}
 
 			@Override
@@ -444,5 +448,23 @@ public class TiImageView extends ViewGroup implements Handler.Callback, OnClickL
 	{
 		this.orientation = orientation;
 		updateScaleType();
+	}
+	
+	private boolean checkImageScrollBeyondBorders(float dx, float dy)
+	{
+		float[] matrixValues = new float[9];
+		Matrix m = new Matrix(changeMatrix);
+		// Apply the translation
+		m.postTranslate(-dx, -dy);
+		m.getValues(matrixValues);
+		// Image can move only the extra width or height that is available
+		// after scaling from the original width or height
+		float scaledAdditionalHeight = imageView.getHeight() * (matrixValues[4] - 1);
+		float scaledAdditionalWidth = imageView.getWidth() * (matrixValues[0] - 1);
+		if (matrixValues[5] > -scaledAdditionalHeight && matrixValues[5] < 0 && matrixValues[2] > -scaledAdditionalWidth
+			&& matrixValues[2] < 0) {
+			return false;
+		}
+		return true;
 	}
 }


### PR DESCRIPTION
Behavior
If the image is in the original size, scrolling is not allowed
If the image is zoomed in, then it can be scrolled until the boundaries, images cannot be scrolled beyond the boundaries.

Fix for 
https://jira.appcelerator.org/browse/TIMOB-13494 and
https://jira.appcelerator.org/browse/TIMOB-13373
