### PR TITLE
[TIMOB-23901] Disable run-on-main-thread

### DIFF
--- a/android/runtime/v8/src/native/V8Runtime.cpp
+++ b/android/runtime/v8/src/native/V8Runtime.cpp
@@ -318,8 +318,8 @@ JNIEXPORT jboolean JNICALL Java_org_appcelerator_kroll_runtime_v8_V8Runtime_nati
 	//}
 
 	// FIXME What is a good value to use here? We're basically giving it 100 ms to run right now
-	double deadline_in_ms = (V8Runtime::platform->MonotonicallyIncreasingTime() * static_cast<double>(1000)) + 100.0;
-	return V8Runtime::v8_isolate->IdleNotificationDeadline(deadline_in_ms);
+	double deadline_in_s = V8Runtime::platform->MonotonicallyIncreasingTime() + 0.1;
+	return V8Runtime::v8_isolate->IdleNotificationDeadline(deadline_in_s);
 }
 
 /*

--- a/android/titanium/src/java/org/appcelerator/titanium/TiApplication.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiApplication.java
@@ -649,7 +649,10 @@ public abstract class TiApplication extends Application implements KrollApplicat
 
 	public boolean runOnMainThread()
 	{
-		return getAppProperties().getBool("run-on-main-thread", DEFAULT_RUN_ON_MAIN_THREAD);
+		// TIMOB-23901: run on main thread currently causes threading issues
+		// disable running on main thread for now
+		// return getAppProperties().getBool("run-on-main-thread", DEFAULT_RUN_ON_MAIN_THREAD);
+		return false;
 	}
 
 	public void setFilterAnalyticsEvents(String[] events)


### PR DESCRIPTION
- Even with https://github.com/appcelerator/titanium_mobile/pull/8411, `run-on-main-thread` needs to be disabled. There seems to be an issue running everything on the main thread. @sgtcoolguy Is there a reason why `KrollRuntime` needed to be executed on the main thread?
- Fixed another occurrence of `IdleNotificationDeadline()`

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-23901)
