### PR TITLE
[TIMOB-17813] Fixed bug where the targetSDK must be an integer (i.e. 20)...

### DIFF
--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -1165,7 +1165,7 @@ AndroidBuilder.prototype.validate = function validate(logger, config, cli) {
 
 		for (; i >= 0; i--) {
 			if (targetSDKMap[levels[i]].sdk >= this.minSupportedApiLevel && targetSDKMap[levels[i]].sdk <= this.maxSupportedApiLevel) {
-				this.targetSDK = levels[i];
+				this.targetSDK = targetSDKMap[levels[i]].sdk;
 				break;
 			}
 		}


### PR DESCRIPTION
[TIMOB-17813] Fixed bug where the targetSDK must be an integer (i.e. 20) and not the Android Target name (i.e. L).

https://jira.appcelerator.org/browse/TIMOB-17813
