### PR TITLE
[TIMOB-18559] iOS CLI: Fixed titaniumIosSdkPath renamed to platformPath

### DIFF
--- a/iphone/cli/commands/_buildModule.js
+++ b/iphone/cli/commands/_buildModule.js
@@ -182,8 +182,8 @@ iOSModuleBuilder.prototype.initialize = function (next) {
 	this.metaData = [];
 	this.metaDataFile = path.join(this.projectDir, 'metadata.json');
 	this.manifestFile = path.join(this.projectDir, 'manifest');
-	this.titaniumIosSdkPath = appc.fs.resolvePath(__dirname, '..', '..');
-	this.templatesDir = path.join(this.titaniumIosSdkPath, 'templates');
+	this.platformPath = appc.fs.resolvePath(__dirname, '..', '..');
+	this.templatesDir = path.join(this.platformPath, 'templates');
 	this.assetsTemplateFile = path.join(this.templatesDir, 'module', 'default', 'template', 'iphone', 'Classes', '{{ModuleIdAsIdentifier}}ModuleAssets.m.ejs');
 
 	this.universalBinaryDir = path.join(this.projectDir, 'build');
@@ -356,7 +356,7 @@ iOSModuleBuilder.prototype.compileJS = function (next) {
 			}
 
 			titaniumPrepHook(
-				path.join(this.titaniumIosSdkPath, 'titanium_prep'),
+				path.join(this.platformPath, 'titanium_prep'),
 				[this.manifest.moduleid, this.assetsDir],
 				{'jsFiles': this.jsFilesToEncrypt, 'placeHolder': 'mainEncryptedAsset'},
 				cb
@@ -379,7 +379,7 @@ iOSModuleBuilder.prototype.compileJS = function (next) {
 				cb();
 			} else {
 				titaniumPrepHook(
-					path.join(this.titaniumIosSdkPath, 'titanium_prep'),
+					path.join(this.platformPath, 'titanium_prep'),
 					[this.manifest.moduleid, this.assetsDir],
 					{'jsFiles': this.jsFilesToEncrypt, 'placeHolder': 'allEncryptedAssets'},
 					cb

--- a/iphone/cli/hooks/install.js
+++ b/iphone/cli/hooks/install.js
@@ -70,7 +70,7 @@ exports.init = function (logger, config, cli) {
 						}
 
 						logger.info(__('Initiating iTunes sync'));
-						run('osascript', path.join(builder.titaniumIosSdkPath, 'itunes_sync.scpt'), function (code, out, err) {
+						run('osascript', path.join(builder.platformPath, 'itunes_sync.scpt'), function (code, out, err) {
 							if (code) {
 								if (err.indexOf('(-1708)') !== -1) {
 									// err == "itunes_sync.scpt: execution error: iTunes got an error: every source doesn’t understand the count message. (-1708)"

--- a/iphone/cli/hooks/package.js
+++ b/iphone/cli/hooks/package.js
@@ -91,7 +91,7 @@ exports.init = function (logger, config, cli) {
 						logger.info(__('Launching Xcode: %s', build.xcodeEnv.xcodeapp.cyan));
 						exec('open -a "' + build.xcodeEnv.xcodeapp + '"', function (err, stdout, stderr) {
 							process.env.TI_ENV_NAME = process.env.STUDIO_NAME || 'Terminal.app';
-							exec('osascript "' + path.join(build.titaniumIosSdkPath, 'xcode_organizer.scpt') + '"', { env: process.env }, function (err, stdout, stderr) {
+							exec('osascript "' + path.join(build.platformPath, 'xcode_organizer.scpt') + '"', { env: process.env }, function (err, stdout, stderr) {
 								logger.info(__('Packaging complete'));
 								finished();
 							});


### PR DESCRIPTION
Testing steps in ticket [TIMOB-18559](https://jira.appcelerator.org/browse/TIMOB-18559)

Just cleaning of some name changes that where missed by https://github.com/appcelerator/titanium_mobile/commit/3702f673b919b34e52d8c6f8eed904fe7a9d4496
