### PR TITLE
Grunt package

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -8,6 +8,17 @@ module.exports = function (grunt) {
         clangFormat: {
             src: [] // unused ATM
         },
+		version: {
+			patchTitaniumVersion: {
+				options: {
+					prefix: '^version\\s+=\\s+[\'"]'
+				},
+				src: ['build/titanium_version.py']
+			},
+			patchPackage: {
+				src: ['package.json']
+			}
+		}
 	});
 
 	// Load grunt plugins for modules
@@ -15,12 +26,19 @@ module.exports = function (grunt) {
 	grunt.loadNpmTasks('grunt-appc-js');
 	grunt.loadNpmTasks('grunt-clang-format');
 	grunt.loadNpmTasks('grunt-contrib-clean');
+	grunt.loadNpmTasks('grunt-version');
 
 	// register tasks
 	grunt.registerTask('lint', ['appcJs']);
 
 	// register tasks
 	grunt.registerTask('format', ['clangFormat']);
+
+	// register tasks
+	grunt.registerTask('bump', ['version::patch']);
+	grunt.registerTask('bump:major', ['version::major']);
+	grunt.registerTask('bump:minor', ['version::minor']);
+	grunt.registerTask('bump:patch', ['version::patch']);
 
 	// register tasks
 	grunt.registerTask('default', ['lint']);

--- a/package.json
+++ b/package.json
@@ -1,65 +1,66 @@
 {
-	"name": "titanium-mobile",
-	"description": "Appcelerator Titanium Mobile",
-	"version": "4.1.0",
-	"keywords": [
-		"appcelerator",
-		"titanium",
-		"mobile",
-		"android",
-		"mobileweb",
-		"iphone",
-		"ipad",
-		"ios"
-	],
-	"author": "Appcelerator, Inc. <npmjs@appcelerator.com>",
-	"scripts": {
-		"test": "grunt"
-	},
-	"dependencies": {
-		"adm-zip": "~0.4.4",
-		"archiver": "~0.4.10",
-		"async": "~0.2.9",
-		"clean-css": "~1.1.1",
-		"colors": "~0.6.2",
-		"css-parse": "~1.5.3",
-		"ejs": "~0.8.4",
-		"fields": "~0.1.23",
-		"humanize": "~0.0.9",
-		"ioslib": "0.2.13",
-		"moment": "~2.4.0",
-		"node-appc": "0.2.24",
-		"node-uuid": "~1.4.1",
-		"request": "~2.34.0",
-		"sprintf": "~0.1.4",
-		"temp": "~0.6.0",
-		"uglify-js": "~2.4.3",
-		"windowslib": "0.1.9",
-		"wrench": "~1.5.1",
-		"xmldom": "~0.1.16"
-	},
-	"devDependencies": {
-	    "grunt-cli": "*",
-	    "grunt-contrib-clean": "^0.6.0",
-	    "grunt-clang-format": "*",
-	    "grunt-appc-js": "*",
-	    "grunt-mocha-test": "^0.12.7",
-		"mocha": "*",
-		"optimist": "~0.6.0",
-		"should": "~1.3.0"
-	},
-	"repository": {
-		"type": "git",
-		"url": "git://github.com/appcelerator/titanium_mobile.git"
-	},
-	"vendorDependencies": {
-		"visual studio": ">=10 <=12",
-		"windows phone sdk": "8.x",
-		"msbuild": ">=4.0",
-		"node": ">=0.10.0 <=0.12.x"
-	},
-	"engines": {
-		"node": ">=0.10.13"
-	},
-	"license": "Apache Public License v2"
+  "name": "titanium-mobile",
+  "description": "Appcelerator Titanium Mobile",
+  "version": "4.1.0",
+  "keywords": [
+    "appcelerator",
+    "titanium",
+    "mobile",
+    "android",
+    "mobileweb",
+    "iphone",
+    "ipad",
+    "ios"
+  ],
+  "author": "Appcelerator, Inc. <npmjs@appcelerator.com>",
+  "scripts": {
+    "test": "grunt"
+  },
+  "dependencies": {
+    "adm-zip": "~0.4.4",
+    "archiver": "~0.4.10",
+    "async": "~0.2.9",
+    "clean-css": "~1.1.1",
+    "colors": "~0.6.2",
+    "css-parse": "~1.5.3",
+    "ejs": "~0.8.4",
+    "fields": "~0.1.23",
+    "humanize": "~0.0.9",
+    "ioslib": "0.2.13",
+    "moment": "~2.4.0",
+    "node-appc": "0.2.24",
+    "node-uuid": "~1.4.1",
+    "request": "~2.34.0",
+    "sprintf": "~0.1.4",
+    "temp": "~0.6.0",
+    "uglify-js": "~2.4.3",
+    "windowslib": "0.1.9",
+    "wrench": "~1.5.1",
+    "xmldom": "~0.1.16"
+  },
+  "devDependencies": {
+    "grunt-appc-js": "*",
+    "grunt-clang-format": "*",
+    "grunt-cli": "*",
+    "grunt-contrib-clean": "^0.6.0",
+    "grunt-mocha-test": "^0.12.7",
+    "grunt-version": "^0.3.1",
+    "mocha": "*",
+    "optimist": "~0.6.0",
+    "should": "~1.3.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/appcelerator/titanium_mobile.git"
+  },
+  "vendorDependencies": {
+    "visual studio": ">=10 <=12",
+    "windows phone sdk": "8.x",
+    "msbuild": ">=4.0",
+    "node": ">=0.10.0 <=0.12.x"
+  },
+  "engines": {
+    "node": ">=0.10.13"
+  },
+  "license": "Apache Public License v2"
 }

--- a/package.json
+++ b/package.json
@@ -1,66 +1,66 @@
 {
-  "name": "titanium-mobile",
-  "description": "Appcelerator Titanium Mobile",
-  "version": "4.1.0",
-  "keywords": [
-    "appcelerator",
-    "titanium",
-    "mobile",
-    "android",
-    "mobileweb",
-    "iphone",
-    "ipad",
-    "ios"
-  ],
-  "author": "Appcelerator, Inc. <npmjs@appcelerator.com>",
-  "scripts": {
-    "test": "grunt"
-  },
-  "dependencies": {
-    "adm-zip": "~0.4.4",
-    "archiver": "~0.4.10",
-    "async": "~0.2.9",
-    "clean-css": "~1.1.1",
-    "colors": "~0.6.2",
-    "css-parse": "~1.5.3",
-    "ejs": "~0.8.4",
-    "fields": "~0.1.23",
-    "humanize": "~0.0.9",
-    "ioslib": "0.2.13",
-    "moment": "~2.4.0",
-    "node-appc": "0.2.24",
-    "node-uuid": "~1.4.1",
-    "request": "~2.34.0",
-    "sprintf": "~0.1.4",
-    "temp": "~0.6.0",
-    "uglify-js": "~2.4.3",
-    "windowslib": "0.1.9",
-    "wrench": "~1.5.1",
-    "xmldom": "~0.1.16"
-  },
-  "devDependencies": {
-    "grunt-appc-js": "*",
-    "grunt-clang-format": "*",
-    "grunt-cli": "*",
-    "grunt-contrib-clean": "^0.6.0",
-    "grunt-mocha-test": "^0.12.7",
-    "grunt-version": "^0.3.1",
-    "mocha": "*",
-    "optimist": "~0.6.0",
-    "should": "~1.3.0"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git://github.com/appcelerator/titanium_mobile.git"
-  },
-  "vendorDependencies": {
-    "visual studio": ">=10 <=12",
-    "windows phone sdk": "8.x",
-    "msbuild": ">=4.0",
-    "node": ">=0.10.0 <=0.12.x"
-  },
-  "engines": {
-    "node": ">=0.10.13"
-  },
-  "license": "Apache Public License v2"
+	"name": "titanium-mobile",
+	"description": "Appcelerator Titanium Mobile",
+	"version": "4.1.0",
+	"keywords": [
+		"appcelerator",
+		"titanium",
+		"mobile",
+		"android",
+		"mobileweb",
+		"iphone",
+		"ipad",
+		"ios"
+	],
+	"author": "Appcelerator, Inc. <npmjs@appcelerator.com>",
+	"scripts": {
+		"test": "grunt"
+	},
+	"dependencies": {
+		"adm-zip": "~0.4.4",
+		"archiver": "~0.4.10",
+		"async": "~0.2.9",
+		"clean-css": "~1.1.1",
+		"colors": "~0.6.2",
+		"css-parse": "~1.5.3",
+		"ejs": "~0.8.4",
+		"fields": "~0.1.23",
+		"humanize": "~0.0.9",
+		"ioslib": "0.2.13",
+		"moment": "~2.4.0",
+		"node-appc": "0.2.24",
+		"node-uuid": "~1.4.1",
+		"request": "~2.34.0",
+		"sprintf": "~0.1.4",
+		"temp": "~0.6.0",
+		"uglify-js": "~2.4.3",
+		"windowslib": "0.1.9",
+		"wrench": "~1.5.1",
+		"xmldom": "~0.1.16"
+	},
+	"devDependencies": {
+		"grunt-appc-js": "*",
+		"grunt-clang-format": "*",
+		"grunt-cli": "*",
+		"grunt-contrib-clean": "^0.6.0",
+		"grunt-mocha-test": "^0.12.7",
+		"grunt-version": "^0.3.1",
+		"mocha": "*",
+		"optimist": "~0.6.0",
+		"should": "~1.3.0"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git://github.com/appcelerator/titanium_mobile.git"
+	},
+	"vendorDependencies": {
+		"visual studio": ">=10 <=12",
+		"windows phone sdk": "8.x",
+		"msbuild": ">=4.0",
+		"node": ">=0.10.0 <=0.12.x"
+	},
+	"engines": {
+		"node": ">=0.10.13"
+	},
+	"license": "Apache Public License v2"
 }


### PR DESCRIPTION
This is meant to solve what was discussed in #6699. We make it easier to bump versions in titanium_mobile.

To use and test:
1. Bump to next patch: grunt bump:patch (should go to X.Y.Z + 1)
2. Bump to next minor: grunt bump:minor (should go to X.Y + 1.Z)
3. Bump to next major: grunt bump:major (should go to X + 1.Y.Z)

Note that we use grunt-version here over grunt-bump because we need to bump package.json and titanium_version. However, we use the grunt-bump syntax as I believe it is the better long-term plugin and there is a discussion to fix this here: https://github.com/vojtajina/grunt-bump/issues/131

See https://jira.appcelerator.org/browse/TIMOB-18662 as well.
