### PR TITLE
[TIMOB-16535] (3_2_X_hybrid) Button font fix

### DIFF
--- a/mobileweb/titanium/Ti/UI/Button.js
+++ b/mobileweb/titanium/Ti/UI/Button.js
@@ -16,7 +16,9 @@ define(['Ti/_/declare', 'Ti/_/UI/Widget', 'Ti/_/dom', 'Ti/_/css', 'Ti/_/style', 
 		},
 		titlePost = {
 			post: function() {
-				this._buttonTitle.text = Locale._getString(this.titleid, this.title);
+				var text = Locale._getString(this.titleid, this.title);
+				//For platform consistency, covert leading spaces to non-breaking
+				this._buttonTitle.text = text.replace(/^[ \t]+/gm, function(x){ return new Array(x.length + 1).join('&nbsp;') });
 				this._hasSizeDimensions() && this._triggerLayout();
 			}
 		};
@@ -132,7 +134,12 @@ define(['Ti/_/declare', 'Ti/_/UI/Widget', 'Ti/_/dom', 'Ti/_/css', 'Ti/_/style', 
 				},
 				value: true
 			},
-
+			font : {
+				set : function(value) {
+					this._buttonTitle.font = value;
+					return value;
+				}
+			},
 			image: {
 				set: function(value) {
 					this._buttonImage.image = value;


### PR DESCRIPTION
1. Leading whitespaces in button titles are treated inconsistenly with Android and iOS
2. Button.js is missing a Font property, so you can't change the font size & face
