### PR TITLE
[TIMOB-23543] TiAPI: require implementation uses incorrect __filename values

### DIFF
--- a/android/runtime/common/src/js/module.js
+++ b/android/runtime/common/src/js/module.js
@@ -71,7 +71,7 @@ Module.runModule = function (source, filename, activityOrService) {
 	if (!Module.main) {
 		Module.main = module;
 	}
-
+	filename = filename.replace('Resources/', '/'); // normalize back to absolute paths (which really are relative to Resources under the hood)
 	module.load(filename, source)
 	return module;
 }
@@ -98,10 +98,13 @@ Module.prototype.load = function (filename, source) {
 	this.path = path.dirname(filename);
 
 	if (!source) {
-		source = assets.readAsset(filename);
+		source = assets.readAsset('Resources' + filename);
 	}
 
-	this._runScript(source, filename.replace('Resources/', ''));
+	// Stick it in the cache
+	Module.cache[this.filename] = this;
+
+	this._runScript(source, this.filename);
 
 	this.loaded = true;
 }
@@ -255,9 +258,9 @@ Module.prototype.require = function (request, context) {
 		if (loaded) {
 			return loaded;
 		}
-	// Treat '/' special as Resources/
+	// Root/absolute path (internally when reading the file, we prepend "Resources/" as root dir)
 	} else if (request.substring(0, 1) === '/') {
-		loaded = this.loadAsFileOrDirectory('Resources' + request, context);
+		loaded = this.loadAsFileOrDirectory(request, context);
 		if (loaded) {
 			return loaded;
 		}
@@ -266,12 +269,12 @@ Module.prototype.require = function (request, context) {
 		if (request.indexOf('/') == -1) {
 			// For CommonJS we need to look for module.id/module.id.js first...
 			// TODO Only look for this _exact file_. DO NOT APPEND .js or .json to it!
-			loaded = this.loadAsFile('Resources/' + request + '/' + request + '.js', context);
+			loaded = this.loadAsFile('/' + request + '/' + request + '.js', context);
 			if (loaded) {
 				return loaded;
 			}
 			// Then try module.id as directory
-			loaded = this.loadAsDirectory('Resources/' + request, context);
+			loaded = this.loadAsDirectory('/' + request, context);
 			if (loaded) {
 				return loaded;
 			}
@@ -288,7 +291,7 @@ Module.prototype.require = function (request, context) {
 		// Fallback to old Titanium behavior of assuming it's actually an absolute path
 		kroll.log(TAG, "require called with un-prefixed module id, should be a core or CommonJS module. Falling back to old Ti behavior and assuming it's an absolute file");
 
-		loaded = this.loadAsFileOrDirectory('Resources/' + request, context);
+		loaded = this.loadAsFileOrDirectory('/' + request, context);
 		if (loaded) {
 			return loaded;
 		}
@@ -428,25 +431,16 @@ Module.prototype.loadAsFileOrDirectory = function (normalizedPath, context) {
  * @return {Object}          module.exports of the file.
  */
 Module.prototype.loadJavascriptText = function (filename, context) {
-	var module,
-		source;
+	var module;
 
 	// Look in the cache!
 	if (Module.cache[filename]) {
 		return Module.cache[filename].exports;
 	}
 
-	module = new Module(filename, this, context); // difference in id vs filename?
-	module.filename = filename;
-	module.path = path.dirname(filename);
-	source = assets.readAsset(filename);
+	module = new Module(filename, this, context);
+	module.load(filename);
 
-	// Stick it in the cache already?
-	Module.cache[filename] = module;
-
-	module._runScript(source, filename.replace('Resources/', ''));
-
-	module.loaded = true;
 	return module.exports;
 }
 
@@ -466,12 +460,12 @@ Module.prototype.loadJavascriptObject = function (filename, context) {
 		return Module.cache[filename].exports;
 	}
 
-	module = new Module(filename, this, context); // difference in id vs filename?
+	module = new Module(filename, this, context);
 	module.filename = filename;
 	module.path = path.dirname(filename);
-	source = assets.readAsset(filename);
+	source = assets.readAsset('Resources' + filename); // Assumes Resources/!
 
-	// Stick it in the cache already?
+	// Stick it in the cache
 	Module.cache[filename] = module;
 
 	module.exports = JSON.parse(source);
@@ -601,6 +595,7 @@ var fileIndex;
  * @return {Boolean}         true if the filename exists in the index.json
  */
 Module.prototype.filenameExists = function (filename) {
+	filename = 'Resources' + filename; // When we actually look for files, assume "Resources/" is the root
 	if (!fileIndex) {
 		var json = assets.readAsset('index.json');
 		fileIndex = JSON.parse(json);

--- a/android/titanium/src/java/org/appcelerator/titanium/io/TiResourceFile.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/io/TiResourceFile.java
@@ -75,7 +75,7 @@ public class TiResourceFile extends TiBaseFile
 		if (context != null) {
 			String p = TiFileHelper2.joinSegments("Resources", path);
 			in = context.getAssets().open(p);
-			
+
 		}
 		return in;
 	}
@@ -150,7 +150,7 @@ public class TiResourceFile extends TiBaseFile
 		try {
 			is = getInputStream();
 			result = (is != null);
-			
+
 		} catch (IOException e) {
 			// getInputStream() will throw a FileNotFoundException if it is a
 			// directory. We check if there are directory listings. If there is,
@@ -177,7 +177,7 @@ public class TiResourceFile extends TiBaseFile
 		int idx = path.lastIndexOf("/");
 		if (idx != -1)
 		{
-			return path.substring(idx);
+			return path.substring(idx+1);
 		}
 		return path;
 	}
@@ -227,7 +227,7 @@ public class TiResourceFile extends TiBaseFile
 			}
 		}
 		return length;
-		
+
 	}
 
 	@Override

--- a/iphone/Classes/KrollBridge.m
+++ b/iphone/Classes/KrollBridge.m
@@ -31,7 +31,7 @@ extern NSString * const TI_APPLICATION_GUID;
 extern NSString * const TI_APPLICATION_BUILD_TYPE;
 
 NSString * TitaniumModuleRequireFormat = @"(function(exports){"
-		"var __OXP=exports;var module={'exports':exports};var __dirname=\"%@\";var __filename=\"/%@\";%@;\n"
+		"var __OXP=exports;var module={'exports':exports};var __dirname=\"%@\";var __filename=\"%@\";%@;\n"
 		"if(module.exports !== __OXP){return module.exports;}"
 		"return exports;})({})";
 
@@ -759,19 +759,10 @@ CFMutableSetRef	krollBridgeRegistry = nil;
 	// Get the relative path to the Resources directory
 	NSString *relativePath = [sourceURL path];
 	relativePath = [relativePath stringByReplacingOccurrencesOfString:[[[NSBundle mainBundle] resourceURL] path] withString:@""];
-	relativePath = [[relativePath substringFromIndex:1] stringByDeletingLastPathComponent];
+	relativePath = [relativePath stringByDeletingLastPathComponent];
 
-	NSString *dirname = [relativePath length] == 0 ? @"." : relativePath;
-	/*
-	 * This is for parity with android, if the file is located in the Resources, then __dirname returns "."
-	 * otherwise the __dirname returns the folder names separated by "/"
-	 * for example:
-	 *      "/Resources/constants.js"           __dirname = "."
-	 *      "/Resources/views/login/window.js"  __dirname = "views/login"
-	 */
-
-	NSString *filename = [NSString stringWithFormat:@"%@/%@", dirname, [sourceURL lastPathComponent]];
-	NSString *js = [[NSString alloc] initWithFormat:TitaniumModuleRequireFormat, dirname, filename,code];
+	NSString *filename = [NSString stringWithFormat:@"%@/%@", relativePath, [sourceURL lastPathComponent]];
+	NSString *js = [[NSString alloc] initWithFormat:TitaniumModuleRequireFormat, relativePath, filename,code];
 
 	/* This most likely should be integrated with normal code flow, but to
 	 * minimize impact until a in-depth reconsideration of KrollContext can be

--- a/iphone/Classes/KrollBridge.m
+++ b/iphone/Classes/KrollBridge.m
@@ -68,11 +68,11 @@ void TiBindingRunLoopAnnounceStart(TiBindingRunLoop runLoop);
 
 		if (TI_APPLICATION_ANALYTICS)
 		{
-            APSAnalytics *sharedAnalytics = [APSAnalytics sharedInstance];
-            if (TI_APPLICATION_BUILD_TYPE != nil || (TI_APPLICATION_BUILD_TYPE.length > 0)) {
-                [sharedAnalytics performSelector:@selector(setBuildType:) withObject:TI_APPLICATION_BUILD_TYPE];
-            }
-            [sharedAnalytics performSelector:@selector(setSDKVersion:) withObject:[NSString stringWithFormat:@"ti.%@",[module performSelector:@selector(version)]]];
+			APSAnalytics *sharedAnalytics = [APSAnalytics sharedInstance];
+			if (TI_APPLICATION_BUILD_TYPE != nil || (TI_APPLICATION_BUILD_TYPE.length > 0)) {
+				[sharedAnalytics performSelector:@selector(setBuildType:) withObject:TI_APPLICATION_BUILD_TYPE];
+			}
+			[sharedAnalytics performSelector:@selector(setSDKVersion:) withObject:[NSString stringWithFormat:@"ti.%@",[module performSelector:@selector(version)]]];
 			[sharedAnalytics enableWithAppKey:TI_APPLICATION_GUID andDeployType:TI_APPLICATION_DEPLOYTYPE];
 		}
 	}
@@ -238,43 +238,43 @@ CFMutableSetRef	krollBridgeRegistry = nil;
 
 -(void)didReceiveMemoryWarning:(NSNotification*)notification
 {
-    OSSpinLockLock(&proxyLock);
-    if (registeredProxies == NULL) {
-        OSSpinLockUnlock(&proxyLock);
-        [self gc];
-        return;
-    }
+	OSSpinLockLock(&proxyLock);
+	if (registeredProxies == NULL) {
+		OSSpinLockUnlock(&proxyLock);
+		[self gc];
+		return;
+	}
 
-    BOOL keepWarning = YES;
-    signed long proxiesCount = CFDictionaryGetCount(registeredProxies);
-    OSSpinLockUnlock(&proxyLock);
+	BOOL keepWarning = YES;
+	signed long proxiesCount = CFDictionaryGetCount(registeredProxies);
+	OSSpinLockUnlock(&proxyLock);
 
-    //During a memory panic, we may not get the chance to copy proxies.
-    while (keepWarning)
-    {
-        keepWarning = NO;
+	//During a memory panic, we may not get the chance to copy proxies.
+	while (keepWarning)
+	{
+		keepWarning = NO;
 
-        for (id proxy in (NSDictionary *)registeredProxies)
-        {
-            [proxy didReceiveMemoryWarning:notification];
+		for (id proxy in (NSDictionary *)registeredProxies)
+		{
+			[proxy didReceiveMemoryWarning:notification];
 
-            OSSpinLockLock(&proxyLock);
-            if (registeredProxies == NULL) {
-                OSSpinLockUnlock(&proxyLock);
-                break;
-            }
+			OSSpinLockLock(&proxyLock);
+			if (registeredProxies == NULL) {
+				OSSpinLockUnlock(&proxyLock);
+				break;
+			}
 
-            signed long newCount = CFDictionaryGetCount(registeredProxies);
-            OSSpinLockUnlock(&proxyLock);
+			signed long newCount = CFDictionaryGetCount(registeredProxies);
+			OSSpinLockUnlock(&proxyLock);
 
-            if (newCount != proxiesCount)
-            {
-                proxiesCount = newCount;
-                keepWarning = YES;
-                break;
-            }
-        }
-    }
+			if (newCount != proxiesCount)
+			{
+				proxiesCount = newCount;
+				keepWarning = YES;
+				break;
+			}
+		}
+	}
 
 	[self gc];
 }
@@ -382,12 +382,12 @@ CFMutableSetRef	krollBridgeRegistry = nil;
 
 -(BOOL)evaluationError
 {
-    return evaluationError;
+	return evaluationError;
 }
 
 - (void)evalFileOnThread:(NSString*)path context:(KrollContext*)context_
 {
-    NSAutoreleasePool* pool = [[NSAutoreleasePool alloc] init];
+	NSAutoreleasePool* pool = [[NSAutoreleasePool alloc] init];
 
 	NSError *error = nil;
 	TiValueRef exception = NULL;
@@ -439,27 +439,27 @@ CFMutableSetRef	krollBridgeRegistry = nil;
 
 	const char *urlCString = [[url_ absoluteString] UTF8String];
 
-    TiStringRef jsCode = TiStringCreateWithCFString((CFStringRef) jcode);
+	TiStringRef jsCode = TiStringCreateWithCFString((CFStringRef) jcode);
 	TiStringRef jsURL = TiStringCreateWithUTF8CString(urlCString);
 
 	if (exception == NULL) {
 #ifndef USE_JSCORE_FRAMEWORK
-        if ([[self host] debugMode]) {
-            TiDebuggerBeginScript(context_,urlCString);
-        }
+		if ([[self host] debugMode]) {
+			TiDebuggerBeginScript(context_,urlCString);
+		}
 
 		TiEvalScript(jsContext, jsCode, NULL, jsURL, 1, &exception);
-        if ([[self host] debugMode]) {
-            TiDebuggerEndScript(context_);
-        }
+		if ([[self host] debugMode]) {
+			TiDebuggerEndScript(context_);
+		}
 #else
-        TiEvalScript(jsContext, jsCode, NULL, jsURL, 1, &exception);
+		TiEvalScript(jsContext, jsCode, NULL, jsURL, 1, &exception);
 #endif
-        if (exception == NULL) {
-            evaluationError = NO;
-        } else {
-            evaluationError = YES;
-        }
+		if (exception == NULL) {
+			evaluationError = NO;
+		} else {
+			evaluationError = YES;
+		}
 	}
 	if (exception != NULL) {
 		id excm = [KrollObject toID:context value:exception];
@@ -469,7 +469,7 @@ CFMutableSetRef	krollBridgeRegistry = nil;
 
 	TiStringRelease(jsCode);
 	TiStringRelease(jsURL);
-    [pool release];
+	[pool release];
 }
 
 - (void)evalFile:(NSString*)path callback:(id)callback selector:(SEL)selector
@@ -500,10 +500,10 @@ CFMutableSetRef	krollBridgeRegistry = nil;
 	KrollObject* eventKrollObject = [self krollObjectForProxy:proxy];
 
 	KrollEvent * newEvent = [[KrollEvent alloc]
-                             initWithType:type
-                             ForKrollObject:eventKrollObject
-                             eventObject:obj
-                             thisObject:eventKrollObject];
+							 initWithType:type
+							 ForKrollObject:eventKrollObject
+							 eventObject:obj
+							 thisObject:eventKrollObject];
 
 	[context enqueue:newEvent];
 	[newEvent release];
@@ -557,9 +557,9 @@ CFMutableSetRef	krollBridgeRegistry = nil;
 -(void)didStartNewContext:(KrollContext*)kroll
 {
 	// create Titanium global object
-    NSAutoreleasePool* pool = [[NSAutoreleasePool alloc] init];
+	NSAutoreleasePool* pool = [[NSAutoreleasePool alloc] init];
 
-    // Load the "Titanium" object into the global scope
+	// Load the "Titanium" object into the global scope
 	NSString *basePath = (url==nil) ? [TiHost resourcePath] : [[[url path] stringByDeletingLastPathComponent] stringByAppendingPathComponent:@"."];
 	titanium = [[TitaniumObject alloc] initWithContext:kroll host:host context:self baseURL:[NSURL fileURLWithPath:basePath]];
 
@@ -571,18 +571,18 @@ CFMutableSetRef	krollBridgeRegistry = nil;
 	TiStringRef prop2 = TiStringCreateWithCFString((CFStringRef) [NSString stringWithFormat:@"%si","T"]);
 	TiObjectRef globalRef = TiContextGetGlobalObject(jsContext);
 	TiObjectSetProperty(jsContext, globalRef, prop, tiRef,
-                        kTiPropertyAttributeDontDelete | kTiPropertyAttributeDontEnum,
-                        NULL);
+						kTiPropertyAttributeDontDelete | kTiPropertyAttributeDontEnum,
+						NULL);
 	TiObjectSetProperty(jsContext, globalRef, prop2, tiRef,
-                        kTiPropertyAttributeDontDelete | kTiPropertyAttributeDontEnum,
-                        NULL);
+						kTiPropertyAttributeDontDelete | kTiPropertyAttributeDontEnum,
+						NULL);
 	TiStringRelease(prop);
 	TiStringRelease(prop2);
 
-    // Load the "console" object into the global scope
-    console = [[KrollObject alloc] initWithTarget:[[[TiConsole alloc] _initWithPageContext:self] autorelease] context:kroll];
-    prop = TiStringCreateWithCFString((CFStringRef)@"console");
-    TiObjectSetProperty(jsContext, globalRef, prop, [KrollObject toValue:kroll value:console], kTiPropertyAttributeNone, NULL);
+	// Load the "console" object into the global scope
+	console = [[KrollObject alloc] initWithTarget:[[[TiConsole alloc] _initWithPageContext:self] autorelease] context:kroll];
+	prop = TiStringCreateWithCFString((CFStringRef)@"console");
+	TiObjectSetProperty(jsContext, globalRef, prop, [KrollObject toValue:kroll value:console], kTiPropertyAttributeNone, NULL);
 
 	//if we have a preload dictionary, register those static key/values into our namespace
 	if (preload!=nil)
@@ -623,7 +623,7 @@ CFMutableSetRef	krollBridgeRegistry = nil;
 	}
 #endif
 
-    [pool release];
+	[pool release];
 }
 
 -(void)willStopNewContext:(KrollContext*)kroll
@@ -659,7 +659,7 @@ CFMutableSetRef	krollBridgeRegistry = nil;
 	TiThreadPerformOnMainThread(^{[self unregisterForMemoryWarning];}, NO);
 	[self removeProxies];
 	RELEASE_TO_NIL(titanium);
-    RELEASE_TO_NIL(console);
+	RELEASE_TO_NIL(console);
 	RELEASE_TO_NIL(context);
 	RELEASE_TO_NIL(preload);
 #ifdef HYPERLOOP
@@ -757,12 +757,10 @@ CFMutableSetRef	krollBridgeRegistry = nil;
 	sourceURL = [NSURL fileURLWithPath:[[sourceURL path] stringByStandardizingPath]];
 
 	// Get the relative path to the Resources directory
-	NSString *relativePath = [sourceURL path];
-	relativePath = [relativePath stringByReplacingOccurrencesOfString:[[[NSBundle mainBundle] resourceURL] path] withString:@""];
-	relativePath = [relativePath stringByDeletingLastPathComponent];
+	NSString *filename = [[sourceURL path] stringByReplacingOccurrencesOfString:[[[NSBundle mainBundle] resourceURL] path] withString:@""];
+	NSString *dirname = [filename stringByDeletingLastPathComponent];
 
-	NSString *filename = [NSString stringWithFormat:@"%@/%@", relativePath, [sourceURL lastPathComponent]];
-	NSString *js = [[NSString alloc] initWithFormat:TitaniumModuleRequireFormat, relativePath, filename,code];
+	NSString *js = [[NSString alloc] initWithFormat:TitaniumModuleRequireFormat, dirname, filename, code];
 
 	/* This most likely should be integrated with normal code flow, but to
 	 * minimize impact until a in-depth reconsideration of KrollContext can be
@@ -837,65 +835,65 @@ CFMutableSetRef	krollBridgeRegistry = nil;
 
 	// TODO Handle the oddball case of mixing in JS to the native module...
 	/*
-    // TODO: Support package.json 'main' file identifier which will load instead
-    // of module JS. Currently neither iOS nor Android support package information.
-    NSRange separatorLocation = [fullPath rangeOfString:@"/"];
-    if (separatorLocation.location == NSNotFound) { // Indicates toplevel module
-    loadNativeJS:
-        if ([module isJSModule]) {
-            data = [module moduleJS];
-        }
-        [self setCurrentURL:[NSURL URLWithString:fullPath relativeToURL:[[self host] baseURL]]];
-    }
-    else {
-        NSString* assetPath = [fullPath substringFromIndex:separatorLocation.location+1];
-        // Handle the degenerate case (supported by MW) where we're loading
-        // module.id/module.id, which should resolve to module.id and mixin.
-        // Rather than create a utility method for this (or C&P if native loading changes)
-        // we use a goto to jump into the if block above.
+	// TODO: Support package.json 'main' file identifier which will load instead
+	// of module JS. Currently neither iOS nor Android support package information.
+	NSRange separatorLocation = [fullPath rangeOfString:@"/"];
+	if (separatorLocation.location == NSNotFound) { // Indicates toplevel module
+	loadNativeJS:
+		if ([module isJSModule]) {
+			data = [module moduleJS];
+		}
+		[self setCurrentURL:[NSURL URLWithString:fullPath relativeToURL:[[self host] baseURL]]];
+	}
+	else {
+		NSString* assetPath = [fullPath substringFromIndex:separatorLocation.location+1];
+		// Handle the degenerate case (supported by MW) where we're loading
+		// module.id/module.id, which should resolve to module.id and mixin.
+		// Rather than create a utility method for this (or C&P if native loading changes)
+		// we use a goto to jump into the if block above.
 
-        if ([assetPath isEqualToString:moduleID]) {
-            goto loadNativeJS;
-        }
+		if ([assetPath isEqualToString:moduleID]) {
+			goto loadNativeJS;
+		}
 
-        NSString* filepath = [assetPath stringByAppendingString:@".js"];
-        data = [module loadModuleAsset:filepath];
-        // Have to reset module so that this code doesn't get mixed in and is loaded as pure JS
-        module = nil;
-    }
+		NSString* filepath = [assetPath stringByAppendingString:@".js"];
+		data = [module loadModuleAsset:filepath];
+		// Have to reset module so that this code doesn't get mixed in and is loaded as pure JS
+		module = nil;
+	}
 
-    if (data == nil && isAbsolute) {
-        // We may have an absolute URL which tried to load from a module instead of a directory. Fix
-        // the fullpath back to the right value, so we can try again.
-        fullPath = [path hasPrefix:@"/"]?[path substringFromIndex:1]:path;
-    }
-    else if (data != nil) {
-        // Set the current URL; it should be the fullPath relative to the host's base URL.
-            [self setCurrentURL:[NSURL URLWithString:[fullPath stringByDeletingLastPathComponent] relativeToURL:[[self host] baseURL]]];
-    }
+	if (data == nil && isAbsolute) {
+		// We may have an absolute URL which tried to load from a module instead of a directory. Fix
+		// the fullpath back to the right value, so we can try again.
+		fullPath = [path hasPrefix:@"/"]?[path substringFromIndex:1]:path;
+	}
+	else if (data != nil) {
+		// Set the current URL; it should be the fullPath relative to the host's base URL.
+			[self setCurrentURL:[NSURL URLWithString:[fullPath stringByDeletingLastPathComponent] relativeToURL:[[self host] baseURL]]];
+	}
 
-    // For right now, we need to mix any compiled JS on top of a compiled module, so that both components
-    // are accessible. We store the exports object and then put references to its properties on the toplevel
-    // object.
+	// For right now, we need to mix any compiled JS on top of a compiled module, so that both components
+	// are accessible. We store the exports object and then put references to its properties on the toplevel
+	// object.
 
-    TiContextRef jsContext = [[self krollContext] context];
-    TiObjectRef jsObject = [wrapper jsobject];
-    KrollObject* moduleObject = [module krollObjectForContext:[self krollContext]];
-    [moduleObject noteObject:jsObject forTiString:kTiStringExportsKey context:jsContext];
+	TiContextRef jsContext = [[self krollContext] context];
+	TiObjectRef jsObject = [wrapper jsobject];
+	KrollObject* moduleObject = [module krollObjectForContext:[self krollContext]];
+	[moduleObject noteObject:jsObject forTiString:kTiStringExportsKey context:jsContext];
 
-    TiPropertyNameArrayRef properties = TiObjectCopyPropertyNames(jsContext, jsObject);
-    size_t count = TiPropertyNameArrayGetCount(properties);
-    for (size_t i=0; i < count; i++) {
-    // Mixin the property onto the module JS object if it's not already there
-    TiStringRef propertyName = TiPropertyNameArrayGetNameAtIndex(properties, i);
-    if (!TiObjectHasProperty(jsContext, [moduleObject jsobject], propertyName)) {
-    TiValueRef property = TiObjectGetProperty(jsContext, jsObject, propertyName, NULL);
-    TiObjectSetProperty([[self krollContext] context], [moduleObject jsobject], propertyName, property, kTiPropertyAttributeReadOnly, NULL);
-    }
-    }
-    TiPropertyNameArrayRelease(properties);
+	TiPropertyNameArrayRef properties = TiObjectCopyPropertyNames(jsContext, jsObject);
+	size_t count = TiPropertyNameArrayGetCount(properties);
+	for (size_t i=0; i < count; i++) {
+	// Mixin the property onto the module JS object if it's not already there
+	TiStringRef propertyName = TiPropertyNameArrayGetNameAtIndex(properties, i);
+	if (!TiObjectHasProperty(jsContext, [moduleObject jsobject], propertyName)) {
+	TiValueRef property = TiObjectGetProperty(jsContext, jsObject, propertyName, NULL);
+	TiObjectSetProperty([[self krollContext] context], [moduleObject jsobject], propertyName, property, kTiPropertyAttributeReadOnly, NULL);
+	}
+	}
+	TiPropertyNameArrayRelease(properties);
 
-    */
+	*/
 
 	return module;
 }
@@ -967,8 +965,8 @@ CFMutableSetRef	krollBridgeRegistry = nil;
 
 	if (![wrapper respondsToSelector:@selector(replaceValue:forKey:notification:)]) {
 		@throw [NSException exceptionWithName:@"org.appcelerator.kroll"
-		                               reason:[NSString stringWithFormat:@"Module \"%@\" failed to leave a valid exports object", filename]
-		                             userInfo:nil];
+									   reason:[NSString stringWithFormat:@"Module \"%@\" failed to leave a valid exports object", filename]
+									 userInfo:nil];
 	}
 
 	// register the module if it's pure JS
@@ -1071,30 +1069,30 @@ CFMutableSetRef	krollBridgeRegistry = nil;
 
 - (NSArray *)nodeModulesPaths:(NSString *)path
 {
-    // What if we're at root? path may be nil here. So let's hack that case
-    if (path == nil) {
-        path = @"/";
-    }
-    // 1. let PARTS = path split(START)
-    NSArray* parts = [path componentsSeparatedByString:@"/"];
-    // 2. let I = count of PARTS - 1
-    NSInteger i = [parts count] - 1;
-    // 3. let DIRS = []
-    NSMutableArray* dirs = [[NSMutableArray alloc] initWithCapacity:0];
+	// What if we're at root? path may be nil here. So let's hack that case
+	if (path == nil) {
+		path = @"/";
+	}
+	// 1. let PARTS = path split(START)
+	NSArray* parts = [path componentsSeparatedByString:@"/"];
+	// 2. let I = count of PARTS - 1
+	NSInteger i = [parts count] - 1;
+	// 3. let DIRS = []
+	NSMutableArray* dirs = [[NSMutableArray alloc] initWithCapacity:0];
 	// 4. while I >= 0,
-    while (i >= 0) {
-        // a. if PARTS[I] = "node_modules" CONTINUE
-        if ([[parts objectAtIndex:i] isEqual: @"node_modules"]) {
-            continue;
-        }
-        // b. DIR = path join(PARTS[0 .. I] + "node_modules")
-        NSString* dir = [[[parts componentsJoinedByString:@"/"] substringFromIndex:1] stringByAppendingPathComponent:@"node_modules"];
-        // c. DIRS = DIRS + DIR
-        [dirs addObject:dir];
-        // d. let I = I - 1
-        i = i - 1;
-    }
-    return dirs;
+	while (i >= 0) {
+		// a. if PARTS[I] = "node_modules" CONTINUE
+		if ([[parts objectAtIndex:i] isEqual: @"node_modules"]) {
+			continue;
+		}
+		// b. DIR = path join(PARTS[0 .. I] + "node_modules")
+		NSString* dir = [[[parts componentsJoinedByString:@"/"] substringFromIndex:1] stringByAppendingPathComponent:@"node_modules"];
+		// c. DIRS = DIRS + DIR
+		[dirs addObject:dir];
+		// d. let I = I - 1
+		i = i - 1;
+	}
+	return dirs;
 }
 
 - (TiModule *)loadNodeModules:(NSString *)path withDir:(NSString *)start withContext:(KrollContext *)kroll
@@ -1303,12 +1301,12 @@ CFMutableSetRef	krollBridgeRegistry = nil;
 
 -(BOOL)shouldDebugContext
 {
-    return [[self host] debugMode];
+	return [[self host] debugMode];
 }
 
 - (BOOL)shouldProfileContext
 {
-    return [[self host] profileMode];
+	return [[self host] profileMode];
 }
 
 @end

--- a/tests/Resources/ti.require.test.js
+++ b/tests/Resources/ti.require.test.js
@@ -1,0 +1,201 @@
+/*
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2011-2016 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+var should = require('./utilities/assertions'),
+	utilities = require('./utilities/utilities');
+
+describe('requireJS', function () {
+	// require should be a function
+	it('requireJS.Function', function () {
+		should(require).be.a.Function;
+	});
+
+	// require should return object
+	it('requireJS.Object', function () {
+		var object = require('ti.require.test_test');
+		should(object).be.an.Object;
+	});
+
+	// require for invalid file should throw error
+	it('requireJS.NonObject', function () {
+		(function () {
+			var object = require('requireJS_test_notfound');
+			should(object).not.be.an.Object;
+		}).should.throw();
+	});
+
+	// require should cache object
+	it('requireJS.ObjectCache', function () {
+		var object1 = require('ti.require.test_test');
+		var object2 = require('ti.require.test_test');
+		should(object1).be.an.Object;
+		should(object2).be.an.Object;
+		should((object1 ==  object2)).be.true;
+		should((object1 === object2)).be.true;
+	});
+
+	// local function and variable should not be exposed
+	it('requireJS.LocalFunc', function () {
+		var object = require('ti.require.test_test');
+		should(object).be.an.Object;
+		should(object.localVariable).be.undefined;
+		should(object.localFunction).be.undefined;
+	});
+
+	// public function with 0 argument
+	it('requireJS.PublicFunc0', function () {
+		var object = require('ti.require.test_test');
+		should(object).be.an.Object;
+		should(object.testFunc0).a.Function;
+		var result = object.testFunc0();
+		should(result).be.a.String;
+		should(result).be.eql('testFunc0');
+	});
+
+	// public function with 1 argument
+	it('requireJS.PublicFunc1', function () {
+		var object = require('ti.require.test_test');
+		should(object).be.an.Object;
+		should(object.testFunc1).be.a.Function;
+		var result = object.testFunc1('A');
+		should(result).be.a.String;
+		should(result).be.eql('testFunc1 A');
+	});
+
+	// public function with 2 arguments
+	it('requireJS.PublicFunc2', function () {
+		var object = require('ti.require.test_test');
+		should(object).be.an.Object;
+		should(object.testFunc2).be.a.Function;
+		var result = object.testFunc2('A', 'B');
+		should(result).be.a.String;
+		should(result).be.eql('testFunc2 A B');
+	});
+
+	// public string variable
+	it('requireJS.PublicStrVar', function () {
+		var object = require('ti.require.test_test');
+		should(object).be.an.Object;
+		should(object.testStrVar).be.a.String;
+		should(object.testStrVar).be.eql('testVar0');
+	});
+
+	// public number variable
+	it('requireJS.PublicNumVar', function () {
+		var object = require('ti.require.test_test');
+		should(object).be.an.Object;
+		should(object.testNumVar).be.a.Number;
+		should(object.testNumVar).be.eql(101);
+	});
+
+	// public boolean variable
+	it('requireJS.PublicBoolVar', function () {
+		var object = require('ti.require.test_test');
+		should(object).be.an.Object;
+		should(object.testBoolVar).be.a.Boolean;
+		should(object.testBoolVar).be.true;
+	});
+
+	// public null variable
+	it('requireJS.PublicNullVar', function () {
+		var object = require('ti.require.test_test');
+		should(object).be.an.Object;
+		should(object.testNullVar).be.null;
+	});
+
+	// internal __filename
+	it('requireJS.__filename', function () {
+		var object = require('ti.require.test_test');
+		should(object).be.an.Object;
+		should(object.filename).be.a.String;
+		should(object.filename).be.eql('/ti.require.test_test.js');
+	});
+
+	// internal __filename
+	it('requireJS.__dirname', function () {
+		var object = require('ti.require.test_test');
+		should(object).be.an.Object;
+		should(object.dirname).be.a.String;
+		should(object.dirname).be.eql('/');
+	});
+
+	it('loads package.json main property when requiring directory', function () {
+		var with_package = require('./with_package');
+		should(with_package).have.property('name');
+		should(with_package.name).be.eql('main.js');
+		should(with_package.filename).be.eql('/with_package/main.js');
+		should(with_package.dirname).be.eql('/with_package');
+	});
+
+	it('falls back to index.js when requiring directory with no package.json', function () {
+		var with_index_js = require('./with_index_js');
+		should(with_index_js).have.property('name');
+		should(with_index_js.name).be.eql('index.js');
+		should(with_index_js.filename).be.eql('/with_index_js/index.js');
+		should(with_index_js.dirname).be.eql('/with_index_js');
+	});
+
+	// TIMOB-23512
+	it('relative require() from sub directory', function () {
+		var with_index_js = require('./with_index_js/sub1');
+		should(with_index_js).have.property('name');
+		should(with_index_js.name).be.eql('sub1.js');
+		should(with_index_js.sub).be.eql('sub2.js');
+		// Was also failing if same file had multiple relative requires
+		should(with_index_js.sub3).be.eql('sub3.js');
+		should(with_index_js.filename).be.eql('/with_index_js/sub1.js');
+		should(with_index_js.dirname).be.eql('/with_index_js');
+	});
+
+	it('falls back to index.json when requiring directory with no package.json or index.js', function () {
+		var with_index_json = require('./with_index_json');
+		should(with_index_json).have.property('name');
+		should(with_index_json.name).be.eql('index.json');
+	});
+
+	it('loads exact match JS file', function () {
+		var exact_js = require('./with_package/index.js');
+		should(exact_js).have.property('name');
+		should(exact_js.name).be.eql('index.js');
+		should(exact_js.filename).be.eql('/with_package/index.js');
+		should(exact_js.dirname).be.eql('/with_package');
+	});
+
+	it('loads exact match JSON file', function () {
+		var package_json = require('./with_package/package.json');
+		should(package_json).have.property('main');
+		should(package_json.main).be.eql('./main.js');
+	});
+
+	it('loads .js with matching file basename if no exact match', function () {
+		var with_index_js = require('./with_index_js/index');
+		should(with_index_js).have.property('name');
+		should(with_index_js.name).be.eql('index.js');
+		should(with_index_js.filename).be.eql('/with_index_js/index.js');
+		should(with_index_js.dirname).be.eql('/with_index_js');
+	});
+
+	it('loads .json with matching file basename if no exact or .js match', function () {
+		var with_index_json = require('./with_index_json/index');
+		should(with_index_json).have.property('name');
+		should(with_index_json.name).be.eql('index.json');
+	});
+
+	it('loads file under Titanium CommonJS module containing moduleid.js file', function () {
+		var object = require('commonjs.legacy.package/main');
+		should(object).have.property('name');
+		should(object.name).be.eql('commonjs.legacy.package/main.js');
+	});
+
+	it ('should load a node module by id in node_modules folder living at same level as requirer', function () {
+		var abbrev = require('abbrev');
+		should(abbrev).be.a.Function;
+		should(abbrev("foo", "fool", "folding", "flop")).eql({ fl: 'flop', flo: 'flop', flop: 'flop', fol: 'folding', fold: 'folding', foldi: 'folding', foldin: 'folding', folding: 'folding', foo: 'foo', fool: 'fool'});
+	});
+
+	// TODO Add a test for requiring a node module up one level from requiring file!
+
+});

--- a/tests/Resources/ti.require.test_test.js
+++ b/tests/Resources/ti.require.test_test.js
@@ -1,0 +1,32 @@
+// local variables and functions which should not be exported
+var localVariable = 'localVariable';
+var localFunction = function () {
+	return 'localFunction';
+};
+
+// public functions which should be exported
+exports.testFunc0 = function () {
+	return 'testFunc0';
+};
+exports.testFunc1 = function (arg1) {
+	return 'testFunc1 ' + arg1;
+};
+exports.testFunc2 = function (arg1, arg2) {
+	return 'testFunc2 ' + arg1 + ' ' + arg2;
+};
+
+// test for internal __filename
+exports.filename = __filename;
+exports.dirname = __dirname;
+
+// public variables which should be exported
+exports.testStrVar = 'testVar0';
+exports.testNumVar = 101;
+exports.testBoolVar = true;
+exports.testNullVar = null;
+
+// these are actually a side effect, but we can expose to global object
+this.globalFunctionFromModule = function () {
+	return "globalFunctionFromModule";
+};
+this.globalStrVarFromModule = "globalStrVarFromModule";

--- a/tests/Resources/with_index_js/index.js
+++ b/tests/Resources/with_index_js/index.js
@@ -1,0 +1,5 @@
+module.exports = {
+	name: 'index.js',
+	filename: __filename,
+	dirname: __dirname
+};

--- a/tests/Resources/with_index_js/index.json
+++ b/tests/Resources/with_index_js/index.json
@@ -1,0 +1,3 @@
+{
+	"name": "index.json"
+}

--- a/tests/Resources/with_index_js/sub1.js
+++ b/tests/Resources/with_index_js/sub1.js
@@ -1,0 +1,10 @@
+var sub2 = require('./sub2'),
+    sub3 = require('./sub3');
+
+module.exports = {
+    name: 'sub1.js',
+    sub: sub2.name,
+    sub3: sub3.name,
+	filename: __filename,
+	dirname: __dirname
+};

--- a/tests/Resources/with_index_js/sub2.js
+++ b/tests/Resources/with_index_js/sub2.js
@@ -1,0 +1,5 @@
+module.exports = {
+    name: 'sub2.js',
+	filename: __filename,
+	dirname: __dirname
+};

--- a/tests/Resources/with_index_js/sub3.js
+++ b/tests/Resources/with_index_js/sub3.js
@@ -1,0 +1,5 @@
+module.exports = {
+    name: 'sub3.js',
+	filename: __filename,
+	dirname: __dirname
+};

--- a/tests/Resources/with_index_json/index.json
+++ b/tests/Resources/with_index_json/index.json
@@ -1,0 +1,3 @@
+{
+	"name": "index.json"
+}

--- a/tests/Resources/with_package/index.js
+++ b/tests/Resources/with_package/index.js
@@ -1,0 +1,5 @@
+module.exports = {
+	name: 'index.js',
+	filename: __filename,
+	dirname: __dirname
+};

--- a/tests/Resources/with_package/index.json
+++ b/tests/Resources/with_package/index.json
@@ -1,0 +1,3 @@
+{
+	"name": "index.json"
+}

--- a/tests/Resources/with_package/main.js
+++ b/tests/Resources/with_package/main.js
@@ -1,0 +1,5 @@
+module.exports = {
+	name: 'main.js',
+	filename: __filename,
+	dirname: __dirname
+};

--- a/tests/Resources/with_package/package.json
+++ b/tests/Resources/with_package/package.json
@@ -1,0 +1,2 @@
+{ "name" : "some-library",
+  "main" : "./main.js" }


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-23543

**Description:**
__filename should now be exposed as the "absolute" path to the resolved file. In our case we define "absolute" as really being relative to the internal Resources directory in the app, since that's the base of any paths that the end-user/developer deals with.

This PR modifies the existing require tests to validate the value of __filename and __dirname under a number of use cases. I did not add support for _-filename and __dirname in JSON files, and haven't investigated if that's supported in Node or not.
