### PR TITLE
[TIMOB-16843] Removed enforcment that app names must start with a letter...

### DIFF
--- a/cli/commands/create.js
+++ b/cli/commands/create.js
@@ -57,8 +57,14 @@ exports.config = function config(logger, config, cli) {
 						desc: __("the App ID in the format 'com.companyname.appname'"),
 						order: 150,
 						prompt: function (callback) {
+							var defaultValue = undefined,
+								name = cli.argv.name.replace(/[ -]/g, '_').replace(/[^a-zA-Z0-9_]/g, '').replace(/_+/g, '_');
+							if (idPrefix) {
+								defaultValue = idPrefix.replace(/\.$/, '') + '.' + (/^[a-zA-Z]/.test(name) || cli.argv.platforms.indexOf('android') == -1 ? '' : 'my') + name;
+							}
+
 							callback(fields.text({
-								default: idPrefix ? idPrefix.replace(/\.$/, '') + '.' + cli.argv.name.replace(/[ -]/g, '_').replace(/[^a-zA-Z0-9_]/g, '').replace(/_+/g, '_') : undefined,
+								default: defaultValue,
 								promptLabel: __('App ID'),
 								validate: conf.options.id.validate
 							}));
@@ -168,11 +174,6 @@ exports.config = function config(logger, config, cli) {
 									logger.error('    ti config android.allowAppNameAmpersands true\n');
 									return callback(true);
 								}
-							}
-
-							if (!/^[a-zA-Z]/.test(value)) {
-								logger.error(__('The first character of the project name must be a letter.') + '\n');
-								return callback(true);
 							}
 
 							callback(null, value);


### PR DESCRIPTION
.... Now app names can be anything. Fixed the default id value to pad namespaces that begin with a non-letter so that the id is acceptable with Android.
