### PR TITLE
[TIMOB-10212] Add readonly duration property to iOS AudioPlayer

### DIFF
--- a/iphone/Classes/AudioStreamer/AudioStreamer.h
+++ b/iphone/Classes/AudioStreamer/AudioStreamer.h
@@ -109,6 +109,7 @@ extern NSString * const ASStatusChangedNotification;
 @property AudioStreamerErrorCode errorCode;
 @property (nonatomic, readonly) AudioStreamerState state;
 @property (readonly) double progress;
+@property (readonly) double duration; 
 @property (readwrite) UInt32 bitRate;
 @property (readwrite) double volume;
 @property (readwrite,assign) id<AudioStreamerDelegate> delegate;

--- a/iphone/Classes/AudioStreamer/AudioStreamer.m
+++ b/iphone/Classes/AudioStreamer/AudioStreamer.m
@@ -165,6 +165,19 @@ RUN_ON_STREAMER_RETURN(state, AudioStreamerState)
 RUN_ON_STREAMER_RETURN(progress, double)
 RUN_ON_STREAMER_RETURN(bufferSize, NSUInteger)
 RUN_ON_STREAMER_RETURN(volume, double)
+-(double)duration
+{
+    if ([TiUtils isiPhoneOS3_2OrGreater])
+    {
+        return [(AudioStreamerCUR*)streamer duration];
+    }
+    else
+    {
+        NSLog(@"[WARN] Returning 0 for duration since it is not supported for older pre-iOS 3.2 BC streamer");
+        
+        return 0.0;
+    }
+} 
 
 // Functions
 RUN_ON_STREAMER_RETURN(isPlaying, BOOL)

--- a/iphone/Classes/AudioStreamer/AudioStreamer.m
+++ b/iphone/Classes/AudioStreamer/AudioStreamer.m
@@ -165,19 +165,7 @@ RUN_ON_STREAMER_RETURN(state, AudioStreamerState)
 RUN_ON_STREAMER_RETURN(progress, double)
 RUN_ON_STREAMER_RETURN(bufferSize, NSUInteger)
 RUN_ON_STREAMER_RETURN(volume, double)
--(double)duration
-{
-    if ([TiUtils isiPhoneOS3_2OrGreater])
-    {
-        return [(AudioStreamerCUR*)streamer duration];
-    }
-    else
-    {
-        NSLog(@"[WARN] Returning 0 for duration since it is not supported for older pre-iOS 3.2 BC streamer");
-        
-        return 0.0;
-    }
-} 
+RUN_ON_STREAMER_RETURN(duration, NSTimeInterval);
 
 // Functions
 RUN_ON_STREAMER_RETURN(isPlaying, BOOL)

--- a/iphone/Classes/TiMediaAudioPlayerProxy.h
+++ b/iphone/Classes/TiMediaAudioPlayerProxy.h
@@ -15,6 +15,7 @@
 	NSURL *url;
     NSUInteger bufferSize;
 	double volume;
+    double duration;
 	AudioStreamer *player;
 	BOOL progress;
 	NSTimer *timer;
@@ -28,6 +29,7 @@
 @property (nonatomic,readonly) NSNumber *bitRate;
 @property (nonatomic,readonly) NSNumber *progress;
 @property (nonatomic,readonly) NSNumber *state;
+@property (nonatomic,readonly) NSNumber *duration;
 
 @property (nonatomic,copy)	NSNumber *volume;
 

--- a/iphone/Classes/TiMediaAudioPlayerProxy.m
+++ b/iphone/Classes/TiMediaAudioPlayerProxy.m
@@ -167,6 +167,7 @@ PLAYER_PROP_BOOL(paused,isPaused);
 PLAYER_PROP_DOUBLE(bitRate,bitRate);
 PLAYER_PROP_DOUBLE(progress,progress);
 PLAYER_PROP_DOUBLE(state,state);
+PLAYER_PROP_DOUBLE(duration,duration);
 
 -(NSNumber *)volume
 {

--- a/iphone/Classes/TiMediaAudioPlayerProxy.m
+++ b/iphone/Classes/TiMediaAudioPlayerProxy.m
@@ -167,7 +167,15 @@ PLAYER_PROP_BOOL(paused,isPaused);
 PLAYER_PROP_DOUBLE(bitRate,bitRate);
 PLAYER_PROP_DOUBLE(progress,progress);
 PLAYER_PROP_DOUBLE(state,state);
-PLAYER_PROP_DOUBLE(duration,duration);
+
+-(NSNumber *)duration
+{
+	if (player != nil){
+        //Convert duration to milliseconds (parity with progress/Android)
+		duration = (int)([player duration]*1000);
+	}
+	return NUMDOUBLE(duration);
+}
 
 -(NSNumber *)volume
 {


### PR DESCRIPTION
As per TIMOB-20212 (https://jira.appcelerator.org/browse/TIMOB-10212) add the duration property to the iOS Ti.Media.AudioPlayer proxy. Read-only and can only be read on > iOS 3.2. Manually merged based on changes by gerry3 in the #86 PR.

Will also be opening a separate PR for the Android equivalent. 

Getting track duration is a prerequisite to other features such as track seeking. 
