### PR TITLE
[TIMOB-23969][TIMOB-23989] Fix TiBaseActivity.onBackPressed()

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
@@ -130,7 +130,6 @@ public abstract class TiBaseActivity extends AppCompatActivity
 	protected TiWindowProxy window;
 	protected TiViewProxy view;
 	protected ActivityProxy activityProxy;
-	protected Activity previousActivity;
 	protected TiWeakList<ConfigurationChangedListener> configChangedListeners = new TiWeakList<ConfigurationChangedListener>();
 	protected int orientationDegrees;
 	protected TiMenuSupport menuHelper;
@@ -612,7 +611,6 @@ public abstract class TiBaseActivity extends AppCompatActivity
 			return;
 		}
 
-		previousActivity = tiApp.getRootOrCurrentActivity();
 		TiApplication.addToActivityStack(this);
 
 		// create the activity proxy here so that it is accessible from the activity in all cases
@@ -862,9 +860,12 @@ public abstract class TiBaseActivity extends AppCompatActivity
 		} else {
 			// there are no parent activities to return to
 			// override back press to background the activity
-			if (previousActivity == null || previousActivity == getTiApp().getRootActivity()) {
-				this.moveTaskToBack(true);
-				return;
+			// note: 2 since there should always be TiLaunchActivity and TiActivity
+			if (TiApplication.activityStack.size() <= 2) {
+				if (topWindow != null && !TiConvert.toBoolean(topWindow.getProperty(TiC.PROPERTY_EXIT_ON_CLOSE), false)) {
+					this.moveTaskToBack(true);
+					return;
+				}
  			}
 
 			// If event is not handled by custom callback allow default behavior.


### PR DESCRIPTION
- Do not background application when `exitOnClose` is `true`
- Use `activityStack` to determine whether to background the application
###### TEST CASE

``` Javascript
var a = Ti.UI.createWindow();
a.addEventListener('click',function(){
    Ti.UI.createWindow({
        backgroundColor:'teal',
        // closeOnExit: true
    }).open();
});
a.open();
```

[TIMOB-23969](https://jira.appcelerator.org/browse/TIMOB-23969)
[TIMOB-23989](https://jira.appcelerator.org/browse/TIMOB-23989)
