### PR TITLE
TC-4654 : iOS 8 : Add isRegisteredForRemoteNotifications to determine whether the app is currently registered for remote notifications.

### DIFF
--- a/iphone/Classes/TiAppiOSProxy.m
+++ b/iphone/Classes/TiAppiOSProxy.m
@@ -500,6 +500,14 @@
 	return NUMINT(0);
 }
 
+-(NSNumber*)isRegisteredForRemoteNotifications:(id)unused
+{
+    if ([TiUtils isIOS8OrGreater]) {
+        return NUMBOOL([[UIApplication sharedApplication] isRegisteredForRemoteNotifications]);
+    }
+    return NUMBOOL(YES);
+}
+
 MAKE_SYSTEM_STR(EVENT_ACCESSIBILITY_LAYOUT_CHANGED,@"accessibilitylayoutchanged");
 MAKE_SYSTEM_STR(EVENT_ACCESSIBILITY_SCREEN_CHANGED,@"accessibilityscreenchanged");
 


### PR DESCRIPTION
Returns a Boolean indicating whether the app is currently registered for remote notifications.

Add support for isRegisteredForRemoteNotifications so that the developer can check if the user has authorized notifications.

var hasAuthorized = Ti.App.iOS.isRegisteredForRemoteNotifications();
if(hasAuthorized){
    Ti.API.info("User has already authorized");
}else{
    Ti.API.info("User needs to authorize, maybe ask them before the iOS rights dialog pops up");
}
