### PR TITLE
[TIMOB-19910] Android: openPhotoGallery fails when remote image selected

### DIFF
--- a/android/modules/media/src/java/ti/modules/titanium/media/MediaModule.java
+++ b/android/modules/media/src/java/ti/modules/titanium/media/MediaModule.java
@@ -9,7 +9,9 @@ package ti.modules.titanium.media;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.File;
+import java.io.FileDescriptor;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.HashMap;
@@ -53,6 +55,7 @@ import android.os.Build;
 import android.os.Environment;
 import android.os.Handler;
 import android.os.Message;
+import android.os.ParcelFileDescriptor;
 import android.os.Vibrator;
 import android.provider.MediaStore;
 import android.view.Window;
@@ -910,8 +913,30 @@ public class MediaModule extends KrollModule
 
 	protected static KrollDict createDictForImage(String path, String mimeType) {
 		String[] parts = { path };
-		TiBlob imageData = TiBlob.blobFromFile(TiFileFactory.createTitaniumFile(parts, false), mimeType);
+		TiBlob imageData;
+		// Workaround for TIMOB-19910. Image is in the Google Photos cloud and not on device.
+		if (path.startsWith("content://com.google.android.apps.photos.contentprovider")) {
+		    ParcelFileDescriptor parcelFileDescriptor;
+		    Bitmap image;
+		    try {
+		        parcelFileDescriptor = TiApplication.getInstance().getContentResolver().openFileDescriptor(Uri.parse(path), "r");
+		        FileDescriptor fileDescriptor = parcelFileDescriptor.getFileDescriptor();
+		        image = BitmapFactory.decodeFileDescriptor(fileDescriptor);
+		        parcelFileDescriptor.close();
+		        imageData = TiBlob.blobFromImage(image);
+		    } catch (FileNotFoundException e) {
+		        imageData = createImageData(parts, mimeType);
+		    } catch (IOException e) {
+		        imageData = createImageData(parts, mimeType);
+		    }
+		} else {
+		    imageData = createImageData(parts, mimeType);
+		}
 		return createDictForImage(imageData, mimeType);
+	}
+
+	public static TiBlob createImageData(String[] parts, String mimeType){
+	    return TiBlob.blobFromFile(TiFileFactory.createTitaniumFile(parts, false), mimeType);
 	}
 
 	protected static KrollDict createDictForImage(TiBlob imageData, String mimeType) {


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-19910

To test, the Android device must be using the app "Google Photos" and you need photos that are in the cloud and not in the device. Run the code and select the photo that is in the cloud when testing.

Test code:

``` javascript
var win = Ti.UI.createWindow({
    backgroundColor : 'black',
    layout : 'vertical'
});

function selectPhoto(){
  Titanium.Media.openPhotoGallery({   
    success:function(e){
        console.log(e.media);
        var image = Ti.UI.createImageView({
          image: e.media
        });
        win.add(image);
    },
    allowEditing:true,
    mediaTypes: [Ti.Media.MEDIA_TYPE_PHOTO]
  });
};

var button = Titanium.UI.createButton({
   title: 'Hello',
   top: 10,
   width: 100,
   height: 50
});
button.addEventListener('click',function(e)
{
   selectPhoto();
});
win.add(button);

win.open(); 
```
