### PR TITLE
[TIMOB-17351] Hyperloop module addon

### DIFF
--- a/iphone/Classes/TiBindingTiValue.m
+++ b/iphone/Classes/TiBindingTiValue.m
@@ -16,6 +16,10 @@
 # import "KrollCoverage.h"
 #endif
 
+#ifdef HAS_HYPERLOOP_MODULE
+static void* HyperloopJSValueToVoidPointer(TiContextRef ctx, TiValueRef value, TiValueRef *exception);
+#endif
+
 /*
  *	Since TiStringRefs are not tied to any particular context, and are
  *	immutable, they are threadsafe and more importantly, ones that are in
@@ -93,6 +97,15 @@ NSObject * TiBindingTiValueToNSObject(TiContextRef jsContext, TiValueRef objRef)
 		}
 		case kTITypeObject: {
 			TiObjectRef obj = TiValueToObject(jsContext, objRef, NULL);
+#ifdef HAS_HYPERLOOP_MODULE
+			TiStringRef hyperloopFlag = TiStringCreateWithUTF8CString("_isHyperloopObject");
+			bool isHyperloop = TiValueToBoolean(jsContext, TiObjectGetProperty(jsContext, obj, hyperloopFlag, NULL));
+			TiStringRelease(hyperloopFlag);
+			
+			if(isHyperloop) {
+				return (id)HyperloopJSValueToVoidPointer(jsContext, objRef, NULL);
+			}
+#endif
 			id privateObject = (id)TiObjectGetPrivate(obj);
 			if ([privateObject isKindOfClass:[KrollObject class]]) {
 				return [privateObject target];

--- a/iphone/iphone/Titanium.xcodeproj/project.pbxproj
+++ b/iphone/iphone/Titanium.xcodeproj/project.pbxproj
@@ -4060,6 +4060,7 @@
 				OTHER_CFLAGS = (
 					"-DDEBUG",
 					"-DTI_POST_1_2",
+					"$(OTHER_CFLAGS)",
 				);
 				"OTHER_LDFLAGS[sdk=iphoneos*]" = (
 					"$(inherited)",
@@ -4098,6 +4099,10 @@
 					"\"$(SRCROOT)/../Classes/APSAnalytics\"",
 					"\"$(SRCROOT)/../Classes/APSHTTPClient\"",
 				);
+				OTHER_CFLAGS = (
+					"-DTI_POST_1_2",
+					"$(OTHER_CFLAGS)",
+				);
 				"OTHER_LDFLAGS[sdk=iphoneos*]" = (
 					"$(inherited)",
 					"-weak_framework",
@@ -4135,6 +4140,7 @@
 					"-DIPAD",
 					"-DTI_POST_1_2",
 					"-DDEBUG",
+					"$(OTHER_CFLAGS)",
 				);
 				"OTHER_LDFLAGS[sdk=iphoneos*]" = (
 					"$(inherited)",
@@ -4169,6 +4175,7 @@
 				OTHER_CFLAGS = (
 					"-DIPAD",
 					"-DTI_POST_1_2",
+					"$(OTHER_CFLAGS)",
 				);
 				"OTHER_LDFLAGS[sdk=iphoneos*]" = (
 					"$(inherited)",
@@ -4329,6 +4336,7 @@
 				OTHER_CFLAGS = (
 					"-DDEBUG",
 					"-DTI_POST_1_2",
+					"$(OTHER_CFLAGS)",
 				);
 				"OTHER_LDFLAGS[sdk=iphoneos*]" = (
 					"$(inherited)",
@@ -4372,6 +4380,7 @@
 					"-DIPAD",
 					"-DTI_POST_1_2",
 					"-DDEBUG",
+					"$(OTHER_CFLAGS)",
 				);
 				"OTHER_LDFLAGS[sdk=iphoneos*]" = (
 					"$(inherited)",
@@ -4409,6 +4418,7 @@
 					"-DIPAD",
 					"-DTI_POST_1_2",
 					"-DDEBUG",
+					"$(OTHER_CFLAGS)",
 				);
 				"OTHER_CFLAGS[arch=*]" = (
 					"-DIPAD",
@@ -4452,6 +4462,7 @@
 					"-DIPAD",
 					"-DTI_POST_1_2",
 					"-DDEBUG",
+					"$(OTHER_CFLAGS)",
 				);
 				"OTHER_CFLAGS[arch=*]" = (
 					"-DIPAD",
@@ -4492,6 +4503,7 @@
 				OTHER_CFLAGS = (
 					"-DIPAD",
 					"-DTI_POST_1_2",
+					"$(OTHER_CFLAGS)",
 				);
 				"OTHER_LDFLAGS[sdk=iphoneos*]" = (
 					"$(inherited)",


### PR DESCRIPTION
Hyperloop modules will have a compiler flag called `HAS_HYPERLOOP_MODULE` and when detected, this adds a new check on JS objects to get the hyperloop object back to the Ti app. Otherwise the app will crash.

To test, build a simple Ti app and run it (without hyperloop modules). If no side effects are encountered then the test passed.

This PR goes along with [Hyperloop-common](https://github.com/appcelerator/hyperloop-common/pull/65) and [Hyperloop-ios](https://github.com/appcelerator/hyperloop-ios/pull/61)
