### PR TITLE
[TIMOB-18965] minSdkVersion defaults to 10 where it should be 14 since 4.0.0.GA

### DIFF
--- a/android/package.json
+++ b/android/package.json
@@ -18,7 +18,7 @@
 		"Ping Wang <pwang@appcelerator.com>",
 		"Allen Yeung <ayeung@appcelerator.com>"
 	],
-	"minSDKVersion": "10",
+	"minSDKVersion": "14",
 	"vendorDependencies": {
 		"android sdk": ">=14 <=22",
 		"android build tools": ">=17 <22.x",


### PR DESCRIPTION
In line with 4.0.0.GA release notes
