### PR TITLE
[TIMOB-11674]iOS:Send statusbarOrientation for defaultImageView initially during boot up

### DIFF
--- a/iphone/Classes/TiRootViewController.m
+++ b/iphone/Classes/TiRootViewController.m
@@ -162,7 +162,7 @@
     rootView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
     [self updateBackground];
     if (defaultImageView != nil) {
-        [self rotateDefaultImageViewToOrientation:UIInterfaceOrientationPortrait];
+        [self rotateDefaultImageViewToOrientation:[[UIApplication sharedApplication] statusBarOrientation]];
         [rootView addSubview:defaultImageView];
     }
     [rootView becomeFirstResponder];


### PR DESCRIPTION
**Test Instruction** 

Import the following [app](https://dl.dropboxusercontent.com/u/43336767/splashtest%202.zip) to TiStudio.
build and install the app to device. 
Start the app in different orientation make sure the correct Splash screen is loaded. 
