### PR TITLE
Add Platform specifier for new permissions

### DIFF
--- a/apidoc/Titanium/Filesystem/Filesystem.yml
+++ b/apidoc/Titanium/Filesystem/Filesystem.yml
@@ -123,6 +123,7 @@ methods:
     summary: Returns `true` if the app has storage permissions.
     returns:
         type: Boolean
+    platforms: [android]
     since: "5.4.0"
 
   - name: requestStoragePermissions
@@ -135,6 +136,7 @@ methods:
       - name: callback
         summary: Function to call upon user decision to grant storage access
         type: Callback<RequestStorageAccessResult>
+    platforms: [android]
     since: "5.4.0"
 
   - name: openStream


### PR DESCRIPTION
Storage Permisions were moved in https://github.com/appcelerator/titanium_mobile/pull/7689 needed platform specifier. 
