### PR TITLE
[TIMOB-23116] iOS: Add session identifiers to urlSession events

### DIFF
--- a/apidoc/Titanium/App/iOS/iOS.yml
+++ b/apidoc/Titanium/App/iOS/iOS.yml
@@ -849,7 +849,9 @@ events:
         type: Number
 
       - name: sessionIdentifier
-        summary: The `urlSession` session identifier. If it does not exist, this property is not provided.
+        summary: | 
+            The `urlSession` session identifier. If it does not exist, this property is not provided.
+            This property is available since Titanium Mobile 5.4.0.GA.
         type: String
 
       - name: bytesWritten
@@ -880,7 +882,9 @@ events:
         type: Number
 
       - name: sessionIdentifier
-        summary: The `urlSession` session identifier. If it does not exist, this property is not provided.
+        summary: | 
+            The `urlSession` session identifier. If it does not exist, this property is not provided.
+            This property is available since Titanium Mobile 5.4.0.GA.
         type: String
 
       - name: bytesSent
@@ -911,7 +915,9 @@ events:
         type: Number
 
       - name: sessionIdentifier
-        summary: The `urlSession` session identifier. If it does not exist, this property is not provided.
+        summary: | 
+            The `urlSession` session identifier. If it does not exist, this property is not provided.
+            This property is available since Titanium Mobile 5.4.0.GA.
         type: String
 
       - name: data
@@ -936,7 +942,9 @@ events:
         type: Number
 
       - name: sessionIdentifier
-        summary: The `urlSession` session identifier. If it does not exist, this property is not provided.
+        summary: | 
+            The `urlSession` session identifier. If it does not exist, this property is not provided.
+            This property is available since Titanium Mobile 5.4.0.GA.
         type: String
 
       - name: success
@@ -974,7 +982,9 @@ events:
         this method.
     properties:
       - name: sessionIdentifier
-        summary: The `urlSession` session identifier. If it does not exist, this property is not provided.
+        summary: | 
+            The `urlSession` session identifier. If it does not exist, this property is not provided.
+            This property is available since Titanium Mobile 5.4.0.GA.
         type: String
     osver: {ios: {min: "7.0"}}
     since: "3.2.0"

--- a/apidoc/Titanium/App/iOS/iOS.yml
+++ b/apidoc/Titanium/App/iOS/iOS.yml
@@ -165,7 +165,7 @@ methods:
     parameters:
       - name: handlerID
         summary: |
-            Unique string identifer for the event (`backgroundfetch`, `silentpush` or `backgroundtransfer`)
+            Unique string identifier for the event (`backgroundfetch`, `silentpush` or `backgroundtransfer`)
             that initiated the background opertation mode.
         type: String
     osver: {ios: {min: "7.0"}}
@@ -191,7 +191,7 @@ methods:
     parameters:
       - name: handlerId
         summary: |
-            Unique string identifer for the event (`watchkitextensionrequest`)
+            Unique string identifier for the event (`watchkitextensionrequest`)
             that initiated from the WatchKit extension calling the openParentApplication:reply method.
         type: String
       - name: userInfo
@@ -748,7 +748,7 @@ events:
     properties:
       - name: handlerId
         summary: |
-            Unique string identifer for the `backgroundfetch` event. This identifier should be passed as the argument
+            Unique string identifier for the `backgroundfetch` event. This identifier should be passed as the argument
             to the [endBackgroundHandler](Titanium.App.iOS.endBackgroundHandler) method.
         type: String
     platforms: [iphone, ipad]
@@ -789,7 +789,7 @@ events:
     properties:
       - name: handlerId
         summary: |
-            Unique string identifer for the `silentpush` event. This identifier should be passed as the argument
+            Unique string identifier for the `silentpush` event. This identifier should be passed as the argument
             to the [endBackgroundHandler](Titanium.App.iOS.endBackgroundHandler) method.
         type: String
     platforms: [iphone, ipad]
@@ -825,7 +825,7 @@ events:
     properties:
       - name: handlerId
         summary: |
-            Unique string identifer for the `backgroundtransfer` event. This identifier should be passed as the argument
+            Unique string identifier for the `backgroundtransfer` event. This identifier should be passed as the argument
             to the [endBackgroundHandler](Titanium.App.iOS.endBackgroundHandler) method.
         type: String
       - name: sessionId
