### PR TITLE
[TIMOB-15443] Android: Enable proxies to get window/tabgroup activity lifecycle events

### DIFF
--- a/android/modules/map/src/java/ti/modules/titanium/map/TiMapView.java
+++ b/android/modules/map/src/java/ti/modules/titanium/map/TiMapView.java
@@ -37,6 +37,7 @@ import android.graphics.drawable.shapes.OvalShape;
 import android.os.Handler;
 import android.os.Looper;
 import android.os.Message;
+import android.os.Bundle;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup.LayoutParams;
@@ -512,6 +513,7 @@ public class TiMapView extends TiUIView
 			public void onDestroy(Activity activity) {}
 			public void onStart(Activity activity) {}
 			public void onStop(Activity activity) {}
+			public void onCreate(Activity activity, Bundle savedInstanceState) {}
 		});
 		view.setBuiltInZoomControls(true);
 		view.setScrollable(true);

--- a/android/modules/map/src/java/ti/modules/titanium/map/ViewProxy.java
+++ b/android/modules/map/src/java/ti/modules/titanium/map/ViewProxy.java
@@ -26,6 +26,7 @@ import android.app.Activity;
 import android.app.LocalActivityManager;
 import android.content.Intent;
 import android.os.Message;
+import android.os.Bundle;
 import android.view.Window;
 
 @Kroll.proxy(creatableInModule = MapModule.class, propertyAccessors = {
@@ -113,6 +114,11 @@ public class ViewProxy extends TiViewProxy implements OnLifecycleEvent
 			// based on its context;
 			rootLifecycleListener = new OnLifecycleEvent()
 			{
+				@Override
+				public void onCreate(Activity activity, Bundle savedInstanceState)
+				{
+				}
+
 				@Override
 				public void onStop(Activity activity)
 				{
@@ -481,6 +487,10 @@ public class ViewProxy extends TiViewProxy implements OnLifecycleEvent
 	public double getLatitudeDelta()
 	{
 		return mapView.getLatitudeDelta();
+	}
+
+	public void onCreate(Activity activity, Bundle savedInstanceState)
+	{
 	}
 
 	public void onDestroy(Activity activity)

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TabGroupProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TabGroupProxy.java
@@ -394,9 +394,6 @@ public class TabGroupProxy extends TiWindowProxy implements TiActivityWindow
 		// Prevent any duplicate events from firing by marking
 		// this group has having focus.
 		isFocused = true;
-
-		// Setup the new tab activity like setting orientation modes.
-		onWindowActivityCreated();
 	}
 
 	@Override

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIImageView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIImageView.java
@@ -45,6 +45,7 @@ import android.graphics.drawable.Drawable;
 import android.os.Handler;
 import android.os.Looper;
 import android.os.Message;
+import android.os.Bundle;
 import android.view.View;
 import android.view.ViewParent;
 
@@ -855,6 +856,10 @@ public class TiUIImageView extends TiUIView implements OnLifecycleEvent, Handler
 		}
 	}
 
+	public void onCreate(Activity activity, Bundle savedInstanceState)
+	{
+	}
+ 
 	public void onDestroy(Activity activity)
 	{
 	}

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUITableView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUITableView.java
@@ -27,6 +27,7 @@ import ti.modules.titanium.ui.widget.tableview.TiTableView.OnItemClickedListener
 import ti.modules.titanium.ui.widget.tableview.TiTableView.OnItemLongClickedListener;
 import android.app.Activity;
 import android.os.Build;
+import android.os.Bundle;
 import android.view.Gravity;
 import android.view.View;
 import android.widget.ListView;
@@ -218,6 +219,7 @@ public class TiUITableView extends TiUIView
 		}
 	}
 
+	@Override public void onCreate(Activity activity, Bundle savedInstanceState) {}
 	@Override public void onStop(Activity activity) {}
 	@Override public void onStart(Activity activity) {}
 	@Override public void onPause(Activity activity) {}

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIActionBarTabGroup.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIActionBarTabGroup.java
@@ -23,6 +23,7 @@ import ti.modules.titanium.ui.TabProxy;
 import ti.modules.titanium.ui.widget.tabgroup.TiUIActionBarTab.TabFragment;
 
 import android.app.Activity;
+import android.os.Bundle;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.ActionBarActivity;
 import android.support.v7.app.ActionBar.Tab;
@@ -328,6 +329,9 @@ public class TiUIActionBarTabGroup extends TiUIAbstractTabGroup implements TabLi
 	@Override
 	public void onTabReselected(Tab tab, FragmentTransaction ft) {
 	}
