### PR TITLE
[TIMOB-23141] iOS: Fix Ti.Filesystem.File.remoteBackup

### DIFF
--- a/iphone/Classes/TiFilesystemFileProxy.h
+++ b/iphone/Classes/TiFilesystemFileProxy.h
@@ -30,9 +30,6 @@
 @property(nonatomic,readonly) id executable;
 @property(nonatomic,readonly) id hidden;
 
-@property(nonatomic,readwrite,assign) NSNumber* remoteBackup;
-
-
 @end
 
 #endif

--- a/iphone/Classes/TiFilesystemFileProxy.m
+++ b/iphone/Classes/TiFilesystemFileProxy.m
@@ -17,8 +17,6 @@
 #define FILE_TOSTR(x) \
 	([x isKindOfClass:[TiFilesystemFileProxy class]]) ? [(TiFilesystemFileProxy*)x nativePath] : [TiUtils stringValue:x]
 
-static const char* backupAttr = "com.apple.MobileBackup";
-
 @implementation TiFilesystemFileProxy
 
 -(id)initWithFile:(NSString*)path_
@@ -492,19 +490,19 @@ FILENOOP(setHidden:(id)x);
 
 -(NSNumber*)remoteBackup
 {
-    NSURL *URL= [NSURL fileURLWithPath: [self path]];
+    NSURL *URL = [NSURL fileURLWithPath: [self path]];
     NSError *error;
-    NSNumber *result = nil;
+    NSNumber *isExcluced;
    
-    BOOL success = [URL getResourceValue:&result
+    BOOL success = [URL getResourceValue:&isExcluced
                                   forKey:NSURLIsExcludedFromBackupKey error:&error];
     if (!success) {
         // Doesn't matter what error is set to; this means that we're backing up.
         return NUMBOOL(YES);
     }
 
-    // A value of 0 means backup, so:
-    return NUMBOOL([result isEqualToNumber:@YES] ? NO : YES);
+    // A value of @FALSE means backup, so:
+    return NUMBOOL([isExcluced isEqualToNumber:@YES] ? NO : YES);
 }
 
 -(void)setRemoteBackup:(id)value
@@ -515,8 +513,8 @@ FILENOOP(setHidden:(id)x);
     NSURL *URL= [NSURL fileURLWithPath: [self path]];
     NSError *error;
     
-    BOOL success = [URL setResourceValue: NUMBOOL(isExcluced)
-                                  forKey: NSURLIsExcludedFromBackupKey error: &error];
+    BOOL success = [URL setResourceValue:NUMBOOL(isExcluced)
+                                  forKey:NSURLIsExcludedFromBackupKey error:&error];
     if (!success) {
         [self throwException:@"Error setting remote backup flag:"
                    subreason:[error localizedDescription]

--- a/iphone/Classes/TiFilesystemFileProxy.m
+++ b/iphone/Classes/TiFilesystemFileProxy.m
@@ -492,33 +492,35 @@ FILENOOP(setHidden:(id)x);
 
 -(NSNumber*)remoteBackup
 {
-    u_int8_t value;
-    const char* fullPath = [[self path] fileSystemRepresentation];
-    
-    ssize_t result = getxattr(fullPath, backupAttr, &value, sizeof(value), 0, 0);
-    if (result == -1) {
-        // Doesn't matter what errno is set to; this means that we're backing up.
-        return [NSNumber numberWithBool:YES];
+    NSURL *URL= [NSURL fileURLWithPath: [self path]];
+    NSError *error;
+    NSNumber *result = nil;
+   
+    BOOL success = [URL getResourceValue:&result
+                                  forKey:NSURLIsExcludedFromBackupKey error:&error];
+    if (!success) {
+        // Doesn't matter what error is set to; this means that we're backing up.
+        return NUMBOOL(YES);
     }
 
     // A value of 0 means backup, so:
-    return [NSNumber numberWithBool:!value];
+    return NUMBOOL([result isEqualToNumber:@YES] ? NO : YES);
 }
 
--(void)setRemoteBackup:(NSNumber *)remoteBackup
+-(void)setRemoteBackup:(id)value
 {
-    // Value of 1 means nobackup
-    u_int8_t value = ![TiUtils boolValue:remoteBackup def:YES];
-    const char* fullPath = [[self path] fileSystemRepresentation];
+    ENSURE_TYPE(value, NSNumber);
     
-    int result = setxattr(fullPath, backupAttr, &value, sizeof(value), 0, 0);
-    if (result != 0) {
-        // Throw an exception with the errno
-        char* errmsg = strerror(errno);
-        [self throwException:@"Error setting remote backup flag:" 
-                   subreason:[NSString stringWithUTF8String:errmsg] 
+    BOOL isExcluced = ![TiUtils boolValue:value def:YES];
+    NSURL *URL= [NSURL fileURLWithPath: [self path]];
+    NSError *error;
+    
+    BOOL success = [URL setResourceValue: NUMBOOL(isExcluced)
+                                  forKey: NSURLIsExcludedFromBackupKey error: &error];
+    if (!success) {
+        [self throwException:@"Error setting remote backup flag:"
+                   subreason:[error localizedDescription]
                     location:CODELOCATION];
-        return;
     }
 }
 

--- a/iphone/Classes/TiFilesystemFileProxy.m
+++ b/iphone/Classes/TiFilesystemFileProxy.m
@@ -492,9 +492,9 @@ FILENOOP(setHidden:(id)x);
 {
     NSURL *URL = [NSURL fileURLWithPath: [self path]];
     NSError *error;
-    NSNumber *isExcluced;
+    NSNumber *isExcluded;
    
-    BOOL success = [URL getResourceValue:&isExcluced
+    BOOL success = [URL getResourceValue:&isExcluded
                                   forKey:NSURLIsExcludedFromBackupKey error:&error];
     if (!success) {
         // Doesn't matter what error is set to; this means that we're backing up.
@@ -502,18 +502,18 @@ FILENOOP(setHidden:(id)x);
     }
 
     // A value of @FALSE means backup, so:
-    return NUMBOOL([isExcluced isEqualToNumber:@YES] ? NO : YES);
+    return NUMBOOL([isExcluded isEqualToNumber:@YES] ? NO : YES);
 }
 
 -(void)setRemoteBackup:(id)value
 {
     ENSURE_TYPE(value, NSNumber);
     
-    BOOL isExcluced = ![TiUtils boolValue:value def:YES];
+    BOOL isExcluded = ![TiUtils boolValue:value def:YES];
     NSURL *URL= [NSURL fileURLWithPath: [self path]];
     NSError *error;
     
-    BOOL success = [URL setResourceValue:NUMBOOL(isExcluced)
+    BOOL success = [URL setResourceValue:NUMBOOL(isExcluded)
                                   forKey:NSURLIsExcludedFromBackupKey error:&error];
     if (!success) {
         [self throwException:@"Error setting remote backup flag:"


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-23141

The initial implementation is outdated and was replaced by a cleaner API in iOS 5.1.
