### PR TITLE
TIMOB-24082 Android: TiSound MediaPlayer.setDataSource error

### DIFF
--- a/android/modules/media/src/java/ti/modules/titanium/media/TiSound.java
+++ b/android/modules/media/src/java/ti/modules/titanium/media/TiSound.java
@@ -104,7 +104,7 @@ public class TiSound
 					}
 					// Why mp.setDataSource(afd) doesn't work is a problem for another day.
 					// http://groups.google.com/group/android-developers/browse_thread/thread/225c4c150be92416
-					mp.setDataSource(afd.getFileDescriptor(), afd.getStartOffset(), afd.getLength());
+					mp.setDataSource(afd.getFileDescriptor(), afd.getStartOffset()+1, afd.getLength());
 				} catch (IOException e) {
 					Log.e(TAG, "Error setting file descriptor: ", e);
 				} finally {


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-24082

**AssetFileDescriptor gives wrong startOffset value which causes media player to crash on Android 4.4.2 device**
