### PR TITLE
[TIMOB-16369] fix disableContextMenu set to false error

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/WebViewProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/WebViewProxy.java
@@ -344,6 +344,18 @@ public class WebViewProxy extends ViewProxy
 	}
 
 	@Kroll.method @Kroll.setProperty
+	public void setDisableContextMenu(boolean disableContextMenu)
+	{
+		setPropertyAndFire(TiC.PROPERTY_DISABLE_CONTEXT_MENU, disableContextMenu);
+	}
+
+	@Kroll.method @Kroll.getProperty
+	public boolean getDisableContextMenu()
+	{
+		return TiConvert.toBoolean(getProperty(TiC.PROPERTY_DISABLE_CONTEXT_MENU));
+	}
+
+	@Kroll.method @Kroll.setProperty
 	public void setPluginState(int pluginState)
 	{
 		switch (pluginState) {

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
@@ -21,7 +21,6 @@ import android.support.annotation.StringRes;
 import android.view.ActionMode;
 import android.view.Menu;
 import android.view.MenuInflater;
-import android.view.MenuItem;
 import android.view.ViewParent;
 import org.appcelerator.kroll.KrollDict;
 import org.appcelerator.kroll.KrollProxy;
@@ -88,8 +87,6 @@ public class TiUIWebView extends TiUIView
 	private class TiWebView extends WebView
 	{
 		public TiWebViewClient client;
-		protected ActionMode actionMode = null;
-		protected ActionMode.Callback actionModeCallback = null;
 
 		public TiWebView(Context context)
 		{
@@ -102,28 +99,25 @@ public class TiUIWebView extends TiUIView
 			if (disableContextMenu) {
 				return nullifiedActionMode();
 			}
-			if (actionModeCallback == null) {
-				actionModeCallback = new CustomActionModeCallback();
-			}
-			return super.startActionMode(actionModeCallback);
+			
+			return super.startActionMode(callback);
 		}
-
+		
+		/**
+		 * API 23 or higher is required for this startActionMode to be invoked otherwise other startActionMode is invoked.
+		 */
 		@Override
 		public ActionMode startActionMode(ActionMode.Callback callback, int type)
 		{
 			if (disableContextMenu) {
 				return nullifiedActionMode();
 			}
-			// this startActionMode is fired and not the other one
-			// it depends on Android version you use, I used Android 6 (API 23)
 			ViewParent parent = getParent();
 			if (parent == null) {
 				return null;
 			}
-			if (actionModeCallback == null) {
-				actionModeCallback = new CustomActionModeCallback();
-			}
-			return parent.startActionModeForChild(this, actionModeCallback);
+			
+			return parent.startActionModeForChild(this, callback, type);
 		}
 		
 		public ActionMode nullifiedActionMode()
@@ -190,35 +184,6 @@ public class TiUIWebView extends TiUIView
 					return null;
 				}
 			};
-		}
-
-		private class CustomActionModeCallback implements ActionMode.Callback
-		{
-
-			@Override
-			public boolean onCreateActionMode(ActionMode mode, Menu menu)
-			{
-				return true;
-			}
-
-			@Override
-			public boolean onPrepareActionMode(ActionMode mode, Menu menu)
-			{
-				return false;
-			}
-
-			@Override
-			public boolean onActionItemClicked(ActionMode mode, MenuItem item)
-			{
-				return true;
-			}
-
-			@Override
-			public void onDestroyActionMode(ActionMode mode)
-			{
-				clearFocus();
-				actionMode = null;
-			}
 		}
 
 		@Override
@@ -524,6 +489,8 @@ public class TiUIWebView extends TiUIView
 			if (newValue instanceof HashMap) {
 				setRequestHeaders((HashMap) newValue);
 			}
+		} else if (TiC.PROPERTY_DISABLE_CONTEXT_MENU.equals(key)) {
+			disableContextMenu = TiConvert.toBoolean(newValue);
 		} else {
 			super.propertyChanged(key, oldValue, newValue, proxy);
 		}


### PR DESCRIPTION
**CHANGED**
+ show menu when disableContextMenu = false
+ accessors (get/set)

**TEST CASE**
Long click on text to select. Wait to see if floating context menu appears.
```
var window = Ti.UI.createWindow(),
    webView = Ti.UI.createWebView({
        url: "http://www.lipsum.com",
        disableContextMenu: true
    });
window.add(webView);
window.open();
```
**EXPECTED**
You should not see floating context menu when disableContextMenu set to false

**JIRA:** https://jira.appcelerator.org/browse/TIMOB-16369

