### PR TITLE
[TC-4078]: make ListSection methods run on UI thread as required

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/ListSectionProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/ListSectionProxy.java
@@ -142,7 +142,7 @@ public class ListSectionProxy extends ViewProxy{
 		if (TiApplication.isUIThread()) {
 			handleSetHeaderView(headerView);
 		} else {
-			TiMessenger.sendBlockingMainMessage(getMainHandler().obtainMessage(MSG_SET_HEADER_VIEW, headerView));
+			TiMessenger.sendBlockingMainMessage(getMainHandler().obtainMessage(MSG_SET_HEADER_VIEW), headerView);
 		}
 	}
 	
@@ -156,7 +156,7 @@ public class ListSectionProxy extends ViewProxy{
 		if (TiApplication.isUIThread()) {
 			handleSetFooterView(footerView);
 		} else {
-			TiMessenger.sendBlockingMainMessage(getMainHandler().obtainMessage(MSG_SET_FOOTER_VIEW, footerView));
+			TiMessenger.sendBlockingMainMessage(getMainHandler().obtainMessage(MSG_SET_FOOTER_VIEW), footerView);
 		}
 	}
 	


### PR DESCRIPTION
Prior to this fix I was seeing an occasional error message in my app: java.lang.IllegalStateException: "The content of the adapter has changed but ListView did not receive a notification. Make sure the content of your adapter is not modified from a background thread, but only from the UI thread. [in ListView(-1, class android.widget.ListView) with Adapter(class android.widget.HeaderViewListAdapter)]

See line notes for the bugs fixed
