### PR TITLE
timob-13002: Android: HTML textfields inside webview do not open keyboard

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
@@ -130,6 +130,16 @@ public class TiUIWebView extends TiUIView
 			super.onLayout(changed, left, top, right, bottom);
 			TiUIHelper.firePostLayoutEvent(proxy);
 		}
+
+		@Override
+		public boolean onCheckIsTextEditor()
+		{
+			if (proxy.hasProperty(TiC.PROPERTY_SOFT_KEYBOARD_ON_FOCUS)
+				&& TiConvert.toInt(proxy.getProperty(TiC.PROPERTY_SOFT_KEYBOARD_ON_FOCUS)) == TiUIView.SOFT_KEYBOARD_HIDE_ON_FOCUS) {
+				return false;
+			}
+			return true;
+		}
 	}
 
 	public TiUIWebView(TiViewProxy proxy)


### PR DESCRIPTION
https://jira.appcelerator.org/browse/TIMOB-13002
For FR, please run KS and Anvil to make sure no new regressions. The test case seems only fail on Droid Razr 2.3.5, so we need Eduardo Gomez to help with testing.
