### PR TITLE
Backport of #7106

### DIFF
--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -4861,7 +4861,7 @@ iOSBuilder.prototype.processTiSymbols = function processTiSymbols() {
 			contents.push('#define USE_JSCORE_FRAMEWORK')
 		}
 		if (!this.runOnMainThread) {
-			content.push('#define TI_USE_KROLL_THREAD');
+			contents.push('#define TI_USE_KROLL_THREAD');
 		}
 		contents = contents.join('\n');
 	}

--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -4858,7 +4858,7 @@ iOSBuilder.prototype.processTiSymbols = function processTiSymbols() {
 		);
 
 		if (this.useJSCore) {
-			contents.push('#define USE_JSCORE_FRAMEWORK')
+			contents.push('#define USE_JSCORE_FRAMEWORK');
 		}
 		if (!this.runOnMainThread) {
 			contents.push('#define TI_USE_KROLL_THREAD');


### PR DESCRIPTION
Fix typo introduced by https://github.com/appcelerator/titanium_mobile/commit/ca8a92c31bcf157bc729e5ed5db8ba9ce16b0f01
