### PR TITLE
modified resourcesDirectory method

### DIFF
--- a/iphone/Classes/FilesystemModule.m
+++ b/iphone/Classes/FilesystemModule.m
@@ -121,7 +121,12 @@ extern NSString * TI_APPLICATION_RESOURCE_DIR;
 
 -(NSString*)resourcesDirectory
 {
-	return fileURLify([TiHost resourcePath]);
+	//when working with NSFileManager, path is preferred over absoluteString
+	//absoluteString should be only used for remote URL.
+	//[TiHost resourcePath] uses [[NSBundle mainBundle] bundlePath], unlike the other
+	//directory methods below. So only apply path to this method for now
+	//slash added to ensure consistency with apps that used this method before
+	return [[NSURL fileURLWithPath:[NSString stringWithFormat:@"%@/",[TiHost resourcePath]] isDirectory:YES] path];
 }
 
 -(NSString*)applicationDirectory


### PR DESCRIPTION
It is discovered that resourcesDirectory doesn't return a reliable result when utilized on iPad devices specifically. After some investigation, it is due to the use of [[NSBundle mainBundle] bundlePath]. Instead of absoluteString, path is recommended to be used when obtaining the path string for NSFileManager.
By doing so, the resourcesDirectory returned reliable results for devices and simulators.
