### PR TITLE
[DOCFIX] Fix docgen compiler warnings, abstract params, ListView insert event, dead links

### DIFF
--- a/apidoc/Titanium/Android/ActionBar.yml
+++ b/apidoc/Titanium/Android/ActionBar.yml
@@ -15,9 +15,8 @@ description: |
     In JavaScript, wait for the window or tab group's `open` event before accessing
     the action bar from the window or tab group's [activity](Titanium.Android.Activity).
 
-    Note that setting the [Window.navBarHidden](Titanium.UI.Window.navBarHidden) or
-    [TabGroup.navBarHidden](Titanium.UI.TabGroup.navBarHidden) property to true disables the
-    Action Bar since it is part of the navigation title bar.
+    Note that setting the [Window.navBarHidden](Titanium.UI.Window.navBarHidden) property
+    to true disables the Action Bar since it is part of the navigation title bar.
 
     For more examples on using the Action Bar, refer to the
     [Android Action Bar guide](http://docs.appcelerator.com/platform/latest/#!/guide/Android_Action_Bar).
@@ -217,7 +216,7 @@ properties:
   - name: navigationMode
     summary: Controls the navigation mode.
     description: |
-        The navigation mode can be [NAVIGATION_MODE_STANDARD](Titanium.Android.NAVIGATION_MODE_STANDARD), or [NAVIGATION_MODE_TABS](Titanium.Android.NAVIGATION_MODE_TABS). 
+        The navigation mode can be [NAVIGATION_MODE_STANDARD](Titanium.Android.NAVIGATION_MODE_STANDARD), or [NAVIGATION_MODE_TABS](Titanium.Android.NAVIGATION_MODE_TABS).
         A TabGroup is initialized by Titanium Mobile with `NAVIGATION_MODE_TABS`, and can be hidden by setting to `NAVIGATION_MODE_STANDARD`. `NAVIGATION_MODE_LIST` is not yet supported.
         See also: [setNavigationMode](http://developer.android.com/reference/android/app/ActionBar.html#setNavigationMode(int))
         in the Android Developer Reference.

--- a/apidoc/Titanium/Android/BigPictureStyle.yml
+++ b/apidoc/Titanium/Android/BigPictureStyle.yml
@@ -35,7 +35,7 @@ platforms: [android]
 properties:
 
   - name: bigLargeIcon
-    summary: Override the <Titanium.UI.Notification.largeIcon> when the big notification is shown.
+    summary: Override the <Titanium.Android.Notification.largeIcon> when the big notification is shown.
     description: |
         If specified as a URL, the icon must be placed in one of the density-specific
         folders under `Resources/android/images`. For example, if your icon is called
@@ -94,9 +94,9 @@ properties:
     type: [Number, String, Titanium.Blob, Titanium.Filesystem.File]
 
   - name: bigContentTitle
-    summary: Overrides <Titanium.UI.Notification.contentTitle> in the big form of the notification. This defaults to the value passed to <Titanium.UI.Notification.contentTitle>.
+    summary: Overrides <Titanium.Android.Notification.contentTitle> in the big form of the notification. This defaults to the value passed to <Titanium.Android.Notification.contentTitle>.
     type: String
-    default: <Titanium.UI.Notification.contentTitle>
+    default: <Titanium.Android.Notification.contentTitle>
 
   - name: decodeRetries
     summary: |

--- a/apidoc/Titanium/Android/BigTextStyle.yml
+++ b/apidoc/Titanium/Android/BigTextStyle.yml
@@ -5,7 +5,7 @@ description: |
     If the platform does not provide large-format notifications, this style helper has no effect.
     The user will always see the normal notification view.
 
-    This style object attaches to a <Titanium.UI.Notification> object and modifies its behavior.
+    This style object attaches to a <Titanium.Android.Notification> object and modifies its behavior.
 examples:
   - title: Big text style Example
     example: |
@@ -36,9 +36,9 @@ properties:
     type: String
 
   - name: bigContentTitle
-    summary: Overrides <Titanium.UI.Notification.contentTitle> in the big form of the notification. This defaults to the value passed to <Titanium.UI.Notification.contentTitle>.
+    summary: Overrides <Titanium.Android.Notification.contentTitle> in the big form of the notification. This defaults to the value passed to <Titanium.Android.Notification.contentTitle>.
     type: String
-    default: <Titanium.UI.Notification.contentTitle>
+    default: <Titanium.Android.Notification.contentTitle>
 
   - name: summaryText
     summary: Set the first line of text after the detail section in the big form of the notification.

--- a/apidoc/Titanium/Android/Notification.yml
+++ b/apidoc/Titanium/Android/Notification.yml
@@ -99,7 +99,6 @@ methods:
   - name: setLatestEventInfo
     summary: Sets the latest event info using the built-in notification view for this notification.
     parameters:
-
       - name: contentTitle
         summary: Title to display when the notification is expanded.
         type: String

--- a/apidoc/Titanium/App/iOS/iOS.yml
+++ b/apidoc/Titanium/App/iOS/iOS.yml
@@ -1171,10 +1171,10 @@ properties:
     summary: | 
         Region the notification will be triggered in. Allowed parameter are:
         
-        * `latitude`: Latitude of the location center, in decimal degrees (required).
-        * `longitude`: Longitude of the location center, in decimal degrees (required).
-        * `triggersOnce`: Whether or not the notification will only fire once (optional, default: true).
-        * `identifier`: Identifier of the region (optional).
+        - `latitude`: Latitude of the location center, in decimal degrees (required).
+        - `longitude`: Longitude of the location center, in decimal degrees (required).
+        - `triggersOnce`: Whether or not the notification will only fire once (optional, default: true).
+        - `identifier`: Identifier of the region (optional).
     type: Dictionary
     optional: true
     since: "5.4.0"

--- a/apidoc/Titanium/App/iOS/iOS.yml
+++ b/apidoc/Titanium/App/iOS/iOS.yml
@@ -1171,10 +1171,10 @@ properties:
     summary: | 
         Region the notification will be triggered in. Allowed parameter are:
         
-        * latitude: Latitude of the location center, in decimal degrees (required).
-        * longitude: Latitude of the location center, in decimal degrees (required).
-        * triggersOnce: Whether or not the notification will only fire once (optional, default: true).
-        * identifier: Identifier of the region (optional).
+        * `latitude`: Latitude of the location center, in decimal degrees (required).
+        * `longitude`: Longitude of the location center, in decimal degrees (required).
+        * `triggersOnce`: Whether or not the notification will only fire once (optional, default: true).
+        * `identifier`: Identifier of the region (optional).
     type: Dictionary
     optional: true
     since: "5.4.0"

--- a/apidoc/Titanium/App/iOS/iOS.yml
+++ b/apidoc/Titanium/App/iOS/iOS.yml
@@ -1168,32 +1168,17 @@ properties:
     optional: true
 
   - name: region
-    summary: Region the notification will be triggered in.
+    summary: | 
+        Region the notification will be triggered in. Allowed parameter are:
+        
+        * latitude: Latitude of the location center, in decimal degrees (required).
+        * longitude: Latitude of the location center, in decimal degrees (required).
+        * triggersOnce: Whether or not the notification will only fire once (optional, default: true).
+        * identifier: Identifier of the region (optional).
     type: Dictionary
     optional: true
     since: "5.4.0"
-    parameters:
-      - name: latitude
-        summary: Latitude of the location center, in decimal degrees.
-        type: Number
-        optional: false
-
-      - name: longitude
-        summary: Longitude of the location center, in decimal degrees.
-        type: Number
-        optional: false
-
-      - name: triggersOnce
-        summary: Longitude of the location center, in decimal degrees.
-        default: true
-        type: Boolean
-        optional: true
-
-      - name: identifier
-        summary: Identifier of the region.
-        type: String
-        optional: true
-
+    
 ---
 name: UserNotificationSettings
 summary: |

--- a/apidoc/Titanium/UI/ListView.yml
+++ b/apidoc/Titanium/UI/ListView.yml
@@ -937,111 +937,6 @@ properties:
     osver: {ios: {min: "7.0"}}
     platforms: [iphone, ipad]
     
-  - name: ListViewAnimationProperties
-    summary: |
-      A simple object for specifying the animation properties to use when inserting or deleting
-      sections or cells, or scrolling the list.
-    description: |
-      These properties are only used on iOS. Not all properties apply to all methods.
-      `animationStyle` does not apply to the `scrollToItem` method.
-      `positon` only applies to the `scrollToItem` method.
-      Since Release 3.3.0 of the Titanium SDK, Android supports the `animated` property and is applicable only to `scrollToItem`
-    platforms: [iphone, ipad, android]
-    since: '3.1.0'
-    properties:
-    - name: animated
-      summary: Whether this list change should be animated. Ignored if any `animationStyle` value is specified.
-      type: Boolean
-      default: true
-    - name: animationStyle
-      summary: Type of animation to use for cell insertions and deletions.
-      type: Number
-      constants: Titanium.UI.iPhone.RowAnimationStyle.*
-      default: |
-        If `animated` is `true` but no `animationStyle` is specified, the style defaults to 
-        [FADE](Titanium.UI.iPhone.RowAnimationStyle.FADE).
-    - name: position
-      summary: Specifies what position to scroll the selected cell to.
-      type: Number
-      constants: Titanium.UI.iPhone.ListViewScrollPosition.*
-      default: Titanium.UI.iPhone.ListViewScrollPosition.NONE
-      
-  - name: ListViewIndexEntry
-    summary: A simple object that represents an index entry in a `ListView`.
-    description: |
-      Used in conjunction with the [sectionIndexTitles](Titanium.UI.ListView.sectionIndexTitles) property of the List View.
-    platforms: [iphone, ipad]
-    since: 3.2.0
-    properties:
-    - name: title
-      summary: Title to display in the index bar.
-      type: String
-    - name: index
-      summary: Section index associated with this title.
-      type: Number
-
-  - name: ListViewContentInsetOption
-    summary: Optional parameter for [setContentInsets](Titanium.UI.ListView.setContentInsets) method.
-    description: |
-      On iOS, the optional parameters `animated` and `duration` to enable the animation and duration 
-      for animation while the content insets are updated. For example
-
-        setContentInset({top:50,bottom:100}, {animated:true, duration:3000})
-    since: 3.2.0
-    platforms: [iphone, ipad]
-    properties:
-    - name: animated
-      summary: Determines whether the list view's content inset change is animated.
-      type: Boolean
-      default: false
-    - name: duration
-      summary: The duration in `milliseconds` for animation while the content inset is  being changed.
-      type: Number
-      
-  - name: ListViewMarkerProps
-    summary: The parameter for [setMarker](Titanium.UI.ListView.setMarker) and [addMarker](Titanium.UI.ListView.addMarker) methods.
-    description: |
-      Use this in conjunction with [setMarker](Titanium.UI.ListView.setMarker) and [addMarker](Titanium.UI.ListView.addMarker) methods. For example:
-
-        setMarker({sectionIndex:5, itemIndex:10});
-        addMarker({sectionIndex:7, itemIndex: 2});
-    since: 3.2.0
-    platforms: [iphone, ipad, android]
-    properties:
-    - name: sectionIndex
-      summary: The sectionIndex of the reference item.
-      type: Number
-    - name: itemIndex
-      summary: The itemIndex of the reference item.
-      type: Number
-
-  - name: ListViewEdgeInsets
-    summary: The parameter for [setContentInsets](Titanium.UI.TableView.setContentInsets) method.
-    description: |
-      On iOS, the parameter `edgeInsets` can be specified to set the distance(`top`, `bottom`,
-      `right`, `left`) that the content view is inset from the enclosing scroll view of the list view.
-      For example
-
-        setContentInset({top:50,bottom:10,right:10,left:10}, {animated:true})
-    since: 3.2.0
-    platforms: [iphone, ipad]
-    properties:
-    - name: top
-      summary: Value specifying the top insets for the enclosing scroll view of the list view.
-      type: Number
-    
-    - name: left
-      summary: Value specifying the left insets for the enclosing scroll view of the list view.
-      type: Number
-    
-    - name: right
-      summary: Value specifying the right insets for the enclosing scroll view of the list view.
-      type: Number
-    
-    - name: bottom
-      summary: Value specifying the bottom insets for the enclosing scroll view of the list view.
-      type: Number
-
 methods:
 
   - name: scrollToItem
@@ -1614,3 +1509,113 @@ examples:
                     </ListView>
                 </Window>
             </Alloy>
+
+---
+name: ListViewAnimationProperties
+summary: |
+    A simple object for specifying the animation properties to use when inserting or deleting
+    sections or cells, or scrolling the list.
+description: |
+    These properties are only used on iOS. Not all properties apply to all methods.
+    `animationStyle` does not apply to the `scrollToItem` method.
+    `positon` only applies to the `scrollToItem` method.
+    Since Release 3.3.0 of the Titanium SDK, Android supports the `animated` property and is applicable only to `scrollToItem`
+platforms: [iphone, ipad, android]
+since: '3.1.0'
+properties:
+  - name: animated
+    summary: Whether this list change should be animated. Ignored if any `animationStyle` value is specified.
+    type: Boolean
+    default: true
+  - name: animationStyle
+    summary: Type of animation to use for cell insertions and deletions.
+    type: Number
+    constants: Titanium.UI.iPhone.RowAnimationStyle.*
+    default: |
+        If `animated` is `true` but no `animationStyle` is specified, the style defaults to 
+        [FADE](Titanium.UI.iPhone.RowAnimationStyle.FADE).
+  - name: position
+    summary: Specifies what position to scroll the selected cell to.
+    type: Number
+    constants: Titanium.UI.iPhone.ListViewScrollPosition.*
+    default: Titanium.UI.iPhone.ListViewScrollPosition.NONE
+
+---      
+name: ListViewIndexEntry
+summary: A simple object that represents an index entry in a `ListView`.
+description: |
+    Used in conjunction with the [sectionIndexTitles](Titanium.UI.ListView.sectionIndexTitles) property of the List View.
+platforms: [iphone, ipad]
+since: 3.2.0
+properties:
+  - name: title
+    summary: Title to display in the index bar.
+    type: String
+  - name: index
+    summary: Section index associated with this title.
+    type: Number
+
+---
+name: ListViewContentInsetOption
+summary: Optional parameter for [setContentInsets](Titanium.UI.ListView.setContentInsets) method.
+description: |
+    On iOS, the optional parameters `animated` and `duration` to enable the animation and duration 
+    for animation while the content insets are updated. For example
+
+        setContentInset({top:50,bottom:100}, {animated:true, duration:3000})
+since: 3.2.0
+platforms: [iphone, ipad]
+properties:
+  - name: animated
+    summary: Determines whether the list view's content inset change is animated.
+    type: Boolean
+    default: false
+  - name: duration
+    summary: The duration in `milliseconds` for animation while the content inset is  being changed.
+    type: Number
+
+---     
+name: ListViewMarkerProps
+summary: The parameter for [setMarker](Titanium.UI.ListView.setMarker) and [addMarker](Titanium.UI.ListView.addMarker) methods.
+description: |
+    Use this in conjunction with [setMarker](Titanium.UI.ListView.setMarker) and [addMarker](Titanium.UI.ListView.addMarker) methods. For example:
+
+        setMarker({sectionIndex:5, itemIndex:10});
+        addMarker({sectionIndex:7, itemIndex: 2});
+since: 3.2.0
+platforms: [iphone, ipad, android]
+properties:
+  - name: sectionIndex
+    summary: The sectionIndex of the reference item.
+    type: Number
+  - name: itemIndex
+    summary: The itemIndex of the reference item.
+    type: Number
+
+---
+name: ListViewEdgeInsets
+summary: The parameter for [setContentInsets](Titanium.UI.TableView.setContentInsets) method.
+description: |
+    On iOS, the parameter `edgeInsets` can be specified to set the distance(`top`, `bottom`,
+    `right`, `left`) that the content view is inset from the enclosing scroll view of the list view.
+    For example
+
+        setContentInset({top:50,bottom:10,right:10,left:10}, {animated:true})
+since: 3.2.0
+platforms: [iphone, ipad]
+properties:
+  - name: top
+    summary: Value specifying the top insets for the enclosing scroll view of the list view.
+    type: Number
+    
+  - name: left
+    summary: Value specifying the left insets for the enclosing scroll view of the list view.
+    type: Number
+    
+  - name: right
+    summary: Value specifying the right insets for the enclosing scroll view of the list view.
+    type: Number
+    
+  - name: bottom
+    summary: Value specifying the bottom insets for the enclosing scroll view of the list view.
+    type: Number

--- a/apidoc/Titanium/UI/ListView.yml
+++ b/apidoc/Titanium/UI/ListView.yml
@@ -291,6 +291,38 @@ events:
       - name: bubbles
         summary: false. This event does not bubble.
         type: Boolean
+        
+  - name: insert
+    summary: Fired when a list row is inserted by the user.
+    description: |
+        Do not rely on the `source` property to determine which item fired the event.  Use the
+        `sectionIndex` and `itemIndex`, or the `itemId` to determine the list item that generated
+        the event, and use the `bindId` to check which child control fired the event. 
+
+        Note that the `sectionIndex` and `itemIndex` properties of this event correspond to the List View state
+        before the user action.
+    platforms: [iphone, ipad]
+    since: 5.4.0
+    properties:
+      - name: section
+        summary: List section from which the item is deleted.
+        type: Titanium.UI.ListSection
+
+      - name: sectionIndex
+        summary: Section index.
+        type: Number
+
+      - name: itemIndex
+        summary: Item index.
+        type: Number
+
+      - name: itemId
+        summary: The item ID bound to the list item that generated the event.
+        type: String
+
+      - name: bubbles
+        summary: false. This event does not bubble.
+        type: Boolean
 
   - name: dragstart
     summary: Fired when the user starts dragging the list view.

--- a/apidoc/Titanium/UI/iOS/LivePhotoView.yml
+++ b/apidoc/Titanium/UI/iOS/LivePhotoView.yml
@@ -3,7 +3,7 @@ name: Titanium.UI.iOS.LivePhotoView
 summary: |
     A view to display a [Live Photo](Titanium.UI.iOS.LivePhoto) object introduced in iOS 9.1.
 description: |    
-    Use the <Titanium.UI.createLivePhotoView> method to create an new `LivePhotoView`.
+    Use the <Titanium.UI.iOS.createLivePhotoView> method to create an new `LivePhotoView`.
     
     Specifying either a `width` or `height` property for this view will scale its `livePhoto` with 
     the aspect ratio maintained, up to a maximum size that does not exceed its parent view.

--- a/apidoc/Titanium/UI/iOS/MenuPopup.yml
+++ b/apidoc/Titanium/UI/iOS/MenuPopup.yml
@@ -19,45 +19,6 @@ properties:
         To hide them again, use the `hide` method in conjunction.
     type: [String]
 
-  - name: MenuPopupShowParams
-    summary: Dictionary of options for showing a menu popup with <Titanium.UI.iOS.MenuPopup.show>.
-    platforms: [iphone,ipad]
-    since: "5.2.0"
-    description: |
-      The parameters used when showing a menu popup. Must include the `view` property to tell the menu popup
-      at which view it should be shown. Also set the `animated` property to `false` if you want to show the
-      menu popup without an animation.
-    properties:
-      - name: view
-        summary: The view where the menu pop is shown at.
-        type: Titanium.UI.View
-        optional: false
-      - name: animated
-        summary: Determines whether the menu popup should be opened or closed animated.
-        type: Boolean
-        default: true
-        optional: true
-      - name: arrowDirection
-        summary: Indicates the arrow direction of the menu popup.
-        description: Use this property to indicate the menu popups arrow to use. 
-        type: Number
-        constants: [Titanium.UI.iOS.MENU_POPUP_ARROW_DIRECTION_UP,Titanium.UI.iOS.MENU_POPUP_ARROW_DIRECTION_DOWN,
-                    Titanium.UI.iOS.MENU_POPUP_ARROW_DIRECTION_LEFT,Titanium.UI.iOS.MENU_POPUP_ARROW_DIRECTION_RIGHT,
-                    Titanium.UI.iOS.MENU_POPUP_ARROW_DIRECTION_DEFAULT]
-
-  - name: MenuPopupHideParams
-    summary: Dictionary of options for hiding a menu popup with <Titanium.UI.iOS.MenuPopup.hide>.
-    platforms: [iphone,ipad]
-    since: "5.2.0"
-    description: |
-      Set the `animated` property to `false` if you want to hide the menu popup without an animation.
-    properties:
-    - name: animated
-      summary: Determines whether the menu popup should be opened or closed animated.
-      type: Boolean
-      default: true
-      optional: true
-
 methods:
   - name: show
     summary: Shows the menu popup.
@@ -123,3 +84,45 @@ examples:
             });
 
             win.open();
