### PR TITLE
[TIMOB-17990] (3_5_X) fix duplications in command shown in log header

### DIFF
--- a/cli/commands/build.js
+++ b/cli/commands/build.js
@@ -342,6 +342,6 @@ function logBanner(cli) {
 		'   SDK version     = ' + cli.argv.sdk + '\n' +
 		'   SDK path        = ' + cli.sdk.path + '\n' +
 		'   Node version    = ' + process.version + '\n' +
-		'   Command         = ' + cli.argv.$ + ' ' + cli.argv.$_.join(' ') + '\n' +
+		'   Command         = ' + cli.argv.$ + ' ' + cli.argv.$_.reduce(function(a,b){if(a.indexOf(b)<0)a.push(b);return a;},[]).join(' ') + '\n' +
 		'\n';
 }


### PR DESCRIPTION
Fixes duplications in the command string that's output in the log header per QE feedback on https://jira.appcelerator.org/browse/TIMOB-17990
