### PR TITLE
TIMOB-14922: Reverted fix to omit tiapp.xml from bin/assets which caused full rebuilds every time

### DIFF
--- a/support/android/android.py
+++ b/support/android/android.py
@@ -118,11 +118,14 @@ class Android(object):
 
 	def build_app_info(self, project_dir):
 		tiapp = ElementTree()
+		assets_tiappxml = os.path.join(project_dir, 'build', 'android', 'bin', 'assets', 'tiapp.xml')
 		
 		self.app_info = {'fullscreen':'false','navbar-hidden':'false'}
 		self.app_properties = {}
+		if not os.path.exists(assets_tiappxml):
+			shutil.copy(os.path.join(project_dir, 'tiapp.xml'), assets_tiappxml)
 		
-		tiapp.parse(open(os.path.join(project_dir, 'tiapp.xml'), 'r'))
+		tiapp.parse(open(assets_tiappxml, 'r'))
 		for key in ['id', 'name', 'version', 'publisher', 'url', 'copyright',
 			'description', 'icon', 'analytics', 'guid', 'navbar-hidden', 'fullscreen']:
 			el = tiapp.find(key)

--- a/support/android/builder.py
+++ b/support/android/builder.py
@@ -2201,7 +2201,9 @@ class Builder(object):
 			if not os.path.exists(self.assets_resources_dir):
 				os.makedirs(self.assets_resources_dir)
 
-			self.tiapp = TiAppXML(self.project_tiappxml)
+			shutil.copy(self.project_tiappxml, self.assets_dir)
+			finalxml = os.path.join(self.assets_dir,'tiapp.xml')
+			self.tiapp = TiAppXML(finalxml)
 			self.tiapp.setDeployType(deploy_type)
 			self.sdcard_copy = False
 			sdcard_property = "ti.android.loadfromsdcard"


### PR DESCRIPTION
https://jira.appcelerator.org/browse/TIMOB-14922

Test case in Jira.  Please also run test case in https://jira.appcelerator.org/browse/TIMOB-12222.
