### PR TITLE
Improve parity report size/performance

### DIFF
--- a/apidoc/templates/parity.ejs
+++ b/apidoc/templates/parity.ejs
@@ -1,115 +1,215 @@
-<!-- Copyright (c) 2015 Appcelerator, Inc. All Rights Reserved. -->
+<!-- Copyright (c) 2015-2016 Appcelerator, Inc. All Rights Reserved. -->
 <!-- Licensed under the terms of the Apache Public License.     -->
-<% var green = '#3CC850', red = '#C83232' %>
-<% function contains(a,b){for(i in a)if(a[i]==b)return true;return false;} %>
-<% function rgbHex(r,g,b){return "#"+((1<<24)+(r<<16)+(g<<8)+b).toString(16).slice(1).split('.')[0];} %>
-<% function colourGradient(sr,sg,sb,er,eg,eb,p){return rgbHex(((sr-er)*p)+er,((sg-eg)*p)+eg,((sb-eb)*p)+eb);} %>
-<% function platformSupportColour(a){var b = (a.platforms.length/Object.keys(apis.coverage).length);if (b == 0) {return red; }else if (b == 1) {return green;} else {return colourGradient(60,200,80,200,240,210,b);}} %>
+<%
+var green = '#3CC850',
+	red = '#C83232',
+	platformCount = Object.keys(apis.coverage).length;
+function contains(a,b){for(i in a)if(a[i]==b)return true;return false;}
+function rgbHex(r,g,b){return "#"+((1<<24)+(r<<16)+(g<<8)+b).toString(16).slice(1).split('.')[0];}
+function colourGradient(sr,sg,sb,er,eg,eb,p){return rgbHex(((sr-er)*p)+er,((sg-eg)*p)+eg,((sb-eb)*p)+eb);}
+function platformSupportColour(count) {
+	if (count == 0) {
+		return red;
+	}
+	if (count == platformCount) {
+		return green;
+	}
+	var b = (count/platformCount);
+	return colourGradient(60,200,80,200,240,210,b);
+}
+-%>
 <style>
