### PR TITLE
[TIDOC-2011] Support add-on YAML files

### DIFF
--- a/apidoc/lib/common.js
+++ b/apidoc/lib/common.js
@@ -1,17 +1,18 @@
 /**
  * Common Library for Doctools
- * Dependencies: js-yaml ~3.2.2, node-appc ~0.2.14 and pagedown ~1.1.0
  */
 
 var yaml = require('js-yaml'),
 	fs = require('fs'),
 	nodeappc = require('node-appc'),
+	colors = require('colors'),
 	pagedown = require('pagedown'),
 	converter = new pagedown.Converter(),
-	ignoreList = ['node_modules', '.travis.yml'];
+	ignoreList = ['node_modules', '.travis.yml'],
+	logLevel = 0;
 
-exports.VALID_PLATFORMS = ['android', 'blackberry', 'iphone', 'ipad', 'mobileweb', 'tizen'];
-exports.VALID_OSES = ['android', 'blackberry', 'ios', 'mobileweb', 'tizen'];
+exports.VALID_PLATFORMS = ['android', 'blackberry', 'iphone', 'ipad', 'mobileweb', 'tizen', 'windowsphone'];
+exports.VALID_OSES = ['android', 'blackberry', 'ios', 'mobileweb', 'tizen', 'windowsphone'];
 exports.DEFAULT_VERSIONS = {
 	'android' : '0.8',
 	'blackberry' : '3.1.2',
@@ -19,9 +20,11 @@ exports.DEFAULT_VERSIONS = {
 	'ipad' : '0.8',
 	'mobileweb' : '1.8',
 	'tizen' : '3.1'
-}
+};
+exports.ADDON_VERSIONS = {
+	'windowsphone' : '3.6.0'
+};
 exports.DATA_TYPES = ['Array', 'Boolean', 'Callback', 'Date', 'Dictionary', 'Number', 'Object', 'String'];
