### PR TITLE
[5_5_X] revert to windowslib 0.4.13

### DIFF
--- a/node_modules/windowslib/CHANGELOG.md
+++ b/node_modules/windowslib/CHANGELOG.md
@@ -1,23 +1,3 @@
-0.4.18 (8/12/2016)
--------------------
-  * [TIMOB-23762] Handle duplicate package error from Windows SDK 10.0.14393
-
-0.4.17 (8/12/2016)
--------------------
-  * [TIMOB-23768] Detect installed Win10 SDK versions
-
-0.4.16 (8/9/2016)
--------------------
-  * [TIMOB-23748] Fix: Failed to connect to WP 8.1 device
-
-0.4.15 (7/13/2016)
--------------------
-  * [TIMOB-23279] Only report detected device 
-
-0.4.14 (6/24/2016)
--------------------
-  * [TIMOB-23484] wptool.detect() ignore errors when results are present
-
 0.4.13 (4/29/2016)
 -------------------
   * Fix [TIMOB-20376] Windows Phone: Cannot read property 'split' of undefined

--- a/node_modules/windowslib/env.properties
+++ b/node_modules/windowslib/env.properties
@@ -1,6 +1,5 @@
-PACKAGE_VERSION=0.4.18
+PACKAGE_VERSION=0.4.13
 PROJECT_KEY=issues
-JIRA_ISSUES=TIMOB-23762,TIMOB-23762,TIMOB-23762
+JIRA_ISSUES=TIMOB-20376
 CHANGES=\
-4986856 Merge pull request #53 from garymathews/TIMOB-23762\
-3a54b76 [TIMOB-23762] Handle duplicate package error from Windows SDK 10.0.14393\
+ccb5eba Fix [TIMOB-20376] Windows Phone: Cannot read property 'split' of undefined (#47)\

--- a/node_modules/windowslib/lib/visualstudio.js
+++ b/node_modules/windowslib/lib/visualstudio.js
@@ -70,9 +70,8 @@ function detect(options, callback) {
 			'HKEY_CURRENT_USER\\Software\\Microsoft\\VisualStudio', // should be the same as the one above, but just to be safe
 			'HKEY_LOCAL_MACHINE\\Software\\Microsoft\\VSWinExpress', // there should not be anything here because VS is currently 32-bit and we'll find it next
 			'HKEY_LOCAL_MACHINE\\Software\\Wow6432Node\\Microsoft\\VSWinExpress', // this is where VS should be found because it's 32-bit
-			'HKEY_CURRENT_USER\\Software\\Microsoft\\VSWinExpress', // should be the same as the one above, but just to be safe
-			'HKEY_CURRENT_USER\\Software\\Microsoft\\VPDExpress' // VS express
-		], function (keyPath, next) {
+			'HKEY_CURRENT_USER\\Software\\Microsoft\\VSWinExpress' // should be the same as the one above, but just to be safe
+			], function (keyPath, next) {
 			appc.subprocess.run('reg', ['query', keyPath], function (code, out, err) {
 				if (!code) {
 					out.trim().split(/\r\n|\n/).forEach(function (configKey) {

--- a/node_modules/windowslib/lib/windowsphone.js
+++ b/node_modules/windowslib/lib/windowsphone.js
@@ -60,8 +60,7 @@ function detectLegacy(options, callback) {
 							path: null,
 							deployCmd: null,
 							xapSignTool: null,
-							selected: false,
-							sdks: []
+							selected: false
 						};
 					}
 				});
@@ -151,8 +150,7 @@ function detectWin10(options, callback) {
 								path: parts[2],
 								deployCmd: null,
 								xapSignTool: null,
-								selected: false,
-								sdks: []
+								selected: false
 							};
 
 							var deployCmd = path.join(parts[2], 'bin', 'x86', 'WinAppDeployCmd.exe'),
@@ -170,14 +168,6 @@ function detectWin10(options, callback) {
 			next();
 		});
 	}, function () {
-		// fetch all Windows 10 SDK install information
-		var win10 = '10.0'
-		if (results.windowsphone[win10] && results.windowsphone[win10].path) {
-			var sdks_path = path.join(results.windowsphone[win10].path, 'Extension SDKs', 'WindowsMobile');
-			if (fs.existsSync(sdks_path)) {
-				results.windowsphone[win10].sdks = fs.readdirSync(sdks_path);
-			}
-		}
 		callback(null, results);
 	});
 };