+
+	@Override
+	public void onCreate(Activity activity, Bundle savedInstanceState) {}
 
 	@Override
 	public void onStart(Activity activity) { }

--- a/android/titanium/src/java/org/appcelerator/kroll/KrollProxy.java
+++ b/android/titanium/src/java/org/appcelerator/kroll/KrollProxy.java
@@ -24,6 +24,8 @@ import org.appcelerator.titanium.TiBaseActivity;
 import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.TiContext;
 import org.appcelerator.titanium.proxy.ActivityProxy;
+import org.appcelerator.titanium.proxy.TiWindowProxy;
+import org.appcelerator.titanium.TiLifecycle.OnLifecycleEvent;
 import org.appcelerator.titanium.util.TiConvert;
 import org.appcelerator.titanium.util.TiRHelper;
 import org.appcelerator.titanium.util.TiUrl;
@@ -42,7 +44,7 @@ import org.json.JSONObject;
  * the view object is a proxy itself.
  */
 @Kroll.proxy(name = "KrollProxy", propertyAccessors = { KrollProxy.PROPERTY_HAS_JAVA_LISTENER })
-public class KrollProxy implements Handler.Callback, KrollProxySupport
+public class KrollProxy implements Handler.Callback, KrollProxySupport, OnLifecycleEvent
 {
 	private static final String TAG = "KrollProxy";
 	private static final int INDEX_NAME = 0;
@@ -180,6 +182,12 @@ public class KrollProxy implements Handler.Callback, KrollProxySupport
 	public void setActivity(Activity activity)
 	{
 		this.activity = new WeakReference<Activity>(activity);
+	}
+
+	public void attachActivityLifecycle(Activity activity)
+	{
+		setActivity(activity);
+		((TiBaseActivity) activity).addOnLifecycleEventListener(this);
 	}
 
 	/**
@@ -384,6 +392,21 @@ public class KrollProxy implements Handler.Callback, KrollProxySupport
 		if (dict.containsKey(TiC.PROPERTY_BUBBLE_PARENT)) {
 			bubbleParent = TiConvert.toBoolean(dict, TiC.PROPERTY_BUBBLE_PARENT, true);
 		}
+
+		if (dict.containsKey(TiC.PROPERTY_LIFECYCLE_CONTAINER)) {
+			KrollProxy lifecycleProxy = (KrollProxy) dict.get(TiC.PROPERTY_LIFECYCLE_CONTAINER);
+			if (lifecycleProxy instanceof TiWindowProxy) {
+				ActivityProxy activityProxy = ((TiWindowProxy) lifecycleProxy).getWindowActivityProxy();
+				if (activityProxy != null) {
+					attachActivityLifecycle(activityProxy.getActivity());
+				} else {
+					((TiWindowProxy) lifecycleProxy).addProxyWaitingForActivity(this);
+				}
+			} else {
+				Log.e(TAG, TiC.PROPERTY_LIFECYCLE_CONTAINER + " must be a WindowProxy or TabGroupProxy (TiWindowProxy)");
+			}
+		}
+
 		properties.putAll(dict);
 		handleDefaultValues();
 		handleLocaleProperties();
@@ -1305,6 +1328,46 @@ public class KrollProxy implements Handler.Callback, KrollProxySupport
 	public String getApiName()
 	{
 		return "Ti.Proxy";
+	}
+
+	/**
+	 * A place holder for subclasses to extend. Its purpose is to receive native Android onResume life cycle events.
+	 * @param activity the activity attached to this module.
+	 * @module.api
+	 */
+	public void onResume(Activity activity) {
+	}
+
+	/**
+	 * A place holder for subclasses to extend. Its purpose is to receive native Android onPause life cycle events.
+	 * @param activity the activity attached to this module.
+	 * @module.api
+	 */
+	public void onPause(Activity activity) {
+	}
+
+	/**
+	 * A place holder for subclasses to extend. Its purpose is to receive native Android onDestroy life cycle events.
+	 * @param activity the activity attached to this module.
+	 * @module.api
+	 */
+	public void onDestroy(Activity activity) {
+	}
+
+	/**
+	 * A place holder for subclasses to extend. Its purpose is to receive native Android onStart life cycle events.
+	 * @param activity the activity attached to this module.
+	 * @module.api
+	 */
+	public void onStart(Activity activity) {
+	}
+
+	/**
+	 * A place holder for subclasses to extend. Its purpose is to receive native Android onStop life cycle events.
+	 * @param activity the activity attached to this module.
+	 * @module.api
+	 */
+	public void onStop(Activity activity) {
 	}
 }
 

