### PR TITLE
[TIMOB-23901] Android: Fix KrollRuntime init on main thread

### DIFF
--- a/android/runtime/common/src/java/org/appcelerator/kroll/KrollRuntime.java
+++ b/android/runtime/common/src/java/org/appcelerator/kroll/KrollRuntime.java
@@ -351,7 +351,12 @@ public abstract class KrollRuntime implements Handler.Callback
 		synchronized (runtimeState) {
 			if (runtimeState == State.DISPOSED) {
 				instance.initLatch = new CountDownLatch(1);
-				instance.handler.sendEmptyMessage(MSG_INIT);
+				
+				if (instance.isRuntimeThread()) {
+					instance.doInit();
+				} else {
+					instance.handler.sendEmptyMessage(MSG_INIT);
+				}
 
 			} else if (runtimeState == State.RELEASED) {
 				runtimeState = State.RELAUNCHED;

--- a/android/runtime/v8/src/native/V8Runtime.cpp
+++ b/android/runtime/v8/src/native/V8Runtime.cpp
@@ -318,8 +318,8 @@ JNIEXPORT jboolean JNICALL Java_org_appcelerator_kroll_runtime_v8_V8Runtime_nati
 	//}
 
 	// FIXME What is a good value to use here? We're basically giving it 100 ms to run right now
-	double deadline_in_ms = (V8Runtime::platform->MonotonicallyIncreasingTime() * static_cast<double>(1000)) + 100.0;
-	return V8Runtime::v8_isolate->IdleNotificationDeadline(deadline_in_ms);
+	double deadline_in_s = V8Runtime::platform->MonotonicallyIncreasingTime() + 0.1;
+	return V8Runtime::v8_isolate->IdleNotificationDeadline(deadline_in_s);
 }
 
 /*


### PR DESCRIPTION
- Fix initialisation of `KrollRuntime` on main thread when resuming application
- Fix `IdleNotificationDeadline()` duration in `nativeIdle()`

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-23901)
