### PR TITLE
[TIMOB-18816] Add support to set language like iOS

### DIFF
--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -3319,9 +3319,25 @@ AndroidBuilder.prototype.generateI18N = function generateI18N(next) {
 	function replaceSpaces(s) {
 		return s.replace(/./g, '\\u0020');
 	}
+	
+	function resolveRegionName(locale) {
+		if (locale.match(/\w{2}(-|_)r?\w{2}/)) {
+			var parts = locale.split(/-|_/),
+			    lang = parts[0],
+			    region = parts[1],
+			    separator = '-';
+	
+			if (region.length == 2) {
+				separator = '-r';
+			}
+	
+			return lang + separator + region;
+		}
+		return locale;
+	}
 
 	Object.keys(data).forEach(function (locale) {
-		var dest = path.join(this.buildResDir, 'values' + (locale == 'en' ? '' : '-' + locale), 'strings.xml'),
+		var dest = path.join(this.buildResDir, 'values' + (locale == 'en' ? '' : '-' + resolveRegionName(locale)), 'strings.xml'),
 			dom = new DOMParser().parseFromString('<resources/>', 'text/xml'),
 			root = dom.documentElement,
 			appname = data[locale].app && data[locale].app.appname || this.tiapp.name,

--- a/android/modules/locale/src/java/ti/modules/titanium/locale/LocaleModule.java
+++ b/android/modules/locale/src/java/ti/modules/titanium/locale/LocaleModule.java
@@ -86,7 +86,26 @@ public class LocaleModule extends KrollModule
 	@Kroll.method @Kroll.setProperty
 	public void setLanguage(String language) 
 	{
-		Log.w(TAG, "Locale.setLanguage not supported for Android.");
+		try {
+			String[] parts = language.split("-");
+			Locale locale = null;
+			
+			if (parts.length > 1) {
+				locale = new Locale(parts[0], parts[1]);
+			} else {
+				locale = new Locale(parts[0]);
+			}
+			 
+			Locale.setDefault(locale);
+			
+			Configuration config = new Configuration();
+			config.locale = locale;
+			
+			Context ctx =  TiApplication.getInstance().getBaseContext();
+			ctx.getResources().updateConfiguration(config, ctx.getResources().getDisplayMetrics());
+		} catch (Exception e) {
+			Log.e(TAG, "Error trying to set language '" + language + "':", e);
+		}
 	}
 
 	@Kroll.method  @Kroll.topLevel("L")


### PR DESCRIPTION
Add support to set language like iOS with language and region, for example: es, es-CO, es-CL.

More information: http://developer.android.com/guide/topics/resources/providing-resources.html#AlternativeResources [Table 2. Configuration qualifier names]
