### PR TITLE
[TIDOC-1954] Fix Alloy elements not appearing in docs

### DIFF
--- a/apidoc/generators/jsduck_generator.py
+++ b/apidoc/generators/jsduck_generator.py
@@ -31,7 +31,7 @@ FOUR_SPACES='  ' + '  '
 # compiling REs ahead of time, since we use them heavily.
 link_parts_re = re.compile(r"(?:\[([^\]]+?)\]\(([^\)\s]+?)\)|\<([^\s]+)\>)", re.MULTILINE)
 # To add Alloy tags in the description, use backticks around the tag (`<Button>`, e.g.).
-find_links_re = re.compile(r"(\[[^\]]+?\]\([^\)\s]+?\)|(?!`)\<[^\s]+\>(?!`))", re.MULTILINE)
+find_links_re = re.compile(r"(\[[^\]]+?\]\([^\)\s]+?\)|(?!`)\<[^\s]+\>(?!`)|(?!**`)\<[^\s]+\>(?!`**))", re.MULTILINE)
 html_scheme_re = re.compile(r"^http:|^https:")
 doc_site_url_re = re.compile(r"http://docs.appcelerator.com/titanium/.*(#!.*)")
 # we use this to distinguish inline HTML tags from Markdown links. Not foolproof, and a


### PR DESCRIPTION
To test, patch the`doctools/deploy.sh` script to use the python script, then run the deploy script.

Change line 167 from:

```
node ${TI_DOCS}/docgen.js -f jsduck -o ./build ${TI_DOCS} $module_dirs
```

to:

```
python ${TI_DOCS}/docgen.py -f jsduck -o ./build ${TI_DOCS} $module_dirs
```
