### PR TITLE
Fix: "ti clean" does not scan SDK hooks

### DIFF
--- a/cli/commands/clean.js
+++ b/cli/commands/clean.js
@@ -89,6 +89,8 @@ exports.run = function (logger, config, cli) {
 	if (cli.argv.platforms) {
 		async.series(cli.argv.platforms.map(function (platform) {
 			return function (next) {
+				// scan platform SDK specific clean hooks
+				cli.scanHooks(path.join(__dirname, '..', '..', platform, 'cli', 'hooks'));
 				cli.fireHook('clean.pre', function () {
 					cli.fireHook('clean.' + platform + '.pre', function () {
 						var dir = path.join(buildDir, platform);
@@ -116,6 +118,13 @@ exports.run = function (logger, config, cli) {
 		}), done);
 	} else if (appc.fs.exists(buildDir)) {
 		logger.debug(__('Deleting all platform build directories'));
+
+		// scan platform SDK specific clean hooks
+		if (ti.targetPlatforms) {
+			ti.targetPlatforms.forEach(function(platform) {
+				cli.scanHooks(path.join(__dirname, '..', '..', platform, 'cli', 'hooks'));
+			});
+		}
 
 		cli.fireHook('clean.pre', function () {
 			async.series(fs.readdirSync(buildDir).map(function (dir) {


### PR DESCRIPTION
Fix for [TIMOB-20085](https://jira.appcelerator.org/browse/TIMOB-20085)

Currently there's no chance for Titanium SDK to load "hooks" while `ti clean` even when you subscribe `clean.post` event. It is required from [Windows SDK](https://github.com/appcelerator/titanium_mobile_windows/pull/505) to load hooks before `ti clean` because it uses special directory for Visual Studio.

This PR basically gives platform-SDK a chance to load hooks before `ti clean`, via `scanHooks` function in `_clean.js`. platform-SDK that needs clean-hook should scan hooks in `cli/commands/_clean.js`, and then subscribe `clean.pre`, `clean.post` and so on.

_cli/commands/_clean.js_

``` javascript
var path = require('path');

exports.scanHooks = function(logger, config, cli) {
    cli.scanHooks(path.join(__dirname, '..', 'hooks'));
}
```

_cli/hooks/clean.js_

``` javascript
 exports.init = function (logger, config, cli) {
    cli.on('clean.post', {
        post: function (builder, finished) {
... // platform-specific clean-up
            finished();
        }
    });
};
```

See discussion in https://github.com/appcelerator/titanium_mobile_windows/pull/505 for more details.
