### PR TITLE
Fix Android crashes

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIImageView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIImageView.java
@@ -137,9 +137,9 @@ public class TiUIImageView extends TiUIView implements OnLifecycleEvent, Handler
 					// Update UI if the current image source has not been changed.
 					if (imageSources != null && imageSources.size() == 1) {
 						TiDrawableReference imgsrc = imageSources.get(0);
-						if (imgsrc.hashCode() == hash
+						if ((imgsrc != null) && ((imgsrc.hashCode() == hash
 							|| (TiDrawableReference.fromUrl(imageViewProxy, TiUrl.getCleanUri(imgsrc.getUrl()).toString())
-								.hashCode() == hash)) {
+								.hashCode() == hash)))) {
 							setImage(bitmap);
 							if (!firedLoad) {
 								fireLoad(TiC.PROPERTY_IMAGE);
@@ -221,9 +221,9 @@ public class TiUIImageView extends TiUIView implements OnLifecycleEvent, Handler
 		// Don't update UI if the current image source has been changed.
 		if (imageSources != null && imageSources.size() == 1) {
 			TiDrawableReference imgsrc = imageSources.get(0);
-			if (imageref.equals(imgsrc)
+			if ((imgsrc != null) && (imageref.equals(imgsrc)
 				|| imageref
-					.equals(TiDrawableReference.fromUrl(imageViewProxy, TiUrl.getCleanUri(imgsrc.getUrl()).toString()))) {
+					.equals(TiDrawableReference.fromUrl(imageViewProxy, TiUrl.getCleanUri(imgsrc.getUrl()).toString())))) {
 				int hash = imageref.hashCode();
 				Bitmap bitmap = imageref.getBitmap(true);
 				if (bitmap != null) {


### PR DESCRIPTION
Application would sometimes crash (NPE) when aggressively scrolling a ListView with remote images. Seems there were some safety checks missing in the code (although they were used elsewhere in the same class). Added the safety checks as needed.

See https://jira.appcelerator.org/browse/TC-2689
