### PR TITLE
[TIMOB-18276] Android: TiUINotification message and accessors not defined

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/NotificationProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/NotificationProxy.java
@@ -8,13 +8,17 @@ package ti.modules.titanium.ui;
 
 import org.appcelerator.kroll.KrollDict;
 import org.appcelerator.kroll.annotations.Kroll;
+import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.proxy.TiViewProxy;
+import org.appcelerator.titanium.util.TiConvert;
 import org.appcelerator.titanium.view.TiUIView;
 
 import ti.modules.titanium.ui.widget.TiUINotification;
 import android.app.Activity;
 
-@Kroll.proxy(creatableInModule=UIModule.class)
+@Kroll.proxy(creatableInModule=UIModule.class, propertyAccessors = {
+	TiC.PROPERTY_MESSAGE
+})
 public class NotificationProxy extends TiViewProxy
 {
 	public NotificationProxy()
@@ -34,6 +38,16 @@ public class NotificationProxy extends TiViewProxy
 
 		TiUINotification n = (TiUINotification) getOrCreateView();
 		n.show(options);
+	}
+
+	@Kroll.method @Kroll.setProperty
+	public void setMessage(String message) {
+		setPropertyAndFire(TiC.PROPERTY_MESSAGE, message);
+	}
+
+	@Kroll.method @Kroll.getProperty
+	public String getMessage() {
+		return TiConvert.toString(getProperty(TiC.PROPERTY_MESSAGE));
 	}
 
 	@Override

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUINotification.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUINotification.java
@@ -9,6 +9,7 @@ package ti.modules.titanium.ui.widget;
 import org.appcelerator.kroll.KrollDict;
 import org.appcelerator.kroll.KrollProxy;
 import org.appcelerator.kroll.common.Log;
+import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.proxy.TiViewProxy;
 import org.appcelerator.titanium.util.TiConvert;
 import org.appcelerator.titanium.view.TiUIView;
@@ -36,6 +37,10 @@ public class TiUINotification extends TiUIView
 		int offsetX = toast.getXOffset();
 		int offsetY = toast.getYOffset();		
 		int gravity = toast.getGravity();		
+		
+		if (proxy.hasProperty(TiC.PROPERTY_MESSAGE)) {
+			toast.setText(TiConvert.toString(proxy.getProperty(TiC.PROPERTY_MESSAGE)));
+		}
 		
 		if (proxy.hasProperty("duration")) {
 			// Technically this should check if the duration is one of the 2 possible options
@@ -86,8 +91,6 @@ public class TiUINotification extends TiUIView
 	}
 
 	public void show(KrollDict options) {
-
-		toast.setText((String) proxy.getProperty("message"));
 		toast.show();
 	}
 


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-18276

**Test Case**

```
var t = Ti.UI.createNotification({
	message: "property msg",
	duration: Ti.UI.NOTIFICATION_DURATION_LONG
});
Ti.API.debug("test msg " + t.getMessage());

t.message = "assignment msg";
Ti.API.debug("test msg " + t.getMessage());

t.setMessage("setMessage msg");
Ti.API.debug("test msg " + t.getMessage());

t.show();
```

Should see see in this log:
```
? D/TiAPI:  test msg property msg
? D/TiAPI:  test msg assignment msg
? D/TiAPI:  test msg setMessage msg
```
