### PR TITLE
[TIMOB-23181, TIMOB-19673] Bump windowslib to 0.4.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "temp": "0.8.3",
     "uglify-js": "2.6.1",
     "unorm": "^1.4.1",
-    "windowslib": "0.4.4",
+    "windowslib": "0.4.6",
     "wrench": "1.5.8",
     "xcode": "0.8.3",
     "xmldom": "0.1.22",


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-23181
- TIMOB-23181 Install of app to Windows 10 Mobile device fails on second build of application 
- TIMOB-19673 windowslib: visualstudio.detect failed for VS 2015
