### PR TITLE
[TIDOC-1898] JavaScript version of "docgen -f jsduck"

### DIFF
--- a/apidoc/Titanium/UI/PickerColumn.yml
+++ b/apidoc/Titanium/UI/PickerColumn.yml
@@ -23,20 +23,20 @@ methods:
       In an Alloy application you can use one or more `<PickerRow>` (or `<Row>`) elements inside 
       a `<PickerColumn>` (or `<Column>`) element.
 
-      <Alloy>
-          <PickerColumn id="hour">
-              <PickerRow title="10"/>
-              <PickerRow title="11"/>
-              <PickerRow title="12"/>
-          </PickerColumn>
-          <!-- Picker shorthand notation -->
-          <Column id="minutes">
-              <Row title="15"/>
-              <Row title="30"/>
-              <Row title="45"/>
-              <Row title="00"/>
-          </Column>
-      </Alloy>
+          <Alloy>
+              <PickerColumn id="hour">
+                  <PickerRow title="10"/>
+                  <PickerRow title="11"/>
+                  <PickerRow title="12"/>
+              </PickerColumn>
+              <!-- Picker shorthand notation -->
+              <Column id="minutes">
+                  <Row title="15"/>
+                  <Row title="30"/>
+                  <Row title="45"/>
+                  <Row title="00"/>
+              </Column>
+          </Alloy>
 
     parameters:
       - name: row

