### PR TITLE
[TIMOB-24011] iOS: require fails to resolve paths like 'hyperloop/uikit/uilabel'

### DIFF
--- a/android/runtime/common/src/js/module.js
+++ b/android/runtime/common/src/js/module.js
@@ -311,7 +311,8 @@ Module.prototype.require = function (request, context) {
 Module.prototype.loadCoreModule = function (id, context) {
 	var wrapper = this.wrapperCache[id],
 		parts,
-		externalBinding;
+		externalBinding,
+		externalCommonJsContents;
 	// check if we have a cached copy of the wrapper
 	if (wrapper) {
 		return wrapper;
@@ -330,14 +331,16 @@ Module.prototype.loadCoreModule = function (id, context) {
 
 		// Could be a sub-module (CommonJS) of an external native module.
 		// We allow that since TIMOB-9730.
-		externalCommonJsContents = kroll.getExternalCommonJsModule(id);
-		if (externalCommonJsContents) {
-			// found it
-			// FIXME Re-use loadAsJavaScriptText?
-			var module = new Module(id, this, context);
-			Module.cache[id] = module;
-			module.load(id, externalCommonJsContents);
-			return module.exports;
+		if (kroll.isExternalCommonJsModule(parts[0])) {
+			externalCommonJsContents = kroll.getExternalCommonJsModule(id);
+			if (externalCommonJsContents) {
+				// found it
+				// FIXME Re-use loadAsJavaScriptText?
+				var module = new Module(id, this, context);
+				Module.cache[id] = module;
+				module.load(id, externalCommonJsContents);
+				return module.exports;
+			}
 		}
 	}
 

--- a/android/runtime/v8/src/native/KrollBindings.cpp
+++ b/android/runtime/v8/src/native/KrollBindings.cpp
@@ -317,6 +317,12 @@ void KrollBindings::getExternalCommonJsModule(const FunctionCallbackInfo<Value>&
 		subPath = nameKey.substr(slashPos + 1);
 	}
 
+	bool exists = (externalCommonJsModules.count(moduleRoot) > 0);
+	if (!exists) {
+		args.GetReturnValue().Set(v8::Undefined(isolate));
+		return;
+	}
+
 	JNIEnv *env = JNIScope::getEnv();
 	jobject sourceProvider = externalCommonJsModules[moduleRoot];
 	jmethodID sourceRetrievalMethod = commonJsSourceRetrievalMethods[moduleRoot];

--- a/iphone/Classes/KrollBridge.m
+++ b/iphone/Classes/KrollBridge.m
@@ -805,73 +805,20 @@ CFMutableSetRef	krollBridgeRegistry = nil;
 	return modulename;
 }
 
-- (TiModule *)loadCoreModule:(NSString *)path withContext:(KrollContext *)kroll
+- (TiModule *)loadTopLevelNativeModule:(TiModule *)module withPath:(NSString *)path withContext:(KrollContext *)kroll
 {
-	// make sure path doesn't begin with ., .., or /
-	// Can't be a "core" module then
-	if ([path hasPrefix:@"/"] || [path hasPrefix:@"."]) {
-		return nil;
+	// does it have JS? No, then nothing else to do...
+	if (![module isJSModule]) {
+		return module;
+	}
+	NSData* data = [module moduleJS];
+	if (data == nil) {
+		// Uh oh, no actual data. Let's just punt and return the native module as-is
+		return module;
 	}
 
-	// moduleId then is the first path component
-	NSString *moduleID = [[path pathComponents] objectAtIndex:0];
-	NSString *moduleClassName = [self pathToModuleClassName:moduleID];
-	Class moduleClass = NSClassFromString(moduleClassName);
-
-	if (moduleClass == nil) {
-		return nil;
-	}
-
-	// We have a module to load resources from! Now we need to determine if
-	// it's a base module (which should be cached) or a pure JS resource
-	// stored on the module.
-	TiModule *module = [modules objectForKey:moduleID];
-	if (module == nil) {
-		module = [[moduleClass alloc] _initWithPageContext:self];
-		[module setHost:host];
-		[module _setName:moduleClassName];
-		[modules setObject:module forKey:moduleID];
-		[module autorelease];
-	}
-
-	// TODO Handle the oddball case of mixing in JS to the native module...
-	/*
-	// TODO: Support package.json 'main' file identifier which will load instead
-	// of module JS. Currently neither iOS nor Android support package information.
-	NSRange separatorLocation = [fullPath rangeOfString:@"/"];
-	if (separatorLocation.location == NSNotFound) { // Indicates toplevel module
-	loadNativeJS:
-		if ([module isJSModule]) {
-			data = [module moduleJS];
-		}
-		[self setCurrentURL:[NSURL URLWithString:fullPath relativeToURL:[[self host] baseURL]]];
-	}
-	else {
-		NSString* assetPath = [fullPath substringFromIndex:separatorLocation.location+1];
-		// Handle the degenerate case (supported by MW) where we're loading
-		// module.id/module.id, which should resolve to module.id and mixin.
-		// Rather than create a utility method for this (or C&P if native loading changes)
-		// we use a goto to jump into the if block above.
-
-		if ([assetPath isEqualToString:moduleID]) {
-			goto loadNativeJS;
-		}
-
-		NSString* filepath = [assetPath stringByAppendingString:@".js"];
-		data = [module loadModuleAsset:filepath];
-		// Have to reset module so that this code doesn't get mixed in and is loaded as pure JS
-		module = nil;
-	}
-
-	if (data == nil && isAbsolute) {
-		// We may have an absolute URL which tried to load from a module instead of a directory. Fix
-		// the fullpath back to the right value, so we can try again.
-		fullPath = [path hasPrefix:@"/"]?[path substringFromIndex:1]:path;
-	}
-	else if (data != nil) {
-		// Set the current URL; it should be the fullPath relative to the host's base URL.
-			[self setCurrentURL:[NSURL URLWithString:[fullPath stringByDeletingLastPathComponent] relativeToURL:[[self host] baseURL]]];
-	}
+    NSString* contents = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+	KrollWrapper* wrapper = (id) [self loadJavascriptText:contents fromFile:path withContext:kroll];
 
 	// For right now, we need to mix any compiled JS on top of a compiled module, so that both components
 	// are accessible. We store the exports object and then put references to its properties on the toplevel
@@ -885,18 +832,72 @@ CFMutableSetRef	krollBridgeRegistry = nil;
 	TiPropertyNameArrayRef properties = TiObjectCopyPropertyNames(jsContext, jsObject);
 	size_t count = TiPropertyNameArrayGetCount(properties);
 	for (size_t i=0; i < count; i++) {
-	// Mixin the property onto the module JS object if it's not already there
-	TiStringRef propertyName = TiPropertyNameArrayGetNameAtIndex(properties, i);
-	if (!TiObjectHasProperty(jsContext, [moduleObject jsobject], propertyName)) {
-	TiValueRef property = TiObjectGetProperty(jsContext, jsObject, propertyName, NULL);
-	TiObjectSetProperty([[self krollContext] context], [moduleObject jsobject], propertyName, property, kTiPropertyAttributeReadOnly, NULL);
-	}
+		// Mixin the property onto the module JS object if it's not already there
+		TiStringRef propertyName = TiPropertyNameArrayGetNameAtIndex(properties, i);
+		if (!TiObjectHasProperty(jsContext, [moduleObject jsobject], propertyName)) {
+			TiValueRef property = TiObjectGetProperty(jsContext, jsObject, propertyName, NULL);
+			TiObjectSetProperty([[self krollContext] context], [moduleObject jsobject], propertyName, property, kTiPropertyAttributeReadOnly, NULL);
+		}
 	}
 	TiPropertyNameArrayRelease(properties);
 
-	*/
-
 	return module;
+}
+
+- (TiModule *)loadCoreModule:(NSString *)path withContext:(KrollContext *)kroll
+{
+	// make sure path doesn't begin with ., .., or /
+	// Can't be a "core" module then
+	if ([path hasPrefix:@"/"] || [path hasPrefix:@"."]) {
+		return nil;
+	}
+
+	// moduleId then is the first path component
+	// try to load up the native module's class...
+	NSString *moduleID = [[path pathComponents] objectAtIndex:0];
+	NSString *moduleClassName = [self pathToModuleClassName:moduleID];
+	Class moduleClass = NSClassFromString(moduleClassName);
+	// If no such module exists, bail out!
+	if (moduleClass == nil) {
+		return nil;
+	}
+
+	// Ok, we have a native module, make sure instantiate and cache it
+	TiModule *module = [modules objectForKey:moduleID];
+	if (module == nil) {
+		module = [[moduleClass alloc] _initWithPageContext:self];
+		[module setHost:host];
+		[module _setName:moduleClassName];
+		[modules setObject:module forKey:moduleID];
+		[module autorelease];
+	}
+
+	// Are they just trying to load the top-level module?
+	NSRange separatorLocation = [path rangeOfString:@"/"];
+	if (separatorLocation.location == NSNotFound) {
+		// Indicates toplevel module
+		return [self loadTopLevelNativeModule:module withPath:path withContext:kroll];
+	}
+
+	// check rest of path
+	NSString* assetPath = [path substringFromIndex: separatorLocation.location + 1];
+	// Treat require('module.id/module.id') == require('module.id')
+	if ([assetPath isEqualToString:moduleID]) {
+		return [self loadTopLevelNativeModule:module withPath:path withContext:kroll];
+	}
+
+	// not top-level module!
+	// Try to load the file as module asset!
+	NSString* filepath = [assetPath stringByAppendingString:@".js"];
+	NSData* data = [module loadModuleAsset:filepath];
+	// does it exist in module?
+	if (data == nil) {
+		// nope, return nil so we can try to fall back to resource in user's app
+		return nil;
+	}
+    NSString* contents = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+	// This is an asset inside the native module. Load it like a "normal" common js file
+	return [self loadJavascriptText:contents fromFile:filepath withContext:kroll];
 }
 
 - (NSString *)loadFile:(NSString *)path
@@ -1187,7 +1188,7 @@ CFMutableSetRef	krollBridgeRegistry = nil;
 
 			// TODO Find a way to determine if the first path segment refers to a CommonJS module, and if so don't log
 			// TODO How can we make this spit this out to Ti.API.log?
-			NSLog(@"require called with un-prefixed module id, should be a core or CommonJS module. Falling back to old Ti behavior and assuming it's an absolute file");
+			NSLog(@"require called with un-prefixed module id: %@, should be a core or CommonJS module. Falling back to old Ti behavior and assuming it's an absolute path: /%@", path, path);
 			module = [self loadAsFileOrDirectory:[path stringByStandardizingPath] withContext:context];
 			if (module) {
 				return module;

--- a/tests/Resources/facebook/example.js
+++ b/tests/Resources/facebook/example.js
@@ -1,0 +1,3 @@
+module.exports = {
+	name: 'facebook/example.js'
+};

--- a/tests/Resources/ti.require.test.js
+++ b/tests/Resources/ti.require.test.js
@@ -1,0 +1,206 @@
+/*
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2011-2016 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+var should = require('./utilities/assertions'),
+	utilities = require('./utilities/utilities');
+
+describe('requireJS', function () {
+	// require should be a function
+	it('requireJS.Function', function () {
+		should(require).be.a.Function;
+	});
+
+	// require should return object
+	it('requireJS.Object', function () {
+		var object = require('ti.require.test_test');
+		should(object).be.an.Object;
+	});
+
+	// require for invalid file should throw error
+	it('requireJS.NonObject', function () {
+		(function () {
+			var object = require('requireJS_test_notfound');
+			should(object).not.be.an.Object;
+		}).should.throw();
+	});
+
+	// require should cache object
+	it('requireJS.ObjectCache', function () {
+		var object1 = require('ti.require.test_test');
+		var object2 = require('ti.require.test_test');
+		should(object1).be.an.Object;
+		should(object2).be.an.Object;
+		should((object1 ==  object2)).be.true;
+		should((object1 === object2)).be.true;
+	});
+
+	// local function and variable should not be exposed
+	it('requireJS.LocalFunc', function () {
+		var object = require('ti.require.test_test');
+		should(object).be.an.Object;
+		should(object.localVariable).be.undefined;
+		should(object.localFunction).be.undefined;
+	});
+
+	// public function with 0 argument
+	it('requireJS.PublicFunc0', function () {
+		var object = require('ti.require.test_test');
+		should(object).be.an.Object;
+		should(object.testFunc0).a.Function;
+		var result = object.testFunc0();
+		should(result).be.a.String;
+		should(result).be.eql('testFunc0');
+	});
+
+	// public function with 1 argument
+	it('requireJS.PublicFunc1', function () {
+		var object = require('ti.require.test_test');
+		should(object).be.an.Object;
+		should(object.testFunc1).be.a.Function;
+		var result = object.testFunc1('A');
+		should(result).be.a.String;
+		should(result).be.eql('testFunc1 A');
+	});
+
+	// public function with 2 arguments
+	it('requireJS.PublicFunc2', function () {
+		var object = require('ti.require.test_test');
+		should(object).be.an.Object;
+		should(object.testFunc2).be.a.Function;
+		var result = object.testFunc2('A', 'B');
+		should(result).be.a.String;
+		should(result).be.eql('testFunc2 A B');
+	});
+
+	// public string variable
+	it('requireJS.PublicStrVar', function () {
+		var object = require('ti.require.test_test');
+		should(object).be.an.Object;
+		should(object.testStrVar).be.a.String;
+		should(object.testStrVar).be.eql('testVar0');
+	});
+
+	// public number variable
+	it('requireJS.PublicNumVar', function () {
+		var object = require('ti.require.test_test');
+		should(object).be.an.Object;
+		should(object.testNumVar).be.a.Number;
+		should(object.testNumVar).be.eql(101);
+	});
+
+	// public boolean variable
+	it('requireJS.PublicBoolVar', function () {
+		var object = require('ti.require.test_test');
+		should(object).be.an.Object;
+		should(object.testBoolVar).be.a.Boolean;
+		should(object.testBoolVar).be.true;
+	});
+
+	// public null variable
+	it('requireJS.PublicNullVar', function () {
+		var object = require('ti.require.test_test');
+		should(object).be.an.Object;
+		should(object.testNullVar).be.null;
+	});
+
+	// internal __filename
+	it('requireJS.__filename', function () {
+		var object = require('ti.require.test_test');
+		should(object).be.an.Object;
+		should(object.filename).be.a.String;
+		should(object.filename).be.eql('/ti.require.test_test.js');
+	});
+
+	// internal __filename
+	it('requireJS.__dirname', function () {
+		var object = require('ti.require.test_test');
+		should(object).be.an.Object;
+		should(object.dirname).be.a.String;
+		should(object.dirname).be.eql('/');
+	});
+
+	it('loads package.json main property when requiring directory', function () {
+		var with_package = require('./with_package');
+		should(with_package).have.property('name');
+		should(with_package.name).be.eql('main.js');
+		should(with_package.filename).be.eql('/with_package/main.js');
+		should(with_package.dirname).be.eql('/with_package');
+	});
+
+	it('falls back to index.js when requiring directory with no package.json', function () {
+		var with_index_js = require('./with_index_js');
+		should(with_index_js).have.property('name');
+		should(with_index_js.name).be.eql('index.js');
+		should(with_index_js.filename).be.eql('/with_index_js/index.js');
+		should(with_index_js.dirname).be.eql('/with_index_js');
+	});
+
+	// TIMOB-23512
+	it('relative require() from sub directory', function () {
+		var with_index_js = require('./with_index_js/sub1');
+		should(with_index_js).have.property('name');
+		should(with_index_js.name).be.eql('sub1.js');
+		should(with_index_js.sub).be.eql('sub2.js');
+		// Was also failing if same file had multiple relative requires
+		should(with_index_js.sub3).be.eql('sub3.js');
+		should(with_index_js.filename).be.eql('/with_index_js/sub1.js');
+		should(with_index_js.dirname).be.eql('/with_index_js');
+	});
+
+	it('falls back to index.json when requiring directory with no package.json or index.js', function () {
+		var with_index_json = require('./with_index_json');
+		should(with_index_json).have.property('name');
+		should(with_index_json.name).be.eql('index.json');
+	});
+
+	it('loads exact match JS file', function () {
+		var exact_js = require('./with_package/index.js');
+		should(exact_js).have.property('name');
+		should(exact_js.name).be.eql('index.js');
+		should(exact_js.filename).be.eql('/with_package/index.js');
+		should(exact_js.dirname).be.eql('/with_package');
+	});
+
+	it('loads exact match JSON file', function () {
+		var package_json = require('./with_package/package.json');
+		should(package_json).have.property('main');
+		should(package_json.main).be.eql('./main.js');
+	});
+
+	it('loads .js with matching file basename if no exact match', function () {
+		var with_index_js = require('./with_index_js/index');
+		should(with_index_js).have.property('name');
+		should(with_index_js.name).be.eql('index.js');
+		should(with_index_js.filename).be.eql('/with_index_js/index.js');
+		should(with_index_js.dirname).be.eql('/with_index_js');
+	});
+
+	it('loads .json with matching file basename if no exact or .js match', function () {
+		var with_index_json = require('./with_index_json/index');
+		should(with_index_json).have.property('name');
+		should(with_index_json.name).be.eql('index.json');
+	});
+
+	it('loads file under Titanium CommonJS module containing moduleid.js file', function () {
+		var object = require('commonjs.legacy.package/main');
+		should(object).have.property('name');
+		should(object.name).be.eql('commonjs.legacy.package/main.js');
+	});
+
+	it ('should load a node module by id in node_modules folder living at same level as requirer', function () {
+		var abbrev = require('abbrev');
+		should(abbrev).be.a.Function;
+		should(abbrev("foo", "fool", "folding", "flop")).eql({ fl: 'flop', flo: 'flop', flop: 'flop', fol: 'folding', fold: 'folding', foldi: 'folding', foldin: 'folding', folding: 'folding', foo: 'foo', fool: 'fool'});
+	});
+
+	// TODO Add a test for requiring a node module up one level from requiring file!
+
+	it('loads path using legacy fallback if first segment matches native moudle id and wasn\'t found inside module', function () {
+		var object = require('facebook/example');
+		should(object).have.property('name');
+		should(object.name).be.eql('facebook/example.js');
+	});
+});

--- a/tests/Resources/ti.require.test.js
+++ b/tests/Resources/ti.require.test.js
@@ -196,9 +196,17 @@ describe('requireJS', function () {
 		should(abbrev("foo", "fool", "folding", "flop")).eql({ fl: 'flop', flo: 'flop', flop: 'flop', fol: 'folding', fold: 'folding', foldi: 'folding', foldin: 'folding', folding: 'folding', foo: 'foo', fool: 'fool'});
 	});
 
+	it('loads native module by id', function () {
+		var object = require('facebook');
+		should(object).have.property('apiName');
+		// Of course, the module's apiName is wrong, so we can't test that
+		// should(object.apiName).be.eql('facebook');
+		should(object).have.property('uid');
+	});
+
 	// TODO Add a test for requiring a node module up one level from requiring file!
 
-	it('loads path using legacy fallback if first segment matches native moudle id and wasn\'t found inside module', function () {
+	it('loads path using legacy fallback if first segment matches native module id and wasn\'t found inside module', function () {
 		var object = require('facebook/example');
 		should(object).have.property('name');
 		should(object.name).be.eql('facebook/example.js');

--- a/tests/modules/modules.xml
+++ b/tests/modules/modules.xml
@@ -1,0 +1,14 @@
+	<modules>
+		<module>commonjs.index_js</module>
+		<module>commonjs.index_json</module>
+		<module>commonjs.legacy</module>
+		<module>commonjs.legacy.index_js</module>
+		<module>commonjs.legacy.index_json</module>
+		<module>commonjs.legacy.package</module>
+		<module>commonjs.package</module>
+		<module>commonjs.package</module>
+		<module platform="android">ti.map</module>
+		<module platform="ios">ti.map</module>
+		<module platform="android">facebook</module>
+		<module platform="ios">facebook</module>
+	</modules>


### PR DESCRIPTION
**JIRA:** 
- https://jira.appcelerator.org/browse/TIMOB-24011
- https://jira.appcelerator.org/browse/TIMOB-24012

**Description:**
This bug was found in hyperloop 2.0.0 against SDK 6+. We generate "legacy" style require paths with no leading '/', './', or '../' in them, but instead something like:

``` js
require('hyperloop/uikit/uilabel');
```

This path style is now considered deprecated and paths should conform to Node.JS style.

In any case, the new require behavior should have fallen back to assuming an "absolute" path absent the leading slash and worked anyways. Instead there's a bug where if the first segment of the path matches a native module in use, we will not properly fall back (and will return the native nodule instance instead).

This patch fixes the issue - we first look in the native module for the asset, and if that fails we should fallback to loading the file from the user's app.