+
+---
+
+name: MenuPopupShowParams
+summary: Dictionary of options for showing a menu popup with <Titanium.UI.iOS.MenuPopup.show>.
+platforms: [iphone,ipad]
+since: "5.2.0"
+description: |
+    The parameters used when showing a menu popup. Must include the `view` property to tell the menu popup
+    at which view it should be shown. Also set the `animated` property to `false` if you want to show the
+    menu popup without an animation.
+properties:
+  - name: view
+    summary: The view where the menu pop is shown at.
+    type: Titanium.UI.View
+    optional: false
+  - name: animated
+    summary: Determines whether the menu popup should be opened or closed animated.
+    type: Boolean
+    default: true
+    optional: true
+  - name: arrowDirection
+    summary: Indicates the arrow direction of the menu popup.
+    description: Use this property to indicate the menu popups arrow to use. 
+    type: Number
+    constants: [Titanium.UI.iOS.MENU_POPUP_ARROW_DIRECTION_UP,Titanium.UI.iOS.MENU_POPUP_ARROW_DIRECTION_DOWN,
+                Titanium.UI.iOS.MENU_POPUP_ARROW_DIRECTION_LEFT,Titanium.UI.iOS.MENU_POPUP_ARROW_DIRECTION_RIGHT,
+                Titanium.UI.iOS.MENU_POPUP_ARROW_DIRECTION_DEFAULT]
+
+---
+name: MenuPopupHideParams
+summary: Dictionary of options for hiding a menu popup with <Titanium.UI.iOS.MenuPopup.hide>.
+platforms: [iphone,ipad]
+since: "5.2.0"
+description: |
+    Set the `animated` property to `false` if you want to hide the menu popup without an animation.
+properties:
+  - name: animated
+    summary: Determines whether the menu popup should be opened or closed animated.
+    type: Boolean
+    default: true
+    optional: true

