### PR TITLE
[TIMOB-24250] Android: TextField AUTOCAPITALIZATION_ALL property doesn't work with googles new keyboard: GBoard

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIText.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIText.java
@@ -84,6 +84,8 @@ public class TiUIText extends TiUIView
 	private boolean disableChangeEvent = false;
 
 	protected EditText tv;
+	
+	private KrollDict keyboard;
 
 	public TiUIText(final TiViewProxy proxy, boolean field)
 	{
@@ -379,6 +381,25 @@ public class TiUIText extends TiUIView
 			proxy.setProperty(TiC.PROPERTY_VALUE, newText);
 			fireEvent(TiC.EVENT_CHANGE, data);
 		}
+		
+		// capitalize if necessary
+		String text = s.toString();
+
+		if (keyboard!=null && !TextUtils.isEmpty(text)) {
+			if (keyboard.containsKey(TiC.PROPERTY_AUTOCAPITALIZATION)) {
+				switch (TiConvert.toInt(keyboard.get(TiC.PROPERTY_AUTOCAPITALIZATION), TEXT_AUTOCAPITALIZATION_NONE)) {
+					case TEXT_AUTOCAPITALIZATION_ALL:
+						if(!TextUtils.equals(text, text.toUpperCase()))
+						{
+							int cursorPosition = tv.getSelectionEnd();
+							text=text.toUpperCase();
+							tv.setText(text);
+							tv.setSelection(cursorPosition);
+						}
+						break;
+				}
+			}
+		}
 	}
 
 	@Override
@@ -472,6 +493,9 @@ public class TiUIText extends TiUIView
 		int autocorrect = InputType.TYPE_TEXT_FLAG_AUTO_CORRECT;
 		int autoCapValue = 0;
 
+		// Initialize keyboard
+		keyboard = d;
+		
 		if (d.containsKey(TiC.PROPERTY_AUTOCORRECT) && !TiConvert.toBoolean(d, TiC.PROPERTY_AUTOCORRECT, true)) {
 			autocorrect = 0;
 		}

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIText.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIText.java
@@ -8,6 +8,7 @@ package ti.modules.titanium.ui.widget;
 
 import java.util.HashMap;
 
+import android.text.*;
 import org.appcelerator.kroll.KrollDict;
 import org.appcelerator.kroll.KrollProxy;
 import org.appcelerator.kroll.common.Log;
@@ -25,11 +26,7 @@ import android.graphics.Rect;
 import android.graphics.Typeface;
 import android.os.Build;
 import android.os.Bundle;
-import android.text.Editable;
-import android.text.InputType;
-import android.text.Spannable;
 import android.text.TextUtils.TruncateAt;
-import android.text.TextWatcher;
 import android.text.method.DialerKeyListener;
 import android.text.method.DigitsKeyListener;
 import android.text.method.LinkMovementMethod;
@@ -85,7 +82,7 @@ public class TiUIText extends TiUIView
 
 	protected EditText tv;
 	
-	private KrollDict keyboard;
+	private boolean autoCapAll;
 
 	public TiUIText(final TiViewProxy proxy, boolean field)
 	{
@@ -383,22 +380,15 @@ public class TiUIText extends TiUIView
 		}
 		
 		// capitalize if necessary
