### PR TITLE
[TIMOB-23406] Adding 'scrolling' event to ListView to track scrolling…

### DIFF
--- a/apidoc/Titanium/UI/ListView.yml
+++ b/apidoc/Titanium/UI/ListView.yml
@@ -598,29 +598,30 @@ events:
         summary: false. This event does not bubble.
         type: Boolean
 
-    - name: scrolling
-	    summary: Fires when the list view is scrolling. Calling the `scrollTo` methods will not fire this event
-	    description: |
-	        This event will fire when the list view is scrolling. Use  `direction` to determine the scroll direction, 
-	         `velocity` to determine scroll speed, targetContentOffset to determine where the scrolling will end (in dpi)
-	    platforms: [iphone, ipad]
-	    since: 5.4.0
-	    properties: 
-	      - name: direction
-	        summary: Direction of the scroll--either 'up', or 'down'.
-	        type: String
+  - name: scrolling
+    summary: Fires when the list view is scrolling. Calling the `scrollTo` methods will not fire this event
+    description: |
+        This event will fire when the list view is scrolling. Use  `direction` to determine the scroll direction,
+        `velocity` to determine scroll speed, targetContentOffset to determine where the scrolling will end (in dpi)
+    platforms: [iphone, ipad]
+    since: 5.4.0
+    properties:
+      - name: direction
+        summary: Direction of the scroll--either 'up', or 'down'.
+        type: String
 
-	      - name: velocity
-	        summary: The velocity of the scroll in scale factor per second
-	        type: number
+      - name: velocity
+        summary: The velocity of the scroll in scale factor per second
+        type: number
 
-	      - name: targetContentOffset
-	        summary: The expected offset when the scrolling action decelerates to a stop.
-	        type: Object
+      - name: targetContentOffset
+        summary: The expected offset when the scrolling action decelerates to a stop.
+        type: Object
 
-	      - name: bubbles
-	        summary: false. This event does not bubble.
-	        type: Boolean
+      - name: bubbles
+        summary: false. This event does not bubble.
+        type: Boolean
+
 
 properties:
   - name: allowsSelection

--- a/apidoc/Titanium/UI/ListView.yml
+++ b/apidoc/Titanium/UI/ListView.yml
@@ -601,13 +601,14 @@ events:
   - name: scrolling
     summary: Fires when the list view is scrolling. Calling the `scrollTo` methods will not fire this event
     description: |
-        This event will fire when the list view is scrolling. Use  `direction` to determine the scroll direction,
-        `velocity` to determine scroll speed, targetContentOffset to determine where the scrolling will end (in dpi)
+        This event will fire while the list view is scrolling and the user releases the finger. Use  `direction` to determine the scroll direction,
+        `velocity` to determine scroll speed, targetContentOffset.y to determine where the scrolling will end (in dpi).The key targetContentOffset.x is always 0.
+         When `direction` is `down`, `velocity` is negative and viceversa
     platforms: [iphone, ipad]
     since: 5.4.0
     properties:
       - name: direction
-        summary: Direction of the scroll--either 'up', or 'down'.
+        summary: Direction of the scroll either 'up', or 'down'.
         type: String
 
       - name: velocity
@@ -615,7 +616,9 @@ events:
         type: number
 
       - name: targetContentOffset
-        summary: The expected offset as an object consisting of x and y keys when the scrolling action decelerates to a stop. 
+        summary: |
+           The expected offset as an object consisting of x and y keys when
+           the scrolling action decelerates to a stop. 
         type: Object
 
 

--- a/apidoc/Titanium/UI/ListView.yml
+++ b/apidoc/Titanium/UI/ListView.yml
@@ -598,6 +598,30 @@ events:
         summary: false. This event does not bubble.
         type: Boolean
 
+    - name: scrolling
+	    summary: Fires when the list view is scrolling. Calling the `scrollTo` methods will not fire this event
+	    description: |
+	        This event will fire when the list view is scrolling. Use  `direction` to determine the scroll direction, 
+	         `velocity` to determine scroll speed, targetContentOffset to determine where the scrolling will end (in dpi)
+	    platforms: [iphone, ipad]
+	    since: 5.4.0
+	    properties: 
+	      - name: direction
+	        summary: Direction of the scroll--either 'up', or 'down'.
+	        type: String
+
+	      - name: velocity
+	        summary: The velocity of the scroll in scale factor per second
+	        type: number
+
+	      - name: targetContentOffset
+	        summary: The expected offset when the scrolling action decelerates to a stop.
+	        type: Object
+
+	      - name: bubbles
+	        summary: false. This event does not bubble.
+	        type: Boolean
+
 properties:
   - name: allowsSelection
     summary: Determines whether this item can be selected.

