### PR TITLE
[TIMOB-23423] Android: Add rotation, rotationX, rotationY, scaleX, scaleY to view

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/TiC.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiC.java
@@ -2309,6 +2309,21 @@ public class TiC
 	/**
 	 * @module.api
 	 */
+	public static final String PROPERTY_ROTATION = "rotation";
+	
+	/**
+	 * @module.api
+	 */
+	public static final String PROPERTY_ROTATION_X = "rotationX";
+	
+	/**
+	 * @module.api
+	 */
+	public static final String PROPERTY_ROTATION_Y = "rotationY";
+
+	/**
+	 * @module.api
+	 */
 	public static final String PROPERTY_ROW_DATA = "rowData";
 
 	/**
@@ -2321,6 +2336,16 @@ public class TiC
 	 */
 	public static final String PROPERTY_SCALE = "scale";
 
+	/**
+	 * @module.api
+	 */
+	public static final String PROPERTY_SCALE_X = "scaleX";
+	
+	/**
+	 * @module.api
+	 */
+	public static final String PROPERTY_SCALE_Y = "scaleY";
+	
 	/**
 	 * @module.api
 	 */

--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/TiViewProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/TiViewProxy.java
@@ -407,6 +407,12 @@ public abstract class TiViewProxy extends KrollProxy implements Handler.Callback
 		setPropertyAndFire(TiC.PROPERTY_HEIGHT, height);
 	}
 	
+	/*@Kroll.setProperty(retain=false) @Kroll.method
+	public void setRotation(Float rotation)
+	{
+		setPropertyAndFire(TiC.PROPERTY_ROTATION, rotation);
+	}
+	
 	@Kroll.setProperty(retain=false) @Kroll.method
 	public void setRotationX(Float rotation)
 	{
@@ -429,7 +435,7 @@ public abstract class TiViewProxy extends KrollProxy implements Handler.Callback
 	public void setScaleY(Float scale)
 	{
 		setPropertyAndFire(TiC.PROPERTY_SCALE_Y, scale);
-	}
+	}*/
 
 	@Kroll.getProperty @Kroll.method
 	public Object getCenter()

--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/TiViewProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/TiViewProxy.java
@@ -68,7 +68,7 @@ import android.view.ViewAnimationUtils;
 	// others
 	"focusable", "touchEnabled", "visible", "enabled", "opacity",
 	"softKeyboardOnFocus", "transform", "elevation", "touchTestId",
-	"translationX", "translationY", "translationZ",
+	"translationX", "translationY", "translationZ", "rotation", "rotationX", "rotationY", "scaleX", "scaleY",
 	
 	TiC.PROPERTY_TRANSITION_NAME
 })
@@ -405,6 +405,30 @@ public abstract class TiViewProxy extends KrollProxy implements Handler.Callback
 	public void setHeight(Object height)
 	{
 		setPropertyAndFire(TiC.PROPERTY_HEIGHT, height);
+	}
+	
+	@Kroll.setProperty(retain=false) @Kroll.method
+	public void setRotationX(Float rotation)
+	{
+		setPropertyAndFire(TiC.PROPERTY_ROTATION_X, rotation);
+	}
+	
+	@Kroll.setProperty(retain=false) @Kroll.method
+	public void setRotationY(Float rotation)
+	{
+		setPropertyAndFire(TiC.PROPERTY_ROTATION_Y, rotation);
+	}
+	
+	@Kroll.setProperty(retain=false) @Kroll.method
+	public void setScaleX(Float scale)
+	{
+		setPropertyAndFire(TiC.PROPERTY_SCALE_X, scale);
+	}
+	
+	@Kroll.setProperty(retain=false) @Kroll.method
+	public void setScaleY(Float scale)
+	{
+		setPropertyAndFire(TiC.PROPERTY_SCALE_Y, scale);
 	}
 
 	@Kroll.getProperty @Kroll.method

--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/TiViewProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/TiViewProxy.java
@@ -407,36 +407,6 @@ public abstract class TiViewProxy extends KrollProxy implements Handler.Callback
 		setPropertyAndFire(TiC.PROPERTY_HEIGHT, height);
 	}
 	