--- a/apidoc/Titanium/UI/iOS/PreviewContext.yml
+++ b/apidoc/Titanium/UI/iOS/PreviewContext.yml
@@ -51,7 +51,7 @@ events:
     summary: Fired when the user peeks the preview. You can configure the preview
     description: |
         You can configure the preview in this event before it is displayed. If the preview context is assigned to a 
-        normal view like a <Ti.UI.Button> the `preview` property can be received here to change the content of it 
+        normal view like a <Titanium.UI.Button> the `preview` property can be received here to change the content of it 
         before displaying. If the preview context is assigned to a <Titanium.UI.ListView>, you can also receive the 
         properties `sectionIndex`, `itemIndex` and `itemId` here to access item-specific data to display. 
         
@@ -83,7 +83,7 @@ events:
     summary: Fired when the user pop the preview. You will most likely open a fullscreen window here.
     description: |
         You can open a window here or update your current UI. If the preview context is assigned to a 
-        normal view like a <Ti.UI.Button> the `preview` property can be received here to change the content of it 
+        normal view like a <Titanium.UI.Button> the `preview` property can be received here to change the content of it 
         before displaying. If the preview context is assigned to a <Titanium.UI.ListView>, you can also receive the 
         properties `sectionIndex`, `itemIndex` and `itemId` here to access item-specific data to display. 
         

