### PR TITLE
[TIMOB-13121] (3_2_X) Ensure touchdelegate is set if we are not going to reconstruct the row.

### DIFF
--- a/iphone/Classes/TiUITableViewRowProxy.m
+++ b/iphone/Classes/TiUITableViewRowProxy.m
@@ -745,6 +745,13 @@ TiProxy * DeepScanForProxyOfViewContainingPoint(UIView * targetView, CGPoint poi
                 [self triggerRowUpdate];
             } else {
                 DeveloperLog(@"Height does not change. Just laying out children. Height %.1f",curHeight);
+                //TIMOB-13121. Ensure touchdelegate is set if we are not going to reconstruct the row.
+                if ([rowContainerView superview] != nil) {
+                    UIView* contentView = [rowContainerView superview];
+                    [[self children] enumerateObjectsUsingBlock:^(TiViewProxy *proxy, NSUInteger idx, BOOL *stop) {
+                        [self redelegateViews:proxy toView:contentView];
+                    }];
+                }
                 [callbackCell setNeedsDisplay];
             }
         } else {


### PR DESCRIPTION
Cherry Pick PR #5079 into 3_2_X

Test is in [JIRA](https://jira.appcelerator.org/browse/TIMOB-13121)
