### PR TITLE
(5_2_X) Minor docfixes to pass all validations

### DIFF
--- a/apidoc/Titanium/Calendar/Calendar.yml
+++ b/apidoc/Titanium/Calendar/Calendar.yml
@@ -501,6 +501,7 @@ properties:
     since: "5.2.0"
     constants: Titanium.Calendar.AUTHORIZATION_*
     permission: read-only
+    type: Number
     platforms: [iphone, ipad]
 
   - name: allAlerts

--- a/apidoc/Titanium/Media/Media.yml
+++ b/apidoc/Titanium/Media/Media.yml
@@ -1662,7 +1662,7 @@ properties:
     type: Number
     since: "3.1.0"
   - name: livePhoto
-    description: |
+    summary: |
         The live photo object, as a [LivePhoto](Titanium.UI.iOS.LivePhoto) and 
         `undefined` if no live photo is selected.
     type: Titanium.UI.iOS.LivePhoto

--- a/apidoc/Titanium/UI/UI.yml
+++ b/apidoc/Titanium/UI/UI.yml
@@ -1579,6 +1579,7 @@ properties:
         notes: Use KEYBOARD_TYPE_URL instead.
 
   - name: KEYBOARD_TYPE_DECIMAL_PAD
+    type: Number
     summary: Use a keyboard with decimal numbers only, with the pad keyboard layout.
     description: |
         Use with the <Titanium.UI.TextField.keyboardType> and <Titanium.UI.TextArea.keyboardType>

--- a/apidoc/Titanium/UI/iOS/iOS.yml
+++ b/apidoc/Titanium/UI/iOS/iOS.yml
@@ -968,6 +968,7 @@ properties:
     type: Boolean
     since: "5.1.0"
     osver: {ios: {min: "9.0"}}
+    permission: read-only
 
   - name: LIVEPHOTO_PLAYBACK_STYLE_FULL
     summary: |
@@ -977,6 +978,7 @@ properties:
     type: Number
     since: "5.2.0"
     osver: {ios: {min: "9.1"}}
+    permission: read-only
 
   - name: LIVEPHOTO_PLAYBACK_STYLE_HINT
     summary: Plays back only a brief section of the motion content of the Live Photo, without sound.
@@ -986,6 +988,7 @@ properties:
     type: Number
     since: "5.2.0"
     osver: {ios: {min: "9.1"}}
+    permission: read-only
 
   - name: MENU_POPUP_ARROW_DIRECTION_UP
     summary: An arrow that points upward.


### PR DESCRIPTION
Although `node validate` passed the tests while commiting the files, `python validate.py` failed on some lines. This PR resolves the python script-errors as well so docs pass all validations.
