### PR TITLE
[TIMOB-18854] : Add Delegate & Reply for openParentApplication to Titanium

### DIFF
--- a/apidoc/Titanium/App/iOS/iOS.yml
+++ b/apidoc/Titanium/App/iOS/iOS.yml
@@ -163,10 +163,10 @@ methods:
 
         This method should be used as part of the `watchkitextensionrequest` event as shown below.
         
-		Ti.App.iOS.addEventListener("watchkitextensionrequest",function(e){
-		    var replyContent = {foo:"bar"};
-		    Ti.App.iOS.sendWatchExtensionReply(e.handlerId,replyContent);
-		});
+        Ti.App.iOS.addEventListener("watchkitextensionrequest",function(e){
+            var replyContent = {foo:"bar"};
+            Ti.App.iOS.sendWatchExtensionReply(e.handlerId,replyContent);
+        });
 
     parameters:
       - name: handlerId
@@ -624,10 +624,10 @@ events:
         current event and the `userInfo` property, containing the dictionary passed from the WatchKit extension.  The `handlerID` identifier
         must be passed as the an argument to the [sendWatchExtensionReply](Titanium.App.iOS.sendWatchExtensionReply) method.
 
-		Ti.App.iOS.addEventListener("watchkitextensionrequest",function(e){
-		    var replyContent = {foo:"bar"};
-		    Ti.App.iOS.sendWatchExtensionReply(e.handlerId,replyContent);
-		});
+        Ti.App.iOS.addEventListener("watchkitextensionrequest",function(e){
+            var replyContent = {foo:"bar"};
+            Ti.App.iOS.sendWatchExtensionReply(e.handlerId,replyContent);
+        });
 
     properties:
       - name: handlerId

--- a/apidoc/Titanium/App/iOS/iOS.yml
+++ b/apidoc/Titanium/App/iOS/iOS.yml
@@ -152,6 +152,35 @@ methods:
     osver: {ios: {min: "7.0"}}
     since: "3.2.0"
 
+  - name: sendWatchExtensionReply
+    summary: |
+        Marks the end of an openParentApplication:reply execution by a WatchKit extension.
+        Available only on iOS 8.2 and later.
+    description: |
+        This method must be called after your Titaium application has finished processing the `watchkitextensionrequest` event. Optional
+        information can be provided in the userInfo argument will be provided back to the WatchKit extension as part of the reply method.
+        If no userInfo is provide nil will be sent to the WatchKit extension to during the reply callback.
+
+        This method should be used as part of the `watchkitextensionrequest` event as shown below.
+        
+		Ti.App.iOS.addEventListener("watchkitextensionrequest",function(e){
+		    var replyContent = {foo:"bar"};
+		    Ti.App.iOS.sendWatchExtensionReply(e.handlerId,replyContent);
+		});
+
+    parameters:
+      - name: handlerId
+        summary: |
+            Unique string identifer for the event (`watchkitextensionrequest`)
+            that initiated from the WatchKit extension calling the openParentApplication:reply method.
+        type: String
+      - name: userInfo
+        summary: |
+            Custom data object which will be passed in the reply method to your WatchKit extension.
+        type: Dictionary        
+    osver: {ios: {min: "8.2"}}
+    since: "4.1.0"
+
 properties:
   - name: EVENT_ACCESSIBILITY_LAYOUT_CHANGED
     summary: Convenience constant for system event "accessibilitylayoutchanged".
@@ -568,7 +597,6 @@ events:
     osver: {ios: {min: "7.0"}}
     since: "3.2.0"
 
-
   - name: usernotificationsettings
     summary: |
         Fired when the user notification settings are registered (available for iOS 8 and later).
@@ -583,6 +611,37 @@ events:
         type: Array<Titanium.App.iOS.UserNotificationCategory>
     osver: {ios: {min: "8.0"}}
     since: "3.4.0"
