### PR TITLE
[TIMOB-16355](5_3_X) iOS: separatorInsets should not be used for header/section titles

### DIFF
--- a/apidoc/Titanium/UI/ListView.yml
+++ b/apidoc/Titanium/UI/ListView.yml
@@ -849,6 +849,9 @@ properties:
 
   - name: separatorInsets
     summary: The insets for list view separators (applies to all cells). This property is applicable on iOS 7 and greater.
+    deprecated:
+        since: "5.2.0"
+        notes: Use tableSeparatorInsets instead
     description: |
         In iOS 7 and later, cell separators do not extend all the way to the edge of the list view. 
         This property sets the default inset for all cells in the table. 
@@ -875,6 +878,46 @@ properties:
     platforms: [iphone, ipad]
     availability: creation
 
+  - name: tableSeparatorInsets
+    summary: The insets for the table view header and footer. This property is applicable on iOS 7 and greater.
+    description: |
+        In iOS 7 and later, cell separators do not extend all the way to the edge of the list view.Set this to a
+        dictionary with two keys, `left` specifying inset from left edge and `right` specifying the inset from the
+        right edge. If the rowSeparatorInsets is not set, the tableSeparatorInsets will also set the cell insets.
+ 
+        For example:
+ 
+             listView.setTableSeparatorInsets({
+                 left:10,
+                 right:10
+             });
+ 
+ 
+    type: Dictionary
+    since: "5.2.0"
+    osver: {ios: {min: "7.0"}}
+    platforms: [iphone, ipad]
+
+
+  - name: rowSeparatorInsets
+    summary: The insets for list view cells (applies to all cells). This property is applicable on iOS 7 and greater.
+    description: |
+        In iOS 7 and later, cell separators do not extend all the way to the edge of the list view.Set this to a
+        dictionary with two keys, `left` specifying inset from left edge and `right` specifying the inset from the
+        right edge. This property is only available upon creation of the cells.
+ 
+        For example:
+ 
+             listView.setRowSeparatorInsets({
+                 left:10,
+                 right:10
+             });
+ 
+ 
+    type: Dictionary
+    since: "5.2.0"
+    osver: {ios: {min: "7.0"}}
+    platforms: [iphone, ipad]
 
 methods:
 

--- a/apidoc/Titanium/UI/ListView.yml
+++ b/apidoc/Titanium/UI/ListView.yml
@@ -881,7 +881,7 @@ properties:
   - name: tableSeparatorInsets
     summary: The insets for the table view header and footer. This property is applicable on iOS 7 and greater.
     description: |
-        In iOS 7 and later, cell separators do not extend all the way to the edge of the list view.Set this to a
+        In iOS 7 and later, cell separators do not extend all the way to the edge of the list view. Set this to a
         dictionary with two keys, `left` specifying inset from left edge and `right` specifying the inset from the
         right edge. If the rowSeparatorInsets is not set, the tableSeparatorInsets will also set the cell insets.
  
@@ -902,7 +902,7 @@ properties:
   - name: rowSeparatorInsets
     summary: The insets for list view cells (applies to all cells). This property is applicable on iOS 7 and greater.
     description: |
-        In iOS 7 and later, cell separators do not extend all the way to the edge of the list view.Set this to a
+        In iOS 7 and later, cell separators do not extend all the way to the edge of the list view. Set this to a
         dictionary with two keys, `left` specifying inset from left edge and `right` specifying the inset from the
         right edge. This property is only available upon creation of the cells.
  

--- a/apidoc/Titanium/UI/TableView.yml
+++ b/apidoc/Titanium/UI/TableView.yml
@@ -1550,7 +1550,7 @@ properties:
   - name: separatorInsets
     summary: The insets for table view separators (applies to all cells). This property is applicable on iOS 7 and greater.
     deprecated:
-        since: "6.0.0"
+        since: "5.2.0"
         notes: Use tableSeparatorInsets instead
     description: |
         In iOS 7 and later, cell separators do not extend all the way to the edge of the table view. 
@@ -1572,7 +1572,7 @@ properties:
   - name: tableSeparatorInsets
     summary: The insets for the table view header and footer. This property is applicable on iOS 7 and greater.
     description: |
-        In iOS 7 and later, cell separators do not extend all the way to the edge of the table view.Set this to a
+        In iOS 7 and later, cell separators do not extend all the way to the edge of the table view. Set this to a
         dictionary with two keys, `left` specifying inset from left edge and `right` specifying the inset from the
         right edge. If the rowSeparatorInsets is not set, the tableSeparatorInsets will also set the cell insets.
 
@@ -1585,14 +1585,14 @@ properties:
 
 
     type: Dictionary
-    since: 6.0.0
+    since: "5.2.0"
     osver: {ios: {min: "7.0"}}
     platforms: [iphone, ipad]
 
   - name: rowSeparatorInsets
     summary: The insets for table view cells (applies to all cells). This property is applicable on iOS 7 and greater.
     description: |
-        In iOS 7 and later, cell separators do not extend all the way to the edge of the table view.Set this to a
+        In iOS 7 and later, cell separators do not extend all the way to the edge of the table view. Set this to a
         dictionary with two keys, `left` specifying inset from left edge and `right` specifying the inset from the
         right edge. This property is only available upon creation of the cells.
 
