### PR TITLE
Insist titanium_prep.macos to return standard out.

### DIFF
--- a/support/android/jspacker.py
+++ b/support/android/jspacker.py
@@ -108,7 +108,7 @@ class Crypt(object):
     output = open(os.path.join(target_dir, 'AssetCryptImpl.java'), 'w')
 
     sys.stdout.flush()
-    cmdargs = [titanium_prep, package, asset_dir]
+    cmdargs = [titanium_prep, "-v", package, asset_dir]
     cmdargs.extend(self.files)
     so, process = run.run(cmdargs, return_process=True)
     retcode = process.returncode


### PR DESCRIPTION
In my environment (osx 10.10.5 / TiSDK 5.0.2.GA / JDK 1.6.0_65), titanium_prep.macos returns no output. 
It causes android module build failure with common.js file in assets folder.
So, I added "-v" option to force standard out and it worked fine.

Thank you.
