### PR TITLE
[TIMOB-23991] Implement Ti.Android.Notification.setProgress()

### DIFF
--- a/android/modules/android/src/java/ti/modules/titanium/android/notificationmanager/NotificationProxy.java
+++ b/android/modules/android/src/java/ti/modules/titanium/android/notificationmanager/NotificationProxy.java
@@ -180,7 +180,7 @@ public class NotificationProxy extends KrollProxy
 		notificationBuilder.setPriority(priority);
 		setProperty(TiC.PROPERTY_PRIORITY, priority);
 	}
-
+	
 	@Kroll.method @Kroll.setProperty
 	public void setTickerText(String tickerText)
 	{
@@ -331,6 +331,12 @@ public class NotificationProxy extends KrollProxy
 		notificationBuilder.setContentIntent(contentIntent.getPendingIntent())
 		.setContentText(contentText)
 		.setContentTitle(contentTitle);
+	}
+	
+	@Kroll.method
+	public void setProgress(int max, int progress, boolean indeterminate)
+	{
+		notificationBuilder.setProgress(max, progress, indeterminate);
 	}
 
 	public Notification buildNotification()

--- a/apidoc/Titanium/Android/Notification.yml
+++ b/apidoc/Titanium/Android/Notification.yml
@@ -111,6 +111,22 @@ methods:
         summary: Intent to launch when the user clicks on the notification.
         type: Titanium.Android.PendingIntent
 
+  - name: setProgress
+    summary: Set the progress this notification represents.
+    since: "6.1.0"
+    parameters:
+      - name: max
+        summary: Defines the maximum value the progress can take.
+        type: Number
+
+      - name: progress
+        summary: Defines the progress value, between 0 and max. 
+        type: Number
+
+      - name: indeterminate
+        summary: Allows to enable the indeterminate mode.
+        type: Boolean
+
 properties:
 
   - name: audioStreamType


### PR DESCRIPTION
- Continued from https://github.com/appcelerator/titanium_mobile/pull/8475
- Implement `Titanium.Android.Notification.setProgress()` to define a progress for the notification
- Update `Titanium.Android.Notification` documentation

###### TEST CASE
```Javascript
var n = Ti.Android.createNotification({contentTitle: 'Progress...'});
n.setProgress(100, 50, false);
Ti.Android.NotificationManager.notify(1, n);
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-23991)