### PR TITLE
[TIMOB-24128] Android: Remove invalid setProperty for Ti.Network.userAgent

### DIFF
--- a/android/modules/network/src/java/ti/modules/titanium/network/NetworkModule.java
+++ b/android/modules/network/src/java/ti/modules/titanium/network/NetworkModule.java
@@ -139,14 +139,6 @@ public class NetworkModule extends KrollModule {
 	}
 
 	@Override
-	public void handleCreationArgs(KrollModule createdInModule, Object[] args)
-	{
-		super.handleCreationArgs(createdInModule, args);
-
-		setProperty("userAgent", NETWORK_USER_AGENT + " Titanium/" + TiApplication.getInstance().getTiBuildVersion());
-	}
-
-	@Override
 	protected void eventListenerAdded(String event, int count, KrollProxy proxy)
 	{
 		super.eventListenerAdded(event, count, proxy);


### PR DESCRIPTION
- Remove redundant `handleCreationArgs` override
- Prevent `W/V8Object: (KrollRuntimeThread) [174,211] Runtime disposed, cannot set property 'userAgent'`

##### TEST CASE
- Launch app, check logs for `Runtime disposed, cannot set property 'userAgent'` warning
- Warning should not be present

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-24128)
