### PR TITLE
[TIMOB-11360] Android: Generate package specific R.java

### DIFF
--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -2163,6 +2163,7 @@ AndroidBuilder.prototype.copyResources = function copyResources(next) {
 		relSplashScreenRegExp = /^default\.(9\.png|png|jpg)$/,
 		drawableResources = {},
 		jsFiles = {},
+		moduleResPackages = this.moduleResPackages = [],
 		jsFilesToEncrypt = this.jsFilesToEncrypt = [],
 		htmlJsFiles = this.htmlJsFiles = {},
 		_t = this;
@@ -2429,6 +2430,17 @@ AndroidBuilder.prototype.copyResources = function copyResources(next) {
 			}, cb);
 		});
 	});
+
+	//get the respackgeinfo files if they exist
+	this.modules.forEach(function (module) {
+		var respackagepath = path.join(module.modulePath,'respackageinfo');
+		if (fs.existsSync(respackagepath)) {
+			var data = fs.readFileSync(respackagepath).toString().split('\n').shift().trim();
+			if(data.length > 0) {
+				this.moduleResPackages.push(data);
+			}
+		}
+	}, this);
 
 	var platformPaths = [
 		path.join(this.projectDir, 'platform', 'android')
@@ -3603,7 +3615,7 @@ AndroidBuilder.prototype.packageApp = function packageApp(next) {
 		);
 	}
 
-	if (!Object.keys(this.resPackages).length) {
+	if ( (!Object.keys(this.resPackages).length) && (!this.moduleResPackages.length) ) {
 		return runAapt();
 	}
 
@@ -3613,6 +3625,11 @@ AndroidBuilder.prototype.packageApp = function packageApp(next) {
 	Object.keys(this.resPackages).forEach(function(resFile){
 		namespaces && (namespaces+=':');
 		namespaces += this.resPackages[resFile];
+	}, this);
+
+	this.moduleResPackages.forEach(function (data) {
+		namespaces && (namespaces+=':');
+		namespaces += data;
 	}, this);
 
 	args.push('--extra-packages', namespaces);

--- a/support/module/android/build.xml
+++ b/support/module/android/build.xml
@@ -406,7 +406,7 @@ timodule.xml.
 		<if>
 			<equals arg1="${valid.respackage}" arg2="true"/>
 			<then>
-				<echo file="${dist}/${module.id}.respackage">${manifest.respackage}</echo>
+				<echo file="${dist}/respackageinfo">${manifest.respackage}</echo>
 			</then>
 		</if>
 	</target>
@@ -432,6 +432,7 @@ timodule.xml.
 			<zipfileset dir="${ti.module.root}" includes="platform/**" excludes="platform/README" prefix="${zip.prefix}"/>
 			<zipfileset dir="${ti.module.root}" includes="LICENSE" prefix="${zip.prefix}"/>
 			<zipfileset dir="${ti.module.root}" includes="example/**" prefix="${zip.prefix}"/>
+			<zipfileset file="${dist}/respackageinfo" prefix="${zip.prefix}"/>
 		</zip>
 		<antcall target="zip.libs"/>
 		<antcall target="zip.metadata"/>

--- a/support/module/android/build.xml
+++ b/support/module/android/build.xml
@@ -411,6 +411,10 @@ timodule.xml.
 		</if>
 	</target>
 
+	<target name="clean.respackage">
+		<delete file="${dist}/respackageinfo"/>
+	</target>
+
 	<target name="dist" depends="compile,pre.dist" description="Generate a distributable module JAR">
 		<ti.string property="module.id" string="${manifest.moduleid}" tolowercase="true"/>
 		<property name="module.jar" location="${dist}/${ant.project.name}.jar"/>
@@ -437,6 +441,7 @@ timodule.xml.
 		<antcall target="zip.libs"/>
 		<antcall target="zip.metadata"/>
 		<delete dir="${lib.expand.dir}" includeemptydirs="true" failonerror="false" deleteonexit="true"/>
+		<antcall target="clean.respackage" />
 		<antcall target="post.dist"/>
 	</target>
 

--- a/support/module/android/build.xml
+++ b/support/module/android/build.xml
@@ -395,6 +395,22 @@ timodule.xml.
 	<target name="post.jar">
 	</target>
 
+	<target name="check.respackage">
+		<!-- This wont do anything if it is already defined in manifest -->
+		<property name="manifest.respackage" value=""/>
+		<condition property="valid.respackage" else="false">
+			<not>
+				<equals arg1="${manifest.respackage}" arg2=""/>
+			</not>
+		</condition>
+		<if>
+			<equals arg1="${valid.respackage}" arg2="true"/>
+			<then>
+				<echo file="${dist}/${module.id}.respackage">${manifest.respackage}</echo>
+			</then>
+		</if>
+	</target>
+
 	<target name="dist" depends="compile,pre.dist" description="Generate a distributable module JAR">
 		<ti.string property="module.id" string="${manifest.moduleid}" tolowercase="true"/>
 		<property name="module.jar" location="${dist}/${ant.project.name}.jar"/>
@@ -405,6 +421,7 @@ timodule.xml.
 		<antcall target="post.jar"/>
 		<property name="zip.prefix" value="modules/android/${module.id}/${manifest.version}"/>
 		<antcall target="docgen"/>
+		<antcall target="check.respackage"/>
 
 		<zip destfile="${dist}/${module.id}-android-${manifest.version}.zip">
 			<zipfileset file="${module.jar}" prefix="${zip.prefix}"/>


### PR DESCRIPTION
This issue fixes [TIMOB-11360](https://jira.appcelerator.org/browse/TIMOB-11360)

This PR allows users to specify package specific R.java files required
All the developers need to so is add an entry to the manifest
`respackage: com.example.mypackage`
This will generate a corresponding java R file `com.example.mypackage.R.java`
