### PR TITLE
[TIMOB-14949] (3_1_X) Make sure searchbar comes back

### DIFF
--- a/iphone/Classes/TiUISearchBar.m
+++ b/iphone/Classes/TiUISearchBar.m
@@ -41,6 +41,11 @@
 		[searchView setShowsCancelButton:[(TiUISearchBarProxy *)[self proxy] showsCancelButton]];
 		[self addSubview:searchView];
 	}
+    //IOS7 DP3 bug fix. See searchcontroller delegate method in listView.
+    if ([searchView superview] != self) {
+        [self addSubview:searchView];
+        [searchView setFrame:[self bounds]];
+    }
 	return searchView;
 }	
 


### PR DESCRIPTION
Fixes [TIMOB-14949](https://jira.appcelerator.org/browse/TIMOB-14949) on 3_1_X.
Already fixed on master
