### PR TITLE
TC-4653 : Add access to iOS App Setting URL

### DIFF
--- a/apidoc/Titanium/App/iOS/iOS.yml
+++ b/apidoc/Titanium/App/iOS/iOS.yml
@@ -251,6 +251,22 @@ properties:
     osver: {ios: {min: "8.0"}}
     since: "3.4.0"
 
+  - name: applicationOpenSettingsURL
+    summary: Returns a URL to open the app’s settings.
+    description: |        
+        Used to create a URL that you can pass to the [openURL](Titanium.Platform.openURL) method. 
+        When you open the URL built from this string, the system launches the Settings app and displays the app’s custom settings, if it has any.
+	    
+	    var settingsURL = Titanium.App.iOS.applicationOpenSettingsURL;
+	    if(Titanium.Platform.canOpenURL(settingsURL)){
+	        Titanium.Platform.openURL(settingsURL);
+	    }        
+
+    type: String
+    permission: read-only
+    osver: {ios: {min: "8.0"}}
+    since: "3.4.0"
+
 events:
   - name: notification
     summary: Fired when a local notification is received by the application.

--- a/iphone/Classes/TiAppiOSProxy.m
+++ b/iphone/Classes/TiAppiOSProxy.m
@@ -500,6 +500,14 @@
 	return NUMINT(0);
 }
 
+-(NSString*)applicationOpenSettingsURL
+{
+    if ([TiUtils isIOS8OrGreater]) {
+        return UIApplicationOpenSettingsURLString;
+    }
+    return nil;
+}
+
 MAKE_SYSTEM_STR(EVENT_ACCESSIBILITY_LAYOUT_CHANGED,@"accessibilitylayoutchanged");
 MAKE_SYSTEM_STR(EVENT_ACCESSIBILITY_SCREEN_CHANGED,@"accessibilityscreenchanged");
 


### PR DESCRIPTION
Add access to the iOS8 UIApplicationOpenSettingsURLString. This allows the developer to launch directly into the iOS8 App Settings Screen using Ti.Platform.canOpenURL.

For example:

```
var settingsURL = Ti.App.iOS.applicationOpenSettingsURL;
if(settingsURL!=undefined){
    if(Ti.Platform.canOpenURL(settingsURL)){
        Ti.Platform.openURL(settingsURL);
    }else{
    alert('cannot open URL');
 }
}

```
