### PR TITLE
[TIMOB-18765] Only escape if it is a local path and has spaces 

### DIFF
--- a/iphone/Classes/TiUtils.m
+++ b/iphone/Classes/TiUtils.m
@@ -795,10 +795,14 @@ If the new path starts with / and the base url is app://..., we have to massage 
         }
         result = [NSURL URLWithString:relativeString relativeToURL:rootPath];
     } else {
-        result = [NSURL URLWithString:[relativeString stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding] relativeToURL:rootPath];
+        //only add percentescape if there are spaces in relativestring
+        if ([[relativeString componentsSeparatedByString:@" "] count] -1 == 0) {
+            result = [NSURL URLWithString:relativeString relativeToURL:rootPath];
+        }
+        else {
+            result = [NSURL URLWithString:[relativeString stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding] relativeToURL:rootPath];
+        }
     }
-    
-    
     //TIMOB-18262
     if (result && ([[result scheme] isEqualToString:@"file"])){
         BOOL isDir = NO;


### PR DESCRIPTION
Titanium calls `[TiUtils toURL:(NSString*)relativeString relativeToURL:(NSURL *)rootPath]` many times and in some scenarios it will call this method more than once on the same parameter. This PR is essentially a cherry pick of a commit that was previously [reverted](https://github.com/cheekiatng/titanium_mobile/commit/8caea4da94f6c0fac48686f9fe38c7a5c8dcdf45). 
