### PR TITLE
[TIMOB-23638] Android: Unable to debug an application with newer V8

### DIFF
--- a/android/runtime/v8/src/java/org/appcelerator/kroll/runtime/v8/V8Runtime.java
+++ b/android/runtime/v8/src/java/org/appcelerator/kroll/runtime/v8/V8Runtime.java
@@ -98,7 +98,7 @@ public final class V8Runtime extends KrollRuntime implements Handler.Callback
 		// Instantiate a debugger here and pass it along to C++ code
 		JSDebugger jsDebugger = null;
 		if (deployData.getDebuggerPort() >= 0) {
-			jsDebugger = new JSDebugger(deployData.getDebuggerPort(), new Handler(Looper.getMainLooper()), application.getSDKVersion());
+			jsDebugger = new JSDebugger(deployData.getDebuggerPort(), application.getSDKVersion());
 		}
 
 		nativeInit(useGlobalRefs, jsDebugger, DBG, deployData.isProfilerEnabled());

--- a/android/runtime/v8/src/native/JSDebugger.cpp
+++ b/android/runtime/v8/src/native/JSDebugger.cpp
@@ -80,10 +80,8 @@ void JSDebugger::MessageHandler(const v8::Debug::Message& message)
 		return;
 	}
 
-	static JNIEnv *env = NULL;
-	if (!env) {
-		titanium::JNIUtil::javaVm->AttachCurrentThread(&env, NULL);
-	}
+	JNIEnv *env = JNIUtil::getJNIEnv();
+	ASSERT(env != NULL);
 
 	auto json = message.GetJSON();
 	jstring s = TypeConverter::jsStringToJavaString(env, json);


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-23638

**Description:**

The should fix some of the issues seen with the Android V8 debugger on master SDK builds. There's still a fix that needs to be applied to Studio to have breakpoints actually get hit.

This fix is related to threading issues leading to hard crashes. Specifically we would very rarely get Android complaining about a JNIEnv\* mismatch that caused a hard crash (on emulator only). This should also fix crashes seen much more frequently around asking V8 to process the incoming debug messages (where it would typically crash doing GC).
