### PR TITLE
[TIMOB-6412] Android: rgba() fixes and addition for floats

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiColorHelper.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiColorHelper.java
@@ -26,6 +26,7 @@ public class TiColorHelper
 	static Pattern rgbPattern = Pattern.compile("rgb\\(\\s*([0-9]{1,3})\\s*,\\s*([0-9]{1,3})\\s*,\\s*([0-9]{1,3})\\s*\\)");
 	static Pattern argbPattern = Pattern.compile("rgba\\(\\s*([0-9]{1,3})\\s*,\\s*([0-9]{1,3})\\s*,\\s*([0-9]{1,3})\\s*,\\s*([0-9]{1,3}[^\\.\\)])\\s*\\)");
 	static Pattern rgbaPattern = Pattern.compile("rgba\\(\\s*([0-9]{1,3})\\s*,\\s*([0-9]{1,3})\\s*,\\s*([0-9]{1,3})\\s*,\\s*(\\d\\.\\d)\\s*\\)");
+	static Pattern floatsPattern = Pattern.compile("rgba\\(\\s*(\\d\\.\\d)\\s*,\\s*(\\d\\.\\d)\\s*,\\s*(\\d\\.\\d)\\s*,\\s*(\\d\\.\\d)\\s*\\)");
 
 	private static final String TAG = "TiColorHelper";
 	private static HashMap<String, Integer> colorTable;
@@ -71,6 +72,13 @@ public class TiColorHelper
 			            Integer.valueOf(m.group(1)),
 			            Integer.valueOf(m.group(2)),
 			            Integer.valueOf(m.group(3))
+			            );
+			} else if ((m = floatsPattern.matcher(lowval)).matches()) {
+			    color = Color.argb(
+			            Math.round(Float.valueOf(m.group(4))*255f),
+			            Math.round(Float.valueOf(m.group(1))*255f),
+			            Math.round(Float.valueOf(m.group(2))*255f),
+			            Math.round(Float.valueOf(m.group(3))*255f)
 			            );
 			} else {
 				// Try the parser, will throw illegalArgument if it can't parse it.

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiColorHelper.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiColorHelper.java
@@ -23,8 +23,9 @@ import android.os.Build;
 public class TiColorHelper
 {
 	static Pattern shortHexPattern = Pattern.compile("#([0-9a-f])([0-9a-f])([0-9a-f])([0-9a-f]?)");
-	static Pattern rgbPattern = Pattern.compile("rgb\\(([0-9]{1,3}),([0-9]{1,3}),([0-9]{1,3})\\)");
-	static Pattern argbPattern = Pattern.compile("rgba\\(([0-9]{1,3}),([0-9]{1,3}),([0-9]{1,3}),([0-9]{1,3})\\)");
+	static Pattern rgbPattern = Pattern.compile("rgb\\(\\s*([0-9]{1,3})\\s*,\\s*([0-9]{1,3})\\s*,\\s*([0-9]{1,3})\\s*\\)");
+	static Pattern argbPattern = Pattern.compile("rgba\\(\\s*([0-9]{1,3})\\s*,\\s*([0-9]{1,3})\\s*,\\s*([0-9]{1,3})\\s*,\\s*([0-9]{1,3}[^\\.\\)])\\s*\\)");
+	static Pattern rgbaPattern = Pattern.compile("rgba\\(\\s*([0-9]{1,3})\\s*,\\s*([0-9]{1,3})\\s*,\\s*([0-9]{1,3})\\s*,\\s*(\\d\\.\\d)\\s*\\)");
 
 	private static final String TAG = "TiColorHelper";
 	private static HashMap<String, Integer> colorTable;
@@ -64,6 +65,13 @@ public class TiColorHelper
 						Integer.valueOf(m.group(2)),
 						Integer.valueOf(m.group(3))
 						);
+			} else if ((m = rgbaPattern.matcher(lowval)).matches()) {
+			    color = Color.argb(
+			            Math.round(Float.valueOf(m.group(4))*255f),
+			            Integer.valueOf(m.group(1)),
+			            Integer.valueOf(m.group(2)),
+			            Integer.valueOf(m.group(3))
+			            );
 			} else {
 				// Try the parser, will throw illegalArgument if it can't parse it.
 				try {


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-6412
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-18821

Allows spaces between values and float values

working TSS values:

```
"#view1":{backgroundColor: "#f00"}
"#view2":{backgroundColor: "rgb(0,    255,    0)"}
"#view3":{backgroundColor: "rgba(0, 0 ,255, 128)"}
"#view4":{backgroundColor: "rgba(0,0 ,255 , 0.3 )"}
"#view5":{backgroundColor: "rgba(0,235,255,128)"}
"#view6":{backgroundColor: "rgba(0.4,0.4,0.4,0.4)"}
```

![Image of Yaktocat](http://migaweb.de/rgba.png)
