### PR TITLE
[TIMOB-17758] Fixed iOS build bug where the device family default isn't ...

### DIFF
--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -1218,7 +1218,7 @@ iOSBuilder.prototype.validate = function (logger, config, cli) {
 	var deviceFamily = this.getDeviceFamily();
 	if (!deviceFamily) {
 		logger.info(__('No device family specified, defaulting to %s', 'universal'));
-		deviceFamily = 'universal';
+		deviceFamily = this.deviceFamily = 'universal';
 	}
 
 	if (!this.deviceFamilies[deviceFamily]) {


### PR DESCRIPTION
...being properly set when there is no 'iphone' or 'ipad' deployment target in the tiapp.xml.
