### PR TITLE
Related to [TIMOB-24059] - Disable logging about legacy require usage

### DIFF
--- a/android/runtime/common/src/js/module.js
+++ b/android/runtime/common/src/js/module.js
@@ -287,9 +287,11 @@ Module.prototype.require = function (request, context) {
 			return loaded;
 		}
 
-		// TODO Can we determine if the first path segment is a commonjs module id? If so, don't spit out this log!
 		// Fallback to old Titanium behavior of assuming it's actually an absolute path
-		kroll.log(TAG, "require called with un-prefixed module id: " + request + ", should be a core or CommonJS module. Falling back to old Ti behavior and assuming it's an absolute path: /" + request);
+
+		// We'd like to warn users about legacy style require syntax so they can update, but the new syntax is not backwards compatible.
+		// So for now, let's just be quite about it. In future versions of the SDK (7.0?) we should warn (once 5.x is end of life so backwards compat is not necessary)
+		//kroll.log(TAG, "require called with un-prefixed module id: " + request + ", should be a core or CommonJS module. Falling back to old Ti behavior and assuming it's an absolute path: /" + request);
 
 		loaded = this.loadAsFileOrDirectory('/' + request, context);
 		if (loaded) {

--- a/iphone/Classes/KrollBridge.m
+++ b/iphone/Classes/KrollBridge.m
@@ -1186,9 +1186,9 @@ CFMutableSetRef	krollBridgeRegistry = nil;
 				return module;
 			}
 
-			// TODO Find a way to determine if the first path segment refers to a CommonJS module, and if so don't log
-			// TODO How can we make this spit this out to Ti.API.log?
-			NSLog(@"require called with un-prefixed module id: %@, should be a core or CommonJS module. Falling back to old Ti behavior and assuming it's an absolute path: /%@", path, path);
+			// We'd like to warn users about legacy style require syntax so they can update, but the new syntax is not backwards compatible.
+			// So for now, let's just be quite about it. In future versions of the SDK (7.0?) we should warn (once 5.x is end of life so backwards compat is not necessary)
+			//NSLog(@"require called with un-prefixed module id: %@, should be a core or CommonJS module. Falling back to old Ti behavior and assuming it's an absolute path: /%@", path, path);
 			module = [self loadAsFileOrDirectory:[path stringByStandardizingPath] withContext:context];
 			if (module) {
 				return module;


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-24059

**Description:**
This disables logging anything when user has "legacy" style require syntax/paths.

Since using the new proper syntax/paths is actually not backwards compatible, it leaves us in an awkward position - we can't update our own global modules like ti.cloud without making them no longer backwards compatible to SDK 5 and lower. So for now, don't annoy the user about updating their paths.

I'd propose we bring this message back in a later SDK (7?) when we're closer to end of life for SDK 5.x and don't need to worry about backwards compatibility as much. 

We should also likely add some documentation explaining the advantages/disadvantages of using old versus new style syntax (likely in the doc section we have explaining the new require behavior) - cc @jawa9000 

Effectively we want people to use the new style to be more precise as to the exact file/directory/module they want loaded. Using a non-prefixed path (particularly with a single name/segment) is meant to be used for core/native modules - and can result in a slower resolution of the file being pointed to now (though we're taking very small amounts of time here). **But** using the new prefixed paths is not backwards compatible with SDKs < 6. So if an app still needs to be built with SDK 5 or lower, they shouldn't update the require usage yet.
