### PR TITLE
[TIMOB-24277] Android: Fix horizontal layout when using 'right'

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiCompositeLayout.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiCompositeLayout.java
@@ -716,9 +716,14 @@ public class TiCompositeLayout extends ViewGroup
             // the width of the screen
             right = Math.min(right, layoutRight);
         }
-
-        hpos[0] = left;
-        hpos[1] = right;
+        
+        if (optionRight != null) {
+            hpos[0] = layoutRight - left;
+            hpos[1] = layoutRight - horiztonalLayoutPreviousRight;
+        } else {
+            hpos[0] = left;
+            hpos[1] = right;
+        }
         horizontalLayoutCurrentLeft = right;
 
         if (enableHorizontalWrap) {


### PR DESCRIPTION
- Correctly calculate components using `right` when used in a horizontal layout

###### TEST CASE
```Javascript
var win = Ti.UI.createWindow(),
	items = [],
	template = {
		properties: {
			accessoryType: Ti.UI.LIST_ACCESSORY_TYPE_NONE,
			backgroundColor: 'white',
			height: Ti.UI.SIZE,
			layout: 'horizontal'
		},
		events: {
			click: function(e) {
				alert(e.source.customProperty);
			}
		},
		childTemplates:
		[
			{
				type: 'Ti.UI.Button',
				bindId: 'bindButton',
				properties: {
					left: 10,
					width: 100,
					height: 40,
					borderRadius: 20,
					borderWidth: 1,
					borderColor: '#dedede',
					backgroundColor: 'green'
				},
			},
			{
				type : 'Ti.UI.Button',
				bindId : 'bindButton2',
				properties : {
					right: 10,
					width: 100,
					height: 40,
					borderRadius: 20,
					borderWidth: 1,
					borderColor: '#dedede',
					backgroundColor: 'red'
				}
			}
		]
	},
	listView = Ti.UI.createListView({templates: {'template': template}}),
	section = Ti.UI.createListSection();

for(var i = 1; i <= 10; i++){
	items.push({
		template: 'template',
		bindButton: {
		   title: 'button a ' + i,
		   customProperty: i
		},
		bindButton2: {
		   title: 'button b ' + i,
		   customProperty: i
		},
		properties: {
		   itemId: i
		}
	});
}

section.setItems(items);
listView.sections = [section];

win.add(listView);
win.open();
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-24277)