### PR TITLE
Fix(TiShadow): Android service dont working in tishadow

### DIFF
--- a/android/modules/android/src/java/ti/modules/titanium/android/TiJSIntervalService.java
+++ b/android/modules/android/src/java/ti/modules/titanium/android/TiJSIntervalService.java
@@ -21,6 +21,7 @@ import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.proxy.IntentProxy;
 import org.appcelerator.titanium.proxy.ServiceProxy;
 import org.appcelerator.titanium.util.TiBindingHelper;
+import org.appcelerator.titanium.util.TiShadowHelper;
 
 import android.app.Service;
 import android.content.Intent;
@@ -28,6 +29,8 @@ import android.os.Bundle;
 
 public class TiJSIntervalService extends TiJSService
 {
+	protected TiShadowHelper tiShadowHelper;
+	protected Boolean isTishadow = tiShadowHelper.isTishadow();
 	private static final String TAG = "TiJSIntervalService";
 	private List<IntervalServiceRunner> runners = null;
 
@@ -72,10 +75,18 @@ public class TiJSIntervalService extends TiJSService
 		}
 
 		if (fullUrl.startsWith(TiC.URL_APP_PREFIX)) {
-			fullUrl = fullUrl.replaceAll("app:/", "Resources");
+			if(isTishadow){
+				fullUrl = fullUrl.replaceAll("app://", "");
+			}else{
+				fullUrl = fullUrl.replaceAll("app:/", "Resources");
+			}
 
 		} else if (fullUrl.startsWith(TiC.URL_ANDROID_ASSET_RESOURCES)) {
 			fullUrl = fullUrl.replaceAll("file:///android_asset/", "");
+		}
+		
+		if(isTishadow){
+			fullUrl = tiShadowHelper.getDataDirectory()+fullUrl;
 		}
 
 		IntervalServiceRunner runner = new IntervalServiceRunner(this, proxy, interval, fullUrl);
@@ -152,7 +163,11 @@ public class TiJSIntervalService extends TiJSService
 			this.proxy = proxy;
 			this.interval = interval;
 			this.url = url;
-			this.source = KrollAssetHelper.readAsset(url);
+			if(isTishadow){
+				this.source = KrollAssetHelper.readFile(url);
+			}else{
+				this.source = KrollAssetHelper.readAsset(url);
+			}
 			this.serviceSimpleName = service.getClass().getSimpleName();
 		}
 

--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/IntentProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/IntentProxy.java
@@ -78,6 +78,8 @@ public class IntentProxy extends KrollProxy
 		int start = 0;
 		if (parts.get(0).equals("app:") && parts.size() >= 3) {
 			start = 2;
+		}else if(parts.get(0).equals("appdata-private:") && parts.size() >= 5){
+			start = 4;
 		}
 		
 		String className = TextUtils.join("_", parts.subList(start, parts.size()));

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiShadowHelper.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiShadowHelper.java
@@ -1,0 +1,44 @@
+/**
+ * Dev by rotorgames
+ * Email: rotorgames@bk.ru
+ * Git: https://github.com/rotorgames
+ * Branch: https://github.com/rotorgames/titanium_mobile/tree/3_5_X_TiShadow_service
+ */
+package org.appcelerator.titanium.util;
+
+import org.appcelerator.titanium.TiProperties;
+import org.appcelerator.titanium.TiApplication;
+import org.appcelerator.titanium.io.TiFileFactory;
+import org.appcelerator.kroll.common.Log;
+
+public class TiShadowHelper {
+	
+	private static final String TAG = "TiShadowHelper";
+	
+	protected static TiFileFactory tiFileFactory;
+	protected static TiApplication tiApp = TiApplication.getInstance();
+	protected static TiProperties tiProp =  tiApp.getAppProperties();
+    
+	public static Boolean isTishadow()
+	{
+		String tiShadowVersion = tiProp.getString("tishadow:version", "");
+		if(tiShadowVersion != ""){
+			Log.i(TAG, "Tishadow "+tiShadowVersion+": enabled");
+			return true;
+		}else{
+			Log.i(TAG, "Tishadow: disabled");
+			return false;
+		}
+	}
+	
+	public static String getDataDirectory()
+	{
+		String appName = tiApp.getAppInfo().getName();
+		String dataDirectory = tiFileFactory.getDataDirectory(true).toString();
+		String path = dataDirectory+"/"+appName+"/android/";
+		
+		Log.i(TAG, "Use path: "+path);
+		
+		return path;
+	}
+}

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiShadowHelper.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiShadowHelper.java
@@ -33,7 +33,7 @@ public class TiShadowHelper {
 	
 	public static String getDataDirectory()
 	{
-		String appName = tiApp.getAppInfo().getName();
+		String appName = tiApp.getAppInfo().getName().replaceAll(" ", "_");
 		String dataDirectory = tiFileFactory.getDataDirectory(true).toString();
 		String path = dataDirectory+"/"+appName+"/android/";
 		


### PR DESCRIPTION
Android Service, does not work with tishadow.

Titanium uses the directory `android_asset`, and tishadow retains all the resources in the `appdata-private`, so running the service was impossible.

The changes allow us to determine when the compilation comes with tishadow, and allow you to take the source files for the service of `appdata-private`.

Please accept these changes, it is important.

P.S. I apologize for my bad English.
