### PR TITLE
[TIMOB-18338] Add command to append windows apis to yaml and jsca

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -226,10 +226,10 @@ def package_sdk(target, source, env):
 	packager = package.Packager(build_jsca=build_jsca)
 	if package_all:
 		print "...on All platforms"
-		packager.build_all_platforms(os.path.abspath('dist'), version, module_apiversion, android, iphone, ipad, mobileweb, blackberry, tizen, windows, ivi, version_tag)
-	else:
+		packager.build_all_platforms(os.path.abspath('dist'), version, module_apiversion, android, iphone, ipad, mobileweb, blackberry, tizen, ivi, windows, version_tag)
+	else:windows
 		print "...on specified platforms"
-		packager.build(os.path.abspath('dist'), version, module_apiversion, android, iphone, ipad, mobileweb, blackberry, tizen, windows, ivi, version_tag)
+		packager.build(os.path.abspath('dist'), version, module_apiversion, android, iphone, ipad, mobileweb, blackberry, tizen, ivi, windows, version_tag)
 	if install and not clean:
 		print "...Installing SDK"
 		install_mobilesdk(version_tag)

--- a/SConstruct
+++ b/SConstruct
@@ -227,7 +227,7 @@ def package_sdk(target, source, env):
 	if package_all:
 		print "...on All platforms"
 		packager.build_all_platforms(os.path.abspath('dist'), version, module_apiversion, android, iphone, ipad, mobileweb, blackberry, tizen, ivi, windows, version_tag)
-	else:windows
+	else:
 		print "...on specified platforms"
 		packager.build(os.path.abspath('dist'), version, module_apiversion, android, iphone, ipad, mobileweb, blackberry, tizen, ivi, windows, version_tag)
 	if install and not clean:

--- a/site_scons/package.py
+++ b/site_scons/package.py
@@ -31,6 +31,10 @@ ivi_dir = os.path.abspath(os.path.join(template_dir, 'ivi'))
 buildtime = datetime.datetime.now()
 ts = buildtime.strftime("%m/%d/%y %H:%M")
 
+print "Installing npm packages..."
+p = subprocess.Popen(["npm","install"],cwd=doc_dir)
+p.wait()
+
 # get the githash for the build so we can always pull this build from a specific
 # commit
 gitCmd = "git"

--- a/site_scons/package.py
+++ b/site_scons/package.py
@@ -56,8 +56,10 @@ def ignore(file):
 			return True
 	 return False
 
-def generate_jsca():
-	 process_args = [sys.executable, os.path.join(doc_dir, 'docgen.py'), '-f', 'jsca', '--stdout']
+def generate_jsca(windows):
+	 process_args = ['node', os.path.join(doc_dir, 'docgen.js'), '-f', 'jsca', '--stdout']
+	 if windows:
+	 	process_args.extend(['-a', os.path.join(top_dir, 'windows', 'doc', 'Titanium')])
 	 print "Generating JSCA..."
 	 print " ".join(process_args)
 	 jsca_temp_file = tempfile.TemporaryFile()
@@ -452,7 +454,7 @@ def zip_mobilesdk(dist_dir, osname, version, module_apiversion, android, iphone,
 
 	# check if we should build the content assist file
 	if build_jsca:
-		jsca = generate_jsca()
+		jsca = generate_jsca(windows)
 		if jsca is None:
 			# This is fatal. If we were meant to build JSCA
 			# but couldn't, then packaging fails.
@@ -507,7 +509,7 @@ class Packager(object):
 		if version_tag == None:
 			version_tag = version
 
-		zip_mobilesdk(dist_dir, os_names[platform.system()], version, module_apiversion, android, iphone, ipad, mobileweb, blackberry, tizen, windows, ivi, version_tag, self.build_jsca)
+		zip_mobilesdk(dist_dir, os_names[platform.system()], version, module_apiversion, android, iphone, ipad, mobileweb, blackberry, tizen, ivi, windows, version_tag, self.build_jsca)
 
 	def build_all_platforms(self, dist_dir, version, module_apiversion, android=True, iphone=True, ipad=True, mobileweb=True, blackberry=True, tizen=True, ivi=True, windows=True, version_tag=None):
 		global packaging_all
@@ -519,7 +521,7 @@ class Packager(object):
 		remove_existing_zips(dist_dir, version_tag)
 
 		for os in os_names.values():
-			zip_mobilesdk(dist_dir, os, version, module_apiversion, android, iphone, ipad, mobileweb, blackberry, tizen, windows, ivi, version_tag, self.build_jsca)
+			zip_mobilesdk(dist_dir, os, version, module_apiversion, android, iphone, ipad, mobileweb, blackberry, tizen, ivi, windows, version_tag, self.build_jsca)
 
 if __name__ == '__main__':
 	Packager().build(os.path.abspath('../dist'), "1.1.0")


### PR DESCRIPTION
This should append all windows APIs into the YAML documentation and JSCA file via the 'docgen -a' command.
- Fixed bug with incorrect ivi and windows parameters in the 'package.build' method
