### PR TITLE
Jenkins: Validate proxy in onFocusChange() callback

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiUIHelper.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiUIHelper.java
@@ -1023,6 +1023,10 @@ public class TiUIHelper
 
 	public static void requestSoftInputChange(KrollProxy proxy, View view) 
 	{
+		if (proxy == null) {
+			return;
+		}
+		
 		int focusState = TiUIView.SOFT_KEYBOARD_DEFAULT_ON_FOCUS;
 		
 		if (proxy.hasProperty(TiC.PROPERTY_SOFT_KEYBOARD_ON_FOCUS)) {


### PR DESCRIPTION
- Fix intermittent crash on Jenkins when `onFocusChange()` is called
- `proxy` might not exist when `requestSoftInputChange()` is executed
- Add validation to prevent this

[Jenkins Example #1](https://jenkins.appcelerator.org/job/titanium_mobile_prs/1334/console)
[Jenkins Example #2](https://jenkins.appcelerator.org/job/titanium_mobile_prs/1315/console)