### PR TITLE
Fixes TC-2813 - "Whenever compiler.py encounters an 'unrecognized error'...

### DIFF
--- a/support/android/compiler.py
+++ b/support/android/compiler.py
@@ -188,7 +188,7 @@ class Compiler(object):
 					sys.exit(1)
 
 			else:
-				sys.stderr.write("[ERROR] unrecognized error encountered: " % se)
+				sys.stderr.write("[ERROR] unrecognized error encountered: %s" % se)
 				sys.exit(1)
 
 		os.unlink(fullpath)


### PR DESCRIPTION
..., it crashes without displaying the error."
