### PR TITLE
[TIMOB-19941] iOS: ScrollableView set pageControl color to transparent

### DIFF
--- a/iphone/Classes/TiUIScrollableView.m
+++ b/iphone/Classes/TiUIScrollableView.m
@@ -88,7 +88,7 @@
 		pageControl = [[UIPageControl alloc] initWithFrame:[self pageControlRect]];
 		[pageControl setAutoresizingMask:UIViewAutoresizingFlexibleWidth|UIViewAutoresizingFlexibleTopMargin];
 		[pageControl addTarget:self action:@selector(pageControlTouched:) forControlEvents:UIControlEventValueChanged];
-		[pageControl setBackgroundColor:pageControlBackgroundColor];
+		[pageControl setBackgroundColor:[UIColor clearColor]];
 		[self addSubview:pageControl];
 	}
 	return pageControl;


### PR DESCRIPTION
:JIRA: https://jira.appcelerator.org/browse/TIMOB-19941

While showPagingControl is disabled , there should now be no longer a black footer.
