### PR TITLE
[TIMOB-15707] (3_2_X) ImageView autoWidth now accounts for DIP height

### DIFF
--- a/iphone/Classes/TiUIImageView.m
+++ b/iphone/Classes/TiUIImageView.m
@@ -51,6 +51,10 @@ DEFINE_EXCEPTIONS
 {
 	if (autoWidth > 0)
 	{
+		//If height is DIP returned a scaled autowidth to maintain aspect ratio
+		if (TiDimensionIsDip(height) && autoHeight > 0) {
+			return roundf(autoWidth*height.value/autoHeight);
+		}
 		return autoWidth;
 	}
 	


### PR DESCRIPTION
Cherry Pick PR #5478 into 3_2_X
Test is in [JIRA](https://jira.appcelerator.org/browse/TIMOB-15707)
