### PR TITLE
TIMOB-16134-make sure that exception is caught while calling isPlaying

### DIFF
--- a/android/modules/media/src/java/ti/modules/titanium/media/TiSound.java
+++ b/android/modules/media/src/java/ti/modules/titanium/media/TiSound.java
@@ -276,7 +276,7 @@ public class TiSound
 	{
 		try {
 			if (mp != null) {
-
+				stopProgressTimer();
 				mp.setOnCompletionListener(null);
 				mp.setOnErrorListener(null);
 				mp.setOnBufferingUpdateListener(null);
@@ -517,11 +517,15 @@ public class TiSound
 		{
 			@Override
 			public void run() {
-				if (mp != null && mp.isPlaying()) {
-					int position = mp.getCurrentPosition();
-					KrollDict event = new KrollDict();
-					event.put("progress", position);
-					proxy.fireEvent(EVENT_PROGRESS, event);
+				try {
+					if (mp != null && mp.isPlaying()) {
+						int position = mp.getCurrentPosition();
+						KrollDict event = new KrollDict();
+						event.put("progress", position);
+						proxy.fireEvent(EVENT_PROGRESS, event);
+					}
+				} catch (Throwable t) {
+					Log.e(TAG, "Issue while progressTimer run: ", t);
 				}
 			}
 		}, 1000, 1000);
@@ -538,6 +542,8 @@ public class TiSound
 	public void onDestroy()
 	{
 		if (mp != null) {
+			// Before we stop, make sure that timer is stopped
+			stopProgressTimer();
 			mp.release();
 			mp = null;
 		}


### PR DESCRIPTION
https://jira.appcelerator.org/browse/TIMOB-16134

Looking at the Android source for mediaplayer, the error message about "subtitle controller" is just a information message saying that the subtitle controller is not set and doesn't cause any problem. The real issue is correctly described in TC-4236. If the timer event get executed during media player is releasing, calling isPlaying will throw IllegalStateException as described in the Android documentation. 
The changes are
Just like in other places, handle the exception while calling isPlaying.
Stop the progress timer in 'onDestroy' and 'release' before media player is released.
