### PR TITLE
TIMOB-16889 update: activity lifecycle calls must be synchronous

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
@@ -907,7 +907,7 @@ public abstract class TiBaseActivity extends ActionBarActivity
 
 		data.put("source", activityProxy);
 
-		activityProxy.callPropertyAsync(name, new Object[] { data });
+		activityProxy.callPropertySync(name, new Object[] { data });
 	}
 
 	private void releaseDialogs(boolean finish)

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiMenuSupport.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiMenuSupport.java
@@ -40,7 +40,7 @@ public class TiMenuSupport
 				menuProxy = new MenuProxy(menu);
 			}
 			event.put(TiC.EVENT_PROPERTY_MENU, menuProxy);
-			onCreate.call(activityProxy.getKrollObject(), new Object[] { event });
+			activityProxy.callPropertySync(TiC.PROPERTY_ON_CREATE_OPTIONS_MENU, new Object[] { event });
 		}
 		// If a callback exists then return true.
 		// There is no need for the Ti Developer to support both methods.
@@ -82,7 +82,7 @@ public class TiMenuSupport
 				menuProxy = new MenuProxy(menu);
 			}
 			event.put(TiC.EVENT_PROPERTY_MENU, menuProxy);
-			onPrepare.call(activityProxy.getKrollObject(), new Object[] { event });
+			activityProxy.callPropertySync(TiC.PROPERTY_ON_PREPARE_OPTIONS_MENU, new Object[] { event });
 		}
 		prepared = true;
 		return prepared;


### PR DESCRIPTION
Strange things happen if the Android Activity lifecycle calls (onCreate, onResume, onCreateOptionsMenu, etc. ) are async: the calls into Javascript happen much later than they should - sometimes disastrously later. For example, if a window is created and opened as the screen is locked, Android will quickly cycle through create, start, resume, pause, stop - and I have seen window.activity.onResume, onCreateOptionsMenu etc called after the activity was stopped! This of course creates issues if the code tries to do something with the activity when the activity's state is inappropriate for the action. This should be merged into master as well as 3_4_X
