### PR TITLE
[TIMOB-20614]iOS: Ti proxies are not always released from memory

### DIFF
--- a/iphone/Classes/KrollBridge.m
+++ b/iphone/Classes/KrollBridge.m
@@ -297,7 +297,7 @@ CFMutableSetRef	krollBridgeRegistry = nil;
 {
 	OSSpinLockLock(&proxyLock);
 	CFDictionaryRef oldProxies = registeredProxies;
-    CFRelease(registeredProxies);
+	CFRelease(registeredProxies);
 	OSSpinLockUnlock(&proxyLock);
 	
 	for (id thisProxy in (NSDictionary *)oldProxies)

--- a/iphone/Classes/KrollBridge.m
+++ b/iphone/Classes/KrollBridge.m
@@ -297,7 +297,7 @@ CFMutableSetRef	krollBridgeRegistry = nil;
 {
 	OSSpinLockLock(&proxyLock);
 	CFDictionaryRef oldProxies = registeredProxies;
-	registeredProxies = NULL;
+    CFRelease(registeredProxies);
 	OSSpinLockUnlock(&proxyLock);
 	
 	for (id thisProxy in (NSDictionary *)oldProxies)
@@ -688,7 +688,7 @@ CFMutableSetRef	krollBridgeRegistry = nil;
 
 - (id)registerProxy:(id)proxy 
 {
-	KrollObject * ourKrollObject = [self krollObjectForProxy:proxy];
+	KrollObject * ourKrollObject = [[self krollObjectForProxy:proxy] autorelease];
 	
 	if (ourKrollObject != nil)
 	{


### PR DESCRIPTION
[JIRA](https://jira.appcelerator.org/browse/TIMOB-20614)
Releasing CF type properly and adding autorealse to krollObject for registerProxy.
