### PR TITLE
[TIDOC-2105] Ported @editurl JSDuck exporter feature to JavaScript.

### DIFF
--- a/apidoc/docgen.js
+++ b/apidoc/docgen.js
@@ -771,17 +771,17 @@ formats.forEach(function (format) {
 			break;
 		case 'jsca' :
 			render = JSON.stringify(exportData, null, '    ');
-			output = output + '/api.jsca';
+			output = output + 'api.jsca';
 			break;
 		case 'jsduck' :
 			templateStr = fs.readFileSync(templatePath + 'jsduck.ejs', 'utf8');
 			render = ejs.render(templateStr, {doc: exportData});
-			output = output + '/titanium.js';
+			output = output + 'titanium.js';
 			break;
 		case 'parity' :
 			templateStr = fs.readFileSync(templatePath + 'parity.ejs', 'utf8');
 			render = ejs.render(templateStr, {apis: exportData});
-			output = output + '/parity.html';
+			output = output + 'parity.html';
 		default:
 			;
 	}

--- a/apidoc/lib/jsduck_generator.js
+++ b/apidoc/lib/jsduck_generator.js
@@ -239,6 +239,59 @@ function exportDefault (api) {
 		return '';
 }
 
+// Returns GitHub edit URL for current API file.
+function exportEditUrl (api) {
+	var file = api.__file;
+	var rv = '';
+	var blackList = ['appcelerator.https', 'ti.geofence']; // Don't include Edit button for these modules
+	var modulename, modulepath;
+
+	// Determine edit URL by file's folder location
+	if(file.indexOf("titanium_mobile/apidoc") != -1){
+		var basePath = "https://github.com/appcelerator/titanium_mobile/edit/master/"
+		var startIndex = file.indexOf('apidoc/')
+		var path = file.substr(startIndex);
+		rv = basePath + path;
+	} else if (file.indexOf("titanium_modules") != -1 || file.indexOf("appc_modules") != -1) {
+		// URL template with placeholders for module name and path.
+		var urlTemplate = 'https://github.com/appcelerator-modules/%MODULE_NAME%/edit/master/%MODULE_PATH%';
+		var re = /titanium_modules|appc_modules\/(.+)\/apidoc/;
+		var match = file.match(re);
+		if(match) {
+			modulename = match[1];
+			if (blackList.indexOf(modulename) != -1)
+				return rv;
+		}
+		else {
+			common.log(common.LOG_ERROR, 'Error creating edit URL for: ', file, ". Couldn't find apidoc/ folder.");
+			return rv;
+		}
+
+		var index = file.indexOf('apidoc/')
+		var modulepath = file.substr(index);
+		var urlReplacements = {
+		    "%MODULE_NAME%": modulename,
+		    "%MODULE_PATH%": modulepath
+		}
+		rv = urlTemplate.replace(/%\w+%/g, function(all) {
+		    return urlReplacements[all] || all;
+		});
+
+	} else if (file.indexOf("titanium_mobile_tizen/modules/tizen/apidoc") != -1) {
+		var basePath = "https://github.com/appcelerator/titanium_mobile_tizen/edit/master/"
+		var index = file.indexOf('modules/tizen/apidoc/')
+		if(index != -1) {
+			var path = file.substr(index);
+			rv = basePath + path;
+		} else {
+			common.log(common.LOG_WARN, 'Error creating edit URL for:', file, ". Couldn't find apidoc/ folder.");
+			return rv;			
+		}
+	}
+
+	return rv;
+}
+
 function exportAPIs (api, type) {
 	var x = 0,
 		member = {},
@@ -317,6 +370,7 @@ exports.exportData = function exportJsDuck (apis) {
 		annotatedClass.events = exportAPIs(cls, 'events') || [];
 		annotatedClass.methods = exportAPIs(cls, 'methods') || [];
 		annotatedClass.properties = exportAPIs(cls, 'properties') || [];
+		annotatedClass.editurl = exportEditUrl(cls);
 		rv.push(annotatedClass);
 		cls = annotatedClass = {};
 	}

--- a/apidoc/templates/jsduck.ejs
+++ b/apidoc/templates/jsduck.ejs
@@ -5,6 +5,7 @@
  * @platform <%- platform %> <%- cls.since[platform] %> <% } %>
 <% if (cls.subtype == 'pseudo') { %> * @pseudo <% } %>
 <% if ('extends' in cls) { %> * @extends <%- cls.extends %> <% } %> 
+<% if (cls.editurl) { %> * @editurl <%- cls.editurl %> <% } %>
  * <%- cls.summary %>
 <% if (cls.deprecated) { %> * <%- cls.deprecated %> <% } %>  
 <% if (cls.osver) { %> * <%- cls.osver %> <% } %> 


### PR DESCRIPTION
Also removed extra forward slashes (/) from default output file paths.
### Testing steps
1. Run `node docgen.js -f jsduck`
2. Open ../dist/titanium.js.
3. Spot check a few @class tags and make sure each has a corresponding @editurl tag. Copy/paste the @editurl URL into a browser and make sure it opens the expected edit page on Github.

Also check that last line of output from docgen.js is "Generated output at ../dist**/**titanium.js" and not "Generated output at ../dist**//**titanium.js" (notice double forward slashes).
