### PR TITLE
Fix NumberFormatException of "toFloat" method to throw class name of argument

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiConvert.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiConvert.java
@@ -459,7 +459,7 @@ public class TiConvert
 			return Float.parseFloat((String) value);
 
 		} else {
-			throw new NumberFormatException("Unable to convert value to float.");
+			throw new NumberFormatException("Unable to convert " + value.getClass().getName() + " to float.");
 		}
 	}
 


### PR DESCRIPTION
I modified "toFloat" method's exception block on TiConvert.java.
If "toFloat" method is failed, it throws NumberFormatException which class name of argument value is included.
