### PR TITLE
[TIMOB-23339] Fixed Android http client setting content type on all http verbs

### DIFF
--- a/android/modules/network/src/java/ti/modules/titanium/network/TiHTTPClient.java
+++ b/android/modules/network/src/java/ti/modules/titanium/network/TiHTTPClient.java
@@ -1147,7 +1147,7 @@ public class TiHTTPClient
 					if (parts.size() > 0 && needMultipart) {
 						boundary = HttpUrlConnectionUtils.generateBoundary();
 						client.setRequestProperty("Content-Type", "multipart/form-data; boundary=" + boundary);
-					} else {
+					} else if (isPostOrPutOrPatch) {
 						client.setRequestProperty("Content-Type","application/x-www-form-urlencoded");
 					}
 


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-23339

This is a bug found when attempting to connect to a backend running Hunchentoot (Clisp web server), and the CLisp web framework Lucerne.
Most other application servers I have experience with wouldn't mind, but this server expects to parse a request body when the Content Type is set. The Android http client, contrary to the iOS one, sets the content type not only on Post/Put/Patch as per the documentation, but actually on all http verbs (GET and DELETE too, which is contrary to the RFC, as far as I know)
