### PR TITLE
[TIMOB-19725] iOS: navBarButtons no longer appear ontop of the keyboard

### DIFF
--- a/iphone/Classes/TiUITextArea.m
+++ b/iphone/Classes/TiUITextArea.m
@@ -129,13 +129,12 @@
         return;
     }
 #if IS_XCODE_7
-    UITextView *tv = (UITextView *)[self textWidgetView];
     if([TiUtils boolValue:value] == YES) {
-        tv.inputAssistantItem.leadingBarButtonGroups = self.inputAssistantItem.leadingBarButtonGroups;
-        tv.inputAssistantItem.trailingBarButtonGroups = self.inputAssistantItem.trailingBarButtonGroups;
+        textWidgetView.inputAssistantItem.leadingBarButtonGroups = self.inputAssistantItem.leadingBarButtonGroups;
+        textWidgetView.inputAssistantItem.trailingBarButtonGroups = self.inputAssistantItem.trailingBarButtonGroups;
     } else {
-        tv.inputAssistantItem.leadingBarButtonGroups = @[];
-        tv.inputAssistantItem.trailingBarButtonGroups = @[];
+        textWidgetView.inputAssistantItem.leadingBarButtonGroups = @[];
+        textWidgetView.inputAssistantItem.trailingBarButtonGroups = @[];
     }
 #endif
 }


### PR DESCRIPTION
Removed the creation a local variable and directly accessed the properties within the class.

:JIRA: https://jira.appcelerator.org/browse/TIMOB-19725
