### PR TITLE
[TIMOB-17937] iOS: Add the ability to set text and hintText for UIAlertDialog Textfields

### DIFF
--- a/apidoc/Titanium/UI/AlertDialog.yml
+++ b/apidoc/Titanium/UI/AlertDialog.yml
@@ -169,6 +169,15 @@ properties:
     type: Number
     default: undefined (Android), -1 (iOS, Mobile Web)
     
+  - name: hintText
+    summary: |
+        Hint text to display when the field is empty if dialog `style` property is defined as
+        <Titanium.UI.iPhone.AlertDialogStyle.PLAIN_TEXT_INPUT> or <Titanium.UI.iPhone.AlertDialogStyle.SECURE_TEXT_INPUT>.
+    description: Hint text is hidden when the user enters text into this text field.
+    type: String
+    default: No hint text.
+    platforms: [iphone, ipad]
+
   - name: message
     summary: Dialog message.
     type: String
@@ -229,6 +238,13 @@ properties:
     default: false on iOS, true on Android
     since: "3.0.0"
     platforms: [android, iphone, ipad]
+
+  - name: value
+    summary: |
+        Value of the text field, which may be set programmatically and modified by the user, if dialog `style` property is defined as
+        <Titanium.UI.iPhone.AlertDialogStyle.PLAIN_TEXT_INPUT> or <Titanium.UI.iPhone.AlertDialogStyle.SECURE_TEXT_INPUT>.
+    type: String
+    platforms: [iphone, ipad]
 
 examples:
   - title: Single-button Alert Dialog (using alias)

--- a/iphone/Classes/TiUIAlertDialogProxy.m
+++ b/iphone/Classes/TiUIAlertDialogProxy.m
@@ -130,6 +130,13 @@ static BOOL alertShowing = NO;
 		int style = [TiUtils intValue:[self valueForKey:@"style"] def:UIAlertViewStyleDefault];
 		[alert setAlertViewStyle:style];
 
+        if( style == UIAlertViewStylePlainTextInput || style == UIAlertViewStyleSecureTextInput )
+        {
+            UITextField *textField  = [alert textFieldAtIndex:0];
+            textField.text          = [TiUtils stringValue:[self valueForKey:@"value"]];
+            textField.placeholder   = [TiUtils stringValue:[self valueForKey:@"hintText"]];
+        }
+        
 		[self retain];
 		[alert show];
 	}


### PR DESCRIPTION
Jira ticket: https://jira.appcelerator.org/browse/TC-4647

The ticket contains the example app.js
