### PR TITLE
[TIMOB-17347] When checking if the Android package manager is running, a...

### DIFF
--- a/android/cli/hooks/run.js
+++ b/android/cli/hooks/run.js
@@ -186,7 +186,7 @@ exports.init = function (logger, config, cli) {
 
 						(function installApp() {
 							adb.shell(device.id, 'ps', function (err, output) {
-								if (output.indexOf('system_server') === -1) {
+								if (err || output.toString().indexOf('system_server') === -1) {
 									logger.trace(__('Package manager not started yet, trying again in %sms...', retryInterval));
 									intervalTimer = setTimeout(installApp, retryInterval);
 									return;


### PR DESCRIPTION
...dded error check and then convert buffer to string before checking if the system_server has started.
