### PR TITLE
[5_4_X][TIMOB-15765] Android: TableView - JNI ERROR (app bug): local reference table overflow (max=512)

### DIFF
--- a/android/runtime/v8/src/java/org/appcelerator/kroll/runtime/v8/V8Runtime.java
+++ b/android/runtime/v8/src/java/org/appcelerator/kroll/runtime/v8/V8Runtime.java
@@ -44,13 +44,25 @@ public final class V8Runtime extends KrollRuntime implements Handler.Callback
 	private AtomicBoolean shouldGC = new AtomicBoolean(false);
 	private long lastV8Idle;
 
+	public static boolean isEmulator() {
+		return "goldfish".equals(Build.HARDWARE)
+			|| Build.FINGERPRINT.startsWith("generic")
+			|| Build.FINGERPRINT.startsWith("unknown")
+			|| Build.MODEL.contains("google_sdk")
+			|| Build.MODEL.contains("Emulator")
+			|| Build.MODEL.contains("Android SDK built for x86")
+			|| Build.MANUFACTURER.contains("Genymotion")
+			|| (Build.BRAND.startsWith("generic") && Build.DEVICE.startsWith("generic"))
+			|| "google_sdk".equals(Build.PRODUCT);
+	}
+
 	@Override
 	public void initRuntime()
 	{
 		boolean useGlobalRefs = true;
 		TiDeployData deployData = getKrollApplication().getDeployData();
 
-		if (Build.PRODUCT.equals("sdk") || Build.PRODUCT.equals("google_sdk") || Build.FINGERPRINT.startsWith("generic")) {
+		if (isEmulator()) {
 			Log.d(TAG, "Emulator detected, storing global references in a global Map", Log.DEBUG_MODE);
 			useGlobalRefs = false;
 		}
@@ -245,4 +257,3 @@ public final class V8Runtime extends KrollRuntime implements Handler.Callback
 	private native void nativeDispose();
 	private native void nativeAddExternalCommonJsModule(String moduleName, KrollSourceCodeProvider sourceProvider);
 }
-


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-15765

**Description:**
Back port of #8147 

Can't add unit tests on 5_4_X branch, unfortunately, so I guess a manual test is needed. Set this as your app.js and run on an older emulator (< Android 6) and a newer emulator (6+):

``` javascript
var numberOfTableRowsToTest = 400; // 50 is enough to trigger on Android 4.4.2. 400 hits error on Android 6.0/23

var vAnswerTable = Ti.UI.createTableView({
    data: [Ti.UI.createTableViewRow({title:'Loading...'})],
});

var numOfQuestions = numberOfTableRowsToTest / 5;
var numOfAnswers = numOfQuestions * 4;
var sections = [];

for (var i = 0; i < numOfQuestions; i++) {
    var questionTableSection = Ti.UI.createTableViewSection({});

    var questionRow = Ti.UI.createTableViewRow({});

    questionTableSection.add(questionRow);

    for (var z = 0; z < numOfAnswers; z++) {
        var answerRow = Ti.UI.createTableViewRow({});
        var lAnswer = Ti.UI.createLabel({});

        answerRow.add(lAnswer);
        questionTableSection.add(answerRow);
    }
    sections.push(questionTableSection);
}

// Add the sections created above to the table view
vAnswerTable.setData(sections);

for (var i = 0; i < vAnswerTable.data.length; i++) {
    Ti.API.info("Here after " + i + " iterations outer loop. Current section: " + vAnswerTable.data[i]);
    for (var k = 0; k < vAnswerTable.data[i].rowCount; k++) {
        Ti.API.info("Here after " + k + " iterations inner loop, " + i + " iterations outer loop. Current section row: "+  vAnswerTable.data[i].rows[k]);
    }
}
```

On older Android it would complain about a JNI local ref overflow at 512 entries. On newer it would complain about a slightly different variant of the error (weak global refs, with a max of 51200).
