### PR TITLE
[TIMOB-16115] iOS Disable animation on ListView.setItems

### DIFF
--- a/iphone/Classes/TiUIListView.m
+++ b/iphone/Classes/TiUIListView.m
@@ -1805,7 +1805,7 @@ static TiViewProxy * FindViewProxyWithBindIdContainingPoint(UIView *view, CGPoin
 		return animationStyle;
 	}
 	BOOL animate = [TiUtils boolValue:@"animated" properties:properties def:NO];
-	return animate ? UITableViewRowAnimationFade : UITableViewRowAnimationNone;
+	return animate ? UITableViewRowAnimationFade : UITableViewRowAnimationAutomatic;
 }
 
 @end

--- a/iphone/Classes/TiUIListViewProxy.m
+++ b/iphone/Classes/TiUIListViewProxy.m
@@ -132,9 +132,7 @@
 		}
 		pthread_mutex_unlock(&_operationQueueMutex);
 		if (block != nil) {
-			[tableView beginUpdates];
 			block(tableView);
-			[tableView endUpdates];
 			Block_release(block);
 		} else {
 			[self.listView updateIndicesForVisibleRows];


### PR DESCRIPTION
Please test this with Kitchen Sink for regressions. 
A change occurs with this PR. If the developer does not specify an animation, the default is `UITableViewRowAnimationAutomatic` _instead_ of `UITableViewRowAnimationNone`.
This PR fixes the `UITableViewRowAnimationNone` animation on `ListView.setItems()`, this is why the default had to change from `UITableViewRowAnimationNone` to `UITableViewRowAnimationAutomatic`

Test case in Jira: [TIMOB-16115](https://jira.appcelerator.org/browse/TIMOB-16115)
Regression test in: Kitchen Sink -> Base UI -> Views -> List View -> ALL
