### PR TITLE
[TIMOB-17629] Back port -  Fixed require on iOS

### DIFF
--- a/iphone/Classes/KrollBridge.m
+++ b/iphone/Classes/KrollBridge.m
@@ -30,7 +30,7 @@ extern NSString * const TI_APPLICATION_GUID;
 extern NSString * const TI_APPLICATION_BUILD_TYPE;
 
 NSString * TitaniumModuleRequireFormat = @"(function(exports){"
-		"var __OXP=exports;var module={'exports':exports};var __dirname=\"%@\";var __filename=\"%@\";\n%@;\n"
+		"var __OXP=exports;var module={'exports':exports};var __dirname=\"%@\";var __filename=\"%@\";%@;\n"
 		"if(module.exports !== __OXP){return module.exports;}"
 		"return exports;})({})";
 


### PR DESCRIPTION
Debugger was off by one line of code due to a new "new line" in the require header code. Details in [TIMOB-17629](https://jira.appcelerator.org/browse/TIMOB-17629)
