### PR TITLE
[TIMOB-24233] Android: stacked background drawable parity

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIActionBarTabGroup.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIActionBarTabGroup.java
@@ -337,6 +337,7 @@ public class TiUIActionBarTabGroup extends TiUIAbstractTabGroup implements TabLi
 		}
 		ColorDrawable drawable = (tabProxy.getProperty(TiC.PROPERTY_BACKGROUND_COLOR) != null) ? TiConvert.toColorDrawable((String) tabProxy.getProperty(TiC.PROPERTY_BACKGROUND_COLOR)) : TiConvert.toColorDrawable((String) tabProxy.getTabGroup().getProperty(TiC.PROPERTY_TABS_BACKGROUND_COLOR));
 		actionBar.setStackedBackgroundDrawable(drawable);
+		actionBar.setBackgroundDrawable(drawable);
 	}
 
 	@Override

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIActionBarTabGroup.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIActionBarTabGroup.java
@@ -10,6 +10,7 @@ import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.concurrent.atomic.AtomicLong;
 
+import android.graphics.drawable.ColorDrawable;
 import org.appcelerator.kroll.KrollDict;
 import org.appcelerator.kroll.KrollProxy;
 import org.appcelerator.kroll.common.Log;
@@ -334,6 +335,8 @@ public class TiUIActionBarTabGroup extends TiUIAbstractTabGroup implements TabLi
 			pendingDisableTabs = true;
 			checkAndDisableTabsIfRequired();
 		}
+		ColorDrawable drawable = (tabProxy.getProperty(TiC.PROPERTY_BACKGROUND_COLOR) != null) ? TiConvert.toColorDrawable((String) tabProxy.getProperty(TiC.PROPERTY_BACKGROUND_COLOR)) : TiConvert.toColorDrawable((String) tabProxy.getTabGroup().getProperty(TiC.PROPERTY_TABS_BACKGROUND_COLOR));
+		actionBar.setStackedBackgroundDrawable(drawable);
 	}
 
 	@Override


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-24233

**Test Case**
Should see same thing on iOS

```
var win1 = Ti.UI.createWindow({
	backgroundColor: 'blue',
	title: 'Blue'
});
win1.add(Ti.UI.createLabel({text: 'I am a blue window.'}));

var win2 = Ti.UI.createWindow({
	backgroundColor: 'red',
	title: 'Red'
});
win2.add(Ti.UI.createLabel({text: 'I am a red window.'}));

var tab1 = Ti.UI.createTab({
			window: win1,
			title: 'Blue'
		}),
		tab2 = Ti.UI.createTab({
			window: win2,
			title: 'Red'
		});

var group = Ti.UI.createTabGroup({
	tabs: [tab1, tab2],
	tabsBackgroundColor: 'green'
});

group.open();
```
