### PR TITLE
[TIMOB-15247] iOS: Ti.Blob.imageAsResized always returns a png image

### DIFF
--- a/iphone/Classes/UIImage+Resize.m
+++ b/iphone/Classes/UIImage+Resize.m
@@ -39,14 +39,16 @@
 	} else {
 		CGRect transposedRect = CGRectMake(0, 0, newRect.size.height, newRect.size.width);
 		
-		// Build a context that's the same dimensions as the new size
-		CGContextRef bitmap = CGBitmapContextCreate(NULL,
-													newRect.size.width,
-													newRect.size.height,
-													8,
-													0,
-													colorSpace,
-													kCGBitmapAlphaInfoMask & kCGImageAlphaPremultipliedLast);
+        CGImageAlphaInfo alphaInfo = [UIImageAlpha hasAlpha:image] ? kCGImageAlphaPremultipliedLast : kCGImageAlphaNoneSkipLast;
+        // Build a context that's the same dimensions as the new size
+        CGContextRef bitmap = CGBitmapContextCreate(NULL,
+                                                    newRect.size.width,
+                                                    newRect.size.height,
+                                                    8,
+                                                    0,
+                                                    colorSpace,
+                                                    kCGBitmapAlphaInfoMask & alphaInfo);
+        
 		
 		// Rotate and/or flip the image if required by its orientation
 		CGContextConcatCTM(bitmap, transform);


### PR DESCRIPTION
Fixes [TIMOB-15247](https://jira.appcelerator.org/browse/TIMOB-15247)