@@ -1605,7 +1605,7 @@ properties:
 
 
     type: Dictionary
-    since: 6.0.0
+    since: "5.2.0"
     osver: {ios: {min: "7.0"}}
     platforms: [iphone, ipad]
 

--- a/iphone/Classes/TiUIListView.m
+++ b/iphone/Classes/TiUIListView.m
@@ -62,6 +62,8 @@ static TiViewProxy * FindViewProxyWithBindIdContainingPoint(UIView *view, CGPoin
     BOOL keepSectionsInSearch;
     NSMutableArray* _searchResults;
     UIEdgeInsets _defaultSeparatorInsets;
+    UIEdgeInsets _rowSeparatorInsets;
+    
     
     NSMutableDictionary* _measureProxies;
     
@@ -538,12 +540,34 @@ static TiViewProxy * FindViewProxyWithBindIdContainingPoint(UIView *view, CGPoin
 -(void)setSeparatorInsets_:(id)arg
 {
     [self tableView];
+    DEPRECATED_REPLACED(@"UI.ListView.separatorInsets", @"5.2.0", @"UI.ListView.tableSeparatorInsets");
+    [self setTableSeparatorInsets_:arg];
+}
+-(void)setTableSeparatorInsets_:(id)arg
+{
+    [self tableView];
+    
     if ([arg isKindOfClass:[NSDictionary class]]) {
         CGFloat left = [TiUtils floatValue:@"left" properties:arg def:_defaultSeparatorInsets.left];
         CGFloat right = [TiUtils floatValue:@"right" properties:arg def:_defaultSeparatorInsets.right];
         [_tableView setSeparatorInset:UIEdgeInsetsMake(0, left, 0, right)];
     } else {
         [_tableView setSeparatorInset:_defaultSeparatorInsets];
+    }
+    if (![searchController isActive]) {
+        [_tableView setNeedsDisplay];
+    }
+}
+
+-(void)setRowSeparatorInsets_:(id)arg
+{
+    [self tableView];
+    
+    if ([arg isKindOfClass:[NSDictionary class]]) {
+        
+        CGFloat left = [TiUtils floatValue:@"left" properties:arg def:_defaultSeparatorInsets.left];
+        CGFloat right = [TiUtils floatValue:@"right" properties:arg def:_defaultSeparatorInsets.right];
+        _rowSeparatorInsets = UIEdgeInsetsMake(0, left, 0, right);
     }
     if (![searchController isActive]) {
         [_tableView setNeedsDisplay];
@@ -1390,7 +1414,10 @@ static TiViewProxy * FindViewProxyWithBindIdContainingPoint(UIView *view, CGPoin
     } else {
         [cell setPosition:TiCellBackgroundViewPositionMiddle isGrouped:NO];
     }
-
+    
+    if (_rowSeparatorInsets.left != 0 || _rowSeparatorInsets.right != 0) {
+        [cell setSeparatorInset:_rowSeparatorInsets];
+    }
     cell.dataItem = item;
     cell.proxy.indexPath = realIndexPath;
     return cell;

--- a/iphone/Classes/TiUIListView.m
+++ b/iphone/Classes/TiUIListView.m
@@ -541,7 +541,6 @@ static TiViewProxy * FindViewProxyWithBindIdContainingPoint(UIView *view, CGPoin
 {
     [self tableView];
     DEPRECATED_REPLACED(@"UI.ListView.separatorInsets", @"5.2.0", @"UI.ListView.tableSeparatorInsets");
-    [self setTableSeparatorInsets_:arg];
 }
 -(void)setTableSeparatorInsets_:(id)arg
 {
@@ -550,12 +549,12 @@ static TiViewProxy * FindViewProxyWithBindIdContainingPoint(UIView *view, CGPoin
     if ([arg isKindOfClass:[NSDictionary class]]) {
         CGFloat left = [TiUtils floatValue:@"left" properties:arg def:_defaultSeparatorInsets.left];
         CGFloat right = [TiUtils floatValue:@"right" properties:arg def:_defaultSeparatorInsets.right];
-        [_tableView setSeparatorInset:UIEdgeInsetsMake(0, left, 0, right)];
+        [[self tableView] setSeparatorInset:UIEdgeInsetsMake(0, left, 0, right)];
     } else {
-        [_tableView setSeparatorInset:_defaultSeparatorInsets];
+        [[self tableView] setSeparatorInset:_defaultSeparatorInsets];
     }
     if (![searchController isActive]) {
-        [_tableView setNeedsDisplay];
+        [[self tableView] setNeedsDisplay];
     }
 }
 
@@ -570,7 +569,7 @@ static TiViewProxy * FindViewProxyWithBindIdContainingPoint(UIView *view, CGPoin
         _rowSeparatorInsets = UIEdgeInsetsMake(0, left, 0, right);
     }
     if (![searchController isActive]) {
-        [_tableView setNeedsDisplay];
+        [[self tableView] setNeedsDisplay];
     }
 }
 


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-16355
