### PR TITLE
[TIMOB-23880] Default classic app template does not show tabs on Windows

### DIFF
--- a/templates/app/default/template/Resources/app.js
+++ b/templates/app/default/template/Resources/app.js
@@ -1,9 +1,4 @@
 /**
- * Set a global background-color (used for iOS)
- */
-Ti.UI.setBackgroundColor("#fff");
-
-/**
  * Create a new `Ti.UI.TabGroup`.
  */
 var tabGroup = Ti.UI.createTabGroup();


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-23880

**Optional Description:**

Overrides #8333 
- Don't set global bg color at all. Makes no difference on iOS/Android by default, and actually breaks Windows UI.
