### PR TITLE
[TIMOB-14953] iOS: Ti.Calendar getEventsBetweenDates is not working

### DIFF
--- a/apidoc/Titanium/Calendar/CalendarProxy.yml
+++ b/apidoc/Titanium/Calendar/CalendarProxy.yml
@@ -34,11 +34,11 @@ methods:
     parameters:
       - name: date1
         summary: Start date.
-        type: Date
+        type: [Date,String]
         
       - name: date2
         summary: End date.
-        type: Date
+        type: [Date,String]
     platforms: [android, iphone, ipad]
         
   - name: getEventsInDate

--- a/iphone/Classes/TiCalendarCalendar.m
+++ b/iphone/Classes/TiCalendarCalendar.m
@@ -150,17 +150,21 @@
     return NULL;
 }
 
--(NSArray*)getEventsBeteenDates:(id)args
+-(NSArray*)getEventsBetweenDates:(id)args
 {
     ENSURE_ARG_COUNT(args, 2);
-    NSString* start = nil;
-    NSString* end = nil;
+    NSDate *start = nil;
+    NSDate *end = nil;
     
-    ENSURE_ARG_AT_INDEX(start, args, 0, NSString);
-    ENSURE_ARG_AT_INDEX(end, args, 1, NSString);
-
-    NSArray* events = [self _fetchAllEventsbetweenDate:[TiUtils dateForUTCDate:start]
-                                              andDate:[TiUtils dateForUTCDate:end]];
+    if ([[args objectAtIndex:0] isKindOfClass:[NSDate class]] && [[args objectAtIndex:1] isKindOfClass:[NSDate class]]){
+        start = [args objectAtIndex:0];
+        end =  [args objectAtIndex:1];
+    } else if ([[args objectAtIndex:0] isKindOfClass:[NSString class]] && [[args objectAtIndex:1] isKindOfClass:[NSString class]]) {
+        start = [TiUtils dateForUTCDate:[args objectAtIndex:0]];
+        end   = [TiUtils dateForUTCDate:[args objectAtIndex:1]];
+    }
+    NSArray* events = [self _fetchAllEventsbetweenDate:start
+                                              andDate:end];
     return [TiCalendarEvent convertEvents:events withContext:[self executionContext]  calendar:[self calendar]  module:module];
 }
 

--- a/ti_mocha_tests/app.js
+++ b/ti_mocha_tests/app.js
@@ -1,6 +1,6 @@
 /*
  * Appcelerator Titanium Mobile
- * Copyright (c) 2011-2015 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2011-2016 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
@@ -26,6 +26,7 @@ require('./ti.analytics.test');
 require('./ti.ui.textfield.test');
 require('./ti.ui.window.test');
 require('./ti.ui.attributedString.test');
+require('./ti.calendar.test');
 /*require('./ti.accelerometer.test');
 require('./ti.app.test');
 require('./ti.app.properties.test');

--- a/ti_mocha_tests/ti.calendar.test.js
+++ b/ti_mocha_tests/ti.calendar.test.js
@@ -1,0 +1,70 @@
+/*
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2011-2016 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+var should = require('./should');
+
+describe("Titanium.UI.Calendar.defaultCalendar", function() {
+    it("Titanium.UI.Calendar.defaultCalendar", function(finish) {
+
+    var date1 = new Date(new Date().getTime() + 3000),
+        date2 = new Date(new Date().getTime() + 900000);
+        date3 = new Date(new Date().getTime() + 1000000);
+        Ti.API.info(date1);
+
+    var defCalendar = Ti.Calendar.defaultCalendar;
+    var event1 = defCalendar.createEvent({
+                        title: 'Sample Event',
+                        notes: 'This is a test event which has some values assigned to it.',
+                        location: 'Appcelerator Inc',
+                        begin: date1,
+                        end: date2,
+                        availability: Ti.Calendar.AVAILABILITY_FREE,
+                        allDay: false,
+                });
+    var event2 = defCalendar.createEvent({
+                        title: 'Sample Event',
+                        notes: 'This is a test event which has some values assigned to it.',
+                        location: 'Appcelerator Inc',
+                        begin: date2,
+                        end: date3,
+                        availability: Ti.Calendar.AVAILABILITY_FREE,
+                        allDay: false,
+                });
+    event1.save(Ti.Calendar.SPAN_THISEVENT);
+    event2.save(Ti.Calendar.SPAN_THISEVENT);
+
+    if (Ti.Calendar.hasCalendarPermissions()) {
+        performCalendarReadFunctions();
+    } else {
+        Ti.Calendar.requestCalendarPermissions(function(e) {
+            if (e.success) {
+                Ti.Calendar.createEvent(eventOne);
+                Ti.Calendar.createEvent(eventTwo);
+                performCalendarReadFunctions();
+            } else {
+                Ti.API.error(e.error);
+                alert('Access to calendar is not allowed');
+            }
+        });
+    }
+
+    function performCalendarReadFunctions() {
+        date2.setHours(date1.getHours() + 24);
+         
+        var date1ISO = date1.toISOString();
+        var date2ISO = date2.toISOString();
+         
+        date1ISO = date1ISO.replace("Z", "+0000");
+        date2ISO = date2ISO.replace("Z", "+0000");
+         
+        events = defCalendar.getEventsBetweenDates(date1, date2); 
+        eventsWithString = defCalendar.getEventsBetweenDates(date1ISO, date2ISO);
+        should(events.length).eql(2);
+        should(eventsWithString.length).eql(2);
+        finish();
+    }
+    });
+});


### PR DESCRIPTION
[JIRA](https://jira.appcelerator.org/browse/TIMOB-14953?filter=-1)
Fixed spelling and change the code so the method takes in Date objects just like its suppose to acording to the docs,  instead of just strings.
