### PR TITLE
[CLI-629] Fix invalid 'titanium' path for Windows

### DIFF
--- a/node_modules/titanium-sdk/lib/titanium.js
+++ b/node_modules/titanium-sdk/lib/titanium.js
@@ -550,7 +550,7 @@ exports.validateCorrectSDK = function (logger, config, cli, commandName) {
 
 		hideBanner = true;
 
-		cmdAdd(argv.$0.split(' ').slice(1).join(' '));
+		cmdAdd(argv.$0.split(' ').pop());
 		cmdAdd(commandName, '--sdk', sdkName);
 
 		var flags = {},


### PR DESCRIPTION
- Rather than discard the node path using _slice()_, instead _pop()_ the titanium path we want
- This prevents paths with spaces being incorrectly split and discarded

[JIRA Ticket](https://jira.appcelerator.org/browse/CLI-629)
