### PR TITLE
Add missing option cacheSize for scrollableViews on Android

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIScrollableView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIScrollableView.java
@@ -297,6 +297,11 @@ public class TiUIScrollableView extends TiUIView
 			}
 		}
 
+    		if (d.containsKey("cacheSize")) {
+        		int cacheSize = TiConvert.toInt(d.get("cacheSize"));
+        		mPager.setOffscreenPageLimit(cacheSize);
+    		}
+    		
 		super.processProperties(d);
 
 	}


### PR DESCRIPTION
On iOS, the cacheSize argument is present, but on Android this is missing. This leads to empty views in some cases that don't get rebuilt correctly after scrolling. Code is tested on SDK 3.5.1.GA Multiple Android versions and works.

Thanks to mikefogg, more info: https://github.com/iskugor/Ti.SwipeRefreshLayout/issues/5#issuecomment-69623928
