### PR TITLE
[TIMOB-19076] Fix: CLI: ti info should show Windows Phone 8.0 SDK as unsupported

### DIFF
--- a/cli/lib/info.js
+++ b/cli/lib/info.js
@@ -68,6 +68,11 @@ exports.detect = function (types, config, callback) {
 					return next(err);
 				}
 
+				// TIMOB-19076: Windows Phone 8.0 is not supported
+				winInfo.windowsphone && delete winInfo.windowsphone['8.0'];
+				winInfo.windows && delete winInfo.windows['8.0'];
+				winInfo.emulators && delete winInfo.emulators['8.0'];
+
 				results.tisdk = tisdk;
 				results.windows = winInfo;
 


### PR DESCRIPTION
Fix for [TIMOB-19076](https://jira.appcelerator.org/browse/TIMOB-19076).

When running the command ti info on Windows, Windows 8.0 and Windows Phone 8.0 SDKs are shown as supported, as these SDKs are not supported and Windows Hybrid is being deprecated then they should not show as supported.
