### PR TITLE
[TIMOB-16458] Fixed a regression introduced in 3.2.0 by moving the valid...

### DIFF
--- a/cli/commands/build.js
+++ b/cli/commands/build.js
@@ -107,11 +107,6 @@ exports.config = function (logger, config, cli) {
 								// make sure the tiapp.xml is sane
 								ti.validateTiappXml(logger, config, tiapp);
 
-								// check that the Titanium SDK version is correct
-								if (!ti.validateCorrectSDK(logger, config, cli, 'build')) {
-									throw new cli.GracefulShutdown;
-								}
-
 								return projectDir;
 							},
 							desc: __('the directory containing the project'),
@@ -171,6 +166,11 @@ exports.config = function (logger, config, cli) {
 exports.validate = function (logger, config, cli) {
 	// TODO: set the type to 'app' for now, but we'll need to determine if the project is an app or a module
 	cli.argv.type = 'app';
+
+	// check that the Titanium SDK version is correct
+	if (!ti.validateCorrectSDK(logger, config, cli, 'build')) {
+		return false;
+	}
 
 	ti.validatePlatform(logger, cli, 'platform');
 


### PR DESCRIPTION
...ateCorrectSDK() call to the validate() function so that all command line args are properly processed before forking the correct sdk version.