--- a/apidoc/docgen.js
+++ b/apidoc/docgen.js
@@ -1,0 +1,432 @@
+/**
+ * Script to preprocess the YAML docs in to a common JSON format,
+ * then calls an generator script to format the API documentation.
+ * Dependencies: node-appc ~0.2.14
+ */
+
+var common = require('./lib/common.js')
+	nodeappc = require('node-appc'),
+	fs = require('fs'),
+	processedData = {},
+	basePath = '.',
+	format = 'html',
+	output = '../dist/',
+	doc = {},
+	errors = [],
+	exporter = '',
+	processFirst = ['Titanium.Proxy', 'Titanium.Module', 'Titanium.UI.View'],
+	formats = [],
+	str = '',
+	libPath = './lib',
+	fsArray = [],
+	tokens = [];
+
+/**
+ * Returns a list of inherited APIs.
+ * @params api {Object} API object to extract inherited APIs
+ * @returns {Object} Object containing all APIs for the API object
+ */
+function getInheritedAPIs (api) {
+
+	var inheritedAPIs = { 'events': [], 'methods': [], 'properties': [] },
+		key = null,
+		removeAPIs = [],
+		copyAPIs = [],
+		match = [],
+		index = 0,
+		x = 0;
+
+	if ('extends' in api && api.extends in doc) {
+		inheritedAPIs = getInheritedAPIs(doc[api.extends]);
+		for (key in inheritedAPIs) {
+			removeAPIs = [];
+			if (!key in api || !api[key]) continue;
+			copyAPIs = nodeappc.util.mixObj([], api[key]);
+			inheritedAPIs[key].forEach(function (inheritedAPI) {
+
+				// See if current API overwrites inherited API
+				match = copyAPIs.filter(function (element) {
+					return element.name == inheritedAPI.name;
+				});
+
+				if (match.length) {
+					removeAPIs.push(match[0]);
+					// If the APIs came from the same class, do nothing
+					if (match[0].__inherits == inheritedAPI.__inherits) return;
+
+					// If the APIs are from different classes, override inherited API with current API
+					index = inheritedAPIs[key].indexOf(inheritedAPI);
+					for (property in match[0]) {
+						inheritedAPIs[key][index][property] = match[0][property];
+					}
+					inheritedAPIs[key][index].__inherits = api.name;
+				}
+
+			});
+			removeAPIs.forEach(function (element) {
+				copyAPIs.splice(copyAPIs.indexOf(element), 1);
+			});
+			for (x = 0; x < copyAPIs.length; x++) {
+				copyAPIs[x].__inherits = api.name;
+			}
+			inheritedAPIs[key] = inheritedAPIs[key].concat(copyAPIs);
+		}
+
+	} else {
+		for (key in inheritedAPIs) {
+			if (!key in api || !api[key]) continue;
+			inheritedAPIs[key] = nodeappc.util.mixObj([], api[key]);
+			for (x = 0; x < inheritedAPIs[key].length; x++) {
+				inheritedAPIs[key][x].__inherits = api.name;
+			}
+		}
+	}
+	return inheritedAPIs;
+}
+
+/**
+ * Returns a list of constants
+ * @params api {Object} API to evaluate
+ * @returns {Array<String>} List of constants the API supports
+ */
+function processConstants (api) {
+	var rv = [];
+	if ('constants' in api) {
+		if (!Array.isArray(api.constants)) api.constants = [api.constants];
+		api.constants.forEach(function (constant) {
+			if (constant.charAt(constant.length - 1) == '*') {
+				var prop = constant.split('.').pop(),
+					prop = prop.substring(0, prop.length - 1),
+					cls = constant.substring(0, constant.lastIndexOf('.'));
+				if (cls in doc && 'properties' in doc[cls]) {
+					doc[cls].properties.forEach(function (property) {
+						if (property.name.indexOf(prop) == 0 && property.name.match(common.REGEXP_CONSTANTS)) rv.push(cls + '.' + property.name);
+					});
+				}
+			} else {
+				rv.push(constant);
+			}
+		});
+	}
+	return rv;
+}
+
+/**
+ * Returns a list of platforms and since versions the API supports
+ * @params api {Object} API to evaluate
+ * @params verions {Object} Possible plaforms and versions the API supports (usually from the class)
+ * @returns {Object} Object containing plaforms and versions the API supports
+ */
+function processVersions (api, versions) {
+	var defaultVersions = nodeappc.util.mixObj({}, versions),
+		platform = null,
+		key = null;
+	if ('platforms' in api) {
+		for (platform in defaultVersions) {
+			if (!~api.platforms.indexOf(platform)) delete defaultVersions[platform];
+		}
+	} else if ('exclude-platforms' in api) {
+		api['exclude-platforms'].forEach(function (platform) {
+			if (platform in defaultVersions) delete defaultVersions[platform];
+		});
+	}
+	if ('since' in api) {
+		if (typeof api.since == 'string') {
+			for (key in defaultVersions) {
+				if (nodeappc.version.gt(api.since, defaultVersions[key])) defaultVersions[key] = api.since;
+			}
+		} else {
+			for (key in defaultVersions) {
+				if (nodeappc.version.gt(api.since[key], defaultVersions[key])) defaultVersions[key] = api.since[key];
+			}
+		}
+	}
+	return defaultVersions;
+}
+
+/**
+ * Processes APIs based on the given list of platforms and versions
+ * @params apis {Array<Object>} List of APIs to evaluate
+ * @param type {String} Type of API
+ * @params defaultVersions {Object} List of plaforms and versions the APIs support
+ * @returns {Array<Object>} List of processed APIs
+ */
+function processAPIMembers (apis, type, defaultVersions) {
+	var rv = [], x = 0;
+	apis.forEach(function (api) {
+		api.since = processVersions(api, defaultVersions);
+		api.platforms = Object.keys(api.since);
+		if (type == 'properties' && api.constants) api.constants = processConstants(api);
+		if (type == 'events' && 'properties' in api) {
+			for (x = 0; x < api.properties.length; x++) {
+				if ('constants' in api.properties[x]) {
+					api.properties[x].constants = processConstants(api.properties[x]);
+				}
+			}
+		}
+		if (type == 'methods') {
+			if ('parameters' in api) {
+				for (x = 0; x < api.parameters.length; x++) {
+					if ('constants' in api.parameters[x]) {
+						api.parameters[x].constants = processConstants(api.parameters[x]);
+					}
+				}
+			}
+			if ('returns' in api) {
+				if (Array.isArray(api.returns)) api.returns = [api.returns];
+				for (x = 0; x < api.returns.length; x++) {
+					if ('constants' in api.returns[x]) {
+						api.returns[x].constants = processConstants(api.returns[x]);
+					}
+				}
+			}
+		}
+		if (api.platforms.length > 0) rv.push(api);
+	});
+	return rv;
+}
+
+/**
+ * Hides APIs based on the excludes list
+ * @params apis {Object} APIs to evaluate
+ * @params type {String} Type of API, one of 'events', 'methods' or 'properties'
+ * @returns {Array<Object>} Processed APIs
+ */
+function hideAPIMembers (apis, type) {
+	if ('excludes' in apis && type in apis.excludes && type in apis) {
+		apis[type].forEach(function (api) {
+			apis[type][apis[type].indexOf(api)].__hide = (~apis.excludes[type].indexOf(api.name)) ? true : false;
+		});
+	}
+	return apis;
+}
+
+/**
+ * Generates accessors from the given list of properties
+ * @param apis {Array<Object>} Array of property objects
+ * @param className {String} Name of the class
+ * @returns {Array<Object>} Array of methods
+ */
+function generateAccessors(apis, className) {
+	var rv = [];
+	apis.forEach(function (api) {
+
+		if ('accessors' in api && api.accessors === false) return;
+
+		// Generate getter
+		if (!('permission' in api && api.permission == 'write-only') && !api.name.match(common.REGEXP_CONSTANTS)) {
+			rv.push({
+				'name': 'get' + api.name.charAt(0).toUpperCase() + api.name.slice(1),
+				'summary': 'Gets the value of the <' + className + '.' + api.name + '> property.',
+				'returns': { 'type': api.type },
+				'__accessor': true,
+				'__inherits': api.__inherits || null
+			});
+		}
+
+		// Generate setter
+		if (!('permission' in api && api.permission == 'read-only')) {
+			rv.push({
+				'name': 'set' + api.name.charAt(0).toUpperCase() + api.name.slice(1),
+				'summary': 'Sets the value of the <' + className + '.' + api.name + '> property.',
+				'parameters': [{
+					'name': api.name,
+					'summary': 'New value for the property.',
+					'type': api.type
+				}],
+				'__accessor': true,
+				'__inherits': api.__inherits || null
+			});
+		}
+	});
+	return rv;
+}
+
+/**
+ * Returns a subtype based on the parent class
+ * @param api {Object} Class object
+ * @returns {String} Class's subtype
+ */
+function getSubtype (api) {
+	switch (api.extends) {
+		case 'Titanium.UI.View' :
+			return 'view';
+		case 'Titanium.Module' :
+			return 'module';
+		case 'Titanium.Proxy' :
+			return 'proxy';
+		default:
+			if ('extends' in api) {
+				return getSubtype(doc[api.extends]);
+			} else {
+				return 'pseudo';
+			}
+	}
+}
+
+function processAPIs (api) {
+	var defaultVersions = nodeappc.util.mix({}, common.DEFAULT_VERSIONS),
+		inheritedAPIs = {};
+
+	// Generate list of supported platforms and versions
+	api.since = processVersions(api, defaultVersions);
+	api.platforms = Object.keys(api.since);
+
+	// Get inherited APIs
+	inheritedAPIs = getInheritedAPIs(api);
+	for (var key in inheritedAPIs) {
+		api[key] = inheritedAPIs[key];
+	}
+
+	api.subtype = (api.name.indexOf('Global') == 0) ? null : (api.name == 'Titanium.Module') ? 'module' : getSubtype(api);
+
+	// Generate create method
+	if ((api.subtype === 'view' || api.subtype === 'proxy') &&
+		(('createable' in api && api.createable === true) ||
+		!('createable' in api))) {
+
+		var name = api.name,
+			prop = name.split('.').pop(),
+			cls = name.substring(0, name.lastIndexOf('.')),
+			methodName = 'create' + prop;
+
+		if (cls in doc) {
+			var matches = [];
+			if ('methods' in doc[cls]) {
+				var matches = doc[cls].methods.filter(function (member) {
+					return member.name == methodName;
+				});
+			}
+			if (matches.length == 0) {
+				var createMethod = {
+					'name': methodName,
+					'summary': 'Creates and returns an instance of <' + name + '>.\n',
+					'deprecated': api.deprecated || null,
+					'since': api.since,
+					'platforms': api.platforms,
+					'returns': { 'type': name },
+					'parameters': [{
+						'name': 'parameters',
+						'summary': 'Properties to set on a new object, including any defined by <' + name + '> except those marked not-creation or read-only.\n',
+						'type': 'Dictionary<' + name + '>',
+						'optional': true
+					}],
+					'__creator': true
+				};
+				'methods' in doc[cls] ? doc[cls].methods.push(createMethod) : doc[cls].methods = [createMethod];
+			}
+		}
+	}
+
+	if ('events' in api) {
+		api = hideAPIMembers(api, 'events');
+		api.events = processAPIMembers(api.events, 'events', api.since);
+	}
+
+	if ('properties' in api ) {
+		var accessors;
+		api = hideAPIMembers(api, 'properties');
+		api.properties = processAPIMembers(api.properties, 'properties', api.since);
+		if (accessors = generateAccessors(api.properties, api.name)) {
+			api.methods = ('methods' in api) ? api.methods.concat(accessors) : accessors;
+		}
+	}
+
+	if ('methods' in api) {
+		api = hideAPIMembers(api, 'methods');
+		api.methods = processAPIMembers(api.methods, 'methods', api.since);
+	}
+
+	return api;
+}
+
+function cliUsage () {
+	console.log('Usage: node docgen.js [--format <EXPORT_FORMAT>] [--output <OUTPUT_DIRECTORY>] [<PATH_TO_YAML_FILES>]'.white);
+	console.log('\nOptions:'.white);
+	console.log('\t--format, -f\tExport format: %s. Default is %s'.white, formats, format);
+	console.log('\t--output, -o\tDirectory to output the files. Default is %s.'.white, output);
+}
+
+// Start of Main Flow
+// Get a list of valid formats
+libPath = process.argv[1].substring(0, process.argv[1].lastIndexOf('/'))  + '/lib';
+fsArray = fs.readdirSync(libPath);
+fsArray.forEach(function (file) {
+	tokens = file.split('_');
+	if (tokens[1] == 'generator.js') formats.push(tokens[0]);
+});
+
+// Check command arguments
+if ((argc = process.argv.length) > 2) {
+	for (var x = 2; x < argc; x++) {
+		switch (process.argv[x]) {
+			case '--help' :
+				cliUsage();
+				process.exit(0);
+				break;
+			case '--format' :
+			case '-f' :
+				if (++x > argc) {
+					console.warn('Did not specify an export format. Valid formats are: %s'.yellow, formats);
+					cliUsage();
+					process.exit(1)
+				}
+				format = process.argv[x];
+				if (!~formats.indexOf(format)) {
+					console.warn('Not a valid export format: %s. Valid formats are: %s'.yellow, format, formats);
+					cliUsage();
+					process.exit(1)
+				}
+				break;
+			case '--output' :
+			case '-o' :
+				if (++x > argc) {
+					console.warn('Specify an output path.'.yellow);
+					cliUsage();
+					process.exit(1)
+				}
+				output = process.argv[x];
+				break;
+			default :
+				if (x == argc - 1) {
+					basePath = process.argv[x];
+				} else {
+					console.warn('Unknown option: %s'.yellow, process.argv[x]);
+					cliUsage();
+					process.exit(1);
+				}
+		}
+	}
+}
+
+rv = common.parseYAML(basePath);
+doc = rv.data;
+errors = rv.errors;
+
+processFirst.forEach(function (cls) {
+	processedData[cls] = processAPIs(doc[cls]);
+});
+for (key in doc) {
+	if (~processFirst.indexOf(key)) continue;
+	processedData[key] = processAPIs(doc[key]);
+}
+
+exporter = require('./lib/' + format + '_generator.js');
+str = exporter.exportData(processedData);
+
+switch (format) {
+	case 'jsduck' :
+		output = output + 'titanium.js';
+		break;
+	default:
+		;
+}
+
+fs.writeFile(output, str, function (err) {
+    if (err) {
+        console.log(err);
+    } else {
+        console.log("Generated output at %s".green, output);
+    }
+});
+

