### PR TITLE
[TIMOB-24072] Fixed bug where asset catalog images were determined to…

### DIFF
--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -5468,9 +5468,7 @@ iOSBuilder.prototype.copyResources = function copyResources(next) {
 
 				if (!fileChanged) {
 					this.logger.trace(__('No change, skipping %s', info.dest.cyan));
-				}
-
-				if (this.copyFileSync(info.src, info.dest, { contents: contents || (contents = fs.readFileSync(info.src)), forceCopy: unsymlinkable })) {
+				} else if (this.copyFileSync(info.src, info.dest, { contents: contents || (contents = fs.readFileSync(info.src)), forceCopy: unsymlinkable })) {
 					if (this.useAppThinning && info.isImage && !this.forceRebuild) {
 						this.logger.info(__('Forcing rebuild: image was updated, recompiling asset catalog'));
 						this.forceRebuild = true;


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-24072

Fixed bug where asset catalog images were determined to have not changed yet the file was copied anyway and thus triggering xcodebuild.