### PR TITLE
Add access method to NSUserActivityTypes

### DIFF
--- a/apidoc/Titanium/App/iOS/iOS.yml
+++ b/apidoc/Titanium/App/iOS/iOS.yml
@@ -275,6 +275,33 @@ properties:
     osver: {ios: {min: "8.0"}}
     since: "3.4.0"
 
+  - name: supportedUserActivityTypes
+    summary: |
+        Provides an Array of the NSUserActivityTypes keys defined within your Titanium project.
+        (available on iOS 8 and later).
+    description: |        
+        Used to obtain a list of the NSUserActivityTypes keys defined in your Titanium project's tiapp.xml file. 
+        These NSUserActivityTypes keys are the keys which you can use working with iOS Titanium User Activities.
+        NSUserActivityTypes must be defined at build time in your tiapp.xml file as shown below:
+
+		<ios>
+		    <plist>
+		        <dict>
+					<key>NSUserActivityTypes</key>
+					<array>
+						<string>com.setdirection.home</string>
+						<string>com.setdirection.shelf</string>
+						<string>com.setdirection.item</string>
+					</array>
+		        </dict>
+		    </plist>
+		</ios>
+
+    type: Array
+    permission: read-only
+    osver: {ios: {min: "8.0"}}
+    since: "4.1.0"
+
   - name: applicationOpenSettingsURL
     summary: Returns a URL to open the app's settings.
     description: |        

--- a/apidoc/Titanium/App/iOS/iOS.yml
+++ b/apidoc/Titanium/App/iOS/iOS.yml
@@ -300,7 +300,7 @@ properties:
     type: Array<string>
     permission: read-only
     osver: {ios: {min: "8.0"}}
-    since: "4.2.0"
+    since: "4.3.0"
 
   - name: applicationOpenSettingsURL
     summary: Returns a URL to open the app's settings.

--- a/apidoc/Titanium/App/iOS/iOS.yml
+++ b/apidoc/Titanium/App/iOS/iOS.yml
@@ -300,7 +300,7 @@ properties:
     type: Array<string>
     permission: read-only
     osver: {ios: {min: "8.0"}}
-    since: "4.1.0"
+    since: "4.2.0"
 
   - name: applicationOpenSettingsURL
     summary: Returns a URL to open the app's settings.

--- a/apidoc/Titanium/App/iOS/iOS.yml
+++ b/apidoc/Titanium/App/iOS/iOS.yml
@@ -284,20 +284,20 @@ properties:
         These NSUserActivityTypes keys are the keys which you can use working with iOS Titanium User Activities.
         NSUserActivityTypes must be defined at build time in your tiapp.xml file as shown below:
 
-		<ios>
-		    <plist>
-		        <dict>
-					<key>NSUserActivityTypes</key>
-					<array>
-						<string>com.setdirection.home</string>
-						<string>com.setdirection.shelf</string>
-						<string>com.setdirection.item</string>
-					</array>
-		        </dict>
-		    </plist>
-		</ios>
+			<ios>
+			    <plist>
+			        <dict>
+					  <key>NSUserActivityTypes</key>
+					  <array>
+						  <string>com.setdirection.home</string>
+						  <string>com.setdirection.shelf</string>
+						  <string>com.setdirection.item</string>
+					  </array>
+			        </dict>
+			    </plist>
+			</ios>
 
-    type: Array
+    type: Array<string>
     permission: read-only
     osver: {ios: {min: "8.0"}}
     since: "4.1.0"

--- a/iphone/Classes/TiAppiOSProxy.m
+++ b/iphone/Classes/TiAppiOSProxy.m
@@ -320,6 +320,18 @@
     }, NO);
 }
 
+-(NSArray*)supportedUserActivityTypes:(id)unused
+{    
+    if (![TiUtils isIOS8OrGreater]) {
+        return nil;
+    }
+    
+    NSArray *supportedActivityTypes = [[NSBundle mainBundle]
+                                       objectForInfoDictionaryKey:@"NSUserActivityTypes"];
+    
+    return supportedActivityTypes;
+}
+
 -(NSDictionary*)currentUserNotificationSettings
 {
     if (![TiUtils isIOS8OrGreater]) {

--- a/iphone/Classes/TiAppiOSProxy.m
+++ b/iphone/Classes/TiAppiOSProxy.m
@@ -320,7 +320,7 @@
     }, NO);
 }
 
--(NSArray*)supportedUserActivityTypes:(id)unused
+-(NSArray*)supportedUserActivityTypes
 {    
     if (![TiUtils isIOS8OrGreater]) {
         return nil;


### PR DESCRIPTION
Provide the ability to access to the NSUserActivityTypes defined in the tiapp.xml ( or in the end the bundle ).

These are needed to work with Hand off, deep linking, and search.

Jira ticket available https://jira.appcelerator.org/browse/TIMOB-19018
