### PR TITLE
TIMOB-17016-Since Android restore fragments on orientation change, make ...

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TabGroupProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TabGroupProxy.java
@@ -117,6 +117,10 @@ public class TabGroupProxy extends TiWindowProxy implements TiActivityWindow
 		return tps;
 	}
 
+	public int getTabIndex(TabProxy tabProxy)
+	{
+		return tabs.indexOf(tabProxy);
+	}
 
 	public ArrayList<TabProxy> getTabList()
 	{

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TabProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TabProxy.java
@@ -6,6 +6,8 @@
  */
 package ti.modules.titanium.ui;
 
+import java.util.concurrent.atomic.AtomicLong;
+
 import org.appcelerator.kroll.KrollDict;
 import org.appcelerator.kroll.annotations.Kroll;
 import org.appcelerator.titanium.TiApplication;
@@ -35,10 +37,14 @@ public class TabProxy extends TiViewProxy
 	private TiWindowProxy window;
 	private boolean windowOpened = false;
 	private int windowId;
+	private String tabTag;
+	private static final String TAB_TAG_NAME = "tabTag";
+	private static final AtomicLong nextTabTagIndex = new AtomicLong();
 
 	public TabProxy()
 	{
 		super();
+		tabTag = TAB_TAG_NAME +  nextTabTagIndex.getAndIncrement();
 	}
 
 	public TabProxy(TiContext tiContext)
@@ -46,6 +52,10 @@ public class TabProxy extends TiViewProxy
 		this();
 	}
 
