### PR TITLE
[TIMOB-17195]iOS: Check if analysis enabled before trying to send FeatureEvent and NavEvent.

### DIFF
--- a/iphone/Classes/AnalyticsModule.m
+++ b/iphone/Classes/AnalyticsModule.m
@@ -8,7 +8,7 @@
 #import "AnalyticsModule.h"
 #import "APSAnalytics/APSAnalytics.h"
 #import "SBJSON.h"
-
+extern BOOL const TI_APPLICATION_ANALYTICS;
 @implementation AnalyticsModule
 
 -(NSString*)apiName
@@ -23,6 +23,10 @@
 
 -(void)navEvent:(id)args
 {
+    if (TI_APPLICATION_ANALYTICS == NO) {
+        DebugLog(@"[ERROR] Analytics service is not enabled in your app. Please set analytics to true in the tiapp.xml. ");
+        return;
+    }
     if ([args count] < 2)
 	{
 		[self throwException:@"invalid number of arguments, expected at least 2" subreason:nil location:CODELOCATION];
@@ -38,6 +42,10 @@
 
 -(void)featureEvent:(id)args
 {
+    if (TI_APPLICATION_ANALYTICS == NO) {
+        DebugLog(@"[ERROR] Analytics service is not enabled in your app. Please set analytics to true in the tiapp.xml.");
+        return;
+    }
     if ([args count] < 1)
 	{
 		[self throwException:@"invalid number of arguments, expected at least 1" subreason:nil location:CODELOCATION];


### PR DESCRIPTION
 Check to see if analytics is enabled for Titanium, instead of crashing on the TItanium app,

Testing instruction can be found on the [TICKET](https://jira.appcelerator.org/browse/TIMOB-17195)
