### PR TITLE
[TIMOB-17670] DocumentViewer not displaying PDF files

### DIFF
--- a/iphone/Classes/TiUIiOSDocumentViewerProxy.m
+++ b/iphone/Classes/TiUIiOSDocumentViewerProxy.m
@@ -89,7 +89,13 @@
 	NSURL *url = [TiUtils toURL:value proxy:self];
 	if (controller!=nil)
 	{
-		[self controller].URL = url;
+		//UIDocumentInteractionController is recommended to be a new instance for every different url
+		//instead of having titanium developer create a new instance every time a new document url is loaded
+		//we assume that setUrl is called to change doc, so we go ahead and release the controller and create
+		//a new one when asked to present
+		[controller release];
+		controller = nil;
+		[self replaceValue:url forKey:@"url" notification:NO];
 	}
 	else 
 	{

--- a/iphone/Classes/TiUIiOSDocumentViewerProxy.m
+++ b/iphone/Classes/TiUIiOSDocumentViewerProxy.m
@@ -87,20 +87,12 @@
 {
 	ENSURE_TYPE(value,NSString);
 	NSURL *url = [TiUtils toURL:value proxy:self];
-	if (controller!=nil)
-	{
-		//UIDocumentInteractionController is recommended to be a new instance for every different url
-		//instead of having titanium developer create a new instance every time a new document url is loaded
-		//we assume that setUrl is called to change doc, so we go ahead and release the controller and create
-		//a new one when asked to present
-		[controller release];
-		controller = nil;
-		[self replaceValue:url forKey:@"url" notification:NO];
-	}
-	else 
-	{
-		[self replaceValue:url forKey:@"url" notification:NO];
-	}
+	//UIDocumentInteractionController is recommended to be a new instance for every different url
+	//instead of having titanium developer create a new instance every time a new document url is loaded
+	//we assume that setUrl is called to change doc, so we go ahead and release the controller and create
+	//a new one when asked to present
+	RELEASE_TO_NIL(controller);
+	[self replaceValue:url forKey:@"url" notification:NO];
 }
 
 -(id)icons


### PR DESCRIPTION
Details: https://jira.appcelerator.org/browse/TIMOB-17670
When trying to change url in a document viewer instance, it sometimes doesn't load the respective document in url.
Reason is because we are using UIDocumentInteractionController, which according to Apple API documents, is supposed to be a preview controller, and recommended to initialize an instance for every different file previewed.
Bug solved by creating new instance every time url is changed for document view.
