### PR TITLE
[TIDOC-1080] Support exclude-platforms key

### DIFF
--- a/apidoc/docgen.py
+++ b/apidoc/docgen.py
@@ -67,6 +67,21 @@ def is_titanium_proxy(one_type):
 	# When you use this, don't forget that modules are also proxies
 	return has_ancestor(one_type, "Titanium.Proxy")
 
+# TIDOC-1080: Support exclude-platforms tag
+def exclude_platforms(obj, parent):
+	platforms = None
+	if parent is not None:
+		all_platforms = None
+		if dict_has_non_empty_member(parent.api_obj, "platforms"):
+			all_platforms = parent.api_obj["platforms"]
+		else:
+			all_platforms = DEFAULT_PLATFORMS
+		if all_platforms is not None:
+			platforms = [x for x in all_platforms if x not in obj["exclude-platforms"]]
+	if not platforms:
+		log.warn("No platforms for %s" % (obj["name"]))
+	return platforms
+
 def combine_platforms_and_since(annotated_obj):
 	parent = annotated_obj.parent
 	obj = annotated_obj.api_obj
@@ -522,6 +537,10 @@ class AnnotatedMethod(AnnotatedApi):
 		self.typestr = "method"
 		self.parent = annotated_parent
 		self.yaml_source_folder = self.parent.yaml_source_folder
+		if dict_has_non_empty_member(api_obj, "exclude-platforms") and not dict_has_non_empty_member(api_obj, "platforms"):
+			platforms = exclude_platforms(api_obj, annotated_parent);
+			if platforms:
+				api_obj["platforms"] = platforms
 
 	@lazyproperty
 	def parameters(self):
@@ -548,6 +567,10 @@ class AnnotatedProperty(AnnotatedApi):
 		self.typestr = "property"
 		self.parent = annotated_parent
 		self.yaml_source_folder = self.parent.yaml_source_folder
+		if dict_has_non_empty_member(api_obj, "exclude-platforms") and not dict_has_non_empty_member(api_obj, "platforms"):
+			platforms = exclude_platforms(api_obj, annotated_parent);
+			if platforms:
+				api_obj["platforms"] = platforms
 
 class AnnotatedEvent(AnnotatedApi):
 	def __init__(self, api_obj, annotated_parent):
@@ -555,6 +578,10 @@ class AnnotatedEvent(AnnotatedApi):
 		self.typestr = "event"
 		self.parent = annotated_parent
 		self.yaml_source_folder = self.parent.yaml_source_folder
+		if dict_has_non_empty_member(api_obj, "exclude-platforms") and not dict_has_non_empty_member(api_obj, "platforms"):
+			platforms = exclude_platforms(api_obj, annotated_parent);
+			if platforms:
+				api_obj["platforms"] = platforms
 
 	@lazyproperty
 	def properties(self):

--- a/apidoc/validate.py
+++ b/apidoc/validate.py
@@ -29,13 +29,13 @@ VALID_KEYS = {
 			"excludes", "since", "deprecated", "osver", "examples", "methods", "properties",
 			"events"],
 		"method": ["name", "summary", "description", "returns", "platforms", "since",
-			"deprecated", "osver", "examples", "parameters"],
+			"deprecated", "osver", "examples", "parameters","exclude-platforms"],
 		"parameter": ["name", "summary", "type", "optional", "default", "repeatable"],
 		"property": ["name", "summary", "description", "type", "platforms", "since",
 			"deprecated", "osver", "examples", "permission", "availability", "accessors",
-			"optional", "value", "default"],
+			"optional", "value", "default","exclude-platforms"],
 		"event": ["name", "summary", "description", "extends", "platforms", "since",
-			"deprecated", "osver", "properties"],
+			"deprecated", "osver", "properties","exclude-platforms"],
 		"eventprop": ["name", "summary", "type", "platforms", "deprecated"],
 		"deprecated": ["since", "removed", "notes"]
 		}


### PR DESCRIPTION
TESTING DIRECTIONS:
1. Edit the YML files to use the `exclude-platforms` tag.  This will generate a list of supported platforms for an object's method, property or event by using the object's `platforms` key (or the default platform list if this is not defined) minus the ones specified with the `exclude-platform` key.

For example:

If an object supports all platforms, changing an attribute with:

```
    platforms: [iphone, ipad]
```

To:

```
    exclude-platforms: [android, mobileweb, tizen]
```

Produces the same result.

If both `platforms` and `exclude-platforms` are defined, `platforms` is used not `exclude-platforms`.

If the `exclude_platforms` method returns an empty list, a warning is outputted to the terminal since this should not happen and means the object's attribute is not supported on any platform.
1. From the `apidoc` directory, execute:
   `validate.py` --> make sure syntax is correct
   `./docgen.py` --> generates HTML version in `/dist/apidoc`
   `./docgen.py -f jsduck -o ../dist`  --> generates `dist/titanium.js`
   `./docgen.py -f jsca -o ../dist` --> generates `dist/apidoc.jsca`
2. Inspect the files to make sure the correct platforms are generated. Note that the jsca version does not list the platforms for events.
