### PR TITLE
[TIMOB-17874] [TIMOB-17813] [TIMOB-17281] Added support for Android L.

### DIFF
--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -1165,7 +1165,7 @@ AndroidBuilder.prototype.validate = function validate(logger, config, cli) {
 
 		for (; i >= 0; i--) {
 			if (targetSDKMap[levels[i]].sdk >= this.minSupportedApiLevel && targetSDKMap[levels[i]].sdk <= this.maxSupportedApiLevel) {
-				this.targetSDK = levels[i];
+				this.targetSDK = targetSDKMap[levels[i]].sdk;
 				break;
 			}
 		}

--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -1089,13 +1089,14 @@ AndroidBuilder.prototype.validate = function validate(logger, config, cli) {
 	}
 
 	if (usesSDK) {
-		usesSDK['minSdkVersion'] && (this.minSDK = ~~usesSDK['minSdkVersion']);
-		usesSDK['targetSdkVersion'] && (this.targetSDK = ~~usesSDK['targetSdkVersion']);
-		usesSDK['maxSdkVersion'] && (this.maxSDK = ~~usesSDK['maxSdkVersion']);
+		usesSDK['minSdkVersion'] && (this.minSDK = usesSDK['minSdkVersion']);
+		usesSDK['targetSdkVersion'] && (this.targetSDK = usesSDK['targetSdkVersion']);
+		usesSDK['maxSdkVersion'] && (this.maxSDK = usesSDK['maxSdkVersion']);
 	}
 
 	// min sdk is too old
-	if (this.minSDK < this.minSupportedApiLevel) {
+	var minApiLevel = targetSDKMap[this.minSDK].sdk;
+	if (minApiLevel < this.minSupportedApiLevel) {
 		logger.error(__('The minimum supported SDK version must be %s or newer, but is currently set to %s', this.minSupportedApiLevel, this.minSDK) + '\n');
 		logger.log(
 			appc.string.wrap(
@@ -1145,7 +1146,7 @@ AndroidBuilder.prototype.validate = function validate(logger, config, cli) {
 	}
 
 	// target sdk < min sdk
-	if (this.targetSDK && this.targetSDK < this.minSDK) {
+	if (this.targetSDK && this.targetSDK < minApiLevel) {
 		logger.error(__('The target SDK must be greater than or equal to the minimum SDK %s, but is currently set to %s', this.minSDK, this.targetSDK) + '\n');
 		process.exit(1);
 	}
@@ -1222,7 +1223,8 @@ AndroidBuilder.prototype.validate = function validate(logger, config, cli) {
 		process.exit(1);
 	}
 
-	if (this.maxSDK && this.maxSDK < this.targetSDK) {
+	var maxApiLevel = targetSDKMap[this.maxSDK].sdk;
+	if (this.maxSDK && maxApiLevel < this.targetSDK) {
 		logger.error(__('Maximum Android SDK version must be greater than or equal to the target SDK %s, but is currently set to %s', this.targetSDK, this.maxSDK) + '\n');
 		process.exit(1);
 	}

--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -4,7 +4,7 @@
  * @module cli/_build
  *
  * @copyright
- * Copyright (c) 2009-2013 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2009-2014 by Appcelerator, Inc. All Rights Reserved.
  *
  * Copyright (c) 2012-2013 Chris Talkington, contributors.
  * {@link https://github.com/ctalkington/node-archiver}
@@ -267,6 +267,7 @@ AndroidBuilder.prototype.config = function config(logger, config, cli) {
 								return {
 									name: emu.name,
 									id: emu.name,
+									api: emu['api-level'],
 									version: emu['sdk-version'],
 									abi: emu.abi,
 									type: emu.type,
@@ -277,6 +278,7 @@ AndroidBuilder.prototype.config = function config(logger, config, cli) {
 								return {
 									name: emu.name,
 									id: emu.name,
+									api: emu['api-level'],
 									version: emu['sdk-version'],
 									abi: emu.abi,
 									type: emu.type,
@@ -605,8 +607,8 @@ AndroidBuilder.prototype.config = function config(logger, config, cli) {
 									// we set the device-id to an array of devices so that later in validate()
 									// after the tiapp.xml has been parsed, we can auto select the best device
 									_t.devicesToAutoSelectFrom = results.sort(function (a, b) {
-										var eq = appc.version.eq(a.version, b.version),
-											gt = appc.version.gt(a.version, b.version);
+										var eq = a.api && b.api && appc.version.eq(a.api, b.api),
+											gt = a.api && b.api && appc.version.gt(a.api, b.api);
 
 										if (eq) {
 											if (a.type == b.type) {
@@ -1043,10 +1045,10 @@ AndroidBuilder.prototype.validate = function validate(logger, config, cli) {
 
 	// map sdk versions to sdk targets instead of by id
 	var targetSDKMap = {};
-	Object.keys(this.androidInfo.targets).forEach(function (id) {
-		var t = this.androidInfo.targets[id];
+	Object.keys(this.androidInfo.targets).forEach(function (i) {
+		var t = this.androidInfo.targets[i];
 		if (t.type == 'platform') {
-			targetSDKMap[~~t.id.replace('android-', '')] = t;
+			targetSDKMap[t.id.replace('android-', '')] = t;
 		}
 	}, this);
 
@@ -1150,11 +1152,18 @@ AndroidBuilder.prototype.validate = function validate(logger, config, cli) {
 
 	// if no target sdk, then default to most recent supported/installed
 	if (!this.targetSDK) {
-		var levels = Object.keys(targetSDKMap).sort(),
+		var levels = Object.keys(targetSDKMap).sort(function (a, b) {
+				if (a.sdk === b.sdk && a.revision === b.revision) {
+					return 0;
+				} else if (a.sdk < b.sdk || (a.sdk === b.sdk && a.revision < b.revision)) {
+					return -1;
+				}
+				return 1;
+			}),
 			i = levels.length - 1;
 
 		for (; i >= 0; i--) {
-			if (levels[i] >= this.minSupportedApiLevel && levels[i] <= this.maxSupportedApiLevel) {
+			if (targetSDKMap[levels[i]].sdk >= this.minSupportedApiLevel && targetSDKMap[levels[i]].sdk <= this.maxSupportedApiLevel) {
 				this.targetSDK = levels[i];
 				break;
 			}
@@ -1244,11 +1253,12 @@ AndroidBuilder.prototype.validate = function validate(logger, config, cli) {
 
 	if (!cli.argv['build-only'] && /^device|emulator$/.test(this.target) && deviceId === undefined && config.get('android.autoSelectDevice', true)) {
 		// no --device-id, so intelligently auto select one
-
 		var ver = targetSDKMap[this.targetSDK].version,
+			apiLevel = targetSDKMap[this.targetSDK].sdk,
 			devices = this.devicesToAutoSelectFrom,
 			i,
-			len = devices.length;
+			len = devices.length,
+			verRegExp = /^((\d\.)?\d\.)?\d$/;
 
 		// reset the device id
 		deviceId = null;
@@ -1270,16 +1280,24 @@ AndroidBuilder.prototype.validate = function validate(logger, config, cli) {
 			}
 
 			if (cli.argv.target == 'device') {
-				logger.info(__('Auto selected device %s %s', devices[i].name.cyan, devices[i].version) + gapi);
+				logger.info(__('Auto selected device %s %s', device.name.cyan, device.version) + gapi);
 			} else {
-				logger.info(__('Auto selected emulator %s %s', devices[i].name.cyan, devices[i].version) + gapi);
+				logger.info(__('Auto selected emulator %s %s', device.name.cyan, device.version) + gapi);
 			}
+		}
+
+		function gte(device) {
+			return device.api >= apiLevel && (!verRegExp.test(device.version) || appc.version.gte(device.version, ver));
+		}
+
+		function lt(device) {
+			return device.api < apiLevel && (!verRegExp.test(device.version) || appc.version.lt(device.version, ver));
 		}
 
 		// find the first one where version is >= and google apis == true
 		logger.debug(__('Searching for version >= %s and has Google APIs', ver));
 		for (i = 0; i < len; i++) {
-			if (appc.version.gte(devices[i].version, ver) && devices[i].googleApis) {
+			if (gte(devices[i]) && devices[i].googleApis) {
 				setDeviceId(devices[i]);
 				break;
 			}
@@ -1289,7 +1307,7 @@ AndroidBuilder.prototype.validate = function validate(logger, config, cli) {
 			// find first one where version is >= and google apis is a maybe
 			logger.debug(__('Searching for version >= %s and may have Google APIs', ver));
 			for (i = 0; i < len; i++) {
-				if (appc.version.gte(devices[i].version, ver) && devices[i].googleApis === null) {
+				if (gte(devices[i]) && devices[i].googleApis === null) {
 					setDeviceId(devices[i]);
 					break;
 				}
@@ -1299,7 +1317,7 @@ AndroidBuilder.prototype.validate = function validate(logger, config, cli) {
 				// find first one where version is >= and no google apis
 				logger.debug(__('Searching for version >= %s and no Google APIs', ver));
 				for (i = 0; i < len; i++) {
-					if (appc.version.gte(devices[i].version, ver)) {
+					if (gte(devices[i])) {
 						setDeviceId(devices[i]);
 						break;
 					}
@@ -1309,7 +1327,7 @@ AndroidBuilder.prototype.validate = function validate(logger, config, cli) {
 					// find first one where version < and google apis == true
 					logger.debug(__('Searching for version < %s and has Google APIs', ver));
 					for (i = len - 1; i >= 0; i--) {
-						if (appc.version.lt(devices[i].version, ver)) {
+						if (lt(devices[i])) {
 							setDeviceId(devices[i]);
 							break;
 						}
@@ -1319,7 +1337,7 @@ AndroidBuilder.prototype.validate = function validate(logger, config, cli) {
 						// find first one where version <
 						logger.debug(__('Searching for version < %s and no Google APIs', ver));
 						for (i = len - 1; i >= 0; i--) {
-							if (appc.version.lt(devices[i].version, ver) && devices[i].googleApis) {
+							if (lt(devices[i]) && devices[i].googleApis) {
 								setDeviceId(devices[i]);
 								break;
 							}

--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -1095,8 +1095,8 @@ AndroidBuilder.prototype.validate = function validate(logger, config, cli) {
 	}
 
 	// min sdk is too old
-	var minApiLevel = targetSDKMap[this.minSDK].sdk;
-	if (minApiLevel < this.minSupportedApiLevel) {
+	var minApiLevel = targetSDKMap[this.minSDK] && targetSDKMap[this.minSDK].sdk;
+	if (minApiLevel && minApiLevel < this.minSupportedApiLevel) {
 		logger.error(__('The minimum supported SDK version must be %s or newer, but is currently set to %s', this.minSupportedApiLevel, this.minSDK) + '\n');
 		logger.log(
 			appc.string.wrap(
@@ -1223,8 +1223,8 @@ AndroidBuilder.prototype.validate = function validate(logger, config, cli) {
 		process.exit(1);
 	}
 
-	var maxApiLevel = targetSDKMap[this.maxSDK].sdk;
-	if (this.maxSDK && maxApiLevel < this.targetSDK) {
+	var maxApiLevel = this.maxSDK && targetSDKMap[this.maxSDK] && targetSDKMap[this.maxSDK].sdk;
+	if (maxApiLevel && maxApiLevel < this.targetSDK) {
 		logger.error(__('Maximum Android SDK version must be greater than or equal to the target SDK %s, but is currently set to %s', this.targetSDK, this.maxSDK) + '\n');
 		process.exit(1);
 	}

--- a/android/package.json
+++ b/android/package.json
@@ -20,9 +20,9 @@
 	],
 	"minSDKVersion": "10",
 	"vendorDependencies": {
-		"android sdk": ">=14 <=20",
-		"android build tools": ">=17 <20.x",
-		"android platform tools": ">=17 <=20.x",
+		"android sdk": ">=14 <=21",
+		"android build tools": ">=17 <21.x",
+		"android platform tools": ">=17 <=21.x",
 		"android tools": "<=23.x",
 		"android ndk": ">=r8e <=r9",
 		"node": ">0.8.0 <=0.10.x",

--- a/node_modules/titanium-sdk/lib/adb.js
+++ b/node_modules/titanium-sdk/lib/adb.js
@@ -452,7 +452,7 @@ ADB.prototype.startServer = function startServer(callback) {
 	androidDetect(this.config, function (err, results) {
 		if (err) return callback(err);
 		appc.subprocess.run(results.sdk.executables.adb, 'start-server', function (code, out, err) {
-			callback(code);
+			callback(code ? new Error(__('Failed to start ADB (code %s): %s', code, err)) : null);
 		});
 	});
 };

--- a/node_modules/titanium-sdk/lib/android.js
+++ b/node_modules/titanium-sdk/lib/android.js
@@ -4,7 +4,7 @@
  * @module lib/android
  *
  * @copyright
- * Copyright (c) 2009-2013 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2009-2014 by Appcelerator, Inc. All Rights Reserved.
  *
  * @license
  * Licensed under the terms of the Apache Public License
@@ -518,7 +518,8 @@ exports.detect = function detect(config, opts, finished) {
 				});
 
 				// process the targets
-				var sdkLookup = {},
+				var apiLevelMap = {},
+					sdkMap = {},
 
 					targets = sections['Available Android targets:'],
 					avds = sections['Available Android Virtual Devices:'],
@@ -564,7 +565,7 @@ exports.detect = function detect(config, opts, finished) {
 							} else if (m = line.match(basedOnRegex)) {
 								info['based-on'] = {
 									'android-version': m[1],
-									'api-level': m[2]
+									'api-level': ~~m[2]
 								};
 							} else {
 								// simple key-value
@@ -596,20 +597,31 @@ exports.detect = function detect(config, opts, finished) {
 											info[key] = value.toLowerCase();
 											break;
 										default:
-											info[key] = value;
+											var num = Number(value);
+											if (value.indexOf('.') === -1 && !isNaN(num) && typeof num === 'number') {
+												info[key] = Number(value);
+											} else {
+												info[key] = value;
+											}
 									}
 								}
 							}
 						}
 
 						if (info.type == 'platform') {
+							var srcPropsFile = path.join(results.sdk.path, 'platforms', info.id, 'source.properties'),
+								srcProps = fs.existsSync(srcPropsFile) ? fs.readFileSync(srcPropsFile).toString() : '';
+
 							info.path = path.join(results.sdk.path, 'platforms', info.id);
-							info.version = (m = info.name.match(/Android (((\d\.)?\d\.)?\d)/)) && m[1];
+							info.sdk = (function (m) { return m ? ~~m[1] : null; })(srcProps.match(/^AndroidVersion.ApiLevel=(.*)$/m));
+							info.version = (function (m) { if (m) return m[1]; m = info.name.match(/Android (((\d\.)?\d\.)?\d)/); return m ? m[1] : null; })(srcProps.match(/^Platform.Version=(.*)$/m));
 							info.androidJar = path.join(info.path, 'android.jar');
 							info.supported = !~~info['api-level'] || appc.version.satisfies(info['api-level'], androidPackageJson.vendorDependencies['android sdk'], true);
 							info.aidl = path.join(info.path, 'framework.aidl');
 							fs.existsSync(info.aidl) || (info.aidl = null);
-							sdkLookup[info['api-level'] || info.id.replace('android-', '')] = info;
+
+							apiLevelMap[info['api-level'] || info.id.replace('android-', '')] = info;
+							sdkMap[info.version] = info;
 						} else if (info.type == 'add-on' && info['based-on']) {
 							info.path = addons[info.name + '|' + info.vendor + '|' + info['based-on']['api-level'] + '|' + info.revision] || null;
 							info.version = info['based-on']['android-version'];
@@ -637,9 +649,9 @@ exports.detect = function detect(config, opts, finished) {
 					// try to find aidl files the add-ons
 					Object.keys(results.targets).forEach(function (id) {
 						var basedOn = results.targets[id]['based-on'];
-						if (results.targets[id].type == 'add-on' && basedOn && sdkLookup[basedOn['api-level']]) {
-							results.targets[id].androidJar = sdkLookup[basedOn['api-level']].androidJar;
-							results.targets[id].aidl = sdkLookup[basedOn['api-level']].aidl;
+						if (results.targets[id].type == 'add-on' && basedOn && apiLevelMap[basedOn['api-level']]) {
+							results.targets[id].androidJar = apiLevelMap[basedOn['api-level']].androidJar;
+							results.targets[id].aidl = apiLevelMap[basedOn['api-level']].aidl;
 						}
 					});
 				});
@@ -685,7 +697,7 @@ exports.detect = function detect(config, opts, finished) {
 							} else if (m = line.match(basedOnRegex)) {
 								info['based-on'] = {
 									'android-version': m[1],
-									'api-level': m[2]
+									'api-level': ~~m[2]
 								};
 							}
 						}
@@ -700,7 +712,7 @@ exports.detect = function detect(config, opts, finished) {
 						if (info['based-on'] && info['based-on']['android-version']) {
 							info['sdk-version'] = info['based-on']['android-version'];
 						} else if (info.target) {
-							if (m = info.target.match(/Android (((\d\.)?\d\.)?\d+) \(/)) {
+							if (m = info.target.match(/^Android ([^\s]+)/)) {
 								info['sdk-version'] = m[1];
 							}
 						}

--- a/node_modules/titanium-sdk/lib/emulator.js
+++ b/node_modules/titanium-sdk/lib/emulator.js
@@ -5,14 +5,15 @@
  * @module lib/emulator
  *
  * @copyright
- * Copyright (c) 2009-2013 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2009-2014 by Appcelerator, Inc. All Rights Reserved.
  *
  * @license
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
 
-var appc = require('node-appc'),
+var android = require('./android'),
+	appc = require('node-appc'),
 	__ = appc.i18n(__dirname).__,
 	ADB = require('./adb'),
 	async = require('async'),
@@ -76,16 +77,32 @@ EmulatorManager.prototype.detect = function detect(opts, callback) {
 		};
 	}), function (err, results) {
 		if (err) {
-			callback(err);
-		} else {
-			var emus = [];
-			results.forEach(function (r) {
-				r && Array.isArray(r.avds) && (emus = emus.concat(r.avds));
+			return callback(err);
+		}
+
+		android.detect(this.config, opts, function (androidEnv) {
+			var ver2api = {},
+				emus = [];
+
+			Object.keys(androidEnv.targets).forEach(function (id) {
+				if (androidEnv.targets[id].type === 'platform') {
+					ver2api[androidEnv.targets[id].version] = androidEnv.targets[id].sdk;
+				}
 			});
+
+			results.forEach(function (r) {
+				if (r && Array.isArray(r.avds)) {
+					r.avds.forEach(function (avd) {
+						avd['api-level'] = ver2api[avd['sdk-version']] || null;
+						emus.push(avd);
+					});
+				}
+			});
+
 			opts.logger && opts.logger.trace(__('Found %s emulators', String(emus.length).cyan));
 			callback(null, emus);
-		}
-	});
+		});
+	}.bind(this));
 };
 
 /**

--- a/node_modules/titanium-sdk/lib/emulators/genymotion.js
+++ b/node_modules/titanium-sdk/lib/emulators/genymotion.js
@@ -5,7 +5,7 @@
  * @module lib/emulators/genymotion
  *
  * @copyright
- * Copyright (c) 2009-2013 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2009-2014 by Appcelerator, Inc. All Rights Reserved.
  *
  * @license
  * Licensed under the terms of the Apache Public License
@@ -311,7 +311,8 @@ function getVMInfo(config, vboxmanage, callback) {
 					guid: m[2],
 					type: 'genymotion',
 					abi: 'x86',
-					googleApis: null // null means maybe since we don't know for sure unless the emulator is running
+					googleApis: null, // null means maybe since we don't know for sure unless the emulator is running
+					'sdk-version': null
 				};
 
 				appc.subprocess.run(vboxmanage, ['guestproperty', 'enumerate', emu.guid], function (code, out, err) {


### PR DESCRIPTION
**CLI: fails to build to device with Android 5.0**
https://jira.appcelerator.org/browse/TIMOB-17281
- Added support for Android L.
- Fixed handling of min and max SDK versions in the android manifest.
- Fixed small bug with min/max sdk versions.

**Android: App fails to install for any Android version other than 5.0 with 3.4.1.v20141001062512**
https://jira.appcelerator.org/browse/TIMOB-17813
- Fixed bug where the targetSDK must be an integer (i.e. 20) and not the Android Target name (i.e. L).

**Android 5.0: Improve CLI support**
https://jira.appcelerator.org/browse/TIMOB-17874
- Properly convert all Android SDK versions from codenames to the real versions. Fixed sorting of Android SDKs so that the correct latest target SDK can be selected if not manually set. Bumped Android SDK, build & platform tools versions to the latest.
