### PR TITLE
[TIMOB-20038] (5_2_X) Android: TableView crash fix

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiTableView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiTableView.java
@@ -161,7 +161,9 @@ public class TiTableView extends FrameLayout
 
 		@Override
 		public int getViewTypeCount() {
-			return maxClassname;
+		        // Fix for TIMOB-20038. Seems that there are 3 more
+		        // hidden views that needs to be recreated onLayout
+			return maxClassname + 3;
 		}
 
 		@Override

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiTableView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiTableView.java
@@ -48,8 +48,7 @@ public class TiTableView extends FrameLayout
 	public static final int TI_TABLE_VIEW_ID = 101;
 	private static final String TAG = "TiTableView";
 
-	// Default maxClassname is 32. It is set to 35 for bug in TIMOB-20038
-	protected int maxClassname = 35;
+	protected int maxClassname = 32;
 
 	private TableViewModel viewModel;
 	private ListView listView;

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiTableView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiTableView.java
@@ -48,7 +48,8 @@ public class TiTableView extends FrameLayout
 	public static final int TI_TABLE_VIEW_ID = 101;
 	private static final String TAG = "TiTableView";
 
-	protected int maxClassname = 32;
+	// Default maxClassname is 32. It is set to 35 for bug in TIMOB-20038
+	protected int maxClassname = 35;
 
 	private TableViewModel viewModel;
 	private ListView listView;
@@ -281,7 +282,7 @@ public class TiTableView extends FrameLayout
 		this.proxy = proxy;
 
 		if (proxy.getProperties().containsKey(TiC.PROPERTY_MAX_CLASSNAME)) {
-		    maxClassname = TiConvert.toInt(proxy.getProperty(TiC.PROPERTY_MAX_CLASSNAME));
+		    maxClassname = Math.max(TiConvert.toInt(proxy.getProperty(TiC.PROPERTY_MAX_CLASSNAME)),maxClassname);
 		}
 		rowTypes = new HashMap<String, Integer>();
 		rowTypeCounter = new AtomicInteger(-1);

--- a/apidoc/Titanium/UI/TableView.yml
+++ b/apidoc/Titanium/UI/TableView.yml
@@ -1291,7 +1291,8 @@ properties:
   - name: maxClassname
     summary: Max number of row class names.
     description: |
-        See <Titanium.UI.TableViewRow.className> for more details.
+        See <Titanium.UI.TableViewRow.className> for more details. This property will default to
+        32 when it is set to a number lesser than that.
     availability: creation
     type: Number
     default: 32


### PR DESCRIPTION
Jira: https://jira.appcelerator.org/browse/TIMOB-20038

To test, change numberOfRows to be lesser than maxClassname. If maxClassname crashes when numberOfRows are more than maxClassname, this is expected. numberOfRows has to be lesser than maxClassname.

Test code:

``` javascript
var section = Ti.UI.createTableViewSection();
var numberOfRows = 4;   
for (var i=0; i < numberOfRows; i++)     
{    
    //fill section with rows    
    section.add(Ti.UI.createTableViewRow({
        height: 50,
        width: Ti.UI.FILL,
        backgroundColor: 'white',
        color:'black',
        className: 'row' + i,
        title: 'row' + i
    }));
};

var table = Ti.UI.createTableView({
    top: 0,
    left: 0,
    maxClassname: 4,
    height: Ti.UI.FILL,
    width: Ti.UI.FILL,
    data: [ section ]
});

var window = Ti.UI.createWindow({
    fullscreen: true        
});

window.add(table);
window.open();
```
