### PR TITLE
TIMOB-20293 Add getFile method for Android

### DIFF
--- a/android/modules/database/src/java/ti/modules/titanium/database/TiDatabaseProxy.java
+++ b/android/modules/database/src/java/ti/modules/titanium/database/TiDatabaseProxy.java
@@ -204,10 +204,10 @@ public class TiDatabaseProxy extends KrollProxy
 	}
 
 	@Kroll.getProperty @Kroll.method
-    public TiFileProxy getFile(){
-        String path = TiApplication.getInstance().getApplicationContext().getDatabasePath(this.name).getAbsolutePath();
-        return new TiFileProxy(TiFileFactory.createTitaniumFile(path,false));               
-    }
+	public TiFileProxy getFile(){
+	        String path = TiApplication.getInstance().getApplicationContext().getDatabasePath(this.name).getAbsolutePath();
+		return new TiFileProxy(TiFileFactory.createTitaniumFile(path,false));               
+	}
 	   
 	@Override
 	public String getApiName()

--- a/android/modules/database/src/java/ti/modules/titanium/database/TiDatabaseProxy.java
+++ b/android/modules/database/src/java/ti/modules/titanium/database/TiDatabaseProxy.java
@@ -12,6 +12,8 @@ import org.appcelerator.kroll.common.Log;
 import org.appcelerator.titanium.TiApplication;
 import org.appcelerator.titanium.TiBlob;
 import org.appcelerator.titanium.TiContext;
+import org.appcelerator.titanium.TiFileProxy;
+import org.appcelerator.titanium.io.TiFileFactory;
 import org.appcelerator.titanium.util.TiConvert;
 
 import android.content.Context;
@@ -201,6 +203,12 @@ public class TiDatabaseProxy extends KrollProxy
 		}
 	}
 
+	@Kroll.getProperty @Kroll.method
+    public TiFileProxy getFile(){
+        String path = TiApplication.getInstance().getApplicationContext().getDatabasePath(this.name).getAbsolutePath();
+        return new TiFileProxy(TiFileFactory.createTitaniumFile(path,false));               
+    }
+	   
 	@Override
 	public String getApiName()
 	{

--- a/apidoc/Titanium/Database/DB.yml
+++ b/apidoc/Titanium/Database/DB.yml
@@ -74,8 +74,10 @@ properties:
     type: Titanium.Filesystem.File
     permission: read-only
     platforms: [android,iphone,ipad]
-    since: "2.0.0"
-    
+    since: 
+      android: "6.0.0"
+      iphone: "2.0.0"
+      ipad: "2.0.0"
   - name: lastInsertRowId
     summary: The identifier of the last populated row.
     type: Number

--- a/apidoc/Titanium/Database/DB.yml
+++ b/apidoc/Titanium/Database/DB.yml
@@ -73,7 +73,7 @@ properties:
       setting file properties.
     type: Titanium.Filesystem.File
     permission: read-only
-    platforms: [iphone,ipad]
+    platforms: [android,iphone,ipad]
     since: "2.0.0"
     
   - name: lastInsertRowId

--- a/apidoc/Titanium/Database/DB.yml
+++ b/apidoc/Titanium/Database/DB.yml
@@ -73,8 +73,11 @@ properties:
       setting file properties.
     type: Titanium.Filesystem.File
     permission: read-only
-    platforms: [android,iphone,ipad]
-    since: {android: "6.0.0", iphone: "2.0.0", ipad: "2.0.0"}
+    platforms: [android, iphone, ipad]
+    since:
+        android: 6.0.0
+        iphone: 2.0.0
+        ipad: 2.0.0
     
   - name: lastInsertRowId
     summary: The identifier of the last populated row.

--- a/apidoc/Titanium/Database/DB.yml
+++ b/apidoc/Titanium/Database/DB.yml
@@ -74,10 +74,8 @@ properties:
     type: Titanium.Filesystem.File
     permission: read-only
     platforms: [android,iphone,ipad]
-    since: 
-      android: "6.0.0"
-      iphone: "2.0.0"
-      ipad: "2.0.0"
+    since: {android: "6.0.0", iphone: "2.0.0", ipad: "2.0.0"}
+    
   - name: lastInsertRowId
     summary: The identifier of the last populated row.
     type: Number


### PR DESCRIPTION
Add Titanium.Database.DB.getFile() for Android.

Jira Ticket: https://jira.appcelerator.org/browse/TIMOB-20293

Tested using KitchenSink db

```
var db = Titanium.Database.install('testdb.db','quotes');
var rows = db.execute('SELECT * FROM TIPS');
var count = rows.getRowCount();
Ti.API.info("count => " + count);
rows.close();

var file = db.getFile();
Ti.API.info("API Name =" + file.apiName);
Ti.API.info("path => " + file.getNativePath());
```
