### PR TITLE
[TIMOB-16594] (3_2_X)  iOS: Refresh Control crash on stringify

### DIFF
--- a/iphone/Classes/TiUIRefreshControlProxy.h
+++ b/iphone/Classes/TiUIRefreshControlProxy.h
@@ -10,7 +10,7 @@
 @interface TiUIRefreshControlProxy : TiProxy {
     UIRefreshControl* _refreshControl;
     NSAttributedString* _attributedString;
-    UIColor* _tintColor;
+    UIColor* refreshTintColor;
 }
 
 #pragma mark - Internal Use Only

--- a/iphone/Classes/TiUIRefreshControlProxy.m
+++ b/iphone/Classes/TiUIRefreshControlProxy.m
@@ -22,7 +22,7 @@
 {
     RELEASE_TO_NIL(_refreshControl);
     RELEASE_TO_NIL(_attributedString);
-    RELEASE_TO_NIL(_tintColor);
+    RELEASE_TO_NIL(refreshTintColor);
     [super dealloc];
 }
 
@@ -43,7 +43,7 @@
 {
     if (_refreshControl != nil) {
         [_refreshControl setAttributedTitle:_attributedString];
-        [_refreshControl setTintColor:_tintColor];
+        [_refreshControl setTintColor:refreshTintColor];
     }
 }
 
@@ -76,8 +76,8 @@
 {
     ENSURE_SINGLE_ARG_OR_NIL(args, NSObject);
     [self replaceValue:args forKey:@"tintColor" notification:NO];
-    RELEASE_TO_NIL(_tintColor);
-    _tintColor = [[[TiUtils colorValue:args] color] retain];
+    RELEASE_TO_NIL(refreshTintColor);
+    refreshTintColor = [[[TiUtils colorValue:args] color] retain];
     //Changing tintColor works on iOS6 but not on iOS7. iOS Bug?
     TiThreadPerformOnMainThread(^{
         [self refreshControl];


### PR DESCRIPTION
Cherry Pick commit ac87e5e from PR #5442 into 3_2_X

Test is in [comments](https://jira.appcelerator.org/browse/TIMOB-16594#comment-296159)
