### PR TITLE
[TIMOB-17993] Correct issues with CFBundleVersion and CFBundleShortVersionString

### DIFF
--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -1975,10 +1975,11 @@ iOSBuilder.prototype.createInfoPlist = function createInfoPlist(next) {
 	}
 
 	// if the user has a Info.plist in their project directory, consider that a custom override
+	var custom;
 	if (fs.existsSync(src)) {
 		this.logger.info(__('Copying custom Info.plist from project directory'));
 
-		var custom = new appc.plist().parse(fs.readFileSync(src).toString());
+		custom = new appc.plist().parse(fs.readFileSync(src).toString());
 		if (custom.CFBundleIdentifier !== this.tiapp.id) {
 			this.logger.info(__('Forcing rebuild: custom Info.plist CFBundleIdentifier not equal to tiapp.xml <id>'));
 			this.forceRebuild = true;
@@ -2069,17 +2070,19 @@ iOSBuilder.prototype.createInfoPlist = function createInfoPlist(next) {
 		plist.CFBundleVersion = String(+new Date);
 		this.logger.debug(__('Building for iTunes sync which requires us to set the CFBundleVersion to a unique number to trigger iTunes to update your app'));
 		this.logger.debug(__('Setting Info.plist CFBundleVersion to current epoch time %s', plist.CFBundleVersion.cyan));
-	} else {
+	} else if (!(ios && ios.plist && ios.plist.CFBundleVersion) && !(custom && custom.CFBundleVersion)) {
 		plist.CFBundleVersion = String(this.tiapp.version);
 		this.logger.debug(__('Setting Info.plist CFBundleVersion to %s', plist.CFBundleVersion.cyan));
 	}
 
-	try {
-		plist.CFBundleShortVersionString = appc.version.format(this.tiapp.version, 0, 3);
-		this.logger.debug(__('Setting Info.plist CFBundleShortVersionString to %s', plist.CFBundleShortVersionString.cyan));
-	} catch (ex) {
-		plist.CFBundleShortVersionString = this.tiapp.version;
-		this.logger.debug(__('Setting Info.plist CFBundleShortVersionString to %s', plist.CFBundleShortVersionString.cyan));
+	if (!(ios && ios.plist && ios.plist.CFBundleShortVersionString) && !(custom && custom.CFBundleShortVersionString)) {
+		try {
+			plist.CFBundleShortVersionString = appc.version.format(this.tiapp.version, 0, 3);
+			this.logger.debug(__('Setting Info.plist CFBundleShortVersionString to %s', plist.CFBundleShortVersionString.cyan));
+		} catch (ex) {
+			plist.CFBundleShortVersionString = this.tiapp.version;
+			this.logger.debug(__('Setting Info.plist CFBundleShortVersionString to %s', plist.CFBundleShortVersionString.cyan));
+		}
 	}
 
 	Array.isArray(plist.CFBundleIconFiles) || (plist.CFBundleIconFiles = []);

--- a/node_modules/titanium-sdk/lib/tiappxml.js
+++ b/node_modules/titanium-sdk/lib/tiappxml.js
@@ -364,7 +364,7 @@ function toJS(obj, doc) {
 									if (elem.tagName == 'dict') {
 										var pl = new plist().parse('<plist version="1.0">' + elem.toString() + '</plist>');
 										Object.keys(pl).forEach(function (prop) {
-											if (!/^CFBundle(DisplayName|Executable|IconFile|Identifier|InfoDictionaryVersion|Name|PackageType|Signature|Version|ShortVersionString)|LSRequiresIPhoneOS$/.test(prop)) {
+											if (!/^CFBundle(DisplayName|Executable|IconFile|Identifier|InfoDictionaryVersion|Name|PackageType|Signature)|LSRequiresIPhoneOS$/.test(prop)) {
 												ios.plist[prop] = pl[prop];
 											}
 										});


### PR DESCRIPTION
A version of https://github.com/appcelerator/titanium_mobile/pull/6408 that only has changes directly related to the original request in https://jira.appcelerator.org/browse/TIMOB-17993
- Reads CFBundleVersion and CFBundleShortVersionString from `tiapp.xml/ios/plist`
- Only sets `CFBundleVersion` if target is iTunes (which needs a unique version) or there is no custom value in either `tiapp.xml/ios/plist` or a custom `Info.plist`
- Only sets `CFBundleShortVersionString` if there is no custom value in either `tiapp.xml/ios/plist` or a custom `Info.plist`
