### PR TITLE
[TIMOB-20483] Android: fix file upload progress by adding setChunkedStreamingMode

### DIFF
--- a/android/modules/network/src/java/ti/modules/titanium/network/TiHTTPClient.java
+++ b/android/modules/network/src/java/ti/modules/titanium/network/TiHTTPClient.java
@@ -1138,6 +1138,7 @@ public class TiHTTPClient
 					client.setDoInput(true);
 					if (isPostOrPutOrPatch) {
 						client.setDoOutput(true);
+						client.setRequestProperty("Transfer-Encoding", "chunked");
 						client.setChunkedStreamingMode(1024);
 					}
 					client.setUseCaches(false);

--- a/android/modules/network/src/java/ti/modules/titanium/network/TiHTTPClient.java
+++ b/android/modules/network/src/java/ti/modules/titanium/network/TiHTTPClient.java
@@ -1138,6 +1138,7 @@ public class TiHTTPClient
 					client.setDoInput(true);
 					if (isPostOrPutOrPatch) {
 						client.setDoOutput(true);
+						client.setChunkedStreamingMode(1024);
 					}
 					client.setUseCaches(false);
 					// This is to set gzip default to disable


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-20483

**Problem**
When upload bigger files the progress is faster then the real upload (see JIRA for full description)

**Solution:**
Android dev guide (https://developer.android.com/reference/java/net/HttpURLConnection.html) recommends the following:

```
For best performance, you should call either setFixedLengthStreamingMode(int) when the body length is known in advance, or setChunkedStreamingMode(int) when it is not. Otherwise HttpURLConnection will be forced to buffer the complete request body in memory before it is transmitted, wasting (and possibly exhausting) heap and increasing latency. 
```

adding setChunkedStreamingMode(1024) fixed the problem. 1024 (1kb) is recommended in different stackoverflow postings as a good default value.
