### PR TITLE
Crittercism temp fix.

### DIFF
--- a/iphone/Classes/TiApp.m
+++ b/iphone/Classes/TiApp.m
@@ -384,6 +384,8 @@ TI_INLINE void waitForMemoryPanicCleared();   //WARNING: This must never be run 
 		[self generateNotification:notification];
 	}
     [self launchToUrl];
+    //TODO : Should be removed once crittercism update's module
+    [self updateModuleAppId];
 	[self boot];
 	
 	return YES;
@@ -506,6 +508,13 @@ TI_INLINE void waitForMemoryPanicCleared();   //WARNING: This must never be run 
         completionHandler();
     } else{
         DebugLog(@"[ERROR] The specified Completion Handler with ID: %@ has already expired or removed from the system", key);
+    }
+}
+
+-(void)updateModuleAppId {
+    id val = [[TiApp tiAppProperties] objectForKey:@"com-appcelerator-apm-id"];
+    if (val != nil) {
+        [[NSUserDefaults standardUserDefaults] setObject:val forKey:@"com-appcelerator-apm-id"];
     }
 }
 


### PR DESCRIPTION
create a new app in Appc Studio using this sdk and the current crittercism module (1.0.7)
Copy the following [app.js](https://gist.github.com/srahim/12691f320aa42bd62124)
run the app on device
Hit the crash button.
go to dashboard.appcelerator.com login with you username and password. 
Select the newly created app from the drop down menu. go to performance tab. and select live stats from the side bar
now open the app again. 
wait for min or so. 
you should see the crash report and app number of app loads 2
