### PR TITLE
[TIMOB-23475] Android: read-only properties with no setter are writable/delete-able

### DIFF
--- a/android/kroll-apt/src/java/org/appcelerator/kroll/annotations/generator/ProxyBindingV8.cpp.fm
+++ b/android/kroll-apt/src/java/org/appcelerator/kroll/annotations/generator/ProxyBindingV8.cpp.fm
@@ -191,7 +191,12 @@ Handle<FunctionTemplate> ${className}::getProxyTemplate()
 			, ${className}::setter_${name}
 		<#else>
 			, titanium::Proxy::onPropertyChanged
-		</#if>, Handle<Value>(), DEFAULT);
+		</#if>, Handle<Value>(), DEFAULT
+		<#if property.set>
+			, static_cast<v8::PropertyAttribute>(v8::DontDelete)
+		<#else>
+			, static_cast<v8::PropertyAttribute>(v8::ReadOnly | v8::DontDelete)
+		</#if>);
 	</@Proxy.listDynamicProperties>
 
 	// Accessors --------------------------------------------------------------


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-23475

**Description:**
Properties like apiName on all proxies, or Ti.App.version are marked as read-only properties in our docs. That means the user should not be able to overwrite their values or delete them. However you currently can:

``` js
Ti.API.info('original version:' + Ti.App.version);
Ti.App.version = 'my own very special string';
Ti.API.info('modified version:' + Ti.App.version);
delete Ti.App.version;
Ti.API.info('deleted version:' + Ti.App.version);
```

I modified our template for proxies, where "dynamic properties" (basically "non-constant" properties, so lower-case) with no setter now get the ReadOnly and DontDelete Property attribute applied to them. Properties with a setter now get the DontDelete property set on them. I assume we'll want to pretty much mark _all_ of our API as DontDelete?
