### PR TITLE
[TIMOB-20130] SDK no longer finds Genymotion after upgrade to 2.6.0

### DIFF
--- a/node_modules/titanium-sdk/lib/emulators/genymotion.js
+++ b/node_modules/titanium-sdk/lib/emulators/genymotion.js
@@ -286,7 +286,7 @@ function findGenymotion(dir, config, callback) {
 	if (!player || !fs.existsSync(player)) {
 		player = path.join(dir, 'player' + exe);
 	}
-	if (!fs.existsSync(player) && process.platform != 'win32') {
+	if (!fs.existsSync(player) && process.platform === 'darwin') {
 		player = path.join(dir, 'player.app', 'Contents', 'MacOS', 'player');
 	}
 	if (!fs.existsSync(player)) {


### PR DESCRIPTION
https://jira.appcelerator.org/browse/TIMOB-20130

A forward port (?) for a fix in https://github.com/appcelerator/titanium_mobile/pull/7649
