### PR TITLE
[TIMOB-18029] iOS: Fix all optimization type errors detected by static analyzer

### DIFF
--- a/iphone/Classes/ListenerEntry.h
+++ b/iphone/Classes/ListenerEntry.h
@@ -12,7 +12,6 @@
 	id<TiEvaluator> context;
 	id listener;
 	TiProxy *proxy;
-	BOOL removed;
 	NSString *type;
 }
 @property(nonatomic,readwrite,retain) NSString *type;

--- a/iphone/Classes/TiMediaVideoPlayerProxy.h
+++ b/iphone/Classes/TiMediaVideoPlayerProxy.h
@@ -17,7 +17,6 @@
 	NSRecursiveLock* playerLock;
 	BOOL playing;
 @private
-	UIView * legacyWindowView;
 
 	NSURL *url;
 	TiColor* backgroundColor;

--- a/iphone/Classes/TiUILabel.h
+++ b/iphone/Classes/TiUILabel.h
@@ -14,7 +14,6 @@
     UIView* wrapperView;
     BOOL requiresLayout;
     CGRect padding;
-    CGRect textPadding;
     UIControlContentVerticalAlignment verticalAlign;
     CGRect initialLabelFrame;
     CGFloat minFontSize;

--- a/iphone/Classes/TiUIProgressBar.h
+++ b/iphone/Classes/TiUIProgressBar.h
@@ -16,7 +16,6 @@
 	CGFloat max;
 	CGFloat min;
 	
-	BOOL requiresLayout;
 	UILabel * messageLabel;
 }
 

--- a/iphone/Classes/TiUIScrollView.h
+++ b/iphone/Classes/TiUIScrollView.h
@@ -33,7 +33,6 @@
 	
 	BOOL needsHandleContentSize;
 	
-	id	lastFocusedView; //DOES NOT RETAIN.
 }
 
 @property(nonatomic,retain,readonly) TiUIScrollViewImpl * scrollView;

--- a/iphone/Classes/TiUITabProxy.h
+++ b/iphone/Classes/TiUITabProxy.h
@@ -21,8 +21,7 @@
 	TiUITabGroupProxy *tabGroup;
     
 	NSMutableArray* controllerStack;
-    
-	BOOL opening;
+	
 	BOOL systemTab;
 	BOOL transitionIsAnimating;
 	BOOL transitionWithGesture;

--- a/iphone/Classes/TiUITableView.h
+++ b/iphone/Classes/TiUITableView.h
@@ -67,10 +67,8 @@
 	BOOL filterAnchored;
 	BOOL filterCaseInsensitive;
 	BOOL allowsSelectionSet;
-	id	lastFocusedView; //DOES NOT RETAIN.	
 	UITableViewController *tableController;
 	UISearchDisplayController *searchController;
-	NSInteger frameChanges;
     TiViewProxy* headerViewProxy;
     TiViewProxy* footerViewProxy;
     BOOL viewWillDetach;

--- a/iphone/Classes/TiUITableViewRowProxy.h
+++ b/iphone/Classes/TiUITableViewRowProxy.h
@@ -24,7 +24,6 @@
 	TiDimension topCap;
 	BOOL configuredChildren;
 	int dirtyRowFlags;
-	BOOL subviewIsAnimating;
 	UIView * rowContainerView;
 	BOOL modifyingRow;
 	BOOL attaching;


### PR DESCRIPTION
Optimization type errors detected by static analyzer are usually instance variables declared but never used. These should be removed.
JIRA: https://jira.appcelerator.org/browse/TIMOB-18029
