### PR TITLE
[TIMOB-19475] Android: Build fails if target SDK is lower than API 23

### DIFF
--- a/android/package.json
+++ b/android/package.json
@@ -16,7 +16,7 @@
 	],
 	"minSDKVersion": "14",
 	"vendorDependencies": {
-		"android sdk": ">=21 <=23",
+		"android sdk": "23",
 		"android build tools": ">=17 <23.x",
 		"android platform tools": ">=17 <=23.x",
 		"android tools": "<=24.3.x",


### PR DESCRIPTION
https://jira.appcelerator.org/browse/TIMOB-19475
