### PR TITLE
[TIMOB-24308] Android: Child-view's percent width incorrect of horizo…

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiCompositeLayout.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiCompositeLayout.java
@@ -285,14 +285,13 @@ public class TiCompositeLayout extends ViewGroup
         int wSuggested = getSuggestedMinimumWidth();
         int hSuggested = getSuggestedMinimumHeight();
         int w = Math.max(wFromSpec, wSuggested);
+        int wRemain = w;
         int wMode = MeasureSpec.getMode(widthMeasureSpec);
         int h = Math.max(hFromSpec, hSuggested);
         int hMode = MeasureSpec.getMode(heightMeasureSpec);
 
         int maxWidth = 0;
         int maxHeight = 0;
-        
-        int rowRemainWidth = w;
 
         // Used for horizontal layout only
         int horizontalRowWidth = 0;
@@ -301,7 +300,7 @@ public class TiCompositeLayout extends ViewGroup
         for (int i = 0; i < childCount; i++) {
             View child = getChildAt(i);
             if (child.getVisibility() != View.GONE) {
-                constrainChild(child, w, wMode, h, hMode, rowRemainWidth);
+                constrainChild(child, w, wMode, h, hMode, wRemain);
             }
 
             int childWidth = child.getMeasuredWidth();
@@ -318,11 +317,11 @@ public class TiCompositeLayout extends ViewGroup
                         horizontalRowWidth = childWidth;
                         maxHeight += horizontalRowHeight;
                         horizontalRowHeight = childHeight;
-                        rowRemainWidth = w;
+                        wRemain = w;
                     } else {
                         horizontalRowWidth += childWidth;
                         maxWidth = Math.max(maxWidth, horizontalRowWidth);
-                        rowRemainWidth -= childWidth;
+                        wRemain -= childWidth;
                     }
 
                 } else {
@@ -366,7 +365,7 @@ public class TiCompositeLayout extends ViewGroup
         setMeasuredDimension(measuredWidth, measuredHeight);
     }
 
-    protected void constrainChild(View child, int width, int wMode, int height, int hMode, int rowRemainWidth)
+    protected void constrainChild(View child, int width, int wMode, int height, int hMode, int remainWidth)
     {
         boolean hasFixedHeightParent = false;
         boolean hasFixedWidthParent = false;
@@ -404,15 +403,15 @@ public class TiCompositeLayout extends ViewGroup
         int widthSpec;
         
         if (p.autoFillsWidth) {
-            widthPadding = getViewWidthPadding(child, rowRemainWidth);
-            widthSpec = ViewGroup.getChildMeasureSpec(MeasureSpec.makeMeasureSpec(rowRemainWidth, wMode),
-                                                      widthPadding,
-                                                      childDimension);
+            widthPadding = getViewWidthPadding(child, remainWidth);
+            widthSpec = ViewGroup.getChildMeasureSpec(MeasureSpec.makeMeasureSpec(remainWidth, wMode),
+                widthPadding,
+                childDimension);
         } else {
             widthPadding = getViewWidthPadding(child, width);
             widthSpec = ViewGroup.getChildMeasureSpec(MeasureSpec.makeMeasureSpec(width, wMode),
-                                                      widthPadding,
-                                                      childDimension);
+                widthPadding,
+                childDimension);
         }
         // If autoFillsHeight is false, and optionHeight is null, then we use
         // size behavior.

--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiCompositeLayout.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiCompositeLayout.java
@@ -291,6 +291,8 @@ public class TiCompositeLayout extends ViewGroup
 
         int maxWidth = 0;
         int maxHeight = 0;
+        
+        int rowRemainWidth = w;
 
         // Used for horizontal layout only
         int horizontalRowWidth = 0;
@@ -299,7 +301,7 @@ public class TiCompositeLayout extends ViewGroup
         for (int i = 0; i < childCount; i++) {
             View child = getChildAt(i);
             if (child.getVisibility() != View.GONE) {
-                constrainChild(child, w, wMode, h, hMode);
+                constrainChild(child, w, wMode, h, hMode, rowRemainWidth);
             }
 
             int childWidth = child.getMeasuredWidth();
@@ -314,11 +316,13 @@ public class TiCompositeLayout extends ViewGroup
 
                     if ((horizontalRowWidth + childWidth) > w) {
                         horizontalRowWidth = childWidth;
+                        maxHeight += horizontalRowHeight;
                         horizontalRowHeight = childHeight;
+                        rowRemainWidth = w;
                     } else {
                         horizontalRowWidth += childWidth;
                         maxWidth = Math.max(maxWidth, horizontalRowWidth);
-                        w -= horizontalRowWidth;
+                        rowRemainWidth -= childWidth;
                     }
 
                 } else {
@@ -362,7 +366,7 @@ public class TiCompositeLayout extends ViewGroup
         setMeasuredDimension(measuredWidth, measuredHeight);
     }
 
-    protected void constrainChild(View child, int width, int wMode, int height, int hMode)
+    protected void constrainChild(View child, int width, int wMode, int height, int hMode, int rowRemainWidth)
     {
         boolean hasFixedHeightParent = false;
         boolean hasFixedWidthParent = false;
@@ -396,10 +400,20 @@ public class TiCompositeLayout extends ViewGroup
             }
         }
 
