### PR TITLE
[TIMOB-24149] Android: Remove redundant Ti.UI.Window url code

### DIFF
--- a/android/modules/ui/src/js/window.js
+++ b/android/modules/ui/src/js/window.js
@@ -110,86 +110,8 @@ exports.bootstrap = function(Titanium) {
 		if (kroll.DBG) {
 			kroll.log(TAG, "Checkpoint: postWindowCreated()");
 		}
-		this.loadUrl();
 		if (this._cachedActivityProxy) {
 			this._internalActivity.extend(this._cachedActivityProxy);
 		}
-	}
-
-	// Run the script where the "url" property specifies in its own sub-context.
-	Window.prototype.loadUrl = function() {
-		if (this.url == null) {
-			return;
-		}
-
-		var resolvedUrl = url.resolve(this._sourceUrl, this.url);
-		if (!resolvedUrl.assetPath) {
-			kroll.log(TAG, "Window URL must be a resources file.");
-			return;
-		}
-
-		// Reset creationUrl of the window
-		this.setCreationUrl(resolvedUrl.href);
-
-		var scopeVars = {
-			currentWindow: this,
-			currentActivity: this._internalActivity,
-			currentTab: this.tab,
-			currentTabGroup: this.tabGroup
-		};
-		var scriptPath = this.resolveFilePathFromURL(resolvedUrl);
-
-		// Use scriptPath as the base URL since that's where we found the window URL.
-		scopeVars = Titanium.initScopeVars(scopeVars, scriptPath.replace("Resources/", "app://"));
-
-		var context = this._urlContext = Script.createContext(scopeVars);
-		// Set up the global object which is needed when calling the Ti.include function from the new window context.
-		scopeVars.global = context;
-		context.Titanium = context.Ti = new Titanium.Wrapper(scopeVars);
-		context.console = NativeModule.require('console');
-		bootstrapModule.bootstrapGlobals(context, Titanium);
-
-		if (!scriptPath) {
-			kroll.log(TAG, "Window URL not found: " + this.url);
-			return;
-		}
-
-		var relScriptPath = scriptPath.replace("Resources/", "");
-		var scriptSource = assets.readAsset(scriptPath);
-
-		// Set up paths, filename and require for the new window context.
-		var module = new kroll.Module("app:///" + relScriptPath, this._module || kroll.Module.main, context);
-		module.paths = [path.dirname(scriptPath)];
-		module.filename = scriptPath;
-		context.require = function(request, context) {
-			return module.require(request, context);
-		};
-
-		Script.runInContext(scriptSource, context, relScriptPath, true);
-	}
-
-	// Determine the full path of the file which is defined by the "url" property.
-	Window.prototype.resolveFilePathFromURL = function(resolvedURL) {
-		var parentModule = this._module || kroll.Module.main,
-			resolved = url.toAssetPath(resolvedURL),
-			moduleId = this.url;
-
-		// Return "resolvedURL" if it is a valid path.
-		if (parentModule.filenameExists(resolved)) {
-			return resolved;
-
-		// Otherwise, try each possible path where the module's source file could be located.
-		} else {
-			if (moduleId.indexOf(".js") == moduleId.length - 3) {
-				moduleId = moduleId.substring(0, moduleId.length -3);
-			}
-			resolved = parentModule.resolveFilename(moduleId);
-			// Return the file path if the file exists.
-			if (resolved) {
-				return resolved[1];
-			}
-		}
-
-		return null;
 	}
 }


### PR DESCRIPTION
- Remove code left over for handling the deprected `url` property of `Titanium.UI.Window`

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-24149)
