### PR TITLE
[TIMOB-20355](5_2_X) iOS: Resolve error log when closing app

### DIFF
--- a/iphone/Classes/TiUIiOSNavWindowProxy.m
+++ b/iphone/Classes/TiUIiOSNavWindowProxy.m
@@ -137,10 +137,8 @@
 {
 	TiWindowProxy *window = [args objectAtIndex:0];
 	ENSURE_TYPE(window,TiWindowProxy);
-    if (window == rootWindow) {
-#ifndef TI_USE_KROLL_THREAD
+    if (window == rootWindow && ![[TiApp app] willTerminate]) {
         DebugLog(@"[ERROR] Can not close root window of the navWindow. Close this window instead");
-#endif
         return;
     }
     TiThreadPerformOnMainThread(^{

--- a/iphone/Classes/TiUIiOSNavWindowProxy.m
+++ b/iphone/Classes/TiUIiOSNavWindowProxy.m
@@ -138,7 +138,9 @@
 	TiWindowProxy *window = [args objectAtIndex:0];
 	ENSURE_TYPE(window,TiWindowProxy);
     if (window == rootWindow) {
+#ifndef TI_USE_KROLL_THREAD
         DebugLog(@"[ERROR] Can not close root window of the navWindow. Close this window instead");
+#endif
         return;
     }
     TiThreadPerformOnMainThread(^{


### PR DESCRIPTION
[JIRA](https://jira.appcelerator.org/browse/TIMOB-20355)
Cherry-Picked Hans commit and added willTerminate check. So debug error message still gets called if the window is force closed by anything else but the krollThread directly
