### PR TITLE
[TIDOC-2058] Fixed bugs generating edit URLs

### DIFF
--- a/apidoc/generators/jsduck_generator.py
+++ b/apidoc/generators/jsduck_generator.py
@@ -357,25 +357,23 @@ def get_edit_url(filepath):
 		path = filepath[index:]
 		url += basePath + path
 		res = "\t * @editurl " + url + "\n"
-	elif isAppCModuleDoc != -1 or isTiModuleDoc !=1:
+	elif isAppCModuleDoc != -1 or isTiModuleDoc !=-1:
 		s = Template('https://github.com/appcelerator-modules/$module/edit/master/$path')
-		index = filepath.find('apidoc/')
+		index = filepath.find('apidoc/')	
 		modulepath = filepath[index:]
-		pathparts = re.split('/', filepath); # ['..', 'appc_modules', 'ti.map', 'apidoc', 'View.yml']
-		# Hack until TIDOC-2103 is fixed
-		try:
-			modulename = pathparts[2]
+		match = re.search('titanium_modules|appc_modules\/(.+)\/apidoc', filepath)
+		if match:
+			modulename = match.group(1)
 			if modulename not in module_black_list:
 				url = s.substitute(module=modulename, path=modulepath)
 				res = "\t * @editurl " + url + "\n"
-		except IndexError:
-			"Error generating edit URL for " + filepath
 	elif isTizenDoc != -1:
 		basePath = "https://github.com/appcelerator/titanium_mobile_tizen/edit/master/modules/tizen/"
 		index = filepath.find('apidoc/')
 		path = filepath[index:]
 		url += basePath + path
 		res = "\t * @editurl " + url + "\n"
+
 	return res
 
 # Side effect of hiding properties is that the accessors do not get hidden


### PR DESCRIPTION
The issue occurs mainly (only?) with module docs when docgen.py is invoked from outside the titanium_modules/apidoc folder. 
#### To verify:
1. Before merging the PR, run `$doctools/deploy.sh -o modules` and open dist/titanium/3.0/index.html. 
2. Open the doc page for Modules.CoreMotion (or other module) and click the Edit button. It should 404 because the URL is bogus.
3. Merge the PR and run `$doctools/deploy.sh -o modules` again.
4. Verify that the Modules.CoreMotion edit button opens the expected page.
