### PR TITLE
[TIMOB-20087](5_2_X) iOS:  breaks ability to bind one collection to different views / reset collection

### DIFF
--- a/iphone/Classes/TiUIScrollableViewProxy.m
+++ b/iphone/Classes/TiUIScrollableViewProxy.m
@@ -71,7 +71,7 @@
 
 -(void)setViews:(id)args
 {
-#ifdef TI_USE_AUTOLAYOUT
+#ifndef TI_USE_AUTOLAYOUT
     ENSURE_UI_THREAD(setViews, args)
 #endif
 	ENSURE_ARRAY(args);


### PR DESCRIPTION
[JIRA](https://jira.appcelerator.org/browse/TIMOB-20087)  Revert ifdef to ifndef
