### PR TITLE
[TIMOB-23191] iOS: Fix non-string PickerRow titles

### DIFF
--- a/iphone/Classes/TiUIPickerRowProxy.m
+++ b/iphone/Classes/TiUIPickerRowProxy.m
@@ -30,7 +30,7 @@
     //Downside -> No touch events from pickerrow or its children
     //Upside -> It works and is performant. Accessibility is configured on the delegate
     
-    NSString *title = [self valueForKey:@"title"];
+    NSString *title = [TiUtils stringValue:[self valueForKey:@"title"]];
     WebFont *pickerFont = [TiUtils fontValue:[self valueForKey:@"font"] def:[WebFont defaultFont]];
     if (title!=nil) {
         UILabel *pickerLabel = nil;


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-23191
![simulator screen shot 12 04 2016 00 42 49](https://cloud.githubusercontent.com/assets/10667698/14444714/9fb78cba-0047-11e6-9a55-ca6ce9e541e7.png)
