### PR TITLE
[TIMOB-14533] Fix the Xperia camera output on Android 4.1.2

### DIFF
--- a/android/modules/media/src/java/ti/modules/titanium/media/MediaModule.java
+++ b/android/modules/media/src/java/ti/modules/titanium/media/MediaModule.java
@@ -140,7 +140,7 @@ public class MediaModule extends KrollModule
 	{
 		Activity activity = TiApplication.getInstance().getCurrentActivity();
 
-		Log.d(TAG, "showCamera called", Log.DEBUG_MODE);
+		Log.d(TAG, "showCamera called on device: " + Build.MANUFACTURER, Log.DEBUG_MODE);
 
 		KrollFunction successCallback = null;
 		KrollFunction cancelCallback = null;
@@ -433,7 +433,7 @@ public class MediaModule extends KrollModule
 					if (data.getData() != null) {
 						c = activity.getContentResolver().query(data.getData(), projection, null, null, null);
 					}
-					if (c == null) {
+					if (c == null && !Build.MANUFACTURER.equals("Sony Ericsson")) {
 						c = activity.getContentResolver().query(Images.Media.EXTERNAL_CONTENT_URI, projection, null, null,
 							Images.ImageColumns.DATE_TAKEN);
 						isDataValid = false;


### PR DESCRIPTION
Solve issues with Xperia Camera:
on our Sony Ericsson Xperia S (LT26i) with Android 4.1.2, the picture output was the last picture in the gallery - not the one just captured by the camera.

We have other Sony Ericsson devices (on Android 2.x.x or 3.x.x):
Xperia Arc,
Xperia Arc S,
Xperia U (ST25i)
The camera output is ok with or without this commit (no regression).
