### PR TITLE
Cleanup tiapp.xml

### DIFF
--- a/support/all/tiapp.xml
+++ b/support/all/tiapp.xml
@@ -16,9 +16,11 @@
 	<ios>
 		<plist>
 			<dict>
-				<key>UISupportedInterfaceOrientations~iphone</key>
+				<key>UISupportedInterfaceOrientations</key>
 				<array>
 					<string>UIInterfaceOrientationPortrait</string>
+					<string>UIInterfaceOrientationLandscapeLeft</string>
+					<string>UIInterfaceOrientationLandscapeRight</string>
 				</array>
 				<key>UISupportedInterfaceOrientations~ipad</key>
 				<array>
@@ -27,28 +29,11 @@
 					<string>UIInterfaceOrientationLandscapeLeft</string>
 					<string>UIInterfaceOrientationLandscapeRight</string>
 				</array>
-				<key>UIRequiresPersistentWiFi</key>
-				<false/>
-				<key>UIPrerenderedIcon</key>
-				<false/>
-				<key>UIStatusBarHidden</key>
-				<false/>
-				<key>UIStatusBarStyle</key>
-				<string>UIStatusBarStyleDefault</string>
 			</dict>
 		</plist>
 	</ios>
 	<android xmlns:android="http://schemas.android.com/apk/res/android">
 	</android>
-	<mobileweb>
-		<precache>
-		</precache>
-		<splash>
-			<enabled>true</enabled>
-			<inline-css-images>true</inline-css-images>
-		</splash>
-		<theme>default</theme>
-	</mobileweb>
 	<modules>
 	</modules>
 </ti:app>


### PR DESCRIPTION
This PR cleans up the following components of the tiapp.xml - used for *new* projects:
- Remove the `<mobileweb>` configuration since it's deprecated and should not be used in new projects
- Remove the `UIRequiresPersistentWiFi`, `UIPrerenderedIcon`, `UIStatusBarHidden` and `UIStatusBarStyle` since this are already the default values used by iOS
- To be discussed: I changed the `UISupportedInterfaceOrientations` to incorporate the behavior of new native iOS projects, which also include landscape-support on iOS (which got more relevant the last years because of the bigger device-screens and splitview-layouts). As it's the default behavior, we could also remove it, but to keep it easy for people to adjust orientations, it should be left there. That's different to the other flags that are more specific.

@cb1kenobi is a good discussion partner for this 🙂 