### PR TITLE
[TIMOB-14878] [TIMOB-16555] [TIMOB-16674] Version number formatting fixes!

### DIFF
--- a/android/cli/lib/AndroidManifest.js
+++ b/android/cli/lib/AndroidManifest.js
@@ -1,6 +1,6 @@
 /**
  * Titanium SDK Library for Node.js
- * Copyright (c) 2012-2013 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2012-2014 by Appcelerator, Inc. All Rights Reserved.
  * Please see the LICENSE file for information about licensing.
  */
 
@@ -229,7 +229,11 @@ function toXml(dom, parent, name, value) {
 function initAttr(node, obj) {
 	xml.forEachAttr(node, function (attr) {
 		obj.__attr__ || (obj.__attr__ = {});
-		obj.__attr__[attr.name] = xml.parse(attr.value);
+		if (attr.name == 'android:versionName') {
+			obj.__attr__[attr.name] = attr.value;
+		} else {
+			obj.__attr__[attr.name] = xml.parse(attr.value);
+		}
 	});
 	return obj;
 }

--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -4,7 +4,7 @@
  * @module cli/_build
  *
  * @copyright
- * Copyright (c) 2009-2013 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2009-2014 by Appcelerator, Inc. All Rights Reserved.
  *
  * @license
  * Licensed under the terms of the Apache Public License
@@ -789,9 +789,9 @@ iOSBuilder.prototype.validate = function (logger, config, cli) {
 	} else {
 		this.deployType = /^device|simulator$/.test(this.target) && cli.argv['deploy-type'] ? cli.argv['deploy-type'] : this.deployTypes[this.target];
 	}
-	
+
 	this.buildType = cli.argv['build-type'] || '';
-	
+
 	// manually inject the build profile settings into the tiapp.xml
 	switch (this.deployType) {
 		case 'production':
@@ -1811,15 +1811,13 @@ iOSBuilder.prototype.createInfoPlist = function createInfoPlist(next) {
 
 	plist.CFBundleIdentifier = this.tiapp.id;
 
-	// device builds require an additional token to ensure uniquiness so that iTunes will detect an updated app to sync
-	if (this.config.get('app.skipVersionValidation') || this.tiapp.properties['ti.skipVersionValidation']) {
-		plist.CFBundleVersion = this.tiapp.version;
-	} else if (this.target == 'device') {
-		plist.CFBundleVersion = appc.version.format(this.tiapp.version, 3, 3) + '.' + (new Date).getTime();
+	if (this.target == 'device' && this.deviceId == 'itunes') {
+		// device builds require an additional token to ensure uniqueness so that iTunes will detect an updated app to sync
+		plist.CFBundleVersion = this.tiapp.version + '.' + (new Date).getTime();
 	} else {
-		plist.CFBundleVersion = appc.version.format(this.tiapp.version, 3, 3);
+		plist.CFBundleVersion = this.tiapp.version;
 	}
-	plist.CFBundleShortVersionString = plist.CFBundleVersion;
+	plist.CFBundleShortVersionString = appc.version.format(plist.CFBundleVersion, 0, 3);
 
 	Array.isArray(plist.CFBundleIconFiles) || (plist.CFBundleIconFiles = []);
 	['.png', '@2x.png', '-72.png', '-60.png', '-60@2x.png', '-76.png', '-76@2x.png', '-Small-50.png', '-72@2x.png', '-Small-50@2x.png', '-Small.png', '-Small@2x.png', '-Small-40.png', '-Small-40@2x.png'].forEach(function (name) {


### PR DESCRIPTION
[TIMOB-14878] Fixed CFBundleVersion and CFBundleShortVersion in the Info.plist so that the CFBundleVersion is exactly what was in the tiapp.xml and the CFBundleShortVersion is the version from the tiapp.xml, but truncated to no more than 3 segments.

[TIMOB-16555] Now allow any number of version segments in the version number when setting the CFBundleVersion.

[TIMOB-16674] Fixed android:versionName parsing to not truncate trailing zeros.
