### PR TITLE
[TIMOB-23150] iOS: EventListener issues in ScrollableView for IOS.

### DIFF
--- a/iphone/Classes/TiUIScrollableViewProxy.m
+++ b/iphone/Classes/TiUIScrollableViewProxy.m
@@ -73,9 +73,6 @@
 
 -(void)setViews:(id)args
 {
-#if defined(TI_USE_AUTOLAYOUT) || defined(TI_USE_KROLL_THREAD)
-	ENSURE_UI_THREAD(setViews, args)
-#endif
 	ENSURE_ARRAY(args);
 	for (id newViewProxy in args)
 	{
@@ -88,7 +85,9 @@
 #ifdef TI_USE_AUTOLAYOUT
 		[self makeViewPerformSelector:@selector(removeSubview:) withObject:[oldViewProxy view] createIfNeeded:NO waitUntilDone:NO];
 #else
-		[[oldViewProxy view] removeFromSuperview];
+		TiThreadPerformOnMainThread(^{
+		  [[oldViewProxy view] removeFromSuperview];
+		}, NO);
 #endif
 		if (![args containsObject:oldViewProxy])
 		{


### PR DESCRIPTION
[JIRA](https://jira.appcelerator.org/browse/TIMOB-23150?filter=-1)

Fixed issue with JS object  being garbage collected causing the views to have no bridge with the objective-C objects.
