### PR TITLE
TIMOB-13901: adding an iOS Label method to calculate the height

### DIFF
--- a/iphone/Classes/TiUILabelProxy.m
+++ b/iphone/Classes/TiUILabelProxy.m
@@ -37,6 +37,26 @@ USE_VIEW_FOR_CONTENT_WIDTH
 	return [self verifyHeight:size.height]; //Todo: We need to verifyHeight elsewhere as well.
 }
 
+-(id)heightFromWidth:(id)args
+{
+	CGFloat suggestedWidth = [TiUtils floatValue:[args objectAtIndex:0]];
+	NSString *value = [TiUtils stringValue:[self valueForKey:@"text"]];
+	id fontValue = [self valueForKey:@"font"];
+	UIFont *font = nil;
+	if (fontValue!=nil)
+	{
+		font = [[TiUtils fontValue:[self valueForKey:@"font"]] font];
+	}
+	else
+	{
+		font = [UIFont systemFontOfSize:[UIFont labelFontSize]];
+	}
+	CGSize maxSize = CGSizeMake(suggestedWidth, 10000);
+	CGSize size = [value sizeWithFont:font constrainedToSize:maxSize];
+
+	return [NSNumber numberWithFloat:size.height];
+}
+
 -(CGFloat) verifyWidth:(CGFloat)suggestedWidth
 {
 	int width = ceil(suggestedWidth);


### PR DESCRIPTION
It turns out that for iOS we need to calculate ListView item heights. The issue is usually caused by wrapped labels, thus we need a method to calculate label heights, given a known width.
`var calculatedHeight = myLabel.heightFromWidth(100);` for example will provide the label's height, constrained to a width of 100, assuming word wrap behavior and accounting for the label's font.
