### PR TITLE
TIMOB-11200-AudioPlayer-pass inputstream to the player for older version...

### DIFF
--- a/android/modules/media/src/java/ti/modules/titanium/media/TiSound.java
+++ b/android/modules/media/src/java/ti/modules/titanium/media/TiSound.java
@@ -110,7 +110,7 @@ public class TiSound
 			} else {
 				Uri uri = Uri.parse(url);
 				if (uri.getScheme().equals(TiC.PROPERTY_FILE)) {
-					if (Build.VERSION.SDK_INT >= TiC.API_LEVEL_HONEYCOMB) {
+					if (Build.VERSION.SDK_INT >= TiC.API_LEVEL_ICE_CREAM_SANDWICH) {
 						mp.setDataSource(uri.getPath());
 					} else {
 						// For 2.2 and below, MediaPlayer uses the native player which requires


### PR DESCRIPTION
For 2.2 and below, MediaPlayer uses the native player which requires files to have worldreadable access, workaround is to open an input stream to the file and give that to the player.

https://jira.appcelerator.org/browse/TIMOB-11200