--- a/apidoc/Titanium/UI/iPhone/AnimationStyle.yml
+++ b/apidoc/Titanium/UI/iPhone/AnimationStyle.yml
@@ -25,7 +25,7 @@ properties:
     permission: read-only
     deprecated:
         since: "5.4.0"
-        notes: Use [Titanium.UI.iOS.AnimationStyle.CURL_DOWN](Titanium.UI.iOS.AnimationStyle.CURL_DOWN) instead.
+        notes: Use [Ti.UI.iOS.AnimationStyle.CURL_DOWN](Titanium.UI.iOS.AnimationStyle.CURL_DOWN) instead.
 
   - name: CURL_UP
     summary: Curl upwards during a transition animation.
@@ -42,7 +42,7 @@ properties:
     permission: read-only
     deprecated:
         since: "5.4.0"
-        notes: Use [Titanium.UI.iOS.AnimationStyle.CURL_UP](Titanium.UI.iOS.AnimationStyle.CURL_UP) instead
+        notes: Use [Ti.UI.iOS.AnimationStyle.CURL_UP](Titanium.UI.iOS.AnimationStyle.CURL_UP) instead
 
   - name: FLIP_FROM_LEFT
     summary: Flip from left to right during a transition animation.
@@ -59,7 +59,7 @@ properties:
     permission: read-only
     deprecated:
         since: "5.4.0"
