### PR TITLE
[TIMOB-15621] reuse the RowProxyItem if it was already associated to the R...

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiTableView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiTableView.java
@@ -202,6 +202,10 @@ public class TiTableView extends FrameLayout
 						}
 					}
 				}
+			} else if (item.proxy != null) {
+				TableViewRowProxy rowProxy = (TableViewRowProxy) item.proxy;
+				//If the proxy is already assigned at layout pass, let us use it
+				v = rowProxy.getTableViewRowProxyItem();
 			}
 			if (v == null) {
 				if (item.className.equals(TableViewProxy.CLASSNAME_HEADERVIEW)) {

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiTableView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiTableView.java
@@ -202,7 +202,7 @@ public class TiTableView extends FrameLayout
 						}
 					}
 				}
-			} else if (item.proxy != null) {
+			} else if (item.proxy instanceof TableViewRowProxy) {
 				TableViewRowProxy rowProxy = (TableViewRowProxy) item.proxy;
 				//If the proxy is already assigned at layout pass, let us use it
 				v = rowProxy.getTableViewRowProxyItem();


### PR DESCRIPTION
If the proxy is already assigned to the RowProxyItem during the layout pass, reuse it.

I am not completely sure about this fix, this may require some regressions to rule out any side effects.

https://jira.appcelerator.org/browse/TIMOB-15621
