### PR TITLE
[TIMOB-23172] Require min-ios-ver to be 8 for storyboard launch file

### DIFF
--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -1689,6 +1689,8 @@ iOSBuilder.prototype.validate = function (logger, config, cli) {
 						minVer = '9.0';
 					} else if (this.hasWatchAppV1 && appc.version.lt(minVer, '8.4')) {
 						minVer = '8.4';
+					} else if (this.tiapp.ios['enable-launch-screen-storyboard'] && appc.version.lt(minVer, '8.0')) {
+						minVer = '8.0';
 					}
 
 					var xcodeInfo = this.iosInfo.xcode;


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-23172

Backport of #7925
