### PR TITLE
Fix for ListView Crash with Segmentaion Fault 11, Release _headerViewProxy observer

### DIFF
--- a/iphone/Classes/TiUIListView.m
+++ b/iphone/Classes/TiUIListView.m
@@ -82,6 +82,7 @@ static TiViewProxy * FindViewProxyWithBindIdContainingPoint(UIView *view, CGPoin
     [_tableView release];
     [_templates release];
     [_defaultItemTemplate release];
+    [_headerViewProxy setProxyObserver:nil];
     RELEASE_TO_NIL(_searchString);
     RELEASE_TO_NIL(_searchResults);
     RELEASE_TO_NIL(_pullViewWrapper);


### PR DESCRIPTION
I noticed that _headerViewProxy observer never gets set back to nil that causes crashing my app with segmentation fault 11

objc_msgSend + 6
-[TiViewProxy relayout](TiViewProxy.m:2243)
-[TiViewProxy refreshView:](TiViewProxy.m:2074)
-[TiViewProxy layoutChildrenIfNeeded](TiViewProxy.m:2274)
+[TiLayoutQueue layoutProxy:](TiLayoutQueue.m:79)
performLayoutRefresh (TiLayoutQueue.m:46)
....

Possibley related to http://developer.appcelerator.com/question/174242/ios-crashing-when-using-native-back-button and
https://jira.appcelerator.org/browse/TC-4136
