### PR TITLE
[TIMOB-16014] 3_2_X  iOS: Fixing TextField setSelection race condition with change event

### DIFF
--- a/iphone/Classes/TiUITextField.m
+++ b/iphone/Classes/TiUITextField.m
@@ -510,7 +510,12 @@
         return NO;
     }
 
-	[(TiUITextFieldProxy *)self.proxy noteValueChange:curText];
+    /*
+        Adding a small delay as `change` event can be fired even before the textfield text is actually updated by the system,
+        leading to race conditions. Refer to TIMOB-16014
+     */
+
+	[(TiUITextFieldProxy *)self.proxy performSelector:@selector(noteValueChange:) withObject:curText afterDelay:0.01];
 	return YES;
 }
 


### PR DESCRIPTION
Test case in [JIRA](https://jira.appcelerator.org/browse/TIMOB-16014)

**Make sure to test on device, as this is a timing issue. Need to confirm it does not occur on device**

Backport of #5124