--- a/apidoc/lib/common.js
+++ b/apidoc/lib/common.js
@@ -1,11 +1,13 @@
 /**
  * Common Library for Doctools
- * Dependencies: js-yaml ~3.2.2 and node-appc ~0.2.14
+ * Dependencies: js-yaml ~3.2.2, node-appc ~0.2.14 and pagedown ~1.1.0
  */
 
 var yaml = require('js-yaml'),
 	fs = require('fs'),
-	nodeappc = require('node-appc');
+	nodeappc = require('node-appc'),
+	pagedown = require('pagedown'),
+	converter = new pagedown.Converter();
 
 exports.VALID_PLATFORMS = ['android', 'blackberry', 'iphone', 'ipad', 'mobileweb', 'tizen'];
 exports.VALID_OSES = ['android', 'blackberry', 'ios', 'mobileweb', 'tizen'];
@@ -18,6 +20,34 @@ exports.DEFAULT_VERSIONS = {
 	'tizen' : '3.1'
 }
 exports.DATA_TYPES = ['Array', 'Boolean', 'Callback', 'Date', 'Dictionary', 'Number', 'Object', 'String'];
+
+exports.PRETTY_PLATFORM = {
+	'android': 'Android',
+	'blackberry': 'Blackberry',
+	'ios': 'iOS',
+	'iphone': 'iPhone',
+	'ipad': 'iPad',
+	'mobileweb': 'Mobile Web',
+	'tizen': 'Tizen'
+};
+
+// Matches FOO_CONSTANT
+exports.REGEXP_CONSTANTS = /^[A-Z_]*$/;
+
+// Matches <a href="...">Foo</a>
+exports.REGEXP_HREF_LINK = /<a href="(.+?)">(.+?)<\/a>/;
+exports.REGEXP_HREF_LINKS = /<a href="(.+?)">(.+?)<\/a>/g;
+
+// Matches <code>, </code>, etc.
+exports.REGEXP_HTML_TAG = /<\/?[a-z]+[^>]*>/;
+
+// Matches <Titanium.UI.Window>, <ItemTemplate>, etc. (and HTML tags)
+exports.REGEXP_CHEVRON_LINK = /<([^s]+?)>/;
+exports.REGEXP_CHEVRON_LINKS = /(?!`)<[^s]+?>(?!`)/g;
+
+exports.markdownToHTML = function markdownToHTML (text) {
+	return converter.makeHtml(text);
+}
 
 /**
  * Recursively find, load and parse YAML files

--- a/apidoc/lib/jsduck_generator.js
+++ b/apidoc/lib/jsduck_generator.js
@@ -1,0 +1,312 @@
+/**
+ * Script to export JSON to JSDuck comments
+ */
+var common = require('./common.js'),
+	colors = require('colors');
+	doc = null;
+
+function findAPI (className, memberName, type) {
+	var cls = doc[className];
+	if (type in cls) {
+		for (var x = 0; x < cls[type].length; x++) {
+			if (cls[type][x].name == memberName) return true;
+		}
+	}
+	return false;
+}
+
+// Convert API name to JSDuck-style link
+function convertAPIToLink (apiName) {
+	if (apiName in doc) {
+		return apiName;
+	}
+	else if ((apiName.match(/\./g)||[]).length) {
+		var member = apiName.split('.').pop(),
+			cls = apiName.substring(0, apiName.lastIndexOf('.'));
+		if (!cls in doc) {
+			console.warn('Cannot find class: %s'.yellow, cls);
+			return null;
+		} else {
+			if (findAPI(cls, member, 'properties')) {
+				return cls + '#property-' + member;
+			}
+			if (findAPI(cls, member, 'methods')) {
+				return cls + '#method-' + member;
+			}
+			if (findAPI(cls, member, 'events')) {
+				return cls + '#event-' + member;
+			}
+		}
+	}
+	console.warn('Cannot find API: %s'.yellow, apiName);
+	return null;
+}
+
+// Scans converted markdown-to-html text for internal links and
+// converts them to JSDuck-style sytnax
+function convertLinks (text) {
+	var matches = text.match(common.REGEXP_HREF_LINKS),
+		tokens,
+		replace,
+		link;
+	if (matches && matches.length) {
+		matches.forEach(function (match) {
+			tokens = common.REGEXP_HREF_LINK.exec(match);
+			if (tokens && tokens[1].indexOf("http") != 0 && !~match.indexOf('#')) {
+				if (link = convertAPIToLink(tokens[1])) {
+					replace = '{@link ' + link + ' ' + tokens[2] + '}';
+					text = text.replace(tokens[0], replace);
+				}
+			}
+		})
+	}
+	matches = text.match(common.REGEXP_CHEVRON_LINKS);
+	if (matches && matches.length) {
+		matches.forEach(function (match) {
+			if(!common.REGEXP_HTML_TAG.exec(match) && !~match.indexOf(' ') && !~match.indexOf('/') && !~match.indexOf('#')) {
+				tokens = common.REGEXP_CHEVRON_LINK.exec(match);
+				if (link = convertAPIToLink(tokens[1])) {
+					replace = '{@link ' + link + '}';
+					text = text.replace(tokens[0], replace);
+				}
+			}
+		});
+	}
+    return text;
+}
+
+function markdownToHTML (text) {
+	return convertLinks(common.markdownToHTML(text));
+}
+
+function exportPlatforms (api) {
+	var rv = '';
+	for (var key in api.since) {
+		rv += ' * @platform ' + key + ' ' + api.since[key] + '\n';
+	}
+	return rv;
+}
+
+function exportSummary (api) {
+	if ('summary' in api) {
+		return ' * ' + markdownToHTML(api.summary) + '\n';
+	}
+	return '';
+}
+
+function exportDescription (api) {
+	if ('description' in api) {
+		return ' * @description ' + markdownToHTML(api.description) + '\n';
+	}
+	return '';
+}
+
+function exportType (api) {
+	var rv = [];
+	if ('type' in api) {
+		var types = api.type;
+		if (!Array.isArray(api.type)) types = [api.type];
+		types.forEach(function (type) {
+			if (type.indexOf('Array') == 0) {
+				rv.push(type.slice(type.indexOf('<') + 1, type.indexOf('>')) + '[]');
+			} else {
+				rv.push(type);
+			}
+		});
+	}
+	if (rv.length > 0) {
+		return ' * @type ' + rv.join('/') + '\n';
+	} else {
+		return '';
+	}
+}
+
+function exportParams (apis) {
+	var rv = '';
+	apis.forEach(function (member) {
+		var platforms = '',
+			optional = '';
+		if (!'type' in member || !member.type) member.type = 'String';
+		if (!Array.isArray(member.type)) member.type = [member.type];
+		if ('platforms' in member) platforms = ' (' + member.platforms.join(' ') + ') ';
+		if ('optional' in member && member.optional == true) optional += ' (optional)';
+		rv += ' * @param {' +  member.type.join('/') + '} ' + platforms + member.name + optional + '\n';
+		rv += exportSummary(member);
+		rv += exportConstants(member);
+	});
+	return rv;
+}
+
+function exportReturns (api) {
+	var returns = api.returns,
+		types = [],
+		summary = '',
+		constants = [],
+		rv = ' * @return void';
+
+	if ('returns' in api && api.returns) {
+		if (!Array.isArray(api.returns)) api.returns = [api.returns];
+		api.returns.forEach(function (ret) {
+			if (Array.isArray(ret.type)) ret.type = ret.type.join('/');
+			types.push(ret.type || 'void');
+
+			if ('summary' in ret) summary += ret.summary;
+			if ('constants' in ret) constants = constants.concat(ret.constants);
+		});
+		if (constants.length) {
+			summary += exportConstants({'constants': constants});
+		}
+		rv = ' * @returns {' + types.join('/') + '}' + summary + '\n';
+	}
+	return rv;
+
+}
+
+
+function exportExamples (api) {
+	var rv = '';
+	if ('examples' in api && api.examples.length > 0) {
+		rv += ' * <h3>Examples</h3>\n'
+		api.examples.forEach(function (example) {
+			if (example.title) rv += ' * <h4>'+ example.title + '</h4>\n';
+			rv += markdownToHTML(example.example) + '\n';
+		});
+	}
+	return rv.replace('/*', '&#47;&#42;').replace('*/', '&#42;&#47;');
+}
+
+function exportOSVer (api) {
+	var rv = '';
+	if ('osver' in api) {
+		rv += "<p> <b>Requires:</b> \n";
+		for (var key in api.osver) {
+			if (Array.isArray(api.osver[key])) {
+				rv += '<li> ' + common.PRETTY_PLATFORM[key] + ' ' + api.osver[key].join(', ') + ' \n';
+			} else {
+				if ('min' in api.osver[key]) rv += common.PRETTY_PLATFORM[key] + ' ' + api.osver[key].min + ' and later \n';
+				if ('max' in api.osver[key]) rv += common.PRETTY_PLATFORM[key] + ' ' + api.osver[key].max + ' and earlier \n';
+			}
+		}
+		rv += "</p>\n";
+	}
+	return rv;
+}
+
+function exportConstants (api) {
+	var rv = '';
+	if ('constants' in api && api.constants && api.constants.length) {
+		rv = "\n<p>This API can be assigned the following constants:<ul>\n"
+		api.constants.forEach(function (constant) {
+			rv += ' <li> {@link ' + convertAPIToLink(constant) + '}\n';
+		});
+		rv += '</ul></p>\n';
+	}
+	return rv;
+}
+
+function exportValue (api) {
+	if ('value' in api) {
+		return '<p><b>Constant value:</b>' + api.value + '</p>\n';
+	}
+	return '';
+}
+
+function exportDeprecated (api) {
+	var rv = '';
+	if ('deprecated' in api && api.deprecated) {
+		if ('removed' in api.deprecated) {
+			rv += ' * @removed ' + api.deprecated.removed;
+		} else {
+			rv += ' * @deprecated ' + api.deprecated.since;
+		}
+		if ('notes' in api.deprecated) rv+= ' ' + api.deprecated.notes;
+		rv += '\n'
+	}
+	return rv;
+}
+
+function exportAPIs (apis, type, versions) {
+	var rv = '',
+		singular = {'events': 'event', 'methods': 'method', 'properties': 'property'};
+	if (type in apis) {
+
+		apis[type].forEach(function (api) {
+
+			if ('__hide' in api && api.__hide) {
+				rv += '/**\n';
+				rv += ' * @' + singular[type] + ' ' + api.name + '\n';
+				rv += ' * @hide\n'
+				rv += ' */\n';
+				return;
+			}
+
+			if ('__inherits' in api && api.__inherits != apis.name) return;
+
+			rv += '/**\n';
+			if ('default' in api) {
+				rv += ' * @' + singular[type] + ' [' + api.name + '=' + api.default +']\n';
+			} else {
+				rv += ' * @' + singular[type] + ' ' + api.name + '\n';
+			}
+
+			rv += exportType(api);
+			if ('permission' in api) {
+				if (api.permission === 'read-only') rv += ' * @readonly\n';
+				if (api.permission === 'write-only') rv += ' * @writeonly\n';
+			}
+			if ('availability' in api) {
+				if (api.availability === 'creation-only') rv += ' * @creationOnly\n';
+			}
+			rv += exportSummary(api);
+			rv += exportDeprecated(api);
+			rv += exportOSVer(api);
+			rv += exportValue(api);
+			rv += exportDescription(api);
+			rv += exportConstants(api);
+			rv += exportExamples(api);
+
+			if ('properties' in api) {
+				rv += exportParams(api.properties);
+			}
+
+			if ('parameters' in api) {
+				rv += exportParams(api.parameters);
+			}
+
+			if ('returns' in api) {
+				rv += exportReturns(api);
+			}
+
+			if (JSON.stringify(versions) != JSON.stringify(api.since)) {
+				rv += exportPlatforms(api);
+			}
+			rv += ' */\n\n';
+		});
+	}
+	return rv;
+}
+
+exports.exportData = function exportJsDuck (apis) {
+	var exportData = '';
+	doc = apis;
+	for (var key in apis) {
+		var api = apis[key];
+
+		exportData += '/**\n';
+		exportData += ' * @class ' + api.name + '\n';
+		exportData += exportPlatforms(api);
+		if (api.subtype === 'pseudo') exportData += ' * @pseudo\n';
+		if ('extends' in api) exportData += ' * @extends ' + api.extends + '\n';
+		exportData += exportSummary(api);
+		exportData += exportDeprecated(api);
+		exportData += exportOSVer(api);
+		exportData += exportDescription(api);
+		exportData += exportExamples(api);
+		exportData += ' */\n\n';
+
+		exportData += exportAPIs(api, "properties", api.since);
+		exportData += exportAPIs(api, "methods", api.since);
+		exportData += exportAPIs(api, "events", api.since);
+	}
+	return exportData;
+}

