### PR TITLE
Update windowslib to 0.4.16

### DIFF
--- a/node_modules/windowslib/CHANGELOG.md
+++ b/node_modules/windowslib/CHANGELOG.md
@@ -1,3 +1,7 @@
+0.4.16 (8/9/2016)
+-------------------
+  * [TIMOB-23748] Fix: Failed to connect to WP 8.1 device
+
 0.4.15 (7/13/2016)
 -------------------
   * [TIMOB-23279] Only report detected device 

--- a/node_modules/windowslib/env.properties
+++ b/node_modules/windowslib/env.properties
@@ -1,10 +1,6 @@
-PACKAGE_VERSION=0.4.15
+PACKAGE_VERSION=0.4.16
 PROJECT_KEY=issues
-JIRA_ISSUES=TIMOB-23279,TIMOB-23279,TIMOB-23279,TIMOB-23279,TIMOB-23484,TIMOB-23484,TIMOB-23484
+JIRA_ISSUES=TIMOB-23748,TIMOB-23748,TIMOB-23748,TIMOB-23749,TIMOB-23749,TIMOB-23749
 CHANGES=\
-2bda4cc Merge pull request #42 from garymathews/TIMOB-23279\
-b209857 [TIMOB-23279] Bump version to 0.4.15\
-c9a22b0 [TIMOB-23279] Only report a device when one has been detected\
-0219deb Merge pull request #48 from garymathews/TIMOB-23484\
-19317f1 Bump to 0.4.14\
-2eb2954 [TIMOB-23484] wptool.detect() ignore errors when results are present\
+715aae5 Merge pull request #50 from infosia/TIMOB-23748\
+9e1da67 [TIMOB-23748] Fix: Failed to connect to WP 8.1 device\

