### PR TITLE
[TIMOB-17640] Adding and updating UserNotification methods

### DIFF
--- a/iphone/Classes/NetworkModule.m
+++ b/iphone/Classes/NetworkModule.m
@@ -300,6 +300,10 @@ MAKE_SYSTEM_PROP(TLS_VERSION_1_2, TLS_VERSION_1_2);
 	//Note adviced to register user notification settings in Ti.App.iOS first before register for remote notifications
 	if([TiUtils isIOS8OrGreater]) {
         [app registerForRemoteNotifications];
+        
+        if ([args objectForKey:@"types"] != nil) {
+            NSLog(@"[WARN] Passing `types` to registerForPushNotifications is not supported on iOS 8 and greater. Use registerUserNotificationSettings to register notification types.");
+        }
 	}
 	else {
         UIRemoteNotificationType ourNotifications = [app enabledRemoteNotificationTypes];

--- a/iphone/Classes/TiApp.m
+++ b/iphone/Classes/TiApp.m
@@ -433,6 +433,11 @@ TI_INLINE void waitForMemoryPanicCleared();   //WARNING: This must never be run 
 
 #pragma mark Remote and Local Notifications iOS 8
 
+- (void)application:(UIApplication *)application didRegisterUserNotificationSettings:(UIUserNotificationSettings *)notificationSettings
+{
+    [[NSNotificationCenter defaultCenter] postNotificationName:kTiUserNotificationSettingsNotification object:notificationSettings userInfo:nil];
+}
+
 - (void) application:(UIApplication *)application handleActionWithIdentifier:(NSString *)identifier forLocalNotification:(UILocalNotification *)notification completionHandler:(void (^)())completionHandler {
 	RELEASE_TO_NIL(localNotification);
 	localNotification = [[TiApp  dictionaryWithLocalNotification:notification withIdentifier:identifier] retain];

--- a/iphone/Classes/TiAppiOSNotificationCategoryProxy.h
+++ b/iphone/Classes/TiAppiOSNotificationCategoryProxy.h
@@ -13,8 +13,8 @@
 
 }
 
-@property (nonatomic,retain) UIMutableUserNotificationCategory *notificationCategory;
-@property (nonatomic, assign) NSString *identifier;
+@property (nonatomic,retain) UIUserNotificationCategory *notificationCategory;
+@property (nonatomic,readonly) NSString *identifier;
 
 @end
 

--- a/iphone/Classes/TiAppiOSNotificationCategoryProxy.m
+++ b/iphone/Classes/TiAppiOSNotificationCategoryProxy.m
@@ -22,10 +22,10 @@
 {
 	return @"Ti.App.iOS.NotificationCategory";
 }
--(UIMutableUserNotificationCategory*)notificationCategory
+-(UIUserNotificationCategory*)notificationCategory
 {
 	if (_notificationCategory == nil) {
-		_notificationCategory = [[UIMutableUserNotificationCategory alloc] init];
+		_notificationCategory = [[UIUserNotificationCategory alloc] init];
 	}
 	return _notificationCategory;
 }
@@ -33,11 +33,6 @@
 -(NSString*)identifier
 {
 	return [[self notificationCategory] identifier];
-}
-
--(void)setIdentifier:(NSString *)identifier
-{
-	[[self notificationCategory] setIdentifier:identifier];
 }
 
 @end

--- a/iphone/Classes/TiAppiOSProxy.m
+++ b/iphone/Classes/TiAppiOSProxy.m
@@ -79,11 +79,7 @@
              (didRegisterUserNotificationSettingsNotification:) name:kTiUserNotificationSettingsNotification object:nil];
         }
     }
-    if ([TiUtils isIOS8OrGreater]){
-        if ((count == 1) && [type isEqual:@"usernotificationsetting"]) {
-            [[NSNotificationCenter defaultCenter] removeObserver:self name:kTiUserNotificationSettingsNotification object:nil];
-        }
-    }
+
 }
 
 -(void)_listenerRemoved:(NSString*)type count:(int)count
@@ -118,6 +114,12 @@
     }
     if ((count == 1) && [type isEqual:@"uploadprogress"]) {
         [[NSNotificationCenter defaultCenter] removeObserver:self name:kTiURLUploadProgress object:nil];
+    }
+    
+    if ([TiUtils isIOS8OrGreater]){
+        if ((count == 1) && [type isEqual:@"usernotificationsetting"]) {
+            [[NSNotificationCenter defaultCenter] removeObserver:self name:kTiUserNotificationSettingsNotification object:nil];
+        }
     }
 }
 

