### PR TITLE
[TIDOC-1900][TIDOC-1902] Port JSON, SOLR and changes generators to JS

### DIFF
--- a/apidoc/docgen.js
+++ b/apidoc/docgen.js
@@ -14,6 +14,7 @@ var common = require('./lib/common.js'),
 	yaml = require('js-yaml'),
 	exec = require('child_process').exec,
 	os = require('os'),
+	pathMod = require('path'),
 	assert = common.assertObjectKey,
 	basePaths = [],
 	processFirst = ['Titanium.Proxy', 'Titanium.Module', 'Titanium.UI.View'],
@@ -498,6 +499,9 @@ function cliUsage () {
 	common.log('\t--output, -o    \tDirectory to output the files.');
 	common.log('\t--platform, -p  \tPlatform to extract for addon format.');
 	common.log('\t--stdout        \tOutput processed YAML to stdout.');
+	common.log('\t--start         \tStart version for changes format (will use the version in the package.json if not defined).');
+	common.log('\t--end           \tEnd version for changes format (optional).');
+
 }
 
 /**
@@ -719,6 +723,34 @@ if ((argc = process.argv.length) > 2) {
 					process.exit(1);
 				}
 				break;
+			case '--start':
+				if (++x > argc) {
+					common.log(common.LOG_WARN, 'Specify a version.');
+					cliUsage();
+					process.exit(1);
+				}
+				processedData.__startVersion = process.argv[x];
+				try {
+					nodeappc.version.gt(0.0, processedData.__startVersion);
+				} catch (e) {
+					common.log(common.LOG_ERROR, 'Not a valid version: %s', processedData.__startVersion);
+					process.exit(1);
+				}
+				break;
+			case '--end':
+				if (++x > argc) {
+					common.log(common.LOG_WARN, 'Specify a version.');
+					cliUsage();
+					process.exit(1);
+				}
+				processedData.__endVersion = process.argv[x];
+				try {
+					nodeappc.version.gt(0.0, processedData.__endVersion);
+				} catch (e) {
+					common.log(common.LOG_ERROR, 'Not a valid version: %s', processedData.__endVersion);
+					process.exit(1);
+				}
+				break;
 			case '--colorize':
 			case '--exclude-external':
 			case '-e':
@@ -805,6 +837,21 @@ for (var key in doc) {
 }
 
 formats.forEach(function (format) {
+
+	// For changes format, make sure we have a start version and it's less than the end version if defined
+	if (format === 'changes') {
+		if (!processedData.__startVersion) {
+			processedData.__startVersion = JSON.parse(fs.readFileSync(pathMod.join(apidocPath, '..', 'package.json'), 'utf8')).version;
+		}
+		if (processedData.__endVersion) {
+			if (nodeappc.version.gt(processedData.__startVersion, processedData.__endVersion)) {
+				common.log(common.LOG_ERROR, 'Skipping changes format.  Start version (%s) is greater than end version (%s).',
+						processedData.__startVersion, processedData.__endVersion);
+				return;
+			}
+		}
+	}
+
 	// Export data
 	exporter = require('./lib/' + format + '_generator.js');
 	if (format === 'modulehtml') {
@@ -846,6 +893,11 @@ formats.forEach(function (format) {
 				});
 			});
 			common.log('Generated output at %s', output);
+			break;
+		case 'changes' :
+			output = pathMod.join(output, 'changes_' + exportData.startVersion.replace(/\./g, '_') + '.html');
+			templateStr = fs.readFileSync(pathMod.join(templatePath, 'changes.ejs'), 'utf8');
+			render = ejs.render(templateStr, {data: exportData, filename: true, assert: common.assertObjectKey});
 			break;
 		case 'html' :
 		case 'modulehtml' :
@@ -914,6 +966,9 @@ formats.forEach(function (format) {
 			render = ejs.render(templateStr, {apis: exportData});
 			output = output + 'parity.html';
 			break;
+		case 'solr' :
+			render = JSON.stringify(exportData, null, '    ');
+			output = output + 'api_solr.json';
 	}
 
 	if (!~['addon'].indexOf(format)) {

--- a/apidoc/docgen.js
+++ b/apidoc/docgen.js
@@ -895,6 +895,10 @@ formats.forEach(function (format) {
 			common.log('Generated output at %s', output);
 			break;
 		case 'changes' :
+			if (exportData.noResults) {
+				common.log('No API changes found.');
+				return;
+			}
 			output = pathMod.join(output, 'changes_' + exportData.startVersion.replace(/\./g, '_') + '.html');
 			templateStr = fs.readFileSync(pathMod.join(templatePath, 'changes.ejs'), 'utf8');
 			render = ejs.render(templateStr, {data: exportData, filename: true, assert: common.assertObjectKey});

--- a/apidoc/lib/changes_generator.js
+++ b/apidoc/lib/changes_generator.js
@@ -1,0 +1,127 @@
+/**
+ * Copyright (c) 2015 Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License.
+ */
+var common = require('./common.js'),
+	assert = common.assertObjectKey,
+	nodeappc = require('node-appc').version;
+/**
+ * Sort the array by API name
+ */
+function arraySort (a, b) {
+	if (a.name < b.name) {
+		return -1;
+	} else if (a.name > b.name) {
+		return 1;
+	}
+	return 0;
+}
+
+/**
+ * Replace links with the label
+ */
+function removeLinks (str) {
+	var rv = str || '';
+	rv = rv.replace(/<([^>]+?)>/g, '$1');
+	rv = rv.replace(/\[([^\]]+?)\]\([^\)]+?\)/g, '$1');
+	rv = rv.replace(common.REGEXP_HREF_LINKS, '$2');
+	return rv;
+}
+
+/**
+ * Checks to see if the API is new, deprecated or removed within the versions.
+ */
+function checkVersions(api, startVersion, endVersion, className) {
+	var rv = {},
+		platform;
+	rv.platforms = [];
+	for (platform in api.since) {
+		if (nodeappc.lte(startVersion, api.since[platform])) {
+			if (!endVersion || (endVersion && nodeappc.gt(endVersion, api.since[platform]))) {
+				rv.platforms.push(platform);
+			}
+		}
+	}
+	if (rv.platforms.length > 0) {
+		rv.summary = removeLinks(api.summary);
+		rv.name = className ? className + '.' + api.name : api.name;
+	}
+
+	if (assert(api, 'deprecated')) {
+		if (assert(api.deprecated, 'removed')) {
+			if (nodeappc.lte(startVersion, api.deprecated.removed)) {
+				if (!endVersion || (endVersion && nodeappc.gt(endVersion, api.deprecated.removed))) {
+					rv.removed = true;
+				}
+			}
+		}
+		if (nodeappc.lte(startVersion, api.deprecated.since)) {
+			if (!endVersion || (endVersion && nodeappc.gt(endVersion, api.deprecated.since))) {
+				rv.deprecated = true;
+			}
+		}
+		rv.name = className ? className + '.' + api.name : api.name;
+		rv.summary = removeLinks(api.deprecated.notes);
+	}
+
+	return rv;
+}
+
+/**
+ * Filters JSON data for APIs that were added, deprecated or removed.
+ */
+exports.exportData = function exportChanges (apis) {
+	var className = null,
+		cls = {},
+		rv = {},
+		startVersion = apis.__startVersion,
+		endVersion = apis.__endVersion || null,
+		changed = null;
+	rv.new = [];
+	rv.deprecated = [];
+	rv.removed = [];
+
+	common.log(common.LOG_INFO, 'Checking API versions...');
+
+	for (className in apis) {
+		cls = apis[className];
+		if (className.indexOf('__') === 0 || cls.__subtype === 'pseudo') {
+			continue;
+		}
+		changed = checkVersions(cls, startVersion, endVersion);
+		changed.type = 'object';
+
+		if (changed.removed) {
+			rv.removed.push(changed);
+		} else if (changed.deprecated) {
+			rv.deprecated.push(changed);
+		} else if (changed.platforms.length > 0) {
+			rv.new.push(changed);
+		} else {
+			['properties', 'methods', 'events'].forEach(function (type) {
+				cls[type].forEach(function (member) {
+					var changed;
+					if (member.__inherits !== className) {
+						return;
+					}
+					changed = checkVersions(member, startVersion, endVersion, className);
+					changed.type = member.__subtype;
+					if (changed.removed) {
+						rv.removed.push(changed);
+					} else if (changed.deprecated) {
+						rv.deprecated.push(changed);
+					} else if (changed.platforms.length > 0) {
+						rv.new.push(changed);
+					}
+				});
+			});
+		}
+		cls = {};
+	}
+	rv.new.sort(arraySort);
+	rv.deprecated.sort(arraySort);
+	rv.removed.sort(arraySort);
+	rv.startVersion = startVersion;
+	rv.endVersion = endVersion;
+	return rv;
+};

