### PR TITLE
[TIMOB-23983] iOS Debugger: Breakpoint not hit for Alloy applications

### DIFF
--- a/iphone/Classes/KrollBridge.m
+++ b/iphone/Classes/KrollBridge.m
@@ -445,15 +445,16 @@ CFMutableSetRef	krollBridgeRegistry = nil;
 	if (exception == NULL) {
 #ifndef USE_JSCORE_FRAMEWORK
 		if ([[self host] debugMode]) {
-			TiDebuggerBeginScript(context_,urlCString);
+			TiDebuggerBeginScript(context_, urlCString);
 		}
+#endif
 
 		TiEvalScript(jsContext, jsCode, NULL, jsURL, 1, &exception);
+
+#ifndef USE_JSCORE_FRAMEWORK
 		if ([[self host] debugMode]) {
 			TiDebuggerEndScript(context_);
 		}
-#else
-		TiEvalScript(jsContext, jsCode, NULL, jsURL, 1, &exception);
 #endif
 		if (exception == NULL) {
 			evaluationError = NO;
@@ -961,7 +962,21 @@ CFMutableSetRef	krollBridgeRegistry = nil;
 	}
 
 	NSURL *url_ = [TiHost resourceBasedURL:filename baseURL:NULL];
+#ifndef USE_JSCORE_FRAMEWORK
+	const char *urlCString = [[url_ absoluteString] UTF8String];
+	if ([[self host] debugMode]) {
+		TiDebuggerBeginScript([self krollContext], urlCString);
+	}
+#endif
+
 	KrollWrapper *wrapper = [self loadCommonJSModule:data withSourceURL:url_];
+
+#ifndef USE_JSCORE_FRAMEWORK
+	if ([[self host] debugMode]) {
+		TiDebuggerEndScript([self krollContext]);
+	}
+#endif
+
 
 	if (![wrapper respondsToSelector:@selector(replaceValue:forKey:notification:)]) {
 		@throw [NSException exceptionWithName:@"org.appcelerator.kroll"


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-23983

**Description:**
- Call TiDebuggerBeginScript and TiDebuggerEndScript before and after loading a JS file via require when not using jscore framework
- This fixes the "legacy" debugger, used when use-jscore-framework is false or not set
- New iOS debugger still has an issue, and I'm looking into it.
