### PR TITLE
[TIMOB-13392] Android: fix TabGroup fragment memory leaks, fix maps in tabs including when acti...

### DIFF
--- a/android/modules/android/src/java/ti/modules/titanium/android/TiJSActivity.java
+++ b/android/modules/android/src/java/ti/modules/titanium/android/TiJSActivity.java
@@ -15,6 +15,7 @@ import org.appcelerator.titanium.util.TiConvert;
 import org.appcelerator.titanium.view.TiUIActivityWindow;
 
 import android.content.Intent;
+import android.os.Bundle;
 
 public abstract class TiJSActivity extends TiLaunchActivity
 {
@@ -68,14 +69,14 @@ public abstract class TiJSActivity extends TiLaunchActivity
 	}
 
 	@Override
-	protected void windowCreated()
+	protected void windowCreated(Bundle savedInstanceState)
 	{
 		// Set the layout proxy here since it's not ready when we indirectly call it inside contextCreated()
 		setLayoutProxy(window);
 
 		// The UIWindow needs to be created before we run the script
 		activityWindow = new TiUIActivityWindow((TiActivityWindowProxy)window, this, getLayout());
-		super.windowCreated();
+		super.windowCreated(savedInstanceState);
 	}
 
 	@Override

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TabGroupProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TabGroupProxy.java
@@ -38,7 +38,8 @@ import android.view.WindowManager;
 	TiC.PROPERTY_TABS_BACKGROUND_COLOR,
 	TiC.PROPERTY_ACTIVE_TAB_BACKGROUND_COLOR,
 	TiC.PROPERTY_SWIPEABLE,
-	TiC.PROPERTY_EXIT_ON_CLOSE
+	TiC.PROPERTY_EXIT_ON_CLOSE,
+	TiC.PROPERTY_SMOOTH_SCROLL_ON_TAB_CLICK
 })
 public class TabGroupProxy extends TiWindowProxy implements TiActivityWindow
 {
@@ -64,6 +65,7 @@ public class TabGroupProxy extends TiWindowProxy implements TiActivityWindow
 	{
 		super();
 		defaultValues.put(TiC.PROPERTY_SWIPEABLE, true);
+		defaultValues.put(TiC.PROPERTY_SMOOTH_SCROLL_ON_TAB_CLICK, true);
 	}
 
 	public TabGroupProxy(TiContext tiContext)

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TabGroupProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TabGroupProxy.java
@@ -30,6 +30,7 @@ import ti.modules.titanium.ui.widget.tabgroup.TiUIActionBarTabGroup;
 import android.app.Activity;
 import android.content.Intent;
 import android.os.Message;
+import android.os.Bundle;
 import android.support.v7.app.ActionBarActivity;
 import android.view.WindowManager;
 
@@ -351,14 +352,14 @@ public class TabGroupProxy extends TiWindowProxy implements TiActivityWindow
 	}
 
 	@Override
