### PR TITLE
[TC-5428] Use a different data directory (tishadow)

### DIFF
--- a/android/modules/android/src/java/ti/modules/titanium/android/TiJSIntervalService.java
+++ b/android/modules/android/src/java/ti/modules/titanium/android/TiJSIntervalService.java
@@ -152,7 +152,7 @@ public class TiJSIntervalService extends TiJSService
 			this.proxy = proxy;
 			this.interval = interval;
 			this.url = url;
-			this.source = KrollAssetHelper.readAsset(url);
+			this.source = KrollAssetHelper.readCustomAsset(url);
 			this.serviceSimpleName = service.getClass().getSimpleName();
 		}
 

--- a/android/modules/android/src/java/ti/modules/titanium/android/TiJSService.java
+++ b/android/modules/android/src/java/ti/modules/titanium/android/TiJSService.java
@@ -71,7 +71,7 @@ public class TiJSService extends TiBaseService
 		}
 
 		proxy.fireEvent(TiC.EVENT_RESUME, new KrollDict());
-		KrollRuntime.getInstance().runModule(KrollAssetHelper.readAsset(fullUrl), fullUrl, proxy);
+		KrollRuntime.getInstance().runModule(KrollAssetHelper.readCustomAsset(fullUrl), fullUrl, proxy);
 		proxy.fireEvent(TiC.EVENT_PAUSE, new KrollDict());
 		proxy.fireEvent(TiC.EVENT_STOP, new KrollDict()); // this basic JS Service class only runs once.
 

--- a/android/runtime/common/src/java/org/appcelerator/kroll/util/KrollAssetHelper.java
+++ b/android/runtime/common/src/java/org/appcelerator/kroll/util/KrollAssetHelper.java
@@ -23,15 +23,30 @@ public class KrollAssetHelper
 	private static WeakReference<AssetManager> manager;
 	private static String packageName, cacheDir;
 	private static AssetCrypt assetCrypt;
+	private static TiResourceUtils tiResourceUtils;
 
 	public interface AssetCrypt
 	{
 		String readAsset(String path);
 	}
+	
+	public interface TiResourceUtils
+	{
+		boolean useCustomResourceDirectory();
+		boolean useAssetDirectory();
+		boolean isExist(String path);
+		String getBasePath();
+		String getPath(String path);
+	}
 
 	public static void setAssetCrypt(AssetCrypt assetCrypt)
 	{
 		KrollAssetHelper.assetCrypt = assetCrypt;
+	}
+	
+	public static void setTiResourceUtils(TiResourceUtils tiResourceUtils)
+	{
+		KrollAssetHelper.tiResourceUtils = tiResourceUtils;
 	}
 
 	public static void init(Context context)
@@ -39,6 +54,22 @@ public class KrollAssetHelper
 		KrollAssetHelper.manager = new WeakReference<AssetManager>(context.getAssets());
 		KrollAssetHelper.packageName = context.getPackageName();
 		KrollAssetHelper.cacheDir = context.getCacheDir().getAbsolutePath();
+	}
+	
+	public static String readCustomAsset(String path)
+	{
+		String resourcePath = path.replace("Resources/", "");
+		
+		if(tiResourceUtils.useCustomResourceDirectory() && tiResourceUtils.isExist(resourcePath)){
+			Log.d(TAG, "Search in folder: "+tiResourceUtils.getBasePath());
+			String fullPath = tiResourceUtils.getPath(resourcePath);
+			if(tiResourceUtils.useAssetDirectory()){
+				return readAsset(fullPath);
+			}else{
+				return readFile(fullPath);
+			}
+		}
+		return readAsset(path);
 	}
 
 	public static String readAsset(String path)

--- a/android/runtime/common/src/js/module.js
+++ b/android/runtime/common/src/js/module.js
@@ -82,7 +82,7 @@ Module.prototype.load = function (filename, source) {
 	this.paths = [path.dirname(filename)];
 
 	if (!source) {
-		source = assets.readAsset(filename);
+		source = assets.readCustomAsset(filename);
 	}
 
 	this._runScript(source, filename.replace("Resources/", ""));
@@ -275,6 +275,18 @@ Module.prototype.require = function (request, context, useCache) {
 			}
 		}
 	}
