### PR TITLE
[TIMOB-23502] Prevent Android module duplicate entry build error

### DIFF
--- a/android/cli/commands/_buildModule.js
+++ b/android/cli/commands/_buildModule.js
@@ -290,6 +290,7 @@ AndroidModuleBuilder.prototype.initialize = function initialize(next) {
 	this.projLibDir = path.join(this.projectDir, 'lib');
 
 	this.buildClassesDir = path.join(this.buildDir, 'classes');
+	this.buildClassesGenDir = path.join(this.buildClassesDir, 'org', 'appcelerator', 'titanium', 'gen');
 	this.buildGenDir = path.join(this.buildDir, 'generated');
 
 	this.buildGenJsDir = path.join(this.buildGenDir, 'js');
@@ -1211,7 +1212,13 @@ AndroidModuleBuilder.prototype.compileAllFinal = function (next) {
 			'@' + javaSourcesFile
 		],
 		{},
-		next
+		function () {
+			// remove gen, prevent duplicate entry error
+			if (fs.existsSync(this.buildClassesGenDir)) {
+				wrench.rmdirSyncRecursive(this.buildClassesGenDir);
+			}
+			next();
+		}.bind(this)
 	);
 
 };


### PR DESCRIPTION
- Remove unnecessary `gen` folder that causes duplicate errors when building Android modules
- Module bindings are stored in the `bindings` folder, leaving `gen` redundant
###### TEST CASE
- Build a module using `appc run --build-only` _(ti.facebook)_
- Add the module to a project
- Add another android module to the project
- The project can be built successfully without errors

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-23502)