--- a/apidoc/Titanium/UI/ListView.yml
+++ b/apidoc/Titanium/UI/ListView.yml
@@ -615,12 +615,12 @@ events:
 
       - name: velocity
         summary: The velocity of the scroll in scale factor per second
-        type: number
+        type: Number
 
       - name: targetContentOffset
         summary: |
            The expected y axis offset when the scrolling action decelerates to a stop. 
-        type: number
+        type: Number
 
 
 properties:

--- a/apidoc/Titanium/UI/ListView.yml
+++ b/apidoc/Titanium/UI/ListView.yml
@@ -615,12 +615,8 @@ events:
         type: number
 
       - name: targetContentOffset
-        summary: The expected offset when the scrolling action decelerates to a stop.
+        summary: The expected offset as an object consisting of x and y keys when the scrolling action decelerates to a stop. 
         type: Object
-
-      - name: bubbles
-        summary: false. This event does not bubble.
-        type: Boolean
 
 
 properties:

--- a/apidoc/Titanium/UI/ListView.yml
+++ b/apidoc/Titanium/UI/ListView.yml
@@ -601,9 +601,11 @@ events:
   - name: scrolling
     summary: Fires when the list view is scrolling. Calling the `scrollTo` methods will not fire this event
     description: |
-        This event will fire while the list view is scrolling and the user releases the finger. Use  `direction` to determine the scroll direction,
-        `velocity` to determine scroll speed, targetContentOffset.y to determine where the scrolling will end (in dpi).The key targetContentOffset.x is always 0.
-         When `direction` is `down`, `velocity` is negative and viceversa
+        This event will fire while the list view is scrolling and the user releases the finger.
+        No event is fired when the finger is not released. Use  `direction` to determine the scroll direction,
+        `velocity` to determine scroll speed, targetContentOffset to determine where the scrolling will end (in dpi). 
+        When `direction` is `down`, `velocity` is negative and viceversa. 
+
     platforms: [iphone, ipad]
     since: 5.4.0
     properties:
@@ -617,9 +619,8 @@ events:
 
       - name: targetContentOffset
         summary: |
-           The expected offset as an object consisting of x and y keys when
-           the scrolling action decelerates to a stop. 
-        type: Object
+           The expected y axis offset when the scrolling action decelerates to a stop. 
+        type: number
 
 
 properties:

