### PR TITLE
[TIMOB-16014]  32X iOS: textfield change should only be fired in didchange delegate method.

### DIFF
--- a/iphone/Classes/TiUITextField.m
+++ b/iphone/Classes/TiUITextField.m
@@ -509,13 +509,6 @@
         [self setValue_:curText];
         return NO;
     }
-
-    /*
-        Adding a small delay as `change` event can be fired even before the textfield text is actually updated by the system,
-        leading to race conditions. Refer to TIMOB-16014
-     */
-
-	[(TiUITextFieldProxy *)self.proxy performSelector:@selector(noteValueChange:) withObject:curText afterDelay:0.01];
 	return YES;
 }
 


### PR DESCRIPTION
Test case in [JIRA](https://jira.appcelerator.org/browse/TIMOB-16014#comment-286550)

**Please regress against the original issue test code too.**

backport of #5178
