### PR TITLE
[TIMOB-18053] Android: fixed default text color value changing

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/picker/TiUINativePicker.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/picker/TiUINativePicker.java
@@ -41,7 +41,8 @@ public class TiUINativePicker extends TiUIPicker
 {
 	private static final String TAG = "TiUINativePicker";
 	private boolean firstSelectedFired = false;
-	private static int defaultTextColor = 0;
+	private static int defaultTextColor;
+	private static boolean setDefaultTextColor = false;
 	
 	public static class TiSpinnerAdapter<T> extends ArrayAdapter<T>
 	{
@@ -80,11 +81,12 @@ public class TiUINativePicker extends TiUIPicker
 				fontProperties[TiUIHelper.FONT_SIZE_POSITION], fontProperties[TiUIHelper.FONT_WEIGHT_POSITION],
 				fontProperties[TiUIHelper.FONT_STYLE_POSITION]);
 			}
+			if (!setDefaultTextColor) {
+				defaultTextColor = tv.getCurrentTextColor();
+				setDefaultTextColor = true;
+			}
 			if (rowProxy.hasProperty(TiC.PROPERTY_COLOR)) {
-				final int color = TiConvert.toColor(rowProxy.getProperties(), TiC.PROPERTY_COLOR);
-				if (defaultTextColor != color) {
-					defaultTextColor = tv.getCurrentTextColor();
-				}
+				final int color = TiConvert.toColor((String) rowProxy.getProperty(TiC.PROPERTY_COLOR));
 				tv.setTextColor(color);
 			} else {
 				tv.setTextColor(defaultTextColor);


### PR DESCRIPTION
**CHANGED**
+ default color value kept getting changed so let default color be set only once

**TEST CASE**
Comment and uncomment colors in each picker row.
```js
var win = Ti.UI.createWindow({
    exitOnClose: true,
    layout: 'vertical',
    backgroundColor: 'black'
});

var picker = Ti.UI.createPicker({
    top: 50
});

var data = [];
data[0] = Ti.UI.createPickerRow({
    title: 'Bananas',
    color: 'yellow'
});
data[1] = Ti.UI.createPickerRow({
    title: 'Strawberries',
    // color: 'red'
});
data[2] = Ti.UI.createPickerRow({
    title: 'Mangos',
    color: 'orange'
});
data[3] = Ti.UI.createPickerRow({
    title: 'Grapes',
    // color: 'purple'
});

picker.add(data);
picker.selectionIndicator = true;

win.add(picker);
win.open();
```
**EXPECTED**
A picker row's text color should only be set if specified otherwise should be default color.

**JIRA:** https://jira.appcelerator.org/browse/TIMOB-18053

