### PR TITLE
Null check in the function isHTCSenseDevice in Android TiUIWebView

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
@@ -162,6 +162,9 @@ public class TiUIWebView extends TiUIView
 		boolean isHTC = false;
 		
 		FeatureInfo[] features = TiApplication.getInstance().getApplicationContext().getPackageManager().getSystemAvailableFeatures();
+		if(features == null) { 
+			return isHTC;
+		}
 		for (FeatureInfo f : features) {
 			String fName = f.name;
 			if (fName != null) {


### PR DESCRIPTION
Getting this on some devices in Production:

java.lang.NullPointerException
TiUIWebView.java line 165 in TiUIWebView.isHTCSenseDevice()

Specifically on this device:

GI­I9500_TMMARS (GI­I9500_TMMARS) Android 4.1.1 (eng.mars.20141028.175733) 52 MB used RAM 1 GB free disk
