### PR TITLE
Android: Fix shared property issue with recent V8 update

### DIFF
--- a/android/runtime/v8/src/native/Proxy.cpp
+++ b/android/runtime/v8/src/native/Proxy.cpp
@@ -315,8 +315,6 @@ Local<FunctionTemplate> Proxy::inheritProxyTemplate(Isolate* isolate,
 	inheritedTemplate->Set(javaClassSymbol.Get(isolate), wrappedClass, static_cast<PropertyAttribute>(DontDelete | DontEnum));
 
 	inheritedTemplate->InstanceTemplate()->SetInternalFieldCount(kInternalFieldCount);
-	// every instance gets a special "_properties" object for us to use inetrnally for get/setProperty
-	inheritedTemplate->InstanceTemplate()->Set(propertiesSymbol.Get(isolate), Object::New(isolate), static_cast<PropertyAttribute>(DontEnum));
 	inheritedTemplate->SetClassName(className);
 	inheritedTemplate->Inherit(superTemplate);
 
@@ -332,6 +330,9 @@ void Proxy::proxyConstructor(const v8::FunctionCallbackInfo<v8::Value>& args)
 
 	JNIEnv *env = JNIScope::getEnv();
 	Local<Object> jsProxy = args.This();
+
+	// every instance gets a special "_properties" object for us to use internally for get/setProperty
+	jsProxy->DefineOwnProperty(isolate->GetCurrentContext(), propertiesSymbol.Get(isolate), Object::New(isolate), static_cast<PropertyAttribute>(DontEnum));
 
 	// First things first, we need to wrap the object in case future calls need to unwrap proxy!
 	Proxy* proxy = new Proxy(NULL);

--- a/android/runtime/v8/src/native/ProxyFactory.cpp
+++ b/android/runtime/v8/src/native/ProxyFactory.cpp
@@ -93,9 +93,8 @@ Local<Object> ProxyFactory::createV8Proxy(v8::Isolate* isolate, jclass javaClass
 		return scope.Escape(Local<Object>());
 	}
 
-	// set the pointer back on the java proxy
-	Proxy* proxy = NativeObject::Unwrap<Proxy>(v8Proxy);
-	jlong ptr = (jlong) &(proxy->persistent());
+	titanium::Proxy* proxy = NativeObject::Unwrap<titanium::Proxy>(v8Proxy); // The v8Proxy is a JS Object containing an internal pointer to the Proxy object that wraps it in C++ world.
+	jlong ptr = (jlong) proxy; // We take the address of that C++ Proxy/JavaObject and store it on the Java side to reference when we need to get teh proxy or JS object again
 
 	jobject javaV8Object = env->NewObject(JNIUtil::v8ObjectClass,
 		JNIUtil::v8ObjectInitMethod, ptr);
@@ -125,12 +124,10 @@ jobject ProxyFactory::createJavaProxy(jclass javaClass, Local<Object> v8Proxy, c
 		return NULL;
 	}
 
-	// Create a persistent handle to the V8 proxy
-	// and cast it to a pointer. The Java proxy needs
-	// a reference to the V8 proxy for later use.
-	Proxy* proxy = NativeObject::Unwrap<Proxy>(v8Proxy); // v8Proxy holds Proxy object in internal field
-	jlong pv8Proxy = (jlong) &(proxy->persistent()); // proxy has a persistent holding the v8Proxy.
-	// So we're getting address of the persistent which holds v8Proxy here...
+	// Grab the Proxy pointer from the JSObject that wraps it,
+	// pass along the address of the Proxy to use a pointer to get it back later when we deal with this object
+	titanium::Proxy* proxy = NativeObject::Unwrap<titanium::Proxy>(v8Proxy); // v8Proxy holds pointer to Proxy object in internal field
+	jlong pv8Proxy = (jlong) proxy; // So now we store pointer to the Proxy on Java side.
 
 	// We also pass the creation URL of the proxy so we can track relative URLs
 	Local<Value> sourceUrl = args.Callee()->GetScriptOrigin().ResourceName();

--- a/android/runtime/v8/src/native/TypeConverter.cpp
+++ b/android/runtime/v8/src/native/TypeConverter.cpp
@@ -12,7 +12,7 @@
 #include "AndroidUtil.h"
 #include "TypeConverter.h"
 #include "JNIUtil.h"
-#include "JavaObject.h"
+#include "Proxy.h"
 #include "ProxyFactory.h"
 #include "V8Runtime.h"
 #include "V8Util.h"
@@ -867,10 +867,9 @@ v8::Local<v8::Value> TypeConverter::javaObjectToJsValue(v8::Isolate* isolate, JN
 			env->DeleteLocalRef(krollObject);
 
 			if (v8ObjectPointer != 0) {
-				Persistent<Object>* persistentV8Object = (Persistent<Object>*) v8ObjectPointer;
-				auto v8Object = (*persistentV8Object).Get(isolate);
-				JavaObject *jo = NativeObject::Unwrap<JavaObject>(v8Object);
-				jo->getJavaObject();
+				titanium::Proxy* proxy = (titanium::Proxy*) v8ObjectPointer;
+				v8::Local<v8::Object> v8Object = proxy->handle(isolate);
+				proxy->getJavaObject();
 				return v8Object;
 			}
 		}

--- a/android/runtime/v8/src/native/TypeConverter.h
+++ b/android/runtime/v8/src/native/TypeConverter.h
@@ -18,7 +18,7 @@ class TypeConverter
 public:
 	// Our global map of "pointers" to persistent functions
 	static std::map<int64_t, v8::Persistent<v8::Function, v8::CopyablePersistentTraits<v8::Function>>> functions;
-	//The incrementing key to store the persistent functions
+	// The incrementing key to store the persistent functions
 	static int64_t functionIndex;
 
 	// short convert methods

--- a/android/runtime/v8/src/native/V8Function.cpp
+++ b/android/runtime/v8/src/native/V8Function.cpp
@@ -9,6 +9,7 @@
 #include <v8.h>
 
 #include "JNIUtil.h"
+#include "Proxy.h"
 #include "TypeConverter.h"
 #include "V8Runtime.h"
 #include "V8Util.h"
@@ -34,8 +35,8 @@ JNIEXPORT jobject JNICALL Java_org_appcelerator_kroll_runtime_v8_V8Function_nati
 	titanium::JNIScope jniScope(env);
 
 	// construct this from pointer
-	Persistent<Object>* persistentJSObject = (Persistent<Object>*) thisPointer;
-	Local<Object> thisObject = persistentJSObject->Get(V8Runtime::v8_isolate);
+	titanium::Proxy* proxy = (titanium::Proxy*) thisPointer;
+	Local<Object> thisObject = proxy->handle(V8Runtime::v8_isolate);
 
 	// construct function from "pointer" - we used to use pointers to Persistent to re-construct Functions
 	// But that was a _BAD_ idea because V8 moves handles around as GC runs, resulting in the stored memory address being invalid

--- a/android/runtime/v8/src/native/V8Object.cpp
+++ b/android/runtime/v8/src/native/V8Object.cpp
@@ -47,8 +47,8 @@ Java_org_appcelerator_kroll_runtime_v8_V8Object_nativeSetProperty
 
 	Local<Object> jsObject;
 	if (ptr != 0) {
-		Persistent<Object>* persistentV8Object = (Persistent<Object>*) ptr;
-		jsObject = persistentV8Object->Get(V8Runtime::v8_isolate);
+		titanium::Proxy* proxy = (titanium::Proxy*) ptr;
+		jsObject = proxy->handle(V8Runtime::v8_isolate);
 	} else {
 		jsObject = TypeConverter::javaObjectToJsValue(V8Runtime::v8_isolate, env, object).As<Object>();
 	}
@@ -77,8 +77,8 @@ Java_org_appcelerator_kroll_runtime_v8_V8Object_nativeFireEvent
 
 	Local<Object> emitter;
 	if (ptr != 0) {
-		Persistent<Object>* persistentV8Object = (Persistent<Object>*) ptr;
-		emitter = persistentV8Object->Get(V8Runtime::v8_isolate);
+		titanium::Proxy* proxy = (titanium::Proxy*) ptr;
+		emitter = proxy->handle(V8Runtime::v8_isolate);
 	} else {
 		emitter = TypeConverter::javaObjectToJsValue(V8Runtime::v8_isolate, env, jEmitter).As<Object>();
 	}
@@ -92,8 +92,8 @@ Java_org_appcelerator_kroll_runtime_v8_V8Object_nativeFireEvent
 	if ((jsource == NULL) || (jsource == jEmitter)) {
 		source = emitter;
 	} else if (sourcePtr != 0) {
-		Persistent<Object>* persistentV8Object = (Persistent<Object>*) sourcePtr;
-		source = persistentV8Object->Get(V8Runtime::v8_isolate);
+		titanium::Proxy* proxy = (titanium::Proxy*) sourcePtr;
+		source = proxy->handle(V8Runtime::v8_isolate);
 	} else {
 		source = TypeConverter::javaObjectToJsValue(V8Runtime::v8_isolate, env, jsource).As<Object>();
 	}
@@ -139,8 +139,8 @@ Java_org_appcelerator_kroll_runtime_v8_V8Object_nativeCallProperty
 
 	Local<Value> jsPropertyName = TypeConverter::javaStringToJsString(V8Runtime::v8_isolate, env, propertyName);
 
-	Persistent<Object>* persistentV8Object = (Persistent<Object>*) ptr;
-	Local<Object> object = persistentV8Object->Get(V8Runtime::v8_isolate);
+	titanium::Proxy* proxy = (titanium::Proxy*) ptr;
+	Local<Object> object = proxy->handle(V8Runtime::v8_isolate);
 	Local<Value> property = object->Get(jsPropertyName);
 	if (!property->IsFunction()) {
 		return JNIUtil::undefinedObject;
@@ -180,11 +180,9 @@ Java_org_appcelerator_kroll_runtime_v8_V8Object_nativeRelease
 	JNIScope jniScope(env);
 
 	if (refPointer) {
-		Persistent<Object>* persistentV8Object = (Persistent<Object>*) refPointer;
-		Local<Object> handle = persistentV8Object->Get(V8Runtime::v8_isolate);
-		JavaObject *javaObject = NativeObject::Unwrap<JavaObject>(handle);
-		if (javaObject && javaObject->isDetached()) {
-			delete javaObject;
+		titanium::Proxy* proxy = (titanium::Proxy*) refPointer;
+		if (proxy && proxy->isDetached()) {
+			delete proxy;
 			return true;
 		}
 	}
@@ -201,8 +199,8 @@ Java_org_appcelerator_kroll_runtime_v8_V8Object_nativeSetWindow
 
 	Local<Object> jsKrollWindow;
 	if (ptr != 0) {
-		Persistent<Object>* persistentV8Object = (Persistent<Object>*) ptr;
-		jsKrollWindow = persistentV8Object->Get(V8Runtime::v8_isolate);
+		titanium::Proxy* proxy = (titanium::Proxy*) ptr;
+		jsKrollWindow = proxy->handle(V8Runtime::v8_isolate);
 	} else {
 		jsKrollWindow = TypeConverter::javaObjectToJsValue(V8Runtime::v8_isolate, env, javaKrollWindow).As<Object>();
 	}


### PR DESCRIPTION
**Description:**
Fix issue where all instances of a given proxy type shared the same _properties object to hold any JS properties not overridden with getter/setters. Tweak how we dereference Proxy pointers.
