### PR TITLE
Adding support for iPhone 6 Plus icons

### DIFF
--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -2070,7 +2070,7 @@ iOSBuilder.prototype.createInfoPlist = function createInfoPlist(next) {
 	}
 
 	Array.isArray(plist.CFBundleIconFiles) || (plist.CFBundleIconFiles = []);
-	['.png', '@2x.png', '-72.png', '-60.png', '-60@2x.png', '-76.png', '-76@2x.png', '-Small-50.png', '-72@2x.png', '-Small-50@2x.png', '-Small.png', '-Small@2x.png', '-Small-40.png', '-Small-40@2x.png'].forEach(function (name) {
+	['.png', '@2x.png', '-72.png', '-60.png', '-60@2x.png', '-60@3x.png', '-76.png', '-76@2x.png', '-Small-50.png', '-72@2x.png', '-Small-50@2x.png', '-Small.png', '-Small@2x.png', '-Small@3x.png', '-Small-40.png', '-Small-40@2x.png'].forEach(function (name) {
 		name = iconName + name;
 		if (fs.existsSync(path.join(this.projectDir, 'Resources', name)) ||
 			fs.existsSync(path.join(this.projectDir, 'Resources', 'iphone', name)) ||


### PR DESCRIPTION
JIRA ticket: https://jira.appcelerator.org/browse/TIMOB-17663
- For App icon, 180x180: Added new `-60@3x.png`
- For Spotlight search results icon, 120x120: Verified it uses existing `-60@2x.png`
- For Settings icon, 87x87: Added new `-Small@3x.png`

Tested this in Simulator by overlaying unique text on each icon.

Reference: https://developer.apple.com/library/prerelease/ios/documentation/UserExperience/Conceptual/MobileHIG/IconMatrix.html#//apple_ref/doc/uid/TP40006556-CH27-SW1
