### PR TITLE
[TIMOB-23885] Do not disable HW acceleration for WebView

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
@@ -958,4 +958,10 @@ public class TiUIWebView extends TiUIView
 	{
 		return chromeClient.interceptOnBackPressed();
 	}
+
+	@Override
+	protected void disableHWAcceleration()
+	{
+		Log.d(TAG, "Do not disable HW acceleration for WebView.", Log.DEBUG_MODE);
+	}
 }

--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiUIView.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiUIView.java
@@ -1940,7 +1940,7 @@ public abstract class TiUIView
 		});
 	}
 
-	private void disableHWAcceleration()
+	protected void disableHWAcceleration()
 	{
 		if (borderView == null) {
 			return;


### PR DESCRIPTION
- Do not disable hardware acceleration for `Titanium.UI.WebView`
- Hardware acceleration is needed for HTML5 embedded video to decode

###### TEST CASE
```Javascript
var win = Titanium.UI.createWindow({layout : 'vertical'}),
	webView = Titanium.UI.createWebView({
		url : 'http://edition.cnn.com/videos',
		borderRadius : 1, // this causes HW acceleration to be disabled
		enableZoomControls : false,
		width: Ti.UI.FILL,
		height: Ti.UI.FILL
	});

win.add(webView);
win.open();
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-23885)