### PR TITLE
iOS: TiUIListView does not resume the ImageLoader

### DIFF
--- a/iphone/Classes/TiUIListView.m
+++ b/iphone/Classes/TiUIListView.m
@@ -1737,6 +1737,7 @@ static TiViewProxy * FindViewProxyWithBindIdContainingPoint(UIView *view, CGPoin
 - (void)scrollViewDidEndDragging:(UIScrollView *)scrollView willDecelerate:(BOOL)decelerate
 {
     if(!decelerate) {
+        [[ImageLoader sharedLoader] resume];
         [self fireScrollEnd:(UITableView *)scrollView];
     }
     if (![self.proxy _hasListeners:@"pullend"]) {


### PR DESCRIPTION
If a user scrolls a list and does not _fling_ the table the shared image loader does not decelerate thus causing the image loader to remain suspended.