--- a/node_modules/windowslib/lib/visualstudio.js
+++ b/node_modules/windowslib/lib/visualstudio.js
@@ -70,8 +70,9 @@ function detect(options, callback) {
 			'HKEY_CURRENT_USER\\Software\\Microsoft\\VisualStudio', // should be the same as the one above, but just to be safe
 			'HKEY_LOCAL_MACHINE\\Software\\Microsoft\\VSWinExpress', // there should not be anything here because VS is currently 32-bit and we'll find it next
 			'HKEY_LOCAL_MACHINE\\Software\\Wow6432Node\\Microsoft\\VSWinExpress', // this is where VS should be found because it's 32-bit
-			'HKEY_CURRENT_USER\\Software\\Microsoft\\VSWinExpress' // should be the same as the one above, but just to be safe
-			], function (keyPath, next) {
+			'HKEY_CURRENT_USER\\Software\\Microsoft\\VSWinExpress', // should be the same as the one above, but just to be safe
+			'HKEY_CURRENT_USER\\Software\\Microsoft\\VPDExpress' // VS express
+		], function (keyPath, next) {
 			appc.subprocess.run('reg', ['query', keyPath], function (code, out, err) {
 				if (!code) {
 					out.trim().split(/\r\n|\n/).forEach(function (configKey) {

--- a/node_modules/windowslib/lib/wptool.js
+++ b/node_modules/windowslib/lib/wptool.js
@@ -149,7 +149,11 @@ function wptoolEnumerate(wpsdk, options, next) {
 		async.parallel([
 			// discover windows 10 devices in network using WinAppDeployCmd
 			function (cb) {
-				winAppDeployCmdEnumerate(phoneResults.windowsphone[wpsdk].deployCmd, cb);
+				if (wpsdk == '10.0') {
+					winAppDeployCmdEnumerate(phoneResults.windowsphone[wpsdk].deployCmd, cb);
+				} else {
+					nativeEnumerate(wpsdk, options, cb);
+				}
 			},
 			// Use our custom wptool binary to gather Windows 10 emulators
 			function (cb) {

--- a/node_modules/windowslib/package.json
+++ b/node_modules/windowslib/package.json
@@ -2,26 +2,26 @@
   "_args": [
     [
       {
-        "raw": "windowslib@0.4.15",
+        "raw": "windowslib@0.4.16",
         "scope": null,
         "escapedName": "windowslib",
         "name": "windowslib",
-        "rawSpec": "0.4.15",
-        "spec": "0.4.15",
+        "rawSpec": "0.4.16",
+        "spec": "0.4.16",
         "type": "version"
       },
       "/Users/chris/appc/titanium_mobile"
     ]
   ],
-  "_from": "windowslib@0.4.15",
-  "_id": "windowslib@0.4.15",
+  "_from": "windowslib@0.4.16",
+  "_id": "windowslib@0.4.16",
   "_inCache": true,
   "_installable": true,
   "_location": "/windowslib",
   "_nodeVersion": "5.1.0",
   "_npmOperationalInternal": {
     "host": "packages-12-west.internal.npmjs.com",
-    "tmp": "tmp/windowslib-0.4.15.tgz_1468372797103_0.2522465765941888"
+    "tmp": "tmp/windowslib-0.4.16.tgz_1470781185057_0.11832122690975666"
   },
   "_npmUser": {
     "name": "appcelerator",
@@ -30,22 +30,22 @@
   "_npmVersion": "3.3.12",
   "_phantomChildren": {},
   "_requested": {
-    "raw": "windowslib@0.4.15",
+    "raw": "windowslib@0.4.16",
     "scope": null,
     "escapedName": "windowslib",
     "name": "windowslib",
-    "rawSpec": "0.4.15",
-    "spec": "0.4.15",
+    "rawSpec": "0.4.16",
+    "spec": "0.4.16",
     "type": "version"
   },
   "_requiredBy": [
     "/"
   ],
-  "_resolved": "https://registry.npmjs.org/windowslib/-/windowslib-0.4.15.tgz",
-  "_shasum": "60234769d923162e324d7a808258ed5234e78870",
+  "_resolved": "https://registry.npmjs.org/windowslib/-/windowslib-0.4.16.tgz",
+  "_shasum": "10fa00b3efacb07d96fc191c3a058e0ca1fbb71a",
   "_shrinkwrap": null,
-  "_spec": "windowslib@0.4.15",
   "_where": "/Users/chris/appc/titanium_mobile",
+  "_spec": "windowslib@0.4.16",
   "author": {
     "name": "Appcelerator, Inc.",
     "email": "npmjs@appcelerator.com"
@@ -70,13 +70,13 @@
     "lib": "./lib"
   },
   "dist": {
-    "shasum": "60234769d923162e324d7a808258ed5234e78870",
-    "tarball": "https://registry.npmjs.org/windowslib/-/windowslib-0.4.15.tgz"
+    "shasum": "10fa00b3efacb07d96fc191c3a058e0ca1fbb71a",
+    "tarball": "https://registry.npmjs.org/windowslib/-/windowslib-0.4.16.tgz"
   },
   "engines": {
     "node": ">=0.8"
   },
-  "gitHead": "2bda4cced0bb233f91942014393dfe576098d142",
+  "gitHead": "715aae507f15c5a1dbf43c09922dd989e7a0f955",
   "homepage": "https://github.com/appcelerator/windowslib#readme",
   "keywords": [
     "appcelerator",
@@ -132,5 +132,5 @@
     "test-winstore": "mocha --require test/init --reporter spec --check-leaks test/test-winstore",
     "test-wptool": "mocha --require test/init --reporter spec --check-leaks test/test-wptool"
   },
-  "version": "0.4.15"
+  "version": "0.4.16"
 }

--- a/node_modules/windowslib/wptool/wptool.cs
+++ b/node_modules/windowslib/wptool/wptool.cs
@@ -174,18 +174,6 @@ namespace wptool
 					return showHelp(String.Format("Invalid device UDID '{0:D}'", udid));
 				}
 
-				// ConnectableDevice throws an error when connecting to a physical Windows 10 device
-				// physical Windows 10 devices can be connected to using 127.0.0.1
-				if (command == "connect" && connectableDevice.Version.Major == 10 && !connectableDevice.IsEmulator())
-				{
-					Console.WriteLine("{");
-					Console.WriteLine("\t\"success\": true,");
-					Console.WriteLine("\t\"ip\": \"127.0.0.1\",");
-					Console.WriteLine("\t\"osVersion\": \"" + connectableDevice.Version.ToString() + "\"");
-					Console.WriteLine("}");
-					return 0;
-				}
-
 				try {
 					IDevice device = connectableDevice.Connect();
 
@@ -197,27 +185,45 @@ namespace wptool
 						Console.WriteLine("\t\"success\": true");
 						Console.WriteLine("}");
 					} else {
-						string destinationIp;
-						string sourceIp;
-						int destinationPort;
-						device.GetEndPoints(0, out sourceIp, out destinationIp, out destinationPort);
-						var address = IPAddress.Parse(destinationIp);
-						ISystemInfo systemInfo = device.GetSystemInfo();
+						try {
+							string destinationIp;
+							string sourceIp;
+							int destinationPort;
+							device.GetEndPoints(0, out sourceIp, out destinationIp, out destinationPort);
+							var address = IPAddress.Parse(destinationIp);
+							ISystemInfo systemInfo = device.GetSystemInfo();
 
-						Version version = new Version(systemInfo.OSMajor, systemInfo.OSMinor, systemInfo.OSBuildNo);
-						Console.WriteLine("{");
-						Console.WriteLine("\t\"success\": true,");
-						Console.WriteLine("\t\"ip\": \"" + address.ToString() + "\",");
-						Console.WriteLine("\t\"port\": " + destinationPort.ToString() + ",");
-						Console.WriteLine("\t\"osVersion\": \"" + version.ToString() + "\",");
-						Console.WriteLine("\t\"availablePhysical\": " + systemInfo.AvailPhys.ToString() + ",");
-						Console.WriteLine("\t\"totalPhysical\": " + systemInfo.TotalPhys.ToString() + ",");
-						Console.WriteLine("\t\"availableVirtual\": " + systemInfo.AvailVirtual.ToString() + ",");
-						Console.WriteLine("\t\"totalVirtual\": " + systemInfo.TotalVirtual.ToString() + ",");
-						Console.WriteLine("\t\"architecture\": \"" + systemInfo.ProcessorArchitecture.ToString() + "\",");
-						Console.WriteLine("\t\"instructionSet\": \"" + systemInfo.InstructionSet.ToString() + "\",");
-						Console.WriteLine("\t\"processorCount\": " + systemInfo.NumberOfProcessors.ToString() + "");
-						Console.WriteLine("}");
+							Version version = new Version(systemInfo.OSMajor, systemInfo.OSMinor, systemInfo.OSBuildNo);
+							Console.WriteLine("{");
+							Console.WriteLine("\t\"success\": true,");
+							Console.WriteLine("\t\"ip\": \"" + address.ToString() + "\",");
+							Console.WriteLine("\t\"port\": " + destinationPort.ToString() + ",");
+							Console.WriteLine("\t\"osVersion\": \"" + version.ToString() + "\",");
+							Console.WriteLine("\t\"availablePhysical\": " + systemInfo.AvailPhys.ToString() + ",");
+							Console.WriteLine("\t\"totalPhysical\": " + systemInfo.TotalPhys.ToString() + ",");
+							Console.WriteLine("\t\"availableVirtual\": " + systemInfo.AvailVirtual.ToString() + ",");
+							Console.WriteLine("\t\"totalVirtual\": " + systemInfo.TotalVirtual.ToString() + ",");
+							Console.WriteLine("\t\"architecture\": \"" + systemInfo.ProcessorArchitecture.ToString() + "\",");
+							Console.WriteLine("\t\"instructionSet\": \"" + systemInfo.InstructionSet.ToString() + "\",");
+							Console.WriteLine("\t\"processorCount\": " + systemInfo.NumberOfProcessors.ToString() + "");
+							Console.WriteLine("}");
+						} catch (Exception ex) {
+							//
+							// ConnectableDevice throws an error when connecting to a physical Windows 10 device
+							// physical Windows 10 devices can be connected to using 127.0.0.1.
+							// From some point of Windows 10 SDK, IDevice.GetEndPoints throws Exception for Windows Phone 8.1 device too.
+							// Interestingly ConnectableDevice.Version returns 8.1 _or_ 6.3 in this case.
+							// Returning ok for now because we can still connect to the device.
+							//
+							if (command == "connect" && !connectableDevice.IsEmulator()) {
+								Console.WriteLine("{");
+								Console.WriteLine("\t\"success\": true,");
+								Console.WriteLine("\t\"ip\": \"127.0.0.1\",");
+								Console.WriteLine("\t\"osVersion\": \"" + connectableDevice.Version.ToString() + "\"");
+								Console.WriteLine("}");
+								return 0;
+							}
+						}
 					}
 					return 0;
 				} catch (Exception ex) {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "temp": "0.8.3",
     "uglify-js": "2.7.0",
     "unorm": "^1.4.1",
-    "windowslib": "0.4.15",
+    "windowslib": "0.4.16",
     "wrench": "1.5.9",
     "xcode": "0.8.9",
     "xmldom": "0.1.22"


### PR DESCRIPTION
- Update `windowslib` to `0.4.16`
  
  [[TIMOB-23749](https://jira.appcelerator.org/browse/TIMOB-23749)] "appc ti info" does not list WP 8.1 emulators 
  [[TIMOB-23748](https://jira.appcelerator.org/browse/TIMOB-23748)] Fix: Failed to connect to WP 8.1 device 
