### PR TITLE
[TIMOB-13927] (3_1_X) Send out row info when availabe in swipe event

### DIFF
--- a/iphone/Classes/TiUITableView.m
+++ b/iphone/Classes/TiUITableView.m
@@ -1021,6 +1021,85 @@
 	[super handleListenerAddedWithEvent:event];
 }
 
+-(void)recognizedSwipe:(UISwipeGestureRecognizer *)recognizer
+{
+    if ([[self proxy] _hasListeners:@"swipe"]) {
+    
+        NSString* swipeString;
+        switch ([recognizer direction]) {
+            case UISwipeGestureRecognizerDirectionUp:
+                swipeString = @"up";
+                break;
+            case UISwipeGestureRecognizerDirectionDown:
+                swipeString = @"down";
+                break;
+            case UISwipeGestureRecognizerDirectionLeft:
+                swipeString = @"left";
+                break;
+            case UISwipeGestureRecognizerDirectionRight:
+                swipeString = @"right";
+                break;
+            default:
+                swipeString = @"unknown";
+                break;
+        }
+        
+        
+        
+        BOOL viaSearch = [searchController isActive];
+        UITableView* theTableView = viaSearch ? [searchController searchResultsTableView] : [self tableView];
+        CGPoint point = [recognizer locationInView:theTableView];
+        CGPoint pointInView = [recognizer locationInView:self];
+        NSIndexPath* indexPath = nil;
+        
+        if (viaSearch) {
+            NSIndexPath* index = [theTableView indexPathForRowAtPoint:point];
+            if (index != nil) {
+                indexPath = [self indexPathFromSearchIndex:[index row]];
+            }
+        } else {
+            indexPath = [theTableView indexPathForRowAtPoint:point];
+        }
+        
+        
+        NSMutableDictionary *event = [[TiUtils pointToDictionary:pointInView] mutableCopy];
+        [event setValue:swipeString forKey:@"direction"];
+        [event setObject:NUMBOOL(NO) forKey:@"detail"];
+        [event setObject:NUMBOOL(viaSearch) forKey:@"search"];
+
+        if (indexPath != nil) {
+            //We have index path. Let us fill out section and row information. Also since the 
+            int sectionIdx = [indexPath section];
+            NSArray * sections = [(TiUITableViewProxy *)[self proxy] internalSections];
+            TiUITableViewSectionProxy *section = [self sectionForIndex:sectionIdx];
+            
+            int rowIndex = [indexPath row];
+            int dataIndex = 0;
+            int c = 0;
+            TiUITableViewRowProxy *row = [section rowAtIndex:rowIndex];
+            
+            // unfortunately, we have to scan to determine our row index
+            for (TiUITableViewSectionProxy *section in sections)
+            {
+                if (c == sectionIdx)
+                {
+                    dataIndex += rowIndex;
+                    break;
+                }
+                dataIndex += [section rowCount];
+                c++;
+            }
+            [event setObject:section forKey:@"section"];
+            [event setObject:row forKey:@"row"];
+            [event setObject:row forKey:@"rowData"];
+            [event setObject:NUMINT(dataIndex) forKey:@"index"];
+            
+        }
+        [[self proxy] fireEvent:@"swipe" withObject:event];
+        [event release];
+    }
+}
+
 -(void)longPressGesture:(UILongPressGestureRecognizer *)recognizer
 {
     if([[self proxy] _hasListeners:@"longpress"] && [recognizer state] == UIGestureRecognizerStateBegan)


### PR DESCRIPTION
Backport of PR #4404

Fixes [TIMOB-13927](https://jira.appcelerator.org/browse/TIMOB-13927)

Adds row information for left and right swipe. tableView eats the up and down swipe events.

Test is in [comments](https://jira.appcelerator.org/browse/TIMOB-13927?focusedCommentId=258600&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-258600)
