### PR TITLE
[TIMOB-16244] Inital implementation of scrollstart and scrollend for listview

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/TiListView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/TiListView.java
@@ -333,20 +333,20 @@ public class TiListView extends TiUIView implements OnSearchChangeListener {
 					{
 						KrollDict eventArgs = new KrollDict();
 						Pair<ListSectionProxy, Pair<Integer, Integer>> info = getSectionInfoByEntryIndex(_firstVisibleItem);
-						
+						int visibleItemCount = _visibleItemCount;
 						
 						int itemIndex = info.second.second;
 						ListSectionProxy section = info.first;
 						
 						if(section.getHeaderTitle() == null || section.getHeaderView() == null) {
 							if(itemIndex > 0) itemIndex -= 1;
-							_visibleItemCount -=1;
+							visibleItemCount -=1;
 						}
 						eventArgs.put("firstVisibleSection", section);
 						eventArgs.put("firstVisibleSectionIndex", info.second.first);
 						eventArgs.put("firstVisibleItem", section.getItemAt(itemIndex));
 						eventArgs.put("firstVisibleItemIndex", itemIndex);
-						eventArgs.put("visibleItemCount", _visibleItemCount);
+						eventArgs.put("visibleItemCount", visibleItemCount);
 						
 						if(scrollState == OnScrollListener.SCROLL_STATE_IDLE) {
 							fProxy.fireEvent(TiC.EVENT_SCROLLEND, eventArgs);

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/TiListView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/TiListView.java
@@ -304,12 +304,12 @@ public class TiListView extends TiUIView implements OnSearchChangeListener {
 		listView.setFocusable(true);
 		listView.setFocusableInTouchMode(true);
 		listView.setDescendantFocusability(ViewGroup.FOCUS_AFTER_DESCENDANTS);
-		final KrollProxy fProxy = proxy;
+
+		final TiViewProxy fProxy = proxy;
 		listView.setOnScrollListener(new OnScrollListener()
 		{
 			private int _firstVisibleItem = 0;
 			private int _visibleItemCount = 0;
-			// private int _totalItemCount = 0;
 			@Override
 			public void onScrollStateChanged(AbsListView view, int scrollState)
 			{
@@ -331,29 +331,31 @@ public class TiListView extends TiUIView implements OnSearchChangeListener {
 					case OnScrollListener.SCROLL_STATE_IDLE:
 					case OnScrollListener.SCROLL_STATE_TOUCH_SCROLL:
 					{
-						KrollDict eventArgs = new KrollDict();
-						Pair<ListSectionProxy, Pair<Integer, Integer>> info = getSectionInfoByEntryIndex(_firstVisibleItem);
-						int visibleItemCount = _visibleItemCount;
-						
-						int itemIndex = info.second.second;
-						ListSectionProxy section = info.first;
-						
-						if(section.getHeaderTitle() == null || section.getHeaderView() == null) {
-							if(itemIndex > 0) itemIndex -= 1;
-							visibleItemCount -=1;
+						if(fProxy.hasListeners(TiC.EVENT_SCROLLSTART) || fProxy.hasListeners(TiC.EVENT_SCROLLEND)) {
+							
+							KrollDict eventArgs = new KrollDict();
+							Pair<ListSectionProxy, Pair<Integer, Integer>> info = getSectionInfoByEntryIndex(_firstVisibleItem);
+							int visibleItemCount = _visibleItemCount;
+							
+							int itemIndex = info.second.second;
+							ListSectionProxy section = info.first;
+							
+							if(section.getHeaderTitle() == null || section.getHeaderView() == null) {
+								if(itemIndex > 0) itemIndex -= 1;
+								visibleItemCount -=1;
+							}
+							eventArgs.put("firstVisibleSection", section);
+							eventArgs.put("firstVisibleSectionIndex", info.second.first);
+							eventArgs.put("firstVisibleItem", section.getItemAt(itemIndex));
+							eventArgs.put("firstVisibleItemIndex", itemIndex);
+							eventArgs.put("visibleItemCount", visibleItemCount);
+							
+							if(scrollState == OnScrollListener.SCROLL_STATE_IDLE) {
+								fProxy.fireEvent(TiC.EVENT_SCROLLEND, eventArgs, false);
+							} else {
+								fProxy.fireEvent(TiC.EVENT_SCROLLSTART, eventArgs, false);
+							}
 						}
-						eventArgs.put("firstVisibleSection", section);
-						eventArgs.put("firstVisibleSectionIndex", info.second.first);
-						eventArgs.put("firstVisibleItem", section.getItemAt(itemIndex));
-						eventArgs.put("firstVisibleItemIndex", itemIndex);
-						eventArgs.put("visibleItemCount", visibleItemCount);
-						
-						if(scrollState == OnScrollListener.SCROLL_STATE_IDLE) {
-							fProxy.fireEvent(TiC.EVENT_SCROLLEND, eventArgs);
-						} else {
-							fProxy.fireEvent(TiC.EVENT_SCROLLSTART, eventArgs);
-						}
-						return;
 					}
 				}
 			}
@@ -362,7 +364,6 @@ public class TiListView extends TiUIView implements OnSearchChangeListener {
 			{
 				_firstVisibleItem = firstVisibleItem;
 				_visibleItemCount = visibleItemCount;
-				// _totalItemCount = totalItemCount;
 			}
 		});
 		

--- a/android/titanium/src/java/org/appcelerator/titanium/TiC.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiC.java
@@ -116,17 +116,22 @@ public class TiC
 	/**
 	 * @module.api
 	 */
-	public static final String EVENT_DOUBLE_CLICK = "dblclick";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_DISPOSE_HANDLE = "disposehandle";
 
 	/**
 	 * @module.api
 	 */
+	public static final String EVENT_DOUBLE_CLICK = "dblclick";
+
+	/**
+	 * @module.api
+	 */
 	public static final String EVENT_DOUBLE_TAP = "doubletap";
+
+	/**
+	 * @module.api
+	 */
+	public static final String EVENT_DRAGEND = "dragend";
 
 	/**
 	 * @module.api
@@ -441,11 +446,6 @@ public class TiC
 	 * @module.api
 	 */
 	public static final String EVENT_SCROLLSTART = "scrollstart";
-
-	/**
-	 * @module.api
-	 */
-	public static final String EVENT_DRAGEND = "dragend";
 
 	/**
 	 * @module.api

--- a/android/titanium/src/java/org/appcelerator/titanium/TiC.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiC.java
@@ -435,12 +435,12 @@ public class TiC
 	/**
 	 * @module.api
 	 */
-	public static final String EVENT_SCROLLEND = "scrollend";
+	public static final String EVENT_SCROLLSTART = "scrollstart";
 
 	/**
 	 * @module.api
 	 */
-	public static final String EVENT_SCROLLSTART = "scrollstart";
+	public static final String EVENT_SCROLLEND = "scrollend";
 
 	/**
 	 * @module.api

--- a/android/titanium/src/java/org/appcelerator/titanium/TiC.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiC.java
@@ -435,12 +435,12 @@ public class TiC
 	/**
 	 * @module.api
 	 */
-	public static final String EVENT_SCROLLSTART = "scrollstart";
+	public static final String EVENT_SCROLLEND = "scrollend";
 
 	/**
 	 * @module.api
 	 */
-	public static final String EVENT_SCROLLEND = "scrollend";
+	public static final String EVENT_SCROLLSTART = "scrollstart";
 
 	/**
 	 * @module.api

--- a/android/titanium/src/java/org/appcelerator/titanium/TiC.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiC.java
@@ -440,6 +440,11 @@ public class TiC
 	/**
 	 * @module.api
 	 */
+	public static final String EVENT_SCROLLSTART = "scrollstart";
+
+	/**
+	 * @module.api
+	 */
 	public static final String EVENT_DRAGEND = "dragend";
 
 	/**

--- a/apidoc/Titanium/UI/ListView.yml
+++ b/apidoc/Titanium/UI/ListView.yml
@@ -434,23 +434,23 @@ events:
     since: 4.1.0
     properties: 
       - name: visibleItemCount
-        summary: The number of visible items in the listView when the event
+        summary: The number of visible items in the listView when the event fires
         type: Number
 
       - name: firstVisibleItem
-        summary: The first visible item in the listView when the event
+        summary: The first visible item in the listView when the event fires
         type: Object
 
       - name: firstVisibleSection
-        summary: The first visible section in the listView when the event
+        summary: The first visible section in the listView when the event fires
         type: Titanium.UI.ListSection
 
       - name: firstVisibleItemIndex
-        summary: The index of the first visible item in the listView when the event
+        summary: The index of the first visible item in the listView when the event fires
         type: Number
 
       - name: firstVisibleSectionIndex
-        summary: The index of the first visible section in the listView when the event
+        summary: The index of the first visible section in the listView when the event fires
         type: Number
 
 properties:

--- a/apidoc/Titanium/UI/ListView.yml
+++ b/apidoc/Titanium/UI/ListView.yml
@@ -398,59 +398,59 @@ events:
         type: Boolean
 
   - name: scrollstart
-    summary: Fires when the listview starts scrolling by user interaction. Calling the `scrollTo` methods will not fire this event
+    summary: Fires when the list view starts scrolling by user interaction. Calling the `scrollTo` methods will not fire this event
     description: |
-        This event will fire when the user starts scrolling the listview. Use the `firstVisibleSectionIndex` and 
-        the `firstVisibleItemIndex` to determine the position of the listview.
+        This event will fire when the user starts scrolling the list view. Use the `firstVisibleSectionIndex` and 
+        the `firstVisibleItemIndex` to determine the position of the list view.
     platforms: [iphone, ipad, android]
     since: 4.1.0
     properties: 
       - name: visibleItemCount
-        summary: The number of visible items in the listView when the event fires
+        summary: The number of visible items in the list view when the event fires.
         type: Number
 
       - name: firstVisibleItem
-        summary: The first visible item in the listView when the event fires, this item might not be fully visible
+        summary: The first visible item in the list view when the event fires; this item might not be fully visible.
         type: Object
 
       - name: firstVisibleSection
-        summary: The first visible section in the listView when the event fires
+        summary: The first visible section in the list view when the event fires.
         type: Titanium.UI.ListSection
 
       - name: firstVisibleItemIndex
-        summary: The index of the first visible item in the listView when the event fires, this item might not be fully visible
+        summary: The index of the first visible item in the list view when the event fires; this item might not be fully visible.
         type: Number
 
       - name: firstVisibleSectionIndex
-        summary: The index of the first visible section in the listView when the event fires
+        summary: The index of the first visible section in the list view when the event fires.
         type: Number
 
   - name: scrollend
-    summary: Fires when the listview ends scrolling. Calling the `scrollTo` methods will not fire this event
+    summary: Fires when the list view ends scrolling. Calling the `scrollTo` methods will not fire this event
     description: |
-        This event will fire when the listview ends scrolling. Use the `firstVisibleSectionIndex` and 
-        the `firstVisibleItemIndex` to determine the position of the listview.
+        This event will fire when the list view ends scrolling. Use the `firstVisibleSectionIndex` and 
+        the `firstVisibleItemIndex` to determine the position of the list view.
     platforms: [iphone, ipad, android]
     since: 4.1.0
     properties: 
       - name: visibleItemCount
-        summary: The number of visible items in the listView when the event fires
+        summary: The number of visible items in the list view when the event fires.
         type: Number
 
       - name: firstVisibleItem
-        summary: The first visible item in the listView when the event fires, this item might not be fully visible
+        summary: The first visible item in the list view when the event fires; this item might not be fully visible.
         type: Object
 
       - name: firstVisibleSection
-        summary: The first visible section in the listView when the event fires
+        summary: The first visible section in the list view when the event fires.
         type: Titanium.UI.ListSection
 
       - name: firstVisibleItemIndex
-        summary: The index of the first visible item in the listView when the event fires, this item might not be fully visible
+        summary: The index of the first visible item in the list view when the event fires; this item might not be fully visible.
         type: Number
 
       - name: firstVisibleSectionIndex
-        summary: The index of the first visible section in the listView when the event fires
+        summary: The index of the first visible section in the list view when the event fires.
         type: Number
 
 properties:

--- a/apidoc/Titanium/UI/ListView.yml
+++ b/apidoc/Titanium/UI/ListView.yml
@@ -425,6 +425,10 @@ events:
         summary: The index of the first visible section in the list view when the event fires.
         type: Number
 
+      - name: bubbles
+        summary: false. This event does not bubble.
+        type: Boolean
+
   - name: scrollend
     summary: Fires when the list view ends scrolling. Calling the `scrollTo` methods will not fire this event
     description: |
@@ -452,6 +456,10 @@ events:
       - name: firstVisibleSectionIndex
         summary: The index of the first visible section in the list view when the event fires.
         type: Number
+
+      - name: bubbles
+        summary: false. This event does not bubble.
+        type: Boolean
 
 properties:
 

--- a/apidoc/Titanium/UI/ListView.yml
+++ b/apidoc/Titanium/UI/ListView.yml
@@ -397,6 +397,62 @@ events:
         summary: false. This event does not bubble.
         type: Boolean
 
+  - name: scrollstart
+    summary: Fires when the listview starts scrolling
+    description: |
+        This event will fire when the user starts scrolling the listview. Use the `firstVisibleSectionIndex` and 
+        the `firstVisibleItemIndex` to determine the position of the listview.
+    platforms: [iphone, ipad, android]
+    since: 4.1.0
+    properties: 
+      - name: visibleItemCount
+        summary: The number of visible items in the listView when the event
+        type: Number
+
+      - name: firstVisibleItem
+        summary: The first visible item in the listView when the event
+        type: Object
+
+      - name: firstVisibleSection
+        summary: The first visible section in the listView when the event
+        type: Titanium.UI.ListSection
+
+      - name: firstVisibleItemIndex
+        summary: The index of the first visible item in the listView when the event
+        type: Number
+
+      - name: firstVisibleSectionIndex
+        summary: The index of the first visible section in the listView when the event
+        type: Number
+
+  - name: scrollend
+    summary: Fires when the listview ends scrolling
+    description: |
+        This event will fire when the listview ends scrolling. Use the `firstVisibleSectionIndex` and 
+        the `firstVisibleItemIndex` to determine the position of the listview.
+    platforms: [iphone, ipad, android]
+    since: 4.1.0
+    properties: 
+      - name: visibleItemCount
+        summary: The number of visible items in the listView when the event
+        type: Number
+
+      - name: firstVisibleItem
+        summary: The first visible item in the listView when the event
+        type: Object
+
+      - name: firstVisibleSection
+        summary: The first visible section in the listView when the event
+        type: Titanium.UI.ListSection
+
+      - name: firstVisibleItemIndex
+        summary: The index of the first visible item in the listView when the event
+        type: Number
+
+      - name: firstVisibleSectionIndex
+        summary: The index of the first visible section in the listView when the event
+        type: Number
+
 properties:
 
   - name: allowsSelection

--- a/apidoc/Titanium/UI/ListView.yml
+++ b/apidoc/Titanium/UI/ListView.yml
@@ -406,23 +406,23 @@ events:
     since: 4.1.0
     properties: 
       - name: visibleItemCount
-        summary: The number of visible items in the listView when the event
+        summary: The number of visible items in the listView when the event fires
         type: Number
 
       - name: firstVisibleItem
-        summary: The first visible item in the listView when the event
+        summary: The first visible item in the listView when the event fires
         type: Object
 
       - name: firstVisibleSection
-        summary: The first visible section in the listView when the event
+        summary: The first visible section in the listView when the event fires
         type: Titanium.UI.ListSection
 
       - name: firstVisibleItemIndex
-        summary: The index of the first visible item in the listView when the event
+        summary: The index of the first visible item in the listView when the event fires
         type: Number
 
       - name: firstVisibleSectionIndex
-        summary: The index of the first visible section in the listView when the event
+        summary: The index of the first visible section in the listView when the event fires
         type: Number
 
   - name: scrollend

--- a/apidoc/Titanium/UI/ListView.yml
+++ b/apidoc/Titanium/UI/ListView.yml
@@ -398,7 +398,7 @@ events:
         type: Boolean
 
   - name: scrollstart
-    summary: Fires when the listview starts scrolling
+    summary: Fires when the listview starts scrolling by user interaction. Calling the `scrollTo` methods will not fire this event
     description: |
         This event will fire when the user starts scrolling the listview. Use the `firstVisibleSectionIndex` and 
         the `firstVisibleItemIndex` to determine the position of the listview.
@@ -426,7 +426,7 @@ events:
         type: Number
 
   - name: scrollend
-    summary: Fires when the listview ends scrolling
+    summary: Fires when the listview ends scrolling. Calling the `scrollTo` methods will not fire this event
     description: |
         This event will fire when the listview ends scrolling. Use the `firstVisibleSectionIndex` and 
         the `firstVisibleItemIndex` to determine the position of the listview.

--- a/apidoc/Titanium/UI/ListView.yml
+++ b/apidoc/Titanium/UI/ListView.yml
@@ -410,7 +410,7 @@ events:
         type: Number
 
       - name: firstVisibleItem
-        summary: The first visible item in the listView when the event fires
+        summary: The first visible item in the listView when the event fires, this item might not be fully visible
         type: Object
 
       - name: firstVisibleSection
@@ -418,7 +418,7 @@ events:
         type: Titanium.UI.ListSection
 
       - name: firstVisibleItemIndex
-        summary: The index of the first visible item in the listView when the event fires
+        summary: The index of the first visible item in the listView when the event fires, this item might not be fully visible
         type: Number
 
       - name: firstVisibleSectionIndex
@@ -438,7 +438,7 @@ events:
         type: Number
 
       - name: firstVisibleItem
-        summary: The first visible item in the listView when the event fires
+        summary: The first visible item in the listView when the event fires, this item might not be fully visible
         type: Object
 
       - name: firstVisibleSection
@@ -446,7 +446,7 @@ events:
         type: Titanium.UI.ListSection
 
       - name: firstVisibleItemIndex
-        summary: The index of the first visible item in the listView when the event fires
+        summary: The index of the first visible item in the listView when the event fires, this item might not be fully visible
         type: Number
 
       - name: firstVisibleSectionIndex

--- a/iphone/Classes/TiUIListView.m
+++ b/iphone/Classes/TiUIListView.m
@@ -67,6 +67,7 @@ static TiViewProxy * FindViewProxyWithBindIdContainingPoint(UIView *view, CGPoin
     
     BOOL canFireScrollStart;
     BOOL canFireScrollEnd;
+    BOOL isScrollingToTop;
 }
 
 - (id)init
@@ -1724,19 +1725,19 @@ static TiViewProxy * FindViewProxyWithBindIdContainingPoint(UIView *view, CGPoin
 - (void)scrollViewDidEndDecelerating:(UIScrollView *)scrollView
 {
     [[ImageLoader sharedLoader] resume];
-    [self fireScrollEnd:(UITableView *)scrollView];
+    if(isScrollingToTop) {
+        isScrollingToTop = NO;
+    } else {
+        [self fireScrollEnd:(UITableView *)scrollView];
+    }
 }
 
 - (BOOL)scrollViewShouldScrollToTop:(UIScrollView *)scrollView
 {
     [[ImageLoader sharedLoader] suspend];
+    isScrollingToTop = YES;
     [self fireScrollStart:(UITableView*) scrollView];
     return YES;
-}
-
-- (void)scrollViewDidEndScrollingAnimation:(UIScrollView *)scrollView
-{
-    [self scrollViewDidEndDecelerating:scrollView];
 }
 
 - (void)scrollViewDidScrollToTop:(UIScrollView *)scrollView


### PR DESCRIPTION
Jira ticket: https://jira.appcelerator.org/browse/TIMOB-16244
Note:
This adds two events to the Ti.UI.ListView for **Android** and **iOS** only: `scrollstart` and `scrollend`
The event arguments contain the following information:

```
eventArgs = {
    firstVisibleSectionIndex: Number
    firstVisibleItemIndex: Number
    firstVisibleSection: [object Ti.UI.ListSection]
    firstVisibleItem: [object Object]
    visibleItemCount: Number
}
```