@@ -845,8 +845,12 @@ events:
         This event only needs to be used if your app is using the `urlSession` module to download data.
     properties:
       - name: taskIdentifier
-        summary: The `urlSession` download task's identifer.
+        summary: The `urlSession` download task's identifier.
         type: Number
+
+      - name: sessionIdentifier
+        summary: The `urlSession` session identifier. If it does not exist, this property is not provided.
+        type: String
 
       - name: bytesWritten
         summary: The number of bytes transferred since the last time this event was fired.
@@ -864,6 +868,37 @@ events:
     osver: {ios: {min: "7.0"}}
     since: "3.2.0"
 
+  - name: uploadprogress
+    summary: |
+        Fired periodically to inform the app about the upload's progress of a [urlSession](Modules.URLSession).
+        Available only on iOS 7 and later.
+    description: |
+        This event only needs to be used if your app is using the `urlSession` module to upload data.
+    properties:
+      - name: taskIdentifier
+        summary: The `urlSession` upload task's identifier.
+        type: Number
+
+      - name: sessionIdentifier
+        summary: The `urlSession` session identifier. If it does not exist, this property is not provided.
+        type: String
+
+      - name: bytesSent
+        summary: The number of bytes transferred since the last time this event was fired.
+        type: Number
+
+      - name: totalBytesSent
+        summary: The total number of bytes transferred so far.
+        type: Number
+
+      - name: totalBytesExpectedToSend
+        summary: |
+            The expected length of the file, as provided by the Content-Length header. If this
+            header was not provided, the value is zero.
+        type: Number
+    osver: {ios: {min: "7.0"}}
+    since: "3.2.0"
+
   - name: downloadcompleted
     summary: |
         Fired to indicate that a [urlSession's](Modules.URLSession) download task has finished downloading.
@@ -872,8 +907,12 @@ events:
         This event only needs to be used if your app is using the `urlSession` module to download data.
     properties:
       - name: taskIdentifier
-        summary: The `urlSession` download task's identifer.
+        summary: The `urlSession` download task's identifier.
         type: Number
+
+      - name: sessionIdentifier
+        summary: The `urlSession` session identifier. If it does not exist, this property is not provided.
+        type: String
 
       - name: data
         summary: The downloaded data as a Titanium.Blob object.
@@ -893,8 +932,12 @@ events:
         the hostname or connect to the host.
     properties:
       - name: taskIdentifier
-        summary: The `urlSession` download task's identifer.
+        summary: The `urlSession` download task's identifier.
         type: Number
+
+      - name: sessionIdentifier
+        summary: The `urlSession` session identifier. If it does not exist, this property is not provided.
+        type: String
 
       - name: success
         summary:  Indicates if the operation succeeded. Returns true if download succeeded, false otherwise.
@@ -929,6 +972,10 @@ events:
         is now safe to invoke [endBackgroundHandler](Titanium.App.iOS.endBackgroundHandler)
         method with the `handlerID` or to begin any internal updates that may result in invoking
         this method.
+    properties:
+      - name: sessionIdentifier
+        summary: The `urlSession` session identifier. If it does not exist, this property is not provided.
+        type: String
     osver: {ios: {min: "7.0"}}
     since: "3.2.0"
 
@@ -970,7 +1017,7 @@ events:
     properties:
       - name: handlerId
         summary: |
-            Unique string identifer for the `watchkitextensionrequest` event. This identifier should be passed an argument
+            Unique string identifier for the `watchkitextensionrequest` event. This identifier should be passed an argument
             to the [sendWatchExtensionReply](Titanium.App.iOS.sendWatchExtensionReply) method.
         type: String
       - name: userInfo
@@ -995,7 +1042,7 @@ events:
     properties:
       - name: activityType
         summary: |
-            Unique string identifer for the handoff user activity. The identifier must be defined in your `tiapp.xml` file.
+            Unique string identifier for the handoff user activity. The identifier must be defined in your `tiapp.xml` file.
         type: String
       - name: searchableItemActivityIdentifier
         summary: |

--- a/iphone/Classes/TiApp.m
+++ b/iphone/Classes/TiApp.m
@@ -715,7 +715,11 @@ TI_INLINE void waitForMemoryPanicCleared();   //WARNING: This must never be run 
 	else {
 		downloadedData = [[[TiBlob alloc] initWithFile:[destinationURL path]] autorelease];
 	}
-	NSMutableDictionary *dict = [NSMutableDictionary dictionaryWithObjectsAndKeys: [NSNumber numberWithUnsignedInteger:downloadTask.taskIdentifier ],@"taskIdentifier",downloadedData,@"data", nil];
+    
+	NSMutableDictionary *dict = [NSMutableDictionary dictionaryWithObjectsAndKeys:
+                                 session.configuration.identifier,@"sessionIdentifier",
+                                 [NSNumber numberWithUnsignedInteger:downloadTask.taskIdentifier ],@"taskIdentifier",
+                                 downloadedData,@"data", nil];
 	[[NSNotificationCenter defaultCenter] postNotificationName:kTiURLDownloadFinished object:self userInfo:dict];
 }
 
