### PR TITLE
[TIMOB-20055](5_2_X) Handle nulled preview in proxy

### DIFF
--- a/iphone/Classes/TiPreviewingDelegate.m
+++ b/iphone/Classes/TiPreviewingDelegate.m
@@ -48,6 +48,10 @@
 
 - (UIViewController*)previewingContext:(id<UIViewControllerPreviewing>)previewingContext viewControllerForLocation:(CGPoint)location
 {
+    if ([[self previewContext] preview] == nil) {
+        return nil;
+    }
+    
     UITableView *tableView = [self ensureTableView];
     
     if (tableView != nil) {

--- a/iphone/Classes/TiViewProxy.m
+++ b/iphone/Classes/TiViewProxy.m
@@ -1296,6 +1296,8 @@ LAYOUTFLAGS_SETTER(setHorizontalWrap,horizontalWrap,horizontalWrap,[self willCha
     
     [context setSourceView:self];
     [context connectToDelegate];
+    
+    [self replaceValue:context forKey:@"previewContext" notification:NO];
 
 #endif
 #endif


### PR DESCRIPTION
Improvements to prevent the preview view on peek, if the preview is set to null. Use case: We want the preview only be shown in a tableview, if the cell contains an image to be previewed. This improvements make that possible. Before, a blank preview would have been shown.

Addition to [this JIRA](https://jira.appcelerator.org/browse/TIMOB-20055).