--- a/iphone/Classes/TiAppiOSProxy.m
+++ b/iphone/Classes/TiAppiOSProxy.m
@@ -73,6 +73,17 @@
     if ((count == 1) && [type isEqual:@"uploadprogress"]) {
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didReceiveUploadProgressNotification:) name:kTiURLUploadProgress object:nil];
     }
+    if ([TiUtils isIOS8OrGreater]){
+        if ((count == 1) && [type isEqual:@"usernotificationsetting"]) {
+            [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector
+             (didRegisterUserNotificationSettingsNotification:) name:kTiUserNotificationSettingsNotification object:nil];
+        }
+    }
+    if ([TiUtils isIOS8OrGreater]){
+        if ((count == 1) && [type isEqual:@"usernotificationsetting"]) {
+            [[NSNotificationCenter defaultCenter] removeObserver:self name:kTiUserNotificationSettingsNotification object:nil];
+        }
+    }
 }
 
 -(void)_listenerRemoved:(NSString*)type count:(int)count
@@ -319,6 +330,43 @@
     return result;
 }
 
+-(NSDictionary*)formatUserNotificationSettings:(UIUserNotificationSettings*)notificationSettings
+{
+    NSMutableArray *notifSettings = [[NSMutableArray alloc] init];
+    if(notificationSettings == nil)
+    {
+        return [NSDictionary dictionaryWithObjectsAndKeys: notifSettings,@"types",nil];
+    }
+
+    if((notificationSettings.types & UIUserNotificationTypeNone) != 0){
+        [notifSettings addObject:NUMINT(UIUserNotificationTypeNone)];
+    }
+
+    if((notificationSettings.types & UIUserNotificationTypeBadge) != 0){
+        [notifSettings addObject:NUMINT(UIUserNotificationTypeBadge)];
+    }
+
+    if((notificationSettings.types & UIUserNotificationTypeSound) != 0){
+        [notifSettings addObject:NUMINT(UIUserNotificationTypeSound)];
+    }
+
+    if((notificationSettings.types & UIUserNotificationTypeAlert) != 0){
+        [notifSettings addObject:NUMINT(UIUserNotificationTypeAlert)];
+    }
+
+    return [NSDictionary dictionaryWithObjectsAndKeys: notifSettings,@"types",nil];
+}
+
+-(NSDictionary*)getCurrentUserNotificationSettings:(id)unused
+{
+
+    if (![TiUtils isIOS8OrGreater]){
+        return nil;
+    }
+
+    return [self formatUserNotificationSettings:[[UIApplication sharedApplication] currentUserNotificationSettings]];
+}
+
 -(id)scheduleLocalNotification:(id)args
 {
 	ENSURE_SINGLE_ARG(args,NSDictionary);
@@ -479,6 +527,12 @@
 -(void)didReceiveUploadProgressNotification:(NSNotification*)note
 {
     [self fireEvent:@"uploadprogress" withObject:[note userInfo]];
+}
+
+-(void)didRegisterUserNotificationSettingsNotification:(NSNotification*)notificationSettings
+{
+    [self fireEvent:@"usernotificationsetting"
+         withObject:[self formatUserNotificationSettings:(UIUserNotificationSettings*)[notificationSettings object]]];
 }
 
 -(void)setMinimumBackgroundFetchInterval:(id)value

--- a/iphone/Classes/TiAppiOSProxy.m
+++ b/iphone/Classes/TiAppiOSProxy.m
@@ -74,7 +74,7 @@
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didReceiveUploadProgressNotification:) name:kTiURLUploadProgress object:nil];
     }
     if ([TiUtils isIOS8OrGreater]){
-        if ((count == 1) && [type isEqual:@"usernotificationsetting"]) {
+        if ((count == 1) && [type isEqual:@"usernotificationsettings"]) {
             [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector
              (didRegisterUserNotificationSettingsNotification:) name:kTiUserNotificationSettingsNotification object:nil];
         }
@@ -295,13 +295,18 @@
         return nil;
     }
     
+    UIUserNotificationSettings *notificationSettings = [[UIApplication sharedApplication] currentUserNotificationSettings];
+    return [self formatUserNotificationSettings:notificationSettings];
+}
+
+-(NSDictionary*)formatUserNotificationSettings:(UIUserNotificationSettings*)notificationSettings
+{
     __block NSMutableArray *typesArray = [NSMutableArray array];
     __block NSMutableArray *categoriesArray = [NSMutableArray array];
-    
+
     TiThreadPerformOnMainThread(^{
-        UIUserNotificationSettings *settings = [[UIApplication sharedApplication] currentUserNotificationSettings];
-        NSUInteger types = settings.types;
-        NSSet *categories = settings.categories;
+        NSUInteger types = notificationSettings.types;
+        NSSet *categories = notificationSettings.categories;
         
         // Types
         if ((types & UIUserNotificationTypeBadge)!=0)
@@ -323,50 +328,12 @@
             categoryProxy.notificationCategory = cat;
             [categoriesArray addObject:categoryProxy];
         }
-    }, YES);
-
-    NSDictionary *result = [NSDictionary dictionaryWithObjectsAndKeys:
-                            typesArray, @"types",
-                            categoriesArray, @"categories",
-                            nil];
-    return result;
-}
-
--(NSDictionary*)formatUserNotificationSettings:(UIUserNotificationSettings*)notificationSettings
-{
-    NSMutableArray *notifSettings = [[NSMutableArray alloc] init];
-    if(notificationSettings == nil)
-    {
-        return [NSDictionary dictionaryWithObjectsAndKeys: notifSettings,@"types",nil];
-    }
-
-    if((notificationSettings.types & UIUserNotificationTypeNone) != 0){
-        [notifSettings addObject:NUMINT(UIUserNotificationTypeNone)];
-    }
-
-    if((notificationSettings.types & UIUserNotificationTypeBadge) != 0){
-        [notifSettings addObject:NUMINT(UIUserNotificationTypeBadge)];
-    }
-
-    if((notificationSettings.types & UIUserNotificationTypeSound) != 0){
-        [notifSettings addObject:NUMINT(UIUserNotificationTypeSound)];
-    }
-
-    if((notificationSettings.types & UIUserNotificationTypeAlert) != 0){
-        [notifSettings addObject:NUMINT(UIUserNotificationTypeAlert)];
-    }
-
-    return [NSDictionary dictionaryWithObjectsAndKeys: notifSettings,@"types",nil];
-}
-
--(NSDictionary*)getCurrentUserNotificationSettings:(id)unused
-{
-
-    if (![TiUtils isIOS8OrGreater]){
-        return nil;
-    }
-
-    return [self formatUserNotificationSettings:[[UIApplication sharedApplication] currentUserNotificationSettings]];
+    },YES);
+    
+    return [NSDictionary dictionaryWithObjectsAndKeys:
+            typesArray, @"types",
+            categoriesArray, @"categories",
+            nil];
 }
 
 -(id)scheduleLocalNotification:(id)args
