### PR TITLE
[TIMOB-17502] iOS: URLSession DownloadCompleted event now returns file url instead of TiBlob

### DIFF
--- a/apidoc/Titanium/App/iOS/iOS.yml
+++ b/apidoc/Titanium/App/iOS/iOS.yml
@@ -494,7 +494,6 @@ events:
         Available only on iOS 7 and later.
     description: |
         This event only needs to be used if your app is using the `urlSession` module to download data.
-
     properties:
       - name: taskIdentifier
         summary: The `urlSession` download task's identifer.

--- a/apidoc/Titanium/App/iOS/iOS.yml
+++ b/apidoc/Titanium/App/iOS/iOS.yml
@@ -494,16 +494,18 @@ events:
         Available only on iOS 7 and later.
     description: |
         This event only needs to be used if your app is using the `urlSession` module to download data.
+        After download is complete, immediately process or save the cached file from the returned url, as it
+        is only cached temporarily.
     properties:
       - name: taskIdentifier
         summary: The `urlSession` download task's identifer.
         type: Number
 
-      - name: data
-        summary: The downloaded data as a Titanium.Blob object.
-        type: Titanium.Blob
+      - name: url
+        summary: The url of the temporarily cached downloaded data.
+        type: String
     osver: {ios: {min: "7.0"}}
-    since: "3.2.0"
+    since: "3.6.0"
 
   - name: sessioncompleted
     summary: |

--- a/apidoc/Titanium/App/iOS/iOS.yml
+++ b/apidoc/Titanium/App/iOS/iOS.yml
@@ -494,18 +494,17 @@ events:
         Available only on iOS 7 and later.
     description: |
         This event only needs to be used if your app is using the `urlSession` module to download data.
-        After download is complete, immediately process or save the cached file from the returned url, as it
-        is only cached temporarily.
+
     properties:
       - name: taskIdentifier
         summary: The `urlSession` download task's identifer.
         type: Number
 
-      - name: url
-        summary: The url of the temporarily cached downloaded data.
-        type: String
+      - name: data
+        summary: The downloaded data as a Titanium.Blob object.
+        type: Titanium.Blob
     osver: {ios: {min: "7.0"}}
-    since: "3.6.0"
+    since: "3.2.0"
 
   - name: sessioncompleted
     summary: |

--- a/iphone/Classes/TiApp.m
+++ b/iphone/Classes/TiApp.m
@@ -611,7 +611,7 @@ TI_INLINE void waitForMemoryPanicCleared();   //WARNING: This must never be run 
 	//copy downloaded file from location to tempFile (in NSTemporaryDirectory), because file in location will be removed after delegate completes
 	NSError *error;
 	NSFileManager *fileManager = [NSFileManager defaultManager];
