### PR TITLE
Update AppModule.m

### DIFF
--- a/iphone/Classes/AppModule.m
+++ b/iphone/Classes/AppModule.m
@@ -128,10 +128,6 @@ extern NSString * const TI_APPLICATION_GUID;
 		id type = [args objectAtIndex:0];
 		id obj = [args count] > 1 ? [args objectAtIndex:1] : nil;
 		
-#ifdef DEBUG
-		NSLog(@"[DEBUG] fire app event: %@",type);
-#endif
-		
 		NSArray *array = [appListeners objectForKey:type];
 		
 		if (array!=nil && [array count] > 0)


### PR DESCRIPTION
Removed annoying and unnecessary debug log.
If developers want to print out logs, they can manually do that in JS. No need to force this inside of the SDK. During development, if you have an app-wide fireEvent running after every x interval, the console output becomes really polluted. Android doesn't do this, would be nice if iOS wouldn't do this either.
