### PR TITLE
[CLI-1124] Android: Hide non Ti Log

### DIFF
--- a/android/cli/hooks/run.js
+++ b/android/cli/hooks/run.js
@@ -236,7 +236,7 @@ exports.init = function (logger, config, cli) {
 						lastLogLevel,
 						displayStartLog = true,
 						tiapiRegExp = /^(\w\/TiAPI\s*\:)/,
-						nonTiLogRegexp = /^\w\/\w+\s*\(\s*\d+\):/,
+						nonTiLogRegexp = /^\w\/.+\s*\(\s*\d+\):/,
 						instances = deviceInfo.length,
 						endLog = false;
 


### PR DESCRIPTION
**JIRA**: https://jira.appcelerator.org/browse/CLI-1124

Change regex so it will match string that contains not only characters (e.g. dots)