### PR TITLE
[TIMOB-15268] View from template java side

### DIFF
--- a/android/build/common.xml
+++ b/android/build/common.xml
@@ -391,13 +391,21 @@ Common ant tasks and macros for building Android-based Titanium modules and proj
 	<target name="build.kroll.common.jar">
 		<property name="kroll.common.classes.dir" location="${dist.classes.dir}/kroll-common"/>
 		<mkdir dir="${kroll.common.classes.dir}"/>
-		<javac srcdir="${kroll.common.project.dir}/src/java"
+		<javac
+			srcdir="${kroll.common.project.dir}/src/java"
 			destdir="${kroll.common.classes.dir}" debug="true"
 			source="1.6" target="1.6"
 			includeantruntime="false">
 			<classpath refid="android"/>
 		</javac>
-
+		<mkdir dir="${kroll.common.project.dir}/generated/java"/>
+		<javac
+			srcdir="${kroll.common.project.dir}/generated/java"
+			destdir="${kroll.common.classes.dir}" debug="true"
+			source="1.6" target="1.6"
+			includeantruntime="false">
+			<classpath refid="android"/>
+		</javac>
 		<property name="kroll.common.dest" value="${dist.dir}/kroll-common.jar"/>
 		<jar destfile="${kroll.common.dest}" basedir="${kroll.common.classes.dir}"/>
 	</target>
@@ -549,6 +557,7 @@ Common ant tasks and macros for building Android-based Titanium modules and proj
 			<arg value="${toString:kroll.apt.path}"/>
 			<arg value="org.appcelerator.kroll.annotations.generator.KrollAPIUpdater"/>
 			<arg value="${dist.dir}"/>
+			<arg value="${kroll.common.project.dir}"/>
 
 			<fileset dir="${dist.json.dir}" includes="**/*.json"/>
 		</apply>

--- a/android/kroll-apt/src/java/org/appcelerator/kroll/common/APIMap.java.fm
+++ b/android/kroll-apt/src/java/org/appcelerator/kroll/common/APIMap.java.fm
@@ -19,8 +19,6 @@ public class APIMap {
     
     public static String getProxyClass(String apiName_) {
         apiName_ = apiName_.replaceFirst("^(Titanium|Ti)\\.", "");
-        Log.d("test", PROXY_MAP.toString());
-        Log.d("APIMap", apiName_);
         return PROXY_MAP.get(apiName_);
     }
 }

--- a/android/kroll-apt/src/java/org/appcelerator/kroll/common/APIMap.java.fm
+++ b/android/kroll-apt/src/java/org/appcelerator/kroll/common/APIMap.java.fm
@@ -1,0 +1,26 @@
+/** This is generated, do not edit by hand. **/
+package org.appcelerator.kroll.common;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class APIMap {
+
+    private static final Map<String, String> PROXY_MAP = createProxyMap();
+
+    private static Map<String, String> createProxyMap() {
+        Map<String, String> result = new HashMap<String, String>();
+        <#list apis?keys as api>
+        	result.put("${api}", "${apis[api]}");
+		</#list>
+        return Collections.unmodifiableMap(result);
+    }
+    
+    public static String getProxyClass(String apiName_) {
+        apiName_ = apiName_.replaceFirst("^(Titanium|Ti)\\.", "");
+        Log.d("test", PROXY_MAP.toString());
+        Log.d("APIMap", apiName_);
+        return PROXY_MAP.get(apiName_);
+    }
+}

--- a/android/modules/accelerometer/project.properties
+++ b/android/modules/accelerometer/project.properties
@@ -10,5 +10,4 @@
 android.library=true
 # Project target.
 target=Google Inc.:Google APIs:10
-android.library.reference.1=../../runtime/common
-android.library.reference.2=../../titanium
+android.library.reference.1=../../titanium

--- a/android/modules/analytics/project.properties
+++ b/android/modules/analytics/project.properties
@@ -10,5 +10,4 @@
 android.library=true
 # Project target.
 target=Google Inc.:Google APIs:10
-android.library.reference.1=../../runtime/common
-android.library.reference.2=../../titanium
+android.library.reference.1=../../titanium

--- a/android/modules/android/project.properties
+++ b/android/modules/android/project.properties
@@ -10,5 +10,4 @@
 android.library=true
 # Project target.
 target=android-14
