### PR TITLE
[TIMOB-23872] Changed the default behavior for how the AndroidManifes…

### DIFF
--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -2116,10 +2116,10 @@ AndroidBuilder.prototype.checkIfShouldForceRebuild = function checkIfShouldForce
 		return true;
 	}
 
-	if (this.config.get('android.mergeCustomAndroidManifest', false) != manifest.mergeCustomAndroidManifest) {
+	if (this.config.get('android.mergeCustomAndroidManifest', true) != manifest.mergeCustomAndroidManifest) {
 		this.logger.info(__('Forcing rebuild: mergeCustomAndroidManifest config has changed since last build'));
 		this.logger.info('  ' + __('Was: %s', manifest.mergeCustomAndroidManifest));
-		this.logger.info('  ' + __('Now: %s', this.config.get('android.mergeCustomAndroidManifest', false)));
+		this.logger.info('  ' + __('Now: %s', this.config.get('android.mergeCustomAndroidManifest', true)));
 		return true;
 	}
 
@@ -3502,7 +3502,7 @@ AndroidBuilder.prototype.generateAndroidManifest = function generateAndroidManif
 		tiappAndroidManifest = this.tiappAndroidManifest;
 
 	// if they are using a custom AndroidManifest and merging is disabled, then write the custom one as is
-	if (!this.config.get('android.mergeCustomAndroidManifest', false) && this.customAndroidManifest) {
+	if (!this.config.get('android.mergeCustomAndroidManifest', true) && this.customAndroidManifest) {
 		(this.cli.createHook('build.android.writeAndroidManifest', this, function (file, xml, done) {
 			this.logger.info(__('Writing unmerged custom AndroidManifest.xml'));
 			fs.writeFileSync(file, xml.toString('xml'));
@@ -4289,7 +4289,7 @@ AndroidBuilder.prototype.writeBuildManifest = function writeBuildManifest(callba
 		fullscreen: this.tiapp.fullscreen,
 		navbarHidden: this.tiapp['navbar-hidden'],
 		skipJSMinification: !!this.cli.argv['skip-js-minify'],
-		mergeCustomAndroidManifest: this.config.get('android.mergeCustomAndroidManifest', false),
+		mergeCustomAndroidManifest: this.config.get('android.mergeCustomAndroidManifest', true),
 		encryptJS: this.encryptJS,
 		minSDK: this.minSDK,
 		targetSDK: this.targetSDK,


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-23872

Changed the default behavior for how the `AndroidManifest.xml` is merged. It now defaults to allow the `tiapp.xml` Android manifest to override a custom `AndroidManifest.xml`. This brings Android in parity with how iOS merges `Info.plist` files.
