### PR TITLE
[TIMOB-23880] Default classic app template does not show tabs on Windows

### DIFF
--- a/templates/app/default/template/Resources/app.js
+++ b/templates/app/default/template/Resources/app.js
@@ -1,7 +1,9 @@
 /**
  * Set a global background-color (used for iOS)
  */
-Ti.UI.setBackgroundColor("#fff");
+if (Ti.Platform.osname === 'iphone' || Ti.Platform.osname === 'ipad') {
+    Ti.UI.setBackgroundColor("#fff");
+}
 
 /**
  * Create a new `Ti.UI.TabGroup`.


### PR DESCRIPTION
[TIMOB-23880](https://jira.appcelerator.org/browse/TIMOB-23880)

When building the default app template for Windows platform the tabs are not visible, this is because on Windows the default text color is white and the background color is set to white.

From comment of the app template:

``` javascript
 /**
  * Set a global background-color (used for iOS)
  */
```

So if this is only for iOS, we should keep this effective only on iOS.
