### PR TITLE
[TIMOB-16857][TIMOB-16855] Define securityManager property of HTTPClient 

### DIFF
--- a/android/modules/network/src/java/ti/modules/titanium/network/HTTPClientProxy.java
+++ b/android/modules/network/src/java/ti/modules/titanium/network/HTTPClientProxy.java
@@ -30,7 +30,9 @@ public class HTTPClientProxy extends KrollProxy
 	@Kroll.constant public static final int LOADING = TiHTTPClient.READY_STATE_LOADING;
 	@Kroll.constant public static final int DONE = TiHTTPClient.READY_STATE_DONE;
 
+	public static final String PROPERTY_SECURITY_MANAGER = "securityManager";
 	private TiHTTPClient client;
+
 
 	public HTTPClientProxy()
 	{
@@ -48,6 +50,16 @@ public class HTTPClientProxy extends KrollProxy
 		super.handleCreationDict(dict);
 		if (hasProperty(TiC.PROPERTY_TIMEOUT)) {
 			client.setTimeout(TiConvert.toInt(getProperty(TiC.PROPERTY_TIMEOUT)));
+		}
+		
+		//Set the securityManager on the client if it is defined as a valid value
+		if (hasProperty(PROPERTY_SECURITY_MANAGER)) {
+			Object prop = getProperty(PROPERTY_SECURITY_MANAGER);
+			if (prop instanceof SecurityManagerProtocol) {
+				this.client.securityManager = (SecurityManagerProtocol)prop;
+			} else {
+				throw new IllegalArgumentException("Invalid argument passed to securityManager property. Does not conform to SecurityManagerProtocol");
+			}
 		}
 	}
 

--- a/android/modules/network/src/java/ti/modules/titanium/network/SecurityManagerProtocol.java
+++ b/android/modules/network/src/java/ti/modules/titanium/network/SecurityManagerProtocol.java
@@ -1,0 +1,36 @@
+/**
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2014 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+
+package ti.modules.titanium.network;
+
+import javax.net.ssl.X509KeyManager;
+import javax.net.ssl.X509TrustManager;
+
+import android.net.Uri;
+
+public interface SecurityManagerProtocol {
+	/**
+	 * Defines if the SecurityManager will provide TrustManagers and KeyManagers for SSL Context given a Uri
+	 * @param uri - The end point for the network connection
+	 * @return true if SecurityManagers will define SSL Context, false otherwise.
+	 */
+	public boolean willHandleURL(Uri uri);
+	
+	/**
+	 * Returns the X509TrustManager array for SSL Context. 
+	 * @param uri - The end point of the network connection
+	 * @return Return array of X509TrustManager for custom server validation. Null otherwise.
+	 */
+	public X509TrustManager[] getTrustManagers(Uri uri);
+	
+	/**
+	 * Reurns the X509KeyManager array for the SSL Context.
+	 * @param uri - The end point of the network connection
+	 * @return Return array of X509KeyManager for custom client certificate management. Null otherwise.
+	 */
+	public X509KeyManager[] getKeyManagers(Uri uri);
+}

