### PR TITLE
TIMOB-16187-3_2_X: Don't merge attributes for module android manifest nodes.

### DIFF
--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -3451,6 +3451,7 @@ AndroidBuilder.prototype.generateAndroidManifest = function generateAndroidManif
 				var am = new AndroidManifest;
 				am.parse(fill(moduleXml.android.manifest));
 				// we don't want modules to override the <supports-screens> or <uses-sdk> tags
+				delete am.__attr__;
 				delete am['supports-screens'];
 				delete am['uses-sdk'];
 				finalAndroidManifest.merge(am);


### PR DESCRIPTION
https://jira.appcelerator.org/browse/TIMOB-16187

Test case in Jira.