-        notes: Use [Titanium.UI.iOS.AnimationStyle.FLIP_FROM_LEFT] (Titanium.UI.iOS.AnimationStyle.FLIP_FROM_LEFT) instead
+        notes: Use [Ti.UI.iOS.AnimationStyle.FLIP_FROM_LEFT] (Titanium.UI.iOS.AnimationStyle.FLIP_FROM_LEFT) instead
 
   - name: FLIP_FROM_RIGHT
     summary: Flip from right to left during a transition animation.
@@ -76,7 +76,7 @@ properties:
     permission: read-only
     deprecated:
         since: "5.4.0"
-        notes: Use [Titanium.UI.iOS.AnimationStyle.FLIP_FROM_RIGHT] (Titanium.UI.iOS.AnimationStyle.FLIP_FROM_RIGHT) instead
+        notes: Use [Ti.UI.iOS.AnimationStyle.FLIP_FROM_RIGHT] (Titanium.UI.iOS.AnimationStyle.FLIP_FROM_RIGHT) instead
 
   - name: NONE
     summary: No animation.
@@ -93,4 +93,4 @@ properties:
     permission: read-only
     deprecated:
         since: "5.4.0"
-        notes: Use [Titanium.UI.iOS.AnimationStyle.NONE](Titanium.UI.iOS.AnimationStyle.NONE) instead
+        notes: Use [Ti.UI.iOS.AnimationStyle.NONE](Titanium.UI.iOS.AnimationStyle.NONE) instead

