### PR TITLE
[TIMOB-23753] Android: Crash when adding Ti.Network event listener

### DIFF
--- a/android/runtime/v8/src/native/Proxy.cpp
+++ b/android/runtime/v8/src/native/Proxy.cpp
@@ -246,7 +246,12 @@ void Proxy::hasListenersForEventType(const v8::FunctionCallbackInfo<v8::Value>& 
 		return;
 	}
 
-	Proxy* proxy = NativeObject::Unwrap<Proxy>(args.Holder());
+	Local<Object> holder = args.Holder();
+	// If holder isn't the JavaObject wrapper we expect, look up the prototype chain
+	if (!JavaObject::isJavaObject(holder)) {
+		holder = holder->FindInstanceInPrototypeChain(baseProxyTemplate.Get(isolate));
+	}
+	Proxy* proxy = NativeObject::Unwrap<Proxy>(holder);
 
 	Local<String> eventType = args[0]->ToString(isolate);
 	Local<Boolean> hasListeners = args[1]->ToBoolean(isolate);
@@ -277,7 +282,12 @@ void Proxy::onEventFired(const v8::FunctionCallbackInfo<v8::Value>& args)
 		return;
 	}
 
-	Proxy* proxy = NativeObject::Unwrap<Proxy>(args.Holder());
+	Local<Object> holder = args.Holder();
+	// If holder isn't the JavaObject wrapper we expect, look up the prototype chain
+	if (!JavaObject::isJavaObject(holder)) {
+		holder = holder->FindInstanceInPrototypeChain(baseProxyTemplate.Get(isolate));
+	}
+	Proxy* proxy = NativeObject::Unwrap<Proxy>(holder);
 
 	Local<String> eventType = args[0]->ToString(isolate);
 	Local<Value> eventData = args[1];


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-23753

**Description:**
This JS code caused a hard crash:

``` javascript

Ti.Network.addEventListener('change', function() {
      console.log('test');
  })
```

I modified proxy method callbacks in C++ to be able to look up the prototype chain on "this" to get the JS object wrapping the Java proxy. In some cases we do some wrapping of APIs to be able to "lazily" load sub-types/methods, and this causes issues in C++ if we assume "this" always wraps the proxy. In some cases "this" is that JS lazy wrapper so we need to search up it's prototype chain to the real JS proxy object holding our Java object. I had already done the same thing for generated proxies in ProxyBindingV8.cpp.fm, but needed to add it manually for titanium::Proxy.cpp.
