### PR TITLE
[TIMOB-23311] iOS simulator inabilty to send mail not restricted to a specific simulator version

### DIFF
--- a/iphone/Classes/TiUIEmailDialogProxy.m
+++ b/iphone/Classes/TiUIEmailDialogProxy.m
@@ -57,7 +57,7 @@
 {
 #if TARGET_IPHONE_SIMULATOR
 	if([TiUtils isIOS8OrGreater]) {
-		DebugLog(@"[INFO] iOS 8 Simulator does not support sending emails. Use a device instead.");
+		DebugLog(@"[INFO] iOS Simulator does not support sending emails. Use a device instead.");
 		return NUMBOOL(NO);
 	}
 #endif
@@ -84,9 +84,9 @@
 
 #if TARGET_IPHONE_SIMULATOR
 	if([TiUtils isIOS8OrGreater]) {
-		DebugLog(@"[INFO] iOS 8 Simulator does not support sending emails. Use a device instead.");
+		DebugLog(@"[INFO] iOS Simulator does not support sending emails. Use a device instead.");
 		NSDictionary *event = [NSDictionary dictionaryWithObject:NUMINT(MFMailComposeResultFailed) forKey:@"result"];
-		[self fireEvent:@"complete" withObject:event errorCode:MFMailComposeResultFailed message:@"iOS 8 Simulator does not support sending emails. Use a device instead."];
+		[self fireEvent:@"complete" withObject:event errorCode:MFMailComposeResultFailed message:@"iOS Simulator does not support sending emails. Use a device instead."];
 		return;
 	}
 #endif


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-23311

**Optional Description:**
The message indicates that its a problem with sending mail on just the iOS 8 simulator, when in reality, no simulator up through iOS 9.x has supported sending mail.  Removed reference to '8' to clarify.
