### PR TITLE
Timob 8714 3 1 x: Android: 'focus' events are not correctly handled for windows in a tabGroup

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TabProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TabProxy.java
@@ -208,6 +208,8 @@ public class TabProxy extends TiViewProxy
 	{
 		// Windows are lazily opened when the tab is first focused.
 		if (window != null && !windowOpened) {
+			// Need to handle the url window in the JS side.
+			window.callPropertySync(TiC.PROPERTY_LOAD_URL, null);
 			windowOpened = true;
 			window.fireEvent(TiC.EVENT_OPEN, null, false);
 		}

--- a/android/titanium/src/java/org/appcelerator/titanium/TiC.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiC.java
@@ -1339,6 +1339,11 @@ public class TiC
 	/**
 	 * @module.api
 	 */
+	public static final String PROPERTY_LOAD_URL = "loadUrl";
+
+	/**
+	 * @module.api
+	 */
 	public static final String PROPERTY_LED_ARGB = "ledARGB";
 
 	/**


### PR DESCRIPTION
https://jira.appcelerator.org/browse/TIMOB-8714
