### PR TITLE
[TIMOB-23584] iOS9: Add support for added textStyles (Title1,Title2, Title2, Callout)

### DIFF
--- a/apidoc/Titanium/UI/UI.yml
+++ b/apidoc/Titanium/UI/UI.yml
@@ -2217,7 +2217,47 @@ properties:
     platforms: [iphone, ipad]
     osver: {ios: {min: "7.0"}}
     since: "3.2.0"
-    
+
+  - name: TEXT_STYLE_CALLOUT
+    summary: Specifies the text style for the <Font> Object.
+    description: |
+        One of the group of textStyle constants for the <Font> Object.
+    type: String
+    permission: read-only
+    platforms: [iphone, ipad]
+    osver: {ios: {min: "9.0"}}
+    since: "6.0.0"
+   
+  - name: TEXT_STYLE_TITLE1
+    summary: Specifies the text style for the <Font> Object.
+    description: |
+        One of the group of textStyle constants for the <Font> Object.
+    type: String
+    permission: read-only
+    platforms: [iphone, ipad]
+    osver: {ios: {min: "9.0"}}
+    since: "6.0.0"
+
+  - name: TEXT_STYLE_TITLE2
+    summary: Specifies the text style for the <Font> Object.
+    description: |
+        One of the group of textStyle constants for the <Font> Object.
+    type: String
+    permission: read-only
+    platforms: [iphone, ipad]
+    osver: {ios: {min: "9.0"}}
+    since: "6.0.0"
+
+  - name: TEXT_STYLE_TITLE3
+    summary: Specifies the text style for the <Font> Object.
+    description: |
+        One of the group of textStyle constants for the <Font> Object.
+    type: String
+    permission: read-only
+    platforms: [iphone, ipad]
+    osver: {ios: {min: "9.0"}}
+    since: "6.0.0"
+
   - name: TEXT_VERTICAL_ALIGNMENT_BOTTOM
     summary: Align text to the bottom of the view.
     description: |

--- a/iphone/Classes/UIModule.h
+++ b/iphone/Classes/UIModule.h
@@ -202,6 +202,12 @@
 @property(nonatomic,readonly) NSString *TEXT_STYLE_CAPTION1;
 @property(nonatomic,readonly) NSString *TEXT_STYLE_CAPTION2;
 
+//IOS9 TextStyle Constants
+@property(nonatomic,readonly) NSString *TEXT_STYLE_TITLE1;
+@property(nonatomic,readonly) NSString *TEXT_STYLE_TITLE2;
+@property(nonatomic,readonly) NSString *TEXT_STYLE_TITLE3;
+@property(nonatomic,readonly) NSString *TEXT_STYLE_CALLOUT;
+
 #ifdef USE_TI_UI2DMATRIX
 -(id)create2DMatrix:(id)args;
 #endif

--- a/iphone/Classes/UIModule.m
+++ b/iphone/Classes/UIModule.m
@@ -357,7 +357,38 @@ MAKE_SYSTEM_PROP(EXTEND_EDGE_ALL,15);   //UIEdgeRectAll
 {
     return UIFontTextStyleCaption2;
 }
-
+-(NSString*)TEXT_STYLE_TITLE1
+{
+  if ([TiUtils isIOS9OrGreater]) {
+    return UIFontTextStyleTitle1;
+  } else {
+    return UIFontTextStyleBody;
+  }
+}
+-(NSString*)TEXT_STYLE_TITLE2
+{
+  if ([TiUtils isIOS9OrGreater]) {
+    return UIFontTextStyleTitle2;
+  } else {
+    return UIFontTextStyleBody;
+  }
+}
+-(NSString*)TEXT_STYLE_TITLE3
+{
+  if ([TiUtils isIOS9OrGreater]) {
+    return UIFontTextStyleTitle3;
+  } else {
+    return UIFontTextStyleBody;
+  }
+}
+-(NSString*)TEXT_STYLE_CALLOUT
+{
+  if ([TiUtils isIOS9OrGreater]) {
+    return UIFontTextStyleCallout;
+  } else {
+    return UIFontTextStyleBody;
+  }  
+}
 -(NSNumber*)isLandscape:(id)args
 {
 	return NUMBOOL([UIApplication sharedApplication].statusBarOrientation!=UIInterfaceOrientationPortrait);

--- a/iphone/Classes/WebFont.m
+++ b/iphone/Classes/WebFont.m
@@ -37,8 +37,29 @@
 
 -(BOOL)isValidTextStyle:(NSString*)theStyle
 {
-    return ([theStyle isEqualToString:UIFontTextStyleBody] || [theStyle isEqualToString:UIFontTextStyleCaption1] || [theStyle isEqualToString:UIFontTextStyleCaption2]
-            || [theStyle isEqualToString:UIFontTextStyleHeadline] || [theStyle isEqualToString:UIFontTextStyleSubheadline] || [theStyle isEqualToString:UIFontTextStyleFootnote]);
+    if ([TiUtils isIOS9OrGreater]) {
+       return ( 
+            [theStyle isEqualToString:UIFontTextStyleBody] || 
+            [theStyle isEqualToString:UIFontTextStyleCaption1] || 
+            [theStyle isEqualToString:UIFontTextStyleCaption2] || 
+            [theStyle isEqualToString:UIFontTextStyleHeadline] || 
+            [theStyle isEqualToString:UIFontTextStyleSubheadline] || 
+            [theStyle isEqualToString:UIFontTextStyleFootnote] ||
+            [theStyle isEqualToString:UIFontTextStyleCallout] ||
+            [theStyle isEqualToString:UIFontTextStyleTitle3] || 
+            [theStyle isEqualToString:UIFontTextStyleTitle2] || 
+            [theStyle isEqualToString:UIFontTextStyleTitle1] 
+        ); 
+   } else {
+        return ( 
+            [theStyle isEqualToString:UIFontTextStyleBody] || 
+            [theStyle isEqualToString:UIFontTextStyleCaption1] || 
+            [theStyle isEqualToString:UIFontTextStyleCaption2] || 
+            [theStyle isEqualToString:UIFontTextStyleHeadline] || 
+            [theStyle isEqualToString:UIFontTextStyleSubheadline] || 
+            [theStyle isEqualToString:UIFontTextStyleFootnote] 
+        ); 
+   }  
 }
 
 -(UIFont *) font


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-23584

**Optional Description:**

Add support for UIFontTextStyleTitle1, UIFontTextStyleTitle2, UIFontTextStyle3, UIFontTextStyleCallout on devices running iOS9 or higher.  On other devices, these 4 are changed to UIFontTextStyleBody and it is the developer's responsibilty to adjust their code accordingly

Thanks to @Core-13 (Malcolm Hollingsworth) for testing backward compatiblity on devices that still have iOS 8.x on them
