### PR TITLE
[TIMOB-14608]IOS: Supporting new icons for icons

### DIFF
--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -1228,7 +1228,7 @@ build.prototype = {
 		plist.CFBundleShortVersionString = plist.CFBundleVersion;
 
 		Array.isArray(plist.CFBundleIconFiles) || (plist.CFBundleIconFiles = []);
-		['.png', '@2x.png', '-72.png', '-Small-50.png', '-72@2x.png', '-Small-50@2x.png', '-Small.png', '-Small@2x.png'].forEach(function (name) {
+		['.png', '@2x.png', '-72.png', '-60.png', '-60@2x.png', '-Small-50.png', '-72@2x.png', '-Small-50@2x.png', '-Small.png', '-Small@2x.png'].forEach(function (name) {
 			name = iconName + name;
 			if (afs.exists(this.projectDir, 'Resources', name) ||
 				afs.exists(this.projectDir, 'Resources', 'iphone', name) ||

--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -1228,7 +1228,7 @@ build.prototype = {
 		plist.CFBundleShortVersionString = plist.CFBundleVersion;
 
 		Array.isArray(plist.CFBundleIconFiles) || (plist.CFBundleIconFiles = []);
-		['.png', '@2x.png', '-72.png', '-60.png', '-60@2x.png', '-Small-50.png', '-72@2x.png', '-Small-50@2x.png', '-Small.png', '-Small@2x.png'].forEach(function (name) {
+		['.png', '@2x.png', '-72.png', '-60.png', '-60@2x.png', '-Small-50.png', '-72@2x.png', '-Small-50@2x.png', '-Small.png', '-Small@2x.png', '-Small-40.png', '-Small-40@2x.png'].forEach(function (name) {
 			name = iconName + name;
 			if (afs.exists(this.projectDir, 'Resources', name) ||
 				afs.exists(this.projectDir, 'Resources', 'iphone', name) ||


### PR DESCRIPTION
Introducing two new icons appicon-60 &60@2x , appicon-Small-40.png &40@2x.png

**Testing Instruction**
- According to apple in iOS 7 all we have to do include all the icons needed in the build project and include them in the CFBundleIconFiles inside info.plist

steps.
- Import this [project](https://dl.dropboxusercontent.com/u/43336767/icontest.zip) into studio
- Build for device.
- Find the build .ipa ,rename it to .zip and open it up.
- Check to verify that all the icons are inside the build folder
- Check to verify that all the icons inside the build folder are mentioned inside the <CFBundleIconFiles> inside info.plist
