### PR TITLE
[TIMOB-23967] Fix double namespace error when building Android modules

### DIFF
--- a/android/cli/commands/_buildModule.js
+++ b/android/cli/commands/_buildModule.js
@@ -729,7 +729,7 @@ AndroidModuleBuilder.prototype.generateV8Bindings = function (next) {
 					return s.toLowerCase();
 				});
 
-				if (!(moduleNamespace in namespaces)) {
+				if (namespaces.indexOf(moduleNamespace) == -1) {
 					namespaces.unshift(moduleNamespace.split('.').join('::'));
 				}
 


### PR DESCRIPTION
- Fix `moduleNamespace` logic in `_buildModule.js`
###### TEST CASE
- Build a module for Android using `appc run --build-only` that contains a module namespace _(ti.facebook, hyperloop)_
- Module should build successfully without any errors

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-23967)
