### PR TITLE
[TIMOB-18103] Error Handler

### DIFF
--- a/android/runtime/v8/src/native/V8Object.cpp
+++ b/android/runtime/v8/src/native/V8Object.cpp
@@ -1,6 +1,6 @@
 /**
  * Appcelerator Titanium Mobile
- * Copyright (c) 2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2009-2015 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
@@ -155,6 +155,7 @@ Java_org_appcelerator_kroll_runtime_v8_V8Object_nativeCallProperty
 	}
 
 	if (tryCatch.HasCaught()) {
+		V8Util::openJSErrorDialog(tryCatch);
 		V8Util::reportException(tryCatch);
 		return JNIUtil::undefinedObject;
 	}

--- a/android/titanium/src/java/org/appcelerator/titanium/TiExceptionHandler.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiExceptionHandler.java
@@ -1,6 +1,6 @@
 /**
  * Appcelerator Titanium Mobile
- * Copyright (c) 2009-2012 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2009-2015 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
@@ -9,6 +9,7 @@ package org.appcelerator.titanium;
 import java.util.LinkedList;
 
 import org.appcelerator.kroll.KrollApplication;
+import org.appcelerator.kroll.KrollDict;
 import org.appcelerator.kroll.KrollExceptionHandler;
 import org.appcelerator.kroll.KrollRuntime;
 import org.appcelerator.kroll.common.AsyncResult;
@@ -75,6 +76,15 @@ public class TiExceptionHandler implements Handler.Callback, KrollExceptionHandl
 			Log.w(TAG, "Activity is null or already finishing, skipping dialog.");
 			return;
 		}
+
+		KrollDict dict = new KrollDict();
+		dict.put("title", error.title);
+		dict.put("message", error.message);
+		dict.put("sourceName", error.sourceName);
+		dict.put("line", error.line);
+		dict.put("lineSource", error.lineSource);
+		dict.put("lineOffset", error.lineOffset);
+		TiApplication.getInstance().fireAppEvent("uncaughtException", dict);
 
 		printError(error.title, error.message, error.sourceName, error.line, error.lineSource, error.lineOffset);
 

--- a/apidoc/Titanium/App/App.yml
+++ b/apidoc/Titanium/App/App.yml
@@ -236,6 +236,43 @@ events:
     platforms: [iphone, android]
     since: {android: "3.3.0"}
     
+  - name: uncaughtException
+    summary: Fired when an uncaught JavaScript exception occurs.
+    description: |
+        This event will occur in both production and development builds, allowing you to warn the
+        user that an error has occured, and log more information to help you fix any bugs.
+    properties:
+      - name: message
+        summary: The error message.
+      - name: line
+        summary: The line where the error occurred.
+      - name: sourceId
+        summary: A unique identification for the source file.
+        platforms: [iphone, ipad]
+      - name: type
+        summary: The type of error.
+        platforms: [iphone, ipad]
+      - name: sourceURL
+        summary: The URL to the source file.
+        platforms: [iphone, ipad]
+      - name: backtrace
+        summary: The backtrace of function calls when the error occurred.
+        platforms: [iphone, ipad]
+      - name: title
+        summary: The title for the error.
+        platforms: [android]
+      - name: sourceName
+        summary: The name of the source file.
+        platforms: [android]
+      - name: lineSource
+        summary: The line source reference.
+        platforms: [android]
+      - name: lineOffset
+        summary: The offset on the line where the error occurred.
+        platforms: [android]
+    platforms: [android, iphone, ipad]
+    since: '4.1.0'
+    
   - name: resume
     summary: Fired when the application returns to the foreground on a multitasked system.
     description: |

--- a/iphone/Classes/AppModule.m
+++ b/iphone/Classes/AppModule.m
@@ -451,6 +451,14 @@ extern BOOL const TI_APPLICATION_ANALYTICS;
 	}
 }
 
+-(void)errored:(NSNotification *)notification
+{
+	if ([self _hasListeners:@"uncaughtException"])
+	{
+		[self fireEvent:@"uncaughtException" withObject:[notification userInfo]];
+	}
+}
+
 #pragma mark Delegate stuff
 
 -(void)proximityDetectionChanged:(NSNotification*)note

--- a/iphone/Classes/TiBase.h
+++ b/iphone/Classes/TiBase.h
@@ -1,6 +1,6 @@
 /**
  * Appcelerator Titanium Mobile
- * Copyright (c) 2009-2014 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2009-2015 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
@@ -574,6 +574,7 @@ extern NSString * const kTiSuspendNotification;
 extern NSString * const kTiPausedNotification;
 extern NSString * const kTiResumeNotification;
 extern NSString * const kTiResumedNotification;
+extern NSString * const kTiErrorNotification;
 extern NSString * const kTiAnalyticsNotification;
 extern NSString * const kTiRemoteDeviceUUIDNotification;
 extern NSString * const kTiGestureShakeNotification;

--- a/iphone/Classes/TiBase.m
+++ b/iphone/Classes/TiBase.m
@@ -1,6 +1,6 @@
 /**
  * Appcelerator Titanium Mobile
- * Copyright (c) 2009-2010 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2009-2015 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
@@ -144,6 +144,7 @@ NSString * const kTiSuspendNotification = @"TiSuspend";
 NSString * const kTiPausedNotification = @"TiPaused";
 NSString * const kTiResumeNotification = @"TiResume";
 NSString * const kTiResumedNotification = @"TiResumed";
+NSString * const kTiErrorNotification = @"TiError";
 NSString * const kTiAnalyticsNotification = @"TiAnalytics";
 NSString * const kTiRemoteDeviceUUIDNotification = @"TiDeviceUUID";
 NSString * const kTiGestureShakeNotification = @"TiGestureShake";

--- a/iphone/Classes/TiExceptionHandler.m
+++ b/iphone/Classes/TiExceptionHandler.m
@@ -1,6 +1,6 @@
 /**
  * Appcelerator Titanium Mobile
- * Copyright (c) 2009-2012 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2009-2015 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
@@ -57,6 +57,9 @@ static NSUncaughtExceptionHandler *prevUncaughtExceptionHandler = NULL;
 - (void)showScriptError:(TiScriptError *)error
 {
 	[[TiApp app] showModalError:[error description]];
+	[[NSNotificationCenter defaultCenter] postNotificationName:kTiErrorNotification
+	                                                    object:self
+	                                                  userInfo:error.dictionaryValue];
 }
 
 #pragma mark - TiExceptionHandlerDelegate

--- a/iphone/Classes/TiModule.m
+++ b/iphone/Classes/TiModule.m
@@ -1,6 +1,6 @@
 /**
  * Appcelerator Titanium Mobile
- * Copyright (c) 2009-2010 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2009-2015 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
@@ -89,6 +89,10 @@
 {
 }
 
+-(void)errored:(id)sender
+{
+}
+
 -(void)registerForNotifications
 {
 	WARN_IF_BACKGROUND_THREAD_OBJ;	//NSNotificationCenter is not threadsafe!
@@ -97,6 +101,7 @@
 	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(paused:) name:kTiPausedNotification object:nil];
 	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(resume:) name:kTiResumeNotification object:nil];
 	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(resumed:) name:kTiResumedNotification object:nil];
+	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(errored:) name:kTiErrorNotification object:nil];
 }
 
 -(void)startup


### PR DESCRIPTION
# The Problem

When an unhandled error occurs in production (or in builds distributed to testers), the error is either completely lost, or is displayed in a rather unfriendly red dialog. This includes both native and JavaScript errors.
## Desired Solution

Let the developer receive errors in their JavaScript. They can then do whatever they want with the error, such as logging it, or displaying a dialog to the user. These errors should be sent regardless of if the app is running in production or not.
## Example

```
Ti.App.addEventListener('uncaughtException', function(evt) {
    alert({
        // Both iOS and Android:
        message: evt.message,
        line: evt.line,

        // iOS Only:
        sourceId: evt.sourceId,
        type: evt.type,
        sourceURL: evt.sourceURL,
        backtrace: String(evt.backtrace).substr(0, 100) + '...',

        // Android Only:
        title: evt.title,
        sourceName: evt.sourceName,
        lineSource: evt.lineSource,
        lineOffset: evt.lineOffset
    });
});

throw new Error('Hello, error handler!');
```
## Jira Ticket

https://jira.appcelerator.org/browse/TIMOB-18103