@@ -724,6 +728,7 @@ TI_INLINE void waitForMemoryPanicCleared();   //WARNING: This must never be run 
 
     //FunctionName();
     NSMutableDictionary *dict = [NSMutableDictionary dictionaryWithObjectsAndKeys:
+                                          session.configuration.identifier,@"sessionIdentifier",
                                           [NSNumber numberWithUnsignedInteger:downloadTask.taskIdentifier], @"taskIdentifier",
                                           [NSNumber numberWithUnsignedLongLong:bytesWritten], @"bytesWritten",
                                           [NSNumber numberWithUnsignedLongLong:totalBytesWritten], @"totalBytesWritten",
@@ -736,6 +741,7 @@ TI_INLINE void waitForMemoryPanicCleared();   //WARNING: This must never be run 
     totalBytesSent:(int64_t) totalBytesSent totalBytesExpectedToSend:(int64_t)totalBytesExpectedToSend
 {
     NSMutableDictionary *dict = [NSMutableDictionary dictionaryWithObjectsAndKeys:NUMUINTEGER(task.taskIdentifier),@"taskIdentifier",
+                                 session.configuration.identifier,@"sessionIdentifier",
                                  [NSNumber numberWithUnsignedLongLong:bytesSent], @"bytesSent",
                                  [NSNumber numberWithUnsignedLongLong:totalBytesSent], @"totalBytesSent",
                                  [NSNumber numberWithUnsignedLongLong:totalBytesExpectedToSend], @"totalBytesExpectedToSend", nil];
@@ -747,6 +753,7 @@ TI_INLINE void waitForMemoryPanicCleared();   //WARNING: This must never be run 
     //FunctionName();
     
     NSMutableDictionary *dict = [NSMutableDictionary dictionaryWithObjectsAndKeys:
+                                 session.configuration.identifier,@"sessionIdentifier",
                                  [NSNumber numberWithUnsignedInteger:task.taskIdentifier], @"taskIdentifier",
                           nil];
     if (error) {
@@ -774,6 +781,9 @@ expectedTotalBytes:(int64_t)expectedTotalBytes {
 
 - (void)URLSessionDidFinishEventsForBackgroundURLSession:(NSURLSession *)session
 {
+    NSMutableDictionary *dict = [NSMutableDictionary dictionaryWithObjectsAndKeys:
+                                 session.configuration.identifier,@"sessionIdentifier",
+                                 nil];
     [[NSNotificationCenter defaultCenter] postNotificationName:kTiURLSessionEventsCompleted object:self userInfo:nil];
 }
 

--- a/iphone/Classes/TiApp.m
+++ b/iphone/Classes/TiApp.m
@@ -717,22 +717,28 @@ TI_INLINE void waitForMemoryPanicCleared();   //WARNING: This must never be run 
 	}
     
 	NSMutableDictionary *dict = [NSMutableDictionary dictionaryWithObjectsAndKeys:
-                                 session.configuration.identifier,@"sessionIdentifier",
                                  [NSNumber numberWithUnsignedInteger:downloadTask.taskIdentifier ],@"taskIdentifier",
                                  downloadedData,@"data", nil];
+    
+    if (session.configuration.identifier) {
+        [dict setObject:session.configuration.identifier forKey:@"sessionIdentifier"];
+    }
+    
 	[[NSNotificationCenter defaultCenter] postNotificationName:kTiURLDownloadFinished object:self userInfo:dict];
 }
 
 -(void)URLSession:(NSURLSession *)session downloadTask:(NSURLSessionDownloadTask *)downloadTask didWriteData:(int64_t)bytesWritten totalBytesWritten:(int64_t)totalBytesWritten totalBytesExpectedToWrite:(int64_t)totalBytesExpectedToWrite
 {
-
-    //FunctionName();
     NSMutableDictionary *dict = [NSMutableDictionary dictionaryWithObjectsAndKeys:
-                                          session.configuration.identifier,@"sessionIdentifier",
                                           [NSNumber numberWithUnsignedInteger:downloadTask.taskIdentifier], @"taskIdentifier",
                                           [NSNumber numberWithUnsignedLongLong:bytesWritten], @"bytesWritten",
                                           [NSNumber numberWithUnsignedLongLong:totalBytesWritten], @"totalBytesWritten",
                                           [NSNumber numberWithUnsignedLongLong:totalBytesExpectedToWrite], @"totalBytesExpectedToWrite", nil];
+
+    if (session.configuration.identifier) {
+        [dict setObject:session.configuration.identifier forKey:@"sessionIdentifier"];
+    }
+    
     [[NSNotificationCenter defaultCenter] postNotificationName:kTiURLDowloadProgress object:self userInfo:dict];
 
 }
@@ -741,10 +747,14 @@ TI_INLINE void waitForMemoryPanicCleared();   //WARNING: This must never be run 
     totalBytesSent:(int64_t) totalBytesSent totalBytesExpectedToSend:(int64_t)totalBytesExpectedToSend
 {
     NSMutableDictionary *dict = [NSMutableDictionary dictionaryWithObjectsAndKeys:NUMUINTEGER(task.taskIdentifier),@"taskIdentifier",
-                                 session.configuration.identifier,@"sessionIdentifier",
                                  [NSNumber numberWithUnsignedLongLong:bytesSent], @"bytesSent",
                                  [NSNumber numberWithUnsignedLongLong:totalBytesSent], @"totalBytesSent",
                                  [NSNumber numberWithUnsignedLongLong:totalBytesExpectedToSend], @"totalBytesExpectedToSend", nil];
+    
+    if (session.configuration.identifier) {
+        [dict setObject:session.configuration.identifier forKey:@"sessionIdentifier"];
+    }
+    
     [[NSNotificationCenter defaultCenter] postNotificationName:kTiURLUploadProgress object:self userInfo:dict];
 }
 
@@ -753,9 +763,13 @@ TI_INLINE void waitForMemoryPanicCleared();   //WARNING: This must never be run 
     //FunctionName();
     
     NSMutableDictionary *dict = [NSMutableDictionary dictionaryWithObjectsAndKeys:
-                                 session.configuration.identifier,@"sessionIdentifier",
                                  [NSNumber numberWithUnsignedInteger:task.taskIdentifier], @"taskIdentifier",
                           nil];
+    
+    if (session.configuration.identifier) {
+        [dict setObject:session.configuration.identifier forKey:@"sessionIdentifier"];
+    }
+    
     if (error) {
         NSDictionary * errorinfo = [NSDictionary dictionaryWithObjectsAndKeys:NUMBOOL(NO), @"success",
                                                 NUMINTEGER([error code]), @"errorCode",
@@ -781,10 +795,13 @@ expectedTotalBytes:(int64_t)expectedTotalBytes {
 
 - (void)URLSessionDidFinishEventsForBackgroundURLSession:(NSURLSession *)session
 {
-    NSMutableDictionary *dict = [NSMutableDictionary dictionaryWithObjectsAndKeys:
-                                 session.configuration.identifier,@"sessionIdentifier",
-                                 nil];
-    [[NSNotificationCenter defaultCenter] postNotificationName:kTiURLSessionEventsCompleted object:self userInfo:nil];
+    NSDictionary *dict = nil;
+    
+    if (session.configuration.identifier) {
+        dict = @{@"sessionIdentifier": session.configuration.identifier};
+    }
+    
+    [[NSNotificationCenter defaultCenter] postNotificationName:kTiURLSessionEventsCompleted object:self userInfo:dict];
 }
 
 #pragma mark


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-23116

Thank you @axmo for the initial PR (https://github.com/appcelerator/titanium_mobile/pull/6941). I added:
- Nil-validations for the case that the `sessionIdentifier` is nil
- The docs for the new property, as well as the docs for the `uploadprogress` event
- The missing dictionary in `URLSessionDidFinishEventsForBackgroundURLSession`.
- The corresponding JIRA-ticket
