### PR TITLE
TC-4671 - iOS8: currentUserNotificationSettings & didRegisterUserNotificationSettings

### DIFF
--- a/iphone/Classes/TiApp.m
+++ b/iphone/Classes/TiApp.m
@@ -433,6 +433,11 @@ TI_INLINE void waitForMemoryPanicCleared();   //WARNING: This must never be run 
 
 #pragma mark Remote and Local Notifications iOS 8
 
+- (void)application:(UIApplication *)application didRegisterUserNotificationSettings:(UIUserNotificationSettings *)notificationSettings
+{
+    [[NSNotificationCenter defaultCenter] postNotificationName:kTiUserNotificationSettingsNotification object:notificationSettings userInfo:nil];
+}
+
 - (void) application:(UIApplication *)application handleActionWithIdentifier:(NSString *)identifier forLocalNotification:(UILocalNotification *)notification completionHandler:(void (^)())completionHandler {
 	RELEASE_TO_NIL(localNotification);
 	localNotification = [[TiApp  dictionaryWithLocalNotification:notification withIdentifier:identifier] retain];

--- a/iphone/Classes/TiAppiOSProxy.m
+++ b/iphone/Classes/TiAppiOSProxy.m
@@ -79,11 +79,7 @@
              (didRegisterUserNotificationSettingsNotification:) name:kTiUserNotificationSettingsNotification object:nil];
         }
     }
-    if ([TiUtils isIOS8OrGreater]){
-        if ((count == 1) && [type isEqual:@"usernotificationsetting"]) {
-            [[NSNotificationCenter defaultCenter] removeObserver:self name:kTiUserNotificationSettingsNotification object:nil];
-        }
-    }
+
 }
 
 -(void)_listenerRemoved:(NSString*)type count:(int)count
@@ -118,6 +114,12 @@
     }
     if ((count == 1) && [type isEqual:@"uploadprogress"]) {
         [[NSNotificationCenter defaultCenter] removeObserver:self name:kTiURLUploadProgress object:nil];
+    }
+    
+    if ([TiUtils isIOS8OrGreater]){
+        if ((count == 1) && [type isEqual:@"usernotificationsetting"]) {
+            [[NSNotificationCenter defaultCenter] removeObserver:self name:kTiUserNotificationSettingsNotification object:nil];
+        }
     }
 }
 

--- a/iphone/Classes/TiAppiOSProxy.m
+++ b/iphone/Classes/TiAppiOSProxy.m
@@ -73,6 +73,17 @@
     if ((count == 1) && [type isEqual:@"uploadprogress"]) {
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didReceiveUploadProgressNotification:) name:kTiURLUploadProgress object:nil];
     }
+    if ([TiUtils isIOS8OrGreater]){
+        if ((count == 1) && [type isEqual:@"usernotificationsetting"]) {
+            [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector
+             (didRegisterUserNotificationSettingsNotification:) name:kTiUserNotificationSettingsNotification object:nil];
+        }
+    }
+    if ([TiUtils isIOS8OrGreater]){
+        if ((count == 1) && [type isEqual:@"usernotificationsetting"]) {
+            [[NSNotificationCenter defaultCenter] removeObserver:self name:kTiUserNotificationSettingsNotification object:nil];
+        }
+    }
 }
 
 -(void)_listenerRemoved:(NSString*)type count:(int)count
@@ -254,6 +265,43 @@
 	[[UIApplication sharedApplication] registerUserNotificationSettings:notif];
 }
 
+-(NSDictionary*)formatUserNotificationSettings:(UIUserNotificationSettings*)notificationSettings
+{
+    NSMutableArray *notifSettings = [[NSMutableArray alloc] init];
+    if(notificationSettings == nil)
+    {
+        return [NSDictionary dictionaryWithObjectsAndKeys: notifSettings,@"types",nil];
+    }
+
+    if((notificationSettings.types & UIUserNotificationTypeNone) != 0){
+        [notifSettings addObject:NUMINT(UIUserNotificationTypeNone)];
+    }
+
+    if((notificationSettings.types & UIUserNotificationTypeBadge) != 0){
+        [notifSettings addObject:NUMINT(UIUserNotificationTypeBadge)];
+    }
+
+    if((notificationSettings.types & UIUserNotificationTypeSound) != 0){
+        [notifSettings addObject:NUMINT(UIUserNotificationTypeSound)];
+    }
+
+    if((notificationSettings.types & UIUserNotificationTypeAlert) != 0){
+        [notifSettings addObject:NUMINT(UIUserNotificationTypeAlert)];
+    }
+
+    return [NSDictionary dictionaryWithObjectsAndKeys: notifSettings,@"types",nil];
+}
+
+-(NSDictionary*)getCurrentUserNotificationSettings:(id)unused
+{
+
+    if (![TiUtils isIOS8OrGreater]){
+        return nil;
+    }
+
+    return [self formatUserNotificationSettings:[[UIApplication sharedApplication] currentUserNotificationSettings]];
+}
+
 -(id)scheduleLocalNotification:(id)args
 {
 	ENSURE_SINGLE_ARG(args,NSDictionary);
@@ -414,6 +462,12 @@
 -(void)didReceiveUploadProgressNotification:(NSNotification*)note
 {
     [self fireEvent:@"uploadprogress" withObject:[note userInfo]];
+}
+
+-(void)didRegisterUserNotificationSettingsNotification:(NSNotification*)notificationSettings
+{
+    [self fireEvent:@"usernotificationsetting"
+         withObject:[self formatUserNotificationSettings:(UIUserNotificationSettings*)[notificationSettings object]]];
 }
 
 -(void)setMinimumBackgroundFetchInterval:(id)value

--- a/iphone/Classes/TiBase.h
+++ b/iphone/Classes/TiBase.h
@@ -573,6 +573,7 @@ extern NSString * const kTiBackgroundTransfer;
 extern NSString * const kTiFrameAdjustNotification;
 extern NSString * const kTiLocalNotification;
 extern NSString * const kTiBackgroundLocalNotification;
+extern NSString * const kTiUserNotificationSettingsNotification;
 extern NSString * const kTiBackgroundTransfer;
 extern NSString * const kTiURLDownloadFinished;
 extern NSString * const kTiURLSessionCompleted;

--- a/iphone/Classes/TiBase.m
+++ b/iphone/Classes/TiBase.m
@@ -154,6 +154,7 @@ NSString * const kTiURLUploadProgress = @"TiUploadProgress";
 NSString * const kTiFrameAdjustNotification = @"TiFrameAdjust";
 NSString * const kTiLocalNotification = @"TiLocalNotification";
 NSString * const kTiBackgroundLocalNotification = @"TiBackgroundLocalNotification";
+NSString * const kTiUserNotificationSettingsNotification = @"TiUserNotificationSettingsNotification";
 
 NSString* const kTiBehaviorSize = @"SIZE";
 NSString* const kTiBehaviorFill = @"FILL";


### PR DESCRIPTION
TC-4671 - iOS8: Access to currentUserNotificationSettings & didRegisterUserNotificationSettings

Add ability to get notification types registered in [UIApplication sharedApplication] currentUserNotificationSettings.
Add ability to recieve an event when didRegisterUserNotificationSettings fires

For details please see https://jira.appcelerator.org/browse/TC-4671
For approach document, please see https://gist.github.com/benbahrenburg/7b65d074c728cba0de4c
