### PR TITLE
[TIMOB-17648] (3_4_X) iOS8: iPad Alert dialog does not consider window orientation modes

### DIFF
--- a/iphone/Classes/TiRootViewController.h
+++ b/iphone/Classes/TiRootViewController.h
@@ -49,6 +49,7 @@
     
     BOOL statusBarIsHidden;
     BOOL statusBarVisibilityChanged;
+    NSInteger activeAlertControllerCount;
 }
 
 //Titanium Support
@@ -56,6 +57,8 @@
 -(void)repositionSubviews;
 -(UIView *)topWindowProxyView;
 -(NSUInteger)supportedOrientationsForAppDelegate;
+-(void)incrementActiveAlertControllerCount;
+-(void)decrementActiveAlertControllerCount;
 -(void)updateStatusBar;
 @property (nonatomic, readonly) BOOL statusBarInitiallyHidden;
 @property (nonatomic, readonly) UIStatusBarStyle defaultStatusBarStyle;

--- a/iphone/Classes/TiRootViewController.m
+++ b/iphone/Classes/TiRootViewController.m
@@ -916,12 +916,17 @@
 	return defaultOrientations;
 }
 
--(UIViewController*)topPresentedController
+-(UIViewController*)topPresentedControllerCheckingPopover:(BOOL)checkPopover
 {
     UIViewController* topmostController = self;
     UIViewController* presentedViewController = nil;
     while ( topmostController != nil ) {
         presentedViewController = [topmostController presentedViewController];
+        if (checkPopover && [TiUtils isIOS8OrGreater]) {
+            if (presentedViewController.modalPresentationStyle == UIModalPresentationPopover) {
+                presentedViewController = nil;
+            }
+        }
         if (presentedViewController != nil) {
             topmostController = presentedViewController;
             presentedViewController = nil;
@@ -931,6 +936,11 @@
         }
     }
     return topmostController;
+}
+
+-(UIViewController*)topPresentedController
+{
+    return [self topPresentedControllerCheckingPopover:NO];
 }
 
 -(UIViewController<TiControllerContainment>*)topContainerController;
@@ -1114,7 +1124,7 @@
     }
     //IOS6. If we are presenting a modal view controller, get the supported
     //orientations from the modal view controller
-    UIViewController* topmostController = [self topPresentedController];
+    UIViewController* topmostController = [self topPresentedControllerCheckingPopover:YES];
     if (topmostController != self) {
         NSUInteger retVal = [topmostController supportedInterfaceOrientations];
         if ([topmostController isBeingDismissed]) {

--- a/iphone/Classes/TiRootViewController.m
+++ b/iphone/Classes/TiRootViewController.m
@@ -1108,11 +1108,25 @@
     return YES;
 }
 
+-(void)incrementActiveAlertControllerCount
+{
+    ++activeAlertControllerCount;
+}
+-(void)decrementActiveAlertControllerCount
+{
+    --activeAlertControllerCount;
+}
+
 -(NSUInteger)supportedOrientationsForAppDelegate;
 {
     if (forcingStatusBarOrientation) {
         return 0;
     }
+    
+    if ([TiUtils isIOS8OrGreater] && activeAlertControllerCount > 0) {
+        return [self supportedInterfaceOrientations];
+    }
+    
     //Since this is used just for intersection, ok to return UIInterfaceOrientationMaskAll
     return 30;//UIInterfaceOrientationMaskAll
 }

--- a/iphone/Classes/TiUIAlertDialogProxy.m
+++ b/iphone/Classes/TiUIAlertDialogProxy.m
@@ -7,6 +7,7 @@
 
 #import "TiUIAlertDialogProxy.h"
 #import "TiUtils.h"
+#import "TiApp.h"
 
 static NSCondition* alertCondition;
 static BOOL alertShowing = NO;
@@ -53,6 +54,7 @@ static BOOL alertShowing = NO;
 		[self forgetSelf];
 		[self autorelease];
 		RELEASE_TO_NIL(alert);
+		[[[TiApp app] controller] decrementActiveAlertControllerCount];
 		[[NSNotificationCenter defaultCenter] removeObserver:self];
 	}
 }
@@ -131,6 +133,7 @@ static BOOL alertShowing = NO;
 		[alert setAlertViewStyle:style];
 
 		[self retain];
+		[[[TiApp app] controller] incrementActiveAlertControllerCount];
 		[alert show];
 	}
 }

--- a/iphone/Classes/TiUIOptionDialogProxy.m
+++ b/iphone/Classes/TiUIOptionDialogProxy.m
@@ -70,6 +70,7 @@
 	[actionSheet setDestructiveButtonIndex:[TiUtils intValue:[self valueForKey:@"destructive"] def:-1]];
 
 	[self retain];
+	[[[TiApp app] controller] incrementActiveAlertControllerCount];
 
 	if ([TiUtils isIPad])
 	{
@@ -104,6 +105,7 @@
                                    nil];
             [self fireEvent:@"click" withObject:event];
         }
+        [[[TiApp app] controller] decrementActiveAlertControllerCount];
         [[NSNotificationCenter defaultCenter] removeObserver:self];
         [self forgetSelf];
         [self release];


### PR DESCRIPTION
Cherry Pick PR #6065 to 3_4_X
Test is in [JIRA](https://jira.appcelerator.org/browse/TIMOB-17648)
