### PR TITLE
[TIMOB-15544]iOS: Clean out tabs before the rootWindow is removed.

### DIFF
--- a/iphone/Classes/TiUITabProxy.m
+++ b/iphone/Classes/TiUITabProxy.m
@@ -28,6 +28,9 @@
 
 -(void)_destroy
 {
+    if (rootWindow != nil) {
+        [self cleanNavStack:YES];
+    }
     RELEASE_TO_NIL(controllerStack);
     RELEASE_TO_NIL(rootWindow);
     RELEASE_TO_NIL(controller);


### PR DESCRIPTION
Test Case in [JIRA](https://jira.appcelerator.org/browse/TIMOB-15940)

Backport of #5166
