### PR TITLE
TIMOB-15378-Use getOuterView instead of getNativeView in getContentView ...

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIAbstractTab.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIAbstractTab.java
@@ -55,7 +55,7 @@ public abstract class TiUIAbstractTab extends TiUIView {
 		// Assign parent so events bubble up correctly.
 		windowProxy.setParent(proxy);
 
-		return windowProxy.getOrCreateView().getNativeView();
+		return windowProxy.getOrCreateView().getOuterView();
 	}
 
 	private TiWindowProxy getWindowProxy() {


### PR DESCRIPTION
Changed getContentView to use getOuterView instead of getNativeView so that for the windows with border, the border is returned.
