### PR TITLE
[TIMOB-24048] Fix Titanium.UI.Window.close() activity animations

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/WindowProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/WindowProxy.java
@@ -151,12 +151,12 @@ public class WindowProxy extends TiWindowProxy implements TiActivityWindow
 	    if (!animated) {
 	        intent.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION);
 	        topActivity.startActivity(intent);
-	        topActivity.overridePendingTransition(0, 0); // Suppress default transition.
-	    } else if (options.containsKey(TiC.INTENT_PROPERTY_ENTER_ANIMATION)
-	            || options.containsKey(TiC.INTENT_PROPERTY_EXIT_ANIMATION)) {
+	        topActivity.overridePendingTransition(0, 0);
+	    } else if (options.containsKey(TiC.PROPERTY_ACTIVITY_ENTER_ANIMATION) || options.containsKey(TiC.PROPERTY_ACTIVITY_EXIT_ANIMATION)) {
 	        topActivity.startActivity(intent);
-	        topActivity.overridePendingTransition(TiConvert.toInt(options.get(TiC.INTENT_PROPERTY_ENTER_ANIMATION), 0),
-	                TiConvert.toInt(options.get(TiC.INTENT_PROPERTY_EXIT_ANIMATION), 0));
+	        int enterAnimation = TiConvert.toInt(options.get(TiC.PROPERTY_ACTIVITY_ENTER_ANIMATION), 0);
+	        int exitAnimation = TiConvert.toInt(options.get(TiC.PROPERTY_ACTIVITY_EXIT_ANIMATION), 0);
+	        topActivity.overridePendingTransition(enterAnimation, exitAnimation);
 	    } else {
 	        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
 	            topActivity.startActivity(intent, createActivityOptionsBundle(topActivity));
@@ -172,18 +172,17 @@ public class WindowProxy extends TiWindowProxy implements TiActivityWindow
 		boolean animated = TiConvert.toBoolean(options, TiC.PROPERTY_ANIMATED, true);
 		TiBaseActivity activity = (windowActivity != null) ? windowActivity.get() : null;
 		if (activity != null && !activity.isFinishing()) {
-			if (!animated) {
-				activity.overridePendingTransition(0, 0); // Suppress default transition.
-			} else if (options.containsKey(TiC.INTENT_PROPERTY_ENTER_ANIMATION)
-				|| options.containsKey(TiC.INTENT_PROPERTY_EXIT_ANIMATION)) {
-				activity.overridePendingTransition(TiConvert.toInt(options.get(TiC.INTENT_PROPERTY_ENTER_ANIMATION), 0),
-					TiConvert.toInt(options.get(TiC.INTENT_PROPERTY_EXIT_ANIMATION), 0));
-			} 
-			
 			if (super.hasActivityTransitions()) {
 			    activity.finishAfterTransition();
 			} else {
 			    activity.finish();
+			}
+			if (!animated) {
+				activity.overridePendingTransition(0, 0);
+			} else if (options.containsKey(TiC.PROPERTY_ACTIVITY_ENTER_ANIMATION) || options.containsKey(TiC.PROPERTY_ACTIVITY_EXIT_ANIMATION)) {
+				int enterAnimation = TiConvert.toInt(options.get(TiC.PROPERTY_ACTIVITY_ENTER_ANIMATION), 0);
+				int exitAnimation = TiConvert.toInt(options.get(TiC.PROPERTY_ACTIVITY_EXIT_ANIMATION), 0);
+				activity.overridePendingTransition(enterAnimation, exitAnimation);
 			}
 
 			// Finishing an activity is not synchronous, so we remove the activity from the activity stack here

--- a/android/titanium/src/java/org/appcelerator/titanium/TiC.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiC.java
@@ -577,8 +577,6 @@ public class TiC
 	 * @module.api
 	 */
 	public static final String EVENT_UNFOCUSED = "unfocused";
-	public static final String INTENT_PROPERTY_ENTER_ANIMATION = "activityEnterAnimation";
-	public static final String INTENT_PROPERTY_EXIT_ANIMATION = "activityExitAnimation";
 	public static final String PROPERTY_ENTER_TRANSITION = "activityEnterTransition";
 	public static final String PROPERTY_EXIT_TRANSITION = "activityExitTransition";
 	public static final String PROPERTY_RETURN_TRANSITION = "activityReturnTransition";


### PR DESCRIPTION
- Allow `overridePendingTransition()` to take place after `finish()`
- Remove redundant property definitions
###### TEST CASE

[project.zip](https://jira.appcelerator.org/secure/attachment/60557/window-animation-test.zip)

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-24048)