-android.library.reference.1=../../runtime/common
-android.library.reference.2=../../titanium
+android.library.reference.1=../../titanium

--- a/android/modules/app/project.properties
+++ b/android/modules/app/project.properties
@@ -10,5 +10,4 @@
 android.library=true
 # Project target.
 target=Google Inc.:Google APIs:10
-android.library.reference.1=../../runtime/common
-android.library.reference.2=../../titanium
+android.library.reference.1=../../titanium

--- a/android/modules/calendar/project.properties
+++ b/android/modules/calendar/project.properties
@@ -10,5 +10,4 @@
 android.library=true
 # Project target.
 target=Google Inc.:Google APIs:14
-android.library.reference.1=../../runtime/common
-android.library.reference.2=../../titanium
+android.library.reference.1=../../titanium

--- a/android/modules/contacts/project.properties
+++ b/android/modules/contacts/project.properties
@@ -10,5 +10,4 @@
 android.library=true
 # Project target.
 target=Google Inc.:Google APIs:10
-android.library.reference.1=../../runtime/common
-android.library.reference.2=../../titanium
+android.library.reference.1=../../titanium

--- a/android/modules/database/project.properties
+++ b/android/modules/database/project.properties
@@ -10,5 +10,4 @@
 android.library=true
 # Project target.
 target=Google Inc.:Google APIs:10
-android.library.reference.1=../../runtime/common
-android.library.reference.2=../../titanium
+android.library.reference.1=../../titanium

--- a/android/modules/filesystem/project.properties
+++ b/android/modules/filesystem/project.properties
@@ -10,5 +10,4 @@
 android.library=true
 # Project target.
 target=Google Inc.:Google APIs:10
-android.library.reference.1=../../runtime/common
-android.library.reference.2=../../titanium
+android.library.reference.1=../../titanium

--- a/android/modules/geolocation/project.properties
+++ b/android/modules/geolocation/project.properties
@@ -10,5 +10,4 @@
 android.library=true
 # Project target.
 target=Google Inc.:Google APIs:10
-android.library.reference.1=../../runtime/common
-android.library.reference.2=../../titanium
+android.library.reference.1=../../titanium

--- a/android/modules/gesture/project.properties
+++ b/android/modules/gesture/project.properties
@@ -10,5 +10,4 @@
 android.library=true
 # Project target.
 target=Google Inc.:Google APIs:10
-android.library.reference.1=../../runtime/common
-android.library.reference.2=../../titanium
+android.library.reference.1=../../titanium

--- a/android/modules/locale/project.properties
+++ b/android/modules/locale/project.properties
@@ -10,5 +10,4 @@
 android.library=true
 # Project target.
 target=Google Inc.:Google APIs:10
-android.library.reference.1=../../runtime/common
-android.library.reference.2=../../titanium
+android.library.reference.1=../../titanium

--- a/android/modules/map/project.properties
+++ b/android/modules/map/project.properties
@@ -10,5 +10,4 @@
 android.library=true
 # Project target.
 target=Google Inc.:Google APIs:10
-android.library.reference.1=../../runtime/common
-android.library.reference.2=../../titanium
+android.library.reference.1=../../titanium

--- a/android/modules/media/project.properties
+++ b/android/modules/media/project.properties
@@ -10,6 +10,5 @@
 android.library=true
 # Project target.
 target=Google Inc.:Google APIs:10
-android.library.reference.1=../../runtime/common
-android.library.reference.3=../filesystem
-android.library.reference.2=../../titanium
+android.library.reference.1=../../titanium
+android.library.reference.2=../filesystem

--- a/android/modules/network/project.properties
+++ b/android/modules/network/project.properties
@@ -10,6 +10,5 @@
 android.library=true
 # Project target.
 target=Google Inc.:Google APIs:10
-android.library.reference.1=../../runtime/common
-android.library.reference.3=../xml
-android.library.reference.2=../../titanium
+android.library.reference.1=../../titanium
+android.library.reference.2=../xml

--- a/android/modules/platform/project.properties
+++ b/android/modules/platform/project.properties
@@ -10,5 +10,4 @@
 android.library=true
 # Project target.
 target=Google Inc.:Google APIs:10
-android.library.reference.1=../../runtime/common
-android.library.reference.2=../../titanium
+android.library.reference.1=../../titanium

