### PR TITLE
[TIMOB-14396] Tab icon/activeIcon Fixes

### DIFF
--- a/iphone/Classes/TiUIButtonBar.m
+++ b/iphone/Classes/TiUIButtonBar.m
@@ -9,12 +9,6 @@
 #import "TiUtils.h"
 #import "Webcolor.h"
 
-@protocol UIImageIOS7Support <NSObject>
-@optional
-- (UIImage *)imageWithRenderingMode:(NSInteger)renderingMode;
-@end
-
-
 @implementation TiUIButtonBar
 
 - (id) init
@@ -188,6 +182,7 @@
 			if (thisSegmentAccessibilityLabel != nil) {
 				thisSegmentImage.accessibilityLabel = thisSegmentAccessibilityLabel;
 			}
+			//CLEANUP CODE WHEN WE UPGRADE MINIMUM XCODE VERSION TO XCODE5
 			if ([thisSegmentImage respondsToSelector:@selector(imageWithRenderingMode:)]) {
 				thisSegmentImage = [(id<UIImageIOS7Support>)thisSegmentImage imageWithRenderingMode:1];//UIImageRenderingModeAlwaysOriginal;
 			}

--- a/iphone/Classes/TiUITabGroup.m
+++ b/iphone/Classes/TiUITabGroup.m
@@ -322,6 +322,15 @@ DEFINE_EXCEPTIONS
     }
 }
 
+-(void)setTabsTintColor_:(id)value
+{
+    if ([TiUtils isIOS7OrGreater]) {
+        TiColor* color = [TiUtils colorValue:value];
+        UITabBar* tabBar = [controller tabBar];
+        tabBar.tintColor = [color color];
+    }
+}
+
 -(void)setTabsBackgroundImage_:(id)value
 {
     controller.tabBar.backgroundImage = [self loadImage:value];

--- a/iphone/Classes/TiUITabProxy.h
+++ b/iphone/Classes/TiUITabProxy.h
@@ -27,6 +27,8 @@
 	BOOL systemTab;
 	BOOL transitionIsAnimating;
 	BOOL hasFocus;
+	BOOL iconOriginal;
+	BOOL activeIconOriginal;
 	
 	id<TiOrientationController> parentOrientationController;
 }

--- a/iphone/Classes/TiUITabProxy.m
+++ b/iphone/Classes/TiUITabProxy.m
@@ -47,6 +47,8 @@
 	[self replaceValue:nil forKey:@"title" notification:NO];
 	[self replaceValue:nil forKey:@"icon" notification:NO];
 	[self replaceValue:nil forKey:@"badge" notification:NO];
+	[self replaceValue:NUMBOOL(YES) forKey:@"imageIsTemplate" notification:NO];
+	[self replaceValue:NUMBOOL(YES) forKey:@"activeImageIsTemplate" notification:NO];
 	[super _configure];
 }
 
@@ -425,7 +427,32 @@
 
 	[rootController setTitle:title];
 	UITabBarItem *ourItem = nil;
-
+    
+    BOOL imageIsMask = NO;
+    
+    if ([TiUtils isIOS7OrGreater]) {
+        
+        //CLEAN UP CODE WHEN WE UPGRADE MIN XCODE VERSION TO XCODE5
+        if (image != nil) {
+            if ([image respondsToSelector:@selector(imageWithRenderingMode:)]) {
+                NSInteger theMode = iconOriginal ? 1/*UIImageRenderingModeAlwaysOriginal*/ : 2/*UIImageRenderingModeAlwaysTemplate*/;
+                image = [(id<UIImageIOS7Support>)image imageWithRenderingMode:theMode];
+            }
+        }
+        if (activeImage != nil) {
+            if ([activeImage respondsToSelector:@selector(imageWithRenderingMode:)]) {
+                NSInteger theMode = iconOriginal ? 1/*UIImageRenderingModeAlwaysOriginal*/ : 2/*UIImageRenderingModeAlwaysTemplate*/;
+                activeImage = [(id<UIImageIOS7Support>)activeImage imageWithRenderingMode:theMode];
+            }
+        }
+        
+        systemTab = NO;
+        ourItem = [[[UITabBarItem alloc] initWithTitle:title image:image selectedImage:activeImage] autorelease];
+        [ourItem setBadgeValue:badgeValue];
+        [rootController setTabBarItem:ourItem];
+        return;
+    }
+    
 	if (!systemTab)
 	{
 		ourItem = [rootController tabBarItem];
@@ -478,6 +505,32 @@
 	[self replaceValue:icon forKey:@"icon" notification:NO];
 
 	[self updateTabBarItem];
+}
+
+-(void)setImageIsTemplate:(id)value
+{
+    if (![TiUtils isIOS7OrGreater]) {
+        return;
+    }
+    [self replaceValue:value forKey:@"imageIsTemplate" notification:NO];
+    BOOL newValue = ![TiUtils boolValue:value def:YES];
+    if (newValue != iconOriginal) {
+        iconOriginal = newValue;
+        [self updateTabBarItem];
+    }
+}
+
+-(void)setActiveImageIsTemplate:(id)value
+{
+    if (![TiUtils isIOS7OrGreater]) {
+        return;
+    }
+    [self replaceValue:value forKey:@"activeImageIsTemplate" notification:NO];
+    BOOL newValue = ![TiUtils boolValue:value def:YES];
+    if (newValue != activeIconOriginal) {
+        activeIconOriginal = newValue;
+        [self updateTabBarItem];
+    }
 }
 
 -(void)setActiveIcon:(id)icon

--- a/iphone/Classes/TiUITabProxy.m
+++ b/iphone/Classes/TiUITabProxy.m
@@ -47,8 +47,8 @@
 	[self replaceValue:nil forKey:@"title" notification:NO];
 	[self replaceValue:nil forKey:@"icon" notification:NO];
 	[self replaceValue:nil forKey:@"badge" notification:NO];
