### PR TITLE
[TIMOB-23798] iOS: Fix clearData nil-value argument

### DIFF
--- a/iphone/Classes/TiUIClipboardProxy.m
+++ b/iphone/Classes/TiUIClipboardProxy.m
@@ -67,11 +67,12 @@ static NSString *mimeTypeToUTType(NSString *mimeType)
 -(void)clearData:(id)arg
 {
 	ENSURE_UI_THREAD(clearData, arg);
-	ENSURE_STRING_OR_NIL(arg);
+	ENSURE_SINGLE_ARG_OR_NIL(arg, NSString);
 
-	NSString *mimeType = arg;
+	NSString *mimeType = arg ?: @"application/octet-stream";
 	UIPasteboard *board = [UIPasteboard generalPasteboard];
 	ClipboardType dataType = mimeTypeToDataType(mimeType);
+	
 	switch (dataType)
 	{
 		case CLIPBOARD_TEXT:


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-23798

Additional infos:
- Extracts the argument from the arguments-array properly
- Sets the correct mime-type for resetting the data to `NSData` (which is `application/octet-stream`)
