### PR TITLE
TC-2396 Android: ListView templates crash when a view is removed and added again (Alloy 1.2)

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/ListSectionProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/ListSectionProxy.java
@@ -730,11 +730,14 @@ public class ListSectionProxy extends ViewProxy{
 	 */
 	public void setTemplateType() {
 		
-		for (int i = 0; i < listItemData.size(); i++) {
-			TiListViewTemplate temp = listItemData.get(i).getTemplate();
-			TiListView listView = getListView();
-			if (temp.getType() == -1) {
-				temp.setType(listView.getItemType());
+		if (listItemData != null)
+		{
+			for (int i = 0; i < listItemData.size(); i++) {
+				TiListViewTemplate temp = listItemData.get(i).getTemplate();
+				TiListView listView = getListView();
+				if (temp.getType() == -1) {
+					temp.setType(listView.getItemType());
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Missing a null check in the setTemplateType of ListSectionProxy
