### PR TITLE
[TIMOB-19779] Android: Added orientation fix for device with natural …

### DIFF
--- a/android/modules/gesture/src/java/ti/modules/titanium/gesture/GestureModule.java
+++ b/android/modules/gesture/src/java/ti/modules/titanium/gesture/GestureModule.java
@@ -26,6 +26,8 @@ import android.hardware.Sensor;
 import android.hardware.SensorEvent;
 import android.hardware.SensorEventListener;
 import android.hardware.SensorManager;
+import android.util.DisplayMetrics;
+import android.view.Display;
 
 @Kroll.module @ContextSpecific
 public class GestureModule extends KrollModule
@@ -73,10 +75,10 @@ public class GestureModule extends KrollModule
 				TiBaseActivity.registerOrientationListener (new TiBaseActivity.OrientationChangedListener()
 				{
 					@Override
-					public void onOrientationChanged (int rotation)
+					public void onOrientationChanged (int rotation, int width, int height)
 					{
 						KrollDict data = new KrollDict();
-						data.put("orientation", TiOrientationHelper.convertRotationToTiOrientationMode(rotation));
+						data.put("orientation", TiOrientationHelper.convertRotationToTiOrientationMode(rotation, width, height));
 						fireEvent(EVENT_ORIENTATION_CHANGE, data);
 					}
 				});
@@ -188,7 +190,12 @@ public class GestureModule extends KrollModule
 	@Kroll.getProperty @Kroll.method
 	public int getOrientation()
 	{
-		return TiOrientationHelper.convertRotationToTiOrientationMode(TiApplication.getAppRootOrCurrentActivity().getWindowManager().getDefaultDisplay().getRotation());
+	    DisplayMetrics dm = new DisplayMetrics();
+	    Display display = TiApplication.getAppRootOrCurrentActivity().getWindowManager().getDefaultDisplay();
+	    display.getMetrics(dm);
+	    int width = dm.widthPixels;
+	    int height = dm.heightPixels;
+	    return TiOrientationHelper.convertRotationToTiOrientationMode(display.getRotation(), width, height);
 	}
 
 	@Override

--- a/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
@@ -56,6 +56,7 @@ import android.os.Bundle;
 import android.os.Message;
 import android.os.Messenger;
 import android.os.RemoteException;
+import android.util.DisplayMetrics;
 import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -211,7 +212,7 @@ public abstract class TiBaseActivity extends AppCompatActivity
 	// forwarded, create a separate interface in order to limit scope and maintain clarity 
 	public static interface OrientationChangedListener
 	{
-		public void onOrientationChanged (int configOrientationMode);
+		public void onOrientationChanged (int configOrientationMode, int width, int height);
 	}
 
 	public static void registerOrientationListener (OrientationChangedListener listener)
@@ -652,14 +653,19 @@ public abstract class TiBaseActivity extends AppCompatActivity
 		orientationListener = new OrientationEventListener(this, SensorManager.SENSOR_DELAY_NORMAL) {
 			@Override
 			public void onOrientationChanged(int orientation) {
-				int rotation = getWindowManager().getDefaultDisplay().getRotation();
-				if ((rotation == Surface.ROTATION_90 || rotation == Surface.ROTATION_270)
-						&& rotation != previousOrientation) {
-					callOrientationChangedListener(TiApplication.getAppRootOrCurrentActivity());
-				} else if ((rotation == Surface.ROTATION_0 || rotation == Surface.ROTATION_180)
-						&& rotation != previousOrientation) {
-					callOrientationChangedListener(TiApplication.getAppRootOrCurrentActivity());
-				}
+			    DisplayMetrics dm = new DisplayMetrics();
+			    getWindowManager().getDefaultDisplay().getMetrics(dm);
+			    int width = dm.widthPixels;
+			    int height = dm.heightPixels;
+			    int rotation = getWindowManager().getDefaultDisplay().getRotation();
+
+			    if ((rotation == Surface.ROTATION_90 || rotation == Surface.ROTATION_270)
+			            && rotation != previousOrientation) {
+			        callOrientationChangedListener(TiApplication.getAppRootOrCurrentActivity(), width, height, rotation);
+			    } else if ((rotation == Surface.ROTATION_0 || rotation == Surface.ROTATION_180)
+			            && rotation != previousOrientation) {
+			        callOrientationChangedListener(TiApplication.getAppRootOrCurrentActivity(), width, height, rotation);
+			    }
 			}
 		};
 
