### PR TITLE
[TIMOB-23175] Android: Replaced condition for build tools to accept 23.x

### DIFF
--- a/android/package.json
+++ b/android/package.json
@@ -17,7 +17,7 @@
 	"minSDKVersion": "14",
 	"vendorDependencies": {
 		"android sdk": "23",
-		"android build tools": ">=17 <23.x",
+		"android build tools": ">=17 <=23.x",
 		"android platform tools": ">=17 <=23.x",
 		"android tools": "<=24.3.x",
 		"android ndk": ">=r8e <=r9",


### PR DESCRIPTION
https://jira.appcelerator.org/browse/TIMOB-23175

Warning "Android Build Tools X are too new" should not replace < with <=
