### PR TITLE
TIMOB-16552-Reset Content width,height so that it is calculated again

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiTableViewRowProxyItem.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiTableViewRowProxyItem.java
@@ -267,7 +267,11 @@ public class TiTableViewRowProxyItem extends TiBaseTableViewItem
 					applyChildProperties(newProxy, view);
 				}
 			}
-			
+			//Reset the content height and width so that it is calculated based on the children
+			LayoutParams p = content.getLayoutParams();
+			p.height = -1;
+			p.width = -1;
+			content.setLayoutParams(p);
 		}
 	}
 


### PR DESCRIPTION
When view heirarchies are same, reset the content height and width to -1 so that it is calculated again based on children.

https://jira.appcelerator.org/browse/TIMOB-16552
