### PR TITLE
[TIMOB-4865] iOS: imageAsCropped rotates image

### DIFF
--- a/iphone/Classes/MediaModule.m
+++ b/iphone/Classes/MediaModule.m
@@ -1863,7 +1863,8 @@ MAKE_SYSTEM_PROP(VIDEO_TIME_OPTION_EXACT,MPMovieTimeOptionExact);
             }
             
             if (resultImage == nil) {
-                resultImage = (editedImage != nil) ? editedImage : originalImage;
+                UIImage *tempImage = (editedImage != nil) ? editedImage : originalImage;
+                resultImage = [TiUtils adjustRoation:tempImage];
             }
             
             media = [[[TiBlob alloc] _initWithPageContext:[self pageContext]] autorelease];

--- a/iphone/Classes/MediaModule.m
+++ b/iphone/Classes/MediaModule.m
@@ -1863,8 +1863,7 @@ MAKE_SYSTEM_PROP(VIDEO_TIME_OPTION_EXACT,MPMovieTimeOptionExact);
             }
             
             if (resultImage == nil) {
-                UIImage *tempImage = (editedImage != nil) ? editedImage : originalImage;
-                resultImage = [TiUtils adjustRoation:tempImage];
+                resultImage = (editedImage != nil) ? [TiUtils adjustRotation:editedImage] : [TiUtils adjustRotation:originalImage];
             }
             
             media = [[[TiBlob alloc] _initWithPageContext:[self pageContext]] autorelease];

--- a/iphone/Classes/TiUtils.h
+++ b/iphone/Classes/TiUtils.h
@@ -155,6 +155,13 @@ typedef enum
 +(UIImage*)toImage:(id)object proxy:(TiProxy*)proxy;
 
 /**
+ Changes to image rotation, so the image is facing up.
+ @param Image to be rotated.
+ @return The rotated image.
+ */
++(UIImage *)adjustRotation:(UIImage *)image;
+
+/**
  Constructs URL from string using provided base URL.
  @param relativeString The relative URL
  @param rootPath The base URL.

--- a/iphone/Classes/TiUtils.h
+++ b/iphone/Classes/TiUtils.h
@@ -156,7 +156,7 @@ typedef enum
 
 /**
  Changes to image rotation, so the image is facing up.
- @param Image to be rotated.
+ @param Image The image to be rotated.
  @return The rotated image.
  */
 +(UIImage *)adjustRotation:(UIImage *)image;

--- a/iphone/Classes/TiUtils.m
+++ b/iphone/Classes/TiUtils.m
@@ -688,6 +688,102 @@ bool Base64AllocAndEncodeData(const void *inInputData, size_t inInputDataSize, c
 	return image;
 	//Note: If url is a nonimmediate image, this returns nil.
 }
