### PR TITLE
[TIMOB-15275] iOS: Use ARC in new native iOS modules

### DIFF
--- a/iphone/Classes/TiThreading.h
+++ b/iphone/Classes/TiThreading.h
@@ -10,10 +10,12 @@
 #define ENSURE_UI_THREAD_1_ARG(x)	\
 if (![NSThread isMainThread]) { \
 	SEL callback = _cmd;\
-	TiThreadPerformOnMainThread(^{[self performSelector:callback withObject:x];}, NO);\
+	_Pragma("clang diagnostic push") \
+	_Pragma("clang diagnostic ignored \"-Warc-performSelector-leaks\"") \
+	TiThreadPerformOnMainThread(^{[self performSelector:callback withObject:x];}, NO); \
+	_Pragma("clang diagnostic pop") \
 	return; \
 } \
-
 
 #define ENSURE_UI_THREAD_0_ARGS		ENSURE_UI_THREAD_1_ARG(nil)
 
@@ -25,7 +27,7 @@ if (![NSThread isMainThread]) { \
 #define ENSURE_UI_THREAD(x,y) \
 if (![NSThread isMainThread]) { \
 	TiThreadPerformOnMainThread(^{[self x:y];},NO); \
-return; \
+	return; \
 } \
 
 #define ENSURE_IOS_API(version, message) \

--- a/iphone/Classes/TiThreading.h
+++ b/iphone/Classes/TiThreading.h
@@ -1,6 +1,6 @@
 /**
  * Appcelerator Titanium Mobile
- * Copyright (c) 2009-2010 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2009-2017 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */

--- a/iphone/Classes/TiThreading.h
+++ b/iphone/Classes/TiThreading.h
@@ -8,12 +8,9 @@
 #import <Foundation/Foundation.h>
 
 #define ENSURE_UI_THREAD_1_ARG(x)	\
-if (![NSThread isMainThread]) { \
+	if (![NSThread isMainThread]) { \
 	SEL callback = _cmd;\
-	_Pragma("clang diagnostic push") \
-	_Pragma("clang diagnostic ignored \"-Warc-performSelector-leaks\"") \
-	TiThreadPerformOnMainThread(^{[self performSelector:callback withObject:x];}, NO); \
-	_Pragma("clang diagnostic pop") \
+	TiThreadPerformOnMainThread(^{[self performSelector:callback withObject:x];}, NO);\
 	return; \
 } \
 

--- a/iphone/Classes/TiThreading.h
+++ b/iphone/Classes/TiThreading.h
@@ -8,7 +8,7 @@
 #import <Foundation/Foundation.h>
 
 #define ENSURE_UI_THREAD_1_ARG(x)	\
-	if (![NSThread isMainThread]) { \
+if (![NSThread isMainThread]) { \
 	SEL callback = _cmd;\
 	TiThreadPerformOnMainThread(^{[self performSelector:callback withObject:x];}, NO);\
 	return; \

--- a/iphone/iphone/Titanium.xcodeproj/project.pbxproj
+++ b/iphone/iphone/Titanium.xcodeproj/project.pbxproj
@@ -2989,6 +2989,7 @@
 				OTHER_CFLAGS = "-DDEBUG";
 				PRODUCT_NAME = Titanium;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				WARNING_CFLAGS = "-Wno-arc-performSelector-leaks";
 			};
 			name = Debug;
 		};
@@ -3020,6 +3021,7 @@
 				);
 				PRODUCT_NAME = Titanium;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				WARNING_CFLAGS = "-Wno-arc-performSelector-leaks";
 			};
 			name = Release;
 		};

--- a/iphone/templates/module/default/template/iphone/Classes/{{ModuleIdAsIdentifier}}Module.m.ejs
+++ b/iphone/templates/module/default/template/iphone/Classes/{{ModuleIdAsIdentifier}}Module.m.ejs
@@ -34,7 +34,7 @@
 	// you *must* call the superclass
 	[super startup];
 
-	NSLog(@"[INFO] %@ loaded",self);
+	NSLog(@"[DEBUG] %@ loaded",self);
 }
 
 -(void)shutdown:(id)sender
@@ -45,14 +45,6 @@
 
 	// you *must* call the superclass
 	[super shutdown:sender];
-}
-
-#pragma mark Cleanup
-
--(void)dealloc
-{
-	// release any resources that have been retained by the module
-	[super dealloc];
 }
 
 #pragma mark Internal Memory Management

--- a/iphone/templates/module/default/template/iphone/build.py.ejs
+++ b/iphone/templates/module/default/template/iphone/build.py.ejs
@@ -262,7 +262,7 @@ if __name__ == '__main__':
 	print "**************************************************************"
 	print "  WARNING!"
 	print "    This Python script is deprecated!"
-	print "    Please use 'appc ti build -p ios --build-only' instead"
+	print "    Please use 'appc run -p ios --build-only' instead"
 	print "**************************************************************"
 	print ""
 

--- a/iphone/templates/module/default/template/iphone/build.py.ejs
+++ b/iphone/templates/module/default/template/iphone/build.py.ejs
@@ -262,7 +262,7 @@ if __name__ == '__main__':
 	print "**************************************************************"
 	print "  WARNING!"
 	print "    This Python script is deprecated!"
