### PR TITLE
[TIMOB-24225] Fire close event on Ti.UI.Window close

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/TiListView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/TiListView.java
@@ -212,7 +212,10 @@ public class TiListView extends TiUIView implements OnSearchChangeListener {
 	
 	public class TiBaseAdapter extends BaseAdapter {
 		
+		Activity context;
+
 		public TiBaseAdapter(Activity activity) {
+			context = activity;
 		}
 
 		@Override

--- a/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
@@ -1498,21 +1498,7 @@ public abstract class TiBaseActivity extends AppCompatActivity
 		Log.d(TAG, "Activity " + this + " onDestroy", Log.DEBUG_MODE);
 		if (activityProxy != null) {
 			dispatchCallback(TiC.PROPERTY_ON_DESTROY, null);
-			activityProxy.release();
-			activityProxy = null;
 		}
-		if (view != null) {
-			view.releaseViews();
-			view.release();
-			view = null;
-		}
-		if (window != null) {
-			window.releaseViews();
-			window.removeAllChildren();
-			window.release();
-			window = null;
-		}
-		layout = null;
 
 		inForeground = false;
 		TiApplication tiApp = getTiApp();
@@ -1566,11 +1552,15 @@ public abstract class TiBaseActivity extends AppCompatActivity
 		//LW windows
 		if (window == null && view != null) {
 			view.releaseViews();
+			view.release();
 			view = null;
 		}
 
 		if (window != null) {
 			window.closeFromActivity(isFinishing);
+			window.releaseViews();
+			window.removeAllChildren();
+			window.release();
 			window = null;
 		}
 

--- a/android/titanium/src/java/ti/modules/titanium/BufferProxy.java
+++ b/android/titanium/src/java/ti/modules/titanium/BufferProxy.java
@@ -196,6 +196,9 @@ public class BufferProxy extends KrollProxy
 	@Kroll.method
 	public int append(Object[] args)
 	{
+		if (args.length < 1) {
+			throw new IllegalArgumentException("At least 1 argument required for append: src");
+		}
 		int destLength = buffer.length;
 		BufferProxy src = (BufferProxy) args[0];
 		byte[] sourceBuffer = src.getBuffer();


### PR DESCRIPTION
- `close` event is not fired when a `Titanium.UI.Window` is closed
- This should fix the failing [`close event is fired`](https://github.com/appcelerator/titanium-mobile-mocha-suite/blob/master/Resources/ti.ui.window.test.js#L184) mocha test
- Add argument validation to `BufferProxy.append()`

###### TEST CASE
```Javascript
var b = Ti.UI.createWindow({backgroundColor: 'red'}),
    w = Ti.UI.createWindow({backgroundColor: 'yellow'});
 
w.addEventListener('close', function () {
    b.setBackgroundColor('green');
});
b.addEventListener('open', function () {
    w.addEventListener('open', function() {
        setTimeout(function () {
            w.close();
        }, 500);
    });
    w.open();
});
 
b.open();
```
- Window should be green

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-24225)