### PR TITLE
[TIMOB-12924] 3_1_X iOS: App becomes unresponsive in landscape mode

### DIFF
--- a/iphone/Classes/TiRootViewController.m
+++ b/iphone/Classes/TiRootViewController.m
@@ -988,7 +988,14 @@
 
 	[window setParentOrientationController:self];
 	[windowProxies addObject:window];
-	[window parentWillShow];
+	
+    //TIMOB-12924 Native implement for JS workaround. This should be replaced with something better.
+    if ([windowProxies count] == 1) {
+        BOOL hidden = [[UIApplication sharedApplication] isStatusBarHidden];
+        [[UIApplication sharedApplication] setStatusBarHidden:hidden withAnimation:UIStatusBarAnimationNone];
+    }
+    
+    [window parentWillShow];
 	//Todo: Move all the root-attaching logic here.
 
 	[self childOrientationControllerChangedFlags:window];


### PR DESCRIPTION
backport for #4487

TEST CASE IN [JIRA](https://jira.appcelerator.org/browse/TIMOB-12924)