-	/*@Kroll.setProperty(retain=false) @Kroll.method
-	public void setRotation(Float rotation)
-	{
-		setPropertyAndFire(TiC.PROPERTY_ROTATION, rotation);
-	}
-	
-	@Kroll.setProperty(retain=false) @Kroll.method
-	public void setRotationX(Float rotation)
-	{
-		setPropertyAndFire(TiC.PROPERTY_ROTATION_X, rotation);
-	}
-	
-	@Kroll.setProperty(retain=false) @Kroll.method
-	public void setRotationY(Float rotation)
-	{
-		setPropertyAndFire(TiC.PROPERTY_ROTATION_Y, rotation);
-	}
-	
-	@Kroll.setProperty(retain=false) @Kroll.method
-	public void setScaleX(Float scale)
-	{
-		setPropertyAndFire(TiC.PROPERTY_SCALE_X, scale);
-	}
-	
-	@Kroll.setProperty(retain=false) @Kroll.method
-	public void setScaleY(Float scale)
-	{
-		setPropertyAndFire(TiC.PROPERTY_SCALE_Y, scale);
-	}*/
-
 	@Kroll.getProperty @Kroll.method
 	public Object getCenter()
 	{

--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiUIView.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiUIView.java
@@ -1022,6 +1022,26 @@ public abstract class TiUIView
 			ViewCompat.setElevation(nativeView, TiConvert.toFloat(d, TiC.PROPERTY_ELEVATION));
 		}
 		
+		if (d.containsKey(TiC.PROPERTY_ROTATION) && !nativeViewNull){
+			ViewCompat.setRotation(nativeView, TiConvert.toFloat(d, TiC.PROPERTY_ROTATION));
+		}
+		
+		if (d.containsKey(TiC.PROPERTY_ROTATION_X) && !nativeViewNull){
+			ViewCompat.setRotationX(nativeView, TiConvert.toFloat(d, TiC.PROPERTY_ROTATION_X));
+		}
+		
+		if (d.containsKey(TiC.PROPERTY_ROTATION_Y) && !nativeViewNull){
+			ViewCompat.setRotationY(nativeView, TiConvert.toFloat(d, TiC.PROPERTY_ROTATION_Y));
+		}
+		
+		if (d.containsKey(TiC.PROPERTY_SCALE_X) && !nativeViewNull){
+			ViewCompat.setScaleX(nativeView, TiConvert.toFloat(d, TiC.PROPERTY_SCALE_X));
+		}
+		
+		if (d.containsKey(TiC.PROPERTY_SCALE_Y) && !nativeViewNull){
+			ViewCompat.setScaleY(nativeView, TiConvert.toFloat(d, TiC.PROPERTY_SCALE_Y));
+		}
+		
 		if (d.containsKey(TiC.PROPERTY_TRANSLATION_X) && !nativeViewNull){
 			ViewCompat.setTranslationX(nativeView, TiConvert.toFloat(d, TiC.PROPERTY_TRANSLATION_X));
 		}