--- a/android/modules/ui/project.properties
+++ b/android/modules/ui/project.properties
@@ -10,7 +10,6 @@
 android.library=true
 # Project target.
 target=android-17
-android.library.reference.1=../../runtime/common
-android.library.reference.3=../filesystem
-android.library.reference.4=../media
-android.library.reference.2=../../titanium
+android.library.reference.1=../../titanium
+android.library.reference.3=../media
+android.library.reference.2=../filesystem

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/PickerColumnProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/PickerColumnProxy.java
@@ -105,12 +105,17 @@ public class PickerColumnProxy extends TiViewProxy implements PickerRowListener
 	}
 
 	@Override
-	public void add(TiViewProxy o)
+	public void add(Object obj) 
 	{
+		TiViewProxy child = null;
+		if(obj instanceof TiViewProxy) {
+			child = (TiViewProxy)obj;
+		}
+		if (child == null) return;
 		if (TiApplication.isUIThread()) {
-			handleAddRow(o);
+			handleAddRow(child);
 		} else {
-			TiMessenger.sendBlockingMainMessage(getMainHandler().obtainMessage(MSG_ADD), o);
+			TiMessenger.sendBlockingMainMessage(getMainHandler().obtainMessage(MSG_ADD), child);
 		}
 	}
 	
