### PR TITLE
[TIDOC-2089] Add parity report support to docgen.js

### DIFF
--- a/apidoc/docgen.js
+++ b/apidoc/docgen.js
@@ -778,6 +778,10 @@ formats.forEach(function (format) {
 			render = ejs.render(templateStr, {doc: exportData});
 			output = output + '/titanium.js';
 			break;
+		case 'parity' :
+			templateStr = fs.readFileSync(templatePath + 'parity.ejs', 'utf8');
+			render = ejs.render(templateStr, {apis: exportData});
+			output = output + '/parity.html';
 		default:
 			;
 	}

--- a/apidoc/lib/parity_generator.js
+++ b/apidoc/lib/parity_generator.js
@@ -1,0 +1,89 @@
+if (!String.prototype.contains) {
+    String.prototype.contains = function (arg) {
+        return !!~this.indexOf(arg);
+    };
+}
+function sort(object) {
+    var sorted = {}, key, array = [];
+    for (key in object)
+		if (object.hasOwnProperty(key))
+			array.push(key);
+    array.sort();
+    for (key=0;key<array.length;key++)
+		sorted[array[key]] = object[array[key]];
+    return sorted;
+}
+function sortByKey(array, key) {
+    return array.sort(
+		function(a, b) {
+			var x = a[key], y = b[key];
+			return ((x < y) ? -1 : ((x > y) ? 1 : 0));
+		}
+	);
+}
+
+// Process api data into a parsable format
+exports.exportData = function exportHTML(apis) {
+
+	// Define return object
+	var rv = { coverage:[], proxies:[], total_apis:0};
+	
+	// Sort proxies
+	apis = sort(apis);
+	
+	// Iterate through proxies
+	for (className in apis) {
+		
+		// Skip platform specific proxies
+		/*if (className == 'Titanium'
+			|| className.contains('iOS') || className.contains('iPhone') || className.contains('iPad')
+			|| className.contains('Android') || className.contains('Tizen')
+		) continue;*/
+	    
+		var api = apis[className];
+		var pseudo = (api.__subtype == 'pseudo');
+		var proxy = {name:className, pseudo : pseudo, platforms:api.platforms, properties:[], methods:[], events:[]};
+		
+		// Sort property, method and event arrays
+		api.properties = sortByKey(api.properties, 'name');
+		api.methods = sortByKey(api.methods, 'name');
+		api.events = sortByKey(api.events, 'name');
+		
+		// Add property, method, and event data into proxy object
+		for (i in api.properties) {
+			var property = api.properties[i];
+			proxy.properties.push({name:property.name, platforms:property.platforms});
+			if (!pseudo) updateCoverage(rv.coverage, property.platforms);
+		}
+		for (i in api.methods) {
+			var method = api.methods[i];
+			proxy.methods.push({name:method.name, platforms:method.platforms});
+			if (!pseudo) updateCoverage(rv.coverage, method.platforms);
+		}
+		for (i in api.events) {
+			var event = api.events[i];
+			proxy.events.push({name:event.name, platforms:event.platforms});
+			if (!pseudo) updateCoverage(rv.coverage, event.platforms);
+		}
+		
+		// Update return object
+		rv.proxies.push(proxy);
+		rv.total_apis += api.properties.length + api.methods.length + api.events.length + 1;
+		
+		if (!pseudo) updateCoverage(rv.coverage, api.platforms);
+	}
+	
+	return rv;
+}
+
+// Update API coverage statistic for each platform
+function updateCoverage(coverage, platforms) {
+	for (i in platforms) {
+		var platform = platforms[i];
+		if (platform in coverage) {
+			coverage[platform] += 1;
+		} else {
+			coverage[platform] = 1;
+		}
+	}
+}

--- a/apidoc/lib/parity_generator.js
+++ b/apidoc/lib/parity_generator.js
@@ -1,3 +1,8 @@
+/**
+* Copyright (c) 2015 Appcelerator, Inc. All Rights Reserved.
+* Licensed under the terms of the Apache Public License.
+*/
+
 if (!String.prototype.contains) {
     String.prototype.contains = function (arg) {
         return !!~this.indexOf(arg);

--- a/apidoc/templates/parity.ejs
+++ b/apidoc/templates/parity.ejs
@@ -1,3 +1,6 @@
+<!-- Copyright (c) 2015 Appcelerator, Inc. All Rights Reserved. -->
+<!-- Licensed under the terms of the Apache Public License.     -->
+
 <% function contains(a,b){for(i in a)if(a[i]==b)return true;return false;} %>
 <% function rgbHex(r,g,b){return "#"+((1<<24)+(r<<16)+(g<<8)+b).toString(16).slice(1);} %>
 <% function colourGradient(sr,sg,sb,er,eg,eb,p){return rgbHex(((sr-er)*p)+er,((sg-eg)*p)+eg,((sb-eb)*p)+eb);} %>

--- a/apidoc/templates/parity.ejs
+++ b/apidoc/templates/parity.ejs
@@ -1,0 +1,104 @@
+<% function contains(a,b){for(i in a)if(a[i]==b)return true;return false;} %>
+<% function rgbHex(r,g,b){return "#"+((1<<24)+(r<<16)+(g<<8)+b).toString(16).slice(1);} %>
+<% function colourGradient(sr,sg,sb,er,eg,eb,p){return rgbHex(((sr-er)*p)+er,((sg-eg)*p)+eg,((sb-eb)*p)+eb);} %>
+<% function platformSupportColour(a){return colourGradient(160,190,0,230,30,20,a.platforms.length/Object.keys(apis.coverage).length);} %>
+<style>
+	html, body, div, span, applet, object, iframe, h1, h2, h3, h4, h5, h6, p, blockquote, pre, a, abbr, acronym, address, big, cite, code, del, dfn, em, font, img, ins, kbd, q, s, samp, small, strike, strong, sub, sup, tt, var, b, u, i, center, dl, dt, dd, ol, ul, li, fieldset, form, label, legend, table, caption, tbody, tfoot, thead, tr, th, td { background: transparent; border: 0; font-size: 100%; margin: 0; outline: 0; padding: 0; vertical-align: baseline; } body { line-height: 1; font-family: Helvetica, Arial, sans-serif; margin: 20px; font-size: 12px; } ol, ul { list-style: none; } blockquote, q { quotes: none; } :focus { outline: 0; } ins { text-decoration: none; } del { text-decoration: line-through; } table { border-collapse: collapse; border-spacing: 0; clear: both; } a { text-decoration: none; } a:hover { text-decoration: underline; } th { padding: 5px 10px; background: #CCC; } td { border: 1px solid #CCC; padding: 5px; } .yes { background-color:#007700; color: #FFF; text-align: center; font-weight: bold; } .no { background-color:#770000; color:#FFF; text-align: center; font-weight: bold; } .module_parent_title { font-weight: bold; } .module_child_title { padding-left: 20px; } div.options { float: left; margin: 0px 20px 10px 0px; } .stats_description { font-weight: normal; }
+	body { text-align: center; }
+	table { margin: 0px auto; background-color: white; }
+	#options { text-align: left; }
+	.option { display: inline; }
+</style>
+<style type="text/css" id="table_row_style">
+	.pseudo_type { display: none; } .module_child { display: none; }
+</style>
+<script type="text/javascript">
+function toggleShowClass(clsName) {
+	var showPseudo = document.getElementById('pseudo_type_checkbox').checked,
+		showChildren = document.getElementById('module_members_checkbox').checked,
+		rowCSS;
+
+	if (showPseudo && showChildren) {
+		rowCSS = ".pseudo_type { display: table-row; } .module_child { display: table-row; }";
+	} else if (!showPseudo && showChildren) {
+		rowCSS = ".module_child { display: table-row; } .pseudo_type { display: none; }";
+	} else if (showPseudo && !showChildren) {
+		rowCSS = ".pseudo_type { display: table-row; } .module_child { display: none; }";
+	} else if (!showPseudo && !showChildren) {
+		rowCSS = ".pseudo_type { display: none; } .module_child { display: none; }";
+	}
+
+	document.getElementById('table_row_style').innerHTML = rowCSS;
+}
+</script>
+
+<table>
+<tr>
+	<th>
+		<div id="options">
+			<div class="option">
+				Show Pseudotypes :
+				<input type="checkbox" id="pseudo_type_checkbox" onclick="toggleShowClass()">
+			</div>
+			<div class="option">
+				Show Members :
+				<input type="checkbox" id="module_members_checkbox" onclick="toggleShowClass()">
+			</div>
+		</div>
+	</th>
+	<% for (platform in apis.coverage) { %>
+		<th><%= platform %></th>
+	<% } %>
+</tr>
+<tr>
+	<th class="stats_description" style="font-weight: bold;">Total APIs (<%= apis.total_apis %>)</th>
+	<% for (platform in apis.coverage) { %>
+		<th><%= apis.coverage[platform] %></th>
+	<% } %>
+</tr>
+<tr>
+	<th class="stats_description" style="font-weight: bold;">Percentage</th>
+	<% for (platform in apis.coverage) { %>
+		<th><%= (100*apis.coverage[platform]/apis.total_apis).toFixed(2) %>%</th>
+	<% } %>
+</tr>
+<% for (i in apis.proxies) { %>
+	<% var proxy = apis.proxies[i] %>
+	<tr class="<%= (proxy.pseudo ? "pseudo_type" : "normal_type") %> module_parent" element_type="<%= (proxy.pseudo ? "pseudo_type" : "normal_type") %>">
+	<td class="module_parent_title" <%= (proxy.pseudo ? "class=\"normal_type\" " : "") %>><a href=<%= "http://docs.appcelerator.com/titanium/latest/#!/api/"+proxy.name %>><%= proxy.name %></a></td>
+	<% for (platform in apis.coverage) { %>
+		<td style="background-color:<%= platformSupportColour(proxy) %>; color: #FFF; text-align: center; font-weight: bold;"><%= (contains(proxy.platforms, platform) ? "YES" : "NO") %></td>
+	<% } %>
+	</tr>
+
+	<% for (i in proxy.properties) { %>
+		<% var property = proxy.properties[i] %>
+		<tr class="<%= (proxy.pseudo ? "pseudo_type" : "normal_type") %> module_child" module_child="true" element_type="<%= (proxy.pseudo ? "pseudo_type" : "normal_type") %>">
+		<td class="module_child_title"><a href=<%= "http://docs.appcelerator.com/titanium/latest/#!/api/"+proxy.name+"-property-"+property.name %>><%= property.name %></a> (<i>property</i>)</td>
+		<% for (platform in apis.coverage) { %>
+			<td style="background-color:<%= platformSupportColour(property) %>; color: #FFF; text-align: center; font-weight: bold;" ><%= (contains(property.platforms, platform) ? "YES" : "NO") %></td>
+		<% } %>
+		</tr>
+	<% } %>
+
+	<% for (i in proxy.methods) { %>
+		<% var method = proxy.methods[i] %>
+		<tr class="<%= (proxy.pseudo ? "pseudo_type" : "normal_type") %> module_child" module_child="true" element_type="<%= (proxy.pseudo ? "pseudo_type" : "normal_type") %>">
+		<td class="module_child_title"><a href=<%= "http://docs.appcelerator.com/titanium/latest/#!/api/"+proxy.name+"-method-"+method.name %>><%= method.name %></a> (<i>method</i>)</td>
+		<% for (platform in apis.coverage) { %>
+			<td style="background-color:<%= platformSupportColour(method) %>; color: #FFF; text-align: center; font-weight: bold;"><%= (contains(method.platforms, platform) ? "YES" : "NO") %></td>
+		<% } %>
+		</tr>
+	<% } %>
+
+	<% for (i in proxy.events) { %>
+		<% var event = proxy.properties[i] %>
+		<tr class="<%= (proxy.pseudo ? "pseudo_type" : "normal_type") %> module_child" module_child="true" element_type="<%= (proxy.pseudo ? "pseudo_type" : "normal_type") %>">
+		<td class="module_child_title"><a href=<%= "http://docs.appcelerator.com/titanium/latest/#!/api/"+proxy.name+"-event-"+event.name %>><%= event.name %></a> (<i>event</i>)</td>
+		<% for (platform in apis.coverage) { %>
+			<td style="background-color:<%= platformSupportColour(event) %>; color: #FFF; text-align: center; font-weight: bold;"><%= (contains(event.platforms, platform) ? "YES" : "NO") %></td>
+		<% } %>
+		</tr>
+	<% } %>
+<% } %>
+</table>


### PR DESCRIPTION
Add the ability to generate a parity report from the JSCA file.

Usage:

```
docgen.js -f parity
```
