### PR TITLE
[TIMOB-15253] Android: Allow intent-filter to run as new task

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIAbstractTab.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIAbstractTab.java
@@ -38,7 +38,7 @@ public abstract class TiUIAbstractTab extends TiUIView {
 	 */
 	public View getContentView() {
 		TiWindowProxy windowProxy = getWindowProxy();
-		if (windowProxy == null) {
+		if (windowProxy == null || proxy == null) {
 			// If no window is provided use an empty view.
 			View emptyContent = new View(TiApplication.getInstance().getApplicationContext());
 			emptyContent.setBackgroundColor(Color.BLACK);

--- a/android/titanium/src/java/org/appcelerator/titanium/TiApplication.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiApplication.java
@@ -652,6 +652,11 @@ public abstract class TiApplication extends Application implements KrollApplicat
 		return getAppProperties().getBool("run-on-main-thread", DEFAULT_RUN_ON_MAIN_THREAD);
 	}
 
+	public boolean intentFilterNewTask()
+	{
+		return getAppProperties().getBool("intent-filter-new-task", false);
+	}
+
 	public void setFilterAnalyticsEvents(String[] events)
 	{
 		filteredAnalyticsEvents = events;

--- a/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
@@ -863,13 +863,17 @@ public abstract class TiBaseActivity extends AppCompatActivity
 			if (windowStack.size() <= 1) {
 				if (topWindow != null) {
 					if (TiConvert.toBoolean(topWindow.getProperty(TiC.PROPERTY_EXIT_ON_CLOSE), true)) {
-						Log.d(TAG, "onBackPressed: exit", Log.DEBUG_MODE);
-						TiApplication.terminateActivityStack();
+						Log.d(TAG, "onBackPressed: exit");
+						if (Build.VERSION.SDK_INT >= 16) {
+							finishAffinity();
+						} else {
+							TiApplication.terminateActivityStack();
+						}
 					} else {
-						Log.d(TAG, "onBackPressed: suspend to background", Log.DEBUG_MODE);
+						Log.d(TAG, "onBackPressed: suspend to background");
 						this.moveTaskToBack(true);
-						return;
 					}
+					return;
 				}
  			}
 

--- a/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
@@ -857,13 +857,19 @@ public abstract class TiBaseActivity extends AppCompatActivity
 			onBackCallback.callAsync(activityProxy.getKrollObject(), new Object[] {});
 		}
 		if (topWindow == null || (topWindow != null && !topWindow.hasProperty(TiC.PROPERTY_ON_BACK) && !topWindow.hasListeners(TiC.EVENT_ANDROID_BACK))) {
-			// there are no parent activities to return to
-			// override back press to background the activity
-			// note: 2 since there should always be TiLaunchActivity and TiActivity
-			if (TiApplication.activityStack.size() <= 2) {
-				if (topWindow != null && !TiConvert.toBoolean(topWindow.getProperty(TiC.PROPERTY_EXIT_ON_CLOSE), true)) {
-					this.moveTaskToBack(true);
-					return;
+			// no windows to return to
+			// check Ti.UI.Window.exitOnClose and either
+			// exit the application or send to background
+			if (windowStack.size() <= 1) {
+				if (topWindow != null) {
+					if (TiConvert.toBoolean(topWindow.getProperty(TiC.PROPERTY_EXIT_ON_CLOSE), true)) {
+						Log.d(TAG, "onBackPressed: exit", Log.DEBUG_MODE);
+						TiApplication.terminateActivityStack();
+					} else {
+						Log.d(TAG, "onBackPressed: suspend to background", Log.DEBUG_MODE);
+						this.moveTaskToBack(true);
+						return;
+					}
 				}
  			}
 

--- a/android/titanium/src/java/org/appcelerator/titanium/TiRootActivity.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiRootActivity.java
@@ -81,7 +81,7 @@ public class TiRootActivity extends TiLaunchActivity
 				rootActivity.setIntent(intent);
 			}
 			if (tiApp.intentFilterNewTask() &&
-				intent.getAction().equals(Intent.ACTION_VIEW) &&
+				intent.getAction() != null && intent.getAction().equals(Intent.ACTION_VIEW) &&
 				intent.getDataString() != null &&
 				(intent.getFlags() & Intent.FLAG_ACTIVITY_NEW_TASK) != Intent.FLAG_ACTIVITY_NEW_TASK) {
 

--- a/android/titanium/src/java/org/appcelerator/titanium/TiRootActivity.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiRootActivity.java
@@ -76,8 +76,25 @@ public class TiRootActivity extends TiLaunchActivity
 		Intent intent = getIntent();
 		TiRootActivity rootActivity = tiApp.getRootActivity();
 
-		if (intent != null && rootActivity != null) {
-			rootActivity.setIntent(intent);
+		if (intent != null) {
+			if (rootActivity != null) {
+				rootActivity.setIntent(intent);
+			}
+			if (tiApp.intentFilterNewTask() &&
+				intent.getAction().equals(Intent.ACTION_VIEW) &&
+				intent.getDataString() != null &&
+				(intent.getFlags() & Intent.FLAG_ACTIVITY_NEW_TASK) != Intent.FLAG_ACTIVITY_NEW_TASK) {
+
+				if (rootActivity == null) {
+					intent.setAction(Intent.ACTION_MAIN);
+				}
+				intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+				startActivity(intent);
+				finish();
+				
+				super.onCreate(savedInstanceState);
+				return;
+			}
 		}
 
 		if (willFinishFalseRootActivity(savedInstanceState)) {


### PR DESCRIPTION
**Requires https://github.com/appcelerator/titanium_mobile/pull/8733**

- Allow `tiapp.xml` property `intent-filter-new-task` to allow intent-filters to run as a new task similar to `singleTask`

###### TEST CASE
##### tiapp.xml
```XML
<property name="intent-filter-new-task" type="bool">true</property>
```
```XML
<android ...>
    ...
   <manifest ...>
       ...
        <intent-filter>
            <action android:name="android.intent.action.VIEW" />
            <category android:name="android.intent.category.DEFAULT" />
            <category android:name="android.intent.category.BROWSABLE" />
            <data android:scheme="http" />
            <data android:scheme="https" />
            <data android:host="www.android.com" />
        </intent-filter>
        ...
    </manifest>
</android>
````

- Open a link to `www.android.com` from an external application, this should launch the Titanium application as a new app or an existing instance (if already in background)

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-15253)