### PR TITLE
[TIMOB-18075] (3_5_X) Restore Focus to top WindowProxy

### DIFF
--- a/iphone/Classes/TiRootViewController.m
+++ b/iphone/Classes/TiRootViewController.m
@@ -1137,11 +1137,30 @@
 
 -(void)incrementActiveAlertControllerCount
 {
-    ++activeAlertControllerCount;
+    if ([TiUtils isIOS8OrGreater]){
+        ++activeAlertControllerCount;
+    }
 }
 -(void)decrementActiveAlertControllerCount
 {
-    --activeAlertControllerCount;
+    if ([TiUtils isIOS8OrGreater]) {
+        --activeAlertControllerCount;
+        if (activeAlertControllerCount == 0) {
+            UIViewController* topVC = [self topPresentedController];
+            if (topVC == self) {
+                [self didCloseWindow:nil];
+            } else {
+                [self dismissKeyboard];
+                
+                if ([topVC respondsToSelector:@selector(proxy)]) {
+                    id theProxy = [(id)topVC proxy];
+                    if ([theProxy conformsToProtocol:@protocol(TiWindowProtocol)]) {
+                        [(id<TiWindowProtocol>)theProxy gainFocus];
+                    }
+                }
+            }
+        }
+    }
 }
 
 -(NSUInteger)supportedOrientationsForAppDelegate;


### PR DESCRIPTION
Cherry Pick PR #6417 to 3_5_X

Since alertDialogs/OptionDialogs are now UIAlertController presented
modally, their dismissal should ensure top most window proxy has focus.

Test is in [JIRA](https://jira.appcelerator.org/browse/TIMOB-18075)
