### PR TITLE
Wrap autolayout-initializer in proper #ifdef

### DIFF
--- a/iphone/Classes/TiUIView.m
+++ b/iphone/Classes/TiUIView.m
@@ -211,6 +211,7 @@ DEFINE_EXCEPTIONS
 	}
 }
 
+#ifdef TI_USE_AUTOLAYOUT
 -(void)initializeTiLayoutView
 {
     [super initializeTiLayoutView];
@@ -219,6 +220,8 @@ DEFINE_EXCEPTIONS
         [self setDefaultWidth:TiDimensionAutoFill];
     }
 }
+#endif
+
 - (id) init
 {
 	self = [super init];


### PR DESCRIPTION
There was a missing `#ifdef` statement inside the `TiUIView` which is required to resolve certain selector-warnings.
