### PR TITLE
[TC-2611] Fix setActivityType typo

### DIFF
--- a/iphone/Classes/GeolocationModule.m
+++ b/iphone/Classes/GeolocationModule.m
@@ -692,7 +692,7 @@ extern BOOL const TI_APPLICATION_ANALYTICS;
 {
     if ([TiUtils isIOS6OrGreater]) {
         activityType = [TiUtils intValue:value];
-        TiThreadPerformOnMainThread(^{[locationManager setActivityType:accuracy];}, NO);
+        TiThreadPerformOnMainThread(^{[locationManager setActivityType:activityType];}, NO);
     }
     
 }


### PR DESCRIPTION
Fix typo in setActivityType where accuracy is being set instead of ActivityType
