### PR TITLE
TIMOB-14940: fix Android touch handling

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiUIView.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiUIView.java
@@ -1264,10 +1264,13 @@ public abstract class TiUIView
 					lastUpEvent.put(TiC.EVENT_PROPERTY_Y, (double) event.getY());
 				}
 
-				scaleDetector.onTouchEvent(event);
-				if (scaleDetector.isInProgress()) {
-					pointersDown = 0;
-					return true;
+				// Check scaling only if waiting for pinch
+ 				if (proxy.hierarchyHasListener(TiC.EVENT_PINCH)) {
+					scaleDetector.onTouchEvent(event);
+					if (scaleDetector.isInProgress()) {
+						pointersDown = 0;
+						return true;
+					}
 				}
 
 				boolean handled = detector.onTouchEvent(event);
@@ -1284,14 +1287,16 @@ public abstract class TiUIView
 						pointersDown++;
 					}
 				} else if (event.getAction() == MotionEvent.ACTION_UP) {
-					if (pointersDown == 1) {
-						fireEvent(TiC.EVENT_TWOFINGERTAP, dictFromEvent(event));
-						pointersDown = 0;
-						return true;
+ 					// Don't fire twofingertap if there is no listener	
+ 					if (proxy.hierarchyHasListener(TiC.EVENT_TWOFINGERTAP)) {
+						if (pointersDown == 1) {
+							fireEvent(TiC.EVENT_TWOFINGERTAP, dictFromEvent(event));
+							pointersDown = 0;
+							return true;
+						}
 					}
 					pointersDown = 0;
 				}
-
 
 				String motionEvent = motionEvents.get(event.getAction());
 				if (motionEvent != null) {


### PR DESCRIPTION
See TIMOB-14940: in Android there are frequent cases when the touchend event is not sent, when the background colors and images are not responding correctly to touches, etc. The root of this issue is the additional handling for (the rarely used) pinch and twofingertap events. (BTW - in the docs pinch is defined for iOS only..... but the Android code apparently supports it, untested by me). This PR skips the handling for pinch and twofingertap if there are no listeners or these events, and thus restoring correct behavior for the rest of the touch events. Item of note: it's not clear how twofingertap is supposed to interact with backgroundSelectedColor/Image, and touchend (all these seem to not function with twofingertap, both before and after this PR). 
