### PR TITLE
[TIMOB-23428] Fix Android: Ti.Media.Sound method 'setUrl' not working

### DIFF
--- a/android/modules/media/src/java/ti/modules/titanium/media/SoundProxy.java
+++ b/android/modules/media/src/java/ti/modules/titanium/media/SoundProxy.java
@@ -94,7 +94,7 @@ public class SoundProxy extends KrollProxy
 		Log.i(TAG, "Creating sound proxy for url: " + TiConvert.toString(getProperty(TiC.PROPERTY_URL)), Log.DEBUG_MODE);
 	}
 
-	@Kroll.getProperty
+	@Kroll.method @Kroll.getProperty
 	public String getUrl() {
 		return TiConvert.toString(getProperty(TiC.PROPERTY_URL));
 	}

--- a/android/modules/media/src/java/ti/modules/titanium/media/SoundProxy.java
+++ b/android/modules/media/src/java/ti/modules/titanium/media/SoundProxy.java
@@ -99,7 +99,7 @@ public class SoundProxy extends KrollProxy
 		return TiConvert.toString(getProperty(TiC.PROPERTY_URL));
 	}
 
-	@Kroll.setProperty
+	@Kroll.method @Kroll.setProperty
 	public void setUrl(Object url) {
 		String path = parseURL(url);
 		if (path != null) {


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-23428

[TIMOB-23428] Fix Android: Ti.Media.Sound method 'setUrl' not working

**Optional Description:**

Update SoundProxy.java Line 102 missing annotation @Kroll.method, caused bug