### PR TITLE
[TIMOB-19274] CLI: Fix for when building for iOS device the app will always be 32-bit

### DIFF
--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -2238,6 +2238,7 @@ iOSBuilder.prototype.createXcodeProject = function createXcodeProject(next) {
 		buildSettings = {
 			IPHONEOS_DEPLOYMENT_TARGET: appc.version.format(this.minIosVer, 2),
 			TARGETED_DEVICE_FAMILY: '"' + this.deviceFamilies[this.deviceFamily] + '"',
+			ONLY_ACTIVE_ARCH: 'NO',
 			DEAD_CODE_STRIPPING: 'YES',
 			SDKROOT: this.xcodeTargetOS
 		};


### PR DESCRIPTION
JIRA Here: https://jira.appcelerator.org/browse/TIMOB-19274
