### PR TITLE
[TIMOB-17407]IOS 8: Moving to new delegates for contacts

### DIFF
--- a/iphone/Classes/ContactsModule.m
+++ b/iphone/Classes/ContactsModule.m
@@ -521,6 +521,7 @@ MAKE_SYSTEM_PROP(AUTHORIZATION_AUTHORIZED, kABAuthorizationStatusAuthorized);
 	}
 }
 
+//Deprecated in iOS 8
 -(BOOL)peoplePickerNavigationController:(ABPeoplePickerNavigationController *)peoplePicker shouldContinueAfterSelectingPerson:(ABRecordRef)person
 {
 	if (selectedPersonCallback) {
@@ -536,6 +537,7 @@ MAKE_SYSTEM_PROP(AUTHORIZATION_AUTHORIZED, kABAuthorizationStatusAuthorized);
 	return YES;
 }
 
+//Deprecated in iOS 8
 -(BOOL)peoplePickerNavigationController:(ABPeoplePickerNavigationController *)peoplePicker shouldContinueAfterSelectingPerson:(ABRecordRef)person property:(ABPropertyID)property identifier:(ABMultiValueIdentifier)identifier
 {
 	if (selectedPropertyCallback) {
@@ -594,6 +596,17 @@ MAKE_SYSTEM_PROP(AUTHORIZATION_AUTHORIZED, kABAuthorizationStatusAuthorized);
 		return NO;
 	}
 	return YES;
+}
+// Called after a person has been selected by the user. New in iOS 8
+- (void)peoplePickerNavigationController:(ABPeoplePickerNavigationController*)peoplePicker didSelectPerson:(ABRecordRef)person
+{
+    [self peoplePickerNavigationController:peoplePicker shouldContinueAfterSelectingPerson:person];
+}
+
+// Called after a property has been selected by the user. New in iOS 8
+- (void)peoplePickerNavigationController:(ABPeoplePickerNavigationController*)peoplePicker didSelectPerson:(ABRecordRef)person property:(ABPropertyID)property identifier:(ABMultiValueIdentifier)identifier
+{
+    [self peoplePickerNavigationController:peoplePicker shouldContinueAfterSelectingPerson:person property:property identifier:identifier];
 }
 
 @end


### PR DESCRIPTION
In iOS 8 the the old delegate methods being used has been deprecated and new delegates have been introduced.

Testing instructions in [JIRA](https://jira.appcelerator.org/browse/TIMOB-17407)