--- a/android/titanium/src/java/org/appcelerator/kroll/KrollProxy.java
+++ b/android/titanium/src/java/org/appcelerator/kroll/KrollProxy.java
@@ -33,6 +33,7 @@ import org.appcelerator.titanium.util.TiUrl;
 import android.app.Activity;
 import android.os.Handler;
 import android.os.Message;
+import android.os.Bundle;
 import android.util.Pair;
 
 import org.json.JSONObject;
@@ -1328,6 +1329,14 @@ public class KrollProxy implements Handler.Callback, KrollProxySupport, OnLifecy
 	public String getApiName()
 	{
 		return "Ti.Proxy";
+	}
+
+	/**
+	 * A place holder for subclasses to extend. Its purpose is to receive native Android onCreate life cycle events.
+	 * @param activity the activity attached to this module.
+	 * @module.api
+	 */
+	public void onCreate(Activity activity, Bundle savedInstanceState) {
 	}
 
 	/**

--- a/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
@@ -548,6 +548,16 @@ public abstract class TiBaseActivity extends ActionBarActivity
 		if (window != null) {
 			window.onWindowActivityCreated();
 		}
+		synchronized (lifecycleListeners.synchronizedList()) {
+			for (OnLifecycleEvent listener : lifecycleListeners.nonNull()) {
+				try {
+					TiLifecycle.fireLifecycleEvent(this, listener, savedInstanceState, TiLifecycle.LIFECYCLE_ON_CREATE);
+
+				} catch (Throwable t) {
+					Log.e(TAG, "Error dispatching lifecycle event: " + t.getMessage(), t);
+				}
+			}
+		}
 	}
 
 	public int getOriginalOrientationMode()

--- a/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
@@ -20,6 +20,7 @@ import org.appcelerator.kroll.common.TiMessenger;
 import org.appcelerator.titanium.TiLifecycle.OnLifecycleEvent;
 import org.appcelerator.titanium.TiLifecycle.OnWindowFocusChangedEvent;
 import org.appcelerator.titanium.TiLifecycle.interceptOnBackPressedEvent;
+import org.appcelerator.titanium.TiLifecycle.onActivityResultEvent;
 import org.appcelerator.titanium.proxy.ActionBarProxy;
 import org.appcelerator.titanium.proxy.ActivityProxy;
 import org.appcelerator.titanium.proxy.IntentProxy;
@@ -75,6 +76,7 @@ public abstract class TiBaseActivity extends ActionBarActivity
 	private TiWeakList<OnLifecycleEvent> lifecycleListeners = new TiWeakList<OnLifecycleEvent>();
 	private TiWeakList<OnWindowFocusChangedEvent> windowFocusChangedListeners = new TiWeakList<OnWindowFocusChangedEvent>();
 	private TiWeakList<interceptOnBackPressedEvent> interceptOnBackPressedListeners = new TiWeakList<interceptOnBackPressedEvent>();
+	private TiWeakList<onActivityResultEvent> onActivityResultListeners = new TiWeakList<onActivityResultEvent>();
 	private APSAnalytics analytics = APSAnalytics.getInstance();
 
 	protected View layout;
@@ -639,6 +641,15 @@ public abstract class TiBaseActivity extends ActionBarActivity
 	protected void onActivityResult(int requestCode, int resultCode, Intent data)
 	{
 		super.onActivityResult(requestCode, resultCode, data);
+		synchronized (onActivityResultListeners.synchronizedList()) {
+			for (onActivityResultEvent listener : onActivityResultListeners.nonNull()) {
+				try {
+					TiLifecycle.fireOnActivityResultEvent(this, listener, requestCode, resultCode, data);
+				} catch (Throwable t) {
+					Log.e(TAG, "Error dispatching onActivityResult event: " + t.getMessage(), t);
+				}
+			}
+		}
 		getSupportHelper().onActivityResult(requestCode, resultCode, data);
 	}
 
@@ -903,6 +914,11 @@ public abstract class TiBaseActivity extends ActionBarActivity
 	public void addInterceptOnBackPressedEventListener(interceptOnBackPressedEvent listener)
 	{
 		interceptOnBackPressedListeners.add(new WeakReference<interceptOnBackPressedEvent>(listener));
+	}
+
+	public void addOnActivityResultListener(onActivityResultEvent listener)
+	{
+		onActivityResultListeners.add(new WeakReference<onActivityResultEvent>(listener));
 	}
 
 	public void removeOnLifecycleEventListener(OnLifecycleEvent listener)

--- a/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
@@ -22,6 +22,8 @@ import org.appcelerator.titanium.TiLifecycle.OnWindowFocusChangedEvent;
 import org.appcelerator.titanium.TiLifecycle.interceptOnBackPressedEvent;
 import org.appcelerator.titanium.TiLifecycle.onActivityResultEvent;
 import org.appcelerator.titanium.TiLifecycle.OnInstanceStateEvent;
+import org.appcelerator.titanium.TiLifecycle.OnCreateOptionsMenuEvent;
+import org.appcelerator.titanium.TiLifecycle.OnPrepareOptionsMenuEvent;
 import org.appcelerator.titanium.proxy.ActionBarProxy;
 import org.appcelerator.titanium.proxy.ActivityProxy;
 import org.appcelerator.titanium.proxy.IntentProxy;
@@ -79,6 +81,8 @@ public abstract class TiBaseActivity extends ActionBarActivity
 	private TiWeakList<interceptOnBackPressedEvent> interceptOnBackPressedListeners = new TiWeakList<interceptOnBackPressedEvent>();
 	private TiWeakList<OnInstanceStateEvent> instanceStateListeners = new TiWeakList<OnInstanceStateEvent>();
 	private TiWeakList<onActivityResultEvent> onActivityResultListeners = new TiWeakList<onActivityResultEvent>();
+	private TiWeakList<OnCreateOptionsMenuEvent>  onCreateOptionsMenuListeners = new TiWeakList<OnCreateOptionsMenuEvent>();
+	private TiWeakList<OnPrepareOptionsMenuEvent> onPrepareOptionsMenuListeners = new TiWeakList<OnPrepareOptionsMenuEvent>();
 	private APSAnalytics analytics = APSAnalytics.getInstance();
 
 	protected View layout;
@@ -828,11 +832,23 @@ public abstract class TiBaseActivity extends ActionBarActivity
 			return false;
 		}
 
+		boolean listenerExists = false;
+		synchronized (onCreateOptionsMenuListeners.synchronizedList()) {
+			for (OnCreateOptionsMenuEvent listener : onCreateOptionsMenuListeners.nonNull()) {
+				try {
+					listenerExists = true;
+					TiLifecycle.fireOnCreateOptionsMenuEvent(this, listener, menu);
+				} catch (Throwable t) {
+					Log.e(TAG, "Error dispatching OnCreateOptionsMenuEvent: " + t.getMessage(), t);
+				}
+			}
+		}
+
 		if (menuHelper == null) {
 			menuHelper = new TiMenuSupport(activityProxy);
 		}
 
-		return menuHelper.onCreateOptionsMenu(super.onCreateOptionsMenu(menu), menu);
+		return menuHelper.onCreateOptionsMenu(super.onCreateOptionsMenu(menu) || listenerExists, menu);
 	}
 
 	@Override
@@ -861,7 +877,18 @@ public abstract class TiBaseActivity extends ActionBarActivity
 	@Override
 	public boolean onPrepareOptionsMenu(Menu menu)
 	{
-		return menuHelper.onPrepareOptionsMenu(super.onPrepareOptionsMenu(menu), menu);
+		boolean listenerExists = false;
+		synchronized (onPrepareOptionsMenuListeners.synchronizedList()) {
+			for (OnPrepareOptionsMenuEvent listener : onPrepareOptionsMenuListeners.nonNull()) {
+				try {
+					listenerExists = true;
+					TiLifecycle.fireOnPrepareOptionsMenuEvent(this, listener, menu);
+				} catch (Throwable t) {
+					Log.e(TAG, "Error dispatching OnPrepareOptionsMenuEvent: " + t.getMessage(), t);
+				}
+			}
+		}
+		return menuHelper.onPrepareOptionsMenu(super.onPrepareOptionsMenu(menu) || listenerExists, menu);
 	}
 
 	public static void callOrientationChangedListener(Configuration newConfig) 
@@ -926,6 +953,16 @@ public abstract class TiBaseActivity extends ActionBarActivity
 	public void addOnActivityResultListener(onActivityResultEvent listener)
 	{
 		onActivityResultListeners.add(new WeakReference<onActivityResultEvent>(listener));
+	}
+
+	public void addOnCreateOptionsMenuEventListener(OnCreateOptionsMenuEvent listener)
+	{
+		onCreateOptionsMenuListeners.add(new WeakReference<OnCreateOptionsMenuEvent>(listener));
+	}
+
+	public void addOnPrepareOptionsMenuEventListener(OnPrepareOptionsMenuEvent listener)
+	{
+		onPrepareOptionsMenuListeners.add(new WeakReference<OnPrepareOptionsMenuEvent>(listener));
 	}
 
 	public void removeOnLifecycleEventListener(OnLifecycleEvent listener)

--- a/android/titanium/src/java/org/appcelerator/titanium/TiC.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiC.java
@@ -1475,6 +1475,11 @@ public class TiC
 	/**
 	 * @module.api
 	 */
