### PR TITLE
[TIMOB-24204] Android: Normalize require() paths

### DIFF
--- a/android/runtime/common/src/js/module.js
+++ b/android/runtime/common/src/js/module.js
@@ -260,7 +260,7 @@ Module.prototype.require = function (request, context) {
 		}
 	// Root/absolute path (internally when reading the file, we prepend "Resources/" as root dir)
 	} else if (request.substring(0, 1) === '/') {
-		loaded = this.loadAsFileOrDirectory(request, context);
+		loaded = this.loadAsFileOrDirectory(path.normalize(request), context);
 		if (loaded) {
 			return loaded;
 		}
@@ -293,7 +293,7 @@ Module.prototype.require = function (request, context) {
 		// So for now, let's just be quite about it. In future versions of the SDK (7.0?) we should warn (once 5.x is end of life so backwards compat is not necessary)
 		//kroll.log(TAG, "require called with un-prefixed module id: " + request + ", should be a core or CommonJS module. Falling back to old Ti behavior and assuming it's an absolute path: /" + request);
 
-		loaded = this.loadAsFileOrDirectory('/' + request, context);
+		loaded = this.loadAsFileOrDirectory(path.normalize('/' + request), context);
 		if (loaded) {
 			return loaded;
 		}


### PR DESCRIPTION
- Always normalize `require()` paths

###### TEST CASE
##### app.js
```Javascript
require('assets/../test.js');
Ti.API.info('Hello, from app.js');
```
##### test.js
```Javascript
Ti.API.info('Hello, from test.js');
```
```
Hello, from test.js
Hello, from app.js
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-24204)