### PR TITLE
[TIMOB-24053] Android: Fix Ti.UI.TextField passwordMask when not editable

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIText.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIText.java
@@ -497,7 +497,11 @@ public class TiUIText extends TiUIView
 		        if (type == KEYBOARD_NUMBERS_PUNCTUATION || type == KEYBOARD_DECIMAL_PAD || type == KEYBOARD_NUMBER_PAD) {
 		            tv.setImeOptions(EditorInfo.IME_FLAG_NO_EXTRACT_UI);
 		        }
-		    }
+		    } else {
+				if (tv.getTransformationMethod() instanceof PasswordTransformationMethod) {
+					tv.setTransformationMethod(null);
+				}
+			}
 		} else if (d.containsKey(TiC.PROPERTY_SOFT_KEYBOARD_ON_FOCUS)
 			&& TiConvert.toInt(d, TiC.PROPERTY_SOFT_KEYBOARD_ON_FOCUS) == TiUIView.SOFT_KEYBOARD_HIDE_ON_FOCUS) {
 			tv.setInputType(InputType.TYPE_NULL);


### PR DESCRIPTION
- Allow `passwordMask` to be set correctly when `editable` is set to `false`
###### TEST CASE

``` Javascript
var win = Ti.UI.createWindow({backgroundColor: 'grey', layout: 'vertical'}),
    txt = Ti.UI.createTextField({value: 'hello', editable: false, passwordMask: true}),
    btn = Ti.UI.createButton({title: 'SHOW/HIDE'});

btn.addEventListener('click', function () {
    txt.passwordMask = !txt.passwordMask;
});

win.add(txt);
win.add(btn);
win.open();
```

[JIRA TIcket](https://jira.appcelerator.org/browse/TIMOB-24053)
