### PR TITLE
Backing out changes for build_<platform> log file from 3_5_X branch

### DIFF
--- a/cli/commands/build.js
+++ b/cli/commands/build.js
@@ -306,18 +306,6 @@ function patchLogger(logger, cli) {
 		// add [INFO] type prefixes for each line
 		prefix = (args[0] != '_') ? '[' + args[0].toUpperCase() + ']' + ((args[0].length===5) ? '  ' : '   ') : '';
 
-		if (logger.log.filestream) {
-			if (logger.log.buffer) {
-				logger.log.filestream.write(logger.log.buffer);
-				logger.log.buffer = null;
-			}
-
-			// log it to our log file, stripping out the color codes
-			logger.log.filestream.write('\n' + prefix + (args.length > 2 ? sprintf.apply(null, args.slice(1)) : args[1]).replace(/\x1B\[\d+m/g, ''));
-		} else {
-			logger.log.buffer += '\n' + prefix + args[1].replace(/\x1B\[\d+m/g, '');
-		}
-
 		// call the original logger with our cleaned up args
 		origLoggerLog.apply(logger, arguments);
 
@@ -330,9 +318,6 @@ function patchLogger(logger, cli) {
 			buildDir = path.join(cli.argv['project-dir'], 'build');
 
 		fs.existsSync(buildDir) || wrench.mkdirSyncRecursive(buildDir);
-
-		// create our write stream
-		logger.log.filestream = fs.createWriteStream(path.join(buildDir, 'build_' + platform + '.log'), { 'flags': 'w', 'encoding': 'ascii' });
 
 		function styleHeading(s) {
 			return ('' + s).bold;
@@ -374,17 +359,7 @@ function patchLogger(logger, cli) {
 				''
 			].join('\n'));
 
-			logger.log.flush();
 			callback();
 		});
 	};
-
-	logger.log.flush = function () {
-		if (logger.log.filestream && logger.log.buffer) {
-			logger.log.filestream.write(logger.log.buffer);
-			logger.log.buffer = null;
-		}
-	};
-
-	logger.log.buffer = '';
 }


### PR DESCRIPTION
We have a couple of reports TISTUD-7088 and TISTUD-7089 that the project cannot be run or deleted on Windows after it is build. The underlying reason is that the node process did not release the lock on build_<platform>.log file and that might be causing these issues. Though the correct fix would be unlock the file either by killing node process or other means, the temp fix would be to back out the changes for creating the build.log file in 3_5_X branch.

Also note that we are still writing the header information in the console, but just trying to avoid build.log file.
