### PR TITLE
TIMOB-19821 Android 6.0: Device & emulator logs don't show up in studio console

### DIFF
--- a/node_modules/titanium-sdk/lib/adb.js
+++ b/node_modules/titanium-sdk/lib/adb.js
@@ -8,7 +8,7 @@
  * @module adb
  *
  * @copyright
- * Copyright (c) 2009-2013 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2009-2015 by Appcelerator, Inc. All Rights Reserved.
  *
  * @license
  * Licensed under the terms of the Apache Public License
@@ -680,7 +680,7 @@ ADB.prototype.logcat = function logcat(deviceId, handler, callback) {
 	androidDetect(this.config, function (err, results) {
 		if (err) return callback(err);
 
-		var child = spawn(results.sdk.executables.adb, ['-s', deviceId, 'logcat', '-b', 'main']); //, '-s', '*:d,*,TiAPI:V']);
+		var child = spawn(results.sdk.executables.adb, ['-s', deviceId, 'logcat', '-v', 'brief', '-b', 'main']); //, '-s', '*:d,*,TiAPI:V']);
 
 		child.stdout.on('data', function (data) {
 			handler(data.toString());


### PR DESCRIPTION
- explicitly set output format for logcat to 'brief'
  https://jira.appcelerator.org/browse/TIMOB-19821
