### PR TITLE
Fix Xcode-8 detection issues

### DIFF
--- a/iphone/iphone/Titanium_Prefix.pch
+++ b/iphone/iphone/Titanium_Prefix.pch
@@ -11,7 +11,7 @@
 #include "ThirdpartyNS.h"
 #import <AvailabilityInternal.h>
 
-#ifdef __IPHONE_10_0
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 100000
 #define IS_XCODE_8 true
 #else
 #define IS_XCODE_8 false


### PR DESCRIPTION
Since there was a problem with `__IPHONE_10_0`, using this method succeeds on Xcode 7.3.1 as well.
