### PR TITLE
[TIMOB-23834] Windows: Skip mobileweb init() when not targeting mobileweb

### DIFF
--- a/mobileweb/cli/hooks/windows.js
+++ b/mobileweb/cli/hooks/windows.js
@@ -27,7 +27,7 @@ const
 exports.cliVersion = '>=3.2.1';
 
 exports.init = function (logger, config, cli) {
-	if (process.platform !== 'win32') {
+	if (process.platform !== 'win32' || (cli.argv['p'] || cli.argv['platform']) !== 'mobileweb') {
 		return;
 	}
 


### PR DESCRIPTION
- Skip mobileweb `init` when targeting other platforms
  - Prevents `windowslib.detect()` being called when targeting any platform on Windows, which causes a significant delay; especially when a Windows device is connected.

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-23834)
