### PR TITLE
[CLI] fix max call stack when iterating through many js files

### DIFF
--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -4493,52 +4493,50 @@ iOSBuilder.prototype.copyResources = function copyResources(next) {
 			this.logger.info(__('Processing JavaScript files'));
 
 			async.eachSeries(Object.keys(jsFiles), function (file, next) {
-				var info = jsFiles[file];
-				if (this.encryptJS) {
-					if (file.indexOf('/') === 0) {
-						file = path.basename(file);
+				setImmediate(function(){
+					var info = jsFiles[file];
+					if (this.encryptJS) {
+						file = file.replace(/\./g, '_');
+						info.dest = path.join(this.buildAssetsDir, file);
+						this.jsFilesToEncrypt.push(file);
 					}
-					file = file.replace(/\./g, '_');
-					info.dest = path.join(this.buildAssetsDir, file);
-					this.jsFilesToEncrypt.push(file);
-				}
+					this.cli.createHook('build.ios.copyResource', this, function (from, to, cb) {
+						try {
+							// parse the AST
+							var r = jsanalyze.analyzeJsFile(from, { minify: this.minifyJS });
+						} catch (ex) {
+							ex.message.split('\n').forEach(this.logger.error);
+							this.logger.log();
+							process.exit(1);
+						}
 
-				this.cli.createHook('build.ios.copyResource', this, function (from, to, cb) {
-					try {
-						// parse the AST
-						var r = jsanalyze.analyzeJsFile(from, { minify: this.minifyJS });
-					} catch (ex) {
-						ex.message.split('\n').forEach(this.logger.error);
-						this.logger.log();
-						process.exit(1);
-					}
+						// we want to sort by the "to" filename so that we correctly handle file overwriting
+						this.tiSymbols[info.dest] = r.symbols;
 
-					// we want to sort by the "to" filename so that we correctly handle file overwriting
-					this.tiSymbols[info.dest] = r.symbols;
+						var dir = path.dirname(to);
+						fs.existsSync(dir) || wrench.mkdirSyncRecursive(dir);
 
-					var dir = path.dirname(to);
-					fs.existsSync(dir) || wrench.mkdirSyncRecursive(dir);
+						delete this.buildDirFiles[to];
 
-					delete this.buildDirFiles[to];
-
-					if (this.minifyJS) {
-						this.cli.createHook('build.ios.compileJsFile', this, function (r, from, to, cb2) {
-							if (!fs.existsSync(to) || r.contents !== fs.readFileSync(to).toString()) {
-								this.logger.debug(__('Copying and minifying %s => %s', from.cyan, to.cyan));
-								fs.writeFileSync(to, r.contents);
-								this.jsFilesChanged = true;
-							} else {
+						if (this.minifyJS) {
+							this.cli.createHook('build.ios.compileJsFile', this, function (r, from, to, cb2) {
+								if (!fs.existsSync(to) || r.contents !== fs.readFileSync(to).toString()) {
+									this.logger.debug(__('Copying and minifying %s => %s', from.cyan, to.cyan));
+									fs.writeFileSync(to, r.contents);
+									this.jsFilesChanged = true;
+								} else {
+									this.logger.trace(__('No change, skipping %s', to.cyan));
+								}
+								cb2();
+							})(r, from, to, cb);
+						} else {
+							if (!this.copyFileSync(from, to)) {
 								this.logger.trace(__('No change, skipping %s', to.cyan));
 							}
-							cb2();
-						})(r, from, to, cb);
-					} else {
-						if (!this.copyFileSync(from, to)) {
-							this.logger.trace(__('No change, skipping %s', to.cyan));
+							cb();
 						}
-						cb();
-					}
-				})(info.src, info.dest, next);
+					})(info.src, info.dest, next);
+				}.bind(this));
 			}.bind(this), next);
 		},
 

--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -4493,53 +4493,53 @@ iOSBuilder.prototype.copyResources = function copyResources(next) {
 			this.logger.info(__('Processing JavaScript files'));
 
 			async.eachSeries(Object.keys(jsFiles), function (file, next) {
-				setImmediate(function(){
-				var info = jsFiles[file];
-				if (this.encryptJS) {
-					if (file.indexOf('/') === 0) {
-						file = path.basename(file);
-					}
-					file = file.replace(/\./g, '_');
-					info.dest = path.join(this.buildAssetsDir, file);
-					this.jsFilesToEncrypt.push(file);
-				}
-
-				this.cli.createHook('build.ios.copyResource', this, function (from, to, cb) {
-					try {
-						// parse the AST
-						var r = jsanalyze.analyzeJsFile(from, { minify: this.minifyJS });
-					} catch (ex) {
-						ex.message.split('\n').forEach(this.logger.error);
-						this.logger.log();
-						process.exit(1);
+				setImmediate(function () {
+					var info = jsFiles[file];
+					if (this.encryptJS) {
+						if (file.indexOf('/') === 0) {
+							file = path.basename(file);
+						}
+						file = file.replace(/\./g, '_');
+						info.dest = path.join(this.buildAssetsDir, file);
+						this.jsFilesToEncrypt.push(file);
 					}
 
-					// we want to sort by the "to" filename so that we correctly handle file overwriting
-					this.tiSymbols[info.dest] = r.symbols;
+					this.cli.createHook('build.ios.copyResource', this, function (from, to, cb) {
+						try {
+							// parse the AST
+							var r = jsanalyze.analyzeJsFile(from, { minify: this.minifyJS });
+						} catch (ex) {
+							ex.message.split('\n').forEach(this.logger.error);
+							this.logger.log();
+							process.exit(1);
+						}
 
-					var dir = path.dirname(to);
-					fs.existsSync(dir) || wrench.mkdirSyncRecursive(dir);
+						// we want to sort by the "to" filename so that we correctly handle file overwriting
+						this.tiSymbols[info.dest] = r.symbols;
 
-					delete this.buildDirFiles[to];
+						var dir = path.dirname(to);
+						fs.existsSync(dir) || wrench.mkdirSyncRecursive(dir);
 
-					if (this.minifyJS) {
-						this.cli.createHook('build.ios.compileJsFile', this, function (r, from, to, cb2) {
-							if (!fs.existsSync(to) || r.contents !== fs.readFileSync(to).toString()) {
-								this.logger.debug(__('Copying and minifying %s => %s', from.cyan, to.cyan));
-								fs.writeFileSync(to, r.contents);
-								this.jsFilesChanged = true;
-							} else {
+						delete this.buildDirFiles[to];
+
+						if (this.minifyJS) {
+							this.cli.createHook('build.ios.compileJsFile', this, function (r, from, to, cb2) {
+								if (!fs.existsSync(to) || r.contents !== fs.readFileSync(to).toString()) {
+									this.logger.debug(__('Copying and minifying %s => %s', from.cyan, to.cyan));
+									fs.writeFileSync(to, r.contents);
+									this.jsFilesChanged = true;
+								} else {
+									this.logger.trace(__('No change, skipping %s', to.cyan));
+								}
+								cb2();
+							})(r, from, to, cb);
+						} else {
+							if (!this.copyFileSync(from, to)) {
 								this.logger.trace(__('No change, skipping %s', to.cyan));
 							}
-							cb2();
-						})(r, from, to, cb);
-					} else {
-						if (!this.copyFileSync(from, to)) {
-							this.logger.trace(__('No change, skipping %s', to.cyan));
+							cb();
 						}
-						cb();
-					}
-				})(info.src, info.dest, next);
+					})(info.src, info.dest, next);
 				}.bind(this));
 			}.bind(this), next);
 		},

--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -4494,48 +4494,52 @@ iOSBuilder.prototype.copyResources = function copyResources(next) {
 
 			async.eachSeries(Object.keys(jsFiles), function (file, next) {
 				setImmediate(function(){
-					var info = jsFiles[file];
-					if (this.encryptJS) {
-						file = file.replace(/\./g, '_');
-						info.dest = path.join(this.buildAssetsDir, file);
-						this.jsFilesToEncrypt.push(file);
+				var info = jsFiles[file];
+				if (this.encryptJS) {
+					if (file.indexOf('/') === 0) {
+						file = path.basename(file);
 					}
-					this.cli.createHook('build.ios.copyResource', this, function (from, to, cb) {
-						try {
-							// parse the AST
-							var r = jsanalyze.analyzeJsFile(from, { minify: this.minifyJS });
-						} catch (ex) {
-							ex.message.split('\n').forEach(this.logger.error);
-							this.logger.log();
-							process.exit(1);
-						}
+					file = file.replace(/\./g, '_');
+					info.dest = path.join(this.buildAssetsDir, file);
+					this.jsFilesToEncrypt.push(file);
+				}
 
-						// we want to sort by the "to" filename so that we correctly handle file overwriting
-						this.tiSymbols[info.dest] = r.symbols;
+				this.cli.createHook('build.ios.copyResource', this, function (from, to, cb) {
+					try {
+						// parse the AST
+						var r = jsanalyze.analyzeJsFile(from, { minify: this.minifyJS });
+					} catch (ex) {
+						ex.message.split('\n').forEach(this.logger.error);
+						this.logger.log();
+						process.exit(1);
+					}
 
-						var dir = path.dirname(to);
-						fs.existsSync(dir) || wrench.mkdirSyncRecursive(dir);
+					// we want to sort by the "to" filename so that we correctly handle file overwriting
+					this.tiSymbols[info.dest] = r.symbols;
 
-						delete this.buildDirFiles[to];
+					var dir = path.dirname(to);
+					fs.existsSync(dir) || wrench.mkdirSyncRecursive(dir);
 
-						if (this.minifyJS) {
-							this.cli.createHook('build.ios.compileJsFile', this, function (r, from, to, cb2) {
-								if (!fs.existsSync(to) || r.contents !== fs.readFileSync(to).toString()) {
-									this.logger.debug(__('Copying and minifying %s => %s', from.cyan, to.cyan));
-									fs.writeFileSync(to, r.contents);
-									this.jsFilesChanged = true;
-								} else {
-									this.logger.trace(__('No change, skipping %s', to.cyan));
-								}
-								cb2();
-							})(r, from, to, cb);
-						} else {
-							if (!this.copyFileSync(from, to)) {
+					delete this.buildDirFiles[to];
+
+					if (this.minifyJS) {
+						this.cli.createHook('build.ios.compileJsFile', this, function (r, from, to, cb2) {
+							if (!fs.existsSync(to) || r.contents !== fs.readFileSync(to).toString()) {
+								this.logger.debug(__('Copying and minifying %s => %s', from.cyan, to.cyan));
+								fs.writeFileSync(to, r.contents);
+								this.jsFilesChanged = true;
+							} else {
 								this.logger.trace(__('No change, skipping %s', to.cyan));
 							}
-							cb();
+							cb2();
+						})(r, from, to, cb);
+					} else {
+						if (!this.copyFileSync(from, to)) {
+							this.logger.trace(__('No change, skipping %s', to.cyan));
 						}
-					})(info.src, info.dest, next);
+						cb();
+					}
+				})(info.src, info.dest, next);
 				}.bind(this));
 			}.bind(this), next);
 		},


### PR DESCRIPTION
Wrapped some code in a `setImmediate` to avoid max call stack. When having too many files this message appears and the build fails

```
(node) warning: Recursive process.nextTick detected. This will break in the next version of node. Please use setImmediate for recursive deferral.
(node) warning: Recursive process.nextTick detected. This will break in the next version of node. Please use setImmediate for recursive deferral.
(node) warning: Recursive process.nextTick detected. This will break in the next version of node. Please use setImmediate for recursive deferral.
(node) warning: Recursive process.nextTick detected. This will break in the next version of node. Please use setImmediate for recursive deferral.

/usr/local/lib/node_modules/titanium/node_modules/longjohn/dist/longjohn.js:194
        throw e;
              ^
RangeError: Maximum call stack size exceeded
```
