### PR TITLE
[TIDOC-2697] Docs: AndroidView Property is Creation Only

### DIFF
--- a/apidoc/Titanium/UI/AlertDialog.yml
+++ b/apidoc/Titanium/UI/AlertDialog.yml
@@ -161,6 +161,7 @@ properties:
     type: Titanium.UI.View
     platforms: [android]
     accessors: false
+    availability: creation
     
   - name: buttonNames
     summary: Name of each button to create.


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIDOC-2697

IMHO androidView property is creation only :
1) No get/set
2) Set this property after the creation do nothing.