### PR TITLE
[TIMOB-24243] Android: Fix wrapping for horizontal layouts

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiCompositeLayout.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiCompositeLayout.java
@@ -314,12 +314,11 @@ public class TiCompositeLayout extends ViewGroup
 
                     if ((horizontalRowWidth + childWidth) > w) {
                         horizontalRowWidth = childWidth;
-                        maxHeight += horizontalRowHeight;
                         horizontalRowHeight = childHeight;
-
                     } else {
                         horizontalRowWidth += childWidth;
                         maxWidth = Math.max(maxWidth, horizontalRowWidth);
+                        w -= horizontalRowWidth;
                     }
 
                 } else {
@@ -700,14 +699,9 @@ public class TiCompositeLayout extends ViewGroup
         }
         horiztonalLayoutPreviousRight = (optionRight == null) ? 0 : optionRight.getAsPixels(this);
 
-        int right;
         // If it's fill width with horizontal wrap, just take up remaining
         // space.
-        if (enableHorizontalWrap && params.autoFillsWidth && params.sizeOrFillWidthEnabled) {
-            right = measuredWidth;
-        } else {
-            right = left + measuredWidth;
-        }
+        int right = left + measuredWidth;
 
         if (enableHorizontalWrap
                 && ((right + horiztonalLayoutPreviousRight) > layoutRight || left >= layoutRight)) {


### PR DESCRIPTION
- Fix wrapping and width calculation of sizeable components for horizontal layouts

###### TEST CASE
```Javascript
var w = Ti.UI.createWindow({backgroundColor: 'grey', layout: 'horizontal'}),
    v = Ti.UI.createView({
        top: 0,
        backgroundColor: 'red',
        width: Ti.UI.FILL,
        height: Ti.UI.SIZE,
        layout: 'horizontal'
    }),
    n = Ti.UI.createLabel({
        top: 0,
        text: '1.',
        backgroundColor: 'purple'
    }),
    t = Ti.UI.createLabel({
        text: 'Replenish the Uranium rod with dry ice every 6 hours.',
        width:  Ti.UI.FILL,
        backgroundColor: 'orange'
    });

v.add([n, t]);

w.add(v);
w.open();
```
![](https://jira.appcelerator.org/secure/attachment/61155/testcase.jpg)

[TIMOB-24243](https://jira.appcelerator.org/browse/TIMOB-24243)