### PR TITLE
[TIMOB-18053] Android: fix picker row text color

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/picker/TiUINativePicker.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/picker/TiUINativePicker.java
@@ -25,7 +25,6 @@ import ti.modules.titanium.ui.PickerColumnProxy;
 import ti.modules.titanium.ui.PickerProxy;
 import android.app.Activity;
 import android.content.Context;
-import android.graphics.Color;
 import android.os.Build;
 import android.view.MotionEvent;
 import android.view.View;
@@ -42,7 +41,7 @@ public class TiUINativePicker extends TiUIPicker
 {
 	private static final String TAG = "TiUINativePicker";
 	private boolean firstSelectedFired = false;
-	private static int DEFAULT_TEXT_COLOR = 0;
+	private static int defaultTextColor = 0;
 	
 	public static class TiSpinnerAdapter<T> extends ArrayAdapter<T>
 	{
@@ -83,12 +82,12 @@ public class TiUINativePicker extends TiUIPicker
 			}
 			if (rowProxy.hasProperty(TiC.PROPERTY_COLOR)) {
 				final int color = TiConvert.toColor(rowProxy.getProperties(), TiC.PROPERTY_COLOR);
-				if (DEFAULT_TEXT_COLOR != color) {
-					DEFAULT_TEXT_COLOR = tv.getCurrentTextColor();
+				if (defaultTextColor != color) {
+					defaultTextColor = tv.getCurrentTextColor();
 				}
 				tv.setTextColor(color);
 			} else {
-				tv.setTextColor(DEFAULT_TEXT_COLOR);
+				tv.setTextColor(defaultTextColor);
 			}
 		}
 	}

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/picker/TiUINativePicker.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/picker/TiUINativePicker.java
@@ -81,9 +81,11 @@ public class TiUINativePicker extends TiUIPicker
 		        fontProperties[TiUIHelper.FONT_STYLE_POSITION]);
 		    }
 		    if (rowProxy.hasProperty(TiC.PROPERTY_COLOR)) {
-		        final int color = TiConvert.toColor(rowProxy.getProperties(), TiC.PROPERTY_COLOR);
-		        tv.setTextColor(color);
-		    }
+				final int color = TiConvert.toColor(rowProxy.getProperties(), TiC.PROPERTY_COLOR);
+				tv.setTextColor(color);
+			} else {
+				tv.setTextColor(Color.WHITE);
+			}
 		}
 	}
 	

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/picker/TiUINativePicker.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/picker/TiUINativePicker.java
@@ -42,6 +42,7 @@ public class TiUINativePicker extends TiUIPicker
 {
 	private static final String TAG = "TiUINativePicker";
 	private boolean firstSelectedFired = false;
+	private static int DEFAULT_TEXT_COLOR = 0;
 	
 	public static class TiSpinnerAdapter<T> extends ArrayAdapter<T>
 	{
@@ -74,17 +75,20 @@ public class TiUINativePicker extends TiUIPicker
 		}
 		
 		private void styleTextView(int position, TextView tv) {
-		    TiViewProxy rowProxy = (TiViewProxy) this.getItem(position);
-		    if (fontProperties != null) {
-		        TiUIHelper.styleText(tv, fontProperties[TiUIHelper.FONT_FAMILY_POSITION],
-		        fontProperties[TiUIHelper.FONT_SIZE_POSITION], fontProperties[TiUIHelper.FONT_WEIGHT_POSITION],
-		        fontProperties[TiUIHelper.FONT_STYLE_POSITION]);
-		    }
-		    if (rowProxy.hasProperty(TiC.PROPERTY_COLOR)) {
+			TiViewProxy rowProxy = (TiViewProxy) this.getItem(position);
+			if (fontProperties != null) {
+				TiUIHelper.styleText(tv, fontProperties[TiUIHelper.FONT_FAMILY_POSITION],
+				fontProperties[TiUIHelper.FONT_SIZE_POSITION], fontProperties[TiUIHelper.FONT_WEIGHT_POSITION],
+				fontProperties[TiUIHelper.FONT_STYLE_POSITION]);
+			}
+			if (rowProxy.hasProperty(TiC.PROPERTY_COLOR)) {
 				final int color = TiConvert.toColor(rowProxy.getProperties(), TiC.PROPERTY_COLOR);
+				if (DEFAULT_TEXT_COLOR != color) {
+					DEFAULT_TEXT_COLOR = tv.getCurrentTextColor();
+				}
 				tv.setTextColor(color);
 			} else {
-				tv.setTextColor(Color.WHITE);
+				tv.setTextColor(DEFAULT_TEXT_COLOR);
 			}
 		}
 	}


### PR DESCRIPTION
[Last PR](https://github.com/appcelerator/titanium_mobile/pull/7959) for issue didn't solve all bugs. Text color behaved weird if color not set for all rows.

**TEST CASE**
Comment and uncomment colors in each picker row.
```js
var win = Ti.UI.createWindow({
    exitOnClose: true,
    layout: 'vertical',
    backgroundColor: 'black'
});

var picker = Ti.UI.createPicker({
    top: 50
});

var data = [];
data[0] = Ti.UI.createPickerRow({
    title: 'Bananas',
    color: 'yellow'
});
data[1] = Ti.UI.createPickerRow({
    title: 'Strawberries',
    // color: 'red'
});
data[2] = Ti.UI.createPickerRow({
    title: 'Mangos',
    color: 'orange'
});
data[3] = Ti.UI.createPickerRow({
    title: 'Grapes',
    // color: 'purple'
});

picker.add(data);
picker.selectionIndicator = true;

win.add(picker);
win.open();
```
**EXPECTED**
A picker row's text color should only be set if specified otherwise should be default color.

**JIRA:** https://jira.appcelerator.org/browse/TIMOB-18053