### PR TITLE
TIMOB-20469 fix to allow us to hook into the toolchain compile before/after

### DIFF
--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -1653,8 +1653,18 @@ AndroidBuilder.prototype.run = function run(logger, config, cli, finished) {
 		'generateAndroidManifest',
 		'packageApp',
 
+		// provide a hook event before javac
+		function (next) {
+			cli.emit('build.pre.build', this, next);
+		},
+
 		// we only need to compile java classes if any files in src or gen changed
 		'compileJavaClasses',
+
+		// provide a hook event after javac
+		function (next) {
+			cli.emit('build.post.build', this, next);
+		},
 
 		// we only need to run proguard if any java classes have changed
 		'runProguard',

--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -1986,8 +1986,18 @@ iOSBuilder.prototype.run = function (logger, config, cli, finished) {
 		'removeFiles',
 		'optimizeFiles',
 
+		// provide a hook event before xcodebuild
+		function (next) {
+			cli.emit('build.pre.build', this, next);
+		},
+
 		// build baby, build
 		'invokeXcodeBuild',
+
+		// provide a hook event after xcodebuild
+		function (next) {
+			cli.emit('build.post.build', this, next);
+		},
 
 		// finalize
 		'writeBuildManifest',


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-20469

**Optional Description:**

This change adds 2 new hook events that are emitted just before and after the native toolchain build which is required for hyperloop to intercept the build in the right location.
