### PR TITLE
iOS: Support the camera as a view

### DIFF
--- a/iphone/Classes/TiUIiOSCameraView.h
+++ b/iphone/Classes/TiUIiOSCameraView.h
@@ -1,0 +1,22 @@
+/**
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2009-2016 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+#import "TiUIView.h"
+#import <AVFoundation/AVFoundation.h>
+
+@interface TiUIiOSCameraView : TiUIView {
+    AVCaptureSession *captureSession;
+    AVCaptureVideoPreviewLayer* previewLayer;
+
+    TiDimension width;
+    TiDimension height;
+    CGFloat autoHeight;
+    CGFloat autoWidth;
+}
+
+-(void)initializeSession;
+
+@end

--- a/iphone/Classes/TiUIiOSCameraView.m
+++ b/iphone/Classes/TiUIiOSCameraView.m
@@ -1,0 +1,141 @@
+/**
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2009-2016 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+
+#import "TiUIiOSCameraView.h"
+
+@implementation TiUIiOSCameraView
+
+-(void)initializeSession
+{
+    captureSession = [[AVCaptureSession alloc] init];
+    [captureSession setSessionPreset:AVCaptureSessionPresetMedium];
+
+    AVCaptureDevice *device = [AVCaptureDevice defaultDeviceWithMediaType:AVMediaTypeVideo];
+    
+    NSError *error = nil;
+    AVCaptureDeviceInput *input = [AVCaptureDeviceInput deviceInputWithDevice:device error:&error];
+    if (!input) {
+        NSLog(@"[ERROR] Cannot open camera: %@", error);
+    }
+    [captureSession addInput:input];
+    
+    previewLayer = [AVCaptureVideoPreviewLayer layerWithSession:captureSession];
+    [previewLayer setFrame:[super bounds]];
+    [[self layer] addSublayer:previewLayer];
+    
+    [captureSession startRunning];
+}
+
+#ifdef TI_USE_AUTOLAYOUT
+-(void)initializeTiLayoutView
+{
+    [super initializeTiLayoutView];
+    [self setDefaultHeight:TiDimensionAutoFill];
+    [self setDefaultWidth:TiDimensionAutoFill];
+}
+#endif
+
+#pragma mark Cleanup
+
+-(void)dealloc
+{
+    RELEASE_TO_NIL(captureSession);
+    [super dealloc];
+}
+
+#pragma mark Public APIs
+
+-(void)setQuality_:(id)value
+{
+    ENSURE_TYPE(value, NSString);
+    [captureSession setSessionPreset:[TiUtils stringValue:value]];
+}
+
+#pragma mark Layout helper
+
+-(void)setWidth_:(id)width_
+{
+    width = TiDimensionFromObject(width_);
+    [self updateContentMode];
+}
+
+-(void)setHeight_:(id)height_
+{
+    height = TiDimensionFromObject(height_);
+    [self updateContentMode];
+}
+
+#pragma mark Layout helper
+
+-(void)updateContentMode
+{
+    [self setContentMode:[self contentModeForLivePhotoView]];
+}
+
+-(UIViewContentMode)contentModeForLivePhotoView
+{
+    if (TiDimensionIsAuto(width) || TiDimensionIsAutoSize(width) || TiDimensionIsUndefined(width) ||
+        TiDimensionIsAuto(height) || TiDimensionIsAutoSize(height) || TiDimensionIsUndefined(height)) {
+        return UIViewContentModeScaleAspectFit;
+    } else {
+        return UIViewContentModeScaleToFill;
+    }
+}
+
+-(void)frameSizeChanged:(CGRect)frame bounds:(CGRect)bounds
+{
+    [previewLayer setFrame:bounds];
+    [super frameSizeChanged:frame bounds:bounds];
+}
+
+-(CGFloat)contentWidthForWidth:(CGFloat)suggestedWidth
+{
+    if (autoWidth > 0) {
+        //If height is DIP returned a scaled autowidth to maintain aspect ratio
+        if (TiDimensionIsDip(height) && autoHeight > 0) {
+            return roundf(autoWidth * height.value / autoHeight);
+        }
+        return autoWidth;
+    }
+    
+    CGFloat calculatedWidth = TiDimensionCalculateValue(width, autoWidth);
+    if (calculatedWidth > 0) {
+        return calculatedWidth;
+    }
+    
+    return 0;
+}
+
+-(CGFloat)contentHeightForWidth:(CGFloat)width_
+{
+    if (width_ != autoWidth && autoWidth > 0 && autoHeight > 0) {
+        return (width_ * autoHeight / autoWidth);
+    }
+    
+    if (autoHeight > 0) {
+        return autoHeight;
+    }
+    
+    CGFloat calculatedHeight = TiDimensionCalculateValue(height, autoHeight);
+    if (calculatedHeight > 0) {
+        return calculatedHeight;
+    }
+    
+    return 0;
+}
+
+-(UIViewContentMode)contentMode
+{
+    if (TiDimensionIsAuto(width) || TiDimensionIsAutoSize(width) || TiDimensionIsUndefined(width) ||
+        TiDimensionIsAuto(height) || TiDimensionIsAutoSize(height) || TiDimensionIsUndefined(height)) {
+        return UIViewContentModeScaleAspectFit;
+    } else {
+        return UIViewContentModeScaleToFill;
+    }
+}
+
+@end

--- a/iphone/Classes/TiUIiOSCameraViewProxy.h
+++ b/iphone/Classes/TiUIiOSCameraViewProxy.h
@@ -1,0 +1,14 @@
+/**
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2009-2016 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+#import "TiViewProxy.h"
+#import "TiUIiOSCameraView.h"
+
+@interface TiUIiOSCameraViewProxy : TiViewProxy {
+
+}
+
+@end

--- a/iphone/Classes/TiUIiOSCameraViewProxy.m
+++ b/iphone/Classes/TiUIiOSCameraViewProxy.m
@@ -1,0 +1,50 @@
+/**
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2009-2016 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+
+#import "TiUIiOSCameraViewProxy.h"
+#import "TiUtils.h"
+
+@implementation TiUIiOSCameraViewProxy
+
+-(NSString*)apiName
+{
+    return @"Ti.UI.iOS.CameraView";
+}
+
+-(void)dealloc
+{
+    [super dealloc];
+}
+
+-(TiUIiOSCameraView*)cameraView
+{
+    return (TiUIiOSCameraView*)[self view];
+}
+
+-(void)_initWithProperties:(NSDictionary *)properties
+{
+    [[self cameraView] initializeSession];
+    [super _initWithProperties:properties];
+}
+
+#pragma mark Helper
+
+USE_VIEW_FOR_CONTENT_WIDTH
+
+USE_VIEW_FOR_CONTENT_HEIGHT
+
+-(TiDimension)defaultAutoWidthBehavior:(id)unused
+{
+    return TiDimensionAutoSize;
+}
+
+-(TiDimension)defaultAutoHeightBehavior:(id)unused
+{
+    return TiDimensionAutoSize;
+}
+
+@end

--- a/iphone/Classes/TiUIiOSProxy.h
+++ b/iphone/Classes/TiUIiOSProxy.h
@@ -282,6 +282,7 @@
 #ifdef USE_TI_UIIOSBLURVIEW
 -(id)createBlurView:(id)args;
 #endif
+-(id)createCameraView:(id)args;
 #ifdef USE_TI_UIIOSAPPLICATIONSHORTCUTS
 -(id)createApplicationShortcuts:(id)args;
 #endif

--- a/iphone/Classes/TiUIiOSProxy.m
+++ b/iphone/Classes/TiUIiOSProxy.m
@@ -106,6 +106,8 @@
 #import "TiUIiOSStepperProxy.h"
 #endif
 
+#import "TiUIiOSCameraViewProxy.h"
+
 @implementation TiUIiOSProxy
 
 #define FORGET_AND_RELEASE(x) \
@@ -723,6 +725,11 @@ MAKE_SYSTEM_PROP_DEPRECATED_REPLACED_REMOVED(ATTRIBUTE_EXPANSION, AttributeNameE
     return [[[TiUIiOSBlurViewProxy alloc] _initWithPageContext:[self executionContext] args:args] autorelease];
 }
 #endif
+
+-(id)createCameraView:(id)args
+{
+    return [[[TiUIiOSCameraViewProxy alloc] _initWithPageContext:[self executionContext] args:args] autorelease];
+}
 
 #ifdef USE_TI_UIIOSSTEPPER
 -(id)createStepper:(id)args

--- a/iphone/iphone/Titanium.xcodeproj/project.pbxproj
+++ b/iphone/iphone/Titanium.xcodeproj/project.pbxproj
@@ -248,6 +248,8 @@
 		3A5AD7291BB9BEA8005B408B /* TiUIiOSPreviewContextProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A5AD7281BB9BEA8005B408B /* TiUIiOSPreviewContextProxy.m */; };
 		3A811CD01C2C21E50023468C /* TiUIiOSBlurViewProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A811CCF1C2C21E50023468C /* TiUIiOSBlurViewProxy.m */; };
 		3A811CD31C2C21FE0023468C /* TiUIiOSBlurView.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A811CD21C2C21FE0023468C /* TiUIiOSBlurView.m */; };
