### PR TITLE
[TIMOB-19629] Use application theme as parent for Theme.Titanium

### DIFF
--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -3384,6 +3384,12 @@ AndroidBuilder.prototype.generateTheme = function generateTheme(next) {
 		if (this.tiapp.fullscreen || this.tiapp['statusbar-hidden']) {
 			flags += '.Fullscreen';
 		}
+		if (this.tiappAndroidManifest && this.tiappAndroidManifest.application && this.tiappAndroidManifest.application.theme) {
+			var theme = this.tiappAndroidManifest.application.theme;
+			if (theme.startsWith('@style/')) {
+				flags = theme.replace('@style/', '');
+			}
+		}
 
 		fs.writeFileSync(themeFile, ejs.render(fs.readFileSync(path.join(this.templatesDir, 'theme.xml')).toString(), {
 			flags: flags


### PR DESCRIPTION
- When an application theme is defined in `tiapp.xml` make sure the parent of `Theme.Titanium` is set as this theme

###### TEST CASE
##### tiapp.xml
```XML
...
<android xmlns:android="http://schemas.android.com/apk/res/android">
    <manifest android:versionCode="1" android:versionName="1.0">
        <application android:theme="@style/Theme.Test"/>
    </manifest>
</android>
...
```

##### platform/android/res/values/test.xml
```XML
<?xml version="1.0" encoding="utf-8"?>
<resources xmlns:android="http://schemas.android.com/apk/res/android">
    <style name="Theme.Test" parent="@style/Theme.AppCompat">
        <item name="android:textAllCaps">false</item>
    </style>
</resources>
```

##### app.js
```Javascript
var win = Ti.UI.createWindow(),
	btn = Ti.UI.createButton({title: 'lower case'}),
	lv = Ti.UI.createListView();

lv.appendSection(Ti.UI.createListSection({
	headerView: btn
}));
win.add(lv);
win.open();
```

For Android 5.0+, the `lower case` title of the button should NOT be uppercase.

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-19629)