### PR TITLE
TIMOB-16822: use AppCompat SearchView for all Android versions

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/android/SearchViewProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/android/SearchViewProxy.java
@@ -31,12 +31,7 @@ public class SearchViewProxy extends TiViewProxy
 	@Override
 	public TiUIView createView(Activity activity)
 	{
-		if (Build.VERSION.SDK_INT >= TiC.API_LEVEL_HONEYCOMB) {
-			return new TiUISearchView(this);
-		}
-
-		Log.e(TAG, "SearchView is only supported on target API 11+");
-		return null;
+		return new TiUISearchView(this);
 	}
 
 	@Override

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/searchview/TiUISearchView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/searchview/TiUISearchView.java
@@ -16,7 +16,7 @@ import org.appcelerator.titanium.util.TiUIHelper;
 import org.appcelerator.titanium.view.TiUIView;
 
 import ti.modules.titanium.ui.widget.searchbar.TiUISearchBar.OnSearchChangeListener;
-import android.widget.SearchView;
+import android.support.v7.widget.SearchView;
 
 public class TiUISearchView extends TiUIView implements SearchView.OnQueryTextListener, SearchView.OnCloseListener {
 	private SearchView searchView;

--- a/apidoc/Titanium/UI/Android/SearchView.yml
+++ b/apidoc/Titanium/UI/Android/SearchView.yml
@@ -18,9 +18,6 @@ description: |
 
         <SearchView ns="Ti.UI.Android" platform="android"/>
 
-    `SearchView` is supported on Google API 11 (Android 3.0) and later. Your project's `tiapp.xml` file
-    must specify that version (or later) as the `targetSDKVersion` key in the Android manifest section.
-    
 extends: Titanium.UI.View
 excludes: { methods: [ add ] }
 since: "3.0.2"
@@ -96,32 +93,20 @@ examples:
                 fullscreen: false
             });
 
-            var search;
-            var searchAsChild = false;
+            // Use action bar search view
+            var search = Ti.UI.Android.createSearchView({
+                hintText: "Table Search"
+            });
 
-            if (Ti.Platform.name == 'android' && Ti.Platform.Android.API_LEVEL >= 11) {
-                // Use action bar search view
-                search = Ti.UI.Android.createSearchView({
-                    hintText: "Table Search"
+            win.activity.onCreateOptionsMenu = function(e) {
+                var menu = e.menu;
+                var menuItem = menu.add({
+                    title: 'Table Search',
+                    actionView : search,
+                    icon: (Ti.Android.R.drawable.ic_menu_search ? Ti.Android.R.drawable.ic_menu_search : "my_search.png"),
+                    showAsAction: Ti.Android.SHOW_AS_ACTION_IF_ROOM | Ti.Android.SHOW_AS_ACTION_COLLAPSE_ACTION_VIEW
                 });
-
-                win.activity.onCreateOptionsMenu = function(e) {
-                    var menu = e.menu;
-                    var menuItem = menu.add({
-                        title: 'Table Search',
-                        actionView : search,
-                        icon: (Ti.Android.R.drawable.ic_menu_search ? Ti.Android.R.drawable.ic_menu_search : "my_search.png"),
-                        showAsAction: Ti.Android.SHOW_AS_ACTION_IF_ROOM | Ti.Android.SHOW_AS_ACTION_COLLAPSE_ACTION_VIEW
-                    });
-                };
-            }
-            else {
-                // Use search bar
-                search = Ti.UI.createSearchBar({
-                    hintText: "Table Search"
-                });
-                searchAsChild = true;
-            }
+            };
 
             var data = [];
             data.push(Ti.UI.createTableViewRow({title:'Apple'}));
@@ -130,9 +115,9 @@ examples:
             data.push(Ti.UI.createTableViewRow({title:'Raspberry'}));
 
             var tableview = Titanium.UI.createTableView({
-                data:data,
-                search:search,
-                searchAsChild:searchAsChild
+                data: data,
+                search: search,
+                searchAsChild: false
             });
 
             win.add(tableview);
@@ -157,36 +142,26 @@ examples:
 
         index.js:
 
-            if (OS_ANDROID && Ti.Platform.Android.API_LEVEL >= 11) {
-                // use action bar search view
-                var search = Alloy.createController("searchview").getView();
-                $.tableview.searchAsChild = false;
-                $.tableview.search = search;
-                $.win.addEventListener("open", function() {
-                    $.win.activity.onCreateOptionsMenu = function(e) {
-                        e.menu.add({
-                            title: "Table Search",
-                            icon: (Ti.Android.R.drawable.ic_menu_search ? Ti.Android.R.drawable.ic_menu_search : "my_search.png"),
-                            actionView: search,
-                            showAsAction : Ti.Android.SHOW_AS_ACTION_ALWAYS | Ti.Android.SHOW_AS_ACTION_COLLAPSE_ACTION_VIEW
-                        });
-                    }
-                    $.win.activity.invalidateOptionsMenu();
-                });
-            } else {
-                // use a search bar
-                $.tableview.search = Alloy.createController("searchbar").getView();
-            }
+            // use action bar search view
+            var search = Alloy.createController("searchview").getView();
+            $.tableview.searchAsChild = false;
+            $.tableview.search = search;
+            $.win.addEventListener("open", function() {
+                $.win.activity.onCreateOptionsMenu = function(e) {
+                    e.menu.add({
+                        title: "Table Search",
+                        icon: (Ti.Android.R.drawable.ic_menu_search ? Ti.Android.R.drawable.ic_menu_search : "my_search.png"),
+                        actionView: search,
+                        showAsAction : Ti.Android.SHOW_AS_ACTION_ALWAYS | Ti.Android.SHOW_AS_ACTION_COLLAPSE_ACTION_VIEW
+                    });
+                }
+                $.win.activity.invalidateOptionsMenu();
+            });
+
             $.win.open();
 
         searchview.xml:
 
             <Alloy>
                 <SearchView id="searchView" ns="Ti.UI.Android" platform="android" hintText="Table Search" />
-            </Alloy>
-
-        searchbar.xml:
-
-            <Alloy>
-                <SearchBar id="searchBar" hintText="Table Search" />
             </Alloy>

--- a/apidoc/Titanium/UI/Android/SearchView.yml
+++ b/apidoc/Titanium/UI/Android/SearchView.yml
@@ -131,7 +131,7 @@ examples:
 
             <Alloy>
                 <Window id="win" backgroundColor="blue" fullscreen="false" layout="vertical">
-                    <TableView id="tableview" top="10">
+                    <TableView id="tableview" top="10" searchAsChild="false">
                         <TableViewRow title="Apple" />
                         <TableViewRow title="Banana" />
                         <TableViewRow title="Orange" />
@@ -144,7 +144,6 @@ examples:
 
             // use action bar search view
             var search = Alloy.createController("searchview").getView();
-            $.tableview.searchAsChild = false;
             $.tableview.search = search;
             $.win.addEventListener("open", function() {
                 $.win.activity.onCreateOptionsMenu = function(e) {


### PR DESCRIPTION
Alloy & Classic examples in docs tested on Android 2.3.6 and Jelly Bean devices.
