### PR TITLE
[TIMOB-23497] Implement Titanium.UI.ActivityIndicator.indicatorColor

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/ActivityIndicatorProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/ActivityIndicatorProxy.java
@@ -22,7 +22,8 @@ import android.os.Message;
 	TiC.PROPERTY_MESSAGEID,
 	TiC.PROPERTY_COLOR,
 	TiC.PROPERTY_FONT,
-	TiC.PROPERTY_STYLE
+	TiC.PROPERTY_STYLE,
+	TiC.PROPERTY_INDICATOR_COLOR
 })
 @Kroll.dynamicApis(methods = {
 	"hide", "show"

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIActivityIndicator.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIActivityIndicator.java
@@ -98,6 +98,9 @@ public class TiUIActivityIndicator extends TiUIView
 		if (d.containsKey(TiC.PROPERTY_COLOR)) {
 			label.setTextColor(TiConvert.toColor(d, TiC.PROPERTY_COLOR));
 		}
+		if (d.containsKey(TiC.PROPERTY_INDICATOR_COLOR)) {
+			progress.getIndeterminateDrawable().setColorFilter(TiConvert.toColor(d, TiC.PROPERTY_INDICATOR_COLOR), android.graphics.PorterDuff.Mode.SRC_IN);
+		}
 
 		view.invalidate();
 	}
@@ -117,6 +120,8 @@ public class TiUIActivityIndicator extends TiUIView
 			label.requestLayout();
 		} else if (key.equals(TiC.PROPERTY_COLOR)) {
 			label.setTextColor(TiConvert.toColor((String) newValue));
+		} else if (key.equals(TiC.PROPERTY_INDICATOR_COLOR)) {
+			progress.getIndeterminateDrawable().setColorFilter(TiConvert.toColor((String) newValue), android.graphics.PorterDuff.Mode.SRC_IN);
 		} else {
 			super.propertyChanged(key, oldValue, newValue, proxy);
 		}

--- a/android/titanium/src/java/org/appcelerator/titanium/TiC.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiC.java
@@ -1608,6 +1608,11 @@ public class TiC
 	/**
 	 * @module.api
 	 */
+	public static final String PROPERTY_INDICATOR_COLOR = "indicatorColor";
+
+	/**
+	 * @module.api
+	 */
 	public static final String PROPERTY_INCLUDE_FONT_PADDING = "includeFontPadding";
 
 	/**

--- a/apidoc/Titanium/UI/ActivityIndicator.yml
+++ b/apidoc/Titanium/UI/ActivityIndicator.yml
@@ -143,7 +143,7 @@ properties:
     since: "2.1.0"
     type: String
     default: <pre>#fff</pre>
-    platforms: [mobileweb,iphone,ipad]
+    platforms: [mobileweb,iphone,ipad,android]
     
   - name: indicatorDiameter
     summary: Diameter of the indicator.


### PR DESCRIPTION
- Implement missing `Titanium.UI.ActivityIndicator.indicatorColor` property
- Update documentation
###### TEST CASE

``` Javascript
var win = Ti.UI.createWindow({backgroundColor: 'grey', layout: 'vertical'}),
    btn = Ti.UI.createButton({title: 'RED'}),
    activityIndicator = Ti.UI.createActivityIndicator({
        style: Ti.UI.ActivityIndicatorStyle.BIG,
        indicatorColor: 'blue'
    });

btn.addEventListener('click', function() {
    activityIndicator.setIndicatorColor('red');
});

activityIndicator.show();
win.add(activityIndicator);
win.add(btn);
win.open();
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-23497)
