### PR TITLE
[TIMOB-19447] CommonJS modules are not copied to the correct location when require encryption

### DIFF
--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -4495,6 +4495,9 @@ iOSBuilder.prototype.copyResources = function copyResources(next) {
 			async.eachSeries(Object.keys(jsFiles), function (file, next) {
 				var info = jsFiles[file];
 				if (this.encryptJS) {
+					if (file.indexOf('/') === 0) {
+						file = path.basename(file);
+					}
 					file = file.replace(/\./g, '_');
 					info.dest = path.join(this.buildAssetsDir, file);
 					this.jsFilesToEncrypt.push(file);

--- a/node_modules/titanium-sdk/lib/builder.js
+++ b/node_modules/titanium-sdk/lib/builder.js
@@ -93,7 +93,7 @@ function Builder(buildModule) {
 
 	this.platformName = path.basename(this.platformPath);
 
-	this.globalModulesPath = path.join(this.titaniumSdkPath, '..', '..', 'modules');
+	this.globalModulesPath = path.join(this.titaniumSdkPath, '..', '..', '..', 'modules');
 
 	this.packageJson = require(path.join(this.platformPath, 'package.json'));
 


### PR DESCRIPTION
https://jira.appcelerator.org/browse/TIMOB-19447
