### PR TITLE
[TIMOB-17059] Fixed bug with paths in the build.properties not escaping ...

### DIFF
--- a/android/templates/module/default/hooks/android-module.js
+++ b/android/templates/module/default/hooks/android-module.js
@@ -73,7 +73,7 @@ exports.init = function (logger, config, cli, appc) {
 
 				// add the maps.jar if we have Google APIs
 				if (target && target.libraries && target.libraries['com.google.android.maps']) {
-					libs.push(path.join(target.path, 'libs', target.libraries['com.google.android.maps'].jar));
+					target.path && libs.push(path.join(target.path, 'libs', target.libraries['com.google.android.maps'].jar));
 				}
 
 				// add the Titanium specific jars
@@ -92,13 +92,13 @@ exports.init = function (logger, config, cli, appc) {
 				}).join('\n\t');
 
 				// set the Android platform path
-				variables.androidPlatformPath = api && api.platformPath || '';
+				variables.androidPlatformPath = api && api.platformPath ? api.platformPath.replace(/\\/g, '\\\\') : '';
 
 				// set the Google APIs path
-				variables.googleAPIPath = api && api.googleAPIPath || '';
+				variables.googleAPIPath = api && api.googleAPIPath ? api.googleAPIPath.replace(/\\/g, '\\\\') : '';
 
 				// set the Titanium Android platform path
-				variables.tisdkAndroidPath = path.join(data.args[0].tisdkPath, 'android');
+				variables.tisdkAndroidPath = path.join(data.args[0].tisdkPath, 'android').replace(/\\/g, '\\\\');
 
 				callback();
 			}.bind(this));

--- a/node_modules/titanium-sdk/lib/android.js
+++ b/node_modules/titanium-sdk/lib/android.js
@@ -462,9 +462,9 @@ exports.detect = function detect(config, opts, finished) {
 					manifestApiRegex = /^(?:api|AndroidVersion\.ApiLevel)=(.*)$/m,
 					manifestRevisionRegex = /^(?:revision|Pkg.Revision)=(.*)$/m;
 				afs.visitDirsSync(path.join(results.sdk.path, 'add-ons'), function (subDir, subDirPath) {
-					var file = path.join(subDirPath, 'source.properties');
+					var file = path.join(subDirPath, 'manifest.ini');
 					if (!fs.existsSync(file)) {
-						file = path.join(subDirPath, 'manifest.ini');
+						file = path.join(subDirPath, 'source.properties');
 					}
 					if (fs.existsSync(file)) {
 						var manifest = fs.readFileSync(file).toString(),
@@ -651,7 +651,12 @@ exports.detect = function detect(config, opts, finished) {
 						for (i = 0, len = lines.length; i < len; i++) {
 							line = lines[i].trim();
 							if (m = line.match(keyValRegex)) {
-								info[m[1].toLowerCase().trim().replace(/\s/g, '-')] = m[2];
+								key = m[1].toLowerCase().trim().replace(/\s/g, '-');
+								if (key == 'tag/abi') {
+									info['abi'] = m[2].replace(/^\w+\//, '');
+								} else {
+									info[key] = m[2];
+								}
 							} else if (m = line.match(basedOnRegex)) {
 								info['based-on'] = {
 									'android-version': m[1],

--- a/node_modules/titanium-sdk/lib/windows.js
+++ b/node_modules/titanium-sdk/lib/windows.js
@@ -334,6 +334,9 @@ exports.detect = function detect(config, opts, finished) {
 
 				async.each(Object.keys(result.windowsphone), function (version, callback) {
 					var wpInfo = result.windowsphone[version];
+
+					if (!wpInfo.supported || !wpInfo.deployCmd) return callback();
+
 					appc.subprocess.run(wpInfo.deployCmd, '/EnumerateDevices', function (code, out, err) {
 						if (err) {
 							if (!results.issues.some(function (i) { return i.id == 'WINDOWS_PHONE_ENUMERATE_DEVICES_FAILED'; })) {


### PR DESCRIPTION
[TIMOB-17059] Fixed bug with paths in the build.properties not escaping backslashes. Fixed a bug with detecting Android Addons and the ABI of Android emulators. Also fixed a bug with the Windows detection when detecting connected Windows Phone devices.
