### PR TITLE
[TIMOB-23614] Update method signature to match superclass (6_0_X)

### DIFF
--- a/templates/applewatch/watchos2-swift/template/{{WatchkitExtName}}/InterfaceController.swift.ejs
+++ b/templates/applewatch/watchos2-swift/template/{{WatchkitExtName}}/InterfaceController.swift.ejs
@@ -22,7 +22,7 @@ class InterfaceController: WKInterfaceController, WCSessionDelegate {
         }
     }
 
-    override func awake(withContext context: AnyObject?) {
+    override func awake(withContext context: Any?) {
         super.awake(withContext: context)
 
         // Configure interface objects here.


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-23614

**Description:**

The original fix for TIMOB-23614 was introduced with Beta 4 of Xcode 8
and contains a now outdated method signature. With Xcode 8 Beta 6
the signature for the awake method changed slightly and this commit
updates the signature to match its superclass again.
