### PR TITLE
Android: Removed unnecessary cast in onPageFinished of TiWebViewClient

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiWebViewClient.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiWebViewClient.java
@@ -9,11 +9,11 @@ package ti.modules.titanium.ui.widget.webview;
 import org.appcelerator.kroll.KrollDict;
 import org.appcelerator.kroll.KrollProxy;
 import org.appcelerator.kroll.common.Log;
+import org.appcelerator.titanium.proxy.TiViewProxy;
 import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.util.TiConvert;
 
 import ti.modules.titanium.media.TiVideoActivity;
-import ti.modules.titanium.ui.WebViewProxy;
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.net.Uri;
@@ -45,7 +45,7 @@ public class TiWebViewClient extends WebViewClient
 	public void onPageFinished(WebView view, String url)
 	{
 		super.onPageFinished(view, url);
-		WebViewProxy proxy = (WebViewProxy) webView.getProxy();
+		TiViewProxy proxy = webView.getProxy();
 		webView.changeProxyUrl(url);
 		KrollDict data = new KrollDict();
 		data.put("url", url);


### PR DESCRIPTION
Hi,

sdk 4.0.0 introduced a breaking change, caused by an unnecessary cast in the onPageFinished method in the TiWebViewClient class. For example that change caused the following issue: https://github.com/viezel/NappJockey/issues/8

This PR removes that cast.

PSanetra
