### PR TITLE
[TIMOB-24008] (6_0_X) Added validation to prevent managed provisioning profiles from being used.

### DIFF
--- a/iphone/cli/lib/info.js
+++ b/iphone/cli/lib/info.js
@@ -204,12 +204,16 @@ exports.render = function (logger, config, rpad, styleHeading, styleValue, style
 			profiles.sort(function (a, b) {
 				return a.name.toLowerCase().localeCompare(b.name.toLowerCase());
 			}).forEach(function (profile) {
+				var appId = profile.entitlements['application-identifier'] || '';
+				appId = profile.appPrefix ? appId.replace(new RegExp('^' + profile.appPrefix + '\\.'), '') : appId;
+
 				logger.log('  ' + profile.name.cyan + (profile.expired ? ' ' + styleBad(__('**EXPIRED**')) : ''));
 				logger.log('  ' + rpad('  ' + __('UUID'))       + ' = ' + styleValue(profile.uuid));
 				logger.log('  ' + rpad('  ' + __('App Prefix')) + ' = ' + styleValue(profile.appPrefix));
-				logger.log('  ' + rpad('  ' + __('App Id'))     + ' = ' + styleValue(profile.appId));
+				logger.log('  ' + rpad('  ' + __('App Id'))     + ' = ' + styleValue(appId));
 				logger.log('  ' + rpad('  ' + __('Date Created')) + ' = ' + styleValue(profile.creationDate ? moment(profile.creationDate).format('l LT') : 'unknown'));
 				logger.log('  ' + rpad('  ' + __('Date Expired')) + ' = ' + styleValue(profile.expirationDate ? moment(profile.expirationDate).format('l LT') : 'unknown'));
+				logger.log('  ' + rpad('  ' + __('Managed')) + ' = ' + (profile.managed ? styleBad(__('Yes and is NOT compatible with Titanium')) : styleValue(__('No'))));
 			});
 			logger.log();
 		} else {


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-24008

To test:
1. Make sure you have at least one managed provisioning profile installed where the provisioning profile must contain "iOS Team Provisioning Profile".
2. Run `ti info -t ios` and verify that it prints that it is unsupported. 
3. Run `ti build -p ios -T device -P foo` and make sure that managed pp-uuids are not listed in prompt.
4. Run `ti build -p ios -T device -P <managed-pp-uuid>` and make sure the build errors with `[ERROR] Specified provisioning profile UUID "<managed-pp-uuid>" is managed and not supported`.
