### PR TITLE
[TIMOB-24161] Android: Fix Ti.UI.AlertDialog.androidView when borderRadius is set

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIDialog.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIDialog.java
@@ -17,6 +17,7 @@ import org.appcelerator.titanium.TiBaseActivity.DialogWrapper;
 import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.proxy.TiViewProxy;
 import org.appcelerator.titanium.util.TiConvert;
+import org.appcelerator.titanium.view.TiBorderWrapperView;
 import org.appcelerator.titanium.view.TiUIView;
 
 import android.app.Activity;
@@ -25,6 +26,7 @@ import android.support.v7.app.AlertDialog.Builder;
 import android.content.DialogInterface;
 import android.content.DialogInterface.OnCancelListener;
 import android.support.v4.view.ViewCompat;
+import android.view.ViewParent;
 import android.widget.ListView;
 
 public class TiUIDialog extends TiUIView
@@ -164,7 +166,18 @@ public class TiUIDialog extends TiUIView
 			//reset the child view context to parent context
 			proxy.setActivity(dialogWrapper.getActivity());
 			view = proxy.getOrCreateView();
-			getBuilder().setView(view.getNativeView());
+			
+			// handle view border
+			ViewParent viewParent = view.getNativeView().getParent();
+			if (viewParent != null) {
+				if (viewParent instanceof TiBorderWrapperView) {
+					getBuilder().setView((TiBorderWrapperView)viewParent);
+				} else {
+					Log.w(TAG, "could not set androidView, unsupported object: " + proxy.getClass().getSimpleName());
+				}
+			} else {
+				getBuilder().setView(view.getNativeView());
+			}
 		}
 	}
 


### PR DESCRIPTION
- Fix `Titanium.UI.AlertDialog.androidView` when combined with a `borderRadius`

###### TEST CASE
```Javascript
var v = Titanium.UI.createView({
        borderRadius : 10,
        backgroundColor : 'red'
    }),
    d = Ti.UI.createAlertDialog({
        message : 'A red label should appear below with round corners.',
        ok : 'OK',
        title : 'Titanium.UI.AlertDialog.androidView',
        androidView : v
    });
v.add(Ti.UI.createLabel({text:'RED LABEL'}));
d.show();
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-24161)