### PR TITLE
[TIMOB-6060] iOS: support blur in UIModalPresentationFormSheet

### DIFF
--- a/iphone/Classes/TiViewController.m
+++ b/iphone/Classes/TiViewController.m
@@ -207,5 +207,7 @@
 {
     return UIStatusBarAnimationNone;
 }
-
+- (BOOL)disablesAutomaticKeyboardDismissal {
+    return NO;
+}
 @end


### PR DESCRIPTION
JIRA:https://jira.appcelerator.org/browse/TIMOB-6060
According to apple reference here: 
https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIViewController_Class/index.html#//apple_ref/occ/instm/UIViewController/disablesAutomaticKeyboardDismissal
"The default implementation of this method returns YES when the modal presentation style of the view controller is set to UIModalPresentationFormSheet and returns NO for other presentation styles." 
Since we support the blur method, it should be ok to default the mentioned method to NO for all cases since it only affects UIModalPresentationFormSheet. 
