### PR TITLE
TC-4029: normalize tab selection/unselection cross-platform, and keyboard hiding improvement

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TabProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TabProxy.java
@@ -214,12 +214,6 @@ public class TabProxy extends TiViewProxy
 			window.fireEvent(TiC.EVENT_OPEN, null, false);
 		}
 		
-		//When tab loses focus, we hide the soft keyboard.
-		Activity currentActivity = TiApplication.getAppCurrentActivity();
-		if (!focused && currentActivity != null) {
-			TiUIHelper.showSoftKeyboard(currentActivity.getWindow().getDecorView(), false);
-		}
-
 		// The focus and blur events for tab changes propagate like so:
 		//    window -> tab -> tab group
 		//    
@@ -247,6 +241,14 @@ public class TabProxy extends TiViewProxy
 
 	void onSelectionChanged(boolean selected)
 	{
+		if (!selected) {
+			//When tab selection changes, we hide the soft keyboard.
+			Activity currentActivity = TiApplication.getAppCurrentActivity();
+			if (currentActivity != null) {
+				TiUIHelper.showSoftKeyboard(currentActivity.getWindow().getDecorView(), false);
+			}
+		}
+
 		((TiUIAbstractTab) view).onSelectionChange(selected);
 	}
 

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIActionBarTabGroup.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIActionBarTabGroup.java
@@ -173,16 +173,19 @@ public class TiUIActionBarTabGroup extends TiUIAbstractTabGroup implements TabLi
 		} else {
 			tabClicked = true;
 		}
+		tabProxy.fireEvent(TiC.EVENT_SELECTED, null, false);
 
 	}
 
 	@Override
 	public void onTabUnselected(Tab tab, FragmentTransaction ft) {
 		TiUIActionBarTab tabView = (TiUIActionBarTab) tab.getTag();
+		TabProxy tabProxy = (TabProxy) tabView.getProxy();
 
 		// Hide the currently selected fragment since another tab is
 		// in the process of being selected.
 		ft.hide(tabView.fragment);
+		tabProxy.fireEvent(TiC.EVENT_UNSELECTED, null, false);
 	}
 
 	@Override

--- a/android/titanium/src/java/org/appcelerator/titanium/TiC.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiC.java
@@ -153,6 +153,16 @@ public class TiC
 	 */
 	public static final String EVENT_FOCUSED = "focused";
 
+        /**
+         * @module.api
+         */
+        public static final String EVENT_SELECTED = "selected";
+
+        /**
+         * @module.api
+         */
+        public static final String EVENT_UNSELECTED = "unselected";
+
 	/**
 	 * @module.api
 	 */

--- a/apidoc/Titanium/UI/Tab.yml
+++ b/apidoc/Titanium/UI/Tab.yml
@@ -249,6 +249,16 @@ properties:
     type: Titanium.UI.Window
 
 events: 
+  - name: selected
+    summary: Fired when the tab is selected.
+    description: |
+        This is the cross-platform normalized event to indicate tab selection, available since the focus and blur events have platform-specific behavior.
+    platforms: [android, iphone, ipad]
+
+  - name: unselected
+    summary: Fired when the tab is unselected.
+    platforms: [android, iphone, ipad]
+
   - name: blur
     summary: Fired when the tab loses focus.
     properties:
@@ -264,7 +274,7 @@ events:
       - name: previousTab
         summary: Previous active tab object.
         type: Titanium.UI.Tab
-    exclude-platforms: [blackberry]
+    exclude-platforms: [blackberry, iphone, ipad]
 
   - name: click
     summary: Fired when this tab is clicked in the tab group.
@@ -291,7 +301,7 @@ events:
       - name: previousTab
         summary: Previous active tab object.
         type: Titanium.UI.Tab
-    platforms: [android, iphone, ipad, mobileweb, tizen]
+    platforms: [android, mobileweb, tizen]
 
   - name: longpress
     platforms: [mobileweb, tizen]

--- a/iphone/Classes/TiUITabProxy.m
+++ b/iphone/Classes/TiUITabProxy.m
@@ -404,8 +404,8 @@
             }
         }
     }
-    if ([self _hasListeners:@"blur"]) {
-        [self fireEvent:@"blur" withObject:nil withSource:self propagate:NO reportSuccess:NO errorCode:0 message:nil];
+    if ([self _hasListeners:@"unselected"]) {
+        [self fireEvent:@"unselected" withObject:nil withSource:self propagate:NO reportSuccess:NO errorCode:0 message:nil];
     }
 }
 
@@ -428,8 +428,8 @@
             }
         }
     }
-    if ([self _hasListeners:@"focus"]) {
-        [self fireEvent:@"focus" withObject:nil withSource:self propagate:NO reportSuccess:NO errorCode:0 message:nil];
+    if ([self _hasListeners:@"selected"]) {
+        [self fireEvent:@"selected" withObject:nil withSource:self propagate:NO reportSuccess:NO errorCode:0 message:nil];
     }
 }
 


### PR DESCRIPTION
Prior to this PR, in Android we had no reliable event for tab selection and unselection. The tab focus and blur events would fire in these cases, but as the JIRA issue shows they also fired under additional circumstances as well. In order to not mess with the (rather complex!!!) focus/blur bubbling logic in Titanium Android (and not break existing apps), this PR simply added the `selected` and `unselected` events for tabs (with the additional benefit of the clearer event name than focus and blur).

In iOS, the `focus` and `blur` events functioned exactly as tab selection indicators, and there was no bubbling event confusion in their case between window, tab, and tab group. However, to be compatible with Android these events were renamed to `selected` and `unselected`. The tab `focus` and `blur` events have been removed for iOS. 

Additionally, in Android the keyboard is now hidden when the tab selection changes, and not when the tab loses focus (e.g. when the screen is locked), providing for a much smoother user experience. 