+	public static final String PROPERTY_LIFECYCLE_CONTAINER = "lifecycleContainer";
+
+	/**
+	 * @module.api
+	 */
 	public static final String PROPERTY_LOAD_URL = "loadUrl";
 	
 	/**

--- a/android/titanium/src/java/org/appcelerator/titanium/TiLifecycle.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiLifecycle.java
@@ -8,6 +8,7 @@ package org.appcelerator.titanium;
 
 import android.app.Activity;
 import android.os.Bundle;
+import android.content.Intent;
 
 /**
  *This class contains a single static utility method for firing a lifecycle event to a single listener.
@@ -75,6 +76,16 @@ public class TiLifecycle
 	}
 
 	/**
+	 * An interface to handle onActivityResult events.
+	 */
+	public interface onActivityResultEvent {
+		/**
+		 * Implementing classes should use this to receive native Android onActivityResult events.
+		 */
+		public void onActivityResult(Activity activity, int requestCode, int resultCode, Intent data);
+	}
+
+	/**
 	 * An interface to intercept OnBackPressed events.
 	 */
 	public interface interceptOnBackPressedEvent {
@@ -101,5 +112,10 @@ public class TiLifecycle
                         case LIFECYCLE_ON_CREATE: listener.onCreate(activity, bundle); break;
                 }
         }
