### PR TITLE
[TIMOB-19741] iOS: Fixed blank webViews

### DIFF
--- a/iphone/Classes/TiUIWebView.m
+++ b/iphone/Classes/TiUIWebView.m
@@ -718,8 +718,11 @@ NSString *HTMLTextEncodingNameForStringEncoding(NSStringEncoding encoding)
     [url release];
     url = [[[webview request] URL] retain];
     NSString* urlAbs = [url absoluteString];
-    [[self proxy] replaceValue:urlAbs forKey:@"url" notification:NO];
-	
+    NSString* appPath = [[[NSBundle mainBundle] resourceURL] absoluteString];
+    if (![urlAbs isEqualToString: appPath]) {
+        [[self proxy] replaceValue:urlAbs forKey:@"url" notification:NO];
+    }
+    
     if ([self.proxy _hasListeners:@"load"]) {
         if (![urlAbs isEqualToString:lastValidLoad]) {
             NSDictionary *event = url == nil ? nil : [NSDictionary dictionaryWithObject:[self url] forKey:@"url"];


### PR DESCRIPTION
Fixed bug ,where cashed webViews could not be loaded. Will not set url for the webView unless there is a url property set in the js.

JIRA: https://jira.appcelerator.org/browse/TIMOB-19741
