### PR TITLE
TIMOB-12993-removed sorting controls for vertical and horizontal layouts

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiCompositeLayout.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiCompositeLayout.java
@@ -169,7 +169,7 @@ public class TiCompositeLayout extends ViewGroup
 			}
 		});
 
-		needsSort = true;
+		setNeedsSort(true);
 		setOnHierarchyChangeListener(this);
 		this.proxy = new WeakReference<TiViewProxy>(proxy);
 	}
@@ -180,20 +180,20 @@ public class TiCompositeLayout extends ViewGroup
 	
 	public void resort()
 	{
-		needsSort = true;
+		setNeedsSort(true);
 		requestLayout();
 		invalidate();
 	}
 
 	public void onChildViewAdded(View parent, View child) {
-		needsSort = true;
+		setNeedsSort(true);
 		if (Log.isDebugModeEnabled() && parent != null && child != null) {
 			Log.d(TAG, "Attaching: " + viewToString(child) + " to " + viewToString(parent), Log.DEBUG_MODE);
 		}
 	}
 
 	public void onChildViewRemoved(View parent, View child) {
-		needsSort = true;
+		setNeedsSort(true);
 		if (Log.isDebugModeEnabled()) {
 			Log.d(TAG, "Removing: " + viewToString(child) + " from " + viewToString(parent), Log.DEBUG_MODE);
 		}
@@ -497,7 +497,7 @@ public class TiCompositeLayout extends ViewGroup
 					attachViewToParent(child, i++, child.getLayoutParams());
 				}
 			}
-			needsSort = false;
+			setNeedsSort(false);
 		}
 		// viewSorter is not needed after this. It's a source of
 		// memory leaks if it retains the views it's holding.
@@ -895,5 +895,15 @@ public class TiCompositeLayout extends ViewGroup
 	{
 		this.proxy = new WeakReference<TiViewProxy>(proxy);
 	}
-
+	
+	private void setNeedsSort(boolean value)
+	{
+		// For vertical and horizontal layouts, since the controls doesn't
+		// overlap, we shouldn't sort based on the zIndex, the original order
+		// that controls added should be preserved
+		if (isHorizontalArrangement() || isVerticalArrangement()) {
+			value = false;
+		}
+		needsSort = value;
+	}
 }


### PR DESCRIPTION
https://jira.appcelerator.org/browse/TIMOB-12993

Since controls doesn't overlap in vertical and horizontal layouts, we shouldn't be sorting controls based on zOrder, the original order should be preserved.
