### PR TITLE
[Timob-17686] iOS8: 'rsync failed' and unable to submit apps with Xcode 6 if including DSYM file

### DIFF
--- a/iphone/cli/hooks/package.js
+++ b/iphone/cli/hooks/package.js
@@ -39,7 +39,7 @@ exports.init = function (logger, config, cli) {
 							name + '_' + (hours >= 10 ? hours : '0' + hours) + '-' + (minutes >= 10 ? minutes : '0' + minutes) + '-' +
 							(seconds >= 10 ? seconds : '0' + seconds) + '.xcarchive'),
 						archiveApp = path.join(archiveBundle, 'Products', 'Applications', name + '.app'),
-						archiveDsym = path.join(archiveBundle, 'dSYM');
+						archiveDsym = path.join(archiveBundle, 'dSYMs', name + '.app.dSYM');
 
 					wrench.mkdirSyncRecursive(archiveApp);
 					wrench.mkdirSyncRecursive(archiveDsym);


### PR DESCRIPTION
Since Xcode 6, Apple has changed the folder name in a xarchive to dSYMs.
Made changes accordingly so that apps can be submitted with app symbols.