-	html, body, div, span, applet, object, iframe, h1, h2, h3, h4, h5, h6, p, blockquote, pre, a, abbr, acronym, address, big, cite, code, del, dfn, em, font, img, ins, kbd, q, s, samp, small, strike, strong, sub, sup, tt, var, b, u, i, center, dl, dt, dd, ol, ul, li, fieldset, form, label, legend, table, caption, tbody, tfoot, thead, tr, th, td { background: transparent; border: 0; font-size: 100%; margin: 0; outline: 0; padding: 0; vertical-align: baseline; } body { line-height: 1; font-family: Helvetica, Arial, sans-serif; margin: 20px; font-size: 12px; } ol, ul { list-style: none; } blockquote, q { quotes: none; } :focus { outline: 0; } ins { text-decoration: none; } del { text-decoration: line-through; } table { border-collapse: collapse; border-spacing: 0; clear: both; } a { text-decoration: none; } a:hover { text-decoration: underline; } th { padding: 5px 10px; background: #CCC; } td { border: 1px solid #CCC; padding: 5px; } .yes { background-color:#007700; color: #FFF; text-align: center; font-weight: bold; } .no { background-color:#770000; color:#FFF; text-align: center; font-weight: bold; } .module_parent_title { font-weight: bold; } .module_child_title { padding-left: 20px; } div.options { float: left; margin: 0px 20px 10px 0px; } .stats_description { font-weight: normal; }
+	html, body, div, span, applet, object, iframe, h1, h2, h3, h4, h5, h6, p, blockquote, pre, a, abbr, acronym, address, big, cite, code, del, dfn, em, font, img, ins, kbd, q, s, samp, small, strike, strong, sub, sup, tt, var, b, u, i, center, dl, dt, dd, ol, ul, li, fieldset, form, label, legend, table, caption, tbody, tfoot, thead, tr, th, td { background: transparent; border: 0; font-size: 100%; margin: 0; outline: 0; padding: 0; vertical-align: baseline; }
+	body { line-height: 1; font-family: Helvetica, Arial, sans-serif; margin: 20px; font-size: 12px; }
+	ol, ul { list-style: none; }
+	blockquote, q { quotes: none; }
+	:focus { outline: 0; }
+	ins { text-decoration: none; }
+	del { text-decoration: line-through; }
+	table { border-collapse: collapse; border-spacing: 0; clear: both; }
+	a { text-decoration: none; }
+	a:hover { text-decoration: underline; }
+	th { padding: 5px 10px; background: #CCC; }
+	td { border: 1px solid #CCC; padding: 5px; }
+	tr.parent td.title { font-weight: bold; }
+	.child tr td.title { padding-left: 20px; }
+	div.options { float: left; margin: 0px 20px 10px 0px; }
+	.stats_description { font-weight: normal; }
 	body { text-align: center; }
 	table { margin: 0px auto; background-color: white; }
 	#options { text-align: left; }
 	.option { display: inline; }
-</style>
-<style type="text/css" id="table_row_style">
-	.pseudo_type { display: none; } .module_child { display: none; }
+	.p { display: none; } /* pseudo */
+	/* .n == normal/non-pseudo */
+	.child { display: none; }
+	.e { color: #FFF; text-align: center; font-weight: bold; } /* entry */
+	th.stats_description { font-weight: bold; }
+	.s { background-color: <%= green %>; } /* supported */
+	.u { background-color: <%= red %>; } /* unsupported */
+
+	/* Create classes for the gradients of support */
+<% for (var i = 0; i <= platformCount; i++) { -%>
+	.s<%= i %> { background-color: <%= platformSupportColour(i) %>; }
+<% } -%>
 </style>
 <script type="text/javascript">
-function toggleShowClass(clsName) {
-	var showPseudo = document.getElementById('pseudo_type_checkbox').checked,
-		showChildren = document.getElementById('module_members_checkbox').checked,
-		rowCSS;
-
-	if (showPseudo && showChildren) {
-		rowCSS = ".pseudo_type { display: table-row; } .module_child { display: table-row; }";
-	} else if (!showPseudo && showChildren) {
-		rowCSS = ".module_child { display: table-row; } .pseudo_type { display: none; }";
-	} else if (showPseudo && !showChildren) {
-		rowCSS = ".pseudo_type { display: table-row; } .module_child { display: none; }";
-	} else if (!showPseudo && !showChildren) {
-		rowCSS = ".pseudo_type { display: none; } .module_child { display: none; }";
+function updateListing(psuedoChanging, membersChanging) {
+	var membersShown = document.getElementById('members_checkbox').checked,
+		pseudoShown = document.getElementById('pseudo_checkbox').checked;
+	if (pseudoShown && membersShown) { // show both
+		if (psuedoChanging) { // showing pseudo, normal members already shown
+			toggleShowClass("p", true); // show all psuedo
+		} else { // showing members, psuedo already shown
+			toggleShowClass("child", true); // show all members
+		}
+	} else if (!pseudoShown && !membersShown) { // hide both
+		if (psuedoChanging) { // hiding psuedo, members already hidden
+			toggleShowClass("p parent", false); // hide all psuedo modules
+		} else { // hiding members, psuedo already hidden
+			toggleShowClass("n child", false); // hide all normal members
+		}
+	} else if (pseudoShown && !membersShown) { // show psuedo modules
+		if (psuedoChanging) { // showing pseudo, members not shown
+			toggleShowClass("p parent", true); // show psuedo modules only
+		} else { // hiding members, pseudo already shown
+			toggleShowClass("child", false); // hide all members
+		}
+	} else { // show members, not pseudo
+		if (psuedoChanging) { // hiding psuedo, members already shown
+			toggleShowClass("p", false); // hide all pseudo modules and children
+		} else { // showing members. Pseudo already hidden
+			toggleShowClass("n child", true); // show normal module children
+		}
 	}
-
-	document.getElementById('table_row_style').innerHTML = rowCSS;
+}
+// Toggling children (properties, events and methods) is quite slow.
+// So far the fastest thing I've seen is to group the children in tbody tags
+// so we can toggle the group as a whole; and to clone the table node, make
+// all the display changes on the cloned node and then replace the table at once
+// effectively batching the while repaint/reflow at once.
+function toggleShowClass(clsName, show) {
+	var table = document.getElementById("coverage_table"),
+		cloned = table.cloneNode(true), // make deep clone
+		elements = cloned.getElementsByClassName(clsName),
+		displayValue = (show ? "table-row-group" : "none");
+	for (var i = 0; i < elements.length; i++) {
+		elements[i].style.display = displayValue;
+	}
+	table.parentNode.replaceChild(cloned, table);
 }
 </script>
 
-<table>
+<table id="coverage_table">
+	<thead>
 <tr>
 	<th>
+		<!-- TODO Add an option to show/hide platform-specific APIs? Also change percentages? -->
 		<div id="options">
 			<div class="option">
-				Show Pseudotypes :
-				<input type="checkbox" id="pseudo_type_checkbox" onclick="toggleShowClass()">
+				Show Pseudotypes:
+				<input type="checkbox" id="pseudo_checkbox" onclick="updateListing(true, false);">
 			</div>
 			<div class="option">
-				Show Members :
-				<input type="checkbox" id="module_members_checkbox" onclick="toggleShowClass()">
+				Show Members:
+				<input type="checkbox" id="members_checkbox" onclick="updateListing(false, true);">
 			</div>
 		</div>
 	</th>
-	<% for (platform in apis.coverage) { %>
+<% for (platform in apis.coverage) { -%>
 		<th><%= platform %></th>
-	<% } %>
+<% } -%>
 	<th>overall</th>
 </tr>
 <tr>
-	<th class="stats_description" style="font-weight: bold;">Total APIs (<%= apis.totalAPIs %>)</th>
-	<% for (platform in apis.coverage) { %>
+	<th class="stats_description">Total APIs (<%= apis.totalAPIs %>)</th>
+<% for (platform in apis.coverage) { -%>
 		<th><%= apis.coverage[platform] %></th>
-	<% } %>
+<% } -%>
 	<th></th>
 </tr>
 <tr>
-	<th class="stats_description" style="font-weight: bold;">Percentage</th>
-	<% for (platform in apis.coverage) { %>
-		<th><%= (100*apis.coverage[platform]/apis.totalAPIs).toFixed(2) %>%</th>
-	<% } %>
+	<th class="stats_description">Percentage</th>
+<% for (platform in apis.coverage) { -%>
+		<th><%= (100 * apis.coverage[platform]/apis.totalAPIs).toFixed(2) %>%</th>
+<% } -%>
 	<th></th>
 </tr>
-<% for (i in apis.proxies) { %>
-	<% var proxy = apis.proxies[i] %>
-	<tr class="<%= (proxy.pseudo ? "pseudo_type" : "normal_type") %> module_parent" element_type="<%= (proxy.pseudo ? "pseudo_type" : "normal_type") %>">
-	<td class="module_parent_title" <%= (proxy.pseudo ? "class=\"normal_type\" " : "") %>><a href=<%= "http://docs.appcelerator.com/platform/latest/#!/api/"+proxy.name %>><%= proxy.name %></a></td>
-	<% for (platform in apis.coverage) { %>
-		<td style="background-color:<%= (contains(proxy.platforms, platform) ? green : red) %>; color: #FFF; text-align: center; font-weight: bold;"><%= (contains(proxy.platforms, platform) ? "YES" : "NO") %></td>
+</thead>
+
+<%
+for (i in apis.proxies) {
+	var proxy = apis.proxies[i],
+		baseDocURI = "http://docs.appcelerator.com/platform/latest/#!/api/" + proxy.name,
+		className = (proxy.pseudo ? "p" : "n"),
+		supported = false;
+-%>
+<tbody class="<%= className %> parent">
+	<tr>
+		<td class="title"><a href=<%= baseDocURI %>><%= proxy.name %></a></td>
+<%
+	for (platform in apis.coverage) {
+		supported = contains(proxy.platforms, platform);
+-%>
+		<td class="e <%= (supported ? "s" : "u") %>"><%= (supported ? "YES" : "NO") %></td>
 	<% } %>
-	<td style="background-color:<%= platformSupportColour(proxy) %>; color: #FFF; text-align: center; font-weight: bold;"><%= proxy.platforms.length+'/'+Object.keys(apis.coverage).length %></td>
+		<td class="e s<%= proxy.platforms.length %>"><%= proxy.platforms.length+'/'+platformCount %></td>
 	</tr>
+</tbody>
+<tbody class="<%= className %> child">
+<%
+	for (i in proxy.properties) {
+		var property = proxy.properties[i];
+-%>
+	<tr>
+		<td class="title"><a href=<%= baseDocURI + "-property-" + property.name %>><%= property.name %></a> (<i>property</i>)</td>
+<%
+		for (platform in apis.coverage) {
+			supported = contains(property.platforms, platform);
+-%>
+		<td class="e <%= (supported ? "s" : "u") %>"><%= (supported ? "YES" : "NO") %></td>
+<%
+		}
+-%>
+		<td class="e s<%= property.platforms.length %>"><%= property.platforms.length+'/'+platformCount %></td>
+	</tr>
+<%
+	}
 
-	<% for (i in proxy.properties) { %>
-		<% var property = proxy.properties[i] %>
-		<tr class="<%= (proxy.pseudo ? "pseudo_type" : "normal_type") %> module_child" module_child="true" element_type="<%= (proxy.pseudo ? "pseudo_type" : "normal_type") %>">
-		<td class="module_child_title"><a href=<%= "http://docs.appcelerator.com/platform/latest/#!/api/"+proxy.name+"-property-"+property.name %>><%= property.name %></a> (<i>property</i>)</td>
-		<% for (platform in apis.coverage) { %>
-		<td style="background-color:<%= (contains(property.platforms, platform) ? green : red) %>; color: #FFF; text-align: center; font-weight: bold;"><%= (contains(property.platforms, platform) ? "YES" : "NO") %></td>
-		<% } %>
-		<td style="background-color:<%= platformSupportColour(proxy) %>; color: #FFF; text-align: center; font-weight: bold;"><%= proxy.platforms.length+'/'+Object.keys(apis.coverage).length %></td>
-		</tr>
-	<% } %>
+	for (i in proxy.methods) {
+		var method = proxy.methods[i];
+-%>
+	<tr>
+		<td class="title"><a href=<%= baseDocURI + "-method-" + method.name %>><%= method.name %></a> (<i>method</i>)</td>
+<%
+		for (platform in apis.coverage) {
+			supported = contains(method.platforms, platform);
+-%>
+		<td class="e <%= (supported ? "s" : "u") %>"><%= (supported ? "YES" : "NO") %></td>
+<%
+		}
+-%>
+		<td class="e s<%= method.platforms.length %>"><%= method.platforms.length+'/'+platformCount %></td>
+	</tr>
+<%
+	}
 
-	<% for (i in proxy.methods) { %>
-		<% var method = proxy.methods[i] %>
-		<tr class="<%= (proxy.pseudo ? "pseudo_type" : "normal_type") %> module_child" module_child="true" element_type="<%= (proxy.pseudo ? "pseudo_type" : "normal_type") %>">
-		<td class="module_child_title"><a href=<%= "http://docs.appcelerator.com/platform/latest/#!/api/"+proxy.name+"-method-"+method.name %>><%= method.name %></a> (<i>method</i>)</td>
-		<% for (platform in apis.coverage) { %>
-		<td style="background-color:<%= (contains(method.platforms, platform) ? green : red) %>; color: #FFF; text-align: center; font-weight: bold;"><%= (contains(method.platforms, platform) ? "YES" : "NO") %></td>
-		<% } %>
-		<td style="background-color:<%= platformSupportColour(proxy) %>; color: #FFF; text-align: center; font-weight: bold;"><%= proxy.platforms.length+'/'+Object.keys(apis.coverage).length %></td>
-		</tr>
-	<% } %>
-
-	<% for (i in proxy.events) { %>
-		<% var event = proxy.properties[i] %>
-		<tr class="<%= (proxy.pseudo ? "pseudo_type" : "normal_type") %> module_child" module_child="true" element_type="<%= (proxy.pseudo ? "pseudo_type" : "normal_type") %>">
-		<td class="module_child_title"><a href=<%= "http://docs.appcelerator.com/platform/latest/#!/api/"+proxy.name+"-event-"+event.name %>><%= event.name %></a> (<i>event</i>)</td>
-		<% for (platform in apis.coverage) { %>
-		<td style="background-color:<%= (contains(event.platforms, platform) ? green : red) %>; color: #FFF; text-align: center; font-weight: bold;"><%= (contains(event.platforms, platform) ? "YES" : "NO") %></td>
-		<% } %>
-		<td style="background-color:<%= platformSupportColour(proxy) %>; color: #FFF; text-align: center; font-weight: bold;"><%= proxy.platforms.length+'/'+Object.keys(apis.coverage).length %></td>
-		</tr>
-	<% } %>
-<% } %>
+	for (i in proxy.events) {
+		var event = proxy.properties[i];
+-%>
+	<tr>
+		<td class="title"><a href=<%= baseDocURI + "-event-" + event.name %>><%= event.name %></a> (<i>event</i>)</td>
+<%
+		for (platform in apis.coverage) {
+			supported = contains(event.platforms, platform);
+-%>
+		<td class="e <%= (supported ? "s" : "u") %>"><%= (supported ? "YES" : "NO") %></td>
+<%
+		}
+-%>
+		<td class="e s<%= event.platforms.length %>"><%= event.platforms.length+'/'+platformCount %></td>
+	</tr>
+<%
+	}
+} -%>
+</tbody>
 </table>
-


### PR DESCRIPTION
There is no JIRA ticket for this change.

This stemmed from my frustrations with the current parity report - mainly that it's long to load (from the web) and slow to toggle showing members/pseudo-types.

As a first cut, this PR cut the size of the parity report HTML file on my Mac from 14,672,146 bytes to 5,798,335 bytes. Initial page load time went from 703ms to 424ms. I attempted to time showing members (without pseudo-types), and there are so many events it's hard to know the exact number, but it's over 15s from click to redraw. After this change it's now 1.8645s.

Future: Ideally I'd love to further improve it to be able to hide platform-specific APIs and change the API coverage percentage reported as a result (since there are a large number of Android/iOS specific APIs that make the API coverage look bad for something like Mobileweb or Windows).