@@ -130,7 +135,6 @@ public class PickerColumnProxy extends TiViewProxy implements PickerRowListener
 	
 	private void handleAddRow(TiViewProxy o)
 	{
-		if (o == null)return;
 		if (o instanceof PickerRowProxy) {
 			((PickerRowProxy)o).setRowListener(this);
 			super.add((PickerRowProxy)o);

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/PickerProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/PickerProxy.java
@@ -206,14 +206,6 @@ public class PickerProxy extends TiViewProxy implements PickerColumnListener
 	}
 
 	@Override
-	public void add(TiViewProxy child)
-	{
-		this.add((Object)child);
-	}
-
-	// We need a special add() method above and beyond the TiViewProxy add() because
-	// because we can also accept array of PickerRowProxys
-	@Kroll.method
 	public void add(Object child) 
 	{
 		if (!isPlainPicker()) {

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/PickerRowProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/PickerRowProxy.java
@@ -61,7 +61,7 @@ public class PickerRowProxy extends TiViewProxy
 	}
 	
 	@Override
-	public void add(TiViewProxy child)
+	public void add(Object child) 
 	{
 		Log.w(TAG, "PickerRow does not support child controls");
 	}

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TableViewRowProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TableViewRowProxy.java
@@ -113,8 +113,13 @@ public class TableViewRowProxy extends TiViewProxy
 		return controls.toArray(new TiViewProxy[controls.size()]);
 	}
 
-	public void add(TiViewProxy control)
+	@Override
+	public void add(Object obj) 
 	{
+		TiViewProxy control = null;
+		if(obj instanceof TiViewProxy) {
+			control = (TiViewProxy)obj;
+		}
 		if (controls == null) {
 			controls = new ArrayList<TiViewProxy>();
 		}

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/ViewProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/ViewProxy.java
@@ -56,9 +56,7 @@ public class ViewProxy extends TiViewProxy
 				getApiName());
 		Object properties = (template_.containsKey(TiC.PROPERTY_PROPERTIES))?template_.get(TiC.PROPERTY_PROPERTIES):template_;
 		try {
-			Log.d("ViewProxy", "type " + type);
 			String result = APIMap.getProxyClass(type);
-					Log.d("ViewProxy", "result " + result);
 			Class<? extends KrollProxy> cls = (Class<? extends KrollProxy>) Class
 					.forName(APIMap.getProxyClass(type));
 			TiViewProxy proxy = (TiViewProxy) KrollProxy.createProxy(cls, null,

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/ViewProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/ViewProxy.java
@@ -56,7 +56,6 @@ public class ViewProxy extends TiViewProxy
 				getApiName());
 		Object properties = (template_.containsKey(TiC.PROPERTY_PROPERTIES))?template_.get(TiC.PROPERTY_PROPERTIES):template_;
 		try {
-			String result = APIMap.getProxyClass(type);
 			Class<? extends KrollProxy> cls = (Class<? extends KrollProxy>) Class
 					.forName(APIMap.getProxyClass(type));
 			TiViewProxy proxy = (TiViewProxy) KrollProxy.createProxy(cls, null,

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/ViewProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/ViewProxy.java
@@ -6,10 +6,17 @@
  */
 package ti.modules.titanium.ui;
 
+import java.util.HashMap;
+
 import org.appcelerator.kroll.annotations.Kroll;
+import org.appcelerator.kroll.KrollProxy;
+import org.appcelerator.kroll.common.APIMap;
+import org.appcelerator.kroll.common.Log;
 import org.appcelerator.titanium.TiContext;
+import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.proxy.TiViewProxy;
 import org.appcelerator.titanium.view.TiUIView;
+import org.appcelerator.titanium.util.TiConvert;
 
 import ti.modules.titanium.ui.widget.TiView;
 import android.app.Activity;
@@ -40,5 +47,65 @@ public class ViewProxy extends TiViewProxy
 	public String getApiName()
 	{
 		return "Ti.UI.View";
+	}
+
+	@SuppressWarnings("unchecked")
+	private TiViewProxy createViewFromTemplate(HashMap template_,
+			KrollProxy rootProxy) {
+		String type = TiConvert.toString(template_, TiC.PROPERTY_TYPE,
+				getApiName());
+		Object properties = (template_.containsKey(TiC.PROPERTY_PROPERTIES))?template_.get(TiC.PROPERTY_PROPERTIES):template_;
+		try {
+			Log.d("ViewProxy", "type " + type);
+			String result = APIMap.getProxyClass(type);
+					Log.d("ViewProxy", "result " + result);
+			Class<? extends KrollProxy> cls = (Class<? extends KrollProxy>) Class
+					.forName(APIMap.getProxyClass(type));
+			TiViewProxy proxy = (TiViewProxy) KrollProxy.createProxy(cls, null,
+					new Object[] { properties }, null);
+			if (proxy == null) return null;
+			proxy.updateKrollObjectProperties();
+			if (rootProxy != null
+					&& template_.containsKey(TiC.PROPERTY_BIND_ID)) {
+				rootProxy.setProperty(
+						TiConvert.toString(template_, TiC.PROPERTY_BIND_ID),
+						proxy);
+			}
+			if (template_.containsKey(TiC.PROPERTY_CHILD_TEMPLATES)) {
+				Object childProperties = template_.get(TiC.PROPERTY_CHILD_TEMPLATES);
+				if (childProperties instanceof Object[]) {
+					Object[] propertiesArray = (Object[]) childProperties;
+					for (int i = 0; i < propertiesArray.length; i++) {
+						Object childDict = propertiesArray[i];
+						if (childDict instanceof TiViewProxy) {
+							proxy.add((TiViewProxy)childDict);
+						}
+						else {
+							TiViewProxy childProxy = createViewFromTemplate((HashMap) childDict, rootProxy);
+							if (childProxy != null) proxy.add(childProxy);
+						}
+					}
+				}
+			}
+			return proxy;
+		} catch (Exception e) {
+			e.printStackTrace();
+			return null;
+		}
+	}
+
+	@Override
+	public void add(Object args) {
+		if (args instanceof Object[]) {
+			for (Object obj : (Object[]) args) {
+				add(obj);
+			}
+			return;
+		} else if (args instanceof HashMap) {
+			TiViewProxy childProxy = createViewFromTemplate((HashMap) args, this);
+			if (childProxy != null) add(childProxy);
+		} else {
+			super.add(args);
+		}
 	}
 }

--- a/android/modules/utils/project.properties
+++ b/android/modules/utils/project.properties
@@ -10,5 +10,4 @@
 android.library=true
 # Project target.
 target=Google Inc.:Google APIs:10
-android.library.reference.1=../../runtime/common
-android.library.reference.2=../../titanium
+android.library.reference.1=../../titanium

--- a/android/modules/xml/project.properties
+++ b/android/modules/xml/project.properties
@@ -10,5 +10,4 @@
 android.library=true
 # Project target.
 target=Google Inc.:Google APIs:10
-android.library.reference.1=../../runtime/common
-android.library.reference.2=../../titanium
+android.library.reference.1=../../titanium

--- a/android/runtime/common/.classpath
+++ b/android/runtime/common/.classpath
@@ -4,6 +4,6 @@
 	<classpathentry kind="src" path="src/java"/>
 	<classpathentry kind="con" path="com.android.ide.eclipse.adt.ANDROID_FRAMEWORK"/>
 	<classpathentry exported="true" kind="con" path="com.android.ide.eclipse.adt.LIBRARIES"/>
-	<classpathentry exported="true" kind="con" path="com.android.ide.eclipse.adt.DEPENDENCIES"/>
+	<classpathentry kind="con" path="com.android.ide.eclipse.adt.DEPENDENCIES"/>
 	<classpathentry kind="output" path="bin/classes"/>
 </classpath>

--- a/android/runtime/common/src/java/org/appcelerator/kroll/KrollObject.java
+++ b/android/runtime/common/src/java/org/appcelerator/kroll/KrollObject.java
@@ -158,5 +158,6 @@ public abstract class KrollObject implements Handler.Callback
 	protected abstract boolean fireEvent(KrollObject source, String type, Object data, boolean bubbles, boolean reportSuccess, int code, String message);
 	protected abstract void doRelease();
 	protected abstract void doSetWindow(Object windowProxyObject);
+	protected abstract void updateNativeProperties(Object properties);
 }
 

--- a/android/runtime/common/src/java/org/appcelerator/kroll/common/APIMap.java
+++ b/android/runtime/common/src/java/org/appcelerator/kroll/common/APIMap.java
@@ -16,8 +16,6 @@ public class APIMap {
     
     public static String getProxyClass(String apiName_) {
     	apiName_ = apiName_.replaceFirst("^(Titanium|Ti)\\.", "");
-    	Log.d("test", PROXY_MAP.toString());
-    	Log.d("APIMap", apiName_);
     	return PROXY_MAP.get(apiName_); 
     }
 }

--- a/android/runtime/common/src/java/org/appcelerator/kroll/common/APIMap.java
+++ b/android/runtime/common/src/java/org/appcelerator/kroll/common/APIMap.java
@@ -1,0 +1,23 @@
+/** This is generated, do not edit by hand. **/
+package org.appcelerator.kroll.common;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class APIMap {
+
+    private static final Map<String, String> PROXY_MAP = createProxyMap();
+
+    private static Map<String, String> createProxyMap() {
+        Map<String, String> result = new HashMap<String, String>();
+        return Collections.unmodifiableMap(result);
+    }
+    
+    public static String getProxyClass(String apiName_) {
+    	apiName_ = apiName_.replaceFirst("^(Titanium|Ti)\\.", "");
+    	Log.d("test", PROXY_MAP.toString());
+    	Log.d("APIMap", apiName_);
+    	return PROXY_MAP.get(apiName_); 
+    }
+}

--- a/android/runtime/v8/project.properties
+++ b/android/runtime/v8/project.properties
@@ -8,6 +8,5 @@
 # project structure.
 
 android.library=true
-android.library.reference.1=../common
 # Project target.
 target=android-10

--- a/android/runtime/v8/src/java/org/appcelerator/kroll/runtime/v8/V8Object.java
+++ b/android/runtime/v8/src/java/org/appcelerator/kroll/runtime/v8/V8Object.java
@@ -97,6 +97,16 @@ public class V8Object extends KrollObject
 			release();
 		}
 	}
