### PR TITLE
[TIMOB-14285] Fix kroll-v8::nativeSetProperty() to set accessor

### DIFF
--- a/android/runtime/v8/src/native/V8Object.cpp
+++ b/android/runtime/v8/src/native/V8Object.cpp
@@ -55,8 +55,9 @@ Java_org_appcelerator_kroll_runtime_v8_V8Object_nativeSetProperty
 
 	Local<Object> properties = jsObject->Get(titanium::Proxy::propertiesSymbol.Get(V8Runtime::v8_isolate)).As<Object>();
 	Local<Value> jsName = TypeConverter::javaStringToJsString(V8Runtime::v8_isolate, env, name);
-
 	Local<Value> jsValue = TypeConverter::javaObjectToJsValue(V8Runtime::v8_isolate, env, value);
+
+	jsObject->SetAccessor(jsName->ToString(V8Runtime::v8_isolate), titanium::Proxy::getProperty, titanium::Proxy::onPropertyChanged);
 	properties->Set(jsName, jsValue);
 }
 


### PR DESCRIPTION
- `nativeSetProperty()` does not set an accessor for custom properties, making them unavailable in JavaScript

###### TEST CASE

``` Javascript
var win = Ti.UI.createWindow();
win.open();
win.applyProperties({customString: 'TEST'});
Ti.API.info('customString: ' + win.customString);
// customString should output 'TEST'
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-14285)
