### PR TITLE
[TIMOB-15952] Fixed bug with missing background images being copied, but...

### DIFF
--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -2423,6 +2423,7 @@ AndroidBuilder.prototype.copyResources = function copyResources(next) {
 					return true;
 				}
 			}, this)) {
+				delete this.lastBuildFiles[destBg];
 				copyFile.call(this, path.join(templateDir, 'default.png'), destBg);
 			}
 		}


### PR DESCRIPTION
... then removed because the background image was not removed from the lastBuildFiles map.
