### PR TITLE
TIMOB-19303: Fix 4.1.0.GA breaking change to modules

### DIFF
--- a/iphone/Classes/TiProxy.h
+++ b/iphone/Classes/TiProxy.h
@@ -10,6 +10,10 @@
 #import "TiBindingRunLoop.h"
 #import <pthread.h>
 
+#ifndef TI_BASE_H
+#import "TiBase.h"
+#endif
+
 @class KrollBridge;
 @class KrollObject;
 


### PR DESCRIPTION
This fixes a breaking change to iOS modules as outlined in the below Jira ticket.

https://jira.appcelerator.org/browse/TIMOB-19303
