### PR TITLE
[TIMOB-24250] Fix Ti.UI.TextView.TEXT_AUTOCAPITALIZATION_ALL

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIText.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIText.java
@@ -26,6 +26,7 @@ import android.graphics.Typeface;
 import android.os.Build;
 import android.os.Bundle;
 import android.text.Editable;
+import android.text.InputFilter;
 import android.text.InputType;
 import android.text.Spannable;
 import android.text.TextUtils.TruncateAt;
@@ -521,8 +522,8 @@ public class TiUIText extends TiUIView
 						autoCapValue = 0;
 						break;
 					case TEXT_AUTOCAPITALIZATION_ALL:
-						autoCapValue = InputType.TYPE_TEXT_FLAG_CAP_CHARACTERS | InputType.TYPE_TEXT_FLAG_CAP_SENTENCES
-							| InputType.TYPE_TEXT_FLAG_CAP_WORDS;
+						autoCapValue = InputType.TYPE_TEXT_FLAG_CAP_CHARACTERS;
+						tv.setFilters(new InputFilter[] {new InputFilter.AllCaps()});
 						break;
 					case TEXT_AUTOCAPITALIZATION_SENTENCES:
 						autoCapValue = InputType.TYPE_TEXT_FLAG_CAP_SENTENCES;
@@ -534,6 +535,9 @@ public class TiUIText extends TiUIView
 					default:
 						Log.w(TAG, "Unknown AutoCapitalization Value [" + d.getString(TiC.PROPERTY_AUTOCAPITALIZATION) + "]");
 						break;
+				}
+				if ((autoCapValue & InputType.TYPE_TEXT_FLAG_CAP_CHARACTERS) != InputType.TYPE_TEXT_FLAG_CAP_CHARACTERS) {
+					tv.setFilters(new InputFilter[] {});
 				}
 			}
 


### PR DESCRIPTION
- Fix `Titanium.UI.TextView.TEXT_AUTOCAPITALIZATION_ALL`

###### TEST CASE
```Java
var win = Ti.UI.createWindow({
	backgroundColor : 'white'
});
 
var textField = Ti.UI.createTextField({
	borderStyle : Ti.UI.INPUT_BORDERSTYLE_ROUNDED,
	color : '#336699',
	top : 10,
	left : 10,
	width : 250,
	height : 60,
	autocapitalization: Ti.UI.TEXT_AUTOCAPITALIZATION_ALL
});
 
win.add(textField); 
win.open();
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-24250)
