### PR TITLE
[TIDOC-2390] Updated WatchSession.yml

### DIFF
--- a/apidoc/Titanium/WatchSession/WatchSession.yml
+++ b/apidoc/Titanium/WatchSession/WatchSession.yml
@@ -122,7 +122,10 @@ methods:
     summary: |
         Sends a message to the apple watch.
     description: |
-        Sends a message to the installed watchapp on the apple watch in the foreground. 
+        Sends a message to the installed watchapp on the apple watch in the foreground. Note: If 
+        you are using a version prior to SDK 5.1.0, you should form your request like this: 
+        `Ti.WatchSession.sendMessage(message)`. If you are using SDK 5.1.0 and above, form your 
+        request like this: `Ti.WatchSession.sendMessage(params)`.
     parameters: 
       - name: message
         summary: | 


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIDOC-2390

**Optional Description:**

Added the following to the description of the sendMessage method per TIDOC-2390: "Note: If you are using a version prior to SDK 5.1.0, you should form your request like this: Ti.WatchSession.sendMessage(message). If you are using SDK 5.1.0 and above, form your request like this: Ti.WatchSession.sendMessage(params)."
