### PR TITLE
fix flickering while scrolling for webview

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
@@ -230,7 +230,10 @@ public class TiUIWebView extends TiUIView
 		if (Build.VERSION.SDK_INT > 16 || enableJavascriptInterface) {
 			client.getBinding().addJavascriptInterfaces();
 		}
-
+		//setLayerType() is supported in API 11+
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
+			webView.setLayerType(View.LAYER_TYPE_SOFTWARE, null);
+		}
 		webView.client = client;
 
 		if (proxy instanceof WebViewProxy) {


### PR DESCRIPTION
fix flickering while scrolling for webview

if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
            webView.setLayerType(View.LAYER_TYPE_SOFTWARE, null);
        }
