### PR TITLE
[TIMOB-17567] Android: Replace the use of getFileExtensionFromUrl as it is for enco...

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiMimeTypeHelper.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiMimeTypeHelper.java
@@ -46,7 +46,11 @@ public class TiMimeTypeHelper
 	
 	public static String getMimeType(String url, String defaultType)
 	{
-		String extension = MimeTypeMap.getFileExtensionFromUrl(url);
+		String extension = "";
+		int pos = url.lastIndexOf('.');
+		if (pos > 0) {
+			extension = url.substring(pos + 1);
+		}
 		return getMimeTypeFromFileExtension(extension, defaultType);
 	}
 	


### PR DESCRIPTION
https://jira.appcelerator.org/browse/TIMOB-17567
Replace the use of getFileExtensionFromUrl as it is for encoded url and won't work with path with special characters.
