### PR TITLE
[TIMOB-23881] Android: Fix analytics not enabled when root activity is not launched

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/TiApplication.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiApplication.java
@@ -425,6 +425,31 @@ public abstract class TiApplication extends Application implements KrollApplicat
 		TiPlatformHelper.getInstance().initialize();
 		// Fastdev has been deprecated
 		// TiFastDev.initFastDev(this);
+
+		if (isAnalyticsEnabled()) {
+
+			TiPlatformHelper.getInstance().initAnalytics();
+			TiPlatformHelper.getInstance().setSdkVersion("ti." + getTiBuildVersion());
+			TiPlatformHelper.getInstance().setAppName(getAppInfo().getName());
+			TiPlatformHelper.getInstance().setAppId(getAppInfo().getId());
+			TiPlatformHelper.getInstance().setAppVersion(getAppInfo().getVersion());
+
+			String deployType = appProperties.getString("ti.deploytype", "unknown");
+			String buildType = appInfo.getBuildType();
+			if ("unknown".equals(deployType)) {
+				deployType = getDeployType();
+			}
+			if (buildType != null && !buildType.equals("")) {
+				TiPlatformHelper.getInstance().setBuildType(buildType);
+			}
+			// Just use type 'other' enum since it's open ended.
+			DeployType.OTHER.setName(deployType);
+			TiPlatformHelper.getInstance().setDeployType(DeployType.OTHER);
+			APSAnalytics.getInstance().sendAppEnrollEvent();
+
+		} else {
+			Log.i(TAG, "Analytics have been disabled");
+		}
 	}
 
 	public void postOnCreate()
@@ -483,30 +508,6 @@ public abstract class TiApplication extends Application implements KrollApplicat
 			}
 		}
 
-		if (isAnalyticsEnabled()) {
-
-			TiPlatformHelper.getInstance().initAnalytics();
-			TiPlatformHelper.getInstance().setSdkVersion("ti." + getTiBuildVersion());
-			TiPlatformHelper.getInstance().setAppName(getAppInfo().getName());
-			TiPlatformHelper.getInstance().setAppId(getAppInfo().getId());
-			TiPlatformHelper.getInstance().setAppVersion(getAppInfo().getVersion());
-
-			String deployType = appProperties.getString("ti.deploytype", "unknown");
-			String buildType = appInfo.getBuildType();
-			if ("unknown".equals(deployType)) {
-				deployType = getDeployType();
-			}
-			if (buildType != null && !buildType.equals("")) {
-				TiPlatformHelper.getInstance().setBuildType(buildType);
-			}
-			// Just use type 'other' enum since it's open ended.
-			DeployType.OTHER.setName(deployType);
-			TiPlatformHelper.getInstance().setDeployType(DeployType.OTHER);
-			APSAnalytics.getInstance().sendAppEnrollEvent();
-
-		} else {
-			Log.i(TAG, "Analytics have been disabled");
-		}
 		tempFileHelper.scheduleCleanTempDir();
 	}
 


### PR DESCRIPTION
- Launching an alternative activity via an intent or shortcut will prevent analytics from running
- Moved analytics initialisation into `postAppInfo`

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-23881)
