### PR TITLE
[TIMOB-17420] iOS: build.py created during iOS module project generation is not executable

### DIFF
--- a/cli/lib/creator.js
+++ b/cli/lib/creator.js
@@ -117,11 +117,14 @@ Creator.prototype.copyDir = function copyDir(srcDir, destDir, callback, variable
 					dest = dest.replace(ejsRegExp, '');
 					_t.logger.debug(__('Copying %s => %s', src.cyan, dest.cyan));
 					// strip the .ejs extension and render the template
-					fs.writeFile(dest, ejs.render(fs.readFileSync(src).toString(), variables), next);
+					fs.writeFileSync(dest, ejs.render(fs.readFileSync(src).toString(), variables));
 				} else {
 					_t.logger.debug(__('Copying %s => %s', src.cyan, dest.cyan));
-					fs.writeFile(dest, fs.readFileSync(src), next);
+					fs.writeFileSync(dest, fs.readFileSync(src));
 				}
+
+				fs.chmodSync(dest, fs.statSync(src).mode & 07777);
+				next();
 
 			} else {
 				// ignore

--- a/cli/lib/creator.js
+++ b/cli/lib/creator.js
@@ -123,7 +123,7 @@ Creator.prototype.copyDir = function copyDir(srcDir, destDir, callback, variable
 					fs.writeFileSync(dest, fs.readFileSync(src));
 				}
 
-				fs.chmodSync(dest, fs.statSync(src).mode & 07777);
+				fs.chmodSync(dest, fs.statSync(src).mode & 0777);
 				next();
 
 			} else {


### PR DESCRIPTION
For https://jira.appcelerator.org/browse/TIMOB-17420
