### PR TITLE
[TIDOC-2101] Display default values for properties in JsDuck

### DIFF
--- a/apidoc/lib/jsduck_generator.js
+++ b/apidoc/lib/jsduck_generator.js
@@ -228,6 +228,17 @@ function exportReturns (api) {
 
 }
 
+function exportDefault (api) {
+		if ('default' in api && api['default'] != 'undefined') {
+				if (typeof api['default'] === 'string') {
+						return convertLinks(api['default']);
+				} else {
+						return api['default'];
+				}
+		}
+		return '';
+}
+
 function exportAPIs (api, type) {
 	var x = 0,
 		member = {},
@@ -265,6 +276,7 @@ function exportAPIs (api, type) {
 					break;
 				case 'properties':
 					annotatedMember.constants = exportConstants(member);
+					annotatedMember.defaultValue = exportDefault(member);
 					annotatedMember.permission = member.permission || 'read-write';
 					annotatedMember.type = exportType(member);
 					annotatedMember.value = exportValue(member);

--- a/apidoc/templates/jsduck.ejs
+++ b/apidoc/templates/jsduck.ejs
@@ -47,7 +47,11 @@
 
 <% cls.properties.forEach(function (property) { %>
 /**
+<% if ('defaultValue' in property && property.defaultValue) { %>
+ * @property [<%- property.name %>=<%- property.defaultValue %>]
+<% } else { %>
  * @property <%- property.name %>
+<% } %>
 <% if ('hide' in property && property.hide) { %> * @hide <% } %>
  * @type <%- property.type %>
 <% if ('permission' in property) { %>


### PR DESCRIPTION
Generate jsduck file

`node docgen -f jsca`

Open the `titanium_mobile/dist/titanium.js` file.

Properties that have a default value should display the default value next to the property name like
`@property [<PROPERTY_NAME>=<DEFAULT_VALUE>]`

Look for bubbleParent, accessibilityLabel, accessibilityValue, backgroundColor, etc.
