### PR TITLE
[TIMOB-17145]Add support to HTTPClient for PATCH requests

### DIFF
--- a/android/modules/network/src/java/ti/modules/titanium/network/TiDefaultHttpRequestFactory.java
+++ b/android/modules/network/src/java/ti/modules/titanium/network/TiDefaultHttpRequestFactory.java
@@ -1,0 +1,55 @@
+/**
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2015 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+
+package ti.modules.titanium.network;
+
+import org.apache.http.HttpRequest;
+import org.apache.http.impl.DefaultHttpRequestFactory;
+import org.apache.http.MethodNotSupportedException;
+import org.apache.http.RequestLine;
+import org.apache.http.message.BasicHttpEntityEnclosingRequest;
+import org.apache.http.message.BasicHttpRequest;
+
+
+public class TiDefaultHttpRequestFactory extends DefaultHttpRequestFactory {
+
+    private static final String  PATCH_METHOD = "PATCH";
+
+
+    public TiDefaultHttpRequestFactory() {
+        super();
+    }
+
+    @Override
+    public HttpRequest newHttpRequest(final RequestLine requestline)
+            throws MethodNotSupportedException {
+
+        String method = requestline.getMethod();
+
+        if (requestline == null) {
+            throw new IllegalArgumentException("Request line may not be null");
+        }
+
+        if (PATCH_METHOD.equalsIgnoreCase(method)){
+            return new BasicHttpEntityEnclosingRequest(requestline);
+        }
+
+        return super.newHttpRequest(requestline);
+    }
+
+    @Override
+    public HttpRequest newHttpRequest(final String method, final String uri)
+            throws MethodNotSupportedException {
+
+        if (PATCH_METHOD.equalsIgnoreCase(method)){
+            return new BasicHttpEntityEnclosingRequest(method, uri);
+        }
+
+        return super.newHttpRequest(method, uri);
+    }
+
+}

--- a/android/modules/network/src/java/ti/modules/titanium/network/TiDefaultHttpRequestFactory.java
+++ b/android/modules/network/src/java/ti/modules/titanium/network/TiDefaultHttpRequestFactory.java
@@ -17,39 +17,39 @@ import org.apache.http.message.BasicHttpRequest;
 
 public class TiDefaultHttpRequestFactory extends DefaultHttpRequestFactory {
 
-    private static final String  PATCH_METHOD = "PATCH";
+	private static final String  PATCH_METHOD = "PATCH";
 
 
-    public TiDefaultHttpRequestFactory() {
-        super();
-    }
+	public TiDefaultHttpRequestFactory() {
+		super();
+	}
 
-    @Override
-    public HttpRequest newHttpRequest(final RequestLine requestline)
-            throws MethodNotSupportedException {
+	@Override
+	public HttpRequest newHttpRequest(final RequestLine requestline)
+			throws MethodNotSupportedException {
 
-        String method = requestline.getMethod();
+		String method = requestline.getMethod();
 
-        if (requestline == null) {
-            throw new IllegalArgumentException("Request line may not be null");
-        }
+		if (requestline == null) {
+			throw new IllegalArgumentException("Request line may not be null");
+		}
 
-        if (PATCH_METHOD.equalsIgnoreCase(method)){
-            return new BasicHttpEntityEnclosingRequest(requestline);
-        }
+		if (PATCH_METHOD.equalsIgnoreCase(method)){
+			return new BasicHttpEntityEnclosingRequest(requestline);
+		}
 
-        return super.newHttpRequest(requestline);
-    }
+		return super.newHttpRequest(requestline);
+	}
 
-    @Override
-    public HttpRequest newHttpRequest(final String method, final String uri)
-            throws MethodNotSupportedException {
+	@Override
+	public HttpRequest newHttpRequest(final String method, final String uri)
+			throws MethodNotSupportedException {
 
-        if (PATCH_METHOD.equalsIgnoreCase(method)){
-            return new BasicHttpEntityEnclosingRequest(method, uri);
-        }
+		if (PATCH_METHOD.equalsIgnoreCase(method)){
+			return new BasicHttpEntityEnclosingRequest(method, uri);
+		}
 
-        return super.newHttpRequest(method, uri);
-    }
+		return super.newHttpRequest(method, uri);
+	}
 
 }

--- a/android/modules/network/src/java/ti/modules/titanium/network/TiDefaultHttpRequestFactory.java
+++ b/android/modules/network/src/java/ti/modules/titanium/network/TiDefaultHttpRequestFactory.java
@@ -28,11 +28,12 @@ public class TiDefaultHttpRequestFactory extends DefaultHttpRequestFactory {
 	public HttpRequest newHttpRequest(final RequestLine requestline)
 			throws MethodNotSupportedException {
 
-		String method = requestline.getMethod();
-
 		if (requestline == null) {
 			throw new IllegalArgumentException("Request line may not be null");
 		}
+		
+		String method = requestline.getMethod();
+
 
 		if (PATCH_METHOD.equalsIgnoreCase(method)){
 			return new BasicHttpEntityEnclosingRequest(requestline);

--- a/android/modules/network/src/java/ti/modules/titanium/network/TiHTTPClient.java
+++ b/android/modules/network/src/java/ti/modules/titanium/network/TiHTTPClient.java
@@ -75,7 +75,6 @@ import org.apache.http.entity.mime.MultipartEntity;
 import org.apache.http.entity.mime.content.ContentBody;
 import org.apache.http.entity.mime.content.FileBody;
 import org.apache.http.entity.mime.content.StringBody;
-import org.apache.http.impl.DefaultHttpRequestFactory;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.impl.client.DefaultRedirectHandler;
 import org.apache.http.impl.conn.tsccm.ThreadSafeClientConnManager;
@@ -172,7 +171,7 @@ public class TiHTTPClient
 
 
 	protected HashMap<String,String> headers = new HashMap<String,String>();
-	
+
 	private Hashtable<String, AuthSchemeFactory> customAuthenticators = new Hashtable<String, AuthSchemeFactory>(1);
 
 	public static final int READY_STATE_UNSENT = 0; // Unsent, open() has not yet been called
@@ -186,7 +185,7 @@ public class TiHTTPClient
 		@Override
 		public URI getLocationURI(HttpResponse response, HttpContext context)
 				throws ProtocolException {
-			
+
 			if (response == null) {
 				throw new IllegalArgumentException("HTTP response may not be null");
 			}
@@ -197,13 +196,13 @@ public class TiHTTPClient
 				throw new ProtocolException("Received redirect response "
 					+ response.getStatusLine() + " but no location header");
 			}
-			
+
 			// bug #2156: https://appcelerator.lighthouseapp.com/projects/32238/tickets/2156-android-invalid-redirect-alert-on-xhr-file-download
 			// in some cases we have to manually replace spaces in the URI (probably because the HTTP server isn't correctly escaping them)
 			String location = locationHeader.getValue().replaceAll (" ", "%20");
 			response.setHeader("location", location);
 			redirectedLocation = location;
-			
+
 			return super.getLocationURI(response, context);
 		}
 
@@ -217,7 +216,7 @@ public class TiHTTPClient
 			}
 		}
 	}
-	
+
 	class LocalResponseHandler implements ResponseHandler<String>
 	{
 		public WeakReference<TiHTTPClient> client;
@@ -367,7 +366,7 @@ public class TiHTTPClient
 			responseData = TiBlob.blobFromFile(tiFile, contentType);
 			return tiFile;
 		}
-		
+
 		private void handleEntityData(byte[] data, int size, long totalSize, long contentLength) throws IOException
 		{
 			if (responseOut == null) {
@@ -386,7 +385,7 @@ public class TiHTTPClient
 				// to a file and re-open as a FileOutputStream w/ append
 				createFileResponseData(true);
 			}
-			
+
 			responseOut.write(data, 0, size);
 
 			KrollDict callbackData = new KrollDict();
@@ -408,7 +407,7 @@ public class TiHTTPClient
 
 			dispatchCallback("ondatastream", callbackData);
 		}
-		
+
 		private void finishedReceivingEntityData(long contentLength) throws IOException
 		{
 			if (responseOut instanceof ByteArrayOutputStream) {
@@ -513,7 +512,7 @@ public class TiHTTPClient
 		public void write(int b) throws IOException
 		{
 			//Donot write if request is aborted
-			if (!aborted) {	
+			if (!aborted) {
 				super.write(b);
 				transferred++;
 				fireProgress();
@@ -560,7 +559,7 @@ public class TiHTTPClient
 		}
 		return false;
 	}
-	
+
 	public void addAuthFactory(String scheme, AuthSchemeFactory theFactory)
 	{
 		customAuthenticators.put(scheme, theFactory);
@@ -785,9 +784,9 @@ public class TiHTTPClient
 			if (!lower_url.contains(cookie.getDomain().toLowerCase())) {
 				client.getCookieStore().addCookie(cookie);
 			}
-		} 
+		}
 	}
-	
+
 	public void setRequestHeader(String header, String value)
 	{
 		if (readyState <= READY_STATE_OPENED) {
@@ -820,12 +819,12 @@ public class TiHTTPClient
 				}
 			}
 			result = sb.toString();
-		
+
 			if (result.length() == 0) {
 				Log.w(TAG, "No value for response header: " + headerName, Log.DEBUG_MODE);
 			}
 
-		} 
+		}
 
 		return result;
 	}
@@ -840,7 +839,7 @@ public class TiHTTPClient
 			throw new IllegalArgumentException("URL cannot be null");
 		}
 
-		// if the url is not prepended with either http or 
+		// if the url is not prepended with either http or
 		// https, then default to http and prepend the protocol
 		// to the url
 		String lowerCaseUrl = url.toLowerCase();
@@ -857,7 +856,7 @@ public class TiHTTPClient
 
 		// If the original url does not contain any
 		// escaped query string (i.e., does not look
-		// pre-encoded), go ahead and reset it to the 
+		// pre-encoded), go ahead and reset it to the
 		// clean uri. Else keep it as is so the user's
 		// escaping stays in effect.  The users are on their own
 		// at that point.
@@ -948,7 +947,7 @@ public class TiHTTPClient
 		}
 		try {
 			if (needMultipart) {
-				// JGH NOTE: this seems to be a bug in RoR where it would puke if you 
+				// JGH NOTE: this seems to be a bug in RoR where it would puke if you
 				// send a content-type of text/plain for key/value pairs in form-data
 				// so we send an empty string by default instead which will cause the
 				// StringBody to not include the content-type header. this should be
@@ -1024,7 +1023,7 @@ public class TiHTTPClient
 		}
 		return 0;
 	}
-	
+
 	private Object titaniumFileAsPutData(Object value)
 	{
 		if (value instanceof TiBaseFile && !(value instanceof TiResourceFile)) {
@@ -1043,7 +1042,7 @@ public class TiHTTPClient
 				FileOutputStream fos = new FileOutputStream(tmpFile);
 				fos.write(blob.getBytes());
 				fos.close();
-		
+
 				tmpFiles.add(tmpFile);
 				return new FileEntity(tmpFile, mimeType);
 			} catch (IOException e) {
@@ -1065,7 +1064,7 @@ public class TiHTTPClient
 
 		HttpProtocolParams.setUseExpectContinue(params, false);
 		HttpProtocolParams.setVersion(params, HttpVersion.HTTP_1_1);
-		
+
 		DefaultHttpClient httpClient = new DefaultHttpClient(new ThreadSafeClientConnManager(params, registry), params);
 		httpClient.setCookieStore(cookieStore);
 
@@ -1075,12 +1074,12 @@ public class TiHTTPClient
 	protected DefaultHttpClient getClient(boolean validating)
 	{
 		SSLSocketFactory sslSocketFactory = null;
-		
+
 		if (this.securityManager != null) {
 			if (this.securityManager.willHandleURL(this.uri)) {
 				TrustManager[] trustManagerArray = this.securityManager.getTrustManagers((HTTPClientProxy)this.proxy);
 				KeyManager[] keyManagerArray = this.securityManager.getKeyManagers((HTTPClientProxy)this.proxy);
-				
+
 				try {
 					sslSocketFactory = new TiSocketFactory(keyManagerArray, trustManagerArray, tlsVersion);
 				} catch(Exception e) {
@@ -1088,22 +1087,22 @@ public class TiHTTPClient
 					sslSocketFactory = null;
 				}
 			}
-		} 
+		}
 		if (sslSocketFactory == null) {
 			if (trustManagers.size() > 0 || keyManagers.size() > 0) {
 				TrustManager[] trustManagerArray = null;
 				KeyManager[] keyManagerArray = null;
-				
+
 				if (trustManagers.size() > 0) {
 					trustManagerArray = new X509TrustManager[trustManagers.size()];
 					trustManagerArray = trustManagers.toArray(trustManagerArray);
 				}
-				
+
 				if (keyManagers.size() > 0) {
 					keyManagerArray = new X509KeyManager[keyManagers.size()];
 					keyManagerArray = keyManagers.toArray(keyManagerArray);
 				}
-				
+
 				try {
 					sslSocketFactory = new TiSocketFactory(keyManagerArray, trustManagerArray, tlsVersion);
 				} catch(Exception e) {
@@ -1120,11 +1119,11 @@ public class TiHTTPClient
 				}
 			}
 		}
-		
+
 		if (client == null) {
 			client = createClient();
 		}
-		
+
 		if (sslSocketFactory != null) {
 			client.getConnectionManager().getSchemeRegistry().register(new Scheme("https", sslSocketFactory, 443));
 		} else if (!validating) {
@@ -1132,7 +1131,7 @@ public class TiHTTPClient
 		} else {
 			client.getConnectionManager().getSchemeRegistry().register(new Scheme("https", SSLSocketFactory.getSocketFactory(), 443));
 		}
-		
+
 		return client;
 	}
 
@@ -1143,13 +1142,13 @@ public class TiHTTPClient
 		// TODO consider using task manager
 		int totalLength = 0;
 		needMultipart = false;
-		
+
 		if (userData != null)
 		{
 			if (userData instanceof HashMap) {
 				HashMap<String, Object> data = (HashMap) userData;
-				boolean isPostOrPut = method.equals("POST") || method.equals("PUT");
-				boolean isGet = !isPostOrPut && method.equals("GET");
+				boolean isPostOrPutOrPatch = method.equals("POST") || method.equals("PUT") || method.equals("PATCH");
+				boolean isGet = !isPostOrPutOrPatch && method.equals("GET");
 
 				// first time through check if we need multipart for POST
 				for (String key : data.keySet()) {
@@ -1171,7 +1170,7 @@ public class TiHTTPClient
 				boolean queryStringAltered = false;
 				for (String key : data.keySet()) {
 					Object value = data.get(key);
-					if (isPostOrPut && (value != null)) {
+					if (isPostOrPutOrPatch && (value != null)) {
 						// if the value is a proxy, we need to get the actual file object
 						if (value instanceof TiFileProxy) {
 							value = ((TiFileProxy) value).getBaseFile();
@@ -1214,7 +1213,7 @@ public class TiHTTPClient
 		Log.d(TAG, "Instantiating http request with method='" + method + "' and this url:", Log.DEBUG_MODE);
 		Log.d(TAG, this.url, Log.DEBUG_MODE);
 
-		request = new DefaultHttpRequestFactory().newHttpRequest(method, this.url);
+		request = new TiDefaultHttpRequestFactory().newHttpRequest(method, this.url);
 		request.setHeader(TITANIUM_ID_HEADER, TiApplication.getInstance().getAppGUID());
 		for (String header : headers.keySet()) {
 			request.setHeader(header, headers.get(header));
@@ -1226,7 +1225,7 @@ public class TiHTTPClient
 
 		Log.d(TAG, "Leaving send()", Log.DEBUG_MODE);
 	}
-	
+
 	private class ClientRunnable implements Runnable
 	{
 		private final int totalLength;
@@ -1379,18 +1378,18 @@ public class TiHTTPClient
 				dispatchCallback("onerror", data);
 			} finally {
 				deleteTmpFiles();
-				
+
 				//Clean up response,request,client,handler and clientThread
 				if(response != null) {
 					responseHeaders = response.getAllHeaders();
 					response = null;
 				}
-				
+
 				request = null;
 				handler = null;
 				client = null;
 				clientThread = null;
-				
+
 				// Fire the disposehandle event if the request is finished successfully or the errors occur.
 				// And it will dispose the handle of the httpclient in the JS.
 				proxy.fireEvent(TiC.EVENT_DISPOSE_HANDLE, null);
@@ -1427,7 +1426,7 @@ public class TiHTTPClient
 		} else {
 			entity = form;
 		}
-		
+
 		if (entity != null) {
 			Header header = request.getFirstHeader("Content-Type");
 			if(header == null) {
@@ -1458,7 +1457,7 @@ public class TiHTTPClient
 	{
 		return connected;
 	}
-	
+
 	public void setTimeout(int millis)
 	{
 		timeout = millis;
@@ -1483,7 +1482,7 @@ public class TiHTTPClient
 	{
 		return autoRedirect;
 	}
-	
+
 	protected void addKeyManager(X509KeyManager manager)
 	{
 		if (Log.isDebugModeEnabled()) {
@@ -1491,7 +1490,7 @@ public class TiHTTPClient
 		}
 		keyManagers.add(manager);
 	}
-	
+
 	protected void addTrustManager(X509TrustManager manager)
 	{
 		if (Log.isDebugModeEnabled()) {
@@ -1499,7 +1498,7 @@ public class TiHTTPClient
 		}
 		trustManagers.add(manager);
 	}
-	
+
 	protected void setTlsVersion(int value)
 	{
 		this.proxy.setProperty(TiC.PROPERTY_TLS_VERSION, value);


### PR DESCRIPTION
Ticket url: https://jira.appcelerator.org/browse/TIMOB-17145
#### Screenshot showing the problem

![patchmethodnotsupported](https://cloud.githubusercontent.com/assets/3160460/7106477/493039c0-e142-11e4-8616-d630d9413aa9.png)
#### Screenshot showing the expected outcome

![patchmethodsupported](https://cloud.githubusercontent.com/assets/3160460/7106476/492f5f5a-e142-11e4-9211-0776c1974408.png)
### Alloy App reproducing the problem
#### index.js

``` javascript
function doClick(e) {
    doPatch();
}

function doPatch(data){
    var url = "https://api.github.com/notifications/threads/65269820";
    var xhr = Ti.Network.createHTTPClient();
    console.log('BEFORE PATCH');
    xhr.open('PATCH', url);

    xhr.onload = function(e){
        console.log('[onload] success');
    };
    xhr.onerror =function(e){
        console.log('[error] success');
    };
    xhr.onreadystatechange = function(e){
        switch(this.readyState) {
             case 0:
             // after HTTPClient declared, prior to open()
             // though Ti won't actually report on this readyState
                            Ti.API.info('case 0, readyState = '+this.readyState);
             break;
             case 1:
             // open() has been called, now is the time to set headers
                            Ti.API.info('case 1, readyState = '+this.readyState);
             break;
             case 2:
             // headers received, xhr.status should be available now
                            Ti.API.info('case 2, readyState = '+this.readyState);
             break;
             case 3:
             // data is being received, onsendstream/ondatastream being called now
                            Ti.API.info('case 3, readyState = '+this.readyState);
                            console.log(this);
             break;
             case 4:
             // done, onload or onerror should be called now
                            Ti.API.info('case 4, readyState = '+this.readyState);
             break;
        };
    };
    xhr.setRequestHeader('Authorization','token ' + '1e95427bc6e6932d37e8f9233ed5cd01dd52ed00');
    xhr.send();
    console.log('SENT');
}

$.index.open();

```
