### PR TITLE
[TIDOC-2580] Remove method thumbnailImageAtTime from SDK and Doc

### DIFF
--- a/apidoc/Titanium/Media/VideoPlayer.yml
+++ b/apidoc/Titanium/Media/VideoPlayer.yml
@@ -205,7 +205,7 @@ methods:
     summary: Stops playing the video.
 
   - name: thumbnailImageAtTime
-     deprecated:
+    deprecated:
         since: '3.4.2'
         notes: Use <Titanium.Media.VideoPlayer.mediaControlStyle> instead.
         removed: '3.6.0'

--- a/apidoc/Titanium/Media/VideoPlayer.yml
+++ b/apidoc/Titanium/Media/VideoPlayer.yml
@@ -205,6 +205,10 @@ methods:
     summary: Stops playing the video.
 
   - name: thumbnailImageAtTime
+     deprecated:
+        since: '3.4.2'
+        notes: Use <Titanium.Media.VideoPlayer.mediaControlStyle> instead.
+        removed: '3.6.0'
     summary: Returns a thumbnail image for the video at the specified time.
     platforms: [iphone, ipad]
     returns:


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIDOC-2580

**Optional Description:**

Ti.Media.VideoPlayer.thumbnailImageAtTime DEPRECATED in 3.4.2, in favor of Ti.Media.VideoPlayer.requestThumbnailImagesAtTimes: REMOVED in 3.6.0
So maybe time to remove it in 6.0.0 ?
