### PR TITLE
[6_0_X][TIMOB-20459] Android: Validate activityProxy before fireSyncEvent

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/TiActivity.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiActivity.java
@@ -9,6 +9,7 @@ package org.appcelerator.titanium;
 import android.content.Intent;
 import android.os.Bundle;
 import org.appcelerator.kroll.KrollDict;
+import org.appcelerator.titanium.proxy.ActivityProxy;
 import org.appcelerator.titanium.proxy.IntentProxy;
 
 public class TiActivity extends TiBaseActivity
@@ -49,10 +50,13 @@ public class TiActivity extends TiBaseActivity
 					setIntent(newIntent);
 
 					// fire 'newintent'
-					IntentProxy intentProxy = new IntentProxy(newIntent);
-					KrollDict data = new KrollDict();
-					data.put(TiC.PROPERTY_INTENT, intentProxy);
-					rootActivity.getActivityProxy().fireSyncEvent(TiC.EVENT_NEW_INTENT, data);
+					ActivityProxy activityProxy = rootActivity.getActivityProxy();
+					if (activityProxy != null) {
+						IntentProxy intentProxy = new IntentProxy(newIntent);
+						KrollDict data = new KrollDict();
+						data.put(TiC.PROPERTY_INTENT, intentProxy);
+						activityProxy.fireSyncEvent(TiC.EVENT_NEW_INTENT, data);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
- Cherry-pick of https://github.com/appcelerator/titanium_mobile/pull/8790

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-20459)