### PR TITLE
[TIMOB-23499](6_0_X) Android: Ti.UI.Label.wordWrap should default to true, but is undefined

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/LabelProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/LabelProxy.java
@@ -46,6 +46,7 @@ public class LabelProxy extends TiViewProxy
 	{
 		defaultValues.put(TiC.PROPERTY_TEXT, "");
 		defaultValues.put(TiC.PROPERTY_ELLIPSIZE, UIModule.TEXT_ELLIPSIZE_TRUNCATE_END);
+		defaultValues.put(TiC.PROPERTY_WORD_WRAP, true);
 	}
 
 	@Override


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-23499
