### PR TITLE
[TIMOB-17826](3_4_X) iOS: Disabling analytics in tiapp.xml leads to iads crash on device

### DIFF
--- a/iphone/Classes/TiUIiOSAdView.m
+++ b/iphone/Classes/TiUIiOSAdView.m
@@ -11,7 +11,7 @@
 
 #ifdef USE_TI_UIIOSADVIEW
 
-extern NSString * const TI_APPLICATION_ANALYTICS;
+extern BOOL const TI_APPLICATION_ANALYTICS;
 
 @implementation TiUIiOSAdView
 


### PR DESCRIPTION
Fixed bug where TI_APPLICATION_ANALYTICS is supposed to be BOOL and not NSString