-
 exports.PRETTY_PLATFORM = {
 	'android': 'Android',
 	'blackberry': 'BlackBerry',
@@ -29,7 +32,8 @@ exports.PRETTY_PLATFORM = {
 	'iphone': 'iPhone',
 	'ipad': 'iPad',
 	'mobileweb': 'Mobile Web',
-	'tizen': 'Tizen'
+	'tizen': 'Tizen',
+	'windowsphone' : 'Windows Phone'
 };
 
 // Matches FOO_CONSTANT
@@ -48,6 +52,46 @@ exports.REGEXP_CHEVRON_LINKS = /(?!`)<[^>]+?>(?!`)/g;
 
 exports.markdownToHTML = function markdownToHTML(text) {
 	return converter.makeHtml(text);
+}
+
+exports.LOG_INFO = LOG_INFO = 0;
+exports.LOG_WARN = LOG_WARN = LOG_INFO + 1;
+exports.LOG_ERROR = LOG_ERROR = LOG_WARN + 1;
+logLevel = LOG_INFO;
+
+exports.log = function log (level, message) {
+	var args = [];
+
+	if (level < logLevel) return;
+
+	if (arguments.length >= 3) {
+		for (key in arguments) {
+			args.push(arguments[key]);
+		}
+		args.splice(0, 2);
+	}
+
+	switch (level) {
+		case LOG_INFO:
+			message = '[INFO] ' + message;
+			args.unshift(message.white);
+			console.info.apply(this, args);
+			break;
+		case LOG_WARN:
+			message = '[WARN] ' + message;
+			args.unshift(message.yellow);
+			console.warn.apply(this, args);
+			break;
+		case LOG_ERROR:
+			message = '[ERROR] ' + message;
+			args.unshift(message.red);
+			console.error.apply(this, args);
+			break;
+	}
+}
+
+exports.setLogLevel = function setLogLevel (level) {
+	logLevel = level;
 }
 
 // Determines if the key exists in the object and is defined

--- a/apidoc/lib/html_generator.js
+++ b/apidoc/lib/html_generator.js
@@ -2,8 +2,6 @@
  * Script to export JSON to HTML-annotated JSON for EJS templates
  */
 var common = require('./common.js'),
-	colors = require('colors');
-	nodeappc = require('node-appc'),
 	assert = common.assertObjectKey,
 	doc = {},
 	remoteURL = false;
@@ -56,7 +54,7 @@ function convertAPIToLink (apiName) {
 			cls = apiName.substring(0, apiName.lastIndexOf('.'));
 
 		if (!cls in doc) {
-			console.warn('Cannot find class: %s'.yellow, cls);
+			common.warn(common.LOG_WARN, 'Cannot find class: %s', cls);
 			return apiName;
 		} else {
 			if (findAPI(cls, member, 'properties')) {
@@ -98,7 +96,7 @@ function convertAPIToLink (apiName) {
 	if (url) {
 		return '<code><a href="' + url + '">' + apiName + '</a></code>';
 	}
-	console.warn('Cannot find API: %s'.yellow, apiName);
+	common.log(common.LOG_WARN, 'Cannot find API: %s', apiName);
 	return apiName;
 }
 
@@ -249,7 +247,7 @@ function exportParams (apis, type) {
 function exportParent(api) {
 	var rv = null,
 		cls = api.name.substring(0, api.name.lastIndexOf('.'));
-	if (cls != '') {
+	if (cls != '' && assert(doc, cls)) {
 		rv = {
 			'name': cls,
 			'filename': exportClassFilename(doc[cls].name)
@@ -428,14 +426,13 @@ exports.exportData = function exportHTML (apis) {
 		};
 	doc = apis;
 
-	console.log('Annotating HTML-specific attributes...'.white);
+	common.log(common.LOG_INFO, 'Annotating HTML-specific attributes...');
 
 	if (assert(doc, '__modules')) remoteURL = true;
 
 	for (className in apis) {
 		if (className.indexOf('__') === 0) continue;
 		cls = apis[className];
-
 		annotatedClass.name = cls.name;
 		annotatedClass.summary = exportSummary(cls);
 		annotatedClass.description = exportDescription(cls);

--- a/apidoc/lib/jsca_generator.js
+++ b/apidoc/lib/jsca_generator.js
@@ -1,9 +1,7 @@
 /**
  * Script to export JSON to JSCA
  */
-var common = require('./common.js'),
-	colors = require('colors');
-	nodeappc = require('node-appc');
+var common = require('./common.js');
 
 // Change chevron-enclosed links (<Titanium.XX.xxx>) to HTML links (<a href="Titanium.XX.xxx">xxx</a>)
 // so the information is not lost when Studio renders it.
@@ -268,7 +266,7 @@ exports.exportData = function exportJSCA (apis) {
 			'aliases': [{ 'type': 'Titanium', 'name': 'Ti' }]
 		};
 
-	console.log('Annotating JSCA-specific attributes...'.white);
+	common.log(common.LOG_INFO, 'Annotating JSCA-specific attributes...');
 
 	for (className in apis) {
 		cls = apis[className];

--- a/apidoc/templates/jsduck.ejs
+++ b/apidoc/templates/jsduck.ejs
@@ -3,7 +3,7 @@
  * @class <%- cls.name %>
 <% for (platform in cls.since) { %>
  * @platform <%- platform %> <%- cls.since[platform] %> <% } %>
-<% if (cls.__subtype == 'pseudo') { %> * @pseudo <% } %>
+<% if (cls.subtype == 'pseudo') { %> * @pseudo <% } %>
 <% if ('extends' in cls) { %> * @extends <%- cls.extends %> <% } %> 
  * <%- cls.summary %>
 <% if (cls.deprecated) { %> * <%- cls.deprecated %> <% } %>  
@@ -15,7 +15,7 @@
 <% cls.events.forEach(function (event) { %>
 /**
  * @event <%- event.name %>
-<% if ('__hide' in event && event.__hide) { %> * @hide <% } %> 
+<% if ('hide' in event && event.hide) { %> * @hide <% } %>
  * <%- event.summary %>
 <% if (event.deprecated) { %> * <%- event.deprecated %> <% } %>
 <% if (event.osver) { %> * <%- event.osver %> <% } %> 
@@ -31,7 +31,7 @@
 <% cls.methods.forEach(function (method) { %>
 /**
  * @method <%- method.name %>
-<% if ('__hide' in method && method.__hide) { %> * @hide <% } %> 
+<% if ('hide' in method && method.hide) { %> * @hide <% } %>
  * <%- method.summary %>
 <% if (method.deprecated) { %> * <%- method.deprecated %> <% } %>
 <% if (method.osver) { %> * <%- method.osver %> <% } %> 
@@ -48,7 +48,7 @@
 <% cls.properties.forEach(function (property) { %>
 /**
  * @property <%- property.name %>
-<% if ('__hide' in property && property.__hide) { %> * @hide <% } %> 
+<% if ('hide' in property && property.hide) { %> * @hide <% } %>
  * @type <%- property.type %>
 <% if ('permission' in property) { %>
 <% if (property.permission == 'read-only') { %> * @readonly <% } %>

--- a/apidoc/validate.js
+++ b/apidoc/validate.js
@@ -16,7 +16,6 @@ var fs = require('fs'),
 	doc = {},
 	parseErrors = [],
 	errorCount = 0,
-	quietFlag = false,
 	standaloneFlag = false;
 
 var validSyntax = {
@@ -527,13 +526,13 @@ if ((argc = process.argv.length) > 2) {
 				break;
 			case "--quiet":
 			case "-q":
-				quietFlag = true;
+				common.setLogLevel(common.LOG_WARN);
 				break;
 			default :
 				if (x == argc - 1) {
 					basePath = process.argv[process.argv.length - 1];
 				} else {
-					console.warn("Unknown option: %s".yellow, process.argv[x]);
+					common.log(common.LOG_WARN, "Unknown option: %s", process.argv[x]);
 					cliUsage();
 					process.exit(1);
 				}
@@ -542,7 +541,7 @@ if ((argc = process.argv.length) > 2) {
 }
 
 if (!fs.existsSync(basePath) || !fs.statSync(basePath).isDirectory()) {
-	console.error('ERROR: Invalid path: %s'.red, basePath);
+	common.log(common.LOG_ERROR, 'Invalid path: %s', basePath);
 	process.exit(1);
 }
 
@@ -551,7 +550,7 @@ rv = common.parseYAML(basePath);
 doc = rv.data;
 parseErrors = rv.errors;
 if (Object.keys(doc).length === 0) {
-	console.error('ERROR: Could not find YAML files in %s'.red, basePath);
+	common.log(common.LOG_ERROR, 'Could not find YAML files in %s', basePath);
 	process.exit(1);
 }
 
@@ -565,28 +564,28 @@ for (var key in doc) {
 	try {
 		errors = outputErrors(validateKey(cls, validSyntax, null, key), 1);
 	} catch (e) {
-		console.error("PARSING ERROR:\n%s\n%s".red, currentFile, e);
+		common.log(common.LOG_ERROR, "PARSING ERROR:\n%s\n%s", currentFile, e);
 		errorCount++;
 	}
 
 	if ((diff = errorCount - currentErrors) > 0) {
-		console.error("%s\n%s: found %s error(s)!\n%s".red, currentFile, cls.name, diff, errors);
+		common.log(common.LOG_ERROR, "%s\n%s: found %s error(s)!\n%s", currentFile, cls.name, diff, errors);
 		currentErrors = errorCount;
-	} else if(!quietFlag) {
-		console.info("%s: OK!".green, cls.name);
+	} else {
+		common.log(common.LOG_INFO, "%s: OK!", cls.name);
 	}
 }
 
 // Exit with error if we found errors or handled exceptions
 if (parseErrors.length + errorCount > 0) {
 	if (errorCount > 0) {
-		console.error("Found %s error(s)!".yellow, errorCount);
+		common.log(common.LOG_ERROR, "Found %s error(s)!", errorCount);
 	}
 	// Output exceptions while parsing YAML files
 	if (parseErrors.length > 0) {
-		console.error("The following files have YAML syntax errors: ".red);
+		common.log(common.LOG_ERROR, "The following files have YAML syntax errors: ");
         parseErrors.forEach(function (error) {
-			console.error("%s\n%s".red, error.__file, error);
+			common.log(common.LOG_ERROR, "%s\n%s", error.__file, error);
 		});
 	}
 	process.exit(1);


### PR DESCRIPTION
Testing:
Create an add-on YAML file.  See example below
Build the docs with the add-on file by specifying the `-a` options and passing it the directory containing the add-on file.
`node docgen.js -a /PATH/TO/ADDON/FILE`
Docs should merge and incorporate the add-on file changes.
With the example file:
- Titanium.UI.Window.hideNavBar method should show support for Windows Phone platform and add the sentence to the description.
- For Button class, nothing should change
- For Label class, Windows Phone platforms should appear as supported for the class.  Most APIs of the class will not show Windows Phone as supported since most APIs are inherited from another class and some are platform specific.
- Titanium.UI.backgroundColor property should show support for Windows Phone platform, version should be 3.6.1, and note should be added to the description.
- Titanium.WindowsPhone and Titanium.WindowsPhone.Foo class should appear in docs.

```

---
name: Titanium.UI.Window

methods:
  - name: hideNavBar
    description: |
        Windows Phone does not yet utilize this method.
    platforms: [windowsphone]

---
name: Titanium.UI.Button
exclude-platforms: [windowsphone]

---
name: Titanium.UI.Label
platforms: [windowsphone]

---
name: Titanium.UI
properties:
  - name: backgroundColor
    description: |

        **Windows Phone Platform Notes**

        On Windows Phone, setting this property makes every window the same color.
    platforms: [windowsphone]
    since: 3.6.1

---
name: Titanium.WindowsPhone
summary: Windows Phone is great!
platforms: [windowsphone]

---
name: Titanium.WindowsPhone.Foo
summary: Converts a bar to a baz.
platforms: [windowsphone]
since: '3.6.2'
properties:
  - name: fooBar
    summary: The bar to convert to a baz.
    type: String

methods:
  - name: convert
    summary: Converts a bar to a baz.
    parameters:
      - name: bar
        summary: FooBar object to convert
        type: FooBar
    returns:
        type: FooBaz
```
