### PR TITLE
[TIMOB-20002] iOS: RequestLocationPermissions is not always called?

### DIFF
--- a/iphone/Classes/GeolocationModule.m
+++ b/iphone/Classes/GeolocationModule.m
@@ -859,14 +859,14 @@ MAKE_SYSTEM_PROP(ACTIVITYTYPE_OTHER_NAVIGATION, CLActivityTypeOtherNavigation);
     
     CLAuthorizationStatus requested = [TiUtils intValue: value];
     CLAuthorizationStatus currentPermissionLevel = [CLLocationManager authorizationStatus];
-    
-    
     BOOL permissionsGranted = (currentPermissionLevel == kCLAuthorizationStatusAuthorizedAlways) || (currentPermissionLevel == kCLAuthorizationStatusAuthorizedWhenInUse);
+    
     if (permissionsGranted) {
         [self executeAndReleaseCallbackWithCode:0 andMessage:nil];
         return;
     } else if (currentPermissionLevel == kCLAuthorizationStatusDenied) {
-        [self executeAndReleaseCallbackWithCode:1 andMessage:nil];
+        NSString *message = @"The user denied access to use location services.";
+        [self executeAndReleaseCallbackWithCode:1 andMessage:message];
         return;
     }
     


### PR DESCRIPTION
:JIRA: https://jira.appcelerator.org/browse/TIMOB-20002
The callback will not be called before the user allows or denys premissions. The callback now returns the correct value 1 ("False') if the premissions are not granted