-        int widthPadding = getViewWidthPadding(child, width);
-        int widthSpec = ViewGroup.getChildMeasureSpec(MeasureSpec.makeMeasureSpec(width, wMode),
-                widthPadding,
-                childDimension);
+        int widthPadding;
+        int widthSpec;
+        
+        if (p.autoFillsWidth) {
+            widthPadding = getViewWidthPadding(child, rowRemainWidth);
+            widthSpec = ViewGroup.getChildMeasureSpec(MeasureSpec.makeMeasureSpec(rowRemainWidth, wMode),
+                                                      widthPadding,
+                                                      childDimension);
+        } else {
+            widthPadding = getViewWidthPadding(child, width);
+            widthSpec = ViewGroup.getChildMeasureSpec(MeasureSpec.makeMeasureSpec(width, wMode),
+                                                      widthPadding,
+                                                      childDimension);
+        }
         // If autoFillsHeight is false, and optionHeight is null, then we use
         // size behavior.
         childDimension = LayoutParams.WRAP_CONTENT;


### PR DESCRIPTION
JIRA: https://jira.appcelerator.org/browse/TIMOB-24308

Android : child view's percent width incorrect of horizontal layout parent view

Optional Description:

This error occurred at Ti.SDK 6.1.0.v20170103224205, 6.1.0.v20170111010012, 6.1.0.v20170112013001, etc.
But, not occurred at Ti.SDK 6.1.0.v20161222061413
Of course, there is no problem with the GA version.

This code has problem.
#8720
( https://jira.appcelerator.org/browse/TIMOB-24243 )

[Incorrect]
<img width="663" alt="2017-01-20 6 43 24" src="https://cloud.githubusercontent.com/assets/7310854/22144258/6d6bfc36-df40-11e6-8580-c0f773991d40.png">

[Correct]
<img width="663" alt="2017-01-20 6 41 26" src="https://cloud.githubusercontent.com/assets/7310854/22144262/71867f58-df40-11e6-8e1a-0ce49c4c4753.png">

[Test Code]
```
var win = Ti.UI.createWindow({
  backgroundColor: '#fff',
  layout: "vertical"
});

// first row
var view = Ti.UI.createView({
  height: Ti.UI.SIZE,
  width: Ti.UI.FILL,
  layout: "horizontal",
  backgroundColor: "gray"
});

var view1 = Ti.UI.createView({
  width: "25%",
  height: 100,
  backgroundColor: "red"
});

var view2 = Ti.UI.createView({
  width: "25%",
  height: 100,
  backgroundColor: "green"
});

var view3 = Ti.UI.createView({
  width: "25%",
  height: 100,
  backgroundColor: "blue"
});

var view4 = Ti.UI.createView({
  width: "25%",
  height: 100,
  backgroundColor: "yellow"
});

view.add(view1);
view.add(view2);
view.add(view3);
view.add(view4);

// second row
var v = Ti.UI.createView({
  backgroundColor: 'red',
  width: Ti.UI.FILL,
  height: Ti.UI.SIZE,
  layout: 'horizontal'
});
var n = Ti.UI.createLabel({
  top: 0,
  text: '1.',
  backgroundColor: 'purple'
});
var t = Ti.UI.createLabel({
  text: 'Replenish the Uranium rod with dry ice every 6 hours.',
  width:  Ti.UI.FILL,
  backgroundColor: 'orange'
});

v.add([n, t]);

// third row
var third = Ti.UI.createView({
  backgroundColor: 'grey',
  left: 20, right: 20,
  width: Ti.UI.FILL,
  height: Ti.UI.SIZE,
  layout: 'horizontal'
});

function createItem(_text) {
  var wrap = Ti.UI.createView({
    backgroundColor:"#ffffff",
    width:Ti.UI.SIZE, height:31,
    left:3, right:3, top:4, bottom: 4,
    borderColor: "#ff5757", borderRadius: 15.5, borderWidth: 1
  });

  var labelWrap = Ti.UI.createView({
    width:Ti.UI.SIZE, height: Ti.UI.SIZE,
    left: 14, right: 14
  });

  var label = Ti.UI.createLabel({
    height : 18,
    width: Ti.UI.SIZE,
    wordWrap:false,
    color:"#ff5757", font: { fontSize: 14, fontWeight: 'regular' },
    textAlign: Ti.UI.TEXT_ALIGNMENT_CENTER, verticalAlign: Ti.UI.TEXT_VERTICAL_ALIGNMENT_CENTER,
    text: _text
  });

  labelWrap.add(label);
  wrap.add(labelWrap);

  return wrap;
}

third.add( createItem('#한자급수') );
third.add( createItem('#자유학기제') );
third.add( createItem('#기반학습') );
third.add( createItem('#많은수업시간') );
third.add( createItem('#레벨시스템') );
third.add( createItem('#담임제도') );

// add to win
win.add(view);
win.add(v);
win.add(third);

win.open();

```