### PR TITLE
TIMOB-17458 : Create ApplicationSupportDirectory on start-up

### DIFF
--- a/iphone/Classes/TiApp.m
+++ b/iphone/Classes/TiApp.m
@@ -174,6 +174,20 @@ TI_INLINE void waitForMemoryPanicCleared();   //WARNING: This must never be run 
     }
 }
 
+- (void)createDefaultDirectories
+{
+    NSError* error = nil;
+    NSURL* dir = [[NSFileManager defaultManager] URLForDirectory:NSApplicationSupportDirectory
+                                                        inDomain:NSUserDomainMask
+                                               appropriateForURL:nil
+                                                          create:YES
+                                                           error:&error];
+    if(error)
+    {
+        DebugLog(@"[ERROR]  %@ %@", error, [error userInfo]);
+    }
+}
+
 - (void)boot
 {
 	DebugLog(@"[INFO] %@/%@ (%s.__GITHASH__)",TI_APPLICATION_NAME,TI_APPLICATION_VERSION,TI_VERSION_STR);
@@ -383,7 +397,7 @@ TI_INLINE void waitForMemoryPanicCleared();   //WARNING: This must never be run 
 	}
     [self launchToUrl];
 	[self boot];
-	
+    [self createDefaultDirectories];
 	return YES;
 }
 


### PR DESCRIPTION
This PR addresses the TIMOB-17458 by checking if the Support Directory exists on start-up. If if doesn't exist, it will be created.

Jira Ticket Link : https://jira.appcelerator.org/browse/TIMOB-17458
Test used to confirm : https://gist.github.com/benbahrenburg/9adb20ded6e2fe218a11
