### PR TITLE
[TIDOC-1202] Suppress warnings when processing examples

### DIFF
--- a/apidoc/common.py
+++ b/apidoc/common.py
@@ -9,7 +9,7 @@
 import os, sys, re
 simple_tag_pattern = re.compile(r"<[^>]*?>")
 not_real_titanium_types = ("Titanium.Proxy", "Titanium.Module", "Titanium.Event")
-DEFAULT_PLATFORMS = ["android", "iphone", "ipad", "mobileweb", "tizen"]
+DEFAULT_PLATFORMS = ["android", "blackberry", "iphone", "ipad", "mobileweb", "tizen"]
 platform_names = { "android": "Android", "blackberry": "BlackBerry", 
 				"iphone": "iPhone", "ipad": "iPad", "mobileweb": "Mobile Web", "tizen": "Tizen" }
 initial_platform_version = { "blackberry": "3.1", "mobileweb" : "1.8", "tizen": "3.1" }

--- a/apidoc/generators/html_generator.py
+++ b/apidoc/generators/html_generator.py
@@ -196,7 +196,7 @@ def annotate(annotated_obj):
 			if dict_has_non_empty_member(example, "title"):
 				one_example["title"] = example["title"]
 			if dict_has_non_empty_member(example, "example"):
-				html_example = markdown_to_html(example["example"], obj=annotated_obj, suppress_link_warnings=is_inherited)
+				html_example = markdown_to_html(example["example"], obj=annotated_obj, suppress_link_warnings=True)
 				# Suspicious if the example has content (beyond the <p></p>) but not <code>.
 				# This can happen if in the .yml the example starts off immediately with code,
 				# because the yaml parser interprets the leading four spaces (which the programmer


### PR DESCRIPTION
Run docgen before this merge.  Notice the multiple warnings related to Alloy XML markup.

Merge this PR.  Run docgen again.  There should be significantly less warnings generated.

Sneaking in fix for BlackBerry as a default platform.  Present in 3.1.x but not master.
