### PR TITLE
[AC-3358] TiHTTPClient.getAllResponseHeaders() throws NullPointerException on timeout (Android)

### DIFF
--- a/android/modules/network/src/java/ti/modules/titanium/network/TiHTTPClient.java
+++ b/android/modules/network/src/java/ti/modules/titanium/network/TiHTTPClient.java
@@ -612,7 +612,7 @@ public class TiHTTPClient
 	public String getAllResponseHeaders()
 	{
 		String result = "";
-		if(!responseHeaders.isEmpty()){
+		if(responseHeaders!=null && !responseHeaders.isEmpty()){
 			StringBuilder sb = new StringBuilder(256);
 			Set<Map.Entry<String, List<String>>> entrySet = responseHeaders.entrySet();
 			


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/AC-3358