+	
+	try{
+		if(!located){
+			var customResourceContents = assets.readCustomAsset(filename+".js");
+			if(customResourceContents){
+				filename += ".js";
+				located = true;
+			}
+		}
+	}catch(e){
+		
+	}
 
 	if (!located) {
 		throw new Error("Requested module not found: " + request);
@@ -296,7 +308,9 @@ Module.prototype.require = function (request, context, useCache) {
 
 	if (externalCommonJsContents) {
 		module.load(filename, externalCommonJsContents);
-	} else {
+	} else if(customResourceContents){
+		module.load(filename, customResourceContents);
+	}else{
 		module.load(filename);
 	}
 
@@ -374,7 +388,7 @@ function resolveLookupPaths(request, parentModule) {
 	// Get the path to the parent module. If the parent
 	// is an index file, its ID is already the directory path.
 	// Ex: path.id = "a/" if index
-	//     path.id = "a/b" if non-index
+	//	 path.id = "a/b" if non-index
 	var isIndex = /^index\.\w+?$/.test(path.basename(parentModule.filename));
 	var parentIdPath = isIndex ? parentModule.id : path.dirname(parentModule.id);
 

--- a/android/runtime/v8/src/native/JNIUtil.cpp
+++ b/android/runtime/v8/src/native/JNIUtil.cpp
@@ -105,6 +105,7 @@ jmethodID JNIUtil::krollProxyGetIndexedPropertyMethod = NULL;
 jmethodID JNIUtil::krollProxyOnPropertyChangedMethod = NULL;
 jmethodID JNIUtil::krollProxyOnPropertiesChangedMethod = NULL;
 jmethodID JNIUtil::krollAssetHelperReadAssetMethod = NULL;
+jmethodID JNIUtil::krollAssetHelperReadCustomAssetMethod = NULL;
 jmethodID JNIUtil::krollLoggingLogWithDefaultLoggerMethod = NULL;
 
 jmethodID JNIUtil::krollRuntimeDispatchExceptionMethod = NULL;
@@ -366,6 +367,7 @@ void JNIUtil::initCache()
 
 	krollRuntimeDispatchExceptionMethod = getMethodID(krollRuntimeClass, "dispatchException", "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;I)V",true);
 	krollAssetHelperReadAssetMethod = getMethodID(krollAssetHelperClass, "readAsset", "(Ljava/lang/String;)Ljava/lang/String;", true);
+	krollAssetHelperReadCustomAssetMethod = getMethodID(krollAssetHelperClass, "readCustomAsset", "(Ljava/lang/String;)Ljava/lang/String;", true);
 
 	krollLoggingLogWithDefaultLoggerMethod = getMethodID(krollLoggingClass, "logWithDefaultLogger", "(ILjava/lang/String;)V", true);
 

--- a/android/runtime/v8/src/native/JNIUtil.h
+++ b/android/runtime/v8/src/native/JNIUtil.h
@@ -132,6 +132,7 @@ public:
 	static jmethodID krollRuntimeDispatchExceptionMethod;
 
 	static jmethodID krollAssetHelperReadAssetMethod;
+	static jmethodID krollAssetHelperReadCustomAssetMethod;
 
 };
 

--- a/android/runtime/v8/src/native/modules/AssetsModule.h
+++ b/android/runtime/v8/src/native/modules/AssetsModule.h
@@ -19,6 +19,7 @@ class AssetsModule
 public:
 	static void Initialize(Handle<Object> target);
 
+	static Handle<Value> readCustomAsset(const Arguments& args);
 	static Handle<Value> readAsset(const Arguments& args);
 	static Handle<Value> readFile(const Arguments& args);
 

--- a/android/templates/App.java
+++ b/android/templates/App.java
@@ -14,6 +14,8 @@ import org.appcelerator.kroll.util.KrollAssetHelper;
 import org.appcelerator.titanium.TiApplication;
 import org.appcelerator.titanium.TiRootActivity;
 
+import org.appcelerator.titanium.util.TiResourceUtils;
+
 import java.util.List;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -34,8 +36,10 @@ public final class ${config['classname']}Application extends TiApplication
 		postAppInfo();
 
 		% if config['compile_js']:
-		    KrollAssetHelper.setAssetCrypt(new AssetCryptImpl());
+			KrollAssetHelper.setAssetCrypt(new AssetCryptImpl());
 		% endif
+
+		KrollAssetHelper.setTiResourceUtils(new TiResourceUtils());
 
 		V8Runtime runtime = new V8Runtime();
 

--- a/android/templates/build/App.java
+++ b/android/templates/build/App.java
@@ -14,6 +14,8 @@ import org.appcelerator.kroll.util.KrollAssetHelper;
 import org.appcelerator.titanium.TiApplication;
 import org.appcelerator.titanium.TiRootActivity;
 
+import org.appcelerator.titanium.util.TiResourceUtils;
+
 import java.util.List;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -33,8 +35,10 @@ public final class <%= classname %>Application extends TiApplication
 		postAppInfo();
 
 <% if (encryptJS) { %>
-	    KrollAssetHelper.setAssetCrypt(new AssetCryptImpl());
+		KrollAssetHelper.setAssetCrypt(new AssetCryptImpl());
 <% } %>
+
+		KrollAssetHelper.setTiResourceUtils(new TiResourceUtils());
 
 		V8Runtime runtime = new V8Runtime();
 

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiResourceUtils.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiResourceUtils.java
@@ -1,0 +1,172 @@
+/**
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2011 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+package org.appcelerator.titanium.util;
+
+import org.appcelerator.titanium.ITiAppInfo;
+import org.appcelerator.titanium.TiProperties;
+import org.appcelerator.titanium.TiApplication;
+import org.appcelerator.titanium.io.TiFileFactory;
+import org.appcelerator.titanium.io.TiBaseFile;
+import org.appcelerator.kroll.util.KrollAssetHelper;
+import org.appcelerator.kroll.common.Log;
+
+import java.util.HashMap;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
+import android.os.Environment;
+
+
+public class TiResourceUtils implements KrollAssetHelper.TiResourceUtils
+{
+	private static final String TAG = "TiResourceUtils";
+	
+	private static boolean isInit;
+	private static boolean useAsset;
+	private static boolean useCustomDir;
+	private static String sourcePathString;
+	private static String baseDirectory;
+	private static String pathString;
+	
+	protected static TiFileFactory tiFileFactory;
+	protected static TiApplication tiApp = TiApplication.getInstance();
+	protected static TiProperties tiProp =  tiApp.getAppProperties();
+	
+	public TiResourceUtils()
+	{
+		
+	}
+	
+	private void init (){
+		sourcePathString = tiProp.getString("dataDirectory", "");
+		if(sourcePathString != ""){
+			useCustomDir = true;
+			baseDirectory = getBaseDirectory(sourcePathString);
+			pathString = parsePathString(sourcePathString);
+		}
+		isInit = true;
+	}
+	
+	private boolean isExternalStoragePresent()
+	{
+		return Environment.getExternalStorageState().equals(Environment.MEDIA_MOUNTED);
+	}
+	
+	private HashMap getValues(){
+		ITiAppInfo appInfo = tiApp.getAppInfo();
+		
+		HashMap<String, String> values = new HashMap<String, String>();
+		values.put("deploytype", appInfo.getDeployType());
+		values.put("id", appInfo.getId());
+		values.put("publisher", appInfo.getPublisher());
+		values.put("url", appInfo.getUrl());
+		values.put("name", appInfo.getName());
+		values.put("version", appInfo.getVersion());
+		values.put("description", appInfo.getDescription());
+		values.put("copyright", appInfo.getCopyright());
+		values.put("guid", appInfo.getGUID());
+		values.put("familyTarget", "android");
+		values.put("platform", "android");
+		values.put("family", "android");
+		values.put("undName", appInfo.getName().replaceAll(" ", "_"));
+		
+		return values;
+	}
+	
+	private String parsePathString(String path){
+		HashMap values = getValues();
+		
+		Pattern dirPattern = Pattern.compile("(.*Directory):/");
+		Pattern valuePattern = Pattern.compile("\\{ *(.*?) *\\}");
+		
+		Matcher dirRegex = dirPattern.matcher(path);
+		
+		if(dirRegex.find()){
+			path = dirRegex.replaceFirst("");
+		}
+		
+		Matcher valueRegex = valuePattern.matcher(path);
+		
+		while(valueRegex.find()){
+			String matchText = valueRegex.group(0);
+			String matchValue = valueRegex.group(1);
+			String value = (String) values.get(matchValue);
+			if(value != null){
+				path = path.replace(matchText, value);
+			}
+		}
+		if(!path.equals("") && !path.endsWith("/")){
+			path += "/";
+		}
+		return path;
+	}
+	
+	private String getBaseDirectory(String path)
+	{
+		Pattern dirPattern = Pattern.compile("(.*Directory):/");
+		Matcher dirRegex = dirPattern.matcher(path);
+		
+		String basePath = "";
+		
+		while (dirRegex.find()) {
+			String matchText = dirRegex.group(1);
+			
+			if(matchText.equals("resourcesDirectory")){
+				useAsset = true;
+				//Use default path
+			}else if(matchText.equals("applicationDataDirectory")){
+				basePath = tiFileFactory.getDataDirectory(true).toString();
+			}else if(matchText.equals("tempDirectory")){
+				basePath = tiApp.getTempFileHelper().getTempDirectory().getAbsolutePath();
+			}else if(matchText.equals("applicationCacheDirectory")){
+				basePath = tiApp.getCacheDir().toString();
+			}else if(matchText.equals("externalStorageDirectory") && isExternalStoragePresent()){
+				basePath = tiFileFactory.getDataDirectory(false).toString();
+			}else{
+				useAsset = true;
+				//Use default path
+			}
+		}
+		if(!basePath.equals("") && !basePath.endsWith("/")){
+			basePath += "/";
+		}
+		return basePath;
+	}
+	
+	public boolean isExist(String path){
+		String basePath = getPath(path);
+		if(useAsset) basePath = "app://"+basePath;
+		TiBaseFile file = tiFileFactory.createTitaniumFile(basePath, false);
+		return file.exists();
+	}
+	
+	public boolean useCustomResourceDirectory()
+	{
+		if(!isInit){
+			init();
+		}
+		return useCustomDir;
+	}
+	
+	public boolean useAssetDirectory(){
+		return useAsset;
+	}
+	
+	public String getBaseDir(){
+		return baseDirectory;
+	}
+	
+	public String getBasePath(){
+		return baseDirectory+pathString;
+	}
+	
+	public String getPath(String path){
+		if(path.startsWith("/")){
+			path = path.substring(1);
+		}
+		return getBasePath()+path;
+	}
+}

--- a/iphone/Classes/KrollBridge.m
+++ b/iphone/Classes/KrollBridge.m
@@ -890,7 +890,7 @@ loadNativeJS:
 	{
 		filepath = [fullPath stringByAppendingString:@".js"];
         NSURL* url_ = [NSURL URLWithString:filepath relativeToURL:[[self host] baseURL]];
-        data = [TiUtils loadAppResource:url_];
+        data = [TiUtils loadCustomAppResource:url_];
         
         if (data == nil) {
             data = [NSData dataWithContentsOfURL:url_];

--- a/iphone/Classes/TiResourceUtils.h
+++ b/iphone/Classes/TiResourceUtils.h
@@ -1,0 +1,20 @@
+/**
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2013 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+
+#import <Foundation/Foundation.h>
+
+@interface TiResourceUtils : NSObject
+
++(BOOL)useCustomResourceDirectory;
+
++(NSString*) getBaseDir;
+
++(NSString*) getBasePath;
+
++(NSString*) getPath:(NSString*) path;
+
+@end

--- a/iphone/Classes/TiResourceUtils.m
+++ b/iphone/Classes/TiResourceUtils.m
@@ -1,0 +1,146 @@
+/**
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2013 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+
+#import "TiResourceUtils.h"
+#import "TiApp.h"
+#import "AppModule.h"
+
+@implementation TiResourceUtils
+
+extern NSString * const TI_APPLICATION_DEPLOYTYPE;
+extern NSString * const TI_APPLICATION_ID;
+extern NSString * const TI_APPLICATION_PUBLISHER;
+extern NSString * const TI_APPLICATION_URL;
+extern NSString * const TI_APPLICATION_NAME;
+extern NSString * const TI_APPLICATION_VERSION;
+extern NSString * const TI_APPLICATION_DESCRIPTION;
+extern NSString * const TI_APPLICATION_COPYRIGHT;
+extern NSString * const TI_APPLICATION_GUID;
+
+static bool useCustomDir = false;
+static NSString* sourcePathString;
+static NSString* baseDirectory;
+static NSString* pathString;
+
++(void) initialize
+{
+    sourcePathString = [[TiApp tiAppProperties] objectForKey:@"dataDirectory"];
+    if(sourcePathString != nil){
+        useCustomDir = true;
+        baseDirectory = [[self getBaseDirectory:sourcePathString] retain];
+        pathString = [[self parsePathString:sourcePathString] retain];
+    }
+}
+
++(NSDictionary*) getValues
+{
+    NSString* familyTarget = UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad ? @"ipad" : @"iphone";
+    NSDictionary* values = [NSDictionary dictionaryWithObjectsAndKeys:
+              TI_APPLICATION_DEPLOYTYPE, @"deploytype",
+              TI_APPLICATION_ID, @"id",
+              TI_APPLICATION_PUBLISHER, @"publisher",
+              TI_APPLICATION_URL, @"url",
+              TI_APPLICATION_NAME, @"name",
+              TI_APPLICATION_VERSION, @"version",
+              TI_APPLICATION_DESCRIPTION, @"description",
+              TI_APPLICATION_COPYRIGHT, @"copyright",
+              TI_APPLICATION_GUID, @"guid",
+              familyTarget, @"familyTarget",
+              @"ios", @"platform",
+              @"iphone", @"family",
+              [ TI_APPLICATION_NAME stringByReplacingOccurrencesOfString:@" " withString:@"_"], @"undName", nil];
+    return values;
+}
+
++(NSString*) parsePathString:(NSString*) path
+{
+    NSString* pattern = @"\\{ *(.*?) *\\}";
+    NSString* patternDir = @".*Directory:/(.*)";
+    NSDictionary* values = [self getValues];
+
+    NSRegularExpression* regexDir = [NSRegularExpression regularExpressionWithPattern: patternDir options:0 error:nil];
+    NSTextCheckingResult* matchDir = [[regexDir matchesInString:path options:0 range: NSMakeRange(0, [path length])] firstObject];
+    if(matchDir != nil){
+        path = [path substringWithRange:[matchDir rangeAtIndex:1]];
+    }
+    if(![path isEqualToString:@""]){
+        NSRegularExpression* regex = [NSRegularExpression regularExpressionWithPattern: pattern options:0 error:nil];
+        NSArray* matches = [[[regex matchesInString:path options:0 range: NSMakeRange(0, [path length])] reverseObjectEnumerator] allObjects];
+        for (NSTextCheckingResult* match in matches) {
+            NSString* matchValue = [path substringWithRange:[match rangeAtIndex:1]];
+            NSString* value = values[matchValue];
+            if(value != nil){
+                path = [path stringByReplacingCharactersInRange:[match range] withString:value];
+            }
+        }
+        if(![path hasSuffix:@"/"]){
+            path = [path stringByAppendingString:@"/"];
+        }
+    }
+    return path;
+}
+
++(NSString*) getBaseDirectory:(NSString*) path
+{
+    NSString* matchText = nil;
+    NSRange   searchedRange = NSMakeRange(0, [path length]);
+    NSString *pattern = @"(.*Directory):/";
+    NSError  *error = nil;
+    
+    NSRegularExpression* regex = [NSRegularExpression regularExpressionWithPattern: pattern options:0 error:&error];
+    NSTextCheckingResult* match = [[regex matchesInString:path options:0 range: searchedRange] firstObject];
+    
+    NSString* basePath = [[NSBundle mainBundle] resourcePath];
+    if(match){
+        matchText = [path substringWithRange:[match rangeAtIndex:1]];
+        if([matchText isEqualToString:@"resourcesDirectory"]){
+            //Use default path
+        }else if([matchText isEqualToString:@"applicationDataDirectory"]){
+            basePath = [NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) firstObject];
+        }else if([matchText isEqualToString:@"tempDirectory"]){
+            basePath = NSTemporaryDirectory();
+        }else if([matchText isEqualToString:@"applicationCacheDirectory"]){
+            basePath = [NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES) firstObject];
+        }else if([matchText isEqualToString:@"externalStorageDirectory"]){
+            DebugLog(@"[ERROR] 'externalStorageDirectory' supports only android device");
+            //Use default path
+        }
+    }
+    if(![basePath hasSuffix:@"/"]){
+        basePath = [basePath stringByAppendingString:@"/"];
+    }
+    return basePath;
+}
+
++(BOOL) useCustomResourceDirectory
+{
+    return useCustomDir;
+}
+
++(NSString*) getBaseDir
+{
+    return baseDirectory;
+}
+
++(NSString*) getBasePath
+{
+    return [baseDirectory stringByAppendingString:pathString];
+}
+
++(NSString*) getPath:(NSString*) path
+{
+    if(!useCustomDir){
+        return nil;
+    }
+    if([path hasPrefix:@"/"]){
+        path = [path substringFromIndex:1];
+    }
+    NSString* fullPath = [[baseDirectory stringByAppendingString:pathString] stringByAppendingString:path];
+    return fullPath;
+}
+
+@end

--- a/iphone/Classes/TiUIWebView.m
+++ b/iphone/Classes/TiUIWebView.m
@@ -575,7 +575,7 @@ NSString *HTMLTextEncodingNameForStringEncoding(NSStringEncoding encoding)
 		// convert it into a app:// relative path to load the resource
 		// from our application
 		url = [[self fileURLToAppURL:url] retain];
-		NSData *data = [TiUtils loadAppResource:url];
+		NSData *data = [TiUtils loadCustomAppResource:url];
 		NSString *html = nil;
 		if (data != nil) {
 			html = [[[NSString alloc] initWithData:data encoding:encoding] autorelease];
@@ -841,7 +841,7 @@ NSString *HTMLTextEncodingNameForStringEncoding(NSStringEncoding encoding)
 	NSString *contentTextEncoding = [[self class] propertyForKey:kContentTextEncoding inRequest:request];
 	NSData *contentData = [[self class] propertyForKey:kContentData inRequest:request];
 	if (contentData == nil) {
-		contentData = [TiUtils loadAppResource:url];
+		contentData = [TiUtils loadCustomAppResource:url];
 		if (contentData == nil) {
 			contentData = [NSData dataWithContentsOfFile:absolutePath];
 			if (contentData == nil) {

--- a/iphone/Classes/TiUtils.h
+++ b/iphone/Classes/TiUtils.h
@@ -130,6 +130,13 @@ typedef enum
 +(TiFile*)createTempFile:(NSString*)extension;
 
 /**
+ Loads application bundle resource by custom URL.
+ @param url The resource URL
+ @return The resource data.
+ */
++(NSData *)loadCustomAppResource:(NSURL*)url;
+
+/**
  Loads application bundle resource by URL.
  @param url The resource URL
  @return The resource data.

--- a/iphone/Classes/TiUtils.m
+++ b/iphone/Classes/TiUtils.m
@@ -20,6 +20,7 @@
 #import "TiBlob.h"
 #import "Base64Transcoder.h"
 #import "TiExceptionHandler.h"
+#import "TiResourceUtils.h"
 
 // for checking version
 #import <sys/utsname.h>
@@ -1351,6 +1352,28 @@ if ([str isEqualToString:@#orientation]) return (UIDeviceOrientation)orientation
 	return CGRectMake(center.x - (anchorPoint.x * bounds.size.width),
 			center.y - (anchorPoint.y * bounds.size.height),
 			bounds.size.width, bounds.size.height);
+}
+
++(NSData *)loadCustomAppResource:(NSURL*)url
+{
+    if([TiResourceUtils useCustomResourceDirectory]){
+        DebugLog(@"Search in folder: %@", [TiResourceUtils getBasePath]);
+        NSString *urlstring = [[url standardizedURL] path];
+        NSString *resourceurl = [[NSBundle mainBundle] resourcePath];
+        NSRange range = [urlstring rangeOfString:resourceurl];
+        NSString *appurlstr = urlstring;
+        if (range.location!=NSNotFound)
+        {
+            appurlstr = [urlstring substringFromIndex:range.location + range.length + 1];
+        }
+        NSString* filePath = [TiResourceUtils getPath:appurlstr];
+        if ([[NSFileManager defaultManager] fileExistsAtPath:filePath])
+        {
+            DebugLog(@"Loading from custom resource directory: %@", filePath);
+            return [NSData dataWithContentsOfFile:filePath];
+        }
+    }
+    return [self loadAppResource:url];
 }
 
 +(NSData *)loadAppResource:(NSURL*)url

--- a/iphone/iphone/Titanium.xcodeproj/project.pbxproj
+++ b/iphone/iphone/Titanium.xcodeproj/project.pbxproj
@@ -493,6 +493,9 @@
 		844812C41A1D4C2100FBE03A /* libti_ios_profiler.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 502E9D2316CAFB9D00C1BD26 /* libti_ios_profiler.a */; };
 		844812C51A1D4C3200FBE03A /* libti_ios_profiler.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 502E9D2316CAFB9D00C1BD26 /* libti_ios_profiler.a */; };
 		844812C61A1D4C4100FBE03A /* libti_ios_profiler.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 502E9D2316CAFB9D00C1BD26 /* libti_ios_profiler.a */; };
