### PR TITLE
[TIMOB-19673] Update windowslib to 0.4.5

### DIFF
--- a/node_modules/windowslib/lib/visualstudio.js
+++ b/node_modules/windowslib/lib/visualstudio.js
@@ -156,8 +156,9 @@ function detect(options, callback) {
 						appc.subprocess.getRealName(info.vcvarsall, function (err, vcvarsall) {
 							if (!err) {
 								info.vcvarsall = vcvarsall;
-								// vcvarsall may contain space
-								vcvarsall = vcvarsall.replace(/\ /g, '^ ');
+								
+								// escape any spaces or brackets
+								vcvarsall = vcvarsall.replace(/(\(|\)|\s)/g, '^$1');
 
 								// now that we have vcvarsall, get the msbuild version
 								appc.subprocess.run('cmd', [ '/C', vcvarsall + ' && MSBuild /version' ], function (code, out, err) {

--- a/node_modules/windowslib/package.json
+++ b/node_modules/windowslib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "windowslib",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Windows Phone Utility Library",
   "keywords": [
     "appcelerator",


### PR DESCRIPTION
- Update `windowslib` to `0.4.5`
  - [TIMOB-19673] Fix unescaped characters in vcvarsall - https://github.com/appcelerator/windowslib/pull/35

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-19673)
