### PR TITLE
TIMOB-23458 - build command should include -d flag

### DIFF
--- a/node_modules/titanium-sdk/lib/adb.js
+++ b/node_modules/titanium-sdk/lib/adb.js
@@ -520,7 +520,7 @@ ADB.prototype.installApp = function installApp(deviceId, apkFile, opts, callback
 			androidDetect(this.config, function (err, results) {
 				if (err) return callback(err);
 
-				opts.logger && opts.logger.trace(__('Executing: %s', [results.sdk.executables.adb, '-s', deviceId, 'install', '-r', apkFile].join(' ').cyan));
+				opts.logger && opts.logger.trace(__('Executing: %s', [results.sdk.executables.adb, '-s', deviceId, 'install', '-r', '-d', apkFile].join(' ').cyan));
 
 				appc.subprocess.run(results.sdk.executables.adb, ['-s', deviceId, 'install', '-r', '-d', apkFile], function (code, out, err) {
 					var m = out.match(/^Failure \[(.+)\]$/m);

--- a/node_modules/titanium-sdk/lib/adb.js
+++ b/node_modules/titanium-sdk/lib/adb.js
@@ -522,7 +522,7 @@ ADB.prototype.installApp = function installApp(deviceId, apkFile, opts, callback
 
 				opts.logger && opts.logger.trace(__('Executing: %s', [results.sdk.executables.adb, '-s', deviceId, 'install', '-r', apkFile].join(' ').cyan));
 
-				appc.subprocess.run(results.sdk.executables.adb, ['-s', deviceId, 'install', '-r', apkFile], function (code, out, err) {
+				appc.subprocess.run(results.sdk.executables.adb, ['-s', deviceId, 'install', '-r', '-d', apkFile], function (code, out, err) {
 					var m = out.match(/^Failure \[(.+)\]$/m);
 					if ((code && err.indexOf('No space left on device') != -1) || (!code && m && m[1] == 'INSTALL_FAILED_INSUFFICIENT_STORAGE')) {
 						callback(new Error(__('Not enough free space on device')));


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-23458

Adds the `-d` (downgrade permitted) flag to the `adb install` command generated when you build to an Android device. This prevents the `[ERROR] Error: INSTALL_FAILED_VERSION_DOWNGRADE` failure if the app exists on the device with a newer version. 

It seems like the titanium-sdk module must be maintained in a separate repository. But, I could not find it. So, I've made the modification here. I'll be glad to submit the PR elsewhere if needed.
