### PR TITLE
[TIMOB-14544] iOS: Update keyboardframechanged event

### DIFF
--- a/apidoc/Titanium/App/App.yml
+++ b/apidoc/Titanium/App/App.yml
@@ -266,6 +266,7 @@ events:
   - name: keyboardFrameChanged
     deprecated:
         since: "3.0.0"
+        removed: "4.0.0"
         notes: |
             Renamed to [keyboardframechanged](Titanium.App.keyboardframechanged)
             (all lowercase).
@@ -285,12 +286,22 @@ events:
     summary: Fired when the soft keyboard is presented, on and off the screen.
     description: |
         This event fires when the application presents the soft keyboard on/off the screen . The 
-        event returns the dictionary containing `keyboardFrame.x`, `keyboardFrame.y`, 
-        `keyboardFrame.height` and `keyboardFrame.width` variables, corresponding to the frame of 
-        the keyboard with respect to the screen coordinates.
+        event returns the dictionary `keyboardFrame` containing `x`, `y`, `height` and `width` keys, 
+        corresponding to the frame of the keyboard with respect to the screen coordinates. 
+
+        On Titanium SDK 4.0.0 and later the event also contains a second parameter `animationDuration` representing
+        the duration of the animation for the presentation and dismissal of the soft keyboard.
         
         Note that the keyboard `height` and `width` properties will not be accurate when the keyboard 
         is being dissmissed.
+    properties:
+      - name: keyboardFrame
+        summary: A dictionary with keys x, y, width and height representing the frame of keyboard on screen.
+        type: Dictionary
+    
+      - name: animationDuration
+        summary: The duration of the keyboard animation. This parameter is only available on Titanium SDK 4.0.0 and later.
+        type: Number
     platforms: [iphone, ipad]
     since: '3.0.0'
 

--- a/iphone/Classes/AppModule.m
+++ b/iphone/Classes/AppModule.m
@@ -1,6 +1,6 @@
 /**
  * Appcelerator Titanium Mobile
- * Copyright (c) 2009-2014 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2009-2015 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
@@ -298,13 +298,13 @@ extern BOOL const TI_APPLICATION_ANALYTICS;
 //To fire the keyboard frame change event.
 -(void)keyboardFrameChanged:(NSNotification*) notification
 {
-    if (![self _hasListeners:@"keyboardFrameChanged"] && ![self _hasListeners:@"keyboardframechanged"])
+    if (![self _hasListeners:@"keyboardframechanged"])
     {
         return;
     }
     
     NSDictionary *userInfo = [notification userInfo];
-    
+    NSNumber* duration = [userInfo objectForKey:UIKeyboardAnimationDurationUserInfoKey];
     CGRect keyboardEndFrame = [[userInfo objectForKey:UIKeyboardFrameEndUserInfoKey] CGRectValue];
     if (![TiUtils isIOS8OrGreater]) {
         // window for keyboard
@@ -314,11 +314,12 @@ extern BOOL const TI_APPLICATION_ANALYTICS;
     }
     
     NSDictionary *event = [NSDictionary dictionaryWithObjectsAndKeys:
-                                [TiUtils rectToDictionary:keyboardEndFrame], @"keyboardFrame",
-                                nil];
+                           [TiUtils rectToDictionary:keyboardEndFrame], @"keyboardFrame",
+                           duration, @"animationDuration",
+                           nil];
     
-    [self fireEvent:@"keyboardFrameChanged" withObject:event]; 
-    [self fireEvent:@"keyboardframechanged" withObject:event];     
+    
+    [self fireEvent:@"keyboardframechanged" withObject:event];
 }
 
 - (void)timeChanged:(NSNotification*)notiication
@@ -400,7 +401,7 @@ extern BOOL const TI_APPLICATION_ANALYTICS;
     [nc addObserver:self selector:@selector(willShutdown:) name:kTiWillShutdownNotification object:nil];
     [nc addObserver:self selector:@selector(willShutdownContext:) name:kTiContextShutdownNotification object:nil];
 
-    [nc addObserver:self selector:@selector(keyboardFrameChanged:) name:UIKeyboardDidChangeFrameNotification object:nil];
+    [nc addObserver:self selector:@selector(keyboardFrameChanged:) name:UIKeyboardWillChangeFrameNotification object:nil];
     [nc addObserver:self selector:@selector(timeChanged:) name:UIApplicationSignificantTimeChangeNotification object:nil];
     
     [super startup];


### PR DESCRIPTION
This PR does a few things.
Removes the `keyboardFrameChanged` event.
The event `keyboardframechanged` now fires from notification `UIKeyboardWillChangeFrameNotification` instead of `UIKeyboardDidChangeFrameNotification`
The event now also includes a second parameter `animationDuration` corresponding to `UIKeyboardAnimationDurationUserInfoKey` key

Test is in [JIRA](https://jira.appcelerator.org/browse/TIMOB-14544)
