### PR TITLE
[TIMOB-17797] iOS: added the floor property from CLFloor needed for geolocation

### DIFF
--- a/iphone/Classes/GeolocationModule.m
+++ b/iphone/Classes/GeolocationModule.m
@@ -108,6 +108,7 @@ extern BOOL const TI_APPLICATION_ANALYTICS;
 @end
 
 
+
 @interface ForwardGeoCallback : GeolocationCallback
 @end
 
@@ -130,6 +131,7 @@ extern BOOL const TI_APPLICATION_ANALYTICS;
 		[event setObject:accuracy forKey:@"accuracy"];
 		[event setObject:latitude forKey:@"latitude"];
 		[event setObject:longitude forKey:@"longitude"];
+		//[event setObject:floor	forKey:@"floor"];
 	}
 	else 
 	{
@@ -866,7 +868,6 @@ MAKE_SYSTEM_PROP(ACTIVITYTYPE_OTHER_NAVIGATION, CLActivityTypeOtherNavigation);
 	
 	CLLocationCoordinate2D latlon = [newLocation coordinate];
 	
-	
 	NSDictionary * data = [NSDictionary dictionaryWithObjectsAndKeys:
 						   [NSNumber numberWithFloat:latlon.latitude],@"latitude",
 						   [NSNumber numberWithFloat:latlon.longitude],@"longitude",
@@ -875,6 +876,7 @@ MAKE_SYSTEM_PROP(ACTIVITYTYPE_OTHER_NAVIGATION, CLActivityTypeOtherNavigation);
 						   [NSNumber numberWithFloat:[newLocation verticalAccuracy]],@"altitudeAccuracy",
 						   [NSNumber numberWithFloat:[newLocation course]],@"heading",
 						   [NSNumber numberWithFloat:[newLocation speed]],@"speed",
+						   [NSNumber numberWithInt:[newLocation floor]],@"floor",
 						   [NSNumber numberWithLongLong:(long long)([[newLocation timestamp] timeIntervalSince1970] * 1000)],@"timestamp",
 						   nil];
 	return data;


### PR DESCRIPTION
I've opened a Jira ticket: [TC-4806](https://jira.appcelerator.org/browse/TC-4806)

In iOS 8 Apple introduced some APIs for indoor geolocation.
See: https://developer.apple.com/library/ios/documentation/CoreLocation/Reference/CLFloor_class/

There is also a slide deck from WWDC 2014 talking about this in more detail.
It is a trivial change, but a useful one. 

The only down side is that finding a list of building that have been mapped by Apple is a difficult task.
