### PR TITLE
[TIMOB-17067] iOS : Return apple as the manufacturer on simulator as well as device

### DIFF
--- a/iphone/Classes/PlatformModule.m
+++ b/iphone/Classes/PlatformModule.m
@@ -196,11 +196,7 @@ NSString* const DATA_IFACE = @"pdp_ip0";
 
 -(NSString*)manufacturer
 {
-#if TARGET_IPHONE_SIMULATOR
-    return @"unknown";
-#else
     return @"apple";
-#endif
 }
 
 -(NSString*)locale


### PR DESCRIPTION
**Testing Instruction**
- Create app with the following in app.js 

``` javascript
alert("Manufacturer ::" + Ti.Platform.getManufacturer());
alert("Manufacturer ::" + Ti.Platform.manufacturer);
```
- Run on both device and simulator to confirm it returns `apple`
