### PR TITLE
[TIMOB-24110] iOS: Expose keyboardDisplayRequiresUserAction in Ti.UI.WebView

### DIFF
--- a/apidoc/Titanium/UI/WebView.yml
+++ b/apidoc/Titanium/UI/WebView.yml
@@ -524,6 +524,18 @@ properties:
         See also: [data](Titanium.UI.WebView.data) and [url](Titanium.UI.WebView.url).
     type: String
 
+  - name: keyboardDisplayRequiresUserAction
+    summary: A Boolean value indicating whether web content can programmatically display the keyboard.
+    description: |
+        When this property is set to true, the user must explicitly tap the elements in the web view 
+        to display the keyboard (or other relevant input view) for that element. When set to false, 
+        a focus event on an element causes the input view to be displayed and associated with 
+        that element automatically.
+    type: Boolean
+    default: undefined but behaves as true
+    since: "6.1.0"
+    platforms: [iphone,ipad]
+
   - name: ignoreSslError
     summary: Controls whether to ignore invalid SSL certificates or not.
     description: |

--- a/iphone/Classes/TiUIWebView.m
+++ b/iphone/Classes/TiUIWebView.m
@@ -673,8 +673,10 @@ NSString *HTMLTextEncodingNameForStringEncoding(NSStringEncoding encoding)
 
 - (void)setKeyboardDisplayRequiresUserAction_:(id)value
 {
+    ENSURE_TYPE(value, NSNumber);
     [[self proxy] replaceValue:value forKey:@"keyboardDisplayRequiresUserAction" notification:NO];
-    webview.keyboardDisplayRequiresUserAction = [TiUtils boolValue:value def:YES];
+    
+    [[self webview] setKeyboardDisplayRequiresUserAction:[TiUtils boolValue:value def:YES]];
 }
 
 #pragma mark WebView Delegate

--- a/iphone/Classes/TiUIWebView.m
+++ b/iphone/Classes/TiUIWebView.m
@@ -671,6 +671,12 @@ NSString *HTMLTextEncodingNameForStringEncoding(NSStringEncoding encoding)
     return ret;
 }
 
+- (void)setKeyboardDisplayRequiresUserAction_:(id)value
+{
+    [[self proxy] replaceValue:value forKey:@"keyboardDisplayRequiresUserAction" notification:NO];
+    webview.keyboardDisplayRequiresUserAction = [TiUtils boolValue:value def:YES];
+}
+
 #pragma mark WebView Delegate
 
 - (BOOL)webView:(UIWebView *)webView shouldStartLoadWithRequest:(NSURLRequest *)request navigationType:(UIWebViewNavigationType)navigationType


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-24110

When this property is set to true, the user must explicitly tap the elements in the web view to display the keyboard (or other relevant input view) for that element. When set to false, a focus event on an element causes the input view to be displayed and associated with that element automatically.
The default value for this property is true.