@@ -1008,12 +1014,12 @@ public abstract class TiBaseActivity extends AppCompatActivity
 		return menuHelper.onPrepareOptionsMenu(super.onPrepareOptionsMenu(menu) || listenerExists, menu);
 	}
 
-	public static void callOrientationChangedListener(Activity activity)
+	public static void callOrientationChangedListener(Activity activity, int width, int height, int rotation)
 	{
 		int currentOrientation = activity.getWindowManager().getDefaultDisplay().getRotation();
 		if (orientationChangedListener != null && previousOrientation != currentOrientation) {
 			previousOrientation = currentOrientation;
-			orientationChangedListener.onOrientationChanged (currentOrientation);
+			orientationChangedListener.onOrientationChanged (currentOrientation, width, height);
 		}
 	}
 

--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/DecorViewProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/DecorViewProxy.java
@@ -16,6 +16,8 @@ import org.appcelerator.titanium.view.TiUIView;
 import android.app.Activity;
 import android.content.pm.ActivityInfo;
 import android.os.Build;
+import android.util.DisplayMetrics;
+import android.view.Display;
 import android.view.View;
 
 
@@ -54,7 +56,12 @@ public class DecorViewProxy extends TiViewProxy
 
 		if (activity != null)
 		{
-			return TiOrientationHelper.convertRotationToTiOrientationMode(activity.getWindowManager().getDefaultDisplay().getRotation());
+		    DisplayMetrics dm = new DisplayMetrics();
+		    Display display = activity.getWindowManager().getDefaultDisplay();
+		    display.getMetrics(dm);
+		    int width = dm.widthPixels;
+		    int height = dm.heightPixels;
+		    return TiOrientationHelper.convertRotationToTiOrientationMode(display.getRotation(), width, height);
 		}
 
 		Log.e(TAG, "Unable to get orientation, activity not found for window", Log.DEBUG_MODE);

--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/TiWindowProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/TiWindowProxy.java
@@ -34,7 +34,9 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.Message;
 import android.support.annotation.Nullable;
+import android.util.DisplayMetrics;
 import android.util.Pair;
