### PR TITLE
[TIMOB-19035] Android: Fix Ti.UI.ScrollableView.height when Ti.UI.SIZE

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIScrollableView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIScrollableView.java
@@ -91,6 +91,21 @@ public class TiUIScrollableView extends TiUIView
 
 				return false;
 			}
+
+			@Override
+			protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+				TiCompositeLayout.LayoutParams layoutParams = (TiCompositeLayout.LayoutParams) mContainer.getLayoutParams();
+				
+				if (layoutParams.sizeOrFillHeightEnabled && !layoutParams.autoFillsHeight) {
+					int index = getCurrentItem();
+					if (index < mViews.size()) {
+						TiUIView view = mViews.get(index).getOrCreateView();
+						int height = view.getLayoutParams().optionHeight.getAsPixels(this);
+						heightMeasureSpec = MeasureSpec.makeMeasureSpec(height, MeasureSpec.EXACTLY);
+					}
+				}
+				super.onMeasure(widthMeasureSpec, heightMeasureSpec);
+			}
 		});
 
 		pager.setAdapter(adapter);


### PR DESCRIPTION
- Fix `Titanium.UI.ScrollableView.height` to scale to child views when `Titanium.UI.SIZE` is used

###### TEST CASE
```Javascript
var win = Ti.UI.createWindow(),
    scrollableView = Ti.UI.createScrollableView({
        height: Titanium.UI.SIZE,
        views: [
            Ti.UI.createView({backgroundColor: 'red', height: '300dp'}),
            Ti.UI.createView({backgroundColor: 'green', height: '300dp'}),
            Ti.UI.createView({backgroundColor: 'blue', height: '300dp'});
        ],
        showPagingControl:true
    });

win.add(scrollableView);
win.open();
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-19035)