### PR TITLE
[TIMOB-23744] Android: Crash using Ti.Android.R values

### DIFF
--- a/android/kroll-apt/src/java/org/appcelerator/kroll/annotations/generator/ProxyBindingV8.cpp.fm
+++ b/android/kroll-apt/src/java/org/appcelerator/kroll/annotations/generator/ProxyBindingV8.cpp.fm
@@ -336,6 +336,12 @@ void ${className}::interceptor(Local<String> property, const v8::PropertyCallbac
 	}
 
 	jobject javaProxy = proxy->getJavaObject();
+	// Java object may be null if we get here during call to DefineOwnProperty for _properties of Proxy::proxyConstructor (and we haven't init'd the Java object yet)
+	if (javaProxy == NULL) {
+		args.GetReturnValue().Set(Undefined(isolate));
+		return;
+	}
+
 	jstring javaProperty = titanium::TypeConverter::jsStringToJavaString(env, property);
 	jobject jResult = (jobject) env->CallObjectMethod(javaProxy, methodID, javaProperty);
 

--- a/android/runtime/v8/src/native/Proxy.cpp
+++ b/android/runtime/v8/src/native/Proxy.cpp
@@ -331,12 +331,12 @@ void Proxy::proxyConstructor(const v8::FunctionCallbackInfo<v8::Value>& args)
 	JNIEnv *env = JNIScope::getEnv();
 	Local<Object> jsProxy = args.This();
 
-	// every instance gets a special "_properties" object for us to use internally for get/setProperty
-	jsProxy->DefineOwnProperty(isolate->GetCurrentContext(), propertiesSymbol.Get(isolate), Object::New(isolate), static_cast<PropertyAttribute>(DontEnum));
-
 	// First things first, we need to wrap the object in case future calls need to unwrap proxy!
 	Proxy* proxy = new Proxy(NULL);
 	proxy->wrap(isolate, jsProxy);
+
+	// every instance gets a special "_properties" object for us to use internally for get/setProperty
+	jsProxy->DefineOwnProperty(isolate->GetCurrentContext(), propertiesSymbol.Get(isolate), Object::New(isolate), static_cast<PropertyAttribute>(DontEnum));
 
 	// Now we hook up a java Object from the JVM...
 	jobject javaProxy = ProxyFactory::unwrapJavaProxy(args); // do we already have one that got passed in?


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-23744

**Description:**
Proxies using "interceptors" on the latest V8 were broken (i.e. The Ti.Android.R proxy). When internally adding our _properties object to the object it would trigger some callbacks to happen that we tried to get all the properties on the object before it was all initialized. I modified the ordering of when we wrap the JS object in C++ and when we define _properties. I also added in a null check to the interceptor C++ code, so that if we try to get a property handled by the interceptor and we haven't initialized the Java object in the JVM, then we'll return undefined for the time being.

This bug fix eliminates the crash seen before when simply adding a reference to Ti.Android.R.anim to your app.js file.

It'd be good to do more thorough testing to be sure that proxy works as intended, i.e. doesn't always give back undefined for values and gives us back values we expect...
