### PR TITLE
TIMOB-19026 : Add support for indicatorColor on ActivityIndicator

### DIFF
--- a/apidoc/Titanium/UI/ActivityIndicator.yml
+++ b/apidoc/Titanium/UI/ActivityIndicator.yml
@@ -134,7 +134,7 @@ properties:
     since: "2.1.0"
     type: String
     default: <pre>#fff</pre>
-    platforms: [mobileweb]
+    platforms: [mobileweb,iOS]
     
   - name: indicatorDiameter
     summary: Diameter of the indicator.

--- a/iphone/Classes/TiUIActivityIndicator.h
+++ b/iphone/Classes/TiUIActivityIndicator.h
@@ -16,6 +16,7 @@
 	
 	WebFont * fontDesc;
 	UIColor * textColor;
+    UIColor * spinnerColor;
 	UILabel * messageLabel;
 }
 

--- a/iphone/Classes/TiUIActivityIndicator.m
+++ b/iphone/Classes/TiUIActivityIndicator.m
@@ -31,6 +31,7 @@
 	RELEASE_TO_NIL(messageLabel);
 	RELEASE_TO_NIL(fontDesc);
 	RELEASE_TO_NIL(textColor);
+    RELEASE_TO_NIL(spinnerColor);
 	[super dealloc];
 }
 
@@ -217,6 +218,17 @@
 		}
 	}
 
+}
+
+-(void)setSpinnerColor_:(id)value
+{
+    UIColor * newColor = [[TiUtils colorValue:value] _color];
+    [spinnerColor release];
+    spinnerColor = [newColor retain];
+    if (indicatorView != nil)
+    {
+        [indicatorView setColor:spinnerColor];
+    }
 }
 
 - (void)didMoveToWindow

--- a/iphone/Classes/TiUIActivityIndicator.m
+++ b/iphone/Classes/TiUIActivityIndicator.m
@@ -220,7 +220,7 @@
 
 }
 
--(void)setSpinnerColor_:(id)value
+-(void)setIndicatorColor_:(id)value
 {
     UIColor * newColor = [[TiUtils colorValue:value] _color];
     [spinnerColor release];


### PR DESCRIPTION
Add indicatorColor support to iOS.

Jira Ticket:  https://jira.appcelerator.org/browse/TIMOB-19026

Example:

```
var spinner = Ti.UI.createActivityIndicator({
  color: 'green',
  font: {fontFamily:'Helvetica Neue', fontSize:26, fontWeight:'bold'},
  message: 'Loading...',
  style:Ti.UI.iPhone.ActivityIndicatorStyle.DARK,
  top:10,
  left:10,
  height:Ti.UI.SIZE,
  width:Ti.UI.SIZE,
  indicatorColor:'purple'   
});
```
