### PR TITLE
[TIMOB-24256] Android: Add support for com.android.providers.media.documents in TitaniumBlob

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/io/TitaniumBlob.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/io/TitaniumBlob.java
@@ -33,21 +33,45 @@ public class TitaniumBlob extends TiBaseFile
 	}
 
 	protected void init() {
-		String [] projection = {
+		String[] projection = {
 			MediaStore.Images.ImageColumns.DISPLAY_NAME,
 			MediaStore.Images.ImageColumns.DATA
 		};
 		Cursor c = null;
-		try {
-			c = TiApplication.getInstance().getContentResolver().query(Uri.parse(url), projection, null, null, null);
 
-			if (c.moveToNext()) {
-				name = c.getString(0);
-				path = c.getString(1);
-			}
-		} finally {
-			if (c != null) {
+		if (url.startsWith("content://com.android.providers.media.documents")) {
+			try {
+				c = TiApplication.getInstance().getContentResolver().query(Uri.parse(url), null, null, null, null);
+				c.moveToFirst();
+				String id = c.getString(0);
+				id = id.substring(id.lastIndexOf(":") + 1);
 				c.close();
+
+				c = TiApplication.getInstance().getContentResolver().query(
+					android.provider.MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
+					projection, MediaStore.Images.Media._ID + " = ? ", new String[]{id}, null);
+
+				if (c.moveToNext()) {
+					name = c.getString(0);
+					path = c.getString(1);
+				}
+			} finally {
+				if (c != null) {
+					c.close();
+				}
+			}
+		} else {
+			try {
+				c = TiApplication.getInstance().getContentResolver().query(Uri.parse(url), projection, null, null, null);
+
+				if (c.moveToNext()) {
+					name = c.getString(0);
+					path = c.getString(1);
+				}
+			} finally {
+				if (c != null) {
+					c.close();
+				}
 			}
 		}
 	}


### PR DESCRIPTION
- Support `content://com.android.providers.media.documents` URLs received from the gallery

###### TEST CASE
```Javascript
var w = Ti.UI.createWindow({backgroundColor : 'grey'}),
    b = Titanium.UI.createButton({
        title : 'OPEN GALLERY',
        top : '10dp'
    }),
    iv = Ti.UI.createImageView({
        top : '65dp',
        width : '95%'
    });

b.addEventListener('click', function(e) {
    Ti.Media.openPhotoGallery({
        mediaTypes : [Ti.Media.MEDIA_TYPE_PHOTO],
        success : function(e) {
            iv.height = e.media.height * (iv.rect.width / e.media.width);
            iv.image = e.media;

            alert(e.media.file.name);
            alert(e.media.length);
        },
        error : function(e) {
            Ti.API.error(JSON.stringify(e));
        }
    });
});

w.add(b);
w.add(iv);

w.open();
```

##### NOTE: This may require `<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>`

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-24256)