### PR TITLE
Android: add margin property to scrollableview

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIScrollableView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIScrollableView.java
@@ -296,6 +296,14 @@ public class TiUIScrollableView extends TiUIView
 				mPager.setOverScrollMode(TiConvert.toInt(d.get(TiC.PROPERTY_OVER_SCROLL_MODE), View.OVER_SCROLL_ALWAYS));
 			}
 		}
+		
+		if (d.containsKey("margin")) {
+			int marginDp = TiConvert.toInt(d, "margin");
+			DisplayMetrics dm = proxy.getActivity().getResources().getDisplayMetrics();
+			float marginPx = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, marginDp, dm);
+			mPager.setPageMargin((int) Math.round(marginPx));
+			mPager.setOffscreenPageLimit(2);
+		}
 
 		super.processProperties(d);
 


### PR DESCRIPTION
This PR add 'margin' property to Ti.UI.ScrollableView for Android. It accepts integer dip value. Essential to those who want to create scrollableview that reveal a bit of previous & next page view, similar like facebook app, when set the margin to negative value