+
+  - name: watchkitextensionrequest
+    summary: Fired when openParentApplication:reply is called from a WatchKit extension. Available only on iOS 8.2 and later.
+    description: |
+        Add this event if your Titanium application if you are using a WatchKit extension.  When your WatchKit extension uses the openParentApplication:reply
+        method your Titanium application will be opened in the background and provides your Titanium app the information from the extension. When this
+        event is fired you must provide a reply by calling the [sendWatchExtensionReply](Titanium.App.iOS.sendWatchExtensionReply) method with
+        the `handlerID` parameter from this event.
+
+        The event returns the dictionary containing the `handlerID` property, which is a unique handler ID for the
+        current event and the `userInfo` property, containing the dictionary passed from the WatchKit extension.  The `handlerID` identifier
+        must be passed as the an argument to the [sendWatchExtensionReply](Titanium.App.iOS.sendWatchExtensionReply) method.
+
+		Ti.App.iOS.addEventListener("watchkitextensionrequest",function(e){
+		    var replyContent = {foo:"bar"};
+		    Ti.App.iOS.sendWatchExtensionReply(e.handlerId,replyContent);
+		});
+
+    properties:
+      - name: handlerId
+        summary: |
+            Unique string identifer for the `watchkitextensionrequest` event. This identifier should be passed an argument
+            to the [sendWatchExtensionReply](Titanium.App.iOS.sendWatchExtensionReply) method.
+        type: String
+      - name: userInfo
+        summary: |
+            The payload passed to the openParentApplication:reply method from the WatchKit extension.
+        type: Dictionary
+    platforms: [iphone, ipad]
+    osver: {ios: {min: "8.2"}}
+    since: '4.1.0'
 
 ---
 name: NotificationParams

--- a/iphone/Classes/TiApp.h
+++ b/iphone/Classes/TiApp.h
@@ -54,6 +54,7 @@ TI_INLINE void waitForMemoryPanicCleared()   //WARNING: This must never be run o
 	id remoteNotificationDelegate;
 	NSDictionary* remoteNotification;
 	NSMutableDictionary* pendingCompletionHandlers;
+    NSMutableDictionary* pendingReplyHandlers;
     NSMutableDictionary* backgroundTransferCompletionHandlers;
     BOOL appBooted;
     
@@ -209,6 +210,6 @@ TI_INLINE void waitForMemoryPanicCleared()   //WARNING: This must never be run o
 -(void)stopBackgroundService:(TiProxy*)proxy;
 -(void)completionHandler:(id)key withResult:(int)result;
 -(void)completionHandlerForBackgroundTransfer:(id)key;
-
+-(void)watchKitExtensionRequestHandler:(id)key withUserInfo:(NSDictionary*)userInfo;
 @end
 

--- a/iphone/Classes/TiApp.m
+++ b/iphone/Classes/TiApp.m
@@ -484,14 +484,14 @@ TI_INLINE void waitForMemoryPanicCleared();   //WARNING: This must never be run 
 }
 
 
-#pragma mark Apple Watch
+#pragma mark Apple Watchkit handleWatchKitExtensionRequest
 - (void)application:(UIApplication *)application
             handleWatchKitExtensionRequest:(NSDictionary *)userInfo
               reply:(void (^)(NSDictionary *replyInfo))reply
 {
 
     // Generate unique key with timestamp.
-    id key = [NSString stringWithFormat:@"watch-reply-%f",[[NSDate date] timeIntervalSince1970]];
+    id key = [NSString stringWithFormat:@"watchkit-reply-%f",[[NSDate date] timeIntervalSince1970]];
     
     if (pendingReplyHandlers == nil) {
         pendingReplyHandlers = [[NSMutableDictionary alloc] init];

--- a/iphone/Classes/TiAppiOSProxy.m
+++ b/iphone/Classes/TiAppiOSProxy.m
@@ -82,6 +82,10 @@
             [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector
              (didRegisterUserNotificationSettingsNotification:) name:kTiUserNotificationSettingsNotification object:nil];
         }
+        if ((count == 1) && [type isEqual:@"watchkitextensionrequest"]) {
+        [[NSNotificationCenter defaultCenter] addObserver:self
+                                                 selector:@selector(didReceiveWatchExtensionRequestNotification:) name:KTiWatchKitExtensionRequest object:nil];
+        }
     }
 
 }
@@ -126,6 +130,9 @@
     if ([TiUtils isIOS8OrGreater]){
         if ((count == 1) && [type isEqual:@"usernotificationsetting"]) {
             [[NSNotificationCenter defaultCenter] removeObserver:self name:kTiUserNotificationSettingsNotification object:nil];
+        }
+        if ((count == 1) && [type isEqual:@"watchkitextensionrequest"]) {
+            [[NSNotificationCenter defaultCenter] removeObserver:self name:KTiWatchKitExtensionRequest object:nil];
         }
     }
 }
