### PR TITLE
[TIMOB-20189] Android: Update AttributeProxy to allow fontStyle to be set without having fontWeight to be manually set.

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/AttributedStringProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/AttributedStringProxy.java
@@ -150,7 +150,7 @@ public class AttributedStringProxy extends KrollProxy
 															fontProperties[TiUIHelper.FONT_SIZE_POSITION], activity)),
 														range[0], range[0] + range[1], Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
 												}
-												if (fontProperties[TiUIHelper.FONT_WEIGHT_POSITION] != null) {
+												if (fontProperties[TiUIHelper.FONT_WEIGHT_POSITION] != null || fontProperties[TiUIHelper.FONT_STYLE_POSITION] != null) {
 													int typefaceStyle = TiUIHelper.toTypefaceStyle(
 														fontProperties[TiUIHelper.FONT_WEIGHT_POSITION],
 														fontProperties[TiUIHelper.FONT_STYLE_POSITION]);


### PR DESCRIPTION
On Android, a user had to manually specify `fontWeight` and `fontStyle` when they wanted to add only a `fontStyle` to an `AttributedString`.

For example:

This would do nothing on Android

```
  Ti.UI.createAttributedString({
    text: "Hello World",
    attributes: [
        {
            type: Ti.UI.ATTRIBUTE_FONT,
            value: { fontStyle: "italic" },
            range: [0, 5]
        }
    ]
})
```

A user would have to add a fontWeight for the text to be "italic"

```
 Ti.UI.createAttributedString({
    text: "Hello World",
    attributes: [
        {
            type: Ti.UI.ATTRIBUTE_FONT,
            value: { fontWeight: "normal", fontStyle: "italic" },
            range: [0, 5]
        }
    ]
})
```