+		844971931AF65E7C004B316D /* TiResourceUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 844971921AF65E7C004B316D /* TiResourceUtils.m */; };
+		844971941AF65E7C004B316D /* TiResourceUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 844971921AF65E7C004B316D /* TiResourceUtils.m */; };
+		844971951AF65E7C004B316D /* TiResourceUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 844971921AF65E7C004B316D /* TiResourceUtils.m */; };
 		844E1F7E14883A3700F5424C /* TiDOMValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = 844E1F7D14883A3700F5424C /* TiDOMValidator.m */; };
 		844E1F7F14883A3700F5424C /* TiDOMValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = 844E1F7D14883A3700F5424C /* TiDOMValidator.m */; };
 		844E1F8014883A3700F5424C /* TiDOMValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = 844E1F7D14883A3700F5424C /* TiDOMValidator.m */; };
@@ -1409,6 +1412,8 @@
 		843FA58217BD4DFF0064E061 /* TiUIiOSNavWindow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TiUIiOSNavWindow.h; sourceTree = "<group>"; };
 		843FA58317BD4DFF0064E061 /* TiUIiOSNavWindow.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TiUIiOSNavWindow.m; sourceTree = "<group>"; };
 		844812C31A1D49FB00FBE03A /* TiProfiler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TiProfiler.h; sourceTree = "<group>"; };
+		844971911AF65E7C004B316D /* TiResourceUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TiResourceUtils.h; sourceTree = "<group>"; };
+		844971921AF65E7C004B316D /* TiResourceUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TiResourceUtils.m; sourceTree = "<group>"; };
 		844E1F7C14883A3700F5424C /* TiDOMValidator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TiDOMValidator.h; sourceTree = "<group>"; };
 		844E1F7D14883A3700F5424C /* TiDOMValidator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TiDOMValidator.m; sourceTree = "<group>"; };
 		8465E6BB19F8644D008479E6 /* CoreMedia.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreMedia.framework; path = System/Library/Frameworks/CoreMedia.framework; sourceTree = SDKROOT; };
@@ -1974,6 +1979,8 @@
 				DAA72342156D642400757987 /* TiConsole.m */,
 				84C3870017417CB800970D26 /* TiSelectedCellbackgroundView.h */,
 				84C3870117417CB800970D26 /* TiSelectedCellbackgroundView.m */,
