### PR TITLE
[TIMOB-19192] Android: Fix for Date & Time Picker on Android 5.0

### DIFF
--- a/android/modules/ui/res/layout/titanium_ui_date_picker_spinner.xml
+++ b/android/modules/ui/res/layout/titanium_ui_date_picker_spinner.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<DatePicker xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/titanium_ui_date_picker_spinner"
+    android:layout_height="wrap_content"
+    android:layout_width="wrap_content"
+    android:datePickerMode ="spinner"/>

--- a/android/modules/ui/res/layout/titanium_ui_time_picker_spinner.xml
+++ b/android/modules/ui/res/layout/titanium_ui_time_picker_spinner.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TimePicker xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/titanium_ui_time_picker_spinner"
+    android:layout_height="wrap_content"
+    android:layout_width="wrap_content"
+    android:timePickerMode ="spinner"/>

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/picker/TiUIDatePicker.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/picker/TiUIDatePicker.java
@@ -15,6 +15,8 @@ import org.appcelerator.kroll.common.Log;
 import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.proxy.TiViewProxy;
 import org.appcelerator.titanium.util.TiConvert;
+import org.appcelerator.titanium.util.TiRHelper;
+import org.appcelerator.titanium.util.TiRHelper.ResourceNotFoundException;
 import org.appcelerator.titanium.util.TiUIHelper;
 import org.appcelerator.titanium.view.TiUIView;
 
@@ -41,15 +43,36 @@ public class TiUIDatePicker extends TiUIView
 		this(proxy);
 		Log.d(TAG, "Creating a date picker", Log.DEBUG_MODE);
 		
-		DatePicker picker = new DatePicker(activity)
-		{
-			@Override
-			protected void onLayout(boolean changed, int left, int top, int right, int bottom)
+		DatePicker picker;
+		// If it is not API Level 21 (Android 5.0), create picker normally.
+		// If not, it will inflate a spinner picker to address a bug.
+		if (Build.VERSION.SDK_INT != Build.VERSION_CODES.LOLLIPOP) {
+			picker = new DatePicker(activity)
 			{
-				super.onLayout(changed, left, top, right, bottom);
-				TiUIHelper.firePostLayoutEvent(proxy);
+				@Override
+				protected void onLayout(boolean changed, int left, int top, int right, int bottom)
+				{
+					super.onLayout(changed, left, top, right, bottom);
+					TiUIHelper.firePostLayoutEvent(proxy);
+				}
+			};
+		} else {
+			// A bug where PickerCalendarDelegate does not send events to the
+			// listener on API Level 21 (Android 5.0) for TIMOB-19192
+			// https://code.google.com/p/android/issues/detail?id=147657
+			// Work around is to use spinner view instead of calendar view in
+			// in Android 5.0
+			int datePickerSpinner;
+			try {
+				datePickerSpinner = TiRHelper.getResource("layout.titanium_ui_date_picker_spinner");
+			} catch (ResourceNotFoundException e) {
+				if (Log.isDebugModeEnabled()) {
+					Log.e(TAG, "XML resources could not be found!!!");
+				}
+				return;
 			}
-		};
+			picker = (DatePicker) activity.getLayoutInflater().inflate(datePickerSpinner, null);
+		}
 		setNativeView(picker);
 	}
 	


### PR DESCRIPTION
-Change event not fired fix
-Picker.value not updated fix
-This fix is targeted for Android 21 (5.0) by using the native spinner mode

Jira: https://jira.appcelerator.org/browse/TIMOB-19192
