### PR TITLE
[TIMOB-23281] iOS: Set BackgroundColor to the search result list view

### DIFF
--- a/iphone/Classes/TiUIListView.m
+++ b/iphone/Classes/TiUIListView.m
@@ -1936,6 +1936,16 @@ static TiViewProxy * FindViewProxyWithBindIdContainingPoint(UIView *view, CGPoin
     [searchButton setTitle:[TiUtils stringValue:searchButtonTitle]];
 }
 
+- (BOOL) searchDisplayController:(UISearchDisplayController *)controller shouldReloadTableForSearchString:(NSString *)searchString
+{
+    TiColor *resultBgColor = [TiUtils colorValue:[self.proxy valueForKey:@"searchResultBackgroundColor"]];
+    
+    resultBgColor? [[self class] setBackgroundColor:resultBgColor onTable:controller.searchResultsTableView]: [[self class] setBackgroundColorWithUIColor:_tableView.backgroundColor onTable:controller.searchResultsTableView];
+    [controller.searchResultsTableView setSeparatorColor:[[TiUtils colorValue:[self.proxy valueForKey:@"searchResultSeparatorColor"]] _color]?:_tableView.separatorColor];
+    
+    return YES;
+}
+
 - (void)searchDisplayControllerDidEndSearch:(UISearchDisplayController *)controller
 {
     self.searchString = @"";
@@ -2129,9 +2139,13 @@ static TiViewProxy * FindViewProxyWithBindIdContainingPoint(UIView *view, CGPoin
 
 + (void)setBackgroundColor:(TiColor*)color onTable:(UITableView*)table
 {
+    [self setBackgroundColorWithUIColor:[color _color] onTable:table];
+}
+
++ (void)setBackgroundColorWithUIColor:(UIColor*)bgColor onTable:(UITableView*)table
+{
 	UIColor* defaultColor = [table style] == UITableViewStylePlain ? [UIColor whiteColor] : [UIColor groupTableViewBackgroundColor];
-	UIColor* bgColor = [color _color];
-	
+
 	// WORKAROUND FOR APPLE BUG: 4.2 and lower don't like setting background color for grouped table views on iPad.
 	// So, we check the table style and device, and if they match up wrong, we replace the background view with our own.
 	if (([table style] == UITableViewStyleGrouped) && [TiUtils isIPad]) {


### PR DESCRIPTION
JIRA: https://jira.appcelerator.org/browse/TIMOB-23281

Optional Description:

Fix bug : 
When the search result tableview appears, it has a white background by default. Now the search result table view has the same color of his tableview by default.

Add two properties :
-searchResultBackgroundColor To set the backgroundColor of the search result.
-searchResultSeparatorColor To set the separatorColor of the search result.
