### PR TITLE
[TIMOB-14270] Adds support for the New Relic module's dex agent.

### DIFF
--- a/support/android/builder.py
+++ b/support/android/builder.py
@@ -2353,6 +2353,24 @@ class Builder(object):
 					dex_args = [self.java, '-Xmx1024M', '-Djava.ext.dirs=%s' % self.sdk.get_platform_tools_dir(), '-jar', self.sdk.get_dx_jar()]
 				else:
 					dex_args = [dx, '-JXmx1536M', '-JXX:-UseGCOverheadLimit']
+
+				# Look for New Relic module
+				newrelic_module = None
+				for module in self.modules:
+					if module.path.find("newrelic") > 0:
+						newrelic_module = module
+						break
+
+				# If New Relic is present, add its Java agent to the dex arguments.
+				if newrelic_module:
+					info("Adding New Relic support.")
+
+					# Copy the dexer java agent jar to a tempfile. Eliminates white space from
+					# the module path which causes problems with the dex -Jjavaagent argument.
+					temp_jar = tempfile.NamedTemporaryFile(suffix='.jar', delete=True)
+					shutil.copyfile(os.path.join(newrelic_module.path, 'class.rewriter.jar'), temp_jar.name)
+					dex_args += ['-Jjavaagent:' + os.path.join(temp_jar.name)]
+
 				dex_args += ['--dex', '--output='+self.classes_dex, self.classes_dir]
 				dex_args += self.android_jars
 				dex_args += self.module_jars


### PR DESCRIPTION
This PR modifies the Android builder script to look for the New Relic module, and if present passes an additional argument to the dx command when it is called. This allows New Relic to do bytecode rewriting for instrumentation.

The Java agent argument to dx is passed via a temporary file to avoid issues the dx command has with spaces in file paths. This temporary file is cleaned up after dx runs.
