### PR TITLE
[TIMOB-19211] iOS: Tapping "undo" will get a range or index out of bounds on TiUITextField

### DIFF
--- a/iphone/Classes/TiUITextField.m
+++ b/iphone/Classes/TiUITextField.m
@@ -492,6 +492,11 @@
 
 - (BOOL)textField:(UITextField *)tf shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString *)string
 {
+    //sanity check for undo bug. Does nothing if undo pressed for certain keyboardsTypes and under some conditions.
+    if (range.length + range.location > [[tf text] length]) {
+        return NO;
+    }
+    
     NSString *curText = [[tf text] stringByReplacingCharactersInRange:range withString:string];
    
     if ( (maxLength > -1) && ([curText length] > maxLength) ) {


### PR DESCRIPTION
JIRA: https://jira.appcelerator.org/browse/TIMOB-19211
Only merge after 4.2.0
