### PR TITLE
TIMOB-14395-if height or width not defined, set those keeping aspect rat...

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiImageView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiImageView.java
@@ -371,7 +371,7 @@ public class TiImageView extends ViewGroup implements Handler.Callback, OnClickL
 		// so that it doesn't get the content height/width
 		if (!viewWidthDefined || !viewHeightDefined) {
 			Drawable d = imageView.getDrawable();
-			float aspectRaio = 1;
+			float aspectRatio = 1;
 			int w = MeasureSpec.getSize(widthMeasureSpec);
 			int h = MeasureSpec.getSize(heightMeasureSpec);
 
@@ -379,17 +379,17 @@ public class TiImageView extends ViewGroup implements Handler.Callback, OnClickL
 				int ih = d.getIntrinsicHeight();
 				int iw = d.getIntrinsicWidth();
 				if (ih != 0 && iw != 0) {
-					aspectRaio = ih / iw;
+					aspectRatio = ih / iw;
 				}
 			}
 
 			if (viewWidthDefined) {
 				maxWidth = w;
-				maxHeight = Math.round(w * aspectRaio);
+				maxHeight = Math.round(w * aspectRatio);
 			}
 			if (viewHeightDefined) {
 				maxHeight = h;
-				maxWidth = Math.round(h / aspectRaio);
+				maxWidth = Math.round(h / aspectRatio);
 			}
 		}
 		

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiImageView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiImageView.java
@@ -367,6 +367,32 @@ public class TiImageView extends ViewGroup implements Handler.Callback, OnClickL
 //			Log.i(LCAT, "w: " + w + " wm: " + wm + " h: " + h + " hm: " + hm);
 //		}
 
+		// If height or width is not defined, we need to set the height/width properly
+		// so that it doesn't get the content height/width
+		if (!viewWidthDefined || !viewHeightDefined) {
+			Drawable d = imageView.getDrawable();
+			float aspectRaio = 1;
+			int w = MeasureSpec.getSize(widthMeasureSpec);
+			int h = MeasureSpec.getSize(heightMeasureSpec);
+
+			if (d != null) {
+				int ih = d.getIntrinsicHeight();
+				int iw = d.getIntrinsicWidth();
+				if (ih != 0 && iw != 0) {
+					aspectRaio = ih / iw;
+				}
+			}
+
+			if (viewWidthDefined) {
+				maxWidth = w;
+				maxHeight = Math.round(w * aspectRaio);
+			}
+			if (viewHeightDefined) {
+				maxHeight = h;
+				maxWidth = Math.round(h / aspectRaio);
+			}
+		}
+		
 		// TODO padding and margins
 
 		measureChild(imageView, widthMeasureSpec, heightMeasureSpec);


### PR DESCRIPTION
The test case is working correctly. If both width and height is defined, the image will scale to fill the area without maintaining the aspect ration. The documentation is not correct.

The test case in the comment should make the image scale keeping the aspect ratio intact and keeping the width. 
Code change fix this issue

https://jira.appcelerator.org/browse/TIMOB-14395