+				844971911AF65E7C004B316D /* TiResourceUtils.h */,
+				844971921AF65E7C004B316D /* TiResourceUtils.m */,
 			);
 			name = Utils;
 			sourceTree = "<group>";
@@ -3332,6 +3339,7 @@
 				24CA8B9A111161FE0084E2DE /* TiUILabel.m in Sources */,
 				24CA8B9B111161FE0084E2DE /* TiUIiPhoneProxy.m in Sources */,
 				24CA8B9C111161FE0084E2DE /* TiUIImageViewProxy.m in Sources */,
+				844971931AF65E7C004B316D /* TiResourceUtils.m in Sources */,
 				24CA8B9D111161FE0084E2DE /* TiUIImageView.m in Sources */,
 				24CA8BA1111161FE0084E2DE /* TiUIEmailDialogProxy.m in Sources */,
 				24CA8BA5111161FE0084E2DE /* TiUICanvasViewProxy.m in Sources */,
@@ -3611,6 +3619,7 @@
 				24D8E412119B9D8A00F8CAA6 /* TiUINavBarButton.m in Sources */,
 				24D8E413119B9D8A00F8CAA6 /* TiUILabelProxy.m in Sources */,
 				24D8E414119B9D8A00F8CAA6 /* TiUILabel.m in Sources */,
