### PR TITLE
[TIMOB-10212] Add readonly duration property to Android AudioPlayer

### DIFF
--- a/android/modules/media/src/java/ti/modules/titanium/media/AudioPlayerProxy.java
+++ b/android/modules/media/src/java/ti/modules/titanium/media/AudioPlayerProxy.java
@@ -98,6 +98,15 @@ public class AudioPlayerProxy extends KrollProxy
 	}
 
 	@Kroll.getProperty @Kroll.method
+	public int getDuration() {
+		TiSound s = getSound();
+		if (s != null) {
+			return s.getDuration();
+		}
+		return 0;
+	} 
+
+	@Kroll.getProperty @Kroll.method
 	public boolean isPlaying() {
 		TiSound s = getSound();
 		if (s != null) {


### PR DESCRIPTION
Addition to bring parity between iOS getDuration addition for Ti.Media.Audioplayer (PR #4427). Original ticket for IOS counterpart: https://jira.appcelerator.org/browse/TIMOB-10212 . Low risk addition, simply exposes functionality already present in Android's MediaPlayer.
