### PR TITLE
[TIMOB-18706] Fix error when Windows Phone SDK is NOT installed

### DIFF
--- a/node_modules/windowslib/lib/windowsphone.js
+++ b/node_modules/windowslib/lib/windowsphone.js
@@ -46,7 +46,7 @@ function detect(options, callback) {
 		}
 
 		var results = {
-				windowsphone: null,
+				windowsphone: {},
 				issues: []
 			},
 			searchPaths = [


### PR DESCRIPTION
- Initialize _results.windowsphone_ to not be _null_

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-18706)