+
+	public static void fireOnActivityResultEvent(Activity activity, onActivityResultEvent listener, int requestCode, int resultCode, Intent data)
+	{
+		listener.onActivityResult(activity, requestCode, resultCode, data);
+	}
 }
 

--- a/android/titanium/src/java/org/appcelerator/titanium/TiLifecycle.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiLifecycle.java
@@ -7,6 +7,7 @@
 package org.appcelerator.titanium;
 
 import android.app.Activity;
+import android.os.Bundle;
 
 /**
  *This class contains a single static utility method for firing a lifecycle event to a single listener.
@@ -19,11 +20,18 @@ public class TiLifecycle
 	public static final int LIFECYCLE_ON_PAUSE = 2;
 	public static final int LIFECYCLE_ON_STOP = 3;
 	public static final int LIFECYCLE_ON_DESTROY = 4;
+	public static final int LIFECYCLE_ON_CREATE = 5;
 
 	/**
 	 * An interface for receiving Android lifecycle events. 
 	 */
 	public interface OnLifecycleEvent {
+
+		/**
+		 * Implementing classes should use this to receive native Android onStart lifecycle events.
+		 * @param activity the attached activity.
+		 */
+		public void onCreate(Activity activity, Bundle savedInstanceState);
 
 		/**
 		 * Implementing classes should use this to receive native Android onStart lifecycle events.
@@ -86,5 +94,12 @@ public class TiLifecycle
 			case LIFECYCLE_ON_DESTROY: listener.onDestroy(activity); break;
 		}
 	}
+
+       public static void fireLifecycleEvent(Activity activity, OnLifecycleEvent listener, Bundle bundle, int which)
+        {
+                switch (which) {
+                        case LIFECYCLE_ON_CREATE: listener.onCreate(activity, bundle); break;
+                }
+        }
 }
 

--- a/android/titanium/src/java/org/appcelerator/titanium/TiLifecycle.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiLifecycle.java
@@ -9,6 +9,7 @@ package org.appcelerator.titanium;
 import android.app.Activity;
 import android.os.Bundle;
 import android.content.Intent;
+import android.view.Menu;
 
 /**
  *This class contains a single static utility method for firing a lifecycle event to a single listener.
@@ -102,6 +103,26 @@ public class TiLifecycle
 		public void onActivityResult(Activity activity, int requestCode, int resultCode, Intent data);
 	}
 
+    /**
+     * An interface to handle onCreateOptionsMenu events.
+     */
+	public interface OnCreateOptionsMenuEvent {
+		/**
+		 * Implementing classes should use this to receive native Android onCreateOptionsMenu events.
+		 */
+		public void onCreateOptionsMenu(Activity activity, Menu menu);
+	}
+
+	/**
+	 * An interface to handle onPrepareOptionsMenu events.
+	 */
+	public interface OnPrepareOptionsMenuEvent {
+		/**
+		 * Implementing classes should use this to receive native Android onPrepareOptionsMenu events.
+		 */
+		public void onPrepareOptionsMenu(Activity activity, Menu menu);
+	}
+
 	/**
 	 * An interface to intercept OnBackPressed events.
 	 */
@@ -110,6 +131,16 @@ public class TiLifecycle
 		 * Implementing classes should use this to intercept native Android onBackPressed events.
 		 */
 		public boolean interceptOnBackPressed();
+	}
+
+	public static void fireOnCreateOptionsMenuEvent(Activity activity, OnCreateOptionsMenuEvent listener, Menu menu)
+	{
+		listener.onCreateOptionsMenu(activity, menu);
+	}
+
+	public static void fireOnPrepareOptionsMenuEvent(Activity activity, OnPrepareOptionsMenuEvent listener, Menu menu)
+	{
+		listener.onPrepareOptionsMenu(activity, menu);
 	}
 
 	public static void fireLifecycleEvent(Activity activity, OnLifecycleEvent listener, int which)

