### PR TITLE
fix exception when building to iOS with "-C all"

### DIFF
--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -875,7 +875,7 @@ iOSBuilder.prototype.validate = function (logger, config, cli) {
 		for (var i = 0, l = this.devices.length; i < l; i++) {
 			if (this.devices[i].id == deviceId) {
 				if (this.target == 'device') {
-					if (this.devices[i].id != 'itunes' && version.lt(this.devices[i].productVersion, this.minIosVer)) {
+					if (this.devices[i].id != 'itunes' && this.devices[i].id != 'all' && version.lt(this.devices[i].productVersion, this.minIosVer)) {
 						logger.error(__('This app does not support the device "%s"', this.devices[i].name) + '\n');
 						logger.log(__("The device is running iOS %s, however the app's the minimum iOS version is set to %s", this.devices[i].productVersion.cyan, version.format(this.minIosVer, 2, 3).cyan));
 						logger.log(__('In order to install this app on this device, lower the %s to %s in the tiapp.xml:', '<min-ios-ver>'.cyan, version.format(this.devices[i].productVersion, 2, 2).cyan));


### PR DESCRIPTION
Line 168 of _build.js checks whether or not more than two iOS
devices are connected including iTunes. Now when the -C all
switch is used, an additional device object is created on line
170 {id: 'all', name: 'All Devices'}.