--- a/apidoc/package.json
+++ b/apidoc/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "doctools",
+    "version": "0.0.0",
+	"description": "documentation tools",
+	"dependencies": {
+		"colors": "~0.6.2",
+		"ejs": "~1.0.0",
+		"js-yaml": "~3.2.2",
+		"node-appc": "~0.2.14",
+		"pagedown": "~1.1.0"
+	}
+}

--- a/apidoc/templates/jsduck.ejs
+++ b/apidoc/templates/jsduck.ejs
@@ -1,0 +1,70 @@
+<% doc.forEach(function (cls) { %>
+/**
+ * @class <%- cls.name %>
+<% for (platform in cls.since) { %>
+ * @platform <%- platform %> <%- cls.since[platform] %> <% } %>
+<% if (cls.subtype == 'pseudo') { %> * @pseudo <% } %>
+<% if ('extends' in cls) { %> * @extends <%- cls.extends %> <% } %> 
+ * <%- cls.summary %>
+<% if (cls.deprecated) { %> * <%- cls.deprecated %> <% } %>  
+<% if (cls.osver) { %> * <%- cls.osver %> <% } %> 
+<% if (cls.description) { %> * @description <%- cls.description %> <% } %>
+<% if (cls.examples) { %> * <%- cls.examples %> <% } %>
+ */
+
+<% cls.events.forEach(function (event) { %>
+/**
+ * @event <%- event.name %>
+<% if ('__hide' in event && event.__hide) { %> * @hide <% } %> 
+ * <%- event.summary %>
+<% if (event.deprecated) { %> * <%- event.deprecated %> <% } %>
+<% if (event.osver) { %> * <%- event.osver %> <% } %> 
+<% if (event.description) { %> * @description <%- event.description %> <% } %>
+<% if (event.examples) { %> * <%- event.examples %> <% } %>
+<% if (event.properties) { %> <% event.properties.forEach(function (param) { %>
+ * @param <%- param %> <% }); %> <% } %>
+<% for (platform in event.since) { %>
+ * @platform <%- platform %> <%- event.since[platform] %> <% } %>
+ */
+<% }); %>
+
+<% cls.methods.forEach(function (method) { %>
+/**
+ * @method <%- method.name %>
+<% if ('__hide' in method && method.__hide) { %> * @hide <% } %> 
+ * <%- method.summary %>
+<% if (method.deprecated) { %> * <%- method.deprecated %> <% } %>
+<% if (method.osver) { %> * <%- method.osver %> <% } %> 
+<% if (method.description) { %> * @description <%- method.description %> <% } %>
+<% if (method.examples) { %> * <%- method.examples %> <% } %>
+ <% if (method.parameters) { %> <% method.parameters.forEach(function (param) { %>
+ * @param <%- param %> <% }); %> <% } %>
+<% if (method.returns) { %>	* @returns <%- method.returns %> <% } %>
+<% for (platform in method.since) { %>
+ * @platform <%- platform %> <%- method.since[platform] %> <% } %>
+ */
+<% }); %>
+
+<% cls.properties.forEach(function (property) { %>
+/**
+ * @property <%- property.name %>
+<% if ('__hide' in property && property.__hide) { %> * @hide <% } %> 
+ * @type <%- property.type %>
+<% if ('permission' in property) { %>
+<% if (property.permission == 'read-only') { %> * @readonly <% } %>
+<% if (property.permission == 'write-only') { %> * @writeonly <% } %>
+<% } %>
+<% if ('availability' in property && property.availability == 'creation-only') { %> * @creationOnly	<% } %>		
+ * <%- property.summary %>
+<% if (property.deprecated) { %> * <%- property.deprecated %> <% } %>
+<% if (property.osver) { %> * <%- property.osver %> <% } %>
+<% if (property.value) { %> * <%- property.value %> <% } %> 		
+<% if (property.description) { %> * @description <%- property.description %> <% } %>
+<% if (property.constants) { %> * <%- property.constants %> <% } %>
+<% if (property.examples) { %> * <%- property.examples %> <% } %>		
+<% for (platform in property.since) { %>
+ * @platform <%- platform %> <%- property.since[platform] %> <% } %>
+ */
+<% }); %>
+
+<% }); %>


### PR DESCRIPTION
**Install prerequisites.**  From the apidoc folder, run `npm install .`

**Sanity check.**  Run `node docgen.js -f jsduck`.  Should produce `../dist/titanium.js`

**Test.**
Merge in locally https://github.com/appcelerator/doctools/pull/62
Run `bash deploy.sh -o alloy -o modules`.
Open `dist/titanium/3.0/index.html`.
Inspect the API docs.  Make sure everything renders correctly, check API members, make sure the filters still work, etc.

Known issues.  API linking is broken for a few of the APIs as seen in the "Cannot find API" warnings.
