### PR TITLE
[TIMOB-23827] Fixed module id validation to allow underscores when cr…

### DIFF
--- a/cli/lib/creator.js
+++ b/cli/lib/creator.js
@@ -199,7 +199,7 @@ Creator.prototype.configOptionId = function configOptionId(order) {
 		}
 
 		if (value.indexOf('_') != -1) {
-			if (cli.argv.type != 'app' || cli.argv.platforms.indexOf('ios') != -1 || cli.argv.platforms.indexOf('iphone') != -1 || cli.argv.platforms.indexOf('ipad') != -1) {
+			if (cli.argv.type != 'app' && (cli.argv.platforms.indexOf('ios') != -1 || cli.argv.platforms.indexOf('iphone') != -1 || cli.argv.platforms.indexOf('ipad') != -1)) {
 				logger.error(__('Invalid App ID "%s"', value));
 				logger.error(__('Underscores are not allowed in the App ID when targeting %s.', 'iOS'.cyan) + '\n');
 				return callback(true);

--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -296,6 +296,25 @@ iOSBuilder.prototype.config = function config(logger, config, cli) {
 			minIosVersion:     this.packageJson.minIosVersion,
 			supportedVersions: this.packageJson.vendorDependencies.xcode
 		}, function (err, iosInfo) {
+			if (err) {
+				// this is bad and probably because we don't have a compatible
+				// node-ios-device binary for the current version of node
+				//
+				// ideally we'd failout, but we can't... the Titanium CLI doesn't
+				// allow the config() call to return an error. my bad design. :(
+				iosInfo = {
+					certs: {
+						keychains: {}
+					},
+					devices: [],
+					issues: [],
+					simulators: {
+						ios: []
+					},
+					xcode: {}
+				};
+			}
+
 			this.iosInfo = iosInfo;
 
 			// add itunes sync


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-23827

Fixed module id validation to allow underscores when creating an Android-only module. Also fixed issue where ioslib.detect() was erroring out when it didn't find a compatible version of node-ios-device, but the error wasn't properly handled.
