### PR TITLE
[TIDOC-1974] Fix warnings reported by JSDuck

### DIFF
--- a/apidoc/Titanium/Android/Android.yml
+++ b/apidoc/Titanium/Android/Android.yml
@@ -20,12 +20,8 @@ description: |
 extends: Titanium.Module
 platforms: [android]
 since: "1.5"
-excludes:
-    methods: [getCurrentActivity, getCurrentService]
 
 methods:
-    
-
 
   - name: createIntentChooser
     summary: |
@@ -1534,6 +1530,7 @@ properties:
   - name: currentActivity
     summary: Activity of the active context.
     type: Titanium.Android.Activity
+    accessor: false
     permission: read-only
     deprecated:
         since: 3.5.0
@@ -1542,6 +1539,7 @@ properties:
   - name: currentService
     summary: Service in the active context.
     type: Titanium.Android.Service
+    accessor: false
     permission: read-only
 
 ---

--- a/apidoc/Titanium/App/iOS/UserNotificationAction.yml
+++ b/apidoc/Titanium/App/iOS/UserNotificationAction.yml
@@ -10,8 +10,7 @@ extends: Titanium.Proxy
 since: "3.4.0"
 platforms: [iphone, ipad]
 excludes:
-    methods: [addEventListener, applyProperties, fireEvent, removeEventListener,
-              getActivationMode, getAuthenticationRequired, getDestructive, getIdentifier, getTitle]
+    methods: [addEventListener, applyProperties, fireEvent, removeEventListener]
     properties: [bubbleParent]
 
 properties:
@@ -31,6 +30,7 @@ properties:
   - name: authenticationRequired
     summary: Set to true if the action requires the device to be unlocked.
     type: Boolean
+    accessor: false
     availability: creation
 
   - name: destructive
@@ -39,15 +39,18 @@ properties:
         The action appears red in the locked screen and notification center instead of the
         default color.
     type: Boolean
+    accessor: false
     availability: creation
 
   - name: identifier
     summary: Identifier for this action. Used to identify the action the user pressed.
     type: String
+    accessor: false
     availability: creation
 
   - name: title
     summary: Title of the button displayed in the notification.
     type: String
+    accessor: false
     availability: creation
 

--- a/apidoc/Titanium/App/iOS/UserNotificationCategory.yml
+++ b/apidoc/Titanium/App/iOS/UserNotificationCategory.yml
@@ -18,8 +18,7 @@ extends: Titanium.Proxy
 since: "3.4.0"
 platforms: [iphone, ipad]
 excludes:
-    methods: [addEventListener, applyProperties, fireEvent, removeEventListener,
-              getActionsForDefaultContext, getActionsForMinimalContext, getIdentifier]
+    methods: [addEventListener, applyProperties, fireEvent, removeEventListener]
     properties: [bubbleParent]
 
 properties:
@@ -30,6 +29,7 @@ properties:
         Note that only the first four actions can be displayed for an alert dialog and the first
         two actions can be displayed for all other notifications.
     type: Array<Titanium.App.iOS.UserNotificationAction>
+    accessor: false
     availability: creation
 
   - name: actionsForMinimalContext
@@ -37,6 +37,7 @@ properties:
     description: |
         If not specified, the first two actions from `actionsForDefaultContent` are displayed.
     type: Array<Titanium.App.iOS.UserNotificationAction>
+    accessor: false
     availability: creation
 
   - name: identifier
@@ -44,5 +45,6 @@ properties:
     description: |
         When scheduling a notification, pass this value to the `category` property.
     type: String
+    accessor: false
     availability: creation
 

--- a/apidoc/Titanium/Platform/DisplayCaps.yml
+++ b/apidoc/Titanium/Platform/DisplayCaps.yml
@@ -50,7 +50,8 @@ properties:
         display dpi. For example, a 240x320 screen will have a density of 1, whether its width is 
         1.8" or 1.3". However, if the resolution is increased to 320x480 but the display remains 
         1.5"x2" then the density would be increased to about 1.5.
-        On iOS devices, this property returns 1, 2 and 3 for @1x, @2x and @3x respectively. 
+
+        On iOS devices, this property returns 1, 2 and 3 for &#64;1x, &#64;2x and &#64;3x respectively.
         Note for iPhone 6+, this value is 3.
     type: Number
     permission: read-only

