### PR TITLE
[TIMOB-14794]iOS: HttpClient responseText does not keep the correct encoding

### DIFF
--- a/iphone/Classes/TiNetworkHTTPClientProxy.m
+++ b/iphone/Classes/TiNetworkHTTPClientProxy.m
@@ -95,6 +95,7 @@ BOOL ExtractEncodingFromData(NSData * inputData, NSStringEncoding* result)
 		TRYENCODING("windows-1253",12,NSWindowsCP1253StringEncoding,result);
 		TRYENCODING("windows-1254",12,NSWindowsCP1254StringEncoding,result);
 		TRYENCODING("windows-1255",12,CFStringConvertEncodingToNSStringEncoding(kCFStringEncodingWindowsHebrew),result);
+        TRYENCODING("big5",4,CFStringConvertEncodingToNSStringEncoding(kCFStringEncodingBig5),result);
 	}	
 	return NO;
 }


### PR DESCRIPTION
Hold off on testing/merging. Needs to confirm on the test case
