### PR TITLE
TIMOB-9913 Android: Remove the unused references to Map View's "animate" property.

### DIFF
--- a/android/modules/map/src/java/ti/modules/titanium/map/TiMapView.java
+++ b/android/modules/map/src/java/ti/modules/titanium/map/TiMapView.java
@@ -72,7 +72,6 @@ public class TiMapView extends TiUIView
 	private static final int MSG_SET_LOCATION = 300;
 	private static final int MSG_SET_MAPTYPE = 301;
 	private static final int MSG_SET_REGIONFIT = 302;
-	private static final int MSG_SET_ANIMATE = 303;
 	private static final int MSG_SET_USERLOCATION = 304;
 	private static final int MSG_SET_SCROLLENABLED = 305;
 	private static final int MSG_CHANGE_ZOOM = 306;
@@ -82,7 +81,6 @@ public class TiMapView extends TiUIView
 
 	private boolean scrollEnabled;
 	private boolean regionFit;
-	private boolean animate;
 	private boolean userLocation;
 
 	private LocalMapView view;
@@ -522,7 +520,6 @@ public class TiMapView extends TiUIView
 		setNativeView(view);
 
 		this.regionFit = true;
-		this.animate = false;
 
 		final TiViewProxy fproxy = proxy;
 
@@ -572,12 +569,8 @@ public class TiMapView extends TiUIView
 				regionFit = msg.arg1 == 1 ? true : false;
 				return true;
 
-			case MSG_SET_ANIMATE :
-				animate = msg.arg1 == 1 ? true : false;
-				return true;
-
 			case MSG_SET_SCROLLENABLED :
-				animate = msg.arg1 == 1 ? true : false;
+				scrollEnabled = msg.arg1 == 1 ? true : false;
 				if (view != null) {
 					view.setScrollable(scrollEnabled);
 				}
@@ -805,9 +798,6 @@ public class TiMapView extends TiUIView
 		if (d.containsKey(TiC.PROPERTY_REGION_FIT)) {
 			regionFit = d.getBoolean(TiC.PROPERTY_REGION_FIT);
 		}
-		if (d.containsKey(TiC.PROPERTY_ANIMATE)) {
-			animate = d.getBoolean(TiC.PROPERTY_ANIMATE);
-		}
 		if (d.containsKey(TiC.PROPERTY_USER_LOCATION)) {
 			doUserLocation(d.getBoolean(TiC.PROPERTY_USER_LOCATION));
 		}
@@ -982,10 +972,10 @@ public class TiMapView extends TiUIView
 			Log.e(TAG, "calling obtainMessage", Log.DEBUG_MODE);
 			
 			KrollDict args = new KrollDict();
-			args.put("select", new Boolean(select));
+			args.put("select", Boolean.valueOf(select));
 			args.put("title", title);
-			args.put("animate", new Boolean(animate));
-			args.put("center", new Boolean(center));
+			args.put("animate", Boolean.valueOf(animate));
+			args.put("center", Boolean.valueOf(center));
 			if (selectedAnnotation != null) {
 				args.put("annotation", selectedAnnotation);
 			}

--- a/android/modules/map/src/java/ti/modules/titanium/map/ViewProxy.java
+++ b/android/modules/map/src/java/ti/modules/titanium/map/ViewProxy.java
@@ -29,7 +29,6 @@ import android.os.Message;
 import android.view.Window;
 
 @Kroll.proxy(creatableInModule = MapModule.class, propertyAccessors = {
-	TiC.PROPERTY_ANIMATE,
 	TiC.PROPERTY_ANNOTATIONS,
 	TiC.PROPERTY_MAP_TYPE,
 	TiC.PROPERTY_REGION,

--- a/apidoc/Titanium/Map/View.yml
+++ b/apidoc/Titanium/Map/View.yml
@@ -378,7 +378,7 @@ properties:
   - name: animate
     summary: Indicates if changes to the mapping region should be animated.
     type: Boolean
-    platforms: [android, iphone, ipad]
+    platforms: [iphone, ipad]
 
   - name: animated
     summary: Indicates if changes to the mapping region should be animated.


### PR DESCRIPTION
See [Testing Notes in JIRA](https://jira.appcelerator.org/browse/TIMOB-9913?focusedCommentId=267199&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-267199).

The "animate" property of a map view was listed
in documentation as being supported by Android.
However, it is never accessed anywhere in the code --
it is only set and never read. It cannot be supported
since it clobbers the animate() method of the view.
