### PR TITLE
[TIMOB-23969] Fix exitOnClose default value

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
@@ -862,7 +862,7 @@ public abstract class TiBaseActivity extends AppCompatActivity
 			// override back press to background the activity
 			// note: 2 since there should always be TiLaunchActivity and TiActivity
 			if (TiApplication.activityStack.size() <= 2) {
-				if (topWindow != null && !TiConvert.toBoolean(topWindow.getProperty(TiC.PROPERTY_EXIT_ON_CLOSE), false)) {
+				if (topWindow != null && !TiConvert.toBoolean(topWindow.getProperty(TiC.PROPERTY_EXIT_ON_CLOSE), true)) {
 					this.moveTaskToBack(true);
 					return;
 				}


### PR DESCRIPTION
- Fix default behaviour of `exitOnClose`
- Documentation states `Default: true if this is the first window launched else false`
- `exitOnClose` must be manually set to `false` for the app to resume to its previous state
###### TEST CASE
1. Open app
2. Press back
3. Open app, should re-launch to root activity and **NOT** resume from previous state