-	[self replaceValue:NUMBOOL(YES) forKey:@"iconIsTemplate" notification:NO];
-	[self replaceValue:NUMBOOL(YES) forKey:@"activeIconIsTemplate" notification:NO];
+	[self replaceValue:NUMBOOL(YES) forKey:@"iconIsMask" notification:NO];
+	[self replaceValue:NUMBOOL(YES) forKey:@"activeIconIsMask" notification:NO];
 	[super _configure];
 }
 
@@ -507,12 +507,12 @@
 	[self updateTabBarItem];
 }
 
--(void)setIconIsTemplate:(id)value
+-(void)setIconIsMask:(id)value
 {
     if (![TiUtils isIOS7OrGreater]) {
         return;
     }
-    [self replaceValue:value forKey:@"iconIsTemplate" notification:NO];
+    [self replaceValue:value forKey:@"iconIsMask" notification:NO];
     BOOL newValue = ![TiUtils boolValue:value def:YES];
     if (newValue != iconOriginal) {
         iconOriginal = newValue;
@@ -520,12 +520,12 @@
     }
 }
 
--(void)setActiveIconIsTemplate:(id)value
+-(void)setActiveIconIsMask:(id)value
 {
     if (![TiUtils isIOS7OrGreater]) {
         return;
     }
-    [self replaceValue:value forKey:@"activeIconIsTemplate" notification:NO];
+    [self replaceValue:value forKey:@"activeIconIsMask" notification:NO];
     BOOL newValue = ![TiUtils boolValue:value def:YES];
     if (newValue != activeIconOriginal) {
         activeIconOriginal = newValue;

--- a/iphone/Classes/TiUITabProxy.m
+++ b/iphone/Classes/TiUITabProxy.m
@@ -441,7 +441,7 @@
         }
         if (activeImage != nil) {
             if ([activeImage respondsToSelector:@selector(imageWithRenderingMode:)]) {
-                NSInteger theMode = iconOriginal ? 1/*UIImageRenderingModeAlwaysOriginal*/ : 2/*UIImageRenderingModeAlwaysTemplate*/;
+                NSInteger theMode = activeIconOriginal ? 1/*UIImageRenderingModeAlwaysOriginal*/ : 2/*UIImageRenderingModeAlwaysTemplate*/;
                 activeImage = [(id<UIImageIOS7Support>)activeImage imageWithRenderingMode:theMode];
             }
         }

--- a/iphone/Classes/TiUITabProxy.m
+++ b/iphone/Classes/TiUITabProxy.m
@@ -47,8 +47,8 @@
 	[self replaceValue:nil forKey:@"title" notification:NO];
 	[self replaceValue:nil forKey:@"icon" notification:NO];
 	[self replaceValue:nil forKey:@"badge" notification:NO];
-	[self replaceValue:NUMBOOL(YES) forKey:@"imageIsTemplate" notification:NO];
-	[self replaceValue:NUMBOOL(YES) forKey:@"activeImageIsTemplate" notification:NO];
+	[self replaceValue:NUMBOOL(YES) forKey:@"iconIsTemplate" notification:NO];
+	[self replaceValue:NUMBOOL(YES) forKey:@"activeIconIsTemplate" notification:NO];
 	[super _configure];
 }
 
@@ -507,12 +507,12 @@
 	[self updateTabBarItem];
 }
 
--(void)setImageIsTemplate:(id)value
+-(void)setIconIsTemplate:(id)value
 {
     if (![TiUtils isIOS7OrGreater]) {
         return;
     }
-    [self replaceValue:value forKey:@"imageIsTemplate" notification:NO];
+    [self replaceValue:value forKey:@"iconIsTemplate" notification:NO];
     BOOL newValue = ![TiUtils boolValue:value def:YES];
     if (newValue != iconOriginal) {
         iconOriginal = newValue;
@@ -520,12 +520,12 @@
     }
 }
 
--(void)setActiveImageIsTemplate:(id)value
+-(void)setActiveIconIsTemplate:(id)value
 {
     if (![TiUtils isIOS7OrGreater]) {
         return;
     }
-    [self replaceValue:value forKey:@"activeImageIsTemplate" notification:NO];
+    [self replaceValue:value forKey:@"activeIconIsTemplate" notification:NO];
     BOOL newValue = ![TiUtils boolValue:value def:YES];
     if (newValue != activeIconOriginal) {
         activeIconOriginal = newValue;

--- a/iphone/Classes/TiUtils.h
+++ b/iphone/Classes/TiUtils.h
@@ -93,6 +93,10 @@ typedef enum
 @property(nonatomic,assign) BOOL automaticallyAdjustsScrollViewInsets; // Defaults to NO
 @end
 
+@protocol UIImageIOS7Support <NSObject>
+@optional
+- (UIImage *)imageWithRenderingMode:(NSInteger)renderingMode;
+@end
 
 /**
  Utilities class.


### PR DESCRIPTION
PR for [TIMOB-14936](https://jira.appcelerator.org/browse/TIMOB-14936)

Test is in [JIRA](https://jira.appcelerator.org/browse/TIMOB-14936?focusedCommentId=268309&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-268309)
1. New property on tabGroup - tabsTintColor
2. icon and activeIcon can now be specified to be rendered in original or template mode on IOS7+. Properties iconIsTemplate, activeIconIsTemplate. Default - true

Known Issue:
1. On IOS7+ activeTabIconTint property of tabGroup is not being honored. No idea why. tabsTintColor seems to work better (though it tints the title as well and works on active tab only though the docs say it should apply to all tabs.)

Docs will be updated along with the windowRefactor doc PR.
