### PR TITLE
[TIMOB-24209] Android: Default WebViewProxy borderRadius to zero

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/WebViewProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/WebViewProxy.java
@@ -75,6 +75,7 @@ public class WebViewProxy extends ViewProxy
 		defaultValues.put(TiC.PROPERTY_OVER_SCROLL_MODE, 0);
 		defaultValues.put(TiC.PROPERTY_LIGHT_TOUCH_ENABLED, true);
 		defaultValues.put(TiC.PROPERTY_ENABLE_JAVASCRIPT_INTERFACE, true);
+		defaultValues.put(TiC.PROPERTY_BORDER_RADIUS, 0);
 	}
 
 	@Override


### PR DESCRIPTION
- Default `WebView` `borderRadius` to `0`

###### TEST CASE
```Javascript
var w = Ti.UI.createWindow(),
    wv = Ti.UI.createWebView({
        url: 'https://player.vimeo.com/video/151036965',
        width: Ti.UI.FILL,
        height: Ti.UI.FILL
    });
w.add(wv);
w.open();
```
- A playable video should be shown

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-24209)