### PR TITLE
[TIMOB-17726] iOS: Support Ti.Platform.displayCaps.logicalDensityFactor

### DIFF
--- a/apidoc/Titanium/Platform/DisplayCaps.yml
+++ b/apidoc/Titanium/Platform/DisplayCaps.yml
@@ -48,9 +48,10 @@ properties:
         display dpi. For example, a 240x320 screen will have a density of 1, whether its width is 
         1.8" or 1.3". However, if the resolution is increased to 320x480 but the display remains 
         1.5"x2" then the density would be increased to about 1.5.
+        On iOS devices, this property returns 1, 2 and 3 for @1x, @2x and @3x respectively. 
+        Note for iPhone 6+, this value is 3.
     type: Number
-    platforms: [android]
-    
+
   - name: platformHeight
     summary: |
         Absolute height of the display in relation to UI orientation. Measured in platform-specific 
@@ -160,9 +161,9 @@ examples:
             Ti.API.info('Ti.Platform.displayCaps.dpi: ' + Ti.Platform.displayCaps.dpi);
             Ti.API.info('Ti.Platform.displayCaps.platformHeight: ' + Ti.Platform.displayCaps.platformHeight);
             Ti.API.info('Ti.Platform.displayCaps.platformWidth: ' + Ti.Platform.displayCaps.platformWidth);
+            Ti.API.info('Ti.Platform.displayCaps.logicalDensityFactor: ' + Ti.Platform.displayCaps.logicalDensityFactor);
             if(Ti.Platform.osname === 'android'){
               Ti.API.info('Ti.Platform.displayCaps.xdpi: ' + Ti.Platform.displayCaps.xdpi);
               Ti.API.info('Ti.Platform.displayCaps.ydpi: ' + Ti.Platform.displayCaps.ydpi);
-              Ti.API.info('Ti.Platform.displayCaps.logicalDensityFactor: ' + Ti.Platform.displayCaps.logicalDensityFactor);
             }
             

--- a/iphone/Classes/TiPlatformDisplayCaps.h
+++ b/iphone/Classes/TiPlatformDisplayCaps.h
@@ -17,6 +17,7 @@
 @property(nonatomic,readonly) NSNumber* platformWidth;
 @property(nonatomic,readonly) NSNumber* density;
 @property(nonatomic,readonly) NSString* dpi;
+@property(nonatomic,readonly) NSNumber* logicalDensityFactor;
 
 @end
 

--- a/iphone/Classes/TiPlatformDisplayCaps.m
+++ b/iphone/Classes/TiPlatformDisplayCaps.m
@@ -71,6 +71,10 @@
 
 }
 
+- (NSNumber*) logicalDensityFactor
+{
+	return [NSNumber numberWithFloat:[[UIScreen mainScreen] scale]];
+}
 @end
 
 #endif


### PR DESCRIPTION
JIRA Ticket: https://jira.appcelerator.org/browse/TIMOB-17726
On iOS devices, this property returns 1, 2 and 3 for @1x, @2x and @3x respectively. 
Note for iPhone 6+, this value is 3.
