### PR TITLE
TIMOB-24249 - Ensuring Ti.UI.iOS.LivePhotoView updates it's size when setting the livePhoto property

### DIFF
--- a/iphone/Classes/TiUIiOSLivePhotoView.m
+++ b/iphone/Classes/TiUIiOSLivePhotoView.m
@@ -8,6 +8,7 @@
 #ifdef USE_TI_UIIOSLIVEPHOTOVIEW
 #import "TiUIiOSLivePhotoView.h"
 #import "TiUIiOSLivePhotoViewProxy.h"
+#import "TiViewProxy.h"
 
 @implementation TiUIiOSLivePhotoView
 
@@ -62,6 +63,7 @@
     autoHeight = livePhoto.size.height;
     
     [[self livePhotoView] setLivePhoto:livePhoto];
+    [(TiViewProxy*)self.proxy relayout];
 }
 
 -(void)setWidth_:(id)width_


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-24249

**Optional Description:**
If a Ti.UI.iOS.LivePhotoView is instantiated without the livePhoto property set, and later it is set (ie, after an http request) , the view size remains at 0x0 pixels instead of updating.