### PR TITLE
[TIMOB-18071] (3_5_X) iOS module build: fixes incorrect architectures being returned by lipo and failing build

### DIFF
--- a/iphone/templates/module/default/template/iphone/build.py.ejs
+++ b/iphone/templates/module/default/template/iphone/build.py.ejs
@@ -193,7 +193,7 @@ def verify_build_arch(manifest, config):
 	binarypath = os.path.join('build', binaryname)
 	manifestarch = set(manifest['architectures'].split(' '))
 
-	output = subprocess.check_output('lipo -info %s' % binarypath, shell=True)
+	output = subprocess.check_output('xcrun lipo -info %s' % binarypath, shell=True)
 
 	builtarch = set(output.split(':')[-1].strip().split(' '))
 


### PR DESCRIPTION
https://jira.appcelerator.org/browse/TIMOB-18071

Cherry-pick of #6482 