-	print "    Please use 'ti build -p ios --build-only' instead"
+	print "    Please use 'appc ti build -p ios --build-only' instead"
 	print "**************************************************************"
 	print ""
 

--- a/iphone/templates/module/default/template/iphone/platform/README.md
+++ b/iphone/templates/module/default/template/iphone/platform/README.md
@@ -3,7 +3,7 @@ when the iOS app is compiled:
 
     <project-dir>/build/iphone
 
-You can place files such as asset catalog files and storyboards in this
+You can place files such as asset catalog files, .framework files and storyboards in this
 directory.
 
 Files in this directory are copied directly on top of whatever files are already

--- a/iphone/templates/module/default/template/iphone/{{ModuleName}}.xcodeproj/project.pbxproj.ejs
+++ b/iphone/templates/module/default/template/iphone/{{ModuleName}}.xcodeproj/project.pbxproj.ejs
@@ -149,10 +149,10 @@
 		0867D690FE84028FC02AAC07 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0600;
+				LastUpgradeCheck = 0800;
 			};
 			buildConfigurationList = 1DEB922208733DC00010E9CD /* Build configuration list for PBXProject "<%- moduleName %>" */;
-			compatibilityVersion = "Xcode 3.2";
+			compatibilityVersion = "Xcode 7.0";
 			developmentRegion = English;
 			hasScannedForEncodings = 1;
 			knownRegions = (
@@ -213,6 +213,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 24DD6D1B1134B66800162E58 /* titanium.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_OBJC_ARC = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DSTROOT = "/tmp/<%- moduleIdAsIdentifier %>.dst";
@@ -232,7 +233,7 @@
 				GCC_WARN_UNUSED_VALUE = NO;
 				GCC_WARN_UNUSED_VARIABLE = NO;
 				INSTALL_PATH = /usr/local/lib;
-				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LIBRARY_SEARCH_PATHS = "";
 				OTHER_CFLAGS = (
 					"-DDEBUG",
@@ -253,6 +254,7 @@
 			baseConfigurationReference = 24DD6D1B1134B66800162E58 /* titanium.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ENABLE_OBJC_ARC = YES;
 				DSTROOT = "/tmp/<%- moduleIdAsIdentifier %>.dst";
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_MODEL_TUNING = G5;
@@ -270,7 +272,7 @@
 				GCC_WARN_UNUSED_VALUE = NO;
 				GCC_WARN_UNUSED_VARIABLE = NO;
 				INSTALL_PATH = /usr/local/lib;
-				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LIBRARY_SEARCH_PATHS = "";
 				OTHER_CFLAGS = "-DTI_POST_1_2";
 				OTHER_LDFLAGS = "-ObjC";
@@ -343,7 +345,7 @@
 				GCC_WARN_UNUSED_VALUE = NO;
 				GCC_WARN_UNUSED_VARIABLE = NO;
 				INSTALL_PATH = /usr/local/lib;
-				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				OTHER_CFLAGS = "-DTI_POST_1_2";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "<%- moduleId %>";

--- a/iphone/templates/module/default/template/iphone/{{ModuleName}}.xcodeproj/project.pbxproj.ejs
+++ b/iphone/templates/module/default/template/iphone/{{ModuleName}}.xcodeproj/project.pbxproj.ejs
@@ -246,6 +246,7 @@
 				RUN_CLANG_STATIC_ANALYZER = NO;
 				SDKROOT = iphoneos;
 				USER_HEADER_SEARCH_PATHS = "";
+				WARNING_CFLAGS = "-Wno-arc-performSelector-leaks";
 			};
 			name = Debug;
 		};
@@ -280,6 +281,7 @@
 				RUN_CLANG_STATIC_ANALYZER = NO;
 				SDKROOT = iphoneos;
 				USER_HEADER_SEARCH_PATHS = "";
+				WARNING_CFLAGS = "-Wno-arc-performSelector-leaks";
 			};
 			name = Release;
 		};


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-15275

- [x] Enable ARC in the project build-settings
- [x] Remove `dealloc:` call from module due to ARC
- [x] Use iOS 8 as the base iOS SDK for new modules
- [x] Recommend `appc ti build -p ios --build-only` in the `build.py`
- [x] Set Xcode compatibility version to 7.0 (from 3.2, lol)

**Note**: I used the `-Wno-arc-performSelector-leaks` in the SDK project, to supress the selector warnings for ARC-based selectors in UI-Thread macros (`ENSURE_UI_THREAD_1_ARG` and `ENSURE_UI_THREAD_0_ARGS`). We use those macros to ensure that the method is executed on the main-thread and always have left it to the developer to know how to use the macro. Even chcking if the instance response to the selector (`respondsToSelector:`) won't mute this warning, so it's recommend ([here](http://stackoverflow.com/a/7933931/5537752), [here](http://stackoverflow.com/a/10797893/5537752), [here](http://stackoverflow.com/a/11895530/5537752), ...) to mute the warning in this case.

This is **no** breaking change, ARC- and non-ARC modules / SDK can play together without problems.