### PR TITLE
[TIDOC-2005] Add API name to search content

### DIFF
--- a/apidoc/generators/solr_generator.py
+++ b/apidoc/generators/solr_generator.py
@@ -181,13 +181,10 @@ def to_solr_remarks(api):
 		return "" 
 
 def to_solr_type(api):
-	# Objects marked as external should be ignored
-	if api.external:
-		return None
 	if api.name in not_real_titanium_types:
 		return None
 	log.trace("Converting %s to json" % api.name)
-	content = to_solr_description(api.api_obj["summary"], api) + " " + to_solr_remarks(api) + to_solr_examples(api)
+	content = api.name + " " + api.name.split('.')[-1] + " " + to_solr_description(api.api_obj["summary"], api) + " " + to_solr_remarks(api) + to_solr_examples(api)
 
 	result = [{
             "id": api.name + "-" + solr_category,


### PR DESCRIPTION
Testing:

From the apidoc folder, run:

```
./docgen.py -f solr -o ../dist
```

Open the ../dist/api_solr.json file.  At the beginning of each contents key, there should be the name of the API.