+	
+	@Override
+	public void updateNativeProperties(Object properties)
+	{
+		if (!KrollRuntime.isInitialized()) {
+			Log.w(TAG, "Runtime disposed, cannot updateNativeProperties");
+			return;
+		}
+		nativeUpdateProperties(ptr, properties);
+	}
 
 	// JNI method prototypes
 	protected static native void nativeInitObject(Class<?> proxyClass, Object proxyObject);
@@ -106,5 +116,6 @@ public class V8Object extends KrollObject
 	private native void nativeSetProperty(long ptr, String name, Object value);
 	private native boolean nativeFireEvent(long ptr, Object source, long sourcePtr, String event, Object data, boolean bubble, boolean reportSuccess, int code, String errorMessage);
 	private native void nativeSetWindow(long ptr, Object windowProxyObject);
+	private native void nativeUpdateProperties(long ptr, Object properties);
 }
 

--- a/android/titanium/.classpath
+++ b/android/titanium/.classpath
@@ -12,5 +12,6 @@
 	<classpathentry exported="true" kind="con" path="com.android.ide.eclipse.adt.LIBRARIES"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/kroll-common"/>
 	<classpathentry exported="true" kind="con" path="com.android.ide.eclipse.adt.DEPENDENCIES"/>
+	<classpathentry exported="true" kind="lib" path="/titanium-dist/lib/kroll-common.jar"/>
 	<classpathentry kind="output" path="bin/classes"/>
 </classpath>

