### PR TITLE
[6_0_X][TIMOB-24253] Android: onBackPressed() validate topWindow before hasProperty()

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
@@ -856,7 +856,7 @@ public abstract class TiBaseActivity extends AppCompatActivity
 			KrollFunction onBackCallback = (KrollFunction) topWindow.getProperty(TiC.PROPERTY_ON_BACK);
 			onBackCallback.callAsync(activityProxy.getKrollObject(), new Object[] {});
 		}
-		if (topWindow != null || (!topWindow.hasProperty(TiC.PROPERTY_ON_BACK) && !topWindow.hasListeners(TiC.EVENT_ANDROID_BACK))) {
+		if (topWindow == null || (topWindow != null && !topWindow.hasProperty(TiC.PROPERTY_ON_BACK) && !topWindow.hasListeners(TiC.EVENT_ANDROID_BACK))) {
 			// there are no parent activities to return to
 			// override back press to background the activity
 			// note: 2 since there should always be TiLaunchActivity and TiActivity


### PR DESCRIPTION
- Cherry-pick of https://github.com/appcelerator/titanium_mobile/pull/8796
- Fixed invalid fix for #8780

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-24253)