### PR TITLE
[TIMOB-17788] ButtonBar property 'Style' deprecated

### DIFF
--- a/apidoc/Titanium/UI/ButtonBar.yml
+++ b/apidoc/Titanium/UI/ButtonBar.yml
@@ -85,6 +85,9 @@ properties:
     type: Number
     constants: Titanium.UI.iPhone.SystemButtonStyle.*
     default: Titanium.UI.iPhone.SystemButtonStyle.PLAIN
+    deprecated:
+        since: "3.4.1"
+        notes: The style property no longer has any effect on iOS7 and greater.
 examples:
   - title: Simple 3 button button bar
     example: |

--- a/iphone/Classes/TiUIButtonBar.m
+++ b/iphone/Classes/TiUIButtonBar.m
@@ -138,6 +138,12 @@
 
 -(void)setStyle_:(id)value
 {
+	if ([TiUtils isIOS7OrGreater])
+	{
+		DebugLog(@"The segmentedControlStyle property no longer has any effect on iOS7 and greater");
+		return;
+	}
+    
 	int newStyle = [TiUtils intValue:value def:-1];
 	isNullStyle = (newStyle < 0);
 	if (isNullStyle)


### PR DESCRIPTION
[Jira Ticket](https://jira.appcelerator.org/browse/TIMOB-17788)

ButtonBar property 'Style' has been deprecated since iOS7.
