### PR TITLE
[TIDOC-1898] Fix platform/version not displaying in JSDuck

### DIFF
--- a/apidoc/lib/jsduck_generator.js
+++ b/apidoc/lib/jsduck_generator.js
@@ -248,6 +248,7 @@ function exportAPIs (api, type) {
 			annotatedMember.osver = exportOSVer(member);
 			annotatedMember.description = exportDescription(member);
 			annotatedMember.examples = exportExamples(member);
+			annotatedMember.since = member.since;
 			annotatedMember.hide = member.__hide || false;
 			if (JSON.stringify(member.since) == JSON.stringify(api.since)) annotatedMember.since = {};
 
@@ -295,6 +296,7 @@ exports.exportData = function exportJsDuck (apis) {
 		annotatedClass.name = cls.name;
 		annotatedClass.extends = cls.extends || null;
 		annotatedClass.subtype = cls.__subtype;
+		annotatedClass.since = cls.since;
 		annotatedClass.summary = exportSummary(cls);
 		annotatedClass.deprecated = exportDeprecated(cls);
 		annotatedClass.osver = exportOSVer(cls);

--- a/apidoc/lib/jsduck_generator.js
+++ b/apidoc/lib/jsduck_generator.js
@@ -248,9 +248,8 @@ function exportAPIs (api, type) {
 			annotatedMember.osver = exportOSVer(member);
 			annotatedMember.description = exportDescription(member);
 			annotatedMember.examples = exportExamples(member);
-			annotatedMember.since = member.since;
 			annotatedMember.hide = member.__hide || false;
-			if (JSON.stringify(member.since) == JSON.stringify(api.since)) annotatedMember.since = {};
+			annotatedMember.since = (JSON.stringify(member.since) == JSON.stringify(api.since)) ? {} : member.since;
 
 			switch (type) {
 				case 'events':


### PR DESCRIPTION
Testing:

Before merging, generate jsduck output: `node docgen.js -f jsduck`
Open the `../dist/titanium.js` file.  Notice that the `@platform` tag is missing.

Merge in PR locally, and regenerate the jsduck docs.  The `@platform` tag should be present.
