### PR TITLE
[TIMOB-23766] Android: Default alloy & classic app crashes after launch with error : Requested module not found: ti.cloud, even though present

### DIFF
--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -2404,7 +2404,7 @@ AndroidBuilder.prototype.copyResources = function copyResources(next) {
 
 						// we use the destination file name minus the path to the assets dir as the id
 						// which will eliminate dupes
-						var id = to.replace(opts.origDest, opts.prefix ? opts.prefix + '/' : '').replace(/\\/g, '/').replace(/^\//, '');
+						var id = to.replace(opts.origDest, opts.prefix ? opts.prefix : '').replace(/\\/g, '/').replace(/^\//, '');
 
 						if (!jsFiles[id] || !opts || !opts.onJsConflict || opts.onJsConflict(from, to, id)) {
 							jsFiles[id] = from;


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-23766

opts.prefix already contains a '/', causing this line to have `id = ti.cloud//ti.cloud.js`
