### PR TITLE
[TIMOB-20202] Android: Camera.open() can throw a RuntimeException.

### DIFF
--- a/android/modules/media/src/java/ti/modules/titanium/media/TiCameraActivity.java
+++ b/android/modules/media/src/java/ti/modules/titanium/media/TiCameraActivity.java
@@ -641,10 +641,14 @@ public class TiCameraActivity extends TiBaseActivity implements SurfaceHolder.Ca
 			camera = null;
 		}
 
-		if (cameraId == Integer.MIN_VALUE) {
-			camera = Camera.open();
-		} else {
-			camera = Camera.open(cameraId);
+		try {
+			if (cameraId == Integer.MIN_VALUE) {
+				camera = Camera.open();
+			} else {
+				camera = Camera.open(cameraId);
+			}
+		} catch (Exception e) {
+			Log.e(TAG, "Could not open camera. Camera may be in use by another process or device policy manager has disabled the camera.", e);
 		}
 
 		if (camera == null) {


### PR DESCRIPTION
[Issue](https://jira.appcelerator.org/browse/TC-5825): Added try catch block to prevent crashes when Camera.open() fails at Runtime.
