### PR TITLE
[TIDOC-1858] Update Tab.yml - iconIsMask wasn't spelled well

### DIFF
--- a/apidoc/Titanium/UI/Tab.yml
+++ b/apidoc/Titanium/UI/Tab.yml
@@ -220,7 +220,7 @@ properties:
          otherwise.
     type: String
 
-  - name: iconIsmask
+  - name: iconIsMask
     summary: Defines if the icon property of the tab must be used as a mask. This property is applicable on iOS 7 and greater. 
     description: |
         When this property is true, the color data of the image specified as the icon is ignored and the image is used as an alpha mask. 


### PR DESCRIPTION
Check out: https://github.com/appcelerator/titanium_mobile/blob/master/iphone/Classes/TiUITabProxy.m#L592
As you can see, the name of the function is setIconIsMask. Currently in the doc we have setIconIsmask which is obviously wrong, because it doesnt exists. I've corrected the spelling mistake.
