### PR TITLE
Include windows in parity report, fix zip_mobilesdk parameters

### DIFF
--- a/site_scons/package.py
+++ b/site_scons/package.py
@@ -533,8 +533,8 @@ class Packager(object):
 		if windows: process_args.extend(['-a', os.path.join(top_dir, 'windows', 'doc', 'Titanium')])
 		subprocess.Popen(process_args, cwd=doc_dir).wait()
 		
-		for os in os_names.values():
-			zip_mobilesdk(dist_dir, os, version, module_apiversion, android, iphone, ipad, mobileweb, blackberry, tizen, ivi, windows, version_tag, self.build_jsca)
+		for os_name in os_names.values():
+			zip_mobilesdk(dist_dir, os_name, version, module_apiversion, android, iphone, ipad, mobileweb, blackberry, tizen, ivi, windows, version_tag, self.build_jsca)
 
 if __name__ == '__main__':
 	Packager().build(os.path.abspath('../dist'), "1.1.0")

--- a/site_scons/package.py
+++ b/site_scons/package.py
@@ -32,8 +32,7 @@ buildtime = datetime.datetime.now()
 ts = buildtime.strftime("%m/%d/%y %H:%M")
 
 print "Installing npm packages..."
-p = subprocess.Popen(["npm","install"],cwd=doc_dir)
-p.wait()
+subprocess.Popen(["npm","install"],cwd=doc_dir).wait()
 
 # get the githash for the build so we can always pull this build from a specific
 # commit
@@ -415,7 +414,7 @@ def create_platform_zip(platform,dist_dir,osname,version,version_tag):
 	zf = zipfile.ZipFile(sdkzip, 'w', zipfile.ZIP_DEFLATED)
 	return (zf, basepath, sdkzip)
 
-def zip_mobilesdk(dist_dir, osname, version, module_apiversion, android, iphone, ipad, mobileweb, blackberry, tizen, windows, ivi, version_tag, build_jsca):
+def zip_mobilesdk(dist_dir, osname, version, module_apiversion, android, iphone, ipad, mobileweb, blackberry, tizen, ivi, windows, version_tag, build_jsca):
 	print "Zipping Mobile SDK..."
 	zf, basepath, filename = create_platform_zip('mobilesdk', dist_dir, osname, version, version_tag)
 
@@ -513,6 +512,11 @@ class Packager(object):
 		if version_tag == None:
 			version_tag = version
 
+		print "Generating parity report..."
+		process_args = ['node', 'docgen.js', '-f', 'parity']
+		if windows: process_args.extend(['-a', os.path.join(top_dir, 'windows', 'doc', 'Titanium')])
+		subprocess.Popen(process_args, cwd=doc_dir).wait()
+
 		zip_mobilesdk(dist_dir, os_names[platform.system()], version, module_apiversion, android, iphone, ipad, mobileweb, blackberry, tizen, ivi, windows, version_tag, self.build_jsca)
 
 	def build_all_platforms(self, dist_dir, version, module_apiversion, android=True, iphone=True, ipad=True, mobileweb=True, blackberry=True, tizen=True, ivi=True, windows=True, version_tag=None):
@@ -524,6 +528,11 @@ class Packager(object):
 
 		remove_existing_zips(dist_dir, version_tag)
 
+		print "Generating parity report..."
+		process_args = ['node', 'docgen.js', '-f', 'parity']
+		if windows: process_args.extend(['-a', os.path.join(top_dir, 'windows', 'doc', 'Titanium')])
+		subprocess.Popen(process_args, cwd=doc_dir).wait()
+		
 		for os in os_names.values():
 			zip_mobilesdk(dist_dir, os, version, module_apiversion, android, iphone, ipad, mobileweb, blackberry, tizen, ivi, windows, version_tag, self.build_jsca)
 


### PR DESCRIPTION
- Include windows in parity report when building for windows
- Fixed zip_mobilesdk parameters
