### PR TITLE
[TIMOB-20217] iOS: Ti.Geolocation.hasGeolocationPermission() and Ti.Geolocation.getCurrentPosition() are not working on IOS 7 - fix for TI_USE_KROLL_THREAD

### DIFF
--- a/iphone/Classes/GeolocationModule.m
+++ b/iphone/Classes/GeolocationModule.m
@@ -869,7 +869,10 @@ MAKE_SYSTEM_PROP(ACTIVITYTYPE_OTHER_NAVIGATION, CLActivityTypeOtherNavigation);
 -(void)requestLocationPermissions:(id)args
 {
     if (![TiUtils isIOS8OrGreater]) {
-        [self requestLocationPermissioniOS7:args];
+        // It is required that delegate is created and permission is presented in main thread.
+        TiThreadPerformOnMainThread(^{
+            [self requestLocationPermissioniOS7:args];
+        }, NO);
         return;
     }
     


### PR DESCRIPTION
This requires that creation of location delegate and subsequent permission alert are presented on main thread. This is because by default JS runs on its own thread enabled by `TI_USE_KROLL_THREAD`.
