### PR TITLE
[TIMOB-18765] (4_0_X) ImageView cleanup

### DIFF
--- a/iphone/Classes/TiUIImageView.m
+++ b/iphone/Classes/TiUIImageView.m
@@ -472,7 +472,7 @@ DEFINE_EXCEPTIONS
     }
 }
 
--(void)loadUrl:(id)img
+-(void)loadUrl:(NSURL*)img
 {
 	[self cancelPendingImageLoads];
 	
@@ -480,8 +480,6 @@ DEFINE_EXCEPTIONS
 	{
 		[self removeAllImagesFromContainer];
 		
-		NSURL *url_ = [TiUtils toURL:[img path] proxy:self.proxy];
-        
         // NOTE: Loading from URL means we can't pre-determine any % value.
 		CGSize imageSize = CGSizeMake(TiDimensionCalculateValue(width, 0.0), 
 									  TiDimensionCalculateValue(height,0.0));
@@ -494,8 +492,8 @@ DEFINE_EXCEPTIONS
         
         // Skip the imageloader completely if this is obviously a file we can load off the fileystem.
         // why were we ever doing that in the first place...?
-        if ([url_ isFileURL]) {
-            UIImage* image = [UIImage imageWithContentsOfFile:[url_ path]];
+        if ([img isFileURL]) {
+            UIImage* image = [UIImage imageWithContentsOfFile:[img path]];
             if (image != nil) {
                 UIImage *imageToUse = [self rotatedImage:image];
                 autoWidth = imageToUse.size.width;
@@ -510,19 +508,19 @@ DEFINE_EXCEPTIONS
         }
         
         
-		UIImage *image = [[ImageLoader sharedLoader] loadImmediateImage:url_];
+		UIImage *image = [[ImageLoader sharedLoader] loadImmediateImage:img];
 		if (image==nil)
 		{
             [self loadDefaultImage:imageSize];
 			placeholderLoading = YES;
-			[(TiUIImageViewProxy *)[self proxy] startImageLoad:url_];
+			[(TiUIImageViewProxy *)[self proxy] startImageLoad:img];
 			return;
 		}
         
 		if (image!=nil)
 		{
 			UIImage *imageToUse = [self rotatedImage:image];
-			[(TiUIImageViewProxy*)[self proxy] setImageURL:url_];
+			[(TiUIImageViewProxy*)[self proxy] setImageURL:img];
             
 			autoWidth = imageToUse.size.width;
 			autoHeight = imageToUse.size.height;
@@ -676,10 +674,7 @@ DEFINE_EXCEPTIONS
 		return;
 	}
 	
-	BOOL replaceProperty = YES;
-	UIImage *image = nil;
-    NSURL* imageURL = nil;
-    image = [self convertToUIImage:arg];
+	UIImage *image = [self convertToUIImage:arg];
 	
 	if (image == nil) 
 	{


### PR DESCRIPTION
We already convert the image parameter to a URL through sanitizeURL. So
loadURL does not need to pass the argument to TiUtils to convert it to
a URL. Use the argument directly.

Cherry Pick PR #6833 into 4_0_X

JIRA TICKETS:
[TIMOB-18765](https://jira.appcelerator.org/browse/TIMOB-18765)
[TIMOB-18889](https://jira.appcelerator.org/browse/TIMOB-18889)
