### PR TITLE
[CLI-629] Fix invalid 'titanium' path for Windows

### DIFF
--- a/node_modules/titanium-sdk/lib/titanium.js
+++ b/node_modules/titanium-sdk/lib/titanium.js
@@ -550,7 +550,22 @@ exports.validateCorrectSDK = function (logger, config, cli, commandName) {
 
 		hideBanner = true;
 
-		cmdAdd(argv.$0.split(' ').pop());
+		// If the titanium path has spaces, then we are trying to combine the paths and verify after they were split.
+		var titaniumPath = function getTitaniumPath (params) {
+			var paramsArray = params.split(' '),
+				pathSegment,
+				prevPath = '';
+			while ((pathSegment = paramsArray.pop())) {
+				if (fs.existsSync(pathSegment + prevPath)) {
+					return pathSegment + prevPath;
+				}
+				prevPath = ' ' + pathSegment;
+			}
+			// fallback to default last segment, if we fail for any reason.
+			return params.split(' ').pop();
+		}(argv.$0);
+
+		cmdAdd(titaniumPath);
 		cmdAdd(commandName, '--sdk', sdkName);
 
 		var flags = {},


### PR DESCRIPTION
- In case if there is any space in the titanium path, then this will handle to get the entire path after we split by spaces.
