### PR TITLE
TIMOB-14521-Do the isNull check first before checking for other types

### DIFF
--- a/android/modules/database/src/java/ti/modules/titanium/database/TiResultSetProxy.java
+++ b/android/modules/database/src/java/ti/modules/titanium/database/TiResultSetProxy.java
@@ -105,14 +105,14 @@ public class TiResultSetProxy extends KrollProxy
 		try {
 			if (rs instanceof AbstractWindowedCursor) {
 				AbstractWindowedCursor cursor = (AbstractWindowedCursor) rs;
-				if (cursor.isFloat(index)) {
+				if (cursor.isNull(index)) {
+					result = null;
+				} else if (cursor.isFloat(index)) {
 					result = cursor.getDouble(index);
 				} else if (cursor.isLong(index)) {
 					result = cursor.getLong(index);
 				} else if (cursor.isBlob(index)) {
 					result = TiBlob.blobFromData(cursor.getBlob(index));
-				} else if (cursor.isNull(index)) {
-					result = null;
 				} else {
 					fromString = true;
 				}


### PR DESCRIPTION
Looks like 2.3 satisfies the isBlob check for null value, moved the isNull check to the top so that null value will be handled first.
https://jira.appcelerator.org/browse/TIMOB-14521
