### PR TITLE
TIMOB-15551-make sure that the view is set in the proxy

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/ListSectionProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/ListSectionProxy.java
@@ -649,6 +649,7 @@ public class ListSectionProxy extends ViewProxy{
 			TiViewProxy proxy = child.getViewProxy();
 			TiUIView view = proxy.createView(proxy.getActivity());
 			view.registerForTouch();
+			proxy.setView(view);
 			generateChildContentViews(child, view, rootItem, false);
 			//Bind view to root.
 			


### PR DESCRIPTION
make sure that the view is set in the proxy so that new view is not created when .start is called on the ImageViewProxy.

https://jira.appcelerator.org/browse/TIMOB-15551
