### PR TITLE
[TIMOB-23186] Android: Webview has blacklistedURLs property implemented

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/WebViewProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/WebViewProxy.java
@@ -29,6 +29,7 @@ import android.os.Message;
 import android.webkit.WebView;
 
 @Kroll.proxy(creatableInModule=UIModule.class, propertyAccessors = {
+	TiC.PROPERTY_BLACKLISTED_URLS,
 	TiC.PROPERTY_DATA,
 	TiC.PROPERTY_ON_CREATE_WINDOW,
 	TiC.PROPERTY_SCALES_PAGE_TO_FIT,

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiWebViewClient.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiWebViewClient.java
@@ -101,6 +101,15 @@ public class TiWebViewClient extends WebViewClient
 	{
 		Log.d(TAG, "url=" + url, Log.DEBUG_MODE);
 
+		if (webView.getProxy().hasProperty(TiC.PROPERTY_BLACKLISTED_URLS)) {
+		    String [] blacklistedSites = TiConvert.toStringArray((Object[])webView.getProxy().getProperty(TiC.PROPERTY_BLACKLISTED_URLS));
+		    for(String site : blacklistedSites) {
+		        if (url.equalsIgnoreCase(site) || (url.indexOf(site) > -1)) {
+		            return true;
+		        }
+		    }
+		}
+
 		if (URLUtil.isAssetUrl(url) || URLUtil.isContentUrl(url) || URLUtil.isFileUrl(url)) {
 			// go through the proxy to ensure we're on the UI thread
 			webView.getProxy().setPropertyAndFire(TiC.PROPERTY_URL, url);

--- a/android/titanium/src/java/org/appcelerator/titanium/TiC.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiC.java
@@ -904,6 +904,11 @@ public class TiC
 	/**
 	 * @module.api
 	 */
+	public static final String PROPERTY_BLACKLISTED_URLS = "blacklistedURLs";
+
+	/**
+	 * @module.api
+	 */
 	public static final String PROPERTY_BORDER_COLOR = "borderColor";
 
 	/**

--- a/apidoc/Titanium/UI/WebView.yml
+++ b/apidoc/Titanium/UI/WebView.yml
@@ -290,6 +290,16 @@ methods:
         summary: Forces the web view to destroy the iFrame (Mobile Web only).
         type: Boolean
 
+- name: blacklistedURLs
+    summary: |
+        An array of url strings to blacklist.
+    description: |
+        An array of url strings to blacklist. This will stop the webview from going to urls listed in
+        the blacklist.
+    type: Array<String>
+    since: "5.4.0"
+    platforms: [android]
+
 
 events:
 

--- a/apidoc/Titanium/UI/WebView.yml
+++ b/apidoc/Titanium/UI/WebView.yml
@@ -299,6 +299,7 @@ methods:
     type: Array<String>
     since: "5.4.0"
     platforms: [android]
+    availability: creation
 
 
 events:


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-23186

To test, scroll down to the bottom of the webview and press `Terms of Use` and `Privacy Policy` links.
Note that `Ti.API.info("load = e.url=" + e.url);` is not called for both of the links. 

Test code:

``` javascript
var win = Ti.UI.createWindow({
    backgroundColor : 'black',
    layout : 'vertical'
});

var webview = Titanium.UI.createWebView({
    blacklistedURLs : [ 'https://m.wikimediafoundation.org/wiki/Terms_of_Use' , 'https://wikimediafoundation.org/wiki/Privacy_policy' ],
    url : 'https://en.m.wikipedia.org/wiki/Main_Page'
});

webview.addEventListener('load', function(e) {
        // This should not be called for blacklistedUrls
    Ti.API.info("load = e.url=" + e.url);
});

win.add(webview);
win.open();
```
