### PR TITLE
[TIMOB-18248] Add windows to SCons builder

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -69,7 +69,7 @@ if clean and os.path.exists('iphone/iphone/build'):
 	shutil.rmtree('iphone/iphone/build')
 
 build_type = 'full'
-build_dirs = ['iphone', 'android', 'mobileweb', 'blackberry', 'tizen', 'ivi']
+build_dirs = ['iphone', 'android', 'mobileweb', 'blackberry', 'tizen', 'windows', 'ivi']
 force_iphone = False
 
 if ARGUMENTS.get('iphone',0):
@@ -95,6 +95,10 @@ if ARGUMENTS.get('blackberry',0):
 if ARGUMENTS.get('tizen',0):
 	build_type='tizen'
 	build_dirs=['tizen']
+
+if ARGUMENTS.get('windows',0):
+	build_type='windows'
+	build_dirs=['windows']
 
 if ARGUMENTS.get('ivi',0):
 	build_type='ivi'
@@ -177,6 +181,16 @@ if build_type in ['full', 'tizen'] and not only_package:
 		finally:
 			os.chdir(d)
 
+if build_type in ['full', 'windows'] and not only_package:
+	d = os.getcwd()
+	if os.path.exists('windows'):
+		os.chdir('windows')
+		try:
+			if clean: build_type = "clean"
+			# nothing to do... yet
+		finally:
+			os.chdir(d)
+
 if build_type in ['full', 'ivi'] and not only_package:
 	d = os.getcwd()
 	if os.path.exists('ivi'):
@@ -203,6 +217,7 @@ def package_sdk(target, source, env):
 	mobileweb = build_type in ['full', 'mobileweb']
 	blackberry = build_type in ['full', 'blackberry']
 	tizen = build_type in ['full', 'tizen']
+	windows = build_type in ['full', 'windows']
 	ivi = build_type in ['full', 'ivi']
 	package_all = ARGUMENTS.get('package_all', 0)
 	version_tag = ARGUMENTS.get('version_tag', version)
@@ -210,11 +225,15 @@ def package_sdk(target, source, env):
 	print "Packaging MobileSDK (%s)..." % version_tag
 	packager = package.Packager(build_jsca=build_jsca)
 	if package_all:
-		packager.build_all_platforms(os.path.abspath('dist'), version, module_apiversion, android, iphone, ipad, mobileweb, blackberry, tizen, ivi, version_tag)
+		print "...on All platforms"
+		packager.build_all_platforms(os.path.abspath('dist'), version, module_apiversion, android, iphone, ipad, mobileweb, blackberry, tizen, windows, ivi, version_tag)
 	else:
-		packager.build(os.path.abspath('dist'), version, module_apiversion, android, iphone, ipad, mobileweb, blackberry, tizen, ivi, version_tag)
+		print "...on specified platforms"
+		packager.build(os.path.abspath('dist'), version, module_apiversion, android, iphone, ipad, mobileweb, blackberry, tizen, windows, ivi, version_tag)
 	if install and not clean:
+		print "...Installing SDK"
 		install_mobilesdk(version_tag)
+	print "Packaging version (%s) complete" % version_tag
 
 def drillbit_builder(target, source, env):
 	sys.path.append("drillbit")