--- a/android/titanium/project.properties
+++ b/android/titanium/project.properties
@@ -8,6 +8,5 @@
 # project structure.
 
 android.library=true
-android.library.reference.1=../runtime/common
 # Project target.
 target=android-16

--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/TiViewProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/TiViewProxy.java
@@ -530,8 +530,13 @@ public abstract class TiViewProxy extends KrollProxy implements Handler.Callback
 	 * @module.api
 	 */
 	@Kroll.method
-	public void add(TiViewProxy child)
+	public void add(Object obj)
 	{
+		TiViewProxy child = null;
+		if (obj instanceof TiViewProxy) {
+			child = (TiViewProxy)obj;
+		}
+
 		if (child == null) {
 			Log.e(TAG, "Add called with a null child");
 			return;

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiConvert.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiConvert.java
@@ -579,6 +579,21 @@ public class TiConvert
 	{
 		return toString(hashMap.get(key));
 	}
+	
+	/**
+	 * Takes a value out of a hash table then attempts to convert it using {@link #toString(Object)} for more details.
+	 * @param hashMap the hash map to search.
+	 * @param key the lookup key.
+	 * @return String or null.
+	 * @module.api
+	 */
+	public static String toString(HashMap<String, Object> hashMap, String key, String def)
+	{
+		if (hashMap != null)
+			return toString(hashMap.get(key), def);
+		return def;
+	}
+
 
 	/**
 	 * Converts an Object array into a String array.


### PR DESCRIPTION
This is kind of a big PR with great consequences. The original idea was for this example to work

```
var win = Ti.UI.createWindow({
    backgroundColor : 'white',
    orientationModes : [Ti.UI.UPSIDE_PORTRAIT, Ti.UI.PORTRAIT, Ti.UI.LANDSCAPE_RIGHT, Ti.UI.LANDSCAPE_LEFT]
});
var btnHolder = Ti.UI.createView({
    left: 0,
    layout: 'vertical',
    height: Ti.UI.SIZE,
    width: Ti.UI.SIZE,
    backgroundColor: 'green'
});
btnHolder.add([
    {type:'Ti.UI.Button', left:0, bid:0,title: 'start'},
    {type:'Ti.UI.Button', right:0, bid:1,title: 'pause'},
    {type:'Ti.UI.Button', left:0, bid:2,title: 'resume'},
    {type:'Ti.UI.Button', right:0, bid:3,title: 'playpause'},
    {type:'Ti.UI.Button', left:0, bid:4,title: 'stop'},
    {type:'Ti.UI.Button', right:0, bid:5,title: 'reverse'},
    {type:'Ti.UI.Button', left:0, bid:6,title: 'autoreverse'},
    {type:'Ti.UI.Button', right:0, bid:7,title: 'transition'}
]);
btnHolder.addEventListener('singletap', function(e) {
    Ti.API.info(JSON.stringify(e));
    alert("we tapped on the button with bid: " + e.source.bid);
});
win.add(btnHolder);
win.open();
```

[jira ticket](https://jira.appcelerator.org/browse/TC-3364)

Now about the PR:
- The "APIMap" can obviously be changed as i didnt really now how to name it.
- You can see that i modified almost all the android projects. Why? The  trick behind that PR is to add a class to kroll.common. But that class can only be created in the ant target "update.apis". This means that when developing the SDK for android in eclipse you would not get the correct jar file. (currently you get the one from the kroll.common project under bin). 
  With that PR, every project will use the one from dist/android, which has been modified by "update.apis"
- As mentioned in the ticket, this PR allows to create any proxy on the java's side using templates. Consequently it will allow to fix [this one](https://jira.appcelerator.org/browse/TIMOB-15268)
- About the native side. Why did i add the "nativeUpdateProperties" method? Without it the sample wouldn't work. Especially you wouldn't be able to read the "bid" property from the "singletap" event. This is because "bid" is not a "compiled" accessor, and so we need to tell the krollobject to store that value (knowing that you won't be able to  change it in the future if there is no bindId).

Once again i am willing to give any amount of work to get this one to go through.
