### PR TITLE
[TIMOB-17247] added contentSize property to scroll event

### DIFF
--- a/iphone/Classes/TiUIScrollViewProxy.m
+++ b/iphone/Classes/TiUIScrollViewProxy.m
@@ -382,6 +382,7 @@ static NSArray* scrollViewKeySequence;
                 NUMBOOL([scrollView isZooming]),@"zooming",
                 NUMBOOL([scrollView isDecelerating]),@"decelerating",
                 NUMBOOL([scrollView isDragging]),@"dragging",
+                [TiUtils sizeToDictionary:scrollView.contentSize], @"contentSize",
                 nil]];
     }
 }


### PR DESCRIPTION
:JIRA: https://jira.appcelerator.org/browse/TIMOB-17247

The 'scroll' event for [Titanium.UI.ScrollView](http://docs.appcelerator.com/titanium/latest/#!/api/Titanium.UI.ScrollView) does not send back the contentSize for the scroll view. Having the content size is useful when adding items to the bottom of the view based on user scrolling (nearing the end). Tableview does have this, in TiUITableView.m in eventObjectForScrollView.
