### PR TITLE
[TIDOC-2058] Added GitHub @editurl field to JSDuck generator.

### DIFF
--- a/apidoc/docgen.py
+++ b/apidoc/docgen.py
@@ -196,7 +196,6 @@ def process_yaml(source_dirs, options=None):
 				if os.path.splitext(filename)[-1] != ".yml" or filename in ignore_files:
 					continue
 				filepath = os.path.join(root, filename)
-				relative_path = os.path.relpath(filepath)
 				log.trace("Processing: %s" % filepath)
 				types = None
 				types = load_one_yaml(filepath)
@@ -207,7 +206,7 @@ def process_yaml(source_dirs, options=None):
 						if one_type["name"] in apis:
 							log.warn("%s has a duplicate" % one_type["name"])
 						one_type["external"] = tag_external
-						one_type["filepath"] = relative_path
+						one_type["filepath"] = filepath
 						apis[one_type["name"]] = one_type
 		tag_external = False
 

--- a/apidoc/docgen.py
+++ b/apidoc/docgen.py
@@ -196,6 +196,7 @@ def process_yaml(source_dirs, options=None):
 				if os.path.splitext(filename)[-1] != ".yml" or filename in ignore_files:
 					continue
 				filepath = os.path.join(root, filename)
+				relative_path = os.path.relpath(filepath)
 				log.trace("Processing: %s" % filepath)
 				types = None
 				types = load_one_yaml(filepath)
@@ -206,6 +207,7 @@ def process_yaml(source_dirs, options=None):
 						if one_type["name"] in apis:
 							log.warn("%s has a duplicate" % one_type["name"])
 						one_type["external"] = tag_external
+						one_type["filepath"] = relative_path
 						apis[one_type["name"]] = one_type
 		tag_external = False
 

--- a/apidoc/generators/jsduck_generator.py
+++ b/apidoc/generators/jsduck_generator.py
@@ -19,6 +19,7 @@ android_support_dir = os.path.abspath(os.path.join(this_dir, "..", "..", "suppor
 sys.path.append(android_support_dir)
 from tilogger import *
 log = TiLogger(None)
+from string import Template
 
 all_annotated_apis = None
 apis = None
@@ -332,6 +333,51 @@ def get_summary_and_description(api_obj):
 		res = u"\t * " + desc
 	return res
 
+def get_edit_url(filepath):
+	res = ""
+	basePath = ""
+	isTiDoc = 0
+	isAppCModuleDoc = 0
+	isTizenDoc = 0
+	isTiModuleDoc = 0
+	url =''
+
+	# Some module are in private repos and can't be edited.
+	module_black_list = ['ti.geofence', 'appcelerator.https']
+
+	# Identify object type by path. These should always be mutually exclusive.
+	isTiDoc = filepath.find('titanium_mobile/')
+	isTiModuleDoc = filepath.find('titanium_modules/')
+	isAppCModuleDoc = filepath.find('appc_modules/')
+	isTizenDoc = filepath.find('titanium_mobile_tizen/')
+
+	if isTiDoc != -1:
+		basePath = "https://github.com/appcelerator/titanium_mobile/edit/master/"
+		index = filepath.find('apidoc/')
+		path = filepath[index:]
+		url += basePath + path
+		res = "\t * @editurl " + url + "\n"
+	elif isAppCModuleDoc != -1 or isTiModuleDoc !=1:
+		s = Template('https://github.com/appcelerator-modules/$module/edit/master/$path')
+		index = filepath.find('apidoc/')
+		modulepath = filepath[index:]
+		pathparts = re.split('/', filepath); # ['..', 'appc_modules', 'ti.map', 'apidoc', 'View.yml']
+		# Hack until TIDOC-2103 is fixed
+		try:
+			modulename = pathparts[2]
+			if modulename not in module_black_list:
+				url = s.substitute(module=modulename, path=modulepath)
+				res = "\t * @editurl " + url + "\n"
+		except IndexError:
+			"Error generating edit URL for " + filepath
+	elif isTizenDoc != -1:
+		basePath = "https://github.com/appcelerator/titanium_mobile_tizen/edit/master/modules/tizen/"
+		index = filepath.find('apidoc/')
+		path = filepath[index:]
+		url += basePath + path
+		res = "\t * @editurl " + url + "\n"
+	return res
+
 # Side effect of hiding properties is that the accessors do not get hidden
 # Explicitly hide accessors for JSDuck
 def hide_accessors(parent_name, property_name):
@@ -441,6 +487,7 @@ def generate(raw_apis, annotated_apis, options):
 			if annotated_obj.is_pseudotype and not is_special_toplevel_type(annotated_obj.api_obj):
 				write_utf8(output, "\t * @pseudo\n")
 			write_utf8(output, output_properties_for_obj(annotated_obj))
+			write_utf8(output, get_edit_url(raw_apis[name]['filepath']))
 			write_utf8(output, get_summary_and_description(annotated_obj.api_obj))
 			write_utf8(output, output_examples_for_obj(annotated_obj.api_obj))
 			write_utf8(output, output_deprecation_for_obj(annotated_obj))


### PR DESCRIPTION
Updated docgen.py to expose a new field on each class that contained the path to the current API file. The jsduck generator was updated to include an @editurl field in each class that pointed to the "Github edit URL". Because different APIs live in different locations, the specific URL needs to be computed based on whether it's a Titanium SDK API, a module API, an Alloy API, or a Tizen API.
- Since some modules are not public, they are 'blacklisted' from their URLs being included in the output.
- Since Alloy docs are passed as-is to JSDuck, it seemed easier just to manually add @editurl tags to Alloy file (see https://github.com/appcelerator/alloy/pull/659).
### Testing steps
1. Run `docgen.py -f jsduck -o ../build/`.
2. View build/titanium.js.

Spot check a few @class tags and make sure each has a corresponding @editurl tag. Copy/paste the @editurl URL into a browser and make sure it opens the expected edit page on Github.
