### PR TITLE
[TIMOB-20028] Layout fails on iOS8 with iOS9-only Picker height set

### DIFF
--- a/iphone/Classes/TiUIPicker.m
+++ b/iphone/Classes/TiUIPicker.m
@@ -47,9 +47,17 @@ USE_PROXY_FOR_VERIFY_AUTORESIZING
 {
 	if (picker==nil)
 	{
-        float width = [TiUtils floatValue:[self.proxy valueForKey:@"width"] def:320];
-        float height = [TiUtils floatValue:[self.proxy valueForKey:@"height"] def:228];
-
+        float width = 320;
+        float height = 216;
+        
+        if ([TiUtils isIOS9OrGreater]) {
+            width = [TiUtils floatValue:[self.proxy valueForKey:@"width"] def:320];
+            height = [TiUtils floatValue:[self.proxy valueForKey:@"height"] def:216];
+        }
+    
+        [[self proxy ]setValue:NUMDOUBLE(width) forKey:@"width"];
+        [[self proxy ]setValue:NUMDOUBLE(height) forKey:@"height"];
+            
         if (type == -1)
 		{
 			//TODO: this is not the way to abstract pickers, note the cast I had to add to the following line


### PR DESCRIPTION
[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-20028?filter=-1)