--- a/apidoc/Titanium/UI/iPhone/iPhone.yml
+++ b/apidoc/Titanium/UI/iPhone/iPhone.yml
@@ -181,7 +181,7 @@ properties:
     type: Number
     deprecated:
         since: "5.4.0"
-        notes: Use [Ti.UI.iOS.appBadge](Ti.UI.iOS.appBadge) instead.
+        notes: Use [Ti.UI.iOS.appBadge](Titanium.UI.iOS.appBadge) instead.
 
   - name: appSupportsShakeToEdit
     summary: Determines whether the shake to edit system-wide capability is enabled.
@@ -199,7 +199,7 @@ properties:
     permission: read-only
     deprecated:
         since: "3.1.3"
-        notes: Use [Titanium.UI.windows.fullscreen](Titanium.UI.windows.fullscreen) instead.
+        notes: Use [Ti.UI.Window.fullscreen](Titanium.UI.Window.fullscreen) instead.
         removed: "6.0.0"
 
   - name: statusBarStyle


### PR DESCRIPTION
This PR fixes 26 docs validation errors occurring after the abstract params have been moved to properties. The problem they didn't work before was, that every abstract param need `---` before, not only once per section.

Also adds the missing docs for the Ti.UI.ListView `insert` event and resolves all compiler warnings when using the docgen script and therefore also fixes all API deadlinks.

Validated everything again and it seems to work fine now. @jawa9000 Please confirm by generating the docs, thanks!
