### PR TITLE
[TIMOB-24052] Allow event listeners when Ti.UI.TextField.editable is false

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIText.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIText.java
@@ -481,7 +481,6 @@ public class TiUIText extends TiUIView
 		if (!editable) {
 		    tv.setInputType(InputType.TYPE_NULL);
 		    tv.setCursorVisible(false);
-		    tv.setEnabled(false);
 		    if (passwordMask) {
 		        Typeface origTF = tv.getTypeface();
 		        // Sometimes password transformation does not work properly when the input type is set after the


### PR DESCRIPTION
- Still allow event listeners to fire when `Titanium.UI.TextField.editable` is `false`
###### TEST CASE

``` Javascript
var win = Ti.UI.createWindow({backgroundColor: 'grey', layout: 'vertical'}),
    txt = Ti.UI.createTextField({value: 'CLICK', editable: false});

txt.addEventListener('click', function () {
    Ti.API.info('CLICKED!');
});

win.add(txt);
win.open();
```

[TIMOB-24052](https://jira.appcelerator.org/browse/TIMOB-24052)
