### PR TITLE
TIMOB-16048: Only use measured height from content view if it's greater ...

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiTableViewRowProxyItem.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiTableViewRowProxyItem.java
@@ -502,7 +502,8 @@ public class TiTableViewRowProxyItem extends TiBaseTableViewItem
 				} else {
 					h = Math.max(minRowHeight, height.getAsPixels(this));
 				}
-				if (hasChildView) {
+				// Make sure the height is greater than 1 (not 0 since image views default to 1)
+				if (hasChildView && h > 1) {
 					content.getLayoutParams().height = h;
 				}
 


### PR DESCRIPTION
...than 1 (default size for image view is 1)

https://jira.appcelerator.org/browse/TIMOB-16048

Test case in Jira.

Please also test:
https://jira.appcelerator.org/browse/TIMOB-12658
https://jira.appcelerator.org/browse/TIMOB-14359
KS (Table view section)
