### PR TITLE
Fix type of setNeedsSave arg

### DIFF
--- a/iphone/Classes/TiAppiOSUserActivityProxy.m
+++ b/iphone/Classes/TiAppiOSUserActivityProxy.m
@@ -270,7 +270,7 @@
 
 -(void)setNeedsSave:(id)value
 {
-    ENSURE_SINGLE_ARG(value, NSString);
+    ENSURE_SINGLE_ARG(value, NSNumber);
     ENSURE_UI_THREAD(setNeedsSave,value);
     
     [_userActivity setNeedsSave:[TiUtils boolValue:value]];


### PR DESCRIPTION
Should be NSNumber instead of NSString since it's a boolean

Backport of https://github.com/appcelerator/titanium_mobile/pull/7116