--- a/apidoc/lib/json_generator.js
+++ b/apidoc/lib/json_generator.js
@@ -1,0 +1,341 @@
+/**
+ * Copyright (c) 2015 Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License.
+ *
+ * Script to convert data to JSON format for third-party extensions
+ */
+var common = require('./common.js'),
+	assert = common.assertObjectKey,
+	doc = {};
+
+/**
+ * Locates an API in the docs
+ */
+function findAPI (className, memberName, type) {
+	var cls = doc[className],
+		x = 0;
+
+	if (cls && type in cls && cls[type]) {
+		for (x = 0; x < cls[type].length; x++) {
+			if (cls[type][x].name === memberName) {
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
+/**
+ * Convert API name to an HTML link
+ */
+function convertAPIToLink (apiName) {
+	var url = null;
+
+	if (~common.DATA_TYPES.indexOf(apiName) || apiName === 'void') {
+		return '<code>' + apiName + '</code>';
+	} else if (apiName in doc) {
+		url = exportClassFilename(apiName) + '.html';
+	} else if ((apiName.match(/\./g) || []).length) {
+		var member = apiName.split('.').pop(),
+			cls = apiName.substring(0, apiName.lastIndexOf('.'));
+
+		if (!(cls in doc)) {
+			common.log(common.LOG_WARN, 'Cannot find class: %s', cls);
+			return apiName;
+		} else {
+			if (findAPI(cls, member, 'properties')) {
+				url = cleanAPIName(apiName) + '-property.html';
+			} else if (findAPI(cls, member, 'methods')) {
+				url = cleanAPIName(apiName) + '-method.html';
+			} else if (findAPI(cls, member, 'events')) {
+				url = cleanAPIName(apiName) + '-event.html';
+			}
+		}
+	}
+
+	if (url) {
+		return '<code><a href="' + url + '">' + apiName + '</a></code>';
+	}
+	common.log(common.LOG_WARN, 'Cannot find API: %s', apiName);
+	return apiName;
+}
+
+/**
+ * Scans converted markdown-to-html text for internal links
+ */
+function convertLinks (text) {
+	var matches = text.match(common.REGEXP_HREF_LINKS),
+		tokens,
+		link;
+	if (matches && matches.length) {
+		matches.forEach(function (match) {
+			tokens = common.REGEXP_HREF_LINK.exec(match);
+			if (tokens && tokens[1].indexOf('http') !== 0 && !~match.indexOf('#')) {
+				if ((link = convertAPIToLink(tokens[1]))) {
+					link = link.replace('>' + tokens[1] + '<', '>' + tokens[2] + '<');
+					text = text.replace(match, link);
+				}
+			}
+		});
+	}
+	matches = text.match(common.REGEXP_CHEVRON_LINKS);
+	if (matches && matches.length) {
+		matches.forEach(function (match) {
+			if (!common.REGEXP_HTML_TAG.exec(match) && !~match.indexOf(' ') && !~match.indexOf('/') && !~match.indexOf('#')) {
+				tokens = common.REGEXP_CHEVRON_LINK.exec(match);
+				if ((link = convertAPIToLink(tokens[1]))) {
+					text = text.replace(match, link);
+				}
+			}
+		});
+	}
+	return text;
+}
+
+/**
+ * Convert markdown to HTML
+ */
+function markdownToHTML (text) {
+	return convertLinks(common.markdownToHTML(text));
+}
+
+/**
+ * Replace unsafe HMTL characters with dashes
+ */
+function cleanAPIName (api) {
+	return api.replace(/:/g, '-');
+}
+
+/**
+ * Convert classname to filename
+ */
+function exportClassFilename (name) {
+	if (assert(doc, name)) {
+		return (doc[name].__subtype === 'module') ? name + '-module' : name + '-object';
+	}
+	return null;
+}
+
+/**
+ * Export deprecated field
+ */
+function exportDeprecated (api) {
+	if ('deprecated' in api && api.deprecated) {
+		return {
+			notes_html: markdownToHTML(api.deprecated.notes || ''),
+			notes: api.deprecated.notes || '',
+			since: api.deprecated.since
+		};
+	}
+	return null;
+}
+
+/**
+ * Export summary field
+ */
+function exportSummary (api) {
+	var rv = '';
+	if ('summary' in api && api.summary) {
+		rv = api.summary;
+	}
+	return markdownToHTML(rv);
+}
+
+/**
+ * Export examples field
+ */
+function exportExamples (api) {
+	var rv = [],
+		code = null;
+	if ('examples' in api && api.examples.length > 0) {
+		api.examples.forEach(function (example) {
+			code = markdownToHTML(example.example);
+			// If we don't find a <code> tag, assume entire example should be code formatted
+			if (!~code.indexOf('<code>')) {
+				code = code.replace(/<p\>/g, '').replace(/<\/p\>/g, '');
+				code = '<pre><code>' + code + '</code></pre>';
+			}
+			rv.push({'description': example.title, 'code': code});
+		});
+	}
+	return rv;
+}
+
+/**
+ * Export method parameters or event properties field
+ */
+function exportParams (apis, type, filename) {
+	var rv = [],
+		annotatedMember = {};
+	if (apis) {
+		apis.forEach(function (member) {
+			annotatedMember.name = member.name;
+			annotatedMember.deprecated = exportDeprecated(member);
+			annotatedMember.summary = exportSummary(member);
+			annotatedMember.description = exportDescription(member);
+			annotatedMember.type = member.type || 'String';
+			if (type === 'properties') {
+				annotatedMember.filename = filename.slice(0, filename.indexOf('-event')) + '.' + member.name + '-callback-property';
+			}
+			if (type === 'parameters') {
+				annotatedMember.optional = member.optional || false;
+				annotatedMember.filename = filename + '.' + member.name + '-param';
+			}
+			rv.push(annotatedMember);
+			annotatedMember = {};
+		});
+	}
+	return rv;
+}
+
+/**
+ * Export description field
+ */
+function exportDescription (api) {
+	var rv = null;
+	if ('description' in api && api.description) {
+		rv = markdownToHTML(api.description);
+	}
+	return rv;
+}
+
+/**
+ * Export returns field
+ */
+function exportReturnTypes (api) {
+	var rv = [];
+	if (assert(api, 'returns')) {
+		if (!Array.isArray(api.returns.type)) {
+			api.returns.type = [api.returns.type];
+		}
+		api.returns.type.forEach(function (ret) {
+			var x = {};
+			if (assert(api.returns, 'summary')) {
+				x.summary = api.returns.summary;
+			}
+			x.type = ret;
+			rv.push(x);
+		});
+	} else {
+		rv.push({'type': 'void'});
+	}
+	if (rv.length === 1) {
+		return rv[0];
+	}
+	return rv;
+}
+
+/**
+ * Export since field
+ */
+function exportPlatforms (api) {
+	var rv = [], platform = null;
+	for (platform in api.since) {
+		rv.push({
+			'pretty_name': common.PRETTY_PLATFORM[platform],
+			'since': api.since[platform],
+			'name': platform
+		});
+	}
+	return rv;
+}
+
+/**
+ * Export members API
+ */
+function exportAPIs (api, type) {
+	var rv = [],
+		x = 0,
+		member = {},
+		annotatedMember = {};
+
+	if (type in api) {
+		for (x = 0; x < api[type].length; x++) {
+			member = api[type][x];
+
+			annotatedMember.name = member.name;
+			annotatedMember.deprecated = exportDeprecated(member);
+			annotatedMember.summary = exportSummary(member);
+			annotatedMember.description = exportDescription(member);
+			annotatedMember.filename = api.name + '.' + cleanAPIName(member.name) + '-' + member.__subtype;
+			annotatedMember.platforms = exportPlatforms(member);
+
+			switch (type) {
+				case 'events':
+					if (member.properties) {
+						if ('Titanium.Event' in doc) {
+							member.properties = member.properties.concat(doc['Titanium.Event'].properties);
+						}
+						annotatedMember.properties = exportParams(member.properties, 'properties', annotatedMember.filename);
+					}
+					break;
+				case 'methods':
+					annotatedMember.examples = exportExamples(member);
+					annotatedMember.parameters = exportParams(member.parameters, 'parameters', annotatedMember.filename);
+					annotatedMember.returns = exportReturnTypes(member);
+					break;
+				case 'properties':
+					annotatedMember.examples = exportExamples(member);
+					annotatedMember.type = member.type || 'String';
+					if (assert(member, 'availability')) {
+						annotatedMember.availability = member.availability;
+					}
+					if (assert(member, 'default')) {
+						annotatedMember['default'] = member['default'];
+					}
+					if (assert(member, 'optional')) {
+						annotatedMember.optional = member.optional;
+					}
+					if (assert(member, 'permission')) {
+						annotatedMember.permission = member.permission;
+					}
+					if (assert(member, 'value')) {
+						annotatedMember.value = member.value;
+					}
+			}
+
+			rv.push(annotatedMember);
+			member = annotatedMember = {};
+		}
+	}
+
+	return rv;
+}
+
+/**
+ * Annotate JSON data for consumption by third-party tools
+ */
+exports.exportData = function exportJSON (apis) {
+	var className = null,
+		cls = {},
+		annotatedClass = {},
+		rv = {};
+	doc = apis;
+
+	common.log(common.LOG_INFO, 'Annotating JSON-specific attributes...');
+
+	for (className in apis) {
+		cls = apis[className];
+		annotatedClass.name = cls.name;
+		annotatedClass.summary = exportSummary(cls);
+		annotatedClass.deprecated = exportDeprecated(cls);
+		annotatedClass.events = exportAPIs(cls, 'events');
+		annotatedClass.examples = exportExamples(cls);
+		annotatedClass.methods = exportAPIs(cls, 'methods');
+		annotatedClass['extends'] = cls['extends'] || 'Object';
+		annotatedClass.properties = exportAPIs(cls, 'properties');
+		annotatedClass.description = exportDescription(cls);
+		annotatedClass.platforms = exportPlatforms(cls);
+		annotatedClass.filename = exportClassFilename(cls);
+		annotatedClass.type = cls.__subtype || 'object';
+		annotatedClass.subtype = null;
+		if (~['proxy', 'view'].indexOf(annotatedClass.type)) {
+			annotatedClass.subtype = annotatedClass.type;
+			annotatedClass.type = 'object';
+		}
+
+		rv[className] = annotatedClass;
+		cls = annotatedClass = {};
+	}
+	return rv;
+};

--- a/apidoc/lib/solr_generator.js
+++ b/apidoc/lib/solr_generator.js
@@ -1,0 +1,227 @@
+/**
+ * Copyright (c) 2015 Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License.
+ *
+ * Script to generate JSON-formmatted data for consumption by the SOLR indexer
+ */
+var common = require('./common.js'),
+	assert = common.assertObjectKey,
+	solr_category = 'platform';
+
+/**
+ * Replaces links with the label
+ */
+function removeLinks (str) {
+	var rv = str;
+	rv = rv.replace(/<([^>]+?)>/g, '$1');
+	rv = rv.replace(/\[([^\]]+?)\]\([^\)]+?\)/g, '$1');
+	rv = rv.replace(common.REGEXP_HREF_LINKS, '$2');
+	return rv;
+}
+
+/**
+ * Remove unwanted characters
+ */
+function cleanContent (str) {
+	var rv = str;
+	rv = rv.replace(/\n/gm, ' ');
+	return rv;
+}
+
+/**
+ * Exports the deprecated field
+ */
+function exportDeprecated (api) {
+	var rv = '';
+	if (assert(api, 'deprecated')) {
+		if (assert(api.deprecated, 'since')) {
+			rv += 'Deprecated since ' + api.deprecated.since + '. ';
+		}
+		if (assert(api.deprecated, 'removed')) {
+			rv += 'Removed in ' + api.deprecated.removed + '. ';
+		}
+		if (assert(api.deprecated, 'notes')) {
+			rv += api.deprecated.notes;
+		}
+	}
+	return rv;
+}
+
+/**
+ * Exports the summary field
+ */
+function exportSummary (api) {
+	var rv = '';
+	if (assert(api, 'summary')) {
+		rv = removeLinks(api.summary);
+	}
+	return rv;
+}
+
+/**
+ * Exports the examples field
+ */
+function exportExamples (api) {
+	var rv = [];
+	if (assert(api, 'examples')) {
+		api.examples.forEach(function (example) {
+			rv.push(example.title);
+			rv.push(example.code);
+		});
+	}
+	return rv.join(' ');
+}
+
+/**
+ * Exports the type field
+ */
+function exportType (api) {
+	var rv = [];
+	if (assert(api, 'type')) {
+		if (!Array.isArray(api.type)) {
+			api.type = [api.type];
+		}
+		api.type.forEach(function (t) {
+			if (t.indexOf('Dictionary<') === 0) {
+				rv = rv.concat(t.substring(t.indexOf('<'), t.lastIndexOf('>')).split(','));
+			} else if (t.indexOf('Array<') === 0) {
+				rv.push(t.substring(t.indexOf('<'), t.lastIndexOf('>')) + '[]');
+			} else {
+				rv.push(t);
+			}
+		});
+	}
+	return rv.join(' ');
+}
+
+/**
+ * Exports the method parameters or event properties field
+ */
+function exportParams (apis) {
+	var rv = [];
+	if (apis && apis.length > 0) {
+		apis.forEach(function (member) {
+			rv.push(member.name);
+			rv.push(exportDeprecated(member));
+			rv.push(exportSummary(member));
+			rv.push(exportDescription(member));
+			rv.push(exportType(member) || 'String');
+		});
+	}
+	return rv.join(' ');
+}
+
+/**
+ * Exports the description field
+ */
+function exportDescription (api) {
+	var rv = null;
+	if (assert(api, 'description')) {
+		rv = removeLinks(api.description);
+	}
+	return rv;
+}
+
+/**
+ * Exports the returns field
+ */
+function exportReturnType (api) {
+	var rv = [];
+	if (assert(api, 'returns')) {
+		rv.push(exportType(api.returns));
+		rv.push(exportSummary(api.returns));
+	} else {
+		rv.push('void');
+	}
+	return rv.join(' ');
+}
+
+/**
+ * Removes the parent namespace and returns the member name
+ */
+function removeNamespace (name) {
+	var rv = name;
+	if (~name.indexOf('.')) {
+		rv = name.slice(name.lastIndexOf('.') + 1);
+	}
+	return rv;
+}
+
+/**
+ * Removes the member name and returns the parent namespace
+ */
+function removeMemberName (name) {
+	var rv = name;
+	if (~name.indexOf('.')) {
+		rv = name.slice(0, name.IndexOf('.'));
+	}
+	return rv;
+}
+
+/**
+ * Exports API members
+ */
+function exportAPI (api, type, className) {
+	var rv = {},
+		content = [],
+		url = api.name;
+
+	if (className) {
+		url = [className, type, api.name].join('-');
+		content.push(className);
+		api.name = className + '.' + api.name;
+	} else {
+		content.push(api.name);
+	}
+
+	content.push(removeNamespace(api.name));
+	content.push(exportSummary(api));
+	content.push(exportDeprecated(api));
+	content.push(exportDescription(api));
+	content.push(exportExamples(api));
+
+	switch (type) {
+	case 'method':
+		content.push(exportReturnType(api));
+		content.push(exportParams(api.parameters));
+		break;
+	case 'event':
+		content.push(exportParams(api.properties));
+	}
+
+	rv = {
+		'id': url + '-' + solr_category,
+		'url': url,
+		'name': api.name,
+		'type': solr_category,
+		'content': cleanContent(content.join(' '))
+	};
+	return rv;
+}
+
+/**
+ * Returns an array of JSON objects for the SOLR server
+ */
+exports.exportData = function exportSOLR (apis) {
+	var className = null,
+		cls = {},
+		rv = [];
+
+	common.log(common.LOG_INFO, 'Annotating SOLR-specific attributes...');
+
+	for (className in apis) {
+		cls = apis[className];
+		rv.push(exportAPI(cls, 'class'));
+		cls.properties.forEach(function (property) {
+			rv.push(exportAPI(property, 'property', className));
+		});
+		cls.methods.forEach(function (method) {
+			rv.push(exportAPI(method, 'method', className));
+		});
+		cls.events.forEach(function (event) {
+			rv.push(exportAPI(event, 'event', className));
+		});
+		cls = {};
+	}
+	return rv;
+};

--- a/apidoc/templates/changes.ejs
+++ b/apidoc/templates/changes.ejs
@@ -1,0 +1,46 @@
+<% if (assert(data, 'new')) { %>
+<a name="new_apis"></a>
+<h2>New APIs</h2>
+
+The following APIs are new or have expanded platform support in Release <%- data.startVersion %>.
+
+<table>
+<tr><th>API</th><th>Type</th><th>Notes</th></tr>
+<% data['new'].forEach(function(member){ %>
+  <tr><td><%- member.name %></td><td><%- member.type %></td><td><%- member.summary %></td></tr>
+<% }) %>
+<tr>
+</table>
+<% } %>
+
+<% if (assert(data, 'deprecated')) { %>
+<a name="deprecated_apis"></a>
+<h2>Deprecated APIs</h2>
+
+The following APIs are deprecated in Release <%- data.startVersion %>.
+
+<table>
+<tr><th>API</th><th>Type</th><th>Notes</th></tr>
+<% data['deprecated'].forEach(function(member){ %>
+  <tr><td><%- member.name %></td><td><%- member.type %></td><td><%- member.summary %></td></tr>
+<% }) %>
+<tr>
+</table>
+<% } %>
+
+<% if (assert(data, 'removed')) { %>
+<a name="removed_apis"></a>
+
+<h2>Removed APIs</h2>
+
+The following APIs have been removed in Release <%- data.startVersion %>.
+
+<table>
+<tr><th>API</th><th>Type</th><th>Notes</th></tr>
+<% data['removed'].forEach(function(member){ %>
+  <tr><td><%- member.name %></td><td><%- member.type %></td><td><%- member.summary %></td></tr>
+<% }) %>
+<tr>
+</table>
+<% } %>
+


### PR DESCRIPTION
Testing:

**JSON**
Generate JSON format by running:
`node docgen -f json`

Format should be similar to output of:
`./docgen.py -f json -o ../dist`

**SOLR**
Generate SOLR content by running:
`node docgen -f solr`

Format should be similar to output of:
Compare to output of `./docgen.py -f solr -o ../dist`

**Changes**
Generate API change list by running:
`node docgen -f changes`

Compare to output of `./docgen.py -f changes -o ../dist`

You can also specify a start and end version with `--start` and `--end`, respectively.
Examples:
`node docgen -f changes --start 3.60 --end 4.0.1`
