### PR TITLE
[TIMOB-19241] iOS: Change the default height and width of the textField.

### DIFF
--- a/iphone/Classes/TiUITextFieldProxy.m
+++ b/iphone/Classes/TiUITextFieldProxy.m
@@ -47,8 +47,17 @@ DEFINE_DEF_INT_PROP(maxLength,-1);
     return @"Ti.UI.TextField";
 }
 
+-(void)_initWithProperties:(NSDictionary*)props
+{
+    float defWidth = [TiUtils floatValue:[self valueForKey:@"width"] def:100];
+    float defHeight = [TiUtils floatValue:[self valueForKey:@"height"] def:100];
+
+    [self setValue:NUMDOUBLE(defHeight) forKey:@"width"];
+    [self setValue:NUMDOUBLE(defWidth) forKey:@"height"];
+    
+    [super _initWithProperties:props];
+}
+
 @end
-
-
 
 #endif


### PR DESCRIPTION
Changed default height and width to 100 if their not initialized.

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-19241?filter=-1)
