### PR TITLE
[TIMOB-23847] iOS: Fix HIGH_QUALITY in video-picker, add missing quality-constants

### DIFF
--- a/apidoc/Titanium/Media/Media.yml
+++ b/apidoc/Titanium/Media/Media.yml
@@ -1040,6 +1040,29 @@ properties:
     type: Number
     permission: read-only
     platforms: [iphone, ipad]
+  - name: QUALITY_640x480
+    summary: Media type constant for medium-quality video recording. 
+    description: |
+        If recording, specifies that you want to use VGA-quality video recording (pixel dimensions 
+        of 640x480).
+    type: Number
+    permission: read-only
+    platforms: [iphone, ipad]
+    since: 6.1.0 
+  - name: QUALITY_IFRAME_1280x720
+    summary: Media type constant for medium-quality video recording. 
+    description: If recording, specifies that you want to use 1280x720 iFrame format.
+    type: Number
+    permission: read-only
+    platforms: [iphone, ipad]
+    since: 6.1.0 
+  - name: QUALITY_IFRAME_960x540
+    summary: Media type constant for medium-quality video recording. 
+    description: If recording, specifies that you want to use 960x540 iFrame format.
+    type: Number
+    permission: read-only
+    platforms: [iphone, ipad]
+    since: 6.1.0 
   - name: UNKNOWN_ERROR
     summary: Constant for unknown media error.
     type: Number
@@ -1590,10 +1613,10 @@ properties:
     default: false
   - name: mediaTypes 
     summary: | 
-        Array of media type constants to allow. Note: iOS 9.1 only allows to
-        select existing photos from the gallery, capturing new live photos is 
-        not supported by the iOS public API, yet.
-    constants: [Titanium.Media.MEDIA_TYPE_PHOTO, Titanium.Media.MEDIA_TYPE_VIDEO]
+        Array of media type constants to allow. Note: If you want to select live photos, iOS only  allows
+        you to select existing live photos from the gallery, capturing new live photos is not supported by 
+        iOS public API, yet.
+    constants: [Titanium.Media.MEDIA_TYPE_PHOTO, Titanium.Media.MEDIA_TYPE_LIVEPHOTO, Titanium.Media.MEDIA_TYPE_VIDEO]
     type: Array<String>
     default: Both photo and video allowed.
     platforms: [android, iphone, ipad]
@@ -1609,6 +1632,7 @@ properties:
     summary: Constant to indicate the video quality during capture. 
     type: Number
     platforms: [android, iphone, ipad]
+    constants: Titanium.Media.QUALITY_*
     since:
         android: 5.4.0  
   - name: whichCamera

--- a/apidoc/Titanium/Media/Media.yml
+++ b/apidoc/Titanium/Media/Media.yml
@@ -1048,21 +1048,20 @@ properties:
     type: Number
     permission: read-only
     platforms: [iphone, ipad]
-    since: 6.1.0 
   - name: QUALITY_IFRAME_1280x720
     summary: Media type constant for medium-quality video recording. 
     description: If recording, specifies that you want to use 1280x720 iFrame format.
     type: Number
     permission: read-only
     platforms: [iphone, ipad]
-    since: 6.1.0 
+    since: 6.0.0 
   - name: QUALITY_IFRAME_960x540
     summary: Media type constant for medium-quality video recording. 
     description: If recording, specifies that you want to use 960x540 iFrame format.
     type: Number
     permission: read-only
     platforms: [iphone, ipad]
-    since: 6.1.0 
+    since: 6.0.0 
   - name: UNKNOWN_ERROR
     summary: Constant for unknown media error.
     type: Number

--- a/iphone/Classes/MediaModule.h
+++ b/iphone/Classes/MediaModule.h
@@ -85,6 +85,8 @@
 @property(nonatomic,readonly) NSNumber* QUALITY_MEDIUM;
 @property(nonatomic,readonly) NSNumber* QUALITY_LOW;
 @property(nonatomic,readonly) NSNumber* QUALITY_640x480;
+@property(nonatomic,readonly) NSNumber* QUALITY_IFRAME_1280x720;
+@property(nonatomic,readonly) NSNumber* QUALITY_IFRAME_960x540;
 
 @property(nonatomic,readonly) NSArray* availableCameraMediaTypes;
 @property(nonatomic,readonly) NSArray* availablePhotoMediaTypes;

--- a/iphone/Classes/MediaModule.m
+++ b/iphone/Classes/MediaModule.m
@@ -311,6 +311,8 @@ MAKE_SYSTEM_PROP(QUALITY_HIGH,UIImagePickerControllerQualityTypeHigh);
 MAKE_SYSTEM_PROP(QUALITY_MEDIUM,UIImagePickerControllerQualityTypeMedium);
 MAKE_SYSTEM_PROP(QUALITY_LOW,UIImagePickerControllerQualityTypeLow);
 MAKE_SYSTEM_PROP(QUALITY_640x480,UIImagePickerControllerQualityType640x480);
+MAKE_SYSTEM_PROP(QUALITY_IFRAME_1280x720,UIImagePickerControllerQualityTypeIFrame1280x720);
+MAKE_SYSTEM_PROP(QUALITY_IFRAME_960x540,UIImagePickerControllerQualityTypeIFrame960x540);
 
 //Constants for MediaTypes in VideoPlayer
 MAKE_SYSTEM_PROP(VIDEO_MEDIA_TYPE_NONE,MPMovieMediaTypeMaskNone);
@@ -1527,17 +1529,13 @@ MAKE_SYSTEM_PROP(VIDEO_TIME_OPTION_EXACT,MPMovieTimeOptionExact);
         }
         
         double videoMaximumDuration = [TiUtils doubleValue:[args objectForKey:@"videoMaximumDuration"] def:0.0];
-        double videoQuality = [TiUtils doubleValue:[args objectForKey:@"videoQuality"] def:0.0];
         
         if (videoMaximumDuration != 0.0)
         {
             [picker setVideoMaximumDuration:videoMaximumDuration/1000];
         }
-
-        if (videoQuality != 0.0)
-        {
-            [picker setVideoQuality:videoQuality];
-        }
+        
+        [picker setVideoQuality:[TiUtils intValue:[args objectForKey:@"videoQuality"] def:UIImagePickerControllerQualityTypeMedium]];
     }
 
     // do this afterwards above so we can first check for video support


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-23847

Note: `QUALITY_640x480` was exposed before but was undocumented.
