### PR TITLE
[TIMOB-20217] iOS: Ti.Geolocation.hasGeolocationPermission() and Ti.Geolocation.getCurrentPosition() are not working on IOS 7 - fix for TI_USE_KROLL_THREAD

### DIFF
--- a/apidoc/Titanium/Geolocation/Geolocation.yml
+++ b/apidoc/Titanium/Geolocation/Geolocation.yml
@@ -229,7 +229,9 @@ methods:
     summary: Returns `true` if the app has location access.
     parameters:
       - name: authorizationType
-        summary: Types of geolocation's authorizations. This is an iOS only parameter and is ignored on Android.
+        summary: |
+            Types of geolocation's authorizations. This is an iOS 8 and above only parameter and is ignored on 
+            Android and iOS 7.
         constants: [Titanium.Geolocation.AUTHORIZATION_ALWAYS,Titanium.Geolocation.AUTHORIZATION_WHEN_IN_USE]
         type: Number 
     returns:
@@ -242,7 +244,8 @@ methods:
     description: |
         On Android, the request view will show if the permission is not accepted by the user, and the user did
         not check the box "Never ask again" when denying the request. If the user checks the box "Never ask again,"
-        the user has to manually enable the permission in device settings.
+        the user has to manually enable the permission in device settings. This method has no effect when running 
+        on iOS 7. 
     parameters:
       - name: authorizationType
         summary: Types of geolocation's authorizations. This is an iOS only parameter and is ignored on Android.

--- a/apidoc/Titanium/Geolocation/Geolocation.yml
+++ b/apidoc/Titanium/Geolocation/Geolocation.yml
@@ -244,8 +244,7 @@ methods:
     description: |
         On Android, the request view will show if the permission is not accepted by the user, and the user did
         not check the box "Never ask again" when denying the request. If the user checks the box "Never ask again,"
-        the user has to manually enable the permission in device settings. This method has no effect when running 
-        on iOS 7. 
+        the user has to manually enable the permission in device settings.
     parameters:
       - name: authorizationType
         summary: Types of geolocation's authorizations. This is an iOS only parameter and is ignored on Android.

--- a/iphone/Classes/GeolocationModule.h
+++ b/iphone/Classes/GeolocationModule.h
@@ -15,7 +15,8 @@
 	CLLocationManager *locationManager;
 	CLLocationManager *tempManager; // Our 'fakey' manager for handling certain <=3.2 requests
 	CLLocationManager *locationPermissionManager; // used for just permissions requests
-    
+	CLLocationManager *iOS7PermissionManager; // specific to iOS7 to maintain parity with iOS8 permissions behavior.
+
 	CLLocationAccuracy accuracy;
 	CLLocationDistance distance;
 	CLLocationDegrees heading;

--- a/iphone/Classes/GeolocationModule.m
+++ b/iphone/Classes/GeolocationModule.m
@@ -869,7 +869,10 @@ MAKE_SYSTEM_PROP(ACTIVITYTYPE_OTHER_NAVIGATION, CLActivityTypeOtherNavigation);
 -(void)requestLocationPermissions:(id)args
 {
     if (![TiUtils isIOS8OrGreater]) {
-        [self requestLocationPermissioniOS7:args];
+        // It is required that delegate is created and permission is presented in main thread.
+        TiThreadPerformOnMainThread(^{
+            [self requestLocationPermissioniOS7:args];
+        }, NO);
         return;
     }
     

--- a/iphone/Classes/GeolocationModule.m
+++ b/iphone/Classes/GeolocationModule.m
@@ -824,15 +824,16 @@ MAKE_SYSTEM_PROP(ACTIVITYTYPE_OTHER_NAVIGATION, CLActivityTypeOtherNavigation);
 
 -(NSNumber*)hasLocationPermissions:(id)args
 {
-    id value = [args objectAtIndex:0];
-    
-    ENSURE_TYPE(value, NSNumber);
-
-    CLAuthorizationStatus currentPermissionLevel = [CLLocationManager authorizationStatus];
-    CLAuthorizationStatus requestedPermissionLevel = [TiUtils intValue: value];
     BOOL locationServicesEnabled = [CLLocationManager locationServicesEnabled];
-    
-    return NUMBOOL(locationServicesEnabled && currentPermissionLevel == requestedPermissionLevel);
+    CLAuthorizationStatus currentPermissionLevel = [CLLocationManager authorizationStatus];
+    if ([TiUtils isIOS8OrGreater]) {
+        id value = [args objectAtIndex:0];
+        ENSURE_TYPE(value, NSNumber);
+        CLAuthorizationStatus requestedPermissionLevel = [TiUtils intValue: value];
+        return NUMBOOL(locationServicesEnabled && currentPermissionLevel == requestedPermissionLevel);
+    } else {
+        return NUMBOOL(locationServicesEnabled && currentPermissionLevel == kCLAuthorizationStatusAuthorized);
+    }
 }
 
 -(void)requestAuthorization:(id)value
@@ -844,6 +845,7 @@ MAKE_SYSTEM_PROP(ACTIVITYTYPE_OTHER_NAVIGATION, CLActivityTypeOtherNavigation);
 -(void)requestLocationPermissions:(id)args
 {
     if (![TiUtils isIOS8OrGreater]) {
+        DebugLog(@"[WARN] requestLocationPermissions has no effect in iOS 7.");
         return;
     }
     


### PR DESCRIPTION
Backport for 5_2_X
JIRA https://jira.appcelerator.org/browse/TIMOB-20217
