### PR TITLE
[TIMOB-17239] iOS: Allow Overwriting CFBundleName and CFBundleDisplayName

### DIFF
--- a/node_modules/titanium-sdk/lib/tiappxml.js
+++ b/node_modules/titanium-sdk/lib/tiappxml.js
@@ -356,7 +356,7 @@ function toJS(obj, doc) {
 									if (elem.tagName == 'dict') {
 										var pl = new plist().parse('<plist version="1.0">' + elem.toString() + '</plist>');
 										Object.keys(pl).forEach(function (prop) {
-											if (!/^CFBundle(DisplayName|Executable|IconFile|Identifier|InfoDictionaryVersion|Name|PackageType|Signature|Version|ShortVersionString)|LSRequiresIPhoneOS$/.test(prop)) {
+											if (!/^CFBundle(Executable|IconFile|Identifier|InfoDictionaryVersion|PackageType|Signature|Version|ShortVersionString)|LSRequiresIPhoneOS$/.test(prop)) {
 												ios.plist[prop] = pl[prop];
 											}
 										});


### PR DESCRIPTION
Sometime developers need to do this. Assuming that the `<name/>` property in the `tiapp.xml`  will be sufficient does not always work.

One example is an application that has a name with a `+` in it. Since all fields are tied to `<name/>` the resulting CFExecutableName will have illegal characters in it and be rejected for App Store submission.

One solution is to change the `<name/>`to remove illegal characters and then customise the CFBundleName and CFBundleDisplayName to include the problematic characters.

/cc @cb1kenobi
