### PR TITLE
[TIMOB-15613] Ti.Map.View always asks for permission to use current location

### DIFF
--- a/iphone/Classes/TiMapView.m
+++ b/iphone/Classes/TiMapView.m
@@ -60,7 +60,7 @@
         map = [[MKMapView alloc] initWithFrame:CGRectZero];
         map.delegate = self;
         map.userInteractionEnabled = YES;
-        map.showsUserLocation = YES; // defaults
+        map.showsUserLocation = [TiUtils boolValue:[self.proxy valueForKey:@"userLocation"]];
         map.autoresizingMask = UIViewAutoresizingFlexibleWidth|UIViewAutoresizingFlexibleHeight;
         [self addSubview:map];
         mapLinesDictionary = [[NSMutableDictionary alloc] init];


### PR DESCRIPTION
When `showsUserLocation` is set to `YES` on init, then the user will get a popup asking for permission, even whith `Ti.Map.createView({ userLocation: false});` or when this property is unset. This fixes it by using the `userLocation` value.

Ticket: https://jira.appcelerator.org/browse/TC-3204
