### PR TITLE
[TIMOB-18027] iOS: Fix all dead store type error in static analyzer

### DIFF
--- a/iphone/Classes/APIModule.m
+++ b/iphone/Classes/APIModule.m
@@ -22,7 +22,6 @@ extern NSString * const TI_APPLICATION_DEPLOYTYPE;
 
 -(void)logMessage:(NSArray*)args severity:(NSString*)severity
 {
-    NSMutableString* message = [NSMutableString string];
     
     NSString* lcSeverity = [severity lowercaseString];
     DebuggerLogLevel level = OUT;

--- a/iphone/Classes/CalendarModule.m
+++ b/iphone/Classes/CalendarModule.m
@@ -207,6 +207,7 @@ typedef void(^EKEventStoreRequestAccessCompletionHandler)(BOOL granted, NSError 
         case EKAuthorizationStatusDenied:
             code = EKAuthorizationStatusDenied;
             errorStr = @"The user has denied access to events in Calendar.";
+			break;
         case EKAuthorizationStatusRestricted:
             code = EKAuthorizationStatusRestricted;
             errorStr = @"The user is unable to allow access to events in Calendar.";

--- a/iphone/Classes/ContactsModule.m
+++ b/iphone/Classes/ContactsModule.m
@@ -125,6 +125,7 @@ void CMExternalChangeCallback (ABAddressBookRef notifyAddressBook,CFDictionaryRe
         case kABAuthorizationStatusDenied:
             code = kABAuthorizationStatusDenied;
             error = @"The user has denied access to the address book";
+			break;
         case kABAuthorizationStatusRestricted:
             code = kABAuthorizationStatusRestricted;
             error = @"The user is unable to allow access to the address book";

--- a/iphone/Classes/ImageLoader.m
+++ b/iphone/Classes/ImageLoader.m
@@ -826,7 +826,6 @@ DEFINE_EXCEPTIONS
 {
 	[[TiApp app] stopNetwork];
 	ImageLoaderRequest *req = [[request userInfo] objectForKey:@"request"];
-	NSError *error = [response error];
     
 	if ([request cancelled]) {
         if ([[req delegate] respondsToSelector:@selector(imageLoadCancelled:)]) {

--- a/iphone/Classes/KrollObject.m
+++ b/iphone/Classes/KrollObject.m
@@ -760,7 +760,6 @@ bool KrollHasInstance(TiContextRef ctx, TiObjectRef constructor, TiValueRef poss
 			else
 			{
 				// it's probably a primitive type - check for them
-				NSMethodSignature *methodSignature = [target methodSignatureForSelector:selector];
 				IMP methodFunction = [target methodForSelector:selector];
 				if ([attributes hasPrefix:@"Td,"])
 				{

--- a/iphone/Classes/MediaModule.m
+++ b/iphone/Classes/MediaModule.m
@@ -1026,7 +1026,6 @@ MAKE_SYSTEM_PROP(VIDEO_TIME_OPTION_EXACT,MPMovieTimeOptionExact);
 -(NSArray*)queryMusicLibrary:(id)arg
 {
     ENSURE_SINGLE_ARG(arg, NSDictionary);
-    MPMediaGrouping grouping = [TiUtils intValue:[arg valueForKey:@"grouping"] def:MPMediaGroupingTitle];
     
     NSMutableSet* predicates = [NSMutableSet set];
     for (NSString* prop in [MediaModule filterableItemProperties]) {
@@ -1683,7 +1682,7 @@ MAKE_SYSTEM_PROP(VIDEO_TIME_OPTION_EXACT,MPMovieTimeOptionExact);
                 
                 NSFileManager *manager = [NSFileManager defaultManager];
                 NSString *outputURL = [documentsDirectory stringByAppendingPathComponent:@"editedVideo"];
-                BOOL created = [manager createDirectoryAtPath:outputURL withIntermediateDirectories:YES attributes:nil error:nil];
+                [manager createDirectoryAtPath:outputURL withIntermediateDirectories:YES attributes:nil error:nil];
                 NSString* fileName = [[[NSString stringWithFormat:@"%f",CFAbsoluteTimeGetCurrent()] stringByReplacingOccurrencesOfString:@"." withString:@"-"] stringByAppendingString:@".MOV"];
                 outputURL = [outputURL stringByAppendingPathComponent:fileName];
                 AVURLAsset *videoAsset = [AVURLAsset URLAssetWithURL:mediaURL options:nil];

--- a/iphone/Classes/NetworkModule.m
+++ b/iphone/Classes/NetworkModule.m
@@ -459,7 +459,6 @@ MAKE_SYSTEM_PROP(TLS_VERSION_1_2, TLS_VERSION_1_2);
     
     NSArray *allCookies = [storage cookies];
     NSMutableArray *returnArray = [NSMutableArray array];
-    NSHTTPCookie *c = [[NSHTTPCookie alloc] initWithProperties:@{}];
     for(NSHTTPCookie *cookie in allCookies)
     {
         if([[cookie domain] isEqualToString:domain] &&

--- a/iphone/Classes/TiAnchorAttachBehavior.m
+++ b/iphone/Classes/TiAnchorAttachBehavior.m
@@ -66,9 +66,7 @@
 
 -(void)updatePositioning
 {
-    CGSize size = [[_item view] bounds].size;
     CGPoint center = [[_item view] center];
-    CGPoint anchor = [[[_item view] layer] anchorPoint];
     
     LayoutConstraint* constraint = [_item layoutProperties];
     constraint->centerX = TiDimensionDip(center.x);

--- a/iphone/Classes/TiCalendarCalendar.m
+++ b/iphone/Classes/TiCalendarCalendar.m
@@ -244,9 +244,6 @@
     date1 = [cal dateFromComponents:comps];
     
     NSTimeInterval secondsPerDay = 24 * 60 * 60;
-    NSRange days = [cal rangeOfUnit:NSDayCalendarUnit
-                             inUnit:NSMonthCalendarUnit
-                            forDate:date1];
     [comps setYear:year+1];
     date2 = [cal dateFromComponents:comps];
     

--- a/iphone/Classes/TiCollisionBehavior.m
+++ b/iphone/Classes/TiCollisionBehavior.m
@@ -106,9 +106,7 @@
 -(void)updatePositioning
 {
     for (TiViewProxy* theItem in _items) {
-        CGSize size = [[theItem view] bounds].size;
         CGPoint center = [[theItem view] center];
-        CGPoint anchor = [[[theItem view] layer] anchorPoint];
         
         LayoutConstraint* constraint = [theItem layoutProperties];
         constraint->centerX = TiDimensionDip(center.x);
@@ -262,13 +260,14 @@
 {
     ENSURE_SINGLE_ARG(args, NSNumber);
     int newVal = [TiUtils intValue:args def:-1];
-    UICollisionBehaviorMode newMode = _mode;
+    UICollisionBehaviorMode newMode;
     switch (newVal) {
         case 0:
             newMode = UICollisionBehaviorModeItems;
             break;
         case 1:
             newMode = UICollisionBehaviorModeBoundaries;
+			break;
         default:
             newMode = UICollisionBehaviorModeEverything;
             break;

--- a/iphone/Classes/TiDatabaseResultSetProxy.m
+++ b/iphone/Classes/TiDatabaseResultSetProxy.m
@@ -232,7 +232,6 @@
 		}
 		// we cache it
 		rowCount = [results fullCount];
-		reset = NO;
 		[results next];
 		return NUMINT(rowCount); 
 	}

--- a/iphone/Classes/TiDynamicItemBehavior.m
+++ b/iphone/Classes/TiDynamicItemBehavior.m
@@ -87,9 +87,7 @@
 -(void)updatePositioning
 {
     for (TiViewProxy* theItem in _items) {
-        CGSize size = [[theItem view] bounds].size;
         CGPoint center = [[theItem view] center];
-        CGPoint anchor = [[[theItem view] layer] anchorPoint];
         
         LayoutConstraint* constraint = [theItem layoutProperties];
         constraint->centerX = TiDimensionDip(center.x);

--- a/iphone/Classes/TiGravityBehavior.m
+++ b/iphone/Classes/TiGravityBehavior.m
@@ -70,9 +70,7 @@
 -(void)updatePositioning
 {
     for (TiViewProxy* theItem in _items) {
-        CGSize size = [[theItem view] bounds].size;
         CGPoint center = [[theItem view] center];
-        CGPoint anchor = [[[theItem view] layer] anchorPoint];
         
         LayoutConstraint* constraint = [theItem layoutProperties];
         constraint->centerX = TiDimensionDip(center.x);

--- a/iphone/Classes/TiNetworkSocketTCPProxy.m
+++ b/iphone/Classes/TiNetworkSocketTCPProxy.m
@@ -760,12 +760,14 @@ TYPESAFE_SETTER(setError, error, KrollCallback)
                     id<TiStreamInternal> stream = [info valueForKey:@"destination"];
 					[event setObject:self forKey:@"fromStream"];
 					[event setObject:stream forKey:@"toStream"];
+					break;
                 }
                 case TO_CALLBACK: {
                     name = @"pump";
 					[event setObject:self forKey:@"source"];
 					[event setObject:NUMINT(readDataLength) forKey:@"totalBytesProcessed"];
 					[event setObject:[NSNull null] forKey:@"buffer"];
+					break;
                 }
                 default: {
                     name = @"write";

--- a/iphone/Classes/TiPushBehavior.m
+++ b/iphone/Classes/TiPushBehavior.m
@@ -74,9 +74,7 @@
 -(void)updatePositioning
 {
     for (TiViewProxy* theItem in _items) {
-        CGSize size = [[theItem view] bounds].size;
         CGPoint center = [[theItem view] center];
-        CGPoint anchor = [[[theItem view] layer] anchorPoint];
         
         LayoutConstraint* constraint = [theItem layoutProperties];
         constraint->centerX = TiDimensionDip(center.x);

--- a/iphone/Classes/TiSnapBehavior.m
+++ b/iphone/Classes/TiSnapBehavior.m
@@ -54,9 +54,7 @@
 
 -(void)updatePositioning
 {
-    CGSize size = [[_snapItem view] bounds].size;
     CGPoint center = [[_snapItem view] center];
-    CGPoint anchor = [[[_snapItem view] layer] anchorPoint];
     
     LayoutConstraint* constraint = [_snapItem layoutProperties];
     constraint->centerX = TiDimensionDip(center.x);

--- a/iphone/Classes/TiUIAlertDialogProxy.m
+++ b/iphone/Classes/TiUIAlertDialogProxy.m
@@ -200,7 +200,6 @@ static BOOL alertShowing = NO;
 -(void) fireClickEventWithAction:(UIAlertAction*)theAction
 {
     if ([self _hasListeners:@"click"]) {
-        NSArray *theActions = [alertController actions];
         NSUInteger indexOfAction = [[alertController actions] indexOfObject:theAction];
         
         NSMutableDictionary *event = [NSMutableDictionary dictionaryWithObjectsAndKeys:

--- a/iphone/Classes/TiUILabel.m
+++ b/iphone/Classes/TiUILabel.m
@@ -48,7 +48,6 @@
 -(CGSize)sizeForFont:(CGFloat)suggestedWidth
 {
 	NSAttributedString *value = [label attributedText];
-	UIFont *font = [label font];
 	CGSize maxSize = CGSizeMake(suggestedWidth<=0 ? 480 : suggestedWidth, 10000);
 	CGSize shadowOffset = [label shadowOffset];
 	requiresLayout = YES;

--- a/iphone/Classes/TiUIListItem.m
+++ b/iphone/Classes/TiUIListItem.m
@@ -481,7 +481,7 @@
     
     id selectedBackgroundGradientValue = [properties objectForKey:@"selectedBackgroundGradient"];
     if (IS_NULL_OR_NIL(selectedBackgroundGradientValue)) {
-        backgroundGradientValue = [_proxy valueForKey:@"selectedBackgroundGradient"];
+        selectedBackgroundGradientValue = [_proxy valueForKey:@"selectedBackgroundGradient"];
     }
     [self setSelectedBackgroundGradient_:selectedBackgroundGradientValue];
 	

--- a/iphone/Classes/TiUIOptionDialogProxy.m
+++ b/iphone/Classes/TiUIOptionDialogProxy.m
@@ -297,7 +297,6 @@
 -(void) fireClickEventWithAction:(UIAlertAction*)theAction
 {
     if ([self _hasListeners:@"click"]) {
-        NSArray *theActions = [alertController actions];
         NSUInteger indexOfAction = [[alertController actions] indexOfObject:theAction];
         
         NSMutableDictionary *event = [NSMutableDictionary dictionaryWithObjectsAndKeys:

--- a/iphone/Classes/TiUIProgressBar.m
+++ b/iphone/Classes/TiUIProgressBar.m
@@ -34,7 +34,6 @@
 -(CGSize)sizeForFont:(CGFloat)suggestedWidth
 {
 	NSAttributedString *value = [messageLabel attributedText];
-	UIFont *font = [messageLabel font];
 	CGSize maxSize = CGSizeMake(suggestedWidth<=0 ? 480 : suggestedWidth, 1000);
     CGSize returnVal = [value boundingRectWithSize:maxSize
                                   options:NSStringDrawingUsesLineFragmentOrigin

--- a/iphone/Classes/TiUIScrollViewProxy.m
+++ b/iphone/Classes/TiUIScrollViewProxy.m
@@ -122,7 +122,6 @@ static NSArray* scrollViewKeySequence;
     }
     
     if (TiDimensionIsAutoFill(contentHeight) || TiDimensionIsDip(contentHeight) || TiDimensionIsPercent(contentHeight)) {
-        flexibleContentHeight = NO;
         contentSize.height = MAX(TiDimensionCalculateValue(contentHeight, size.height), size.height);
     }
     
@@ -209,7 +208,6 @@ static NSArray* scrollViewKeySequence;
         }
     }
     else if (TiLayoutRuleIsHorizontal(layoutProperties.layoutStyle)) {
-        BOOL horizontalWrap = TiLayoutFlagsHasHorizontalWrap(&layoutProperties);
         if(flexibleContentWidth) {
             CGFloat thisHeight = 0;
             NSArray* subproxies = [self children];

--- a/iphone/Classes/TiUITableView.m
+++ b/iphone/Classes/TiUITableView.m
@@ -1875,7 +1875,6 @@
 		[sectionIndexMap setObject:[NSNumber numberWithInt:[TiUtils intValue:theindex]] forKey:title];
 	}
     
-	int sectionCount = [self numberOfSectionsInTableView:tableview]-1;
 
     // Instead of calling back through our mechanism to reload specific sections, because the entire index of the table
     // has been regenerated, we can assume it's okay to just reload the whole dataset.

--- a/iphone/Classes/TiUITableViewProxy.m
+++ b/iphone/Classes/TiUITableViewProxy.m
@@ -525,7 +525,6 @@ USE_VIEW_FOR_CONTENT_HEIGHT
 	
 	TiUITableViewRowProxy *newrow = [self tableRowFromArg:data];
     TiUITableViewActionType actionType = TiUITableViewActionInsertRowBefore;
-    TiUITableViewSectionProxy *actionSection = section;
     id header = [newrow valueForKey:@"header"];
     if (header != nil) {
         TiUITableViewSectionProxy *newSection = [self sectionWithHeader:header table:table];
@@ -554,7 +553,6 @@ USE_VIEW_FOR_CONTENT_HEIGHT
         
         // Configure the action
         actionType = TiUITableViewActionInsertSectionBefore;
-        actionSection = newSection;
     }
     else {
 		[section rememberProxy:newrow];	//If we wait until the main thread, it'll be too late!
@@ -605,7 +603,6 @@ USE_VIEW_FOR_CONTENT_HEIGHT
 	
 	TiUITableViewRowProxy *newrow = [self tableRowFromArg:data];
     TiUITableViewActionType actionType = TiUITableViewActionInsertRowAfter;
-    TiUITableViewSectionProxy *actionSection = section;
     id header = [newrow valueForKey:@"header"];
     if (header != nil) {
         TiUITableViewSectionProxy *newSection = [self sectionWithHeader:header table:table];
@@ -631,7 +628,6 @@ USE_VIEW_FOR_CONTENT_HEIGHT
         
         // Configure the action
         actionType = TiUITableViewActionInsertSectionAfter;
-        actionSection = newSection;
     }
     else {
 		[section rememberProxy:newrow];	//If we wait until the main thread, it'll be too late!
@@ -979,7 +975,6 @@ DEFINE_DEF_PROP(scrollsToTop,[NSNumber numberWithBool:YES]);
 				[ourTable insertSections:[NSIndexSet indexSetWithIndexesInRange:sectionRange] withRowAnimation:ourAnimation];
 			} else { //UITableView doesn't know we had 0 sections.
 				[ourTable beginUpdates];
-				NSRange insertedSectionRange = NSMakeRange(1, sectionRange.length - 1);
 				[ourTable deleteSections:[NSIndexSet indexSetWithIndex:0] withRowAnimation:ourAnimation];
 				[ourTable insertSections:[NSIndexSet indexSetWithIndexesInRange:sectionRange] withRowAnimation:ourAnimation];
 				[ourTable endUpdates];

--- a/iphone/Classes/TiUITextArea.m
+++ b/iphone/Classes/TiUITextArea.m
@@ -322,9 +322,8 @@ Text area constrains the text event though the content offset and edge insets ar
 -(CGFloat)contentHeightForWidth:(CGFloat)value
 {
     UITextView* ourView = (UITextView*)[self textWidgetView];
-    NSString* txt = ourView.text;
-    if (txt.length == 0) {
-        txt = @" ";
+    if (ourView.text.length == 0) {
+        ourView.text = @" ";
     }
     
     return [ourView sizeThatFits:CGSizeMake(value, 1E100)].height;

--- a/iphone/Classes/TiUIView.m
+++ b/iphone/Classes/TiUIView.m
@@ -505,7 +505,6 @@ DEFINE_EXCEPTIONS
 
 -(void)setTileBackground_:(id)image
 {
-    UIImage* tileImage = [TiUtils loadBackgroundImage:image forProxy:proxy];
 
 }
 

--- a/iphone/Classes/TiViewAttachBehavior.m
+++ b/iphone/Classes/TiViewAttachBehavior.m
@@ -66,9 +66,7 @@
 
 -(void)updatePositioning
 {
-    CGSize size = [[_item view] bounds].size;
     CGPoint center = [[_item view] center];
-    CGPoint anchor = [[[_item view] layer] anchorPoint];
     
     LayoutConstraint* constraint = [_item layoutProperties];
     constraint->centerX = TiDimensionDip(center.x);

--- a/iphone/Classes/TiViewProxy.m
+++ b/iphone/Classes/TiViewProxy.m
@@ -721,7 +721,6 @@ LAYOUTFLAGS_SETTER(setHorizontalWrap,horizontalWrap,horizontalWrap,[self willCha
 	for (TiViewProxy * thisChildProxy in subproxies)
 	{
         if (isHorizontal) {
-            sandBox = CGRectZero;
             sandBox = [self computeChildSandbox:thisChildProxy withBounds:bounds];
             thisWidth = sandBox.origin.x + sandBox.size.width;
         }
@@ -775,7 +774,6 @@ LAYOUTFLAGS_SETTER(setHorizontalWrap,horizontalWrap,horizontalWrap,[self willCha
 	for (TiViewProxy * thisChildProxy in array)
 	{
         if (!isAbsolute) {
-            sandBox = CGRectZero;
             sandBox = [self computeChildSandbox:thisChildProxy withBounds:bounds];
             thisHeight = sandBox.origin.y + sandBox.size.height;
         }


### PR DESCRIPTION
Dead store errors are values assigned to variables during initialization that are never used or read. These should be removed.
JIRA: https://jira.appcelerator.org/browse/TIMOB-18027