--- a/android/modules/network/src/java/ti/modules/titanium/network/SecurityManagerProtocol.java
+++ b/android/modules/network/src/java/ti/modules/titanium/network/SecurityManagerProtocol.java
@@ -28,7 +28,7 @@ public interface SecurityManagerProtocol {
 	public X509TrustManager[] getTrustManagers(Uri uri);
 	
 	/**
-	 * Reurns the X509KeyManager array for the SSL Context.
+	 * Returns the X509KeyManager array for the SSL Context.
 	 * @param uri - The end point of the network connection
 	 * @return Return array of X509KeyManager for custom client certificate management. Null otherwise.
 	 */

--- a/android/modules/network/src/java/ti/modules/titanium/network/TiHTTPClient.java
+++ b/android/modules/network/src/java/ti/modules/titanium/network/TiHTTPClient.java
@@ -163,6 +163,7 @@ public class TiHTTPClient
 	private ArrayList<File> tmpFiles = new ArrayList<File>();
 	private ArrayList<X509TrustManager> trustManagers = new ArrayList<X509TrustManager>();
 	private ArrayList<X509KeyManager> keyManagers = new ArrayList<X509KeyManager>();
+	protected SecurityManagerProtocol securityManager;
 
 	private static CookieStore cookieStore = NetworkModule.getHTTPCookieStoreInstance();
 
@@ -1038,7 +1039,22 @@ public class TiHTTPClient
 	protected DefaultHttpClient getClient(boolean validating)
 	{
 		SSLSocketFactory sslSocketFactory = null;
-		if (trustManagers.size() > 0 || keyManagers.size() > 0) {
+		
+		if (this.securityManager != null) {
+			if (this.securityManager.willHandleURL(this.uri)) {
+				TrustManager[] trustManagerArray = this.securityManager.getTrustManagers(this.uri);
+				KeyManager[] keyManagerArray = this.securityManager.getKeyManagers(this.uri);
+				
+				try {
+					sslSocketFactory = new TiSocketFactory(keyManagerArray, trustManagerArray);
+				} catch(Exception e) {
+					Log.e(TAG, "Error creating SSLSocketFactory: " + e.getMessage());
+					sslSocketFactory = null;
+				}
+			}
+		} 
+		
+		if (sslSocketFactory == null && (trustManagers.size() > 0 || keyManagers.size() > 0)) {
 			TrustManager[] trustManagerArray = null;
 			KeyManager[] keyManagerArray = null;
 			
@@ -1424,11 +1440,17 @@ public class TiHTTPClient
 	
 	protected void addKeyManager(X509KeyManager manager)
 	{
+		if (Log.isDebugModeEnabled()) {
+			Log.d(TAG, "addKeyManager method is deprecated. Use the securityManager property on the HttpClient to define custom SSL Contexts", Log.DEBUG_MODE);
+		}
 		keyManagers.add(manager);
 	}
 	
 	protected void addTrustManager(X509TrustManager manager)
 	{
+		if (Log.isDebugModeEnabled()) {
+			Log.d(TAG, "addTrustManager method is deprecated. Use the securityManager property on the HttpClient to define custom SSL Contexts", Log.DEBUG_MODE);
+		}
 		trustManagers.add(manager);
 	}
 }

--- a/android/modules/network/src/java/ti/modules/titanium/network/TiHTTPClient.java
+++ b/android/modules/network/src/java/ti/modules/titanium/network/TiHTTPClient.java
@@ -1053,35 +1053,35 @@ public class TiHTTPClient
 				}
 			}
 		} 
