### PR TITLE
[TIMOB-15967] (3_2_X) Refactor of TextField responder code

### DIFF
--- a/iphone/Classes/TiUITextField.m
+++ b/iphone/Classes/TiUITextField.m
@@ -194,26 +194,24 @@
 	}
 }
 
--(BOOL)canBecomeFirstResponder
-{
-    return self.isEnabled;
-}
 
 -(BOOL)resignFirstResponder
 {
-	becameResponder = NO;
-	
 	if ([super resignFirstResponder])
 	{
 		[self repaintMode];
-		return YES;
+        if (becameResponder) {
+            becameResponder = NO;
+            [touchHandler makeRootViewFirstResponder];
+        }
+        return YES;
 	}
 	return NO;
 }
 
 -(BOOL)becomeFirstResponder
 {
-    if (self.canBecomeFirstResponder) {
+    if (self.isEnabled) {
         if ([super becomeFirstResponder])
         {
             becameResponder = YES;

--- a/iphone/Classes/TiUITextWidget.m
+++ b/iphone/Classes/TiUITextWidget.m
@@ -150,20 +150,11 @@
 
 -(BOOL)resignFirstResponder
 {
-	if (![textWidgetView isFirstResponder])
-	{
-		return NO;
-	}
 	return [[self textWidgetView] resignFirstResponder];
 }
 
 -(BOOL)becomeFirstResponder
 {
-	if ([textWidgetView isFirstResponder])
-	{
-		return NO;
-	}
-	
 	return [[self textWidgetView] becomeFirstResponder];
 }
 

--- a/iphone/Classes/TiUITextWidgetProxy.m
+++ b/iphone/Classes/TiUITextWidgetProxy.m
@@ -102,11 +102,11 @@ DEFINE_DEF_BOOL_PROP(suppressReturn,YES);
 		[self replaceValue:newValue forKey:@"value" notification:NO];
 		[self contentsWillChange];
 		[self fireEvent:@"change" withObject:[NSDictionary dictionaryWithObject:newValue forKey:@"value"]];
+        TiThreadPerformOnMainThread(^{
+            //Make sure the text widget is in view when editing.
+            [(TiUITextWidget*)[self view] updateKeyboardStatus];
+        }, NO);
 	}
-    TiThreadPerformOnMainThread(^{
-        //Make sure the text widget is in view when editing.
-        [(TiUITextWidget*)[self view] updateKeyboardStatus];
-    }, NO);
 }
 
 #pragma mark Toolbar


### PR DESCRIPTION
Backport PR #5184 to 3_2_X

Fix for [TIMOB-15967](https://jira.appcelerator.org/browse/TIMOB-15967)

Regress against
[TIMOB-15940](https://jira.appcelerator.org/browse/TIMOB-15940)
[TIMOB-15033](https://jira.appcelerator.org/browse/TIMOB-15033)
[TIMOB-10210](https://jira.appcelerator.org/browse/TIMOB-10210)
[TIMOB-15445](https://jira.appcelerator.org/browse/TIMOB-15445)
[TIMOB-8720](https://jira.appcelerator.org/browse/TIMOB-8720)
[TIMOB-10800](https://jira.appcelerator.org/browse/TIMOB-10800)

Dev keyboard Suite

Regression tests must be performed on both iOS6 and iOS7.