@@ -533,7 +500,7 @@
 
 -(void)didRegisterUserNotificationSettingsNotification:(NSNotification*)notificationSettings
 {
-    [self fireEvent:@"usernotificationsetting"
+    [self fireEvent:@"usernotificationsettings"
          withObject:[self formatUserNotificationSettings:(UIUserNotificationSettings*)[notificationSettings object]]];
 }
 

--- a/iphone/Classes/TiBase.h
+++ b/iphone/Classes/TiBase.h
@@ -573,6 +573,7 @@ extern NSString * const kTiBackgroundTransfer;
 extern NSString * const kTiFrameAdjustNotification;
 extern NSString * const kTiLocalNotification;
 extern NSString * const kTiBackgroundLocalNotification;
+extern NSString * const kTiUserNotificationSettingsNotification;
 extern NSString * const kTiBackgroundTransfer;
 extern NSString * const kTiURLDownloadFinished;
 extern NSString * const kTiURLSessionCompleted;

--- a/iphone/Classes/TiBase.m
+++ b/iphone/Classes/TiBase.m
@@ -154,6 +154,7 @@ NSString * const kTiURLUploadProgress = @"TiUploadProgress";
 NSString * const kTiFrameAdjustNotification = @"TiFrameAdjust";
 NSString * const kTiLocalNotification = @"TiLocalNotification";
 NSString * const kTiBackgroundLocalNotification = @"TiBackgroundLocalNotification";
+NSString * const kTiUserNotificationSettingsNotification = @"TiUserNotificationSettingsNotification";
 
 NSString* const kTiBehaviorSize = @"SIZE";
 NSString* const kTiBehaviorFill = @"FILL";


### PR DESCRIPTION
https://jira.appcelerator.org/browse/TIMOB-17640
- `remoteNotificationsEnabled` calls `isRegisteredForRemoteNotifications` on iOS8 and up
- `enabledRemoteNotificationTypes` calls `currentUserNotificationSettings` on iOS8 and up
- method name change `registerForLocalNotifications` ---> `registerUserNotificationSettings`
- `registerUserNotificationSettings` takes an array of types
- new property ---> `currentUserNotificationSettings`
- notification constants in Ti.App.iOS are prefixed with USER_
  - eg. `NOTIFICATION_TYPE_BADGE` ---> `USER_NOTIFICATION_TYPE_BADGE`
  - To avoid confusion with similarly named constants in Network.
- TiAppiOSNotificationCategoryProxy ---> properties are creation time only
  - `identifier` is readable after creation
