### PR TITLE
[TIMOB-20519] If --platform is not explicitly set, then automatically…

### DIFF
--- a/cli/commands/build.js
+++ b/cli/commands/build.js
@@ -144,10 +144,14 @@ exports.config = function config(logger, config, cli) {
 
 									var manifest = cli.manifest = ti.loadModuleManifest(logger, path.join(projectDir, 'manifest'));
 
-									timodule.properties || (timodule.properties = {});
+									// if they didn't explicitly set --platform and we have a platform in the manifest,
+									// then just use that and skip the platform prompting
+									if (!cli.argv.platform && manifest.platform) {
+										cli.argv.platform = ti.resolvePlatform(manifest.platform);
+										conf.options.platform.required = false;
+									}
 
-									// make sure the module manifest is sane
-									ti.validateModuleManifest(logger, cli, manifest);
+									timodule.properties || (timodule.properties = {});
 
 									cli.argv.type = 'module';
 
@@ -234,6 +238,9 @@ exports.config = function config(logger, config, cli) {
 exports.validate = function validate(logger, config, cli) {
 	// Determine if the project is an app or a module, run appropriate build command
 	if (cli.argv.type === 'module') {
+
+		// make sure the module manifest is sane
+		ti.validateModuleManifest(logger, cli, cli.manifest);
 
 		return function (finished) {
 			logger.log.init(function () {

--- a/node_modules/titanium-sdk/lib/titanium.js
+++ b/node_modules/titanium-sdk/lib/titanium.js
@@ -356,7 +356,7 @@ exports.validateModuleManifest = function (logger, cli, manifest) {
 		}
 	});
 
-	if (cli.argv.platform != manifest.platform) {
+	if (cli.argv.platform !== exports.resolvePlatform(manifest.platform)) {
 		logger.error(__('Unable to find "%s" module', cli.argv.platform));
 		logger.log();
 		process.exit(1);
@@ -564,7 +564,7 @@ exports.validateCorrectSDK = function (logger, config, cli, commandName) {
 			// fallback to default last segment, if we fail for any reason.
 			return params.split(' ').pop();
 		}(argv.$0);
-		
+
 		cmdAdd(titaniumPath);
 		cmdAdd(commandName, '--sdk', sdkName);
 


### PR DESCRIPTION
https://jira.appcelerator.org/browse/TIMOB-20519

[TIMOB-20519] If --platform is not explicitly set, then automatically set it to the platform in the module's manifest. Moved module manifest validation to validate(). Resolved module's platform prior to validation.
