### PR TITLE
[TIMOB-23999] Accept CR+LF line endings when reading manifest

### DIFF
--- a/node_modules/titanium-sdk/lib/titanium.js
+++ b/node_modules/titanium-sdk/lib/titanium.js
@@ -323,7 +323,7 @@ exports.loadModuleManifest = function (logger, manifestFile) {
 		process.exit(1);
 	}
 
-	fs.readFileSync(manifestFile).toString().split('\n').forEach(function (line) {
+	fs.readFileSync(manifestFile).toString().split(/\r?\n/).forEach(function (line) {
 		match = line.match(re);
 		if (match) {
 			manifest[match[1].trim()] = match[2].trim();


### PR DESCRIPTION
- Accept `CR+LF` line endings when reading the module `manifest` file on Windows
###### TEST CASE

```
# build android module
appc run -p android

# should not see
[ERROR] Missing required manifest key "name"
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-23999)
