### PR TITLE
[TIDOC-1581] Add missing fields to JSCA supplied by the YAML: availability, permission and osver

### DIFF
--- a/apidoc/generators/jsca_generator.py
+++ b/apidoc/generators/jsca_generator.py
@@ -273,7 +273,7 @@ def to_jsca_type(api):
 			"remarks": to_jsca_remarks(api),
 			"userAgents": to_jsca_userAgents(api),
 			"since": to_jsca_since(api.platforms),
-			"inherits": to_jsca_inherits(api),
+			"inherits": to_jsca_inherits(api)
 			}
 	# TIMOB-7169. If it's a proxy (non-module) and it has no "class properties",
 	# mark it as internal.  This avoids it being displayed in Code Assist.

--- a/apidoc/generators/jsca_generator.py
+++ b/apidoc/generators/jsca_generator.py
@@ -97,6 +97,18 @@ def to_jsca_inherits(api):
 	else:
 		return 'Object'
 
+def to_jsca_permission(prop):
+	if dict_has_non_empty_member(prop.api_obj, "permission"):
+		return prop.api_obj["permission"]
+	else:
+		return "read-write"
+
+def to_jsca_availability(prop):
+	if dict_has_non_empty_member(prop.api_obj, "availability"):
+		return prop.api_obj["availability"]
+	else:
+		return "always"
+
 def to_jsca_type_name(type_info):
 	if isinstance(type_info, list) or isinstance(type_info, tuple) and len(type_info) > 0:
 		# Currently the JSCA spec allows for just one type per parameter/property/returnType.
@@ -133,9 +145,11 @@ def to_jsca_property(prop, for_event=False):
 		result["isClassProperty"] = (prop.name == prop.name.upper())
 		result["isInstanceProperty"] = (prop.name != prop.name.upper())
 		result["since"] = to_jsca_since(prop.platforms)
-		result["userAgents"] = to_jsca_userAgents(prop.platforms)
+		result["userAgents"] = to_jsca_userAgents(prop)
 		result["isInternal"] = False
 		result["examples"] = to_jsca_examples(prop)
+		result["availability"] = to_jsca_availability(prop)
+		result["permission"] = to_jsca_permission(prop)
 	return to_ordered_dict(result, ("name",))
 
 def to_jsca_properties(props, for_event=False):
@@ -188,7 +202,7 @@ def to_jsca_function(method):
 	if method.parameters is not None and len(method.parameters) > 0:
 		result["parameters"] = [to_jsca_method_parameter(p) for p in method.parameters]
 	result["since"] = to_jsca_since(method.platforms)
-	result['userAgents'] = to_jsca_userAgents(method.platforms)
+	result['userAgents'] = to_jsca_userAgents(method)
 	result['isInstanceProperty'] = True # we don't have class static methods
 	result['isClassProperty'] = False # we don't have class static methods
 	result['isInternal'] = False # we don't make this distinction (yet anyway)
@@ -219,8 +233,20 @@ def to_jsca_remarks(api):
 	else:
 		return []
 
-def to_jsca_userAgents(platforms):
-	return [{"platform": platform["name"]} for platform in platforms]
+def to_jsca_userAgents(api):
+	rv = [{"platform": platform["name"]} for platform in api.platforms]
+	if dict_has_non_empty_member(api.api_obj, "osver"):
+		osversions = api.api_obj["osver"]
+		for key in osversions.keys():
+			for platform in rv:
+				platform_name = platform["platform"]
+				if re.match("ios", key, re.IGNORECASE) and (platform_name == "ipad" or platform_name == "iphone"):
+					platform["os"] = "ios"
+					platform["osversion"] = osversions[key]
+				if re.match("android", key, re.IGNORECASE) and platform_name == "android":
+					platform["os"] = "android"
+					platform["osversion"] = osversions[key]
+	return rv
 
 def to_jsca_since(platforms):
 	return [to_ordered_dict({
@@ -245,9 +271,9 @@ def to_jsca_type(api):
 			"functions": to_jsca_functions(api.methods),
 			"events": to_jsca_events(api.events),
 			"remarks": to_jsca_remarks(api),
-			"userAgents": to_jsca_userAgents(api.platforms),
+			"userAgents": to_jsca_userAgents(api),
 			"since": to_jsca_since(api.platforms),
-			"inherits": to_jsca_inherits(api)
+			"inherits": to_jsca_inherits(api),
 			}
 	# TIMOB-7169. If it's a proxy (non-module) and it has no "class properties",
 	# mark it as internal.  This avoids it being displayed in Code Assist.


### PR DESCRIPTION
To test, from the `apidoc` directory run:

```
./docgen.py -f jsca -o ../dist
```

Open the ../dist/api.jsca file and check to see the `availability` and `permission` fields are added to the properties, and for API elements that specify the `osver` in the YAML, those values are populated in the JSCA file in the `userAgents` field.