--- a/iphone/Classes/TiUIListView.m
+++ b/iphone/Classes/TiUIListView.m
@@ -1818,17 +1818,22 @@ static TiViewProxy * FindViewProxyWithBindIdContainingPoint(UIView *view, CGPoin
 -(void)scrollViewWillEndDragging:(UIScrollView *)scrollView withVelocity:(CGPoint)velocity targetContentOffset:(inout CGPoint *)targetContentOffset{
     
     if ([self.proxy _hasListeners:@"scrolling"]) {
-        NSMutableDictionary *eventArgs = [NSMutableDictionary dictionary];
-        NSString* swipeString = @"none";
+        NSString* directionString = @"none";
         if (velocity.y > 0){
-            swipeString = @"up";
+            directionString = @"up";
         }
         if (velocity.y < 0){
-            swipeString = @"down";
+            directionString = @"down";
         }
-        if(swipeString !=(id)[NSNull null])
-        {
-            [eventArgs setValue:swipeString forKey:@"direction"];
+        if(directionString != @"none") {
+            NSMutableDictionary *eventArgs = [NSMutableDictionary dictionary];
+            NSDictionary *pointObject = [NSDictionary dictionaryWithObjectsAndKeys:
+             [NSNumber numberWithDouble:targetContentOffset->x],@"x",
+             [NSNumber numberWithDouble:targetContentOffset->y],@"y",
+                                         nil];
+            [eventArgs setValue:directionString forKey:@"direction"];
+            [eventArgs setValue:NUMDOUBLE(velocity.y) forKey:@"velocity"];
+            [eventArgs setObject:pointObject forKey:@"targetContentOffset"];
             [self.proxy fireEvent:@"scrolling" withObject:eventArgs withSource:self.proxy propagate:NO reportSuccess:NO errorCode:0 message:nil];
         }
     }

--- a/iphone/Classes/TiUIListView.m
+++ b/iphone/Classes/TiUIListView.m
@@ -1819,12 +1819,15 @@ static TiViewProxy * FindViewProxyWithBindIdContainingPoint(UIView *view, CGPoin
     
     if ([self.proxy _hasListeners:@"scrolling"]) {
         NSString* directionString = @"none";
-        if (velocity.y > 0){
+
+        if (velocity.y > 0) {
             directionString = @"up";
         }
-        if (velocity.y < 0){
+
+        if (velocity.y < 0) {
             directionString = @"down";
         }
+        
         if(directionString != @"none") {
             NSMutableDictionary *eventArgs = [NSMutableDictionary dictionary];
             NSDictionary *pointObject = [NSDictionary dictionaryWithObjectsAndKeys:

--- a/iphone/Classes/TiUIListView.m
+++ b/iphone/Classes/TiUIListView.m
@@ -1830,13 +1830,9 @@ static TiViewProxy * FindViewProxyWithBindIdContainingPoint(UIView *view, CGPoin
         }
         
         NSMutableDictionary *event = [NSMutableDictionary dictionaryWithDictionary:@{
-            @"targetContentOffset": @{
-               @"x": NUMFLOAT(targetContentOffset->x),
-               @"y": NUMFLOAT(targetContentOffset->y),
-            },
+            @"targetContentOffset": NUMFLOAT(targetContentOffset->y),
             @"velocity": NUMFLOAT(velocity.y)
         }];
-        
         if (direction != nil) {
             [event setValue:direction forKey:@"direction"];
         }

--- a/iphone/Classes/TiUIListView.m
+++ b/iphone/Classes/TiUIListView.m
@@ -1829,12 +1829,12 @@ static TiViewProxy * FindViewProxyWithBindIdContainingPoint(UIView *view, CGPoin
         }
         
         NSMutableDictionary *event = [NSMutableDictionary dictionaryWithDictionary:@{
-                                                                                     @"targetContentOffset": @{
-                                                                                             @"x": NUMFLOAT(targetContentOffset->x),
-                                                                                             @"y": NUMFLOAT(targetContentOffset->y),
-                                                                                             },
-                                                                                     @"velocity": NUMFLOAT(velocity.y)
-                                                                                     }];
+            @"targetContentOffset": @{
+               @"x": NUMFLOAT(targetContentOffset->x),
+               @"y": NUMFLOAT(targetContentOffset->y),
+            },
+            @"velocity": NUMFLOAT(velocity.y)
+        }];
         
         if (direction != nil) {
             [event setValue:direction forKey:@"direction"];

--- a/iphone/Classes/TiUIListView.m
+++ b/iphone/Classes/TiUIListView.m
@@ -1815,30 +1815,33 @@ static TiViewProxy * FindViewProxyWithBindIdContainingPoint(UIView *view, CGPoin
         [self.proxy fireEvent:@"dragstart" withObject:nil withSource:self.proxy propagate:NO reportSuccess:NO errorCode:0 message:nil];
     }
 }
--(void)scrollViewWillEndDragging:(UIScrollView *)scrollView withVelocity:(CGPoint)velocity targetContentOffset:(inout CGPoint *)targetContentOffset{
-    
-    if ([self.proxy _hasListeners:@"scrolling"]) {
-        NSString* directionString = @"none";
-
+-(void)scrollViewWillEndDragging:(UIScrollView *)scrollView withVelocity:(CGPoint)velocity targetContentOffset:(inout CGPoint *)targetContentOffset
+{
+    if ([[self proxy] _hasListeners:@"scrolling"]) {
+        NSString* direction = nil;
+        
         if (velocity.y > 0) {
-            directionString = @"up";
-        }
-
-        if (velocity.y < 0) {
-            directionString = @"down";
+            direction = @"up";
         }
         
-        if(directionString != @"none") {
-            NSMutableDictionary *eventArgs = [NSMutableDictionary dictionary];
-            NSDictionary *pointObject = [NSDictionary dictionaryWithObjectsAndKeys:
-             [NSNumber numberWithDouble:targetContentOffset->x],@"x",
-             [NSNumber numberWithDouble:targetContentOffset->y],@"y",
-                                         nil];
-            [eventArgs setValue:directionString forKey:@"direction"];
-            [eventArgs setValue:NUMDOUBLE(velocity.y) forKey:@"velocity"];
-            [eventArgs setObject:pointObject forKey:@"targetContentOffset"];
-            [self.proxy fireEvent:@"scrolling" withObject:eventArgs withSource:self.proxy propagate:NO reportSuccess:NO errorCode:0 message:nil];
+        if (velocity.y < 0) {
+            direction = @"down";
         }
+        
+        NSMutableDictionary *event = [NSMutableDictionary dictionaryWithDictionary:@{
+                                                                                     @"targetContentOffset": @{
+                                                                                             @"x": NUMFLOAT(targetContentOffset->x),
+                                                                                             @"y": NUMFLOAT(targetContentOffset->y),
+                                                                                             },
+                                                                                     @"velocity": NUMFLOAT(velocity.y)
+                                                                                     }];
+        
+        if (direction != nil) {
+            [event setValue:direction forKey:@"direction"];
+        }
+        
+        [[self proxy] fireEvent:@"scrolling" withObject:event];
+        RELEASE_TO_NIL(direction);
     }
 }
 - (void)scrollViewDidEndDragging:(UIScrollView *)scrollView willDecelerate:(BOOL)decelerate

--- a/iphone/Classes/TiUIListView.m
+++ b/iphone/Classes/TiUIListView.m
@@ -1815,7 +1815,24 @@ static TiViewProxy * FindViewProxyWithBindIdContainingPoint(UIView *view, CGPoin
         [self.proxy fireEvent:@"dragstart" withObject:nil withSource:self.proxy propagate:NO reportSuccess:NO errorCode:0 message:nil];
     }
 }
-
+-(void)scrollViewWillEndDragging:(UIScrollView *)scrollView withVelocity:(CGPoint)velocity targetContentOffset:(inout CGPoint *)targetContentOffset{
+    
+    if ([self.proxy _hasListeners:@"scrolling"]) {
+        NSMutableDictionary *eventArgs = [NSMutableDictionary dictionary];
+        NSString* swipeString = @"none";
+        if (velocity.y > 0){
+            swipeString = @"up";
+        }
+        if (velocity.y < 0){
+            swipeString = @"down";
+        }
+        if(swipeString !=(id)[NSNull null])
+        {
+            [eventArgs setValue:swipeString forKey:@"direction"];
+            [self.proxy fireEvent:@"scrolling" withObject:eventArgs withSource:self.proxy propagate:NO reportSuccess:NO errorCode:0 message:nil];
+        }
+    }
+}
 - (void)scrollViewDidEndDragging:(UIScrollView *)scrollView willDecelerate:(BOOL)decelerate
 {
     if (!decelerate) {

--- a/iphone/Classes/TiUIListView.m
+++ b/iphone/Classes/TiUIListView.m
@@ -1815,6 +1815,7 @@ static TiViewProxy * FindViewProxyWithBindIdContainingPoint(UIView *view, CGPoin
         [self.proxy fireEvent:@"dragstart" withObject:nil withSource:self.proxy propagate:NO reportSuccess:NO errorCode:0 message:nil];
     }
 }
+
 -(void)scrollViewWillEndDragging:(UIScrollView *)scrollView withVelocity:(CGPoint)velocity targetContentOffset:(inout CGPoint *)targetContentOffset
 {
     if ([[self proxy] _hasListeners:@"scrolling"]) {
@@ -1844,6 +1845,7 @@ static TiViewProxy * FindViewProxyWithBindIdContainingPoint(UIView *view, CGPoin
         RELEASE_TO_NIL(direction);
     }
 }
+
 - (void)scrollViewDidEndDragging:(UIScrollView *)scrollView willDecelerate:(BOOL)decelerate
 {
     if (!decelerate) {


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-23406

At the moment is not possible to determine the scroll direction of a ListView natively and as the view is scrolling. Very common effects such as the hiding of the navigation bar when scrolling (like on the Facebook app) become impossible to achieve without cumbersome workarounds.
I will send a PR with a modification to the SDK core.
