### PR TITLE
[TIMOB-24058] Android: Fix Ti.UI.TableViewRow backgroundSelectedColor and backgroundSelectedImage

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TableViewRowProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TableViewRowProxy.java
@@ -48,6 +48,10 @@ public class TableViewRowProxy extends TiViewProxy
 	public TableViewRowProxy()
 	{
 		super();
+
+		// TIMOB-24058: Prevent setOnClickListener() from being set allowing
+		// backgroundSelectedColor and backgroundSelectedImage to function
+		defaultValues.put(TiC.PROPERTY_TOUCH_ENABLED, false);
 	}
 
 	@Override


### PR DESCRIPTION
- Prevent `setOnClickListener()` from being set on the `TiUILabel` used by `TableViewRow` for the title

###### TEST CASE
```Javascript
var win = Ti.UI.createWindow(),
    rows = [];

for (var i = 0; i < 10; i++) {
    rows.push(Ti.UI.createTableViewRow({
        title: 'ROW #' + i,
        // backgroundSelectedImage: '/KS_nav_ui.png',
        backgroundSelectedColor: 'red',
        backgroundColor: 'blue',
        height: 50
    }));
}

win.add(Ti.UI.createTableView({data: rows, separatorColor: 'black'}));
win.open();
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-24058)