### PR TITLE
[TIMOB-20217] iOS: Ti.Geolocation.hasGeolocationPermission() and Ti.Geolocation.getCurrentPosition() are not working on IOS 7

### DIFF
--- a/apidoc/Titanium/Geolocation/Geolocation.yml
+++ b/apidoc/Titanium/Geolocation/Geolocation.yml
@@ -244,8 +244,7 @@ methods:
     description: |
         On Android, the request view will show if the permission is not accepted by the user, and the user did
         not check the box "Never ask again" when denying the request. If the user checks the box "Never ask again,"
-        the user has to manually enable the permission in device settings. This method has no effect when running 
-        on iOS 7. 
+        the user has to manually enable the permission in device settings.
     parameters:
       - name: authorizationType
         summary: Types of geolocation's authorizations. This is an iOS only parameter and is ignored on Android.

--- a/iphone/Classes/GeolocationModule.h
+++ b/iphone/Classes/GeolocationModule.h
@@ -15,7 +15,8 @@
 	CLLocationManager *locationManager;
 	CLLocationManager *tempManager; // Our 'fakey' manager for handling certain <=3.2 requests
 	CLLocationManager *locationPermissionManager; // used for just permissions requests
-    
+	CLLocationManager *iOS7PermissionManager; // specific to iOS7 to maintain parity with iOS8 permissions behavior.
+
 	CLLocationAccuracy accuracy;
 	CLLocationDistance distance;
 	CLLocationDegrees heading;


### PR DESCRIPTION
https://jira.appcelerator.org/browse/TIMOB-20217

Reworked to make requestLocationPermissions to behave like iOS8+, where permission alert is presented and continued based on User selection. 