-	public void windowCreated(TiBaseActivity activity) {
+	public void windowCreated(TiBaseActivity activity, Bundle savedInstanceState) {
 		tabGroupActivity = new WeakReference<ActionBarActivity>(activity);
 		activity.setWindowProxy(this);
 		activity.setLayoutProxy(this);
 		setActivity(activity);
 
 		if (activity.getSupportActionBar() != null) {
-			view = new TiUIActionBarTabGroup(this, activity);
+			view = new TiUIActionBarTabGroup(this, activity, savedInstanceState);
 		} else {
 			Log.e(TAG, "ActionBar not available for TabGroup");
 			return;

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TabProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TabProxy.java
@@ -37,23 +37,15 @@ public class TabProxy extends TiViewProxy
 	private TiWindowProxy window;
 	private boolean windowOpened = false;
 	private int windowId;
-	private String tabTag;
-	private static final String TAB_TAG_NAME = "tabTag";
-	private static final AtomicLong nextTabTagIndex = new AtomicLong();
 
 	public TabProxy()
 	{
 		super();
-		tabTag = TAB_TAG_NAME +  nextTabTagIndex.getAndIncrement();
 	}
 
 	public TabProxy(TiContext tiContext)
 	{
 		this();
-	}
-
-	public String getTabTag() {
-		return tabTag;
 	}
 
 	@Override

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/WindowProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/WindowProxy.java
@@ -36,6 +36,7 @@ import android.graphics.PixelFormat;
 import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
 import android.os.Message;
+import android.os.Bundle;
 import android.view.View;
 import android.view.ViewGroup.LayoutParams;
 import android.view.Window;
@@ -169,7 +170,7 @@ public class WindowProxy extends TiWindowProxy implements TiActivityWindow
 
 	@SuppressWarnings("unchecked")
 	@Override
-	public void windowCreated(TiBaseActivity activity) {
+	public void windowCreated(TiBaseActivity activity, Bundle savedInstanceState) {
 		windowActivity = new WeakReference<TiBaseActivity>(activity);
 		activity.setWindowProxy(this);
 		setActivity(activity);

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIActionBarTab.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIActionBarTab.java
@@ -10,6 +10,8 @@ import org.appcelerator.kroll.KrollProxy;
 import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.util.TiUIHelper;
 
+import org.appcelerator.kroll.common.Log;
+
 import ti.modules.titanium.ui.TabProxy;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
@@ -48,14 +50,6 @@ public class TiUIActionBarTab extends TiUIAbstractTab {
 
 	ActionBar.Tab tab;
 
-	/**
-	 * The fragment that will provide the content view of the tab.
-	 * This fragment will be attached when the tab is selected and
-	 * detached when it is later unselected. This reference will be
-	 * initialized when the tab is first selected.
-	 */
-	TabFragment fragment;
-
 	public TiUIActionBarTab(TabProxy proxy, ActionBar.Tab tab) {
 		super(proxy);
 		this.tab = tab;
@@ -78,10 +72,6 @@ public class TiUIActionBarTab extends TiUIAbstractTab {
 		
 	}
 
-	public String getTabTag() {
-		return ((TabProxy)proxy).getTabTag();
-	}
-
 	@Override
 	public void propertyChanged(String key, Object oldValue, Object newValue, KrollProxy proxy) {
 		if (key.equals(TiC.PROPERTY_TITLE)) {
@@ -101,9 +91,14 @@ public class TiUIActionBarTab extends TiUIAbstractTab {
 	 * when the tab is first selected to create the fragment which
 	 * will display the tab's content view.
 	 */
-	void initializeFragment() {
-		fragment = new TabFragment();
+
+	public TabFragment createFragment() {
+		TabFragment fragment = new TabFragment();
 		fragment.setTab(this);
+		return fragment;
 	}
 
+	public void setTabOnFragment(TabFragment fragment) {
+		fragment.setTab(this);
+	}
 }

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIActionBarTabGroup.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIActionBarTabGroup.java
@@ -238,7 +238,7 @@ public class TiUIActionBarTabGroup extends TiUIAbstractTabGroup implements TabLi
 			}
 			while (fragmentTags.size() <= position) {
 				fragmentTags.add(null);
-            }
+			}
 			fragmentTags.set(position, tag);
 			return fragment;
 		}

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIActionBarTabGroup.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIActionBarTabGroup.java
@@ -382,7 +382,7 @@ public class TiUIActionBarTabGroup extends TiUIAbstractTabGroup implements TabLi
 	@Override
 	public void onTabSelected(Tab tab, FragmentTransaction ft) {
 		TiUIActionBarTab tabView = (TiUIActionBarTab) tab.getTag();
-		tabGroupViewPager.setCurrentItem(tab.getPosition());
+		tabGroupViewPager.setCurrentItem(tab.getPosition(), false);
 		TabProxy tabProxy = (TabProxy) tabView.getProxy();
 		((TabGroupProxy) proxy).onTabSelected(tabProxy);
 		if (tabClicked) {

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIActionBarTabGroup.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIActionBarTabGroup.java
@@ -201,7 +201,7 @@ public class TiUIActionBarTabGroup extends TiUIAbstractTabGroup implements TabLi
 		public int getCount() {
 			if (tabsDisabled) {
 				// Since we don't want the FragmentPagerAdapter to do all kinds of rearrangements
-				// just because we decided to disable tags. We want the fragments to stay alive for when
+				// just because we decided to disable tabs. We want the fragments to stay alive for when
 				// we reenable the tabs.
 				return numTabsWhenDisabled;
 			} else {

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIActionBarTabGroup.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIActionBarTabGroup.java
@@ -54,6 +54,10 @@ import android.view.MotionEvent;
  */
 public class TiUIActionBarTabGroup extends TiUIAbstractTabGroup implements TabListener, OnLifecycleEvent , OnInstanceStateEvent {
 	private static final String TAG = "TiUIActionBarTabGroup";
+	private static final String FRAGMENT_ID_ARRAY = "fragmentIdArray";
+	private static final String FRAGMENT_TAGS_ARRAYLIST = "fragmentTagsArrayList";
+	private static final String SAVED_INITIAL_FRAGMENT_ID = "savedInitialFragmentId";
+	private static final String TABS_DISABLED = "tabsDisabled";
 	private ActionBar actionBar;
 	private boolean activityPaused = false;
 	// Default value is true. Set it to false if the tab is selected using the selectTab() method.
@@ -91,21 +95,21 @@ public class TiUIActionBarTabGroup extends TiUIAbstractTabGroup implements TabLi
 		// so that addTab will not create new ones every time the Activity is re-created
 		// which would cause a massive leak of fragments
 		if (savedInstanceState != null){
-			long [] fragmentIdArray = savedInstanceState.getLongArray("fragmentIdArray");
-			restoredFragmentTags = savedInstanceState.getStringArrayList("fragmentTagsArrayList");
+			long [] fragmentIdArray = savedInstanceState.getLongArray(FRAGMENT_ID_ARRAY);
+			restoredFragmentTags = savedInstanceState.getStringArrayList(FRAGMENT_TAGS_ARRAYLIST);
 			int numRestoredTabs = 0;
 			if (fragmentIdArray != null) {
 				numRestoredTabs = fragmentIdArray.length;
 			}
 			if (numRestoredTabs > 0) {
 				// initialFragmentId guaranteed greater than any old ID
-				fragmentIdGenerator.set(savedInstanceState.getLong("initialFragmentId"));
+				fragmentIdGenerator.set(savedInstanceState.getLong(SAVED_INITIAL_FRAGMENT_ID));
 				for (int i = 0; i < numRestoredTabs; i++) {
 					restoredFragmentIds.add(new Long(fragmentIdArray[i]));
 				}
 			}
 			// putting into temp until we actually disable tabs
-			tempTabsDisabled = savedInstanceState.getBoolean("tabsDisabled");
+			tempTabsDisabled = savedInstanceState.getBoolean(TABS_DISABLED);
 		}
 		activity.addOnLifecycleEventListener(this);
 		activity.addOnInstanceStateEventListener(this);
@@ -292,7 +296,6 @@ public class TiUIActionBarTabGroup extends TiUIAbstractTabGroup implements TabLi
 		long itemId;
 		ActionBar.Tab tab = actionBar.newTab();
 		tab.setTabListener(this);
-		int numTabs = actionBar.getTabCount();
 		TiUIActionBarTab actionBarTab = new TiUIActionBarTab(tabProxy, tab);
 		boolean shouldUpdateTabsDisabled = false;
 
@@ -325,7 +328,7 @@ public class TiUIActionBarTabGroup extends TiUIAbstractTabGroup implements TabLi
 
 		actionBar.addTab(tab, false);
 		tabGroupPagerAdapter.notifyDataSetChanged();
-		numTabs++; // since we added one
+		int numTabs = actionBar.getTabCount();
 		int offscreen = numTabs > 1 ? numTabs - 1 : 1; // Must be at least 1
 		tabGroupViewPager.setOffscreenPageLimit(offscreen);
 		if (tempTabsDisabled && shouldUpdateTabsDisabled) {
@@ -451,20 +454,20 @@ public class TiUIActionBarTabGroup extends TiUIAbstractTabGroup implements TabLi
 		} else {
 			numTabs = numTabsWhenDisabled;
 		}
-		outState.putBoolean("tabsDisabled", tabsDisabled);
+		outState.putBoolean(TABS_DISABLED, tabsDisabled);
 		if (numTabs == 0) {
-			outState.remove("fragmentIdArray");
-			outState.remove("initialFragmentId");
-			outState.remove("fragmentTagsArrayList");
+			outState.remove(FRAGMENT_ID_ARRAY);
+			outState.remove(SAVED_INITIAL_FRAGMENT_ID);
+			outState.remove(FRAGMENT_TAGS_ARRAYLIST);
 			return;
 		}
-		outState.putStringArrayList("fragmentTagsArrayList", fragmentTags);
+		outState.putStringArrayList(FRAGMENT_TAGS_ARRAYLIST, fragmentTags);
 		long[] fragmentIdArray = new long [numTabs];
-		outState.putLong("initialFragmentId", fragmentIdGenerator.get());
+		outState.putLong(SAVED_INITIAL_FRAGMENT_ID, fragmentIdGenerator.get());
 		for (int i = 0; i < numTabs; i++) {
 			fragmentIdArray[i] = fragmentIds.get(i).longValue();
 		}
-		outState. putLongArray ("fragmentIdArray", fragmentIdArray);
+		outState.putLongArray(FRAGMENT_ID_ARRAY, fragmentIdArray);
 	}
 
 	@Override

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIActionBarTabGroup.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIActionBarTabGroup.java
@@ -63,6 +63,7 @@ public class TiUIActionBarTabGroup extends TiUIAbstractTabGroup implements TabLi
 	private int numTabsWhenDisabled;
 	private boolean savedSwipeable = true;
 	private boolean swipeable = true;
+	private boolean smoothScrollOnTabClick = true;
 	private boolean pendingDisableTabs = false;
 	private boolean viewPagerRestoreComplete = false;
 	private AtomicLong fragmentIdGenerator = new AtomicLong();
@@ -254,6 +255,9 @@ public class TiUIActionBarTabGroup extends TiUIAbstractTabGroup implements TabLi
 		if (d.containsKey(TiC.PROPERTY_SWIPEABLE)) {
 			swipeable = d.getBoolean(TiC.PROPERTY_SWIPEABLE);
 		}
+		if (d.containsKey(TiC.PROPERTY_SMOOTH_SCROLL_ON_TAB_CLICK)) {
+			smoothScrollOnTabClick = d.getBoolean(TiC.PROPERTY_SMOOTH_SCROLL_ON_TAB_CLICK);
+		}
 	}
 
 	@Override
@@ -268,6 +272,8 @@ public class TiUIActionBarTabGroup extends TiUIAbstractTabGroup implements TabLi
 			} else {
 				swipeable = TiConvert.toBoolean(newValue);
 			}
+		} else if (key.equals(TiC.PROPERTY_SMOOTH_SCROLL_ON_TAB_CLICK)) {
+			smoothScrollOnTabClick = TiConvert.toBoolean(newValue);
 		} else {
 			super.propertyChanged(key, oldValue, newValue, proxy);
 		}
@@ -382,7 +388,7 @@ public class TiUIActionBarTabGroup extends TiUIAbstractTabGroup implements TabLi
 	@Override
 	public void onTabSelected(Tab tab, FragmentTransaction ft) {
 		TiUIActionBarTab tabView = (TiUIActionBarTab) tab.getTag();
-		tabGroupViewPager.setCurrentItem(tab.getPosition(), false);
+		tabGroupViewPager.setCurrentItem(tab.getPosition(), smoothScrollOnTabClick);
 		TabProxy tabProxy = (TabProxy) tabView.getProxy();
 		((TabGroupProxy) proxy).onTabSelected(tabProxy);
 		if (tabClicked) {

--- a/android/titanium/src/java/org/appcelerator/titanium/TiActivityWindow.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiActivityWindow.java
@@ -6,6 +6,8 @@
  */
 package org.appcelerator.titanium;
 
+import android.os.Bundle;
+
 /**
  * Implementations of this interface can be notified when their activity window has been created
  * by registering themselves with {@link TiActivityWindows#addWindow(TiActivityWindow)}.
@@ -19,5 +21,5 @@ package org.appcelerator.titanium;
  */
 public interface TiActivityWindow
 {
-	public void windowCreated(TiBaseActivity activity);
+	public void windowCreated(TiBaseActivity activity, Bundle savedInstanceState);
 }

--- a/android/titanium/src/java/org/appcelerator/titanium/TiActivityWindows.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiActivityWindows.java
@@ -9,6 +9,7 @@ package org.appcelerator.titanium;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import android.util.SparseArray;
+import android.os.Bundle;
 
 /**
  * A registry for TiBaseActivity<->Window creation logic.
@@ -25,11 +26,11 @@ public class TiActivityWindows
 		return windowId;
 	}
 
-	public static void windowCreated(TiBaseActivity activity, int windowId)
+	public static void windowCreated(TiBaseActivity activity, int windowId, Bundle savedInstanceState)
 	{
 		TiActivityWindow window = windows.get(windowId);
 		if (window != null) {
-			window.windowCreated(activity);
+			window.windowCreated(activity, savedInstanceState);
 		}
 	}
 

--- a/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
@@ -416,7 +416,7 @@ public abstract class TiBaseActivity extends ActionBarActivity
 	}
 
 	// Subclasses can override to handle post-creation (but pre-message fire) logic
-	protected void windowCreated()
+	protected void windowCreated(Bundle savedInstanceState)
 	{
 		boolean fullscreen = getIntentBoolean(TiC.PROPERTY_FULLSCREEN, false);
 		boolean modal = getIntentBoolean(TiC.PROPERTY_MODAL, false);
@@ -448,7 +448,7 @@ public abstract class TiBaseActivity extends ActionBarActivity
 		boolean useActivityWindow = getIntentBoolean(TiC.INTENT_PROPERTY_USE_ACTIVITY_WINDOW, false);
 		if (useActivityWindow) {
 			int windowId = getIntentInt(TiC.INTENT_PROPERTY_WINDOW_ID, -1);
-			TiActivityWindows.windowCreated(this, windowId);
+			TiActivityWindows.windowCreated(this, windowId, savedInstanceState);
 		}
 	}
 
@@ -536,7 +536,7 @@ public abstract class TiBaseActivity extends ActionBarActivity
 		Activity tempCurrentActivity = tiApp.getCurrentActivity();
 		tiApp.setCurrentActivity(this, this);
 
-		windowCreated();
+		windowCreated(savedInstanceState);
 
 		if (activityProxy != null) {
 			dispatchCallback(TiC.PROPERTY_ON_CREATE, null);
@@ -1418,7 +1418,6 @@ public abstract class TiBaseActivity extends ActionBarActivity
 				Log.e(TAG, "Unable to retrieve the activity support helper.");
 			}
 		}
-
 		synchronized (instanceStateListeners.synchronizedList()) {
 			for (OnInstanceStateEvent listener : instanceStateListeners.nonNull()) {
 				try {

--- a/android/titanium/src/java/org/appcelerator/titanium/TiC.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiC.java
@@ -599,6 +599,11 @@ public class TiC
 	/**
 	 * @module.api
 	 */
+	public static final String PROPERTY_SMOOTH_SCROLL_ON_TAB_CLICK = "smoothScrollOnTabClick";
+
+	/**
+	 * @module.api
+	 */
 	public static final String PROPERTY_ACTIVE_TAB_BACKGROUND_COLOR = "activeTabBackgroundColor";
 
 	/**

--- a/android/titanium/src/java/org/appcelerator/titanium/TiLaunchActivity.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiLaunchActivity.java
@@ -145,9 +145,9 @@ public abstract class TiLaunchActivity extends TiBaseActivity
 	}
 
 	@Override
-	protected void windowCreated()
+	protected void windowCreated(Bundle savedInstanceState)
 	{
-		super.windowCreated();
+		super.windowCreated(savedInstanceState);
 		loadActivityScript();
 		scriptLoaded();
 	}

--- a/android/titanium/src/java/org/appcelerator/titanium/TiRootActivity.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiRootActivity.java
@@ -100,12 +100,12 @@ public class TiRootActivity extends TiLaunchActivity
 	}
 
 	@Override
-	protected void windowCreated()
+	protected void windowCreated(Bundle savedInstanceState)
 	{
 		// Use settings from tiapp.xml
 		ITiAppInfo appInfo = getTiApp().getAppInfo();
 		getIntent().putExtra(TiC.PROPERTY_FULLSCREEN, appInfo.isFullscreen());
-		super.windowCreated();
+		super.windowCreated(savedInstanceState);
 	}
 
 	@Override

--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiUIFragment.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiUIFragment.java
@@ -35,15 +35,7 @@ public abstract class TiUIFragment extends TiUIView implements Handler.Callback
 		setNativeView(container);
 
 		FragmentManager manager = ((FragmentActivity) activity).getSupportFragmentManager();
-		Fragment tabFragment = manager.findFragmentById(android.R.id.tabcontent);
-		FragmentTransaction transaction = null;
-		//check if this map is opened inside an actionbar tab, which is another fragment
-		if (tabFragment != null) {
-			FragmentManager childManager = tabFragment.getChildFragmentManager();
-			transaction = childManager.beginTransaction();
-		} else {
-			transaction = manager.beginTransaction();
-		}
+		FragmentTransaction transaction = manager.beginTransaction();
 		fragment = createFragment();
 		transaction.add(container.getId(), fragment);
 		transaction.commit();

--- a/apidoc/Titanium/UI/TabGroup.yml
+++ b/apidoc/Titanium/UI/TabGroup.yml
@@ -340,7 +340,7 @@ properties:
     description: |
         If true, when clicking the tab the page transition is animated, false otherwise.
     platforms: [android]
-    since: 3.4.0
+    since: 3.5.0
     default: true
     type: Boolean
 

--- a/apidoc/Titanium/UI/TabGroup.yml
+++ b/apidoc/Titanium/UI/TabGroup.yml
@@ -334,6 +334,16 @@ properties:
     default: true
     type: Boolean
 
+  - name: smoothScrollOnTabClick
+    summary: |
+        Boolean value indicating if changing pages by tab clicks is animated.
+    description: |
+        If true, when clicking the tab the page transition is animated, false otherwise.
+    platforms: [android]
+    since: 3.4.0
+    default: true
+    type: Boolean
+
   - name: tabs
     summary: |
         Tabs managed by the tab group.


### PR DESCRIPTION
This fixes and improves the initial commit using the ViewPager for the TabGroup.
Issues solved:
1. Huge memory leak when the tab group activity was destroyed and later recreated (i.e. as in https://jira.appcelerator.org/browse/TIMOB-17016). The issue was that ever since 3.3.0 we have been keeping references to the fragments in our own data structures, and also never detaching and destroying fragment. So if this cycle happens a few times - memory explodes. This was masked by the crash we had until now.... The main fix was to remove ALL fragment references in our code.
2. The tab group needed to restore data structures coming back (same situation as in 17016), so that we can point to the correct fragments when coming back, and not blindly create new ones (the leak). So for this we had no choice but update TiLifecycle, and add onSaveInstanceState and onRestoreInstanceState. onSaveInstanceState is now used in the tab group.
3. We needed the restore state as early as possible (i.e. activity creation), so I had to add the restored Bundle to the windowCreated() calls. The tab group must use this, and it's a good thing - hopefully other window modules and can make use of this stuff and be more intelligent in their handling.
4. These are the key fixes. The rest of the changes are to accommodate  these infrastructure changes.

In general, this is very well tested, since it built on the testing done for the previous commit which was already heavy. Specifically tested: removing and adding tabs, using a map in the tabs, disabling and enabling tabs, doing all the previous then opening a new window (destroying the tab group activity), and then coming back to the tab group - all works splendidly and no memory leak.
Please merge ASAP since this fixes serious issues in the previous commit. Thanks!
