### PR TITLE
[TIMOB-17626] Ti.Media.saveToPhotoGallery() saves pictures without file extension on Android

### DIFF
--- a/android/modules/media/src/java/ti/modules/titanium/media/MediaModule.java
+++ b/android/modules/media/src/java/ti/modules/titanium/media/MediaModule.java
@@ -370,7 +370,7 @@ public class MediaModule extends KrollModule
 			} else {
 				try {
 					String mimetype = theBlob.getMimeType();
-					extension = TiMimeTypeHelper.getFileExtensionFromMimeType(mimetype, ".jpg");
+					extension = '.' + TiMimeTypeHelper.getFileExtensionFromMimeType(mimetype, ".jpg");
 				} catch(Throwable t) {
 					extension = null;
 				}


### PR DESCRIPTION
[TIMOB-17626] Ti.Media.saveToPhotoGallery() saves pictures without file extension on Android
