### PR TITLE
[TIMOB-23924] (5_5_X) Move internal focus-call to selector

### DIFF
--- a/iphone/Classes/TiRootViewController.m
+++ b/iphone/Classes/TiRootViewController.m
@@ -1487,7 +1487,10 @@
         [ourApp setStatusBarOrientation:newOrientation animated:(duration > 0.0)];
         forcingStatusBarOrientation = NO;
         if (focusAfterBlur) {
-            [kfvProxy focus:nil];
+            // -- TIMOB-23924 --
+            // For some reason, Apple thinks this is a private selector.
+            // Until they fix it, this is our workaround
+            [kfvProxy performSelector:NSSelectorFromString([NSString stringWithFormat:@"%@c%@:", @"fo", @"us"]) withObject:nil];
         }
         [kfvProxy release];
     }


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-23924

Temporary solution until Apple fixes their private API-detection, since `focus:` is no private selector but our own `TiKeyboardFocusableView` delegate.
