### PR TITLE
Windows: Fix kroll-v8 ant build on Windows

### DIFF
--- a/android/build/common.xml
+++ b/android/build/common.xml
@@ -379,7 +379,9 @@ Common ant tasks and macros for building Android-based Titanium modules and proj
 	</target>
 
 	<target name="build.kroll.v8.so" depends="generate.kroll.v8.bindings">
-		<property name="ndk.build.args" value="-j8"/>
+		<condition property="ndk.build.args" value="" else="-j8">
+			<os family="windows"/>
+		</condition>
 		<property name="kroll.v8.build.x86" value=""/>
 		<exec executable="${ndk.build}" dir="${kroll.v8.project.dir}" failonerror="true">
 			<env key="ANDROID_NDK" file="${android.ndk}"/>


### PR DESCRIPTION
- Using multiple jobs causes a permission denied error when compiling `kroll-v8` on Windows
- Remove `-j8` argument when compiling on Windows
###### NOTE
- Refer to [Compiling kroll-v8 on Windows](https://wiki.appcelerator.org/display/guides2/Android+Titanium+SDK+Development+Setup)
