### PR TITLE
[TIMOB-19725] iOS : Toggled action buttons display over keyboard

### DIFF
--- a/apidoc/Titanium/UI/TextArea.yml
+++ b/apidoc/Titanium/UI/TextArea.yml
@@ -309,7 +309,7 @@ properties:
     since: 2.1.2
 
   - name: showUndoRedoActions
-    summary: Determinates if the undo and redo buttons on the left side of the keyboard should be displayed or not. Only valid on iOS9 and above.
+    summary: Determinates if the undo and redo buttons on the left side of the keyboard should be displayed or not. Only valid on iOS9 and above. This property can only be set upon creation.
     type: Boolean
     default: true
     platforms: [ipad]

--- a/iphone/Classes/TiUITextArea.h
+++ b/iphone/Classes/TiUITextArea.h
@@ -24,6 +24,8 @@
     NSRange lastSelectedRange;
 }
 
+-(void)setShowUndoRedoActions:(id)value;
+
 @end
 
 #endif

--- a/iphone/Classes/TiUITextArea.m
+++ b/iphone/Classes/TiUITextArea.m
@@ -123,19 +123,25 @@
 
 #pragma mark Public APIs
 
--(void)setShowUndoRedoActions_:(id)value
+-(void)setShowUndoRedoActions:(id)value
 {
     if(![TiUtils isIOS9OrGreater]){
         return;
     }
+    
 #if IS_XCODE_7
-    if([TiUtils boolValue:value] == YES) {
-        textWidgetView.inputAssistantItem.leadingBarButtonGroups = self.inputAssistantItem.leadingBarButtonGroups;
-        textWidgetView.inputAssistantItem.trailingBarButtonGroups = self.inputAssistantItem.trailingBarButtonGroups;
-    } else {
-        textWidgetView.inputAssistantItem.leadingBarButtonGroups = @[];
-        textWidgetView.inputAssistantItem.trailingBarButtonGroups = @[];
-    }
+    
+        UITextView *tv = (UITextView *)[self textWidgetView];
+        if([TiUtils boolValue:value] == YES) {
+            
+            tv.inputAssistantItem.leadingBarButtonGroups = self.inputAssistantItem.leadingBarButtonGroups;
+            tv.inputAssistantItem.trailingBarButtonGroups = self.inputAssistantItem.trailingBarButtonGroups;
+            
+        } else {
+            
+            tv.inputAssistantItem.leadingBarButtonGroups = @[];
+            tv.inputAssistantItem.trailingBarButtonGroups = @[];
+        }
 #endif
 }
 

--- a/iphone/Classes/TiUITextArea.m
+++ b/iphone/Classes/TiUITextArea.m
@@ -129,13 +129,12 @@
         return;
     }
 #if IS_XCODE_7
-    UITextView *tv = (UITextView *)[self textWidgetView];
     if([TiUtils boolValue:value] == YES) {
-        tv.inputAssistantItem.leadingBarButtonGroups = self.inputAssistantItem.leadingBarButtonGroups;
-        tv.inputAssistantItem.trailingBarButtonGroups = self.inputAssistantItem.trailingBarButtonGroups;
+        textWidgetView.inputAssistantItem.leadingBarButtonGroups = self.inputAssistantItem.leadingBarButtonGroups;
+        textWidgetView.inputAssistantItem.trailingBarButtonGroups = self.inputAssistantItem.trailingBarButtonGroups;
     } else {
-        tv.inputAssistantItem.leadingBarButtonGroups = @[];
-        tv.inputAssistantItem.trailingBarButtonGroups = @[];
+        textWidgetView.inputAssistantItem.leadingBarButtonGroups = @[];
+        textWidgetView.inputAssistantItem.trailingBarButtonGroups = @[];
     }
 #endif
 }

--- a/iphone/Classes/TiUITextAreaProxy.m
+++ b/iphone/Classes/TiUITextAreaProxy.m
@@ -22,6 +22,18 @@ DEFINE_DEF_INT_PROP(maxLength,-1);
     return @"Ti.UI.TextArea";
 }
 
+-(void)_initWithProperties:(NSDictionary*)props
+{
+    if ([props valueForKey:@"showUndoRedoActions"])
+    {
+        TiUITextArea* textArea = (TiUITextArea*)[self view];
+        [textArea setShowUndoRedoActions: [props valueForKey:@"showUndoRedoActions"]];
+    }
+    
+    [super _initWithProperties:props];
+}
+
+
 @end
 
 #endif


### PR DESCRIPTION
The action buttons can now only be set upon creation.

:JIRA: https://jira.appcelerator.org/browse/TIMOB-19725?filter=-1
