### PR TITLE
[TIMOB-23960] iOS: Fix unrecognized selector crash when using background-notifications

### DIFF
--- a/iphone/Classes/TiApp.m
+++ b/iphone/Classes/TiApp.m
@@ -654,7 +654,9 @@ TI_INLINE void waitForMemoryPanicCleared();   //WARNING: This must never be run 
 {
     //FunctionName();
     //Forward the callback
-    [self application:application didReceiveRemoteNotification:userInfo];
+    if ([self respondsToSelector:@selector(application:didReceiveRemoteNotification:)]) {
+        [self application:application didReceiveRemoteNotification:userInfo];
+    }
     
     //This only here for Simulator builds.
     


### PR DESCRIPTION
**JIRA**: https://jira.appcelerator.org/browse/TIMOB-23960

If you enable background notifications in iOS it crashes the application when a push is received. It looks like TiApp never implements the method that its forwarding on, so I am guessing its relying on a module to swizzle that method into place. 

Discovered this when updating the UA module. We dropped that method because its been deprecated in iOS 8 and we now require background fetch.
