### PR TITLE
[TIMOB-12399] iOS:Always retrieve children on main thread

### DIFF
--- a/iphone/Classes/TiViewProxy.m
+++ b/iphone/Classes/TiViewProxy.m
@@ -44,6 +44,13 @@
 @synthesize children;
 -(NSArray*)children
 {
+    if (![NSThread isMainThread]) {
+        __block NSArray* result = nil;
+        TiThreadPerformOnMainThread(^{
+            result = [[self children] retain];
+        }, YES);
+        return [result autorelease];
+    }
     NSArray* copy = nil;
     
 	pthread_rwlock_rdlock(&childrenLock);


### PR DESCRIPTION
Test is in [JIRA](https://jira.appcelerator.org/browse/TIMOB-12399)
