### PR TITLE
[TIMOB-20502] Android: Allow Alloy to init when launching alternative activities

### DIFF
--- a/android/runtime/common/src/java/org/appcelerator/kroll/util/KrollAssetHelper.java
+++ b/android/runtime/common/src/java/org/appcelerator/kroll/util/KrollAssetHelper.java
@@ -105,6 +105,22 @@ public class KrollAssetHelper
 		return null;
 	}
 
+	public static boolean assetExists(String path) {
+		if (assetCrypt != null) {
+			String asset = assetCrypt.readAsset(path.replace("Resources/", ""));
+			if (asset != null) {
+				return true;
+			}
+		}
+		if (manager != null) {
+			AssetManager assetManager = manager.get();
+			try {
+				return assetManager != null && assetManager.open(path) != null;
+			} catch (IOException e) {}
+		}
+		return false;
+	}
+
 	public static String getPackageName()
 	{
 		return packageName;


### PR DESCRIPTION
- Alloy applications initialize (global variables etc..) in the root activity, this gets skipped when an intent launches an alternative activity. This PR runs the root activity before executing the alternative activity.

**NOTE: depends on** https://github.com/appcelerator/titanium_mobile/pull/8347

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-20502)