@@ -542,6 +549,31 @@
 {
     [self fireEvent:@"usernotificationsettings"
          withObject:[self formatUserNotificationSettings:(UIUserNotificationSettings*)[notificationSettings object]]];
+}
+
+-(void)didReceiveWatchExtensionRequestNotification:(NSNotification*)notif
+{
+    [self fireEvent:@"watchkitextensionrequest" withObject:[notif userInfo]];
+}
+
+-(void)sendWatchExtensionReply:(id)args
+{
+    enum Args {
+        kArgKey = 0,
+        kArgCount,
+        kArgUserInfo = kArgCount
+    };
+    
+    ENSURE_TYPE(args,NSArray);
+    ENSURE_ARG_COUNT(args, kArgCount);
+    
+    NSString *key = [TiUtils stringValue:[args objectAtIndex:kArgKey]];
+    NSDictionary *userInfo = [args objectAtIndex:kArgUserInfo];
+    if([args count] > 1){
+        [[TiApp app] watchKitExtensionRequestHandler:key withUserInfo:userInfo];
+    }else{
+        [[TiApp app] watchKitExtensionRequestHandler:key withUserInfo:nil];
+    }
 }
 
 -(void)setMinimumBackgroundFetchInterval:(id)value

--- a/iphone/Classes/TiAppiOSProxy.m
+++ b/iphone/Classes/TiAppiOSProxy.m
@@ -551,13 +551,21 @@
          withObject:[self formatUserNotificationSettings:(UIUserNotificationSettings*)[notificationSettings object]]];
 }
 
+#pragma mark Apple Watchkit notifications
+
 -(void)didReceiveWatchExtensionRequestNotification:(NSNotification*)notif
 {
     [self fireEvent:@"watchkitextensionrequest" withObject:[notif userInfo]];
 }
 
+#pragma mark Apple Watchkit handleWatchKitExtensionRequest reply
+
 -(void)sendWatchExtensionReply:(id)args
 {
+    if(![TiUtils isIOS8OrGreater]) {
+        return;
+    }
+    
     enum Args {
         kArgKey = 0,
         kArgCount,

--- a/iphone/Classes/TiAppiOSProxy.m
+++ b/iphone/Classes/TiAppiOSProxy.m
@@ -576,9 +576,9 @@
     ENSURE_ARG_COUNT(args, kArgCount);
     
     NSString *key = [TiUtils stringValue:[args objectAtIndex:kArgKey]];
-    NSDictionary *userInfo = [args objectAtIndex:kArgUserInfo];
+
     if([args count] > 1){
-        [[TiApp app] watchKitExtensionRequestHandler:key withUserInfo:userInfo];
+        [[TiApp app] watchKitExtensionRequestHandler:key withUserInfo:[args objectAtIndex:kArgUserInfo]];
     }else{
         [[TiApp app] watchKitExtensionRequestHandler:key withUserInfo:nil];
     }

--- a/iphone/Classes/TiBase.h
+++ b/iphone/Classes/TiBase.h
@@ -592,6 +592,7 @@ extern NSString * const kTiURLSessionCompleted;
 extern NSString * const kTiURLSessionEventsCompleted;
 extern NSString * const kTiURLDowloadProgress;
 extern NSString * const kTiURLUploadProgress;
+extern NSString * const KTiWatchKitExtensionRequest;
     
 extern NSString* const kTiBehaviorSize;
 extern NSString* const kTiBehaviorFill;

--- a/iphone/Classes/TiBase.m
+++ b/iphone/Classes/TiBase.m
@@ -161,6 +161,7 @@ NSString * const kTiLocalNotification = @"TiLocalNotification";
 NSString * const kTiLocalNotificationAction = @"TiLocalNotificationAction";
 NSString * const kTiRemoteNotificationAction = @"TiRemoteNotificationAction";
 NSString * const kTiUserNotificationSettingsNotification = @"TiUserNotificationSettingsNotification";
+NSString * const KTiWatchKitExtensionRequest = @"TiWatchKitExtensionRequest";
 
 NSString* const kTiBehaviorSize = @"SIZE";
 NSString* const kTiBehaviorFill = @"FILL";


### PR DESCRIPTION
Original PR from: #6803

This PR relates to ticket [TIMOB-18854](https://jira.appcelerator.org/browse/TIMOB-18854)

Included in this PR is:

1.Addition of the required Application Delegate
2.Ti.App.iOS notification with information provided by the calling WatchKit Extension
3.sendWatchExtensionReply method to reply back to the [openParentApplication](https://developer.apple.com/library/ios/documentation/WatchKit/Reference/WKInterfaceController_class/#//apple_ref/occ/clm/WKInterfaceController/openParentApplication:reply:)

A detail of all the changes included in this PR is available [here](https://gist.github.com/benbahrenburg/0c9cfcd816fbd718fb08)
