### PR TITLE
[TIMOB-18365] iOS: TextField - Fixed value not updated when autocorrect ...

### DIFF
--- a/iphone/Classes/TiUITextField.m
+++ b/iphone/Classes/TiUITextField.m
@@ -515,6 +515,8 @@
 - (void)textFieldDidEndEditing:(UITextField *)tf
 {
 	[self textWidget:tf didBlurWithText:[tf text]];
+	//TIMOB-18365. Value not updated when autocorrect is up and return is pressed
+	[self textFieldDidChange:nil];
 }
 
 - (void)textFieldDidChange:(NSNotification *)notification


### PR DESCRIPTION
...is up and return is pressed

Test case in ticket: [TIMOB-18365](https://jira.appcelerator.org/browse/TIMOB-18365)
