### PR TITLE
[TIMOB-23406] Android: add 'scrolling' event to listView 

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/TiListView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/TiListView.java
@@ -58,7 +58,7 @@ import android.util.AttributeSet;
 
 public class TiListView extends TiUIView implements OnSearchChangeListener {
 
-	private ListViewScollEvent listView;
+	private ListViewScrollEvent listView;
 	private TiBaseAdapter adapter;
 	private ArrayList<ListSectionProxy> sections;
 	private AtomicInteger itemTypeCount;
@@ -100,16 +100,16 @@ public class TiListView extends TiUIView implements OnSearchChangeListener {
 	public static final int BUILT_IN_TEMPLATE_ITEM_TYPE = 2;
 	public static final int CUSTOM_TEMPLATE_ITEM_TYPE = 3;
 
-	public class ListViewScollEvent extends ListView {
-	    public ListViewScollEvent(Context context) {
+	public class ListViewScrollEvent extends ListView {
+	    public ListViewScrollEvent(Context context) {
 	        super(context);
 	    }
 
-	    public ListViewScollEvent(Context context, AttributeSet attrs) {
+	    public ListViewScrollEvent(Context context, AttributeSet attrs) {
 	        super(context,attrs);
 	    }
 
-	    public ListViewScollEvent(Context context, AttributeSet attrs, int defStyle) {
+	    public ListViewScrollEvent(Context context, AttributeSet attrs, int defStyle) {
 	        super(context, attrs, defStyle);
 	    }
 
@@ -314,7 +314,7 @@ public class TiListView extends TiUIView implements OnSearchChangeListener {
 		ListViewWrapper wrapper = new ListViewWrapper(activity);
 		wrapper.setFocusable(false);
 		wrapper.setFocusableInTouchMode(false);
-		listView = new ListViewScollEvent(activity);
+		listView = new ListViewScrollEvent(activity);
 		listView.setLayoutParams(new ViewGroup.LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT));
 		wrapper.addView(listView);
 		adapter = new TiBaseAdapter(activity);
@@ -391,7 +391,7 @@ public class TiListView extends TiUIView implements OnSearchChangeListener {
 				_firstVisibleItem = firstVisibleItem;
 				_visibleItemCount = visibleItemCount;
 				int scrolledOffset = listView.getVerticalScrollOffset();
-			    if (scrolledOffset != mInitialScroll) {
+				if (scrolledOffset != mInitialScroll) {
 					if (scrolledOffset > mInitialScroll) {
 						scrollUp = 1;
 					} else {
@@ -399,7 +399,7 @@ public class TiListView extends TiUIView implements OnSearchChangeListener {
 					}
 					if (scrollUp != newScrollUp) {
 						KrollDict eventArgs = new KrollDict();
-						eventArgs.put("direction", (scrollUp>0)?"up":"down");
+						eventArgs.put("direction", (scrollUp > 0) ? "up" : "down");
 						eventArgs.put("velocity", 0);
 						eventArgs.put("targetContentOffset", 0);
 						fProxy.fireEvent(TiC.EVENT_SCROLLING, eventArgs, false);

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/TiListView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/TiListView.java
@@ -54,10 +54,11 @@ import android.widget.FrameLayout;
 import android.widget.ListView;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
+import android.util.AttributeSet;
 
 public class TiListView extends TiUIView implements OnSearchChangeListener {
 
-	private ListView listView;
+	private ListViewScollEvent listView;
 	private TiBaseAdapter adapter;
 	private ArrayList<ListSectionProxy> sections;
 	private AtomicInteger itemTypeCount;
@@ -98,6 +99,25 @@ public class TiListView extends TiUIView implements OnSearchChangeListener {
 	public static final int HEADER_FOOTER_TITLE_TYPE = 1;
 	public static final int BUILT_IN_TEMPLATE_ITEM_TYPE = 2;
 	public static final int CUSTOM_TEMPLATE_ITEM_TYPE = 3;
+
+	public class ListViewScollEvent extends ListView {
+	    public ListViewScollEvent(Context context) {
+	        super(context);
+	    }
+
+	    public ListViewScollEvent(Context context, AttributeSet attrs) {
+	        super(context,attrs);
+	    }
+
+	    public ListViewScollEvent(Context context, AttributeSet attrs, int defStyle) {
+	        super(context, attrs, defStyle);
+	    }
+
+	    //we need this protected method for scroll detection
+	    public int getVerticalScrollOffset() {
+	        return computeVerticalScrollOffset();
+	    }
+	}
 
 	class ListViewWrapper extends FrameLayout {
 		private boolean viewFocused = false;
@@ -294,7 +314,7 @@ public class TiListView extends TiUIView implements OnSearchChangeListener {
 		ListViewWrapper wrapper = new ListViewWrapper(activity);
 		wrapper.setFocusable(false);
 		wrapper.setFocusableInTouchMode(false);
-		listView = new ListView(activity);
+		listView = new ListViewScollEvent(activity);
 		listView.setLayoutParams(new ViewGroup.LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT));
 		wrapper.addView(listView);
 		adapter = new TiBaseAdapter(activity);
@@ -318,6 +338,9 @@ public class TiListView extends TiUIView implements OnSearchChangeListener {
 			private int _visibleItemCount = 0;
 			private boolean canFireScrollStart = true;
 			private boolean canFireScrollEnd = false;
+			private int mInitialScroll = 0;
+			private int scrollUp = 0;
+			private int newScrollUp = 0;
 
 			@Override
 			public void onScrollStateChanged(AbsListView view, int scrollState)
@@ -327,6 +350,7 @@ public class TiListView extends TiUIView implements OnSearchChangeListener {
 					eventName = TiC.EVENT_SCROLLEND;
 					canFireScrollEnd = false;
 					canFireScrollStart = true;
+					newScrollUp = 0;
 				} else if (scrollState == OnScrollListener.SCROLL_STATE_TOUCH_SCROLL && canFireScrollStart) {
 					eventName = TiC.EVENT_SCROLLSTART;					
 					canFireScrollEnd = true;
@@ -366,6 +390,23 @@ public class TiListView extends TiUIView implements OnSearchChangeListener {
 			{
 				_firstVisibleItem = firstVisibleItem;
 				_visibleItemCount = visibleItemCount;
+				int scrolledOffset = listView.getVerticalScrollOffset();
+			    if (scrolledOffset != mInitialScroll) {
+					if (scrolledOffset > mInitialScroll) {
+						scrollUp = 1;
+					} else {
+						scrollUp = -1;
+					}
+					if (scrollUp != newScrollUp) {
+						KrollDict eventArgs = new KrollDict();
+						eventArgs.put("direction", (scrollUp>0)?"up":"down");
+						eventArgs.put("velocity", 0);
+						eventArgs.put("targetContentOffset", 0);
+						fProxy.fireEvent(TiC.EVENT_SCROLLING, eventArgs, false);
+						newScrollUp = scrollUp;
+					}
+			        mInitialScroll = scrolledOffset;
+			    }
 			}
 		});
 		

--- a/android/titanium/src/java/org/appcelerator/titanium/TiC.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiC.java
@@ -486,6 +486,11 @@ public class TiC
 	/**
 	 * @module.api
 	 */
+	public static final String EVENT_SCROLLING = "scrolling";
+
+	/**
+	 * @module.api
+	 */
 	public static final String EVENT_SCROLLSTART = "scrollstart";
 
 	/**

--- a/apidoc/Titanium/UI/ListView.yml
+++ b/apidoc/Titanium/UI/ListView.yml
@@ -608,12 +608,15 @@ events:
     summary: Fires when the list view is scrolling. Calling the `scrollTo` methods will not fire this event
     description: |
         This event will fire while the list view is scrolling and the user releases the finger.
-        No event is fired when the finger is not released. Use  `direction` to determine the scroll direction,
+        On iOS no event is fired when the finger is not released. Use  `direction` to determine the scroll direction,
         `velocity` to determine scroll speed, targetContentOffset to determine where the scrolling will end (in dpi). 
-        When `direction` is `down`, `velocity` is negative and viceversa. 
+        When `direction` is `down`, `velocity` is negative and viceversa. On Android `velocity` and `targetContentOffset` is 0.
 
-    platforms: [iphone, ipad]
-    since: 5.4.0
+    platforms: [android, iphone, ipad]
+    since:
+        android: 6.1.0
+        iphone: 5.4.0
+        ipad: 5.4.0
     properties:
       - name: direction
         summary: Direction of the scroll either 'up', or 'down'.


### PR DESCRIPTION
JIRA: https://jira.appcelerator.org/browse/TIMOB-23406

Partiy PR

Based on this Code from Stackoverflow: http://stackoverflow.com/a/25564729/5193915
Using the onScroll in JAVA but only firering an event to Titanium when the direction changes. So instide Ti you won't get too many calls.

Will handle big (bigger than screen) and small listItems. Using computeVerticalScrollOffset is better than checking for   "listview.getChildAt(0).getTop()" because it will be recycled once in a while.