+	public String getTabTag() {
+		return tabTag;
+	}
+	
 	@Override
 	protected KrollDict getLangConversionTable()
 	{

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIActionBarTab.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIActionBarTab.java
@@ -6,9 +6,6 @@
  */
 package ti.modules.titanium.ui.widget.tabgroup;
 
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
-
 import org.appcelerator.kroll.KrollProxy;
 import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.util.TiUIHelper;
@@ -52,14 +49,9 @@ public class TiUIActionBarTab extends TiUIAbstractTab {
 	 * initialized when the tab is first selected.
 	 */
 	TabFragment fragment;
-	private String tabTag;
-	private static final String TAB_TAG_NAME = "tabTag";
-	private static final AtomicLong nextTabTagIndex = new AtomicLong();
 
 	public TiUIActionBarTab(TabProxy proxy, ActionBar.Tab tab) {
 		super(proxy);
-
-		tabTag = TAB_TAG_NAME + nextTabTagIndex.getAndIncrement();
 
 		this.tab = tab;
 
@@ -82,7 +74,7 @@ public class TiUIActionBarTab extends TiUIAbstractTab {
 	}
 	
 	public String getTabTag() {
-		return tabTag;
+		return ((TabProxy)proxy).getTabTag();
 	}
 
 	@Override

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIActionBarTab.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIActionBarTab.java
@@ -22,10 +22,14 @@ import android.view.ViewGroup;
 public class TiUIActionBarTab extends TiUIAbstractTab {
 
 	private static final String TAG = "TiUIActionBarTab";
+	
 	public static class TabFragment extends Fragment {
 		private TiUIActionBarTab tab;
 
-		public TabFragment(TiUIActionBarTab tab) {
+		public TabFragment() {
+		}
+
+		public void setTab(TiUIActionBarTab tab) {
 			this.tab = tab;
 		}
 
@@ -45,9 +49,14 @@ public class TiUIActionBarTab extends TiUIAbstractTab {
 	 * initialized when the tab is first selected.
 	 */
 	TabFragment fragment;
+	private String tabTag;
+	private static final String TAB_TAG_NAME = "tabTag";
 
 	public TiUIActionBarTab(TabProxy proxy, ActionBar.Tab tab) {
 		super(proxy);
+
+		tabTag = TAB_TAG_NAME + proxy.getTabGroup().getTabIndex(proxy);
+
 		this.tab = tab;
 
 		proxy.setModelListener(this);
@@ -66,6 +75,10 @@ public class TiUIActionBarTab extends TiUIAbstractTab {
 			tab.setIcon(icon);
 		}
 		
+	}
+	
+	public String getTabTag() {
+		return tabTag;
 	}
 
 	@Override
@@ -88,7 +101,8 @@ public class TiUIActionBarTab extends TiUIAbstractTab {
 	 * will display the tab's content view.
 	 */
 	void initializeFragment() {
-		fragment = new TabFragment(this);
+		fragment = new TabFragment();
+		fragment.setTab(this);
 	}
 
 }

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIActionBarTab.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIActionBarTab.java
@@ -6,6 +6,9 @@
  */
 package ti.modules.titanium.ui.widget.tabgroup;
 
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
 import org.appcelerator.kroll.KrollProxy;
 import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.util.TiUIHelper;
@@ -51,11 +54,12 @@ public class TiUIActionBarTab extends TiUIAbstractTab {
 	TabFragment fragment;
 	private String tabTag;
 	private static final String TAB_TAG_NAME = "tabTag";
+	private static final AtomicLong nextTabTagIndex = new AtomicLong();
 
 	public TiUIActionBarTab(TabProxy proxy, ActionBar.Tab tab) {
 		super(proxy);
 
-		tabTag = TAB_TAG_NAME + proxy.getTabGroup().getTabIndex(proxy);
+		tabTag = TAB_TAG_NAME + nextTabTagIndex.getAndIncrement();
 
 		this.tab = tab;
 

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIActionBarTabGroup.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIActionBarTabGroup.java
@@ -6,6 +6,8 @@
  */
 package ti.modules.titanium.ui.widget.tabgroup;
 
+import java.lang.ref.WeakReference;
+
 import org.appcelerator.kroll.KrollDict;
 import org.appcelerator.kroll.KrollProxy;
 import org.appcelerator.titanium.TiBaseActivity;
@@ -16,11 +18,12 @@ import org.appcelerator.titanium.view.TiCompositeLayout;
 
 import ti.modules.titanium.ui.TabGroupProxy;
 import ti.modules.titanium.ui.TabProxy;
+import ti.modules.titanium.ui.widget.tabgroup.TiUIActionBarTab.TabFragment;
+import android.app.Activity;
+import android.support.v4.app.FragmentTransaction;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.ActionBar.Tab;
 import android.support.v7.app.ActionBar.TabListener;
-import android.app.Activity;
-import android.support.v4.app.FragmentTransaction;
 import android.view.ViewGroup;
 import android.widget.FrameLayout;
 
@@ -43,10 +46,11 @@ public class TiUIActionBarTabGroup extends TiUIAbstractTabGroup implements TabLi
 
 	// The tab to be selected once the activity resumes.
 	private Tab selectedTabOnResume;
+	private WeakReference<TiBaseActivity> tabActivity;
 
 	public TiUIActionBarTabGroup(TabGroupProxy proxy, TiBaseActivity activity) {
 		super(proxy, activity);
-
+		tabActivity = new WeakReference<TiBaseActivity>(activity);
 		activity.addOnLifecycleEventListener(this);
 
 		// Setup the action bar for navigation tabs.
@@ -96,8 +100,24 @@ public class TiUIActionBarTabGroup extends TiUIAbstractTabGroup implements TabLi
 		tab.setTabListener(this);
 
 		// Create a view for this tab proxy.
-		tabProxy.setView(new TiUIActionBarTab(tabProxy, tab));
-
+		TiUIActionBarTab actionBarTab = new TiUIActionBarTab(tabProxy, tab);
+		tabProxy.setView(actionBarTab);
+		
+		// If the fragment was already restored automatically by Android due to orientation change etc
+		// setup the references properly
+		TiBaseActivity activity = tabActivity.get();
+		TabFragment fragment = null;
+		if (activity != null) {
+			fragment = (TabFragment) activity.getSupportFragmentManager().findFragmentByTag(actionBarTab.getTabTag());
+		}
+		if (fragment != null) {
+			fragment.setTab(actionBarTab);
+			actionBarTab.fragment = fragment;
+			FragmentTransaction ft = activity.getSupportFragmentManager().beginTransaction();
+			// This will be shown during setting the active tab
+			ft.hide(fragment);
+			ft.commit();
+		}
 		// Add the new tab, but don't select it just yet.
 		// The selected tab is set once the group is done opening.
 		actionBar.addTab(tab, false);
@@ -159,8 +179,7 @@ public class TiUIActionBarTabGroup extends TiUIAbstractTabGroup implements TabLi
 			// If not we will create it here then attach it
 			// to the tab group activity inside the "content" container.
 			tabView.initializeFragment();
-			ft.add(android.R.id.tabcontent, tabView.fragment);
-
+			ft.add(android.R.id.tabcontent, tabView.fragment, tabView.getTabTag());
 		} else {
 			// If the fragment is already attached just make it visible.
 			ft.show(tabView.fragment);
@@ -173,7 +192,6 @@ public class TiUIActionBarTabGroup extends TiUIAbstractTabGroup implements TabLi
 		} else {
 			tabClicked = true;
 		}
-
 	}
 
 	@Override

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIActionBarTabGroup.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIActionBarTabGroup.java
@@ -127,6 +127,13 @@ public class TiUIActionBarTabGroup extends TiUIAbstractTabGroup implements TabLi
 	public void removeTab(TabProxy tabProxy) {
 		TiUIActionBarTab tabView = (TiUIActionBarTab) tabProxy.peekView();
 		actionBar.removeTab(tabView.tab);
+		// Let us remove this from the fragment manager
+		TiBaseActivity activity = tabActivity.get();
+		if (activity != null && tabView.fragment != null) {
+			FragmentTransaction ft = activity.getSupportFragmentManager().beginTransaction();
+			ft.remove(tabView.fragment);
+			ft.commit();
+		}
 	}
 
 	@Override


### PR DESCRIPTION
Added empty constructor so that Android can restore the state. Since Android restore fragments on orientation change, make sure the properties are set correctly

https://jira.appcelerator.org/browse/TIMOB-17016
