### PR TITLE
Empty Entitlements when building for dist-adhoc or dist-appstore

### DIFF
--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -3441,8 +3441,10 @@ iOSBuilder.prototype.writeEntitlementsPlist = function writeEntitlementsPlist() 
 
 			if (target === 'device') {
 				return getPP(provisioning.development, uuid);
-			} else if (target !== 'dist-appstore' && target !== 'dist-adhoc') {
-				return getPP(provisioning.distribution, uuid) || getPP(provisioning.adhoc, uuid);
+			} else if (target === 'dist-appstore') {
+				return getPP(provisioning.distribution, uuid);
+			} else if (target === 'dist-adhoc'){
+				return getPP(provisioning.adhoc, uuid);
 			}
 		}(this.iosInfo.provisioning, this.target, this.provisioningProfileUUID));
 


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/AC-4482

CRITICAL bug: when building for App store or Adhoc, an empty Entitlements file is created.
This behaviour cause the automatic rejection from Apple when you're using push notifications or other features that need a valid entry in that file:

```
Missing Push Notification Entitlement - Your app includes an API for Apple's Push Notification service, but the aps-environment entitlement is missing from the app's signature. 
To resolve this, make sure your App ID is enabled for push notification in the Provisioning Portal. Then, sign your app with a distribution provisioning profile that includes the aps-environment entitlement. This will create the correct signature, and you can resubmit your app. 
See "Provisioning and Development" in the Local and Push Notification Programming Guide for more information. If your app does not use the Apple Push Notification service, no action is required. You may remove the API from future submissions to stop this warning. 
If you use a third-party framework, you may need to contact the developer for information on removing the API.
```