--- a/node_modules/windowslib/lib/winstore.js
+++ b/node_modules/windowslib/lib/winstore.js
@@ -396,8 +396,7 @@ function detect(options, callback) {
 								signTool: null,
 								makeCert: null,
 								pvk2pfx: null,
-								selected: false,
-								sdks: []
+								selected: false
 							};
 						}
 					});
@@ -460,15 +459,6 @@ function detect(options, callback) {
 						__('You will be unable to build Windows Store apps.')
 					});
 					return finalize();
-				}
-
-				// fetch all Windows 10 SDK install information
-				var win10 = '10.0'
-				if (results.windows[win10] && results.windows[win10].path) {
-					var sdks_path = path.join(results.windows[win10].path, 'Extension SDKs', 'WindowsDesktop');
-					if (fs.existsSync(sdks_path)) {
-						results.windows[win10].sdks = fs.readdirSync(sdks_path);
-					}
 				}
 
 				var preferred = options.preferred;

--- a/node_modules/windowslib/lib/wptool.js
+++ b/node_modules/windowslib/lib/wptool.js
@@ -149,11 +149,7 @@ function wptoolEnumerate(wpsdk, options, next) {
 		async.parallel([
 			// discover windows 10 devices in network using WinAppDeployCmd
 			function (cb) {
-				if (wpsdk == '10.0') {
-					winAppDeployCmdEnumerate(phoneResults.windowsphone[wpsdk].deployCmd, cb);
-				} else {
-					nativeEnumerate(wpsdk, options, cb);
-				}
+				winAppDeployCmdEnumerate(phoneResults.windowsphone[wpsdk].deployCmd, cb);
 			},
 			// Use our custom wptool binary to gather Windows 10 emulators
 			function (cb) {
@@ -288,10 +284,7 @@ function detect(options, callback) {
 		},
 		tmp = {};
 
-		if (err && !results) {
-			// detected an error with no results
-			callback(err);
-		} else {
+		if (!err) {
 			Object.keys(results).forEach(function (wpsdk) {
 				result.emulators[wpsdk] = results[wpsdk].emulators;
 				results[wpsdk].devices.forEach(function (dev) {
@@ -327,7 +320,7 @@ function detect(options, callback) {
 			}
 		}
 
-		callback(null, result);
+		callback(err, result);
 	});
 }
 
@@ -356,8 +349,8 @@ function enumerate(options, callback) {
 
 			// wpsdks is a constant above that contains all supported Windows Phone SDK versions
 			async.eachSeries(wpsdks, function (wpsdk, next) {
-				// Use custom wptool for 10.0 and 8.1, use native tooling for 8.0
-				var funcToCall = (wpsdk != '8.0') ? wptoolEnumerate : nativeEnumerate;
+				// We use our custom tool for Win 10, the native tooling for 8.x
+				var funcToCall = (wpsdk == '10.0') ? wptoolEnumerate : nativeEnumerate;
 
 				funcToCall(wpsdk, options, function (err, result) {
 					if (err) {
@@ -365,7 +358,7 @@ function enumerate(options, callback) {
 						// Then later if we have no results for any version, we propagate the error
 						if (!results[wpsdk]) {
 							results[wpsdk] = {
-								devices: [],
+								devices: [{name: 'Device', udid: 0, index: 0, wpsdk: null}],
 								emulators: [],
 							};
 						}
@@ -386,7 +379,7 @@ function enumerate(options, callback) {
 					return results[wpsdk].emulators.length > 0;
 				})) {
 					emitter.emit('error', errors[0]);
-					return callback(errors[0], results);
+					return callback(errors[0]);
 				}
 
 				// add a helper function to get a device by udid
@@ -830,15 +823,9 @@ function wpToolInstall(deployCmd, device, appPath, options, callback) {
 		clearTimeout(abortTimer);
 
 		if (code) {
-			// handle duplicate package identity error code from Windows 10.0.14393 tooling and above
-			if (code == '2148734208') {
-				options.forceUnInstall = true;
-				wpToolInstall(deployCmd, device, appPath, options, callback);
-			} else {
-				var errmsg = out.trim().split(/\r\n|\n/).shift(),
-					ex = new Error(/^Error: /.test(errmsg) ? errmsg.substring(7) : __('Failed to install app (code %s): %s', code, out));
-				callback(ex);
-			}
+			var errmsg = out.trim().split(/\r\n|\n/).shift(),
+				ex = new Error(/^Error: /.test(errmsg) ? errmsg.substring(7) : __('Failed to install app (code %s): %s', code, out));
+			callback(ex);
 		} else {
 			var errmsg = /failed\. (\w*)\r?\n(.*)/.exec(out);
 			if (errmsg) {

--- a/node_modules/windowslib/package.json
+++ b/node_modules/windowslib/package.json
@@ -2,50 +2,50 @@
   "_args": [
     [
       {
-        "raw": "windowslib@0.4.18",
+        "raw": "windowslib@0.4.13",
         "scope": null,
         "escapedName": "windowslib",
         "name": "windowslib",
-        "rawSpec": "0.4.18",
-        "spec": "0.4.18",
+        "rawSpec": "0.4.13",
+        "spec": "0.4.13",
         "type": "version"
       },
       "/Users/chris/appc/titanium_mobile"
     ]
   ],
-  "_from": "windowslib@0.4.18",
-  "_id": "windowslib@0.4.18",
+  "_from": "windowslib@0.4.13",
+  "_id": "windowslib@0.4.13",
   "_inCache": true,
   "_installable": true,
   "_location": "/windowslib",
-  "_nodeVersion": "5.1.0",
+  "_nodeVersion": "4.2.2",
   "_npmOperationalInternal": {
-    "host": "packages-16-east.internal.npmjs.com",
-    "tmp": "tmp/windowslib-0.4.18.tgz_1471087812760_0.2898555537685752"
+    "host": "packages-12-west.internal.npmjs.com",
+    "tmp": "tmp/windowslib-0.4.13.tgz_1461941718073_0.969214336713776"
   },
   "_npmUser": {
     "name": "appcelerator",
     "email": "npmjs@appcelerator.com"
   },
-  "_npmVersion": "3.3.12",
+  "_npmVersion": "2.14.19",
   "_phantomChildren": {},
   "_requested": {
-    "raw": "windowslib@0.4.18",
+    "raw": "windowslib@0.4.13",
     "scope": null,
     "escapedName": "windowslib",
     "name": "windowslib",
-    "rawSpec": "0.4.18",
-    "spec": "0.4.18",
+    "rawSpec": "0.4.13",
+    "spec": "0.4.13",
     "type": "version"
   },
   "_requiredBy": [
     "/"
   ],
-  "_resolved": "https://registry.npmjs.org/windowslib/-/windowslib-0.4.18.tgz",
-  "_shasum": "c2a2e93c633415da1053d000786ceec2af5e0350",
+  "_resolved": "https://registry.npmjs.org/windowslib/-/windowslib-0.4.13.tgz",
+  "_shasum": "f9db83ba0b5b5b823d0ea6792950f32ea2074ad0",
   "_shrinkwrap": null,
-  "_spec": "windowslib@0.4.18",
   "_where": "/Users/chris/appc/titanium_mobile",
+  "_spec": "windowslib@0.4.13",
   "author": {
     "name": "Appcelerator, Inc.",
     "email": "npmjs@appcelerator.com"
@@ -70,13 +70,13 @@
     "lib": "./lib"
   },
   "dist": {
-    "shasum": "c2a2e93c633415da1053d000786ceec2af5e0350",
-    "tarball": "https://registry.npmjs.org/windowslib/-/windowslib-0.4.18.tgz"
+    "shasum": "f9db83ba0b5b5b823d0ea6792950f32ea2074ad0",
+    "tarball": "https://registry.npmjs.org/windowslib/-/windowslib-0.4.13.tgz"
   },
   "engines": {
     "node": ">=0.8"
   },
-  "gitHead": "4986856f0fe70260c7ddea2f6725a5805b40c61f",
+  "gitHead": "ccb5eba1e43a618406262de280a0c77b9b6c17b1",
   "homepage": "https://github.com/appcelerator/windowslib#readme",
   "keywords": [
     "appcelerator",
@@ -110,9 +110,6 @@
   ],
   "name": "windowslib",
   "optionalDependencies": {},
-  "os": [
-    "win32"
-  ],
   "readme": "ERROR: No README data found!",
   "repository": {
     "type": "git",
@@ -132,5 +129,5 @@
     "test-winstore": "mocha --require test/init --reporter spec --check-leaks test/test-winstore",
     "test-wptool": "mocha --require test/init --reporter spec --check-leaks test/test-wptool"
   },
-  "version": "0.4.18"
+  "version": "0.4.13"
 }

--- a/node_modules/windowslib/test/test-windowsphone.js
+++ b/node_modules/windowslib/test/test-windowsphone.js
@@ -34,7 +34,7 @@ describe('windowsphone', function () {
 				should(results.windowsphone).be.an.Object;
 				Object.keys(results.windowsphone).forEach(function (ver) {
 					should(results.windowsphone[ver]).be.an.Object;
-					should(results.windowsphone[ver]).have.keys('version', 'registryKey', 'supported', 'path', 'deployCmd', 'selected', 'xapSignTool', 'sdks');
+					should(results.windowsphone[ver]).have.keys('version', 'registryKey', 'supported', 'path', 'deployCmd', 'selected', 'xapSignTool');
 
 					should(results.windowsphone[ver].version).be.a.String;
 					should(results.windowsphone[ver].version).not.equal('');

--- a/node_modules/windowslib/test/test-winstore.js
+++ b/node_modules/windowslib/test/test-winstore.js
@@ -100,7 +100,7 @@ describe('winstore', function () {
 				should(results.windows).be.an.Object;
 				Object.keys(results.windows).forEach(function (ver) {
 					should(results.windows[ver]).be.an.Object;
-					should(results.windows[ver]).have.keys('version', 'registryKey', 'supported', 'path', 'signTool', 'selected', 'makeCert', 'pvk2pfx', 'sdks');
+					should(results.windows[ver]).have.keys('version', 'registryKey', 'supported', 'path', 'signTool', 'selected', 'makeCert', 'pvk2pfx');
 
 					should(results.windows[ver].version).be.a.String;
 					should(results.windows[ver].version).not.equal('');

--- a/node_modules/windowslib/wptool/wptool.cs
+++ b/node_modules/windowslib/wptool/wptool.cs
@@ -104,9 +104,6 @@ namespace wptool
 							sdk = "\"8.1\"";
 						} else if (versionString == "10.0") {
 							sdk = "\"10.0\"";
-						// skip invalid device
-						} else if (versionString.StartsWith("2147483647")) {
-							continue;
 						}
 						Console.WriteLine("\t\t{\n");
 						Console.WriteLine("\t\t\t\"name\": \"" + dev.Name.Replace("\"", "\\\"") + "\",");
@@ -174,6 +171,18 @@ namespace wptool
 					return showHelp(String.Format("Invalid device UDID '{0:D}'", udid));
 				}
 
+				// ConnectableDevice throws an error when connecting to a physical Windows 10 device
+				// physical Windows 10 devices can be connected to using 127.0.0.1
+				if (command == "connect" && connectableDevice.Version.Major == 10 && !connectableDevice.IsEmulator())
+				{
+					Console.WriteLine("{");
+					Console.WriteLine("\t\"success\": true,");
+					Console.WriteLine("\t\"ip\": \"127.0.0.1\",");
+					Console.WriteLine("\t\"osVersion\": \"" + connectableDevice.Version.ToString() + "\"");
+					Console.WriteLine("}");
+					return 0;
+				}
+
 				try {
 					IDevice device = connectableDevice.Connect();
 
@@ -185,45 +194,27 @@ namespace wptool
 						Console.WriteLine("\t\"success\": true");
 						Console.WriteLine("}");
 					} else {
-						try {
-							string destinationIp;
-							string sourceIp;
-							int destinationPort;
-							device.GetEndPoints(0, out sourceIp, out destinationIp, out destinationPort);
-							var address = IPAddress.Parse(destinationIp);
-							ISystemInfo systemInfo = device.GetSystemInfo();
+						string destinationIp;
+						string sourceIp;
+						int destinationPort;
+						device.GetEndPoints(0, out sourceIp, out destinationIp, out destinationPort);
+						var address = IPAddress.Parse(destinationIp);
+						ISystemInfo systemInfo = device.GetSystemInfo();
 
-							Version version = new Version(systemInfo.OSMajor, systemInfo.OSMinor, systemInfo.OSBuildNo);
-							Console.WriteLine("{");
-							Console.WriteLine("\t\"success\": true,");
-							Console.WriteLine("\t\"ip\": \"" + address.ToString() + "\",");
-							Console.WriteLine("\t\"port\": " + destinationPort.ToString() + ",");
-							Console.WriteLine("\t\"osVersion\": \"" + version.ToString() + "\",");
-							Console.WriteLine("\t\"availablePhysical\": " + systemInfo.AvailPhys.ToString() + ",");
-							Console.WriteLine("\t\"totalPhysical\": " + systemInfo.TotalPhys.ToString() + ",");
-							Console.WriteLine("\t\"availableVirtual\": " + systemInfo.AvailVirtual.ToString() + ",");
-							Console.WriteLine("\t\"totalVirtual\": " + systemInfo.TotalVirtual.ToString() + ",");
-							Console.WriteLine("\t\"architecture\": \"" + systemInfo.ProcessorArchitecture.ToString() + "\",");
-							Console.WriteLine("\t\"instructionSet\": \"" + systemInfo.InstructionSet.ToString() + "\",");
-							Console.WriteLine("\t\"processorCount\": " + systemInfo.NumberOfProcessors.ToString() + "");
-							Console.WriteLine("}");
-						} catch (Exception ex) {
-							//
-							// ConnectableDevice throws an error when connecting to a physical Windows 10 device
-							// physical Windows 10 devices can be connected to using 127.0.0.1.
-							// From some point of Windows 10 SDK, IDevice.GetEndPoints throws Exception for Windows Phone 8.1 device too.
-							// Interestingly ConnectableDevice.Version returns 8.1 _or_ 6.3 in this case.
-							// Returning ok for now because we can still connect to the device.
-							//
-							if (command == "connect" && !connectableDevice.IsEmulator()) {
-								Console.WriteLine("{");
-								Console.WriteLine("\t\"success\": true,");
-								Console.WriteLine("\t\"ip\": \"127.0.0.1\",");
-								Console.WriteLine("\t\"osVersion\": \"" + connectableDevice.Version.ToString() + "\"");
-								Console.WriteLine("}");
-								return 0;
-							}
-						}
+						Version version = new Version(systemInfo.OSMajor, systemInfo.OSMinor, systemInfo.OSBuildNo);
+						Console.WriteLine("{");
+						Console.WriteLine("\t\"success\": true,");
+						Console.WriteLine("\t\"ip\": \"" + address.ToString() + "\",");
+						Console.WriteLine("\t\"port\": " + destinationPort.ToString() + ",");
+						Console.WriteLine("\t\"osVersion\": \"" + version.ToString() + "\",");
+						Console.WriteLine("\t\"availablePhysical\": " + systemInfo.AvailPhys.ToString() + ",");
+						Console.WriteLine("\t\"totalPhysical\": " + systemInfo.TotalPhys.ToString() + ",");
+						Console.WriteLine("\t\"availableVirtual\": " + systemInfo.AvailVirtual.ToString() + ",");
+						Console.WriteLine("\t\"totalVirtual\": " + systemInfo.TotalVirtual.ToString() + ",");
+						Console.WriteLine("\t\"architecture\": \"" + systemInfo.ProcessorArchitecture.ToString() + "\",");
+						Console.WriteLine("\t\"instructionSet\": \"" + systemInfo.InstructionSet.ToString() + "\",");
+						Console.WriteLine("\t\"processorCount\": " + systemInfo.NumberOfProcessors.ToString() + "");
+						Console.WriteLine("}");
 					}
 					return 0;
 				} catch (Exception ex) {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "temp": "0.8.3",
     "uglify-js": "2.7.0",
     "unorm": "^1.4.1",
-    "windowslib": "0.4.15",
+    "windowslib": "0.4.13",
     "wrench": "1.5.9",
     "xcode": "0.8.9",
     "xmldom": "0.1.22"


### PR DESCRIPTION
Related to [TIMOB-23671](https://jira.appcelerator.org/browse/TIMOB-23671)

It seems `windowslib` is accidentally bumped to `0.4.18` when [TIMOB-23671](https://jira.appcelerator.org/browse/TIMOB-23671) commits are pushed. This PR basically reverts it to `0.4.13`.