+import android.view.Display;
 import android.view.View;
 
 @Kroll.proxy(propertyAccessors={
@@ -475,7 +477,12 @@ public abstract class TiWindowProxy extends TiViewProxy
 
 		if (activity != null)
 		{
-			return TiOrientationHelper.convertRotationToTiOrientationMode(activity.getWindowManager().getDefaultDisplay().getRotation());
+		    DisplayMetrics dm = new DisplayMetrics();
+		    Display display = activity.getWindowManager().getDefaultDisplay();
+		    display.getMetrics(dm);
+		    int width = dm.widthPixels;
+		    int height = dm.heightPixels;
+		    return TiOrientationHelper.convertRotationToTiOrientationMode(display.getRotation(), width, height);
 		}
 
 		Log.e(TAG, "Unable to get orientation, activity not found for window", Log.DEBUG_MODE);

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiOrientationHelper.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiOrientationHelper.java
@@ -20,25 +20,52 @@ public class TiOrientationHelper
 	public static final int ORIENTATION_LANDSCAPE_REVERSE = 4;
 	public static final int ORIENTATION_SQUARE = 5;
 
-	public static int convertRotationToTiOrientationMode (int rotation)
+	public static int convertRotationToTiOrientationMode (int rotation, int width, int height)
 	{
-		switch (rotation)
-		{
-			case Surface.ROTATION_0:
-				return ORIENTATION_PORTRAIT;
+	    // Device that has portrait natural orientation
+	    if ((rotation == Surface.ROTATION_0 || rotation == Surface.ROTATION_180) && height > width ||
+	            (rotation == Surface.ROTATION_90 || rotation == Surface.ROTATION_270) && width > height) {
 
-			case Surface.ROTATION_90:
-				return ORIENTATION_LANDSCAPE;
+	        switch (rotation)
+	        {
+	            case Surface.ROTATION_0:
+	                return ORIENTATION_PORTRAIT;
 
-			case Surface.ROTATION_180:
-				return ORIENTATION_PORTRAIT_REVERSE;
+	            case Surface.ROTATION_90:
+	                return ORIENTATION_LANDSCAPE;
 
-			case Surface.ROTATION_270:
-				return ORIENTATION_LANDSCAPE_REVERSE;
+	            case Surface.ROTATION_180:
+	                return ORIENTATION_PORTRAIT_REVERSE;
 
-			default:
-				return ORIENTATION_UNKNOWN;
-		}
+	            case Surface.ROTATION_270:
+	                return ORIENTATION_LANDSCAPE_REVERSE;
+
+	            default:
+	                return ORIENTATION_UNKNOWN;
+	        }
+
+	        // Device that has landscape natural orientation. Eg Samsung Galaxy Tab 3 10.1
+	    } else {
+	        switch (rotation)
+	        {
+	            case Surface.ROTATION_0:
+	                return ORIENTATION_LANDSCAPE;
+
+	            case Surface.ROTATION_90:
+	                return ORIENTATION_PORTRAIT;
+
+	            case Surface.ROTATION_180:
+	                return ORIENTATION_LANDSCAPE_REVERSE;
+
+	            case Surface.ROTATION_270:
+	                return ORIENTATION_PORTRAIT_REVERSE;
+
+	            default:
+	                return ORIENTATION_UNKNOWN;
+	        }
+
+	    }
+
 	}
 }
 


### PR DESCRIPTION
…orientation Landscape

Jira: https://jira.appcelerator.org/browse/TIMOB-19779

Run this on a tablet that has a natural landscape orientation. Eg A Samsung Galaxy Tab. This is needed to test this code. Tab I used for this was `SM-P600 Samsung`.

When testing, please check that when device is Landscape is true, the Window Orientation and Gesture Orientation gives the orientation to to be either `landscapeLeft` or `landscapeRight`. This should be true for Portrait mode too, with `portrait` and `upsidePortrait`.

To test, rotate device.

Test code:-

``` javascript
var win = Ti.UI.createWindow({
    backgroundColor: '#000'
});

win.open();

Ti.API.info('Window Orientation: ', win.orientation);
Ti.API.info('Landscape: ', Ti.Gesture.isLandscape());
Ti.API.info('Portrait: ', Ti.Gesture.isPortrait());
Ti.API.info('Orientations: ', JSON.stringify({
    portrait: Ti.UI.PORTRAIT,
    upsidePortrait: Ti.UI.UPSIDE_PORTRAIT,
    landscapeLeft: Ti.UI.LANDSCAPE_LEFT,
    landscapeRight: Ti.UI.LANDSCAPE_RIGHT,
    faceDown: Ti.UI.FACE_DOWN,
    faceUp: Ti.UI.FACE_UP,
    unknown: Ti.UI.UNKNOWN
}));

Ti.Gesture.addEventListener('orientationchange', function (event) {

    Ti.API.info('Window Orientation: ', win.orientation);
    Ti.API.info('Gesture Orientation: ', event.orientation);
    Ti.API.info('Landscape: ', Ti.Gesture.isLandscape());
    Ti.API.info('Portrait: ', Ti.Gesture.isPortrait());
    Ti.API.info('Orientations: ', JSON.stringify({
      portrait: Ti.UI.PORTRAIT,
      upsidePortrait: Ti.UI.UPSIDE_PORTRAIT,
      landscapeLeft: Ti.UI.LANDSCAPE_LEFT,
      landscapeRight: Ti.UI.LANDSCAPE_RIGHT,
      faceDown: Ti.UI.FACE_DOWN,
      faceUp: Ti.UI.FACE_UP,
      unknown: Ti.UI.UNKNOWN
    }));

  });
```