--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiUIView.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiUIView.java
@@ -895,21 +895,41 @@ public abstract class TiUIView
 				ViewCompat.setElevation(nativeView, TiConvert.toFloat(newValue));
 			}
 		} else if (key.equals(TiC.PROPERTY_TRANSLATION_X)) {
-			if (nativeView != null) {
-				ViewCompat.setTranslationX(nativeView, TiConvert.toFloat(newValue));
+			if (getOuterView() != null) {
+				ViewCompat.setTranslationX(getOuterView(), TiConvert.toFloat(newValue));
 			}
 		} else if (key.equals(TiC.PROPERTY_TRANSLATION_Y)) {
-			if (nativeView != null) {
-				ViewCompat.setTranslationY(nativeView, TiConvert.toFloat(newValue));
+			if (getOuterView() != null) {
+				ViewCompat.setTranslationY(getOuterView(), TiConvert.toFloat(newValue));
 			}
 		} else if (key.equals(TiC.PROPERTY_TRANSLATION_Z)) {
-			if (nativeView != null) {
-				ViewCompat.setTranslationZ(nativeView, TiConvert.toFloat(newValue));
+			if (getOuterView() != null) {
+				ViewCompat.setTranslationZ(getOuterView(), TiConvert.toFloat(newValue));
 			}
 		} else if (key.equals(TiC.PROPERTY_TRANSITION_NAME)) { 
 		    if (LOLLIPOP_OR_GREATER && (nativeView != null)) { 
 		        ViewCompat.setTransitionName(nativeView, TiConvert.toString(newValue));
 		    }
+		} else if (key.equals(TiC.PROPERTY_SCALE_X)) { 			
+			if (getOuterView() != null) {
+				ViewCompat.setScaleX(getOuterView(), TiConvert.toFloat(newValue));
+			}
+		} else if (key.equals(TiC.PROPERTY_SCALE_Y)) { 
+			if (getOuterView() != null) {
+				ViewCompat.setScaleY(getOuterView(), TiConvert.toFloat(newValue));
+			}
+		} else if (key.equals(TiC.PROPERTY_ROTATION)) { 
+			if (getOuterView() != null) {
+				ViewCompat.setRotation(getOuterView(), TiConvert.toFloat(newValue));
+			}
+		} else if (key.equals(TiC.PROPERTY_ROTATION_X)) { 
+			if (getOuterView() != null) {
+				ViewCompat.setRotationX(getOuterView(), TiConvert.toFloat(newValue));
+			}
+		} else if (key.equals(TiC.PROPERTY_ROTATION_Y)) { 
+			if (getOuterView() != null) {
+				ViewCompat.setRotationY(getOuterView(), TiConvert.toFloat(newValue));
+			}
 		} else if (Log.isDebugModeEnabled()) {
 		    Log.d(TAG, "Unhandled property key: " + key, Log.DEBUG_MODE);
 		}

--- a/apidoc/Titanium/UI/View.yml
+++ b/apidoc/Titanium/UI/View.yml
@@ -1466,6 +1466,40 @@ properties:
     permission: read-only
     since: "2.0.0"
 
+  - name: rotation
+    summary: Clockwise 2D rotation of the view in degrees.
+    description: Translation values are applied to the static post layout value.
+    type: Number
+    platforms: [android]
+    since: 6.0.0
+    
+  - name: rotationX
+    summary: Clockwise rotation of the view in degrees (x-axis).
+    description: Translation values are applied to the static post layout value.
+    type: Number
+    platforms: [android]
+    since: 6.0.0
+    
+  - name: rotationY
+    summary: Clockwise rotation of the view in degrees (y-axis).
+    description: Translation values are applied to the static post layout value.
+    type: Number
+    platforms: [android]
+    since: 6.0.0
+
+  - name: scaleX
+    summary: Scaling of the view in x-axis in pixels.
+    description: Translation values are applied to the static post layout value.
+    type: Number
+    platforms: [android]
+    since: 6.0.0
+    
+  - name: scaleY
+    summary: Scaling of the view in y-axis in pixels.
+    description: Translation values are applied to the static post layout value.
+    type: Number
+    platforms: [android]
+    since: 6.0.0
 
   - name: size
     summary: |

--- a/apidoc/Titanium/UI/View.yml
+++ b/apidoc/Titanium/UI/View.yml
@@ -1471,35 +1471,35 @@ properties:
     description: Translation values are applied to the static post layout value.
     type: Number
     platforms: [android]
-    since: 6.0.0
+    since: 5.4.0
     
   - name: rotationX
     summary: Clockwise rotation of the view in degrees (x-axis).
     description: Translation values are applied to the static post layout value.
     type: Number
     platforms: [android]
-    since: 6.0.0
+    since: 5.4.0
     
   - name: rotationY
     summary: Clockwise rotation of the view in degrees (y-axis).
     description: Translation values are applied to the static post layout value.
     type: Number
     platforms: [android]
-    since: 6.0.0
+    since: 5.4.0
 
   - name: scaleX
     summary: Scaling of the view in x-axis in pixels.
     description: Translation values are applied to the static post layout value.
     type: Number
     platforms: [android]
-    since: 6.0.0
+    since: 5.4.0
     
   - name: scaleY
     summary: Scaling of the view in y-axis in pixels.
     description: Translation values are applied to the static post layout value.
     type: Number
     platforms: [android]
-    since: 6.0.0
+    since: 5.4.0
 
   - name: size
     summary: |


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-23423

**Optional Description:**

Allow to set rotation (x,y,z) and scaling (x,y) to a view without the need of 2dmatrix. Similar to the existing translationX(), translationY() (with a small bugfix allowing to use views with borders, too).

With these settings it is possible to do smooth rotation/scaling in a drag event.
GIF comparing 2dmatrix vs setters: http://migaweb.de/matrix.gif