--- a/android/titanium/src/java/org/appcelerator/titanium/TiLifecycle.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiLifecycle.java
@@ -22,6 +22,8 @@ public class TiLifecycle
 	public static final int LIFECYCLE_ON_STOP = 3;
 	public static final int LIFECYCLE_ON_DESTROY = 4;
 	public static final int LIFECYCLE_ON_CREATE = 5;
+	public static final int ON_SAVE_INSTANCE_STATE = 6;
+	public static final int ON_RESTORE_INSTANCE_STATE = 7;
 
 	/**
 	 * An interface for receiving Android lifecycle events. 
@@ -63,6 +65,21 @@ public class TiLifecycle
 		 * @param activity the attached activity.
 		 */
 		public void onDestroy(Activity activity);
+	}
+
+	public interface OnInstanceStateEvent {
+
+		/**
+		 * Implementing classes should use this to receive native Android onSaveInstanceState events.
+		 * @param activity the attached activity.
+		 */
+		public void onSaveInstanceState(Bundle bundle);
+
+		/**
+		 * Implementing classes should use this to receive native Android onRestoreInstanceState events.
+		 * @param activity the attached activity.
+		 */
+		public void onRestoreInstanceState(Bundle bundle);
 	}
 
 	/**
@@ -116,6 +133,14 @@ public class TiLifecycle
 	public static void fireOnActivityResultEvent(Activity activity, onActivityResultEvent listener, int requestCode, int resultCode, Intent data)
 	{
 		listener.onActivityResult(activity, requestCode, resultCode, data);
+	}
+
+	public static void fireInstanceStateEvent(Bundle bundle, OnInstanceStateEvent listener, int which)
+	{
+		switch (which) {
+			case ON_SAVE_INSTANCE_STATE: listener.onSaveInstanceState(bundle); break;
+			case ON_RESTORE_INSTANCE_STATE: listener.onRestoreInstanceState(bundle); break;	
+		}
 	}
 }
 

--- a/apidoc/Titanium/Proxy.yml
+++ b/apidoc/Titanium/Proxy.yml
@@ -96,3 +96,13 @@ properties:
     type: String
     platforms: [android, blackberry, iphone, ipad, mobileweb, tizen]
     since: "3.2.0"
+
+  - name: lifecycleContainer
+    summary: The Window or TabGroup whose Activity lifecycle should be triggered on the proxy.
+    description: |
+      If this property is set to a Window or TabGroup, then the corresponding Activity lifecycle event callbacks
+      will also be called on the proxy. Proxies that require the activity lifecycle will need this property set
+      to the appropriate containing Window or TabGroup.
+    type: [Titanium.UI.Window, Titanium.UI.TabGroup]
+    platforms: [android]
+    since: "3.5.0"


### PR DESCRIPTION
Very simple to use: 
1. In the proxy creation dictionary pass `lifecycleContainer: windowOrTabGroup`
2. In the proxy set the lifecycle callbacks.

See example in JIRA https://jira.appcelerator.org/browse/TIMOB-15443
