### PR TITLE
[CLI-709] (4_1_X) Android classic app crashes on launch with java.lang.Illega…

### DIFF
--- a/android/modules/network/src/java/ti/modules/titanium/network/HTTPClientProxy.java
+++ b/android/modules/network/src/java/ti/modules/titanium/network/HTTPClientProxy.java
@@ -67,10 +67,12 @@ public class HTTPClientProxy extends KrollProxy
 		//Set the securityManager on the client if it is defined as a valid value
 		if (hasProperty(PROPERTY_SECURITY_MANAGER)) {
 			Object prop = getProperty(PROPERTY_SECURITY_MANAGER);
-			if (prop instanceof SecurityManagerProtocol) {
-				this.client.securityManager = (SecurityManagerProtocol)prop;
-			} else {
-				throw new IllegalArgumentException("Invalid argument passed to securityManager property. Does not conform to SecurityManagerProtocol");
+			if (prop != null) {
+				if (prop instanceof SecurityManagerProtocol) {
+					this.client.securityManager = (SecurityManagerProtocol)prop;
+				} else {
+					throw new IllegalArgumentException("Invalid argument passed to securityManager property. Does not conform to SecurityManagerProtocol");
+				}
 			}
 		}
 		client.setTlsVersion(TiConvert.toInt(getProperty(TiC.PROPERTY_TLS_VERSION), NetworkModule.TLS_DEFAULT));


### PR DESCRIPTION
…lArgumentException due to CLI injected code related to ACS caused by null securityManager property
