### PR TITLE
[TIMOB-24253] Android: onBackPressed() validate topWindow before hasProperty()

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
@@ -856,7 +856,7 @@ public abstract class TiBaseActivity extends AppCompatActivity
 			KrollFunction onBackCallback = (KrollFunction) topWindow.getProperty(TiC.PROPERTY_ON_BACK);
 			onBackCallback.callAsync(activityProxy.getKrollObject(), new Object[] {});
 		}
-		if (topWindow == null || (!topWindow.hasProperty(TiC.PROPERTY_ON_BACK) && !topWindow.hasListeners(TiC.EVENT_ANDROID_BACK))) {
+		if (topWindow == null || (topWindow != null && !topWindow.hasProperty(TiC.PROPERTY_ON_BACK) && !topWindow.hasListeners(TiC.EVENT_ANDROID_BACK))) {
 			// there are no parent activities to return to
 			// override back press to background the activity
 			// note: 2 since there should always be TiLaunchActivity and TiActivity


### PR DESCRIPTION
- Prevent intermittent crash when `topWindow` is `null`

###### TEST CASE
```Javascript
var win = Titanium.UI.createWindow();
var imageView = Ti.UI.createImageView({
    height: Ti.UI.FILL,
    width: Ti.UI.FILL
});
 
var btn = Ti.UI.createButton({
    title: "Cam"
});
win.add(btn);
 
var overlay = Ti.UI.createView({});
var btn2 = Ti.UI.createButton({
    title: "take image"
});
btn2.addEventListener("click",function(e){
    Ti.Media.takePicture();
})
overlay.add(btn2)
 
btn.addEventListener("click", function(e) {
    console.log("----------------------------start camera------------------------");
    Titanium.Media.showCamera({
        overlay: overlay,
        success: function(event) {
              imageView.image = f.nativePath;
        },
        cancel: function() {     Ti.API.info('#### Camera Cancel');    },
        error: function(error) {},
        allowEditing: true
    });
})
win.add(imageView);
win.addEventListener("open", function() {
 
});
win.open();
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-24253)