### PR TITLE
[TIMOB-23649] Use per-platform moduleAPIVersions in the SDK manifest.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,12 @@
   "name": "titanium-mobile",
   "description": "Appcelerator Titanium Mobile",
   "version": "6.0.0",
-  "moduleApiVersion": 2,
+  "moduleApiVersion": {
+    "iphone": "2",
+    "android": "3",
+    "mobileweb": "2",
+    "windows": "2"
+  },
   "keywords": [
     "appcelerator",
     "titanium",


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-23649

**Description:**
This change the moduleAPIVersion in the SDK's manifest.json from a single string value (of "2") to an object with string values for each platform. Right now we're at "2" for every platform except android, which is now "3".

We should likely wait until the Studio PR to enable support for this and the older model is merged: 
appcelerator/titanium_studio#788