+				844971941AF65E7C004B316D /* TiResourceUtils.m in Sources */,
 				24D8E415119B9D8A00F8CAA6 /* TiUIiPhoneProxy.m in Sources */,
 				24D8E416119B9D8A00F8CAA6 /* TiUIImageViewProxy.m in Sources */,
 				24D8E417119B9D8A00F8CAA6 /* TiUIImageView.m in Sources */,
@@ -3890,6 +3899,7 @@
 				DABB36ED12E8CB280026A6EA /* TiUINavBarButton.m in Sources */,
 				DABB36EE12E8CB280026A6EA /* TiUILabelProxy.m in Sources */,
 				DABB36EF12E8CB280026A6EA /* TiUILabel.m in Sources */,
+				844971951AF65E7C004B316D /* TiResourceUtils.m in Sources */,
 				DABB36F012E8CB280026A6EA /* TiUIiPhoneProxy.m in Sources */,
 				DABB36F112E8CB280026A6EA /* TiUIImageViewProxy.m in Sources */,
 				DABB36F212E8CB280026A6EA /* TiUIImageView.m in Sources */,


### PR DESCRIPTION
###### Jira https://jira.appcelerator.org/browse/TC-5428
###### First discussion https://github.com/appcelerator/titanium_mobile/pull/6698
## Why do it?

