### PR TITLE
[TIMOB-13105] Add no-launch flag for Android

### DIFF
--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -296,6 +296,14 @@ AndroidBuilder.prototype.config = function config(logger, config, cli) {
 	return function (finished) {
 		cli.createHook('build.android.config', this, function (callback) {
 			var conf = {
+				flags: {
+					'launch': {
+						desc: __('disable launching the app after installing'),
+						default: true,
+						hideDefault: true,
+						negate: true
+					}
+				},
 				options: {
 					'alias': {
 						abbr: 'L',
@@ -891,14 +899,6 @@ AndroidBuilder.prototype.config = function config(logger, config, cli) {
 						order: 120,
 						required: true,
 						values: _t.targets
-					}
-				},
-				flags: {
-					'launch': {
-						desc: __('disable launching the app after installing'),
-						default: true,
-						hideDefault: true,
-						negate: true
 					}
 				}
 			};

--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -892,6 +892,14 @@ AndroidBuilder.prototype.config = function config(logger, config, cli) {
 						required: true,
 						values: _t.targets
 					}
+				},
+				flags: {
+					'launch': {
+						desc: __('disable launching the app after installing'),
+						default: true,
+						hideDefault: true,
+						negate: true
+					}
 				}
 			};
 

--- a/android/cli/hooks/run.js
+++ b/android/cli/hooks/run.js
@@ -223,6 +223,14 @@ exports.init = function (logger, config, cli) {
 					}, next);
 				},
 
+				function(next) {
+					if (!cli.argv.launch) {
+						logger.info(__('Skipping launch of: %s', (builder.appid + '/.' + builder.classname + 'Activity').cyan));
+						return next(true);
+					}
+					next();
+				},
+
 				function (next) {
 					var logBuffer = [],
 						displayStartLog = true,
@@ -308,10 +316,6 @@ exports.init = function (logger, config, cli) {
 				},
 
 				function (next) {
-					if (!cli.argv.launch) {
-						logger.info(__('Skipping launch of: %s', (builder.appid + '/.' + builder.classname + 'Activity').cyan));
-						return next();
-					}
 					logger.info(__('Starting app: %s', (builder.appid + '/.' + builder.classname + 'Activity').cyan));
 
 					var failCounter = 0,
@@ -399,7 +403,7 @@ exports.init = function (logger, config, cli) {
 				}
 
 			], function (err) {
-				if (err) {
+				if (err && err instanceof Error) {
 					logger.error(err);
 				}
 				finished();

--- a/android/cli/hooks/run.js
+++ b/android/cli/hooks/run.js
@@ -308,9 +308,9 @@ exports.init = function (logger, config, cli) {
 				},
 
 				function (next) {
-					if(cli.argv.$_.indexOf('--no-launch') !== -1 || cli.argv.$_['--no-launch'] === true) {
+					if (!cli.argv.launch) {
 						logger.info(__('Skipping launch of: %s', (builder.appid + '/.' + builder.classname + 'Activity').cyan));
-						return;
+						return next();
 					}
 					logger.info(__('Starting app: %s', (builder.appid + '/.' + builder.classname + 'Activity').cyan));
 

--- a/android/cli/hooks/run.js
+++ b/android/cli/hooks/run.js
@@ -308,6 +308,10 @@ exports.init = function (logger, config, cli) {
 				},
 
 				function (next) {
+					if(cli.argv.$_.indexOf('--no-launch') !== -1 || cli.argv.$_['--no-launch'] === true) {
+						logger.info(__('Skipping launch of: %s', (builder.appid + '/.' + builder.classname + 'Activity').cyan));
+						return;
+					}
 					logger.info(__('Starting app: %s', (builder.appid + '/.' + builder.classname + 'Activity').cyan));
 
 					var failCounter = 0,

--- a/cli/commands/build.js
+++ b/cli/commands/build.js
@@ -56,6 +56,10 @@ exports.config = function (logger, config, cli) {
 						'skip-js-minify': {
 							default: false,
 							desc: __('bypasses JavaScript minification; %s builds are never minified; only supported for %s and %s', 'simulator'.cyan, 'Android'.cyan, 'iOS'.cyan)
+						},
+						'no-launch': {
+							default: false,
+							desc: __('skips launching the app after installing', 'simulator'.cyan, 'Android'.cyan, 'iOS'.cyan)
 						}
 					},
 					options: appc.util.mix({

--- a/cli/commands/build.js
+++ b/cli/commands/build.js
@@ -56,10 +56,6 @@ exports.config = function (logger, config, cli) {
 						'skip-js-minify': {
 							default: false,
 							desc: __('bypasses JavaScript minification; %s builds are never minified; only supported for %s and %s', 'simulator'.cyan, 'Android'.cyan, 'iOS'.cyan)
-						},
-						'no-launch': {
-							default: false,
-							desc: __('skips launching the app after installing', 'simulator'.cyan, 'Android'.cyan, 'iOS'.cyan)
 						}
 					},
 					options: appc.util.mix({


### PR DESCRIPTION
Would resolve https://jira.appcelerator.org/browse/TIMOB-13105

Not sure that this is the solution you'd want. If it is, I think there should be a process.exit() call rather than a return in the if block. But I wasn't sure of the ramifications of that. As it stands, execution stops after the log message, which doesn't seem like it would fit into the workflow described in the ticket.