--- a/site_scons/package.py
+++ b/site_scons/package.py
@@ -493,7 +493,7 @@ def zip_mobilesdk(dist_dir, osname, version, module_apiversion, android, iphone,
 	if mobileweb: zip_mobileweb(zf, basepath, version)
 	if blackberry: zip_blackberry(zf, basepath, version)
 	if tizen: zip_tizen(zf, basepath, version)
-	if windows: zip_windows(zf, basepath, basepath)
+	if (windows) and osname == "win32":: zip_windows(zf, basepath, basepath)
 	if ivi: zip_ivi(zf, basepath, version)
 	if osname == 'win32': zip_dir(zf, win32_dir, basepath)
 

--- a/site_scons/package.py
+++ b/site_scons/package.py
@@ -25,6 +25,7 @@ win32_dir = os.path.abspath(os.path.join(template_dir, 'win32'))
 mobileweb_dir = os.path.abspath(os.path.join(template_dir, 'mobileweb'))
 blackberry_dir = os.path.abspath(os.path.join(template_dir, 'blackberry'))
 tizen_dir = os.path.abspath(os.path.join(template_dir, 'tizen'))
+windows_dir = os.path.abspath(os.path.join(template_dir, 'windows'))
 ivi_dir = os.path.abspath(os.path.join(template_dir, 'ivi'))
 
 buildtime = datetime.datetime.now()
@@ -114,6 +115,7 @@ def zip2zip(src_zip, dest_zip, prepend_path=None):
 		dest_zip.writestr(zinfo, f.read())
 
 def zip_packaged_modules(zf, source_dir, iphone=False):
+	print "Zipping packaged modules..."
 	for root, dirs, files in os.walk(source_dir):
 		for name in ignoreDirs:
 			if name in dirs:
@@ -131,6 +133,7 @@ def zip_packaged_modules(zf, source_dir, iphone=False):
 				source_zip.close()
 
 def zip_android(zf, basepath, version):
+	print "Zipping Android platform..."
 	android_dist_dir = os.path.join(top_dir, 'dist', 'android')
 
 	for jar in ['titanium.jar', 'kroll-apt.jar', 'kroll-common.jar', 'kroll-v8.jar']:
@@ -242,7 +245,7 @@ def make_symbol(fn):
 	return fn
 
 def zip_iphone_ipad(zf,basepath,platform,version,version_tag):
-
+	print "Zipping iOS platform..."
 #	zf.writestr('%s/iphone/imports.json'%basepath,resolve_source_imports(platform))
 
 	# include our headers such that 3rd party modules can be compiled
@@ -318,6 +321,7 @@ def zip_iphone_ipad(zf,basepath,platform,version,version_tag):
 				zip_dir(zf,module_images,'%s/%s/modules/%s/images' % (basepath,platform,module_name))
 
 def zip_mobileweb(zf, basepath, version):
+	print "Zipping MobileWeb platform..."
 	dir = os.path.join(top_dir, 'mobileweb')
 
 	# for speed, mobileweb has its own zip logic
@@ -333,6 +337,7 @@ def zip_mobileweb(zf, basepath, version):
 			zf.write(from_, to_)
 
 def zip_blackberry(zf, basepath, version):
+	print "Zipping Blackberry platform..."
 	dir = os.path.join(top_dir, 'blackberry')
 
 	# for speed, mobileweb has its own zip logic
@@ -348,6 +353,7 @@ def zip_blackberry(zf, basepath, version):
 			zf.write(from_, to_)
 
 def zip_tizen(zf, basepath, version):
+	print "Zipping Tizen platform..."
 	dir = os.path.join(top_dir, 'tizen')
 
 	# for speed, mobileweb has its own zip logic
@@ -362,7 +368,25 @@ def zip_tizen(zf, basepath, version):
 			to_ = from_.replace(dir, os.path.join(basepath,'tizen'), 1)
 			zf.write(from_, to_)
 
+
+def zip_windows(zf, basepath, version):
+	print "Zipping Windows platform..."
+	dir = os.path.join(top_dir, 'windows')
+
+	# for speed, mobileweb has its own zip logic
+	for root, dirs, files in os.walk(dir):
+		for name in ignoreDirs:
+			if name in dirs:
+				dirs.remove(name)
+		for file in files:
+			e = os.path.splitext(file)
+			if len(e)==2 and e[1] in ignoreExtensions: continue
+			from_ = os.path.join(root, file)
+			to_ = from_.replace(dir, os.path.join(basepath,'windows'), 1)
+			zf.write(from_, to_)
+
 def zip_ivi(zf, basepath, version):
+	print "Zipping IVI platform..."
 	dir = os.path.join(top_dir, 'ivi')
 
 	# for speed, mobileweb has its own zip logic
@@ -385,7 +409,8 @@ def create_platform_zip(platform,dist_dir,osname,version,version_tag):
 	zf = zipfile.ZipFile(sdkzip, 'w', zipfile.ZIP_DEFLATED)
 	return (zf, basepath, sdkzip)
 
-def zip_mobilesdk(dist_dir, osname, version, module_apiversion, android, iphone, ipad, mobileweb, blackberry, tizen, ivi, version_tag, build_jsca):
+def zip_mobilesdk(dist_dir, osname, version, module_apiversion, android, iphone, ipad, mobileweb, blackberry, tizen, windows, ivi, version_tag, build_jsca):
+	print "Zipping Mobile SDK..."
 	zf, basepath, filename = create_platform_zip('mobilesdk', dist_dir, osname, version, version_tag)
 
 	ignore_paths = []
@@ -403,7 +428,7 @@ def zip_mobilesdk(dist_dir, osname, version, module_apiversion, android, iphone,
 	for dir in os.listdir(top_dir):
 		if dir != 'support' and os.path.isdir(os.path.join(top_dir, dir)) and os.path.isfile(os.path.join(top_dir, dir, 'package.json')):
 			# if new platforms are added, be sure to add them to the line below!
-			if (dir == 'android' and android) or (osname == "osx" and dir == 'iphone' and (iphone or ipad)) or (dir == 'mobileweb' and mobileweb) or (dir == 'blackberry' and blackberry) or (dir == 'tizen' and tizen) or (dir == 'ivi' and ivi):
+			if (dir == 'android' and android) or (osname == "osx" and dir == 'iphone' and (iphone or ipad)) or (dir == 'mobileweb' and mobileweb) or (dir == 'blackberry' and blackberry) or (dir == 'tizen' and tizen) or  (dir == 'windows' and windows) or (dir == 'ivi' and ivi):
 				platforms.append(dir)
 
 	# bundle root files
@@ -468,6 +493,7 @@ def zip_mobilesdk(dist_dir, osname, version, module_apiversion, android, iphone,
 	if mobileweb: zip_mobileweb(zf, basepath, version)
 	if blackberry: zip_blackberry(zf, basepath, version)
 	if tizen: zip_tizen(zf, basepath, version)
+	if windows: zip_windows(zf, basepath, basepath)
 	if ivi: zip_ivi(zf, basepath, version)
 	if osname == 'win32': zip_dir(zf, win32_dir, basepath)
 
@@ -477,13 +503,13 @@ class Packager(object):
 	def __init__(self, build_jsca=1):
 		self.build_jsca = build_jsca
 
-	def build(self, dist_dir, version, module_apiversion, android=True, iphone=True, ipad=True, mobileweb=True, blackberry=True, tizen=True, ivi=True, version_tag=None):
+	def build(self, dist_dir, version, module_apiversion, android=True, iphone=True, ipad=True, mobileweb=True, blackberry=True, tizen=True, ivi=True, windows=True, version_tag=None):
 		if version_tag == None:
 			version_tag = version
 
-		zip_mobilesdk(dist_dir, os_names[platform.system()], version, module_apiversion, android, iphone, ipad, mobileweb, blackberry, tizen, ivi, version_tag, self.build_jsca)
+		zip_mobilesdk(dist_dir, os_names[platform.system()], version, module_apiversion, android, iphone, ipad, mobileweb, blackberry, tizen, windows, ivi, version_tag, self.build_jsca)
 
-	def build_all_platforms(self, dist_dir, version, module_apiversion, android=True, iphone=True, ipad=True, mobileweb=True, blackberry=True, tizen=True, ivi=True, version_tag=None):
+	def build_all_platforms(self, dist_dir, version, module_apiversion, android=True, iphone=True, ipad=True, mobileweb=True, blackberry=True, tizen=True, ivi=True, windows=True, version_tag=None):
 		global packaging_all
 		packaging_all = True
 

--- a/site_scons/package.py
+++ b/site_scons/package.py
@@ -493,7 +493,7 @@ def zip_mobilesdk(dist_dir, osname, version, module_apiversion, android, iphone,
 	if mobileweb: zip_mobileweb(zf, basepath, version)
 	if blackberry: zip_blackberry(zf, basepath, version)
 	if tizen: zip_tizen(zf, basepath, version)
-	if (windows) and osname == "win32":: zip_windows(zf, basepath, basepath)
+	if (windows) and osname == "win32": zip_windows(zf, basepath, basepath)
 	if ivi: zip_ivi(zf, basepath, version)
 	if osname == 'win32': zip_dir(zf, win32_dir, basepath)
 


### PR DESCRIPTION
To Test:
1. Download the windows folder from http://studio-jenkins.appcelerator.org/job/titanium_mobile_windows/lastSuccessfulBuild/artifact/dist/windows/*zip*/windows.zip
2. Unzip that into titanium_mobile as a "windows" directory
3. Run `scons`

The generated project should have a windows folder in it (for the windows build only)
