### PR TITLE
TIMOB-15734: Move isNull() check after isFloat() so we error out appropriately

### DIFF
--- a/android/modules/database/src/java/ti/modules/titanium/database/TiResultSetProxy.java
+++ b/android/modules/database/src/java/ti/modules/titanium/database/TiResultSetProxy.java
@@ -105,12 +105,13 @@ public class TiResultSetProxy extends KrollProxy
 		try {
 			if (rs instanceof AbstractWindowedCursor) {
 				AbstractWindowedCursor cursor = (AbstractWindowedCursor) rs;
-				if (cursor.isNull(index)) {
-					result = null;
-				} else if (cursor.isFloat(index)) {
+				
+				if (cursor.isFloat(index)) {
 					result = cursor.getDouble(index);
 				} else if (cursor.isLong(index)) {
 					result = cursor.getLong(index);
+				} else if (cursor.isNull(index)) {
+					result = null;
 				} else if (cursor.isBlob(index)) {
 					result = TiBlob.blobFromData(cursor.getBlob(index));
 				} else {


### PR DESCRIPTION
https://jira.appcelerator.org/browse/TIMOB-15734

Test case in Jira.  As a part of the test, please also run https://jira.appcelerator.org/browse/TIMOB-14521 since it was a regression caused by this.
