### PR TITLE
Update deprecation msg with ListView one

### DIFF
--- a/iphone/Classes/TiUIiPhoneListViewSeparatorStyleProxy.m
+++ b/iphone/Classes/TiUIiPhoneListViewSeparatorStyleProxy.m
@@ -18,13 +18,13 @@
 
 -(NSNumber*)SINGLE_LINE
 {
-    DEPRECATED_REPLACED(@"UI.iPhone.ListViewSeparatorStyle.SINGLE_LINE", @"5.2.0", @"UI.TABLE_VIEW_SEPARATOR_STYLE_SINGLE_LINE");
+    DEPRECATED_REPLACED(@"UI.iPhone.ListViewSeparatorStyle.SINGLE_LINE", @"5.2.0", @"UI.iOS.ListViewSeparatorStyle.SINGLE_LINE");
     return [NSNumber numberWithInt:UITableViewCellSeparatorStyleSingleLine];
 }
 
 -(NSNumber*)NONE
 {
-    DEPRECATED_REPLACED(@"UI.iPhone.ListViewSeparatorStyle.NONE", @"5.2.0", @"UI.TABLE_VIEW_SEPARATOR_STYLE_NONE");
+    DEPRECATED_REPLACED(@"UI.iPhone.ListViewSeparatorStyle.NONE", @"5.2.0", @"UI.iOS.ListViewSeparatorStyle.NONE");
     return [NSNumber numberWithInt:UITableViewCellSeparatorStyleNone];
 }
 


### PR DESCRIPTION
**JIRA:** Soon

This msg doesn't make sense

```
[WARN]  Ti.UI.iPhone.ListViewSeparatorStyle.NONE DEPRECATED in 5.2.0, in favor of Ti.UI.TABLE_VIEW_SEPARATOR_STYLE_NONE
```

Updated with

```
[WARN]  Ti.UI.iPhone.ListViewSeparatorStyle.NONE DEPRECATED in 5.2.0, in favor of Ti.UI.iOS.ListViewSeparatorStyle.NONE
```

But i think Ti.UI.iOS.ListViewSeparatorStyle missing
