### PR TITLE
[TIDOC-1901] Ignore node_modules folder

### DIFF
--- a/apidoc/lib/common.js
+++ b/apidoc/lib/common.js
@@ -8,7 +8,7 @@ var yaml = require('js-yaml'),
 	nodeappc = require('node-appc'),
 	pagedown = require('pagedown'),
 	converter = new pagedown.Converter(),
-	ignoreList = ['node_modules'];
+	ignoreList = ['node_modules', '.travis.yml'];
 
 exports.VALID_PLATFORMS = ['android', 'blackberry', 'iphone', 'ipad', 'mobileweb', 'tizen'];
 exports.VALID_OSES = ['android', 'blackberry', 'ios', 'mobileweb', 'tizen'];

--- a/apidoc/lib/common.js
+++ b/apidoc/lib/common.js
@@ -7,7 +7,8 @@ var yaml = require('js-yaml'),
 	fs = require('fs'),
 	nodeappc = require('node-appc'),
 	pagedown = require('pagedown'),
-	converter = new pagedown.Converter();
+	converter = new pagedown.Converter(),
+	ignoreList = ['node_modules'];
 
 exports.VALID_PLATFORMS = ['android', 'blackberry', 'iphone', 'ipad', 'mobileweb', 'tizen'];
 exports.VALID_OSES = ['android', 'blackberry', 'ios', 'mobileweb', 'tizen'];
@@ -78,6 +79,9 @@ exports.parseYAML = function parseYAML(path) {
 			var elem = path + '/' + fsElement,
 				stat = fs.statSync(elem);
 			currentFile = elem;
+
+			if (~ignoreList.indexOf(fsElement)) return;
+
 			if (stat.isDirectory()) {
 				nodeappc.util.mixObj(rv, parseYAML(elem));
 			}


### PR DESCRIPTION
Before merging, run the validate script: `node validate.js`

Notice that there are YAML parsing errors in files located in the node_modules folder.

Merge PR and rerun validate script.  The errors should disappear.
