### PR TITLE
[TIMOB-24065] (6_0_X) Fixed issue where --build-only sim builds needs a sim UUID

### DIFF
--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -1813,14 +1813,14 @@ iOSBuilder.prototype.validate = function (logger, config, cli) {
 			},
 
 			function selectDevice(next) {
-				if (cli.argv.target === 'dist-appstore' || cli.argv.target === 'dist-adhoc' || cli.argv['build-only']) {
+				if (cli.argv.target === 'dist-appstore' || cli.argv.target === 'dist-adhoc') {
 					return next();
 				}
 
 				// no --device-id or doing a build-only sim build, so pick a device
 
 				if (cli.argv.target === 'device') {
-					if (!cli.argv['device-id']) {
+					if (!cli.argv['build-only'] && !cli.argv['device-id']) {
 						cli.argv['device-id'] = this.iosInfo.devices.length ? this.iosInfo.devices[0].udid : 'itunes';
 					}
 					return next();


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-24065

[TIMOB-24065] Fixed issue where --build-only sim builds needs a sim udid to make Xcode 8 happy.
