### PR TITLE
[TIDOC-2294] Ti.WatchSession.recentAppContext documentation is incorrect

### DIFF
--- a/apidoc/Titanium/WatchSession/WatchSession.yml
+++ b/apidoc/Titanium/WatchSession/WatchSession.yml
@@ -39,7 +39,7 @@ properties:
     osver: {ios: {min: "9.0"}}
     platforms: [iphone,ipad]
   - name: recentAppContext
-    summary: The most recent app context received from apple watch.
+    summary: The most recent app context sent to apple watch.
     type: Dictionary
     permission: read-only
     osver: {ios: {min: "9.0"}}


### PR DESCRIPTION
https://jira.appcelerator.org/browse/TIDOC-2294
