### PR TITLE
(3_5_X) Cleanup in the action handler

### DIFF
--- a/iphone/Classes/TiUIOptionDialogProxy.m
+++ b/iphone/Classes/TiUIOptionDialogProxy.m
@@ -308,6 +308,7 @@
         
         [self fireEvent:@"click" withObject:event];
     }
+    [self cleanup];
 }
 
 -(void)cleanup


### PR DESCRIPTION
Cherry Pick PR #6472 into 3_5_X
**No Ticket. Just a Bug Fix**
On the iPhone idiom the UIPopoverPresentationControllerDelegate methods
are never called. So there is a memory leak and also we never decrement
the activeAlertController count. This fixes it by calling cleanup in
the action handler
