### PR TITLE
[TIMOB-24246] Android: Init SSLContext with SecureRandom

### DIFF
--- a/android/modules/network/src/java/ti/modules/titanium/network/TiSocketFactory.java
+++ b/android/modules/network/src/java/ti/modules/titanium/network/TiSocketFactory.java
@@ -13,6 +13,7 @@ import java.net.UnknownHostException;
 import java.security.KeyManagementException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
 import java.security.UnrecoverableKeyException;
 import java.util.ArrayList;
 import java.util.List;
@@ -71,7 +72,7 @@ public class TiSocketFactory extends SSLSocketFactory {
 		}
 				
 		sslContext = SSLContext.getInstance(tlsVersion);
-		sslContext.init(keyManagers, trustManagers, null);
+		sslContext.init(keyManagers, trustManagers, new SecureRandom());
 		
 	}
 	


### PR DESCRIPTION
- Initialise `SSLContext` with an instance of `SecureRandom`

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-24246)