### PR TITLE
[TIMOB-16355] iOS: SeparatorInsets should not be used for header/sect…

### DIFF
--- a/apidoc/Titanium/UI/TableView.yml
+++ b/apidoc/Titanium/UI/TableView.yml
@@ -1537,9 +1537,11 @@ properties:
     type: String
     default: platform-specific default color
 
-    
   - name: separatorInsets
     summary: The insets for table view separators (applies to all cells). This property is applicable on iOS 7 and greater.
+    deprecated:
+        since: "6.0.0"
+        notes: Use tableSeparatorInsets instead
     description: |
         In iOS 7 and later, cell separators do not extend all the way to the edge of the table view. 
         This property sets the default inset for all cells in the table. Set this to a dictionary 
@@ -1551,17 +1553,56 @@ properties:
                 left:10,
                 right:10
             });
-        
-        
+
     type: Dictionary
     since: 3.2.0
     osver: {ios: {min: "7.0"}}
     platforms: [iphone, ipad]
-    
-  - name: separatorStyle
-    summary: Separator style constant. 
+
+  - name: tableSeparatorInsets
+    summary: The insets for the table view header and footer. This property is applicable on iOS 7 and greater.
     description: |
-        For iOS specify one of the 
+        In iOS 7 and later, cell separators do not extend all the way to the edge of the table view.Set this to a
+        dictionary with two keys, `left` specifying inset from left edge and `right` specifying the inset from the
+        right edge. If the rowSeparatorInsets is not set, the tableSeparatorInsets will also set the cell insets.
+
+        For example:
+
+            tableView1.setTableSeparatorInsets({
+                left:10,
+                right:10
+            });
+
+
+    type: Dictionary
+    since: 6.0.0
+    osver: {ios: {min: "7.0"}}
+    platforms: [iphone, ipad]
+
+  - name: rowSeparatorInsets
+    summary: The insets for table view cells (applies to all cells). This property is applicable on iOS 7 and greater.
+    description: |
+        In iOS 7 and later, cell separators do not extend all the way to the edge of the table view.Set this to a
+        dictionary with two keys, `left` specifying inset from left edge and `right` specifying the inset from the
+        right edge. This property is only available upon creation of the cells.
+
+        For example:
+
+            tableView1.setRowSeparatorInsets({
+                left:10,
+                right:10
+            });
+
+
+    type: Dictionary
+    since: 6.0.0
+    osver: {ios: {min: "7.0"}}
+    platforms: [iphone, ipad]
+
+  - name: separatorStyle
+    summary: Separator style constant.
+    description: |
+        For iOS specify one of the
         [TableViewSeparatorStyle](Titanium.UI.iPhone.TableViewSeparatorStyle) constants.
         
         For Mobile Web specify one of the

--- a/iphone/Classes/TiUITableView.h
+++ b/iphone/Classes/TiUITableView.h
@@ -76,6 +76,7 @@
     TiUIRefreshControlProxy* _refreshControlProxy;
 #endif
     UIEdgeInsets defaultSeparatorInsets;
+    UIEdgeInsets rowSeparatorInsets;
 }
 
 @property (nonatomic, assign) BOOL viewWillDetach;

--- a/iphone/Classes/TiUITableView.m
+++ b/iphone/Classes/TiUITableView.m
@@ -300,6 +300,7 @@
 		filterAnchored = NO; // defaults to false on search
 		searchString = @"";
 		defaultSeparatorInsets = UIEdgeInsetsZero;
+        rowSeparatorInsets = UIEdgeInsetsZero;
 	}
 	return self;
 }
@@ -1658,6 +1659,13 @@
 -(void)setSeparatorInsets_:(id)arg
 {
     [self tableView];
+    DEPRECATED_REPLACED(@"UI.TableView.separatorInsets", @"6.0.0", @"UI.TableView.tableSeparatorInsets")
+    [self setTableSeparatorInsets_:arg];
+}
+
+-(void)setTableSeparatorInsets_:(id)arg
+{
+    [self tableView];
     
     if ([arg isKindOfClass:[NSDictionary class]]) {
         CGFloat left = [TiUtils floatValue:@"left" properties:arg def:defaultSeparatorInsets.left];
@@ -1670,6 +1678,22 @@
         [tableview setNeedsDisplay];
     }
 }
+
+-(void)setRowSeparatorInsets_:(id)arg
+{
+    [self tableView];
+    
+    if ([arg isKindOfClass:[NSDictionary class]]) {
+        
+        CGFloat left = [TiUtils floatValue:@"left" properties:arg def:defaultSeparatorInsets.left];
+        CGFloat right = [TiUtils floatValue:@"right" properties:arg def:defaultSeparatorInsets.right];
+        rowSeparatorInsets = UIEdgeInsetsMake(0, left, 0, right);
+    }
+    if (!searchActivated) {
+        [tableview setNeedsDisplay];
+    }
+}
+
 
 -(void)setBackgroundColor_:(id)arg
 {
@@ -2116,7 +2140,11 @@ return result;	\
     if ([TiUtils isIOS8OrGreater] && (tableview == ourTableView)) {
         [cell setLayoutMargins:UIEdgeInsetsZero];
     }
-	
+    
+    if (rowSeparatorInsets.left && rowSeparatorInsets.right != 0) {
+        [cell setSeparatorInset:rowSeparatorInsets];
+    }
+    
 	return cell;
 }
 

--- a/iphone/Classes/TiUITableView.m
+++ b/iphone/Classes/TiUITableView.m
@@ -2141,7 +2141,7 @@ return result;	\
         [cell setLayoutMargins:UIEdgeInsetsZero];
     }
     
-    if (rowSeparatorInsets.left && rowSeparatorInsets.right != 0) {
+    if (rowSeparatorInsets.left != 0 || rowSeparatorInsets.right != 0) {
         [cell setSeparatorInset:rowSeparatorInsets];
     }
     

--- a/iphone/Classes/TiUITableView.m
+++ b/iphone/Classes/TiUITableView.m
@@ -300,7 +300,7 @@
 		filterAnchored = NO; // defaults to false on search
 		searchString = @"";
 		defaultSeparatorInsets = UIEdgeInsetsZero;
-        rowSeparatorInsets = UIEdgeInsetsZero;
+		rowSeparatorInsets = UIEdgeInsetsZero;
 	}
 	return self;
 }


### PR DESCRIPTION
Setting the separatorInsets can now be done by 2 properties., rowSeparatorInsets and tableSeparatorInsets. If rowSeparatorInsets is not the cell insets will be set to the tableSeparatorInsets.

:JIRA: https://jira.appcelerator.org/browse/TIMOB-16355?filter=-1