-	NSString *destinationFilename = downloadTask.originalRequest.URL.lastPathComponent;
+	NSString *destinationFilename = location.lastPathComponent;
 	NSURL *destinationURL = [[NSURL fileURLWithPath:NSTemporaryDirectory()] URLByAppendingPathComponent:destinationFilename];
 	if ([fileManager fileExistsAtPath:[destinationURL path]]) {
 		[fileManager removeItemAtURL:destinationURL error:nil];

--- a/iphone/Classes/TiApp.m
+++ b/iphone/Classes/TiApp.m
@@ -607,22 +607,26 @@ TI_INLINE void waitForMemoryPanicCleared();   //WARNING: This must never be run 
 
 -(void)URLSession:(NSURLSession *)session downloadTask:(NSURLSessionDownloadTask *)downloadTask didFinishDownloadingToURL:(NSURL *)location
 {
-    //FunctionName();
-	//copy downloaded file from location to NSCacheDirectory, because file in url will be removed after delegate completes
+	//FunctionName();
+	//copy downloaded file from location to tempFile (in NSTemporaryDirectory), because file in location will be removed after delegate completes
 	NSError *error;
 	NSFileManager *fileManager = [NSFileManager defaultManager];
 	NSString *destinationFilename = downloadTask.originalRequest.URL.lastPathComponent;
-	NSURL *destinationURL = [[[[NSFileManager defaultManager] URLsForDirectory:NSCachesDirectory inDomains:NSUserDomainMask] objectAtIndex:0] URLByAppendingPathComponent:destinationFilename];
+	NSURL *destinationURL = [[NSURL fileURLWithPath:NSTemporaryDirectory()] URLByAppendingPathComponent:destinationFilename];
 	if ([fileManager fileExistsAtPath:[destinationURL path]]) {
 		[fileManager removeItemAtURL:destinationURL error:nil];
 	}
 	BOOL success = [fileManager copyItemAtURL:location toURL:destinationURL error:&error];
+	TiBlob* downloadedData;
 	if (!success) {
 		DebugLog(@"Unable to copy temp file. Error: %@", [error localizedDescription]);
+		downloadedData =[[[TiBlob alloc] initWithData:[NSData dataWithContentsOfURL:location] mimetype:[Mimetypes mimeTypeForExtension:[location absoluteString]]] autorelease];
 	}
-	NSMutableDictionary *dict = [NSMutableDictionary dictionaryWithObjectsAndKeys: [NSNumber numberWithUnsignedInteger:downloadTask.taskIdentifier ],@"taskIdentifier",destinationURL,@"url", nil];
+	else {
+		downloadedData = [[[TiBlob alloc] initWithFile:[destinationURL path]] autorelease];
+	}
+	NSMutableDictionary *dict = [NSMutableDictionary dictionaryWithObjectsAndKeys: [NSNumber numberWithUnsignedInteger:downloadTask.taskIdentifier ],@"taskIdentifier",downloadedData,@"data", nil];
 	[[NSNotificationCenter defaultCenter] postNotificationName:kTiURLDownloadFinished object:self userInfo:dict];
-    
 }
 
 -(void)URLSession:(NSURLSession *)session downloadTask:(NSURLSessionDownloadTask *)downloadTask didWriteData:(int64_t)bytesWritten totalBytesWritten:(int64_t)totalBytesWritten totalBytesExpectedToWrite:(int64_t)totalBytesExpectedToWrite

--- a/iphone/Classes/TiApp.m
+++ b/iphone/Classes/TiApp.m
@@ -616,9 +616,7 @@ TI_INLINE void waitForMemoryPanicCleared();   //WARNING: This must never be run 
 	if ([fileManager fileExistsAtPath:[destinationURL path]]) {
 		[fileManager removeItemAtURL:destinationURL error:nil];
 	}
-	BOOL success = [fileManager copyItemAtURL:location
-										toURL:destinationURL
-										error:&error];
+	BOOL success = [fileManager copyItemAtURL:location toURL:destinationURL error:&error];
 	if (!success) {
 		DebugLog(@"Unable to copy temp file. Error: %@", [error localizedDescription]);
 	}


### PR DESCRIPTION
JIRA: https://jira.appcelerator.org/browse/TIMOB-17502

**To test:**

```
// Require in the urlSession module
var urlSession = require("com.appcelerator.urlSession");
var session;

// App UI
var win = Ti.UI.createWindow({backgroundColor:"white"});
var progress = Ti.UI.createProgressBar({
    width: 200,
    height: 50,
    min: 0,
    max: 1,
    value: 0,
    style: Ti.UI.iPhone.ProgressBarStyle.PLAIN,
    top: 10,
    message: 'Downloading image URL',
    font: { fontSize: 12, fontWeight: 'bold'},
    color: '#888'
});
win.add(progress);
var imageView = Ti.UI.createImageView({
        top:150,
          height:300,
          width:200
    });
win.add(imageView);

var button = Ti.UI.createButton({
    title:'Download Image (url)',
    height:40,
    width:200,
    top:70
});

button.addEventListener('click', function()
{
    // Check if the device is running iOS 8 or later, before registering for local notifications
    if (Ti.Platform.name == "iPhone OS" && parseInt(Ti.Platform.version.split(".")[0]) >= 8) {
        Ti.App.iOS.registerUserNotificationSettings({
           types: [
                Ti.App.iOS.USER_NOTIFICATION_TYPE_ALERT,
                Ti.App.iOS.USER_NOTIFICATION_TYPE_SOUND,
                Ti.App.iOS.USER_NOTIFICATION_TYPE_BADGE
            ]
        });
    }
    // Create a session configuration
    // The string parameter is an arbitrary string used to identify the session in events
    var sessionConfig = urlSession.createURLSessionBackgroundConfiguration("com.appcelerator.test");
    // Create a session
    session = urlSession.createURLSession(sessionConfig);
    // Create a background download task to get the asset with the URL
    //urlSession.backgroundDownloadTaskWithURL(session,"https://raw.github.com/appcelerator-developer-relations/KitchenSink/master/Resources/images/dog@2x~iphone.jpg"); //small file
    //urlSession.backgroundDownloadTaskWithURL(session,"http://imgsrc.hubblesite.org/hu/db/images/hs-2004-07-a-full_jpg.jpg"); //medium sized file
    urlSession.backgroundDownloadTaskWithURL(session,"http://www.wswd.net/testdownloadfiles/1GB.zip"); //huge file
    progress.show();
});

win.add(button);
win.open();

// Monitor this event to receive updates on the progress of the download
Ti.App.iOS.addEventListener("downloadprogress", function(e) {
    // Update the progress indicator
    progress.value = (e.totalBytesWritten/e.totalBytesExpectedToWrite);
});


// Monitor this event to know when the download completes
Ti.App.iOS.addEventListener("downloadcompleted", function(e) {
    Ti.API.info("download completed " + JSON.stringify(e));
    var cacheFile = e.data.getFile();
    var downloadedFile = Ti.Filesystem.getFile(Ti.Filesystem.applicationDataDirectory, cacheFile.getName());
    downloadedFile.write(e.data); // copy and save from cache
    Ti.API.info("downloadedFile: " + downloadedFile.getNativePath());
    // set new Image
    //imageView.image = e.data;
    // Invalidate the session and cancel current session tasks
    urlSession.invalidateAndCancel(session);

    // Notify the user the download is complete if the application is in the background
    var notification = Ti.App.iOS.scheduleLocalNotification({
        alertBody: "Download completed!",
        badge: 1,
        sound: "/alert.wav",
        date: new Date(new Date().getTime())
    });

    progress.hide();
});


// Monitor this event to know when all session tasks have completed
Ti.App.iOS.addEventListener('sessioncompleted', function(e) {
    Ti.API.info("sessioncompleted " + JSON.stringify(e));
    if (e.success) {
        alert("Downloads completed successfully.");
    }
});
```
- Create a new Project
- Double-click the Project's "tiapp.xml" file to open it in the Overview tab.
- In the Modules section, click the Add button (green plus sign) to open the Mobile Modules dialog.
- Locate and select "com.appcelerator.urlSession". 
- Click OK.
- Copy the code segment above to the project "app.js" file
- Run the Project 
- _Note: the link downloaded is 1GB in size in the test code above. Replace with commented out lines of code linked to smaller files if necessary._