-		String text = s.toString();
+		if (autoCapAll && !TextUtils.isEmpty(newText)) {
 
-		if (keyboard!=null && !TextUtils.isEmpty(text)) {
-			if (keyboard.containsKey(TiC.PROPERTY_AUTOCAPITALIZATION)) {
-				switch (TiConvert.toInt(keyboard.get(TiC.PROPERTY_AUTOCAPITALIZATION), TEXT_AUTOCAPITALIZATION_NONE)) {
-					case TEXT_AUTOCAPITALIZATION_ALL:
-						if(!TextUtils.equals(text, text.toUpperCase()))
-						{
-							int cursorPosition = tv.getSelectionEnd();
-							text=text.toUpperCase();
-							tv.setText(text);
-							tv.setSelection(cursorPosition);
-						}
-						break;
-				}
+			if (!TextUtils.equals(newText, newText.toUpperCase())) {
+				int cursorPosition = tv.getSelectionEnd();
+				newText = newText.toUpperCase();
+				tv.setText(newText);
+				tv.setSelection(cursorPosition);
 			}
+
 		}
 	}
 
@@ -493,9 +483,6 @@ public class TiUIText extends TiUIView
 		int autocorrect = InputType.TYPE_TEXT_FLAG_AUTO_CORRECT;
 		int autoCapValue = 0;
 
-		// Initialize keyboard
-		keyboard = d;
-		
 		if (d.containsKey(TiC.PROPERTY_AUTOCORRECT) && !TiConvert.toBoolean(d, TiC.PROPERTY_AUTOCORRECT, true)) {
 			autocorrect = 0;
 		}
@@ -539,7 +526,7 @@ public class TiUIText extends TiUIView
 
 		} else {
 			if (d.containsKey(TiC.PROPERTY_AUTOCAPITALIZATION)) {
-
+				autoCapAll = false;
 				switch (TiConvert.toInt(d.get(TiC.PROPERTY_AUTOCAPITALIZATION), TEXT_AUTOCAPITALIZATION_NONE)) {
 					case TEXT_AUTOCAPITALIZATION_NONE:
 						autoCapValue = 0;
@@ -547,6 +534,7 @@ public class TiUIText extends TiUIView
 					case TEXT_AUTOCAPITALIZATION_ALL:
 						autoCapValue = InputType.TYPE_TEXT_FLAG_CAP_CHARACTERS | InputType.TYPE_TEXT_FLAG_CAP_SENTENCES
 							| InputType.TYPE_TEXT_FLAG_CAP_WORDS;
+						autoCapAll = true;    // autoCapAll flag ON only when TEXT_AUTOCAPITALIZATION_ALL observed
 						break;
 					case TEXT_AUTOCAPITALIZATION_SENTENCES:
 						autoCapValue = InputType.TYPE_TEXT_FLAG_CAP_SENTENCES;

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIText.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIText.java
@@ -81,8 +81,6 @@ public class TiUIText extends TiUIView
 	private boolean disableChangeEvent = false;
 
 	protected EditText tv;
-	
-	private boolean autoCapAll;
 
 	public TiUIText(final TiViewProxy proxy, boolean field)
 	{
@@ -378,18 +376,6 @@ public class TiUIText extends TiUIView
 			proxy.setProperty(TiC.PROPERTY_VALUE, newText);
 			fireEvent(TiC.EVENT_CHANGE, data);
 		}
-		
-		// capitalize if necessary
-		if (autoCapAll && !TextUtils.isEmpty(newText)) {
-
-			if (!TextUtils.equals(newText, newText.toUpperCase())) {
-				int cursorPosition = tv.getSelectionEnd();
-				newText = newText.toUpperCase();
-				tv.setText(newText);
-				tv.setSelection(cursorPosition);
-			}
-
-		}
 	}
 
 	@Override
@@ -526,15 +512,13 @@ public class TiUIText extends TiUIView
 
 		} else {
 			if (d.containsKey(TiC.PROPERTY_AUTOCAPITALIZATION)) {
-				autoCapAll = false;
 				switch (TiConvert.toInt(d.get(TiC.PROPERTY_AUTOCAPITALIZATION), TEXT_AUTOCAPITALIZATION_NONE)) {
 					case TEXT_AUTOCAPITALIZATION_NONE:
 						autoCapValue = 0;
 						break;
 					case TEXT_AUTOCAPITALIZATION_ALL:
-						autoCapValue = InputType.TYPE_TEXT_FLAG_CAP_CHARACTERS | InputType.TYPE_TEXT_FLAG_CAP_SENTENCES
-							| InputType.TYPE_TEXT_FLAG_CAP_WORDS;
-						autoCapAll = true;    // autoCapAll flag ON only when TEXT_AUTOCAPITALIZATION_ALL observed
+						autoCapValue = InputType.TYPE_TEXT_FLAG_CAP_CHARACTERS;
+						tv.setFilters(new InputFilter[] {new InputFilter.AllCaps()});
 						break;
 					case TEXT_AUTOCAPITALIZATION_SENTENCES:
 						autoCapValue = InputType.TYPE_TEXT_FLAG_CAP_SENTENCES;
@@ -546,6 +530,9 @@ public class TiUIText extends TiUIView
 					default:
 						Log.w(TAG, "Unknown AutoCapitalization Value [" + d.getString(TiC.PROPERTY_AUTOCAPITALIZATION) + "]");
 						break;
+				}
+				if ((autoCapValue & InputType.TYPE_TEXT_FLAG_CAP_CHARACTERS) != InputType.TYPE_TEXT_FLAG_CAP_CHARACTERS) {
+					tv.setFilters(new InputFilter[] {});
 				}
 			}
 


### PR DESCRIPTION
Titanium.UI.TEXT_AUTOCAPITALIZATION_ALL is not working. It doesn't work in native Android as well if user choose shift to enter small letter. Listen to the TextChange to fix the bug

**JIRA:** https://jira.appcelerator.org/browse/TIMOB-24250