-		
-		if (sslSocketFactory == null && (trustManagers.size() > 0 || keyManagers.size() > 0)) {
-			TrustManager[] trustManagerArray = null;
-			KeyManager[] keyManagerArray = null;
-			
-			if (trustManagers.size() > 0) {
-				trustManagerArray = new X509TrustManager[trustManagers.size()];
-				trustManagerArray = trustManagers.toArray(trustManagerArray);
-			}
-			
-			if (keyManagers.size() > 0) {
-				keyManagerArray = new X509KeyManager[keyManagers.size()];
-				keyManagerArray = keyManagers.toArray(keyManagerArray);
-			}
-			
-			try {
-				sslSocketFactory = new TiSocketFactory(keyManagerArray, trustManagerArray);
-			} catch(Exception e) {
-				Log.e(TAG, "Error creating SSLSocketFactory: " + e.getMessage());
-				sslSocketFactory = null;
-			}
-		}
-		else if (!validating) {
-			TrustManager trustManagerArray[] = new TrustManager[] { new NonValidatingTrustManager() };
-			try {
-				sslSocketFactory = new TiSocketFactory(null, trustManagerArray);
-			} catch(Exception e) {
-				Log.e(TAG, "Error creating SSLSocketFactory: " + e.getMessage());
-				sslSocketFactory = null;
+		if (sslSocketFactory == null) {
+			if (trustManagers.size() > 0 || keyManagers.size() > 0) {
+				TrustManager[] trustManagerArray = null;
+				KeyManager[] keyManagerArray = null;
+				
+				if (trustManagers.size() > 0) {
+					trustManagerArray = new X509TrustManager[trustManagers.size()];
+					trustManagerArray = trustManagers.toArray(trustManagerArray);
+				}
+				
+				if (keyManagers.size() > 0) {
+					keyManagerArray = new X509KeyManager[keyManagers.size()];
+					keyManagerArray = keyManagers.toArray(keyManagerArray);
+				}
+				
+				try {
+					sslSocketFactory = new TiSocketFactory(keyManagerArray, trustManagerArray);
+				} catch(Exception e) {
+					Log.e(TAG, "Error creating SSLSocketFactory: " + e.getMessage());
+					sslSocketFactory = null;
+				}
+			} else if (!validating) {
+				TrustManager trustManagerArray[] = new TrustManager[] { new NonValidatingTrustManager() };
+				try {
+					sslSocketFactory = new TiSocketFactory(null, trustManagerArray);
+				} catch(Exception e) {
+					Log.e(TAG, "Error creating SSLSocketFactory: " + e.getMessage());
+					sslSocketFactory = null;
+				}
 			}
 		}
 		

--- a/apidoc/Titanium/Network/HTTPClient.yml
+++ b/apidoc/Titanium/Network/HTTPClient.yml
@@ -119,6 +119,9 @@ methods:
         type: Object
     platforms: [android]
     since: {android: "3.1.0"}
+    deprecated:
+        since: "3.3.0"
+        removed: "3.4.0"
 
   - name: addTrustManager
     summary: Adds a custom trust manager.
@@ -133,6 +136,9 @@ methods:
         type: Object
     platforms: [android]
     since: {android: "3.1.0"}
+    deprecated:
+        since: "3.3.0"
+        removed: "3.4.0"
 
   - name: clearCookies
     summary: Clears any cookies stored for the host.
@@ -430,14 +436,14 @@ properties:
     permission: read-only
 
   - name: securityManager
-    summary: The APSConnectionDelegate for this client.
+    summary: The Security Manager for this client.
     description:
         This property **must** be specified during creation.
         Set this property on the HTTPClient to participate in the authentication and resource management
         of the connection.
-        See <APSConnectionDelegate> for further information. 
-    type: APSConnectionDelegate
-    platforms: [ipad, iphone]
+        See <SecurityManagerProtocol> for further information. 
+    type: SecurityManagerProtocol
+    platforms: [ipad, iphone, android]
     since: "3.3.0"
     availability: creation
 
@@ -547,12 +553,79 @@ examples:
              client.send();
 
 ---
+name: SecurityManagerProtocol
+summary: The protocol that the <Titanium.Network.HTTPClient.securityManager> must implement.
+description: |
+    The object representing <Titanium.Network.HTTPClient.securityManager> must implement this protocol.
+    Assigning the securityManager property to an object that does not implement this protocol will cause an exception to be raised.
+    All methods in this protocol are required.
+
+methods:
+  - name: willHandleURL
+    summary: Returns if the security manager will participate in authentication of this end point.
+    description: |
+        The parameter passed to this method is a [NSURL](https://developer.apple.com/library/mac/documentation/Cocoa/Reference/Foundation/Classes/NSURL_Class/Reference/Reference.html) 
+        on iOS and a [Uri](http://developer.android.com/reference/android/net/Uri.html) on android. 
+
+        Return **true** to participate, **false** to allow default authentication flow. 
+    returns:
+        type: Boolean
+    parameters:
+      - name: url
+        summary: The Object representing representing the end point of this connection.
+        type: Object
+
+  - name: connectionDelegateForUrl
+    summary: The <APSConnectionDelegate> for this connection.
+    description: |
+        This method is only called if <SecurityManagerProtocol.willHandleURL> returns true.
+        See <APSConnectionDelegate> for further information.
+    returns:
+        type: APSConnectionDelegate
+    parameters:
+      - name: url
+        summary: The [NSURL](https://developer.apple.com/library/mac/documentation/Cocoa/Reference/Foundation/Classes/NSURL_Class/Reference/Reference.html) representing the end point of this connection.
+        type: Object
+    platforms: [iphone, ipad]
+
+  - name: getTrustManagers
+    summary: Returns an array of objects implementing the [X509TrustManager](http://developer.android.com/reference/javax/net/ssl/X509TrustManager.html) protocol for the SSL Context.
+    description: |
+        This method is only called if <SecurityManagerProtocol.willHandleURL> returns true.
+
+        Return null to set up a SSL Context with the default system trust managers.
+    returns:
+        type: Array<Object>
+    parameters:
+      - name: url
+        summary: The [Uri](http://developer.android.com/reference/android/net/Uri.html) representing the end point of this connection.
+        type: Object
+    platforms: [android]
+
+  - name: getKeyManagers
+    summary: Returns an array of objects implementing the [X509KeyManager](http://developer.android.com/reference/javax/net/ssl/X509KeyManager.html) protocol for the SSL Context.
+    description: |
+        This method is only called if <SecurityManagerProtocol.willHandleURL> returns true.
+
+        Return null to set up a SSL Context with the default system key managers.
+    returns:
+        type: Array<Object>
+    parameters:
+      - name: url
+        summary: The [Uri](http://developer.android.com/reference/android/net/Uri.html) representing the end point of this connection.
+        type: Object
+    platforms: [android]
+
+since: 3.3.0
+platforms: [iphone, ipad, android]
+
+---
 name: APSConnectionDelegate
-summary: An extension of the [NSURLConnectionDelegate](https://developer.apple.com/library/mac/documentation/Foundation/Reference/NSURLConnectionDelegate_Protocol/Reference/Reference.html#//apple_ref/occ/intf/NSURLConnectionDelegate) protocol to allow users to participate in authentication and resource mnagement for this HTTPClient.
+summary: An extension of the [NSURLConnectionDelegate](https://developer.apple.com/library/mac/documentation/Foundation/Reference/NSURLConnectionDelegate_Protocol/Reference/Reference.html#//apple_ref/occ/intf/NSURLConnectionDelegate) protocol to allow users to participate in authentication and resource management for this HTTPClient.
 description: |
     The APSConnectionDelegate protocol is an extension of the NSURLConnectionDelegate protocol. 
-    The object representing <Titanium.Network.HTTPClient.securityManager> must implement this protocol.
-    Although all methods in this protocol are optional, the securityManager must implement at least one of the methods to 
+    
+    Although all methods in this protocol are optional, the connection delegate must implement at least one of the methods to 
     participate in the authentication and resource management.
 
     The deprecated methods as defined by the NSURLConnectionDelegate protocol are not supported.
@@ -561,13 +634,13 @@ description: |
 
     `-(BOOL)willHandleChallenge:(NSURLAuthenticationChallenge *)challenge forConnection:(NSURLConnection *)connection`.
         
-    This method is called on the <Titanium.Network.HTTPClient.securityManager> only if it also implements the 
+    This method is called on the connection delegate only if it also implements the 
     `connection:willSendRequestForAuthenticationChallenge:` method of the NSURLConnectionDelegate protocol.
-    Return `true` if the securityManager wants to handle this challenge. 
+    Return `true` if the connection delegate wants to handle this challenge. 
     Return `false` if the default delegate will handle this challenge.
 
-    If the securityManager does not implement this method but implements `connection:willSendRequestForAuthenticationChallenge:`, the return 
-    value is assumed to be `true` and all challenges will be forwarded to the securityManager.
+    If the connection delegate does not implement this method but implements `connection:willSendRequestForAuthenticationChallenge:`, the return 
+    value is assumed to be `true` and all challenges will be forwarded to the connection delegate.
 
 since: 3.3.0
 platforms: [iphone, ipad]

--- a/iphone/Classes/TiNetworkHTTPClientProxy.h
+++ b/iphone/Classes/TiNetworkHTTPClientProxy.h
@@ -12,12 +12,19 @@
 #import "TiDOMDocumentProxy.h"
 #import "TiBlob.h"
 
+@protocol SecurityManagerProtocol <NSObject>
+@required
+-(BOOL) willHandleURL:(NSURL*)url;
+-(id<APSConnectionDelegate>) connectionDelegateForUrl:(NSURL*)url;
+@end
+
 @interface TiNetworkHTTPClientProxy : TiProxy<APSHTTPRequestDelegate>
 {
     APSHTTPRequest *httpRequest;
     NSTimeInterval _uploadTime;
     NSTimeInterval _downloadTime;
-    id<APSConnectionDelegate> apsConnectionManager;
+    id<APSConnectionDelegate> apsConnectionDelegate;
+    id<SecurityManagerProtocol> apsConnectionManager;
     
     BOOL hasOnload;
     BOOL hasOnerror;

--- a/iphone/Classes/TiNetworkHTTPClientProxy.m
+++ b/iphone/Classes/TiNetworkHTTPClientProxy.m
@@ -32,7 +32,9 @@ extern NSString * const TI_APPLICATION_GUID;
     id arg = [properties valueForKey:@"securityManager"];
     
     if (IS_NULL_OR_NIL(arg) || [arg conformsToProtocol:@protocol(SecurityManagerProtocol)]) {
-        apsConnectionManager = [arg retain];
+        if (arg != [NSNull null]) {
+            apsConnectionManager = [arg retain];
+        }
     } else {
         [self throwException:@"Invalid argument passed to securityManager property" subreason:@"Does not conform to SecurityManagerProtocol" location:CODELOCATION];
     }

--- a/iphone/Classes/TiNetworkHTTPClientProxy.m
+++ b/iphone/Classes/TiNetworkHTTPClientProxy.m
@@ -23,17 +23,23 @@ extern NSString * const TI_APPLICATION_GUID;
 {
     RELEASE_TO_NIL(httpRequest);
     RELEASE_TO_NIL(apsConnectionManager);
+    RELEASE_TO_NIL(apsConnectionDelegate);
     [super dealloc];
 }
 
 -(void)_initWithProperties:(NSDictionary *)properties
 {
     id arg = [properties valueForKey:@"securityManager"];
-    apsConnectionManager = [arg retain];
+    
+    if (IS_NULL_OR_NIL(arg) || [arg conformsToProtocol:@protocol(SecurityManagerProtocol)]) {
+        apsConnectionManager = [arg retain];
+    } else {
+        [self throwException:@"Invalid argument passed to securityManager property" subreason:@"Does not conform to SecurityManagerProtocol" location:CODELOCATION];
+    }
     [super _initWithProperties:properties];
 }
 
--(APSHTTPRequest*)request
+-(void)ensureClient
 {
     if(httpRequest == nil) {
         httpRequest = [[APSHTTPRequest alloc] init];
@@ -42,12 +48,12 @@ extern NSString * const TI_APPLICATION_GUID;
         [httpRequest addRequestHeader:[NSString stringWithFormat:@"%s-%s%s-%s", "X","Tita","nium","Id"] value:TI_APPLICATION_GUID];
         
     }
-    return httpRequest;
 }
 
 -(APSHTTPResponse*)response
 {
-    return [[self request] response];
+    [self ensureClient];
+    return [httpRequest response];
 }
 
 #pragma mark - Public methods
@@ -57,10 +63,15 @@ extern NSString * const TI_APPLICATION_GUID;
     ENSURE_ARRAY(args);
     NSString *method = [TiUtils stringValue:[args objectAtIndex:0]];
     NSURL *url = [TiUtils toURL:[args objectAtIndex:1] proxy:self];
-    [[self request] setMethod: method];
-    [[self request] setUrl:url];
+    [self ensureClient];
+    [httpRequest setMethod: method];
+    [httpRequest setUrl:url];
     
-    [[self request] setConnectionDelegate:apsConnectionManager];
+    if ( (apsConnectionManager != nil) && ([apsConnectionManager willHandleURL:url]) ){
+        apsConnectionDelegate = [[apsConnectionManager connectionDelegateForUrl:url] retain];
+    }
+    
+    [httpRequest setConnectionDelegate:apsConnectionDelegate];
     
     if([args count] >= 3) {
         [self replaceValue:[args objectAtIndex:2] forKey:@"async" notification: YES];
@@ -75,28 +86,28 @@ extern NSString * const TI_APPLICATION_GUID;
     [self rememberSelf];
     
     if([self valueForUndefinedKey:@"timeout"]) {
-        [[self request] setTimeout: [TiUtils intValue:[self valueForUndefinedKey:@"timeout"] def:15000] / 1000 ];
+        [httpRequest setTimeout: [TiUtils intValue:[self valueForUndefinedKey:@"timeout"] def:15000] / 1000 ];
     }
     if([self valueForUndefinedKey:@"autoRedirect"]) {
-        [[self request] setRedirects:
+        [httpRequest setRedirects:
          [TiUtils boolValue: [self valueForUndefinedKey:@"autoRedirect"] def:YES] ];
     }
     if([self valueForUndefinedKey:@"cache"]) {
-        [[self request] setCachePolicy:
+        [httpRequest setCachePolicy:
          [TiUtils boolValue: [self valueForUndefinedKey:@"cache"] def:YES] ?
              NSURLRequestUseProtocolCachePolicy : NSURLRequestReloadIgnoringLocalAndRemoteCacheData
          ];
     }
     if([self valueForUndefinedKey:@"validatesSecureCertificate"]) {
-        [[self request] setValidatesSecureCertificate:
+        [httpRequest setValidatesSecureCertificate:
          [TiUtils boolValue: [self valueForUndefinedKey:@"validatesSecureCertificate"] def:YES] ];
     }
     if([self valueForUndefinedKey:@"username"]) {
-        [[self request] setRequestUsername:
+        [httpRequest setRequestUsername:
          [TiUtils stringValue: [self valueForUndefinedKey:@"username"]]];
     }
     if([self valueForUndefinedKey:@"password"]) {
-        [[self request] setRequestPassword:
+        [httpRequest setRequestPassword:
          [TiUtils stringValue: [self valueForUndefinedKey:@"password"]]];
     }
     if([self valueForUndefinedKey:@"domain"]) {
@@ -107,7 +118,7 @@ extern NSString * const TI_APPLICATION_GUID;
     // this header to indicate an XHR request (such as RoR)
     if ([[self valueForUndefinedKey:@"url"] rangeOfString:@"twitter.com"].location==NSNotFound)
     {
-        [[self request] addRequestHeader:@"X-Requested-With" value:@"XMLHttpRequest"];
+        [httpRequest addRequestHeader:@"X-Requested-With" value:@"XMLHttpRequest"];
     }
     id file = [self valueForUndefinedKey:@"file"];
     if(file) {
@@ -119,7 +130,7 @@ extern NSString * const TI_APPLICATION_GUID;
             filePath = [TiUtils stringValue:file];
         }
         if(filePath != nil) {
-            [[self request] setFilePath:filePath];
+            [httpRequest setFilePath:filePath];
         }
     }
     
@@ -179,7 +190,7 @@ extern NSString * const TI_APPLICATION_GUID;
     }
     
     if(form != nil) {
-        [[self request] setPostForm:form];
+        [httpRequest setPostForm:form];
     }
     
     BOOL async = [TiUtils boolValue:[self valueForUndefinedKey:@"async"] def:YES];
@@ -188,11 +199,11 @@ extern NSString * const TI_APPLICATION_GUID;
     
     [[TiApp app] startNetwork];
     if(async) {
-        [[self request] setTheQueue:operationQueue];
-        [[self request] send];
+        [httpRequest setTheQueue:operationQueue];
+        [httpRequest send];
     } else {
-        [[self request] setSynchronous:YES];
-        [[self request] send];
+        [httpRequest setSynchronous:YES];
+        [httpRequest send];
         [[TiApp app] stopNetwork];
         [self forgetSelf];
     }
@@ -200,7 +211,7 @@ extern NSString * const TI_APPLICATION_GUID;
 
 -(void)abort:(id)args
 {
-    [[self request] abort];
+    [httpRequest abort];
 }
 
 -(void)clearCookies:(id)args
@@ -360,10 +371,10 @@ extern NSString * const TI_APPLICATION_GUID;
 -(void)setRequestHeader:(id)args
 {
     ENSURE_ARG_COUNT(args,2);
-    
+    [self ensureClient];
     NSString *key = [TiUtils stringValue:[args objectAtIndex:0]];
     NSString *value = [TiUtils stringValue:[args objectAtIndex:1]];
-    [[self request] addRequestHeader:key value:value];
+    [httpRequest addRequestHeader:key value:value];
 }
 
 #pragma mark - Public getter properties
@@ -383,7 +394,7 @@ extern NSString * const TI_APPLICATION_GUID;
     if([self response] == nil) {
         return NUMBOOL(NO);
     }
-    APSHTTPResponseState state = [[[self request] response] readyState];
+    APSHTTPResponseState state = [[self response] readyState];
     return NUMBOOL(
                    state == APSHTTPResponseStateHeaders ||
                    state == APSHTTPResponseStateLoading ||


### PR DESCRIPTION
This PR does a few things
1. Defines securityManager as a creation only property on Android
2. Defines the SecurityManagerProtocol for the securityManager on iOS and Android
3. Validates the securityManager property
4. Hides the APSHTTPRequest object on iOS so that the connectionDelegate can only be set only by the Proxy
5. Deprecates the addTrustManager and addKeyManager methods on Android.

Associated JIRA tickets
[TIMOB-16855](https://jira.appcelerator.org/browse/TIMOB-16855)
[TIMOB-16857](https://jira.appcelerator.org/browse/TIMOB-16857)
