### PR TITLE
[TIMOB-16100] iOS9: TextField with passwordMask & fontFamily changes its fontSize

### DIFF
--- a/iphone/Classes/TiUITextField.m
+++ b/iphone/Classes/TiUITextField.m
@@ -305,6 +305,13 @@
 		NSNotificationCenter * theNC = [NSNotificationCenter defaultCenter];
 		[theNC addObserver:self selector:@selector(textFieldDidChange:) name:UITextFieldTextDidChangeNotification object:textWidgetView];
 	}
+  
+    if (![TiUtils isIOS10OrGreater]) {
+        NSString *str = ((UITextField *)textWidgetView).text;
+        ((UITextField *)textWidgetView).text = @"";
+        ((UITextField *)textWidgetView).text = str;
+    }
+    
 	return textWidgetView;
 }
 

--- a/iphone/Classes/TiUITextField.m
+++ b/iphone/Classes/TiUITextField.m
@@ -306,16 +306,16 @@
 		[theNC addObserver:self selector:@selector(textFieldDidChange:) name:UITextFieldTextDidChangeNotification object:textWidgetView];
 	}
   
-    // TIMOB-16100: Native issue that prevents the textfield to mutate the font-config
-    BOOL needsAdjustment = (![TiUtils isIOS10OrGreater] && ((UITextField *)textWidgetView).secureTextEntry);
-    
-    if (needsAdjustment)
-    {
-        NSString *str = ((UITextField *)textWidgetView).text;
-        ((UITextField *)textWidgetView).text = @"";
-        ((UITextField *)textWidgetView).text = str;
-    }
-    
+	// TIMOB-16100: Native issue that prevents the textfield to mutate the font-config
+	BOOL needsAdjustment = (![TiUtils isIOS10OrGreater] && ((UITextField *)textWidgetView).secureTextEntry);
+
+	if (needsAdjustment)
+	{
+		NSString *str = ((UITextField *)textWidgetView).text;
+		((UITextField *)textWidgetView).text = @"";
+		((UITextField *)textWidgetView).text = str;
+	}
+
 	return textWidgetView;
 }
 

--- a/iphone/Classes/TiUITextField.m
+++ b/iphone/Classes/TiUITextField.m
@@ -306,7 +306,11 @@
 		[theNC addObserver:self selector:@selector(textFieldDidChange:) name:UITextFieldTextDidChangeNotification object:textWidgetView];
 	}
   
-    if (![TiUtils isIOS10OrGreater]) {
+    // TIMOB-16100: Native issue that prevents the textfield to mutate the font-config
+    BOOL needsAdjustment = (![TiUtils isIOS10OrGreater] && ((UITextField *)textWidgetView).secureTextEntry);
+    
+    if (needsAdjustment)
+    {
         NSString *str = ((UITextField *)textWidgetView).text;
         ((UITextField *)textWidgetView).text = @"";
         ((UITextField *)textWidgetView).text = str;


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-16100

**Optional Description:**

[TIMOB-16100] Position of cursor was not resetting while unmasking as end of document calculation goes wrong in iOS below 10 . That made fix by resetting textfield value to blank character and then setting to its actual value.
