### PR TITLE
[TIMOB-15353] Window moves incorrectly when in-call/hotspot/etc. status bar is showing

### DIFF
--- a/iphone/Classes/TiBase.h
+++ b/iphone/Classes/TiBase.h
@@ -570,6 +570,7 @@ extern NSString * const kTiRemoteControlNotification;
 extern NSString * const kTiBackgroundFetchNotification;
 extern NSString * const kTiSilentPushNotification;
 extern NSString * const kTiBackgroundTransfer;
+extern NSString * const kTiFrameAdjustNotification;
 extern NSString * const kTiLocalNotification;
 extern NSString * const kTiBackgroundTransfer;
 extern NSString * const kTiURLDownloadFinished;

--- a/iphone/Classes/TiBase.m
+++ b/iphone/Classes/TiBase.m
@@ -151,7 +151,7 @@ NSString * const kTiURLSessionCompleted = @"TiSessionCompleted";
 NSString * const kTiURLSessionEventsCompleted = @"TiSessionEventsCompleted";
 NSString * const kTiURLDowloadProgress = @"TiDownloadProgress";
 NSString * const kTiURLUploadProgress = @"TiUploadProgress";
-
+NSString * const kTiFrameAdjustNotification = @"TiFrameAdjust";
 NSString * const kTiLocalNotification = @"TiLocalNotification";
 
 NSString* const kTiBehaviorSize = @"SIZE";

--- a/iphone/Classes/TiRootViewController.m
+++ b/iphone/Classes/TiRootViewController.m
@@ -76,6 +76,7 @@
 -(void)keyboardWillShow:(NSNotification*)notification;
 -(void)keyboardDidHide:(NSNotification*)notification;
 -(void)keyboardDidShow:(NSNotification*)notification;
+-(void)adjustFrameForUpSideDownOrientation:(NSNotification*)notification;
 @end
 
 @implementation TiRootViewController
@@ -135,6 +136,7 @@
         [nc addObserver:self selector:@selector(keyboardDidShow:) name:UIKeyboardDidShowNotification object:nil];
         [nc addObserver:self selector:@selector(keyboardWillHide:) name:UIKeyboardWillHideNotification object:nil];
         [nc addObserver:self selector:@selector(keyboardWillShow:) name:UIKeyboardWillShowNotification object:nil];
+        [nc addObserver:self selector:@selector(adjustFrameForUpSideDownOrientation:) name:UIApplicationDidChangeStatusBarFrameNotification object:nil];
         [[UIDevice currentDevice] beginGeneratingDeviceOrientationNotifications];
     }
     return self;
@@ -963,6 +965,49 @@
     return TI_ORIENTATION_ALLOWED([self getFlags:check],toInterfaceOrientation) ? YES : NO;
 }
 
+-(void)adjustFrameForUpSideDownOrientation:(NSNotification*)notification
+{
+    if ( (![TiUtils isIPad]) &&  ([[UIApplication sharedApplication] statusBarOrientation] == UIInterfaceOrientationPortraitUpsideDown) ) {
+        CGRect statusBarFrame = [[UIApplication sharedApplication] statusBarFrame];
+        if (statusBarFrame.size.height == 0) {
+            return;
+        }
+        
+        CGRect mainScreenBounds = [[UIScreen mainScreen] bounds];
+        CGRect appFrame = [[UIScreen mainScreen] applicationFrame];
+        CGRect viewBounds = [[self view] bounds];
+        
+        if ([TiUtils isIOS7OrGreater]) {
+            //Need to do this to force navigation bar to draw correctly on iOS7
+            [[NSNotificationCenter defaultCenter] postNotificationName:kTiFrameAdjustNotification object:nil];
+            if (statusBarFrame.size.height > 20) {
+                if (viewBounds.size.height != (mainScreenBounds.size.height - statusBarFrame.size.height)) {
+                    CGRect newBounds = CGRectMake(0, 0, mainScreenBounds.size.width, mainScreenBounds.size.height - statusBarFrame.size.height);
+                    CGPoint newCenter = CGPointMake(mainScreenBounds.size.width/2, (mainScreenBounds.size.height - statusBarFrame.size.height)/2);
+                    [[self view] setBounds:newBounds];
+                    [[self view] setCenter:newCenter];
+                    [[self view] setNeedsLayout];
+                }
+            } else {
+                if (viewBounds.size.height != mainScreenBounds.size.height) {
+                    CGRect newBounds = CGRectMake(0, 0, mainScreenBounds.size.width, mainScreenBounds.size.height);
+                    CGPoint newCenter = CGPointMake(mainScreenBounds.size.width/2, mainScreenBounds.size.height/2);
+                    [[self view] setBounds:newBounds];
+                    [[self view] setCenter:newCenter];
+                    [[self view] setNeedsLayout];
+                }
+            }
+            
+        } else {
+            if (viewBounds.size.height != appFrame.size.height) {
+                [[self view] setFrame:appFrame];
+                [[self view] setNeedsLayout];
+            }
+        }
+    }
+}
+
+
 #ifdef DEVELOPER
 - (void)viewWillLayoutSubviews
 {
@@ -986,6 +1031,7 @@
         }
     }
     [super viewDidLayoutSubviews];
+    [self adjustFrameForUpSideDownOrientation:nil];
 }
 
 //IOS5 support. Begin Section. Drop in 3.2


### PR DESCRIPTION
Test case is in [JIRA](https://jira.appcelerator.org/browse/TIMOB-15353)

Make sure to test this on both iOS7 and iOS6 for the iPhone idiom