+		3AB4BA0D1CF1C71100FDAF93 /* TiUIiOSCameraViewProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 3AB4BA0C1CF1C71100FDAF93 /* TiUIiOSCameraViewProxy.m */; };
+		3AB4BA101CF1C72000FDAF93 /* TiUIiOSCameraView.m in Sources */ = {isa = PBXBuildFile; fileRef = 3AB4BA0F1CF1C72000FDAF93 /* TiUIiOSCameraView.m */; };
 		3AB9137C1BB60F070063A4AD /* TiPreviewingDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 3AB9137B1BB60F070063A4AD /* TiPreviewingDelegate.m */; };
 		3AB913801BB61FDA0063A4AD /* TiUIiOSPreviewActionProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 3AB9137F1BB61FDA0063A4AD /* TiUIiOSPreviewActionProxy.m */; };
 		4688700715E39A9D008FA326 /* TiUIiPhoneAlertDialogStyleProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 4688700615E39A9D008FA326 /* TiUIiPhoneAlertDialogStyleProxy.m */; };
@@ -821,6 +823,10 @@
 		3A811CCF1C2C21E50023468C /* TiUIiOSBlurViewProxy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TiUIiOSBlurViewProxy.m; sourceTree = "<group>"; };
 		3A811CD11C2C21FE0023468C /* TiUIiOSBlurView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TiUIiOSBlurView.h; sourceTree = "<group>"; };
 		3A811CD21C2C21FE0023468C /* TiUIiOSBlurView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TiUIiOSBlurView.m; sourceTree = "<group>"; };
+		3AB4BA0B1CF1C71100FDAF93 /* TiUIiOSCameraViewProxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TiUIiOSCameraViewProxy.h; sourceTree = "<group>"; };
+		3AB4BA0C1CF1C71100FDAF93 /* TiUIiOSCameraViewProxy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TiUIiOSCameraViewProxy.m; sourceTree = "<group>"; };
+		3AB4BA0E1CF1C72000FDAF93 /* TiUIiOSCameraView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TiUIiOSCameraView.h; sourceTree = "<group>"; };
+		3AB4BA0F1CF1C72000FDAF93 /* TiUIiOSCameraView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TiUIiOSCameraView.m; sourceTree = "<group>"; };
 		3AB9137A1BB60F070063A4AD /* TiPreviewingDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TiPreviewingDelegate.h; sourceTree = "<group>"; };
 		3AB9137B1BB60F070063A4AD /* TiPreviewingDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TiPreviewingDelegate.m; sourceTree = "<group>"; };
 		3AB9137E1BB61FDA0063A4AD /* TiUIiOSPreviewActionProxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TiUIiOSPreviewActionProxy.h; sourceTree = "<group>"; };
@@ -1951,6 +1957,7 @@
 		24D06FDE11D020E600F615D8 /* iOS */ = {
 			isa = PBXGroup;
 			children = (
+				3AB4BA0A1CF1C6F300FDAF93 /* Camera View */,
 				0BF933871CA0929A0091C7EC /* Stepper */,
 				3A811CCD1C2C21CA0023468C /* BlurView */,
 				3A0B56721C0CD7FE00709DA4 /* LivePhotoView */,
@@ -2279,6 +2286,17 @@
 				3A811CD21C2C21FE0023468C /* TiUIiOSBlurView.m */,
 			);
 			name = BlurView;
+			sourceTree = "<group>";
+		};
+		3AB4BA0A1CF1C6F300FDAF93 /* Camera View */ = {
+			isa = PBXGroup;
+			children = (
+				3AB4BA0B1CF1C71100FDAF93 /* TiUIiOSCameraViewProxy.h */,
+				3AB4BA0C1CF1C71100FDAF93 /* TiUIiOSCameraViewProxy.m */,
+				3AB4BA0E1CF1C72000FDAF93 /* TiUIiOSCameraView.h */,
+				3AB4BA0F1CF1C72000FDAF93 /* TiUIiOSCameraView.m */,
+			);
+			name = "Camera View";
 			sourceTree = "<group>";
 		};
 		3AB9137D1BB61EB00063A4AD /* PreviewActions */ = {
@@ -2700,12 +2718,14 @@
 				24CA8B7D111161FE0084E2DE /* TiUITabProxy.m in Sources */,
 				3A811CD01C2C21E50023468C /* TiUIiOSBlurViewProxy.m in Sources */,
 				CA0D39E51B7F55C6009D534C /* TiAppiOSSearchableItemAttributeSetProxy.m in Sources */,
+				3AB4BA0D1CF1C71100FDAF93 /* TiUIiOSCameraViewProxy.m in Sources */,
 				24CA8B80111161FE0084E2DE /* TiUITableViewProxy.m in Sources */,
 				24CA8B84111161FE0084E2DE /* TiUITableView.m in Sources */,
 				159C59981C358538009A8860 /* TiUIiOSAnimationStyleProxy.m in Sources */,
 				24CA8B85111161FE0084E2DE /* TiUITabGroupProxy.m in Sources */,
 				24CA8B86111161FE0084E2DE /* TiUITabGroup.m in Sources */,
 				24CA8B89111161FE0084E2DE /* TiUIiPhoneSystemIconProxy.m in Sources */,
+				3AB4BA101CF1C72000FDAF93 /* TiUIiOSCameraView.m in Sources */,
 				24CA8B8A111161FE0084E2DE /* TiUIiPhoneSystemButtonStyleProxy.m in Sources */,
 				24CA8B8B111161FE0084E2DE /* TiUIiPhoneSystemButtonProxy.m in Sources */,
 				24CA8B8C111161FE0084E2DE /* TiUISwitchProxy.m in Sources */,


### PR DESCRIPTION
No JIRA-ticket, yet (is there one?). Just a quick proof of concept for now, supporting the camera as a view instead of instead a modal picker using the native `AVCaptureSession` class. 

**Example**:

``` js
var win = Ti.UI.createWindow();

var camera = Ti.UI.iOS.createCameraView({
    width: 200,
    height: 300
});
win.add(camera);

win.open();
```

Docs, tests and more public API's to come sometime.
