### PR TITLE
[TIMOB-15296] Android: Support for window flags

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TabGroupProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TabGroupProxy.java
@@ -479,11 +479,11 @@ public class TabGroupProxy extends TiWindowProxy implements TiActivityWindow
 		intent.putExtra(TiC.PROPERTY_WINDOW_FLAGS, windowFlags);
 
 		if (hasProperty(TiC.PROPERTY_WINDOW_SOFT_INPUT_MODE)) {
-			intent.putExtra(TiC.PROPERTY_WINDOW_SOFT_INPUT_MODE, TiConvert.toInt(getProperty(TiC.PROPERTY_WINDOW_SOFT_INPUT_MODE)));
+			intent.putExtra(TiC.PROPERTY_WINDOW_SOFT_INPUT_MODE, TiConvert.toInt(getProperty(TiC.PROPERTY_WINDOW_SOFT_INPUT_MODE), -1));
 		}
 
 		if (hasProperty(TiC.PROPERTY_EXIT_ON_CLOSE)) {
-			intent.putExtra(TiC.INTENT_PROPERTY_FINISH_ROOT, TiConvert.toBoolean(getProperty(TiC.PROPERTY_EXIT_ON_CLOSE)));
+			intent.putExtra(TiC.INTENT_PROPERTY_FINISH_ROOT, TiConvert.toBoolean(getProperty(TiC.PROPERTY_EXIT_ON_CLOSE), false));
 		} else {
 			intent.putExtra(TiC.INTENT_PROPERTY_FINISH_ROOT, activity.isTaskRoot());
 		}

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TabGroupProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TabGroupProxy.java
@@ -455,22 +455,22 @@ public class TabGroupProxy extends TiWindowProxy implements TiActivityWindow
 	private void fillIntent(Activity activity, Intent intent)
 	{
 		int windowFlags = 0;
-		if(hasProperty(TiC.PROPERTY_WINDOW_FLAGS)) {
+		if (hasProperty(TiC.PROPERTY_WINDOW_FLAGS)) {
 			windowFlags = TiConvert.toInt(getProperty(TiC.PROPERTY_WINDOW_FLAGS), 0);
 		}
 		
 		//Set the fullscreen flag
 		if (hasProperty(TiC.PROPERTY_FULLSCREEN)) {
-			boolean fullScreen = TiConvert.toBoolean(getProperty(TiC.PROPERTY_FULLSCREEN), false);
-			if(fullScreen) {
+			boolean flagVal = TiConvert.toBoolean(getProperty(TiC.PROPERTY_FULLSCREEN), false);
+			if (flagVal) {
 				windowFlags = windowFlags | WindowManager.LayoutParams.FLAG_FULLSCREEN;
 			}
 		}
 		
 		//Set the secure flag
 		if (hasProperty(TiC.PROPERTY_FLAG_SECURE)) {
-			boolean fullScreen = TiConvert.toBoolean(getProperty(TiC.PROPERTY_FLAG_SECURE), false);
-			if(fullScreen) {
+			boolean flagVal = TiConvert.toBoolean(getProperty(TiC.PROPERTY_FLAG_SECURE), false);
+			if (flagVal) {
 				windowFlags = windowFlags | WindowManager.LayoutParams.FLAG_SECURE;
 			}
 		}

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TabGroupProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TabGroupProxy.java
@@ -32,6 +32,7 @@ import android.app.Activity;
 import android.content.Intent;
 import android.os.Message;
 import android.support.v7.app.ActionBarActivity;
+import android.view.WindowManager;
 
 @Kroll.proxy(creatableInModule=UIModule.class, propertyAccessors={
 	TiC.PROPERTY_TABS_BACKGROUND_COLOR,
@@ -291,20 +292,15 @@ public class TabGroupProxy extends TiWindowProxy implements TiActivityWindow
 	@Override
 	protected void handleOpen(KrollDict options)
 	{
-		Activity activity = TiApplication.getAppCurrentActivity();
-		if (activity instanceof ActionBarActivity) {
-			ActionBarActivity topActivity = (ActionBarActivity) TiApplication.getAppCurrentActivity();
-			Intent intent = new Intent(topActivity, TiActivity.class);
-			fillIntent(topActivity, intent);
+		Activity topActivity = TiApplication.getAppCurrentActivity();
+		Intent intent = new Intent(topActivity, TiActivity.class);
+		fillIntent(topActivity, intent);
 
-			int windowId = TiActivityWindows.addWindow(this);
-			intent.putExtra(TiC.INTENT_PROPERTY_USE_ACTIVITY_WINDOW, true);
-			intent.putExtra(TiC.INTENT_PROPERTY_WINDOW_ID, windowId);
+		int windowId = TiActivityWindows.addWindow(this);
+		intent.putExtra(TiC.INTENT_PROPERTY_USE_ACTIVITY_WINDOW, true);
+		intent.putExtra(TiC.INTENT_PROPERTY_WINDOW_ID, windowId);
 
-			topActivity.startActivity(intent);
-		} else {
-			Log.e(TAG, "TabGroupProxy requires an activity that is a descendent of ActionBarActivity to work with AppCompat", Log.DEBUG_MODE);
-		}
+		topActivity.startActivity(intent);
 	}
 
 	@Override
@@ -456,11 +452,32 @@ public class TabGroupProxy extends TiWindowProxy implements TiActivityWindow
 		selectedTab.onFocusChanged(true, focusEventData);
 	}
 
-	private void fillIntent(ActionBarActivity activity, Intent intent)
+	private void fillIntent(Activity activity, Intent intent)
 	{
-		if (hasProperty(TiC.PROPERTY_FULLSCREEN)) {
-			intent.putExtra(TiC.PROPERTY_FULLSCREEN, TiConvert.toBoolean(getProperty(TiC.PROPERTY_FULLSCREEN)));
+		int windowFlags = 0;
+		if(hasProperty(TiC.PROPERTY_WINDOW_FLAGS)) {
+			windowFlags = TiConvert.toInt(getProperty(TiC.PROPERTY_WINDOW_FLAGS), 0);
 		}
+		
+		//Set the fullscreen flag
+		if (hasProperty(TiC.PROPERTY_FULLSCREEN)) {
+			boolean fullScreen = TiConvert.toBoolean(getProperty(TiC.PROPERTY_FULLSCREEN), false);
+			if(fullScreen) {
+				windowFlags = windowFlags | WindowManager.LayoutParams.FLAG_FULLSCREEN;
+			}
+		}
+		
+		//Set the secure flag
+		if (hasProperty(TiC.PROPERTY_FLAG_SECURE)) {
+			boolean fullScreen = TiConvert.toBoolean(getProperty(TiC.PROPERTY_FLAG_SECURE), false);
+			if(fullScreen) {
+				windowFlags = windowFlags | WindowManager.LayoutParams.FLAG_SECURE;
+			}
+		}
+		
+		//Stuff flags in intent
+		intent.putExtra(TiC.PROPERTY_WINDOW_FLAGS, windowFlags);
+
 		if (hasProperty(TiC.PROPERTY_WINDOW_SOFT_INPUT_MODE)) {
 			intent.putExtra(TiC.PROPERTY_WINDOW_SOFT_INPUT_MODE, TiConvert.toInt(getProperty(TiC.PROPERTY_WINDOW_SOFT_INPUT_MODE)));
 		}

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/WindowProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/WindowProxy.java
@@ -187,13 +187,6 @@ public class WindowProxy extends TiWindowProxy implements TiActivityWindow
 		}
 
 		Window win = activity.getWindow();
-		boolean flagSecure = TiConvert.toBoolean(getProperty(TiC.PROPERTY_FLAG_SECURE), false);
-		if (flagSecure) {
-			if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.HONEYCOMB) {
-				activity.getWindow()
-					.setFlags(WindowManager.LayoutParams.FLAG_SECURE, WindowManager.LayoutParams.FLAG_SECURE);
-			}
-		}
 		// Handle the background of the window activity if it is a translucent activity.
 		// If it is a modal window, set a translucent dimmed background to the window.
 		// If the opacity is given, set a transparent background to the window. In this case, if no backgroundColor or

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/WindowProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/WindowProxy.java
@@ -259,22 +259,22 @@ public class WindowProxy extends TiWindowProxy implements TiActivityWindow
 	private void fillIntent(Activity activity, Intent intent)
 	{
 		int windowFlags = 0;
-		if(hasProperty(TiC.PROPERTY_WINDOW_FLAGS)) {
+		if (hasProperty(TiC.PROPERTY_WINDOW_FLAGS)) {
 			windowFlags = TiConvert.toInt(getProperty(TiC.PROPERTY_WINDOW_FLAGS), 0);
 		}
 		
 		//Set the fullscreen flag
 		if (hasProperty(TiC.PROPERTY_FULLSCREEN)) {
-			boolean fullScreen = TiConvert.toBoolean(getProperty(TiC.PROPERTY_FULLSCREEN), false);
-			if(fullScreen) {
+			boolean flagVal = TiConvert.toBoolean(getProperty(TiC.PROPERTY_FULLSCREEN), false);
+			if (flagVal) {
 				windowFlags = windowFlags | WindowManager.LayoutParams.FLAG_FULLSCREEN;
 			}
 		}
 		
 		//Set the secure flag
 		if (hasProperty(TiC.PROPERTY_FLAG_SECURE)) {
-			boolean fullScreen = TiConvert.toBoolean(getProperty(TiC.PROPERTY_FLAG_SECURE), false);
-			if(fullScreen) {
+			boolean flagVal = TiConvert.toBoolean(getProperty(TiC.PROPERTY_FLAG_SECURE), false);
+			if (flagVal) {
 				windowFlags = windowFlags | WindowManager.LayoutParams.FLAG_SECURE;
 			}
 		}

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/WindowProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/WindowProxy.java
@@ -294,7 +294,10 @@ public class WindowProxy extends TiWindowProxy implements TiActivityWindow
 		}
 		if (hasProperty(TiC.PROPERTY_EXIT_ON_CLOSE)) {
 			intent.putExtra(TiC.INTENT_PROPERTY_FINISH_ROOT, TiConvert.toBoolean(getProperty(TiC.PROPERTY_EXIT_ON_CLOSE), false));
+		} else {
+			intent.putExtra(TiC.INTENT_PROPERTY_FINISH_ROOT, activity.isTaskRoot());
 		}
+
 		boolean modal = false;
 		if (hasProperty(TiC.PROPERTY_MODAL)) {
 			modal = TiConvert.toBoolean(getProperty(TiC.PROPERTY_MODAL), false);

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/WindowProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/WindowProxy.java
@@ -265,9 +265,30 @@ public class WindowProxy extends TiWindowProxy implements TiActivityWindow
 
 	private void fillIntent(Activity activity, Intent intent)
 	{
-		if (hasProperty(TiC.PROPERTY_FULLSCREEN)) {
-			intent.putExtra(TiC.PROPERTY_FULLSCREEN, TiConvert.toBoolean(getProperty(TiC.PROPERTY_FULLSCREEN), false));
+		int windowFlags = 0;
+		if(hasProperty(TiC.PROPERTY_WINDOW_FLAGS)) {
+			windowFlags = TiConvert.toInt(getProperty(TiC.PROPERTY_WINDOW_FLAGS), 0);
 		}
+		
+		//Set the fullscreen flag
+		if (hasProperty(TiC.PROPERTY_FULLSCREEN)) {
+			boolean fullScreen = TiConvert.toBoolean(getProperty(TiC.PROPERTY_FULLSCREEN), false);
+			if(fullScreen) {
+				windowFlags = windowFlags | WindowManager.LayoutParams.FLAG_FULLSCREEN;
+			}
+		}
+		
+		//Set the secure flag
+		if (hasProperty(TiC.PROPERTY_FLAG_SECURE)) {
+			boolean fullScreen = TiConvert.toBoolean(getProperty(TiC.PROPERTY_FLAG_SECURE), false);
+			if(fullScreen) {
+				windowFlags = windowFlags | WindowManager.LayoutParams.FLAG_SECURE;
+			}
+		}
+		
+		//Stuff flags in intent
+		intent.putExtra(TiC.PROPERTY_WINDOW_FLAGS, windowFlags);
+		
 		if (hasProperty(TiC.PROPERTY_WINDOW_SOFT_INPUT_MODE)) {
 			intent.putExtra(TiC.PROPERTY_WINDOW_SOFT_INPUT_MODE, TiConvert.toInt(getProperty(TiC.PROPERTY_WINDOW_SOFT_INPUT_MODE), -1));
 		}

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/WindowProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/WindowProxy.java
@@ -61,10 +61,6 @@ public class WindowProxy extends TiWindowProxy implements TiActivityWindow
 
 	private WeakReference<TiBaseActivity> windowActivity;
 
-	// This flag is just for a temporary use. We won't need it after the lightweight window
-	// is completely removed.
-	private boolean lightweight = false;
-
 
 	public WindowProxy()
 	{
@@ -90,50 +86,6 @@ public class WindowProxy extends TiWindowProxy implements TiActivityWindow
 		return v;
 	}
 
-	public void addLightweightWindowToStack() 
-	{
-		// Add LW window to the decor view and add it to stack.
-		Activity topActivity = TiApplication.getAppCurrentActivity();
-		if (topActivity instanceof TiBaseActivity) {
-			TiBaseActivity baseActivity = (TiBaseActivity) topActivity;
-			ActivityProxy activityProxy = baseActivity.getActivityProxy();
-			if (activityProxy != null) {
-				DecorViewProxy decorView = activityProxy.getDecorView();
-				if (decorView != null) {
-					decorView.add(this);
-					windowActivity = new WeakReference<TiBaseActivity>(baseActivity);
-
-					// Need to handle the url window in the JS side.
-					callPropertySync(PROPERTY_LOAD_URL, null);
-
-					opened = true;
-					fireEvent(TiC.EVENT_OPEN, null);
-
-					baseActivity.addWindowToStack(this);
-					return;
-				}
-			}
-		}
-		Log.e(TAG, "Unable to open the lightweight window because the current activity is not available.");
-	}
-
-	public void removeLightweightWindowFromStack()
-	{
-		// Remove LW window from decor view and remove it from stack
-		TiBaseActivity activity = (windowActivity != null) ? windowActivity.get() : null;
-		if (activity != null) {
-			ActivityProxy activityProxy = activity.getActivityProxy();
-			if (activityProxy != null) {
-				activityProxy.getDecorView().remove(this);
-			}
-			releaseViews();
-			opened = false;
-
-			activity.removeWindowFromStack(this);
-			fireEvent(TiC.EVENT_CLOSE, null);
-		}
-	}
-
 	@Override
 	public void open(@Kroll.argument(optional = true) Object arg)
 	{
@@ -152,33 +104,12 @@ public class WindowProxy extends TiWindowProxy implements TiActivityWindow
 			}
 		}
 
-		// When we open a window using tab.open(win), we treat it as opening a HW window on top of the tab.
-		if (hasProperty("tabOpen")) {
-			lightweight = false;
-
-		// If "ti.android.useLegacyWindow" is set to true in the tiapp.xml, follow the old window behavior:
-		// create a HW window if any of the three properties, "fullscreen", "windowSoftInputMode" and
-		// "modal", is specified; otherwise create a LW window.
-		} else if (TiApplication.USE_LEGACY_WINDOW && !hasProperty(TiC.PROPERTY_FULLSCREEN)
-			&& !hasProperty(TiC.PROPERTY_WINDOW_SOFT_INPUT_MODE)
-			&& !hasProperty(TiC.PROPERTY_MODAL)) {
-			lightweight = true;
-		}
-
-		if (Log.isDebugModeEnabled()) {
-			Log.d(TAG, "open the window: lightweight = " + lightweight);
-		}
-
-		if (lightweight) {
-			addLightweightWindowToStack();
-		} else {
-			// The "top", "bottom", "left" and "right" properties do not work for heavyweight windows.
-			properties.remove(TiC.PROPERTY_TOP);
-			properties.remove(TiC.PROPERTY_BOTTOM);
-			properties.remove(TiC.PROPERTY_LEFT);
-			properties.remove(TiC.PROPERTY_RIGHT);
-			super.open(arg);
-		}
+		// The "top", "bottom", "left" and "right" properties do not work for heavyweight windows.
+		properties.remove(TiC.PROPERTY_TOP);
+		properties.remove(TiC.PROPERTY_BOTTOM);
+		properties.remove(TiC.PROPERTY_LEFT);
+		properties.remove(TiC.PROPERTY_RIGHT);
+		super.open(arg);
 	}
 
 	@Override
@@ -187,11 +118,7 @@ public class WindowProxy extends TiWindowProxy implements TiActivityWindow
 		if (!(opened || opening)) {
 			return;
 		}
-		if (lightweight) {
-			removeLightweightWindowFromStack();
-		} else {
-			super.close(arg);
-		}
+		super.close(arg);
 	}
 
 	@Override
@@ -371,7 +298,7 @@ public class WindowProxy extends TiWindowProxy implements TiActivityWindow
 	@Override
 	public void onPropertyChanged(String name, Object value)
 	{
-		if ((opening || opened) && !lightweight) {
+		if (opening || opened)  {
 			if (TiC.PROPERTY_WINDOW_PIXEL_FORMAT.equals(name)) {
 				getMainHandler().obtainMessage(MSG_SET_PIXEL_FORMAT, value).sendToTarget();
 			} else if (TiC.PROPERTY_TITLE.equals(name)) {
@@ -391,7 +318,7 @@ public class WindowProxy extends TiWindowProxy implements TiActivityWindow
 	public void setWidth(Object width)
 	{
 		// We know it's a HW window only when it's opening/opened.
-		if ((opening || opened) && !lightweight) {
+		if (opening || opened) {
 			Object current = getProperty(TiC.PROPERTY_WIDTH);
 			if (shouldFireChange(current, width)) {
 				Object height = getProperty(TiC.PROPERTY_HEIGHT);
@@ -410,7 +337,7 @@ public class WindowProxy extends TiWindowProxy implements TiActivityWindow
 	public void setHeight(Object height)
 	{
 		// We know it's a HW window only when it's opening/opened.
-		if ((opening || opened) && !lightweight) {
+		if (opening || opened) {
 			Object current = getProperty(TiC.PROPERTY_HEIGHT);
 			if (shouldFireChange(current, height)) {
 				Object width = getProperty(TiC.PROPERTY_WIDTH);
@@ -497,7 +424,7 @@ public class WindowProxy extends TiWindowProxy implements TiActivityWindow
 	public boolean isLightweight()
 	{
 		// We know whether a window is lightweight or not only after it opens.
-		return (opened && lightweight);
+		return false;
 	}
 
 	@Override

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIText.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIText.java
@@ -387,7 +387,7 @@ public class TiUIText extends TiUIView
 		}
 
 		boolean enableReturnKey = false;
-		if(proxy.hasProperty(TiC.PROPERTY_ENABLE_RETURN_KEY)) {
+		if (proxy.hasProperty(TiC.PROPERTY_ENABLE_RETURN_KEY)) {
 			enableReturnKey = TiConvert.toBoolean(proxy.getProperty(TiC.PROPERTY_ENABLE_RETURN_KEY), false);
 		}
 		if (enableReturnKey && v.getText().length() == 0) {

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIText.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIText.java
@@ -386,8 +386,11 @@ public class TiUIText extends TiUIView
 			fireEvent(TiC.EVENT_RETURN, data);
 		}
 
-		Boolean enableReturnKey = TiConvert.toBoolean(proxy.getProperty(TiC.PROPERTY_ENABLE_RETURN_KEY));
-		if (enableReturnKey != null && enableReturnKey && v.getText().length() == 0) {
+		boolean enableReturnKey = false;
+		if(proxy.hasProperty(TiC.PROPERTY_ENABLE_RETURN_KEY)) {
+			enableReturnKey = TiConvert.toBoolean(proxy.getProperty(TiC.PROPERTY_ENABLE_RETURN_KEY), false);
+		}
+		if (enableReturnKey && v.getText().length() == 0) {
 			return true;
 		}
 		return false;

--- a/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
@@ -412,9 +412,14 @@ public abstract class TiBaseActivity extends ActionBarActivity
 		boolean fullscreen = getIntentBoolean(TiC.PROPERTY_FULLSCREEN, false);
 		boolean modal = getIntentBoolean(TiC.PROPERTY_MODAL, false);
 		int softInputMode = getIntentInt(TiC.PROPERTY_WINDOW_SOFT_INPUT_MODE, -1);
+		int windowFlags = getIntentInt(TiC.PROPERTY_WINDOW_FLAGS, 0);
 		boolean hasSoftInputMode = softInputMode != -1;
 		
 		setFullscreen(fullscreen);
+		
+		if(windowFlags > 0) {
+			getWindow().addFlags(windowFlags);
+		}
 
 		this.requestWindowFeature(Window.FEATURE_PROGRESS);
 		this.requestWindowFeature(Window.FEATURE_INDETERMINATE_PROGRESS);

--- a/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
@@ -417,7 +417,7 @@ public abstract class TiBaseActivity extends ActionBarActivity
 		
 		setFullscreen(fullscreen);
 		
-		if(windowFlags > 0) {
+		if (windowFlags > 0) {
 			getWindow().addFlags(windowFlags);
 		}
 

--- a/android/titanium/src/java/org/appcelerator/titanium/TiC.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiC.java
@@ -2357,6 +2357,10 @@ public class TiC
 	/**
 	 * @module.api
 	 */
+	public static final String PROPERTY_WINDOW_FLAGS = "windowFlags";
+	/**
+	 * @module.api
+	 */
 	public static final String PROPERTY_WINDOW_PIXEL_FORMAT = "windowPixelFormat";
 
 	/**

--- a/apidoc/Titanium/UI/Window.yml
+++ b/apidoc/Titanium/UI/Window.yml
@@ -314,13 +314,11 @@ properties:
   - name: flagSecure
     summary: |
         Treat the content of the window as secure, preventing it from appearing in screenshots or from being viewed on non-secure displays.
-        Valid only on API level 11 and above.
     description: |
         When the value is true, preventing it from appearing in screenshots or from being viewed on non-secure displays.
     platforms: [android]
     type: Boolean
     since: "3.3.0"
-    osver: {android: { min: "11"}}
     default: false
     availability: creation
     
@@ -788,6 +786,18 @@ properties:
     type: String
     availability: creation
     exclude-platforms: [blackberry]
+
+  - name: windowFlags
+    summary: Additional flags to set on the Activity Window.
+    description: |
+        Set the flags of the window, as per the WindowManager.LayoutParams flags. 
+        See [WindowManager.LayoutParams](http://developer.android.com/reference/android/view/WindowManager.LayoutParams.html) for a 
+        list of supported flags. Setting <Titanium.UI.Window.fullscreen> to true automatically sets the [WindowManager.LayoutParams.FLAG_FULLSCREEN](http://developer.android.com/reference/android/view/WindowManager.LayoutParams.html#FLAG_FULLSCREEN) 
+        flag. Setting <Titanium.UI.Window.flagSecure> to true automatically sets the [WindowManager.LayoutParams.FLAG_SECURE](http://developer.android.com/reference/android/view/WindowManager.LayoutParams.html#FLAG_SECURE) flag.
+    platforms: [android]
+    type: Number
+    since: "3.3.0"
+    availability: creation
 
   - name: windowSoftInputMode
     summary: |


### PR DESCRIPTION
This PR does a few things
1. Exposes a windowFlags property on WindowProxy for developers to specify extra flags
2. Refactors the Intent processing on BaseActivity so even JS Activities can support these falgs if specified
3. Removes support for deprecated light weight windows 
4. The first window launched treats exitOnClose set to true unless explicitly overridden by user

Test case is in [JIRA](https://jira.appcelerator.org/browse/TIMOB-15296)