++(UIImage *)adjustRotation:(UIImage *) image {
+    
+    CGImageRef imgRef = image.CGImage;
+    
+    CGFloat width = CGImageGetWidth(imgRef);
+    CGFloat height = CGImageGetHeight(imgRef);
+    
+    
+    CGAffineTransform transform = CGAffineTransformIdentity;
+    CGRect bounds = CGRectMake(0, 0, width, height);
+    
+    
+    CGFloat scaleRatio = bounds.size.width / width;
+    CGSize imageSize = CGSizeMake(CGImageGetWidth(imgRef), CGImageGetHeight(imgRef));
+    CGFloat boundHeight;
+    UIImageOrientation orient = image.imageOrientation;
+    switch(orient) {
+            
+        case UIImageOrientationUp: //EXIF = 1
+            transform = CGAffineTransformIdentity;
+            break;
+            
+        case UIImageOrientationUpMirrored: //EXIF = 2
+            transform = CGAffineTransformMakeTranslation(imageSize.width, 0.0);
+            transform = CGAffineTransformScale(transform, -1.0, 1.0);
+            break;
+            
+        case UIImageOrientationDown: //EXIF = 3
+            transform = CGAffineTransformMakeTranslation(imageSize.width, imageSize.height);
+            transform = CGAffineTransformRotate(transform, M_PI);
+            break;
+            
+        case UIImageOrientationDownMirrored: //EXIF = 4
+            transform = CGAffineTransformMakeTranslation(0.0, imageSize.height);
+            transform = CGAffineTransformScale(transform, 1.0, -1.0);
+            break;
+            
+        case UIImageOrientationLeftMirrored: //EXIF = 5
+            boundHeight = bounds.size.height;
+            bounds.size.height = bounds.size.width;
+            bounds.size.width = boundHeight;
+            transform = CGAffineTransformMakeTranslation(imageSize.height, imageSize.width);
+            transform = CGAffineTransformScale(transform, -1.0, 1.0);
+            transform = CGAffineTransformRotate(transform, 3.0 * M_PI / 2.0);
+            break;
+            
+        case UIImageOrientationLeft: //EXIF = 6
+            boundHeight = bounds.size.height;
+            bounds.size.height = bounds.size.width;
+            bounds.size.width = boundHeight;
+            transform = CGAffineTransformMakeTranslation(0.0, imageSize.width);
+            transform = CGAffineTransformRotate(transform, 3.0 * M_PI / 2.0);
+            break;
+            
+        case UIImageOrientationRightMirrored: //EXIF = 7
+            boundHeight = bounds.size.height;
+            bounds.size.height = bounds.size.width;
+            bounds.size.width = boundHeight;
+            transform = CGAffineTransformMakeScale(-1.0, 1.0);
+            transform = CGAffineTransformRotate(transform, M_PI / 2.0);
+            break;
+            
+        case UIImageOrientationRight: //EXIF = 8
+            boundHeight = bounds.size.height;
+            bounds.size.height = bounds.size.width;
+            bounds.size.width = boundHeight;
+            transform = CGAffineTransformMakeTranslation(imageSize.height, 0.0);
+            transform = CGAffineTransformRotate(transform, M_PI / 2.0);
+            break;
+            
+        default:
+            [NSException raise:NSInternalInconsistencyException format:@"Invalid image orientation"];
+            
+    }
+    
+    UIGraphicsBeginImageContext(bounds.size);
+    
+    CGContextRef context = UIGraphicsGetCurrentContext();
+    
+    if (orient == UIImageOrientationRight || orient == UIImageOrientationLeft) {
+        CGContextScaleCTM(context, -scaleRatio, scaleRatio);
+        CGContextTranslateCTM(context, -height, 0);
+    }
+    else {
+        CGContextScaleCTM(context, scaleRatio, -scaleRatio);
+        CGContextTranslateCTM(context, 0, -height);
+    }
+    
+    CGContextConcatCTM(context, transform);
+    
+    CGContextDrawImage(UIGraphicsGetCurrentContext(), CGRectMake(0, 0, width, height), imgRef);
+    UIImage *imageCopy = UIGraphicsGetImageFromCurrentImageContext();
+    UIGraphicsEndImageContext();
+    
+    return imageCopy;
+}
 
 +(NSURL*)checkFor2XImage:(NSURL*)url
 {

--- a/iphone/Classes/TiUtils.m
+++ b/iphone/Classes/TiUtils.m
@@ -691,15 +691,10 @@ bool Base64AllocAndEncodeData(const void *inInputData, size_t inInputDataSize, c
 +(UIImage *)adjustRotation:(UIImage *) image {
     
     CGImageRef imgRef = image.CGImage;
-    
     CGFloat width = CGImageGetWidth(imgRef);
     CGFloat height = CGImageGetHeight(imgRef);
-    
-    
     CGAffineTransform transform = CGAffineTransformIdentity;
     CGRect bounds = CGRectMake(0, 0, width, height);
-    
-    
     CGFloat scaleRatio = bounds.size.width / width;
     CGSize imageSize = CGSizeMake(CGImageGetWidth(imgRef), CGImageGetHeight(imgRef));
     CGFloat boundHeight;
@@ -760,7 +755,6 @@ bool Base64AllocAndEncodeData(const void *inInputData, size_t inInputDataSize, c
             
         default:
             [NSException raise:NSInternalInconsistencyException format:@"Invalid image orientation"];
-            
     }
     
     UIGraphicsBeginImageContext(bounds.size);
@@ -770,8 +764,7 @@ bool Base64AllocAndEncodeData(const void *inInputData, size_t inInputDataSize, c
     if (orient == UIImageOrientationRight || orient == UIImageOrientationLeft) {
         CGContextScaleCTM(context, -scaleRatio, scaleRatio);
         CGContextTranslateCTM(context, -height, 0);
-    }
-    else {
+    } else {
         CGContextScaleCTM(context, scaleRatio, -scaleRatio);
         CGContextTranslateCTM(context, 0, -height);
     }


### PR DESCRIPTION
[JIRA](https://jira.appcelerator.org/browse/TIMOB-4865)

The issue with the camera returning images with the wrong orientation is a very old issue that i found on stakc and apple forums. All of which had this as the only preposed fix.
- [Apple Forum](https://discussions.apple.com/message/7271151#7271151)
- [Stack 1](http://stackoverflow.com/questions/10600613/ios-image-orientation-has-strange-behavior)
- [Stack 2](http://stackoverflow.com/questions/5427656/ios-uiimagepickercontroller-result-image-orientation-after-upload)

This change should not effect the behavior of any of our UI elements that can contain an image.
