### PR TITLE
TIMOB-17279-Use getOrCreateView instead of peekView so that view is crea...

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/MenuProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/MenuProxy.java
@@ -152,7 +152,7 @@ public class MenuProxy extends KrollProxy
 			//check if view has a parent. If not, add it as action view. Otherwise, log error.
 			Object viewProxy = d.get(TiC.PROPERTY_ACTION_VIEW);
 			if (viewProxy instanceof TiViewProxy) {
-				TiUIView view = ((TiViewProxy)viewProxy).peekView();
+				TiUIView view = ((TiViewProxy) viewProxy).getOrCreateView();
 				if (view != null) {
 					View nativeView = view.getNativeView();
 					ViewGroup viewParent = (ViewGroup)nativeView.getParent();


### PR DESCRIPTION
Used getOrCreateView instead of peekView so that view will be created if it is not already created.

https://jira.appcelerator.org/browse/TIMOB-17279
