### PR TITLE
Fix TC-5784 - setting a view layout to null on android crashes the app

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiView.java
@@ -20,7 +20,7 @@ public class TiView extends TiUIView
 		super(proxy);
 		LayoutArrangement arrangement = LayoutArrangement.DEFAULT;
 
-		if (proxy.hasProperty(TiC.PROPERTY_LAYOUT)) {
+		if (proxy.hasPropertyAndNotNull(TiC.PROPERTY_LAYOUT)) {
 			String layoutProperty = TiConvert.toString(proxy.getProperty(TiC.PROPERTY_LAYOUT));
 			if (layoutProperty.equals(TiC.LAYOUT_HORIZONTAL)) {
 				arrangement = LayoutArrangement.HORIZONTAL;

--- a/android/titanium/src/java/org/appcelerator/kroll/KrollProxy.java
+++ b/android/titanium/src/java/org/appcelerator/kroll/KrollProxy.java
@@ -564,6 +564,16 @@ public class KrollProxy implements Handler.Callback, KrollProxySupport, OnLifecy
 	}
 
 	/**
+	 * @param name  the lookup key.
+	 * @return  true if the proxy contains this property and it is not null, false otherwise.
+	 * @module.api
+	 */
+	public boolean hasPropertyAndNotNull(String name)
+	{
+		return properties.containsKeyAndNotNull(name);
+	}
+
+	/**
 	 * Returns the property value given its key.
 	 * Properties are cached on the Proxy and updated from JS for relevant annotated APIs
 	 * @param name  the lookup key.

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiConvert.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiConvert.java
@@ -546,7 +546,7 @@ public class TiConvert
 	}
 
 	/**
-	 * Converts a vlaue into a String. If value is null, a default value is returned.
+	 * Converts a value into a String. If value is null, a default value is returned.
 	 * @param value the value to convert.
 	 * @param defaultString the default value.
 	 * @return a String.


### PR DESCRIPTION
This PR fixes the bug described in the ticket [TC-5784](https://jira.appcelerator.org/browse/TC-5784).

The `TiView` class constructor does not correctly check that the layout property is not null, and it crashes  when calling the `equals()` method. This PR assumes that, when a null layout is passed, the layout will default to a composite layout (the default value).