--- a/apidoc/Titanium/UI/AlertDialog.yml
+++ b/apidoc/Titanium/UI/AlertDialog.yml
@@ -56,9 +56,6 @@ description: |
 extends: Titanium.Proxy
 since: "0.8"
 
-excludes:
-    methods: [setAndroidView]
-
 events:
   - name: click
     summary: Fired when a button in the dialog is clicked.
@@ -136,6 +133,7 @@ properties:
 
     type: Titanium.UI.View
     platforms: [android]
+    accessor: false
     
   - name: buttonNames
     summary: Name of each button to create.

--- a/apidoc/docgen.js
+++ b/apidoc/docgen.js
@@ -429,6 +429,17 @@ function cliUsage () {
 	console.log('\t--stdout    \tOutput processed YAML to stdout.'.white);
 }
 
+// Create path if it does not exist
+function mkdirDashP(path) {
+	var p = path.substring(0, path.lastIndexOf('/'));
+	if(!fs.existsSync(p)) {
+		mkdirDashP(p)
+	}
+	if(!fs.existsSync(path)) {
+		fs.mkdirSync(path);
+	}
+}
+
 // Start of Main Flow
 // Get a list of valid formats
 apidocPath = process.argv[1].substring(0, process.argv[1].lastIndexOf('/'))
@@ -549,6 +560,7 @@ formats.forEach(function (format) {
 	exportData = exporter.exportData(processedData);
 	templatePath = apidocPath + '/templates/';
 	output = outputPath;
+	mkdirDashP(output);
 
 	console.log('Generating %s output...'.white, format.toUpperCase());
 

--- a/apidoc/docgen.js
+++ b/apidoc/docgen.js
@@ -433,7 +433,7 @@ function cliUsage () {
 function mkdirDashP(path) {
 	var p = path.substring(0, path.lastIndexOf('/'));
 	if(!fs.existsSync(p)) {
-		mkdirDashP(p)
+		mkdirDashP(p);
 	}
 	if(!fs.existsSync(path)) {
 		fs.mkdirSync(path);

--- a/apidoc/lib/jsduck_generator.js
+++ b/apidoc/lib/jsduck_generator.js
@@ -172,7 +172,7 @@ function exportType (api) {
 		if (!Array.isArray(api.type)) types = [api.type];
 		types.forEach(function (type) {
 			if (type.indexOf('Array') == 0) {
-				rv.push(type.slice(type.indexOf('<') + 1, type.indexOf('>')) + '[]');
+				rv.push(exportType({'type': type.slice(type.indexOf('<') + 1, type.lastIndexOf('>'))}) + '[]');
 			} else {
 				rv.push(type);
 			}
@@ -212,8 +212,11 @@ function exportReturns (api) {
 	if ('returns' in api && api.returns) {
 		if (!Array.isArray(api.returns)) api.returns = [api.returns];
 		api.returns.forEach(function (ret) {
-			if (Array.isArray(ret.type)) ret.type = ret.type.join('/');
-			types.push(ret.type || 'void');
+			if (Array.isArray(ret.type)) {
+				types = types.concat(ret.type);
+			} else {
+				types.push(ret.type || 'void');
+			}
 
 			if ('summary' in ret) summary += ret.summary;
 			if ('constants' in ret) constants = constants.concat(ret.constants);
@@ -221,7 +224,7 @@ function exportReturns (api) {
 		if (constants.length) {
 			summary += exportConstants({'constants': constants});
 		}
-		rv = '{' + types.join('/') + '}' + summary;
+		rv = '{' + exportType({'type': types}) + '}' + summary;
 	}
 	return rv;
 


### PR DESCRIPTION
Modify the deploy.sh script in doctools to use the JavaScript version of doctools.  Change line #167 from:
`python ${TI_DOCS}/docgen.py -f jsduck -o ./build $module_dirs`
to
`node ${TI_DOCS}/docgen.js -f jsduck -o ./build $module_dirs`

Run deploy.sh.  Should only see warnings for guide names as not valid JS identifiers and unclosed HTML tags.  You can add `-html` to the warnings key in the `jsduck.config` file to suppress unclosed HTML tags warning.
