### PR TITLE
[TIMOB-20252][5_2_X] Fix windowslib 0.3.1 utilities.js

### DIFF
--- a/node_modules/windowslib/lib/utilities.js
+++ b/node_modules/windowslib/lib/utilities.js
@@ -50,3 +50,22 @@ exports.magik = function magik(options, callback, body) {
 
 	return emitter;
 };
+
+exports.mix = function mix(src, dest) {
+	Object.keys(src).forEach(function (name) {
+		if (Array.isArray(src[name])) {
+			if (Array.isArray(dest[name])) {
+				dest[name] = dest[name].concat(src[name]);
+			} else {
+				dest[name] = src[name];
+			}
+		} else if (src[name] !== null && typeof src[name] === 'object') {
+			dest[name] || (dest[name] = {});
+			Object.keys(src[name]).forEach(function (key) {
+				dest[name][key] = src[name][key];
+			});
+		} else {
+			dest[name] = src[name];
+		}
+	});
+};


### PR DESCRIPTION
-  `master` already contained a later `utilities.js`, which is why it was left out of the `5_2_X` backport since it was not part of the initial commit

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-20299)
