### PR TITLE
[TIMOB-24177] Fix unicode character calculation in TiHTTPClient

### DIFF
--- a/android/modules/network/src/java/ti/modules/titanium/network/TiHTTPClient.java
+++ b/android/modules/network/src/java/ti/modules/titanium/network/TiHTTPClient.java
@@ -1151,7 +1151,7 @@ public class TiHTTPClient
 							contentLength += 6 + boundary.length();
 						} else {
 							if (data instanceof String) {
-								contentLength += ((String) data).length();
+								contentLength += ((String) data).getBytes().length;
 							} else if (data instanceof FileEntity) {
 								contentLength += ((FileEntity) data).getContentLength();
 							} else if (form != null) {


### PR DESCRIPTION
- Fix the `contentLength` calculation of unicode characters in `TiHTTPClient`

###### TEST CASE
```Javascript
var http = Ti.Network.createHTTPClient({
        onload: function (e) {
            Ti.API.info('success: ' + this.responseText);
        }
    });

http.open('POST', 'http://requestb.in/1c42dug1');
http.send('인연');
```
```
success: ok
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-24177)