Currently tishadow uses `eval`, to run scripts. Therefore, if an error occurs, the console may indicate the wrong line, or even a file.

Also, for the same reason tishadow can not run services on android.

This Pull request, allows the use of native tishadow `require` to load scripts.
## How does it work?

tishadow adds `tiapp.xml`:

``` xml
<property name="dataDirectory" type="string">applicationDataDirectory:/{undName}/{family}</property>
```

And now any call `require` will primarily look into`applicationDataDirectory:/{undName}/{family}/..`and then in`Resource/..`

The `applicationDataDirectory:/{undName}/{family}` 
is converted to 
`/data/data/com.classname.test/app_appdata/App_Name/android`

Now if you run the `require('lib/q.js')`, the search will start again from `/data/data/com.classname.test/app_appdata/App_Name/android/lib/q.js` and then in the resources folder.
## Support Directory

applicationDataDirectory
tempDirectory
applicationCacheDirectory
externalStorageDirectory (only Android)
## Support Values

deploytype
id
publisher
url
name
version
description
copyright
guid
familyTarget = Android: android; IOS: Iphone, Ipad
platform = ios || android
family = iphone || android
undName = My App Name == My_App_Name
## Todo
- [x] Test Android Device
- [x] Test Android Emulator
- [x] Test IOS Emulator
- [ ] Test IOS Device
- [ ] Doc
## Tishadow issues
#### Service

https://github.com/dbankier/TiShadow/issues/260
https://github.com/dbankier/TiShadow/issues/418
#### Error line

https://github.com/dbankier/TiShadow/issues/429
## Ugly code

Copy-past: https://github.com/rotorgames/titanium_mobile/blob/fd81ebce9c924ec6dfa885a8cfdc3a2f84df0a33/android/runtime/v8/src/native/modules/AssetsModule.cpp#L36-L122
Creating an instance in `App.java`: https://github.com/rotorgames/titanium_mobile/blob/fd81ebce9c924ec6dfa885a8cfdc3a2f84df0a33/android/templates/App.java#L42

If anyone knows how to do better, the whole attention.
## P.S.

Who can be tested for IOS device?
