### PR TITLE
[TIMOB-16338]iOS : Fixing barimage regression on iOS 6 

### DIFF
--- a/iphone/Classes/TiUIWindowProxy.m
+++ b/iphone/Classes/TiUIWindowProxy.m
@@ -434,7 +434,7 @@
     id barImageValue = [self valueForUndefinedKey:@"barImage"];
     
     UINavigationBar* ourNB = [[controller navigationController] navigationBar];
-    UIImage* theImage = [TiUtils toImage:barImageValue proxy:self];
+    UIImage* theImage = [TiUtils toImage:barImageValue proxy:self size:[ourNB bounds].size];
     
     if (theImage == nil) {
         [ourNB setBackgroundImage:nil forBarMetrics:UIBarMetricsDefault];


### PR DESCRIPTION
Please test on both iOS 6 & 7 on all form factors with all orientation. 

**NOTE :  Make sure the image used is being resized properly.**

Jira ticket [Link](https://jira.appcelerator.org/browse/TIMOB-16338)
