### PR TITLE
[TIMOB-17954] Android: fix scroll view #scrollTo parity

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIScrollView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIScrollView.java
@@ -617,14 +617,9 @@ public class TiUIScrollView extends TiUIView
 
 	public void scrollTo(int x, int y)
 	{
-		getNativeView().scrollTo(convertDpToPixel(x), convertDpToPixel(y));
-		getNativeView().computeScroll();
-		getNativeView().computeScroll();
-	}
-
-	private int convertDpToPixel(final float dp)
-	{
-		return Math.round(dp * getNativeView().getContext().getResources().getDisplayMetrics().density);
+		final View view = getNativeView();
+		view.scrollTo(TiConvert.toTiDimension(x, -1).getAsPixels(view), TiConvert.toTiDimension(y, -1).getAsPixels(view));
+		view.computeScroll();
 	}
 
 	public void scrollToBottom()

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIScrollView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIScrollView.java
@@ -617,8 +617,14 @@ public class TiUIScrollView extends TiUIView
 
 	public void scrollTo(int x, int y)
 	{
-		getNativeView().scrollTo(x, y);
+		getNativeView().scrollTo(convertDpToPixel(x), convertDpToPixel(y));
 		getNativeView().computeScroll();
+		getNativeView().computeScroll();
+	}
+
+	private int convertDpToPixel(final float dp)
+	{
+		return Math.round(dp * getNativeView().getContext().getResources().getDisplayMetrics().density);
 	}
 
 	public void scrollToBottom()


### PR DESCRIPTION
**Changes**
+ made unit of x, y coordinates more reliable.

App code in ticket is adequate: https://jira.appcelerator.org/browse/TIMOB-17954