### PR TITLE
Titanium update

### DIFF
--- a/iphone/Classes/KrollMethod.m
+++ b/iphone/Classes/KrollMethod.m
@@ -332,14 +332,6 @@ TiValueRef KrollCallAsNamedFunction(TiContextRef jsContext, TiObjectRef func, Ti
     
     [invocation invoke];
     
-    if ([_methodSignature methodReturnLength] == sizeof(id)) {
-		id result = nil;
-        void *tempResult;
-        [invocation getReturnValue:&tempResult];
-        result = (__bridge id)tempResult;
-        return result;
-    }
-
     const char * retType = [_methodSignature methodReturnType];
     char t = retType[0];
     switch(t)
@@ -348,11 +340,25 @@ TiValueRef KrollCallAsNamedFunction(TiContextRef jsContext, TiObjectRef func, Ti
         {
             return nil;
         }
+        case '@':
+        {
+            id result = nil;
+            void *tempResult;
+            [invocation getReturnValue:&tempResult];
+            result = (__bridge id)tempResult;
+            return result;
+        }
         case 'c':
         {
             char c;
             [invocation getReturnValue:&c];
             return [NSNumber numberWithChar:c];
+        }
+        case 'C':
+        {
+            unsigned char uc;
+            [invocation getReturnValue:&uc];
+            return [NSNumber numberWithUnsignedChar:uc];
         }
         case 'f':
         {
@@ -366,6 +372,24 @@ TiValueRef KrollCallAsNamedFunction(TiContextRef jsContext, TiObjectRef func, Ti
             [invocation getReturnValue:&i];
             return [NSNumber numberWithInt:i];
         }
+        case 'I':
+        {
+            unsigned int ui;
+            [invocation getReturnValue:&ui];
+            return [NSNumber numberWithUnsignedInt:ui];
+        }
+        case 's':
+        {
+            short s;
+            [invocation getReturnValue:&s];
+            return [NSNumber numberWithShort:s];
+        }
+        case 'S':
+        {
+            unsigned short us;
+            [invocation getReturnValue:&us];
+            return [NSNumber numberWithUnsignedShort:us];
+        }
         case 'd':
         {
             double d;
@@ -378,21 +402,33 @@ TiValueRef KrollCallAsNamedFunction(TiContextRef jsContext, TiObjectRef func, Ti
             [invocation getReturnValue:&l];
             return [NSNumber numberWithLong:l];
         }
+        case 'L':
+        {
+            unsigned long ul;
+            [invocation getReturnValue:&ul];
+            return [NSNumber numberWithUnsignedLong:ul];
+        }
         case 'q':
         {
-            long long l;
-            [invocation getReturnValue:&l];
-            return [NSNumber numberWithLongLong:l];
+            long long ll;
+            [invocation getReturnValue:&ll];
+            return [NSNumber numberWithLongLong:ll];
         }
         case 'Q':
         {
-            unsigned long long l;
-            [invocation getReturnValue:&l];
-            return [NSNumber numberWithUnsignedLongLong:l];
+            unsigned long long ull;
+            [invocation getReturnValue:&ull];
+            return [NSNumber numberWithUnsignedLongLong:ull];
+        }
+        case 'b':
+        {
+            bool b;
+            [invocation getReturnValue:&b];
+            return [NSNumber numberWithBool:b];
         }
         default:
         {
-            DeveloperLog(@"[ERROR] Unsupported primitive return type: %c for target:%@->%@",t,target,NSStringFromSelector(selector));
+            DebugLog(@"[ERROR] Unsupported primitive return type: %c for target:%@->%@",t,target,NSStringFromSelector(selector));
             break;
         }
     }

--- a/iphone/headers/JavaScriptCore/TiBase.h
+++ b/iphone/headers/JavaScriptCore/TiBase.h
@@ -147,6 +147,7 @@ JS_EXPORT void TiGarbageCollect(TiContextRef ctx);
 #endif
 
 /* Enable the Objective-C API for platforms with a modern runtime. */
+#define JSC_OBJC_API_ENABLED 0
 #if !defined(JSC_OBJC_API_ENABLED)
 #define JSC_OBJC_API_ENABLED (defined(__clang__) && defined(__APPLE__) && ((defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 1090 && !defined(__i386__)) || (defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE)))
 #endif


### PR DESCRIPTION
Updates the JavaScriptCore headers to latest version of tijscore we are using
Applies [TIMOB-18214] fix to KrollMethod as well

No JIRA ticket.

Testing->KS
