### PR TITLE
Revert "Fix typo, which causes runtime error at builder"

### DIFF
--- a/node_modules/titanium-sdk/lib/builder.js
+++ b/node_modules/titanium-sdk/lib/builder.js
@@ -411,7 +411,7 @@ Builder.prototype.generateAppIcons = function generateAppIcons(icons, callback) 
 
 	if (!fs.existsSync(defaultIcon)) {
 		if (requiredMissing === 0) {
-			this.logger.warn(__('There is a missing app icon', 'There are missing app icons', icons.length));
+			this.logger.warn(__n('There is a missing app icon', 'There are missing app icons', icons.length));
 			this.logger.warn(__('You can either create the missing icons below or create an image named "DefaultIcon.png" in the root of your project'));
 			this.logger.warn(__('If the DefaultIcon.png image is present, the build will use it to generate all missing icons'));
 			this.logger.warn(__('It is highly recommended that the DefaultIcon.png be 1024x1024'));
@@ -419,7 +419,7 @@ Builder.prototype.generateAppIcons = function generateAppIcons(icons, callback) 
 			return callback();
 		}
 
-		this.logger.error(__('There is a missing app icon', 'There are missing app icons', icons.length));
+		this.logger.error(__n('There is a missing app icon', 'There are missing app icons', icons.length));
 		this.logger.error(__('You must either create the missing icons below or create an image named "DefaultIcon.png" in the root of your project'));
 		this.logger.error(__('If the DefaultIcon.png image is present, the build will use it to generate all missing icons'));
 		this.logger.error(__('It is highly recommended that the DefaultIcon.png be 1024x1024'));


### PR DESCRIPTION
This reverts commit dca9792ee1edc0bad82a4c7646fb745d7a1c66af.
