### PR TITLE
[TIMOB-23118] iOS: Remove fast enumeration from TiDynamicItemBehavior's updateItems

### DIFF
--- a/iphone/Classes/TiDynamicItemBehavior.m
+++ b/iphone/Classes/TiDynamicItemBehavior.m
@@ -73,14 +73,15 @@
 
 -(void)updateItems
 {
-    NSUInteger theIndex = 0;
-    for (TiViewProxy* theItem in _items) {
+    NSUInteger itemCount = [_items count];
+    
+    for (NSUInteger index = 0; index < itemCount; index++) {
+        TiViewProxy* theItem = [_items objectAtIndex:index];
         CGPoint linearVel = [_dynamicItemBehavior linearVelocityForItem:[theItem view]];
         CGFloat angVelocity = [_dynamicItemBehavior angularVelocityForItem:[theItem view]];
-        [_angularVelocities replaceObjectAtIndex:theIndex withObject:NUMFLOAT(angVelocity)];
-        TiPoint* thePoint = [_linearVelocities objectAtIndex:theIndex];
+        [_angularVelocities replaceObjectAtIndex:index withObject:NUMFLOAT(angVelocity)];
+        TiPoint* thePoint = [_linearVelocities objectAtIndex:index];
         [thePoint setPoint:linearVel];
-        theIndex ++;
     }
 }
 


### PR DESCRIPTION
JIRA: https://jira.appcelerator.org/browse/TIMOB-23118

Removes fast enumeration from `TiDynamicItemBehavior`'s `updateItems` because of mutation issues; replaced with simple iteration.

My CLA e-mail: jacob@kettlenyc.com

See potential issue below:

```
    Last Exception Backtrace:
    0   CoreFoundation                  0x28f96f82 __exceptionPreprocess + 122
    1   libobjc.A.dylib                 0x36b05c72 objc_exception_throw + 34
    2   CoreFoundation                  0x28f96a08 __NSFastEnumerationMutationHandler + 124
    3   Word Game                       0x00241416 -[TiDynamicItemBehavior updateItems] (TiDynamicItemBehavior.m:79)
    4   Word Game                       0x002412e2 __39-[TiDynamicItemBehavior behaviorObject]_block_invoke (TiDynamicItemBehavior.m:68)
    5   UIKit                           0x2caf19e2 -[UIDynamicAnimator _postSolverStep] + 226
    6   UIKit                           0x2caf1f02 -[UIDynamicAnimator _animatorStep:] + 190
    7   UIKit                           0x2caf1fe8 -[UIDynamicAnimator _displayLinkTick:] + 120
    8   UIKit                           0x2caed6a8 -[UIDynamicAnimatorTicker _displayLinkTick:] + 56
    9   libglInterpose.dylib            0x00aa61b2 0x8e8000 + 1827250
    10  QuartzCore                      0x2be8ad76 CA::Display::DisplayLinkItem::dispatch() + 94
    11  QuartzCore                      0x2be8abde CA::Display::DisplayLink::dispatch_items(unsigned long long, unsigned long long, unsigned long long) + 362
    12  IOMobileFramebuffer             0x3072082a IOMobileFramebufferVsyncNotifyFunc + 86
    13  IOKit                           0x29eba518 IODispatchCalloutFromCFMessage + 252
    14  CoreFoundation                  0x28f4cbe0 __CFMachPortPerform + 128
    15  CoreFoundation                  0x28f5d01e __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE1_PERFORM_FUNCTION__ + 30
    16  CoreFoundation                  0x28f5cfba __CFRunLoopDoSource1 + 342
    17  CoreFoundation                  0x28f5b5dc __CFRunLoopRun + 1604
    18  CoreFoundation                  0x28ea8dac CFRunLoopRunSpecific + 472
    19  CoreFoundation                  0x28ea8bbe CFRunLoopRunInMode + 102
    20  GraphicsServices                0x3021a04c GSEventRunModal + 132
    21  UIKit                           0x2c474a2c UIApplicationMain + 1436
    22  Word Game                       0x000ed1ae main (main.m:37)
    23  Word Game                       0x000ec704 start + 36
```
