### PR TITLE
[TIMOB-24165] Android: Title Bar still shows when NoTitleBar theme and opacity set

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/WindowProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/WindowProxy.java
@@ -327,14 +327,7 @@ public class WindowProxy extends TiWindowProxy implements TiActivityWindow
 			}
 			intent.putExtra(TiC.PROPERTY_MODAL, modal);
 		}
-		if (!modal && hasProperty(TiC.PROPERTY_OPACITY)) {
-			intent.setClass(activity, TiTranslucentActivity.class);
-		} else if (hasProperty(TiC.PROPERTY_BACKGROUND_COLOR)) {
-			int bgColor = TiConvert.toColor(properties, TiC.PROPERTY_BACKGROUND_COLOR);
-			if (Color.alpha(bgColor) < 0xFF) {
-				intent.setClass(activity, TiTranslucentActivity.class);
-			}
-		}
+		
 		if (hasProperty(TiC.PROPERTY_WINDOW_PIXEL_FORMAT)) {
 			intent.putExtra(TiC.PROPERTY_WINDOW_PIXEL_FORMAT, TiConvert.toInt(getProperty(TiC.PROPERTY_WINDOW_PIXEL_FORMAT), PixelFormat.UNKNOWN));
 		}


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-24165

**Test case:**
Ensure you set the theme to `Theme.AppCompat.NoTitleBar` in `AndroidManifest.xml`. 

```
var w = Ti.UI.createWindow({
			title: "Oops! Something went wrong.",
			backgroundColor: "#00FF00",
			opacity: 0.5,
			exitOnClose: true
		});
w.open();
Ti.API.debug("test msg backgroundColor " + w.getBackgroundColor());
Ti.API.debug("test msg opacity " + w.getOpacity());
```
**Console output**
```
? D/TiAPI:  test msg backgroundColor #00FF00
? D/TiAPI:  test msg opacity 0.5
```

**You should expect to NOT see the title bar**
