### PR TITLE
TC-4653 : Add access to iOS App Setting URL

### DIFF
--- a/iphone/Classes/TiAppiOSProxy.m
+++ b/iphone/Classes/TiAppiOSProxy.m
@@ -500,6 +500,14 @@
 	return NUMINT(0);
 }
 
+-(NSString*)applicationOpenSettingsURL
+{
+    if ([TiUtils isIOS8OrGreater]) {
+        return UIApplicationOpenSettingsURLString;
+    }
+    return nil;
+}
+
 MAKE_SYSTEM_STR(EVENT_ACCESSIBILITY_LAYOUT_CHANGED,@"accessibilitylayoutchanged");
 MAKE_SYSTEM_STR(EVENT_ACCESSIBILITY_SCREEN_CHANGED,@"accessibilityscreenchanged");
 


### PR DESCRIPTION
Add access to the iOS8 UIApplicationOpenSettingsURLString. This allows the developer to launch directly into the iOS8 App Settings Screen using Ti.Platform.canOpenURL.

For example:

```
var settingsURL = Ti.App.iOS.ApplicationOpenSettingsURL;
if(settingsURL!=undefined){
if(Ti.Platform.canOpenURL(settingsURL))

{ Ti.Platform.openURL(settingsURL);  }
else

{ alert('cannot open URL'); }

}
```
