### PR TITLE
[CLI] ios_sdk_minor_version

### DIFF
--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -210,13 +210,13 @@ iOSBuilder.prototype.config = function config(logger, config, cli) {
 				var m = sdkRoot.match(/\/iphone(?:os|simulator)(\d.\d).sdk/i);
 				if (m) {
 					defaultIosVersion = m[1];
-					var file = path.join(sdkRoot, 'System', 'Library', 'CoreServices', 'SystemVersion.plist');
-					if (fs.existsSync(file)) {
-						var p = new appc.plist(file);
-						if (p.ProductVersion) {
-							defaultIosVersion = p.ProductVersion;
-						}
-					}
+					// var file = path.join(sdkRoot, 'System', 'Library', 'CoreServices', 'SystemVersion.plist');
+					// if (fs.existsSync(file)) {
+					// 	var p = new appc.plist(file);
+					// 	if (p.ProductVersion) {
+					// 		defaultIosVersion = p.ProductVersion;
+					// 	}
+					// }
 				}
 			}
 

--- a/iphone/cli/lib/detect.js
+++ b/iphone/cli/lib/detect.js
@@ -143,14 +143,14 @@ exports.detect = function detect(config, opts, finished) {
 									var m = d.match(sdkRegExp);
 									if (m && (!opts.minSDK || appc.version.gte(m[2], opts.minSDK))) {
 										var ver = m[2];
-										file = path.join(file, 'System', 'Library', 'CoreServices', 'SystemVersion.plist');
-										if (fs.existsSync(file)) {
-											var p = new appc.plist(file);
-											if (p.ProductVersion) {
-												ver = p.ProductVersion;
-											}
-										}
-										vers.push(ver);
+										// file = path.join(file, 'System', 'Library', 'CoreServices', 'SystemVersion.plist');
+										// if (fs.existsSync(file)) {
+										// 	var p = new appc.plist(file);
+										// 	if (p.ProductVersion) {
+										// 		ver = p.ProductVersion;
+										// 	}
+										// }
+										// vers.push(ver);
 									}
 								}
 							});


### PR DESCRIPTION
Don't use the minor version number of ios SDK when looking. This breaks build in TiStudio
- i really dont need we should use the minor version number. "7.0" should be more than enough
