### PR TITLE
[TIMOB-23341] Exception on iPhone: no row found for index. 

### DIFF
--- a/iphone/Classes/TiUITableViewProxy.m
+++ b/iphone/Classes/TiUITableViewProxy.m
@@ -502,6 +502,11 @@ USE_VIEW_FOR_CONTENT_HEIGHT
 {
 //	ENSURE_UI_THREAD(insertRowBefore,args);
 	
+	if (![NSThread isMainThread]) {
+        TiThreadPerformOnMainThread(^{[self insertRowBefore:args];},YES); // YES = wait for the operation to complete on the main thread !!!
+        return;
+}
+	
 	int index = [TiUtils intValue:[args objectAtIndex:0]];
 	NSDictionary *data = [args objectAtIndex:1];
 	NSDictionary *anim = [args count] > 2 ? [args objectAtIndex:2] : nil;
@@ -579,6 +584,11 @@ USE_VIEW_FOR_CONTENT_HEIGHT
 -(void)insertRowAfter:(id)args
 {
 //	ENSURE_UI_THREAD(insertRowAfter,args);
+	
+		if (![NSThread isMainThread]) {
+        TiThreadPerformOnMainThread(^{[self insertRowAfter:args];},YES); // YES = wait for the operation to complete on the main thread !!!
+        return;
+}
 	
 	int index = [TiUtils intValue:[args objectAtIndex:0]];
 	NSDictionary *data = [args objectAtIndex:1];


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-23341

Fix the bug : insert in the insertRowBefore and insertRowAfter

``` objc
if (![NSThread isMainThread]) {
        TiThreadPerformOnMainThread(^{[self insertRowBefore:args];},YES); // YES = wait for the operation to complete on the main thread !!!
        return;
}
```

Explaination : 
'The problem here is actually very simple, but it took me few hours to find this out. JS engine itself runs in async context, which means that if one is inserting multiple rows in JavaScript (e.g. in a loop) using insertRowBefore then the obj-c code behind this does the work in async (non-UI) thread. I think the reason the ENSURE_UI_THREAD(insertRowBefore,args); line was commented is becase the actual action happens in UI thread anyway - see how [table dispatchAction:action] works (TiUITableViewProxy.m around line 535).

The code that checks the row indexes and verifies against existing list still runs asynchronously and thus if you run inserting rows in loop this can have unpredictable results because the list might not yet be updated, etc.. So the solution here is to synchronize the insertion and wait for it’s completion. Finally the commented code mentioned by Dave Cadwallader should be replaced with this:'

From https://archive.appcelerator.com/question/129708/obj-c-fix-for-error-on-tableview-insertrowbefore--insertrowafter
