### PR TITLE
[TC-2451] Fix FS on iOS 7

### DIFF
--- a/iphone/Classes/FilesystemModule.m
+++ b/iphone/Classes/FilesystemModule.m
@@ -32,7 +32,7 @@ extern NSString * TI_APPLICATION_RESOURCE_DIR;
 {
 	NSString * newpath;
 	id first = [args objectAtIndex:0];
-	if ([first hasPrefix:@"file://localhost/"])
+	if ([first hasPrefix:@"file://"])
 	{
 		NSURL * fileUrl = [NSURL URLWithString:first];
 		//Why not just crop? Because the url may have some things escaped that need to be unescaped.


### PR DESCRIPTION
By relaxing the file://localhost/ prefix check to just file://, we can fix the bug preventing iOS 7 from reading and writing to the filesystem.

Works on my iPhone 5 running iOS 7, and in simulator running iOS 6.

https://jira.appcelerator.org/browse/TC-2451
