### PR TITLE
[TIMOB-24273] iOS: Overwriting existing event listeners only calls the last one (Regression from 6.0.1)

### DIFF
--- a/iphone/Classes/KrollObject.m
+++ b/iphone/Classes/KrollObject.m
@@ -1369,7 +1369,7 @@ TI_INLINE TiStringRef TiStringCreateWithPointerValue(int value)
 
 	// Default to NULL array object, if value doesn't exist or isn't an object
 	TiObjectRef jsCallbackArray = NULL;
-	if (TiValueGetType(jsContext, jsCallbackArray) == kTITypeObject)
+	if (TiValueGetType(jsContext, jsCallbackArrayValue) == kTITypeObject)
 	{
 		jsCallbackArray = TiValueToObject(jsContext, jsCallbackArrayValue, &exception);
 	}


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-24273

**Optional Description:**
Dumb typo referred to an always null variable rather than the correct one, resulting in us always creating a new array to hold listeners for events of any given type (resulting in the last listener being it's only member).