### PR TITLE
[TIDOC-2611] Since 5.5.0.GA iOS platform return iOS not iPhone OS

### DIFF
--- a/apidoc/Titanium/Platform/Platform.yml
+++ b/apidoc/Titanium/Platform/Platform.yml
@@ -208,6 +208,8 @@ properties:
     summary: |
         Name of the platform. Returns `android` for the Android platform, `iPhone OS` for the iOS
         platform (iPhone, iPad, or iPod Touch), `windows` for the Windows platform, and `mobileweb` for the Mobile Web platform.
+        
+        Since 5.5.0.GA return 'iOS' for for the iOS platform (iPhone, iPad, or iPod Touch).
     type: String
     permission: read-only
     

--- a/apidoc/Titanium/Platform/Platform.yml
+++ b/apidoc/Titanium/Platform/Platform.yml
@@ -209,7 +209,7 @@ properties:
         Name of the platform. Returns `android` for the Android platform, `iPhone OS` for the iOS
         platform (iPhone, iPad, or iPod Touch), `windows` for the Windows platform, and `mobileweb` for the Mobile Web platform.
         
-        Since 5.5.0.GA return 'iOS' for for the iOS platform (iPhone, iPad, or iPod Touch).
+        Since 5.5.0.GA and Xcode 8, this property returns `iOS` for for the iOS platform (iPhone, iPad, or iPod Touch).
     type: String
     permission: read-only
     


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/AC-4460
