### PR TITLE
[6_0_X] [TIMOB-24183] Windows: Failed to install WP 8.1 app

### DIFF
--- a/node_modules/windowslib/CHANGELOG.md
+++ b/node_modules/windowslib/CHANGELOG.md
@@ -1,3 +1,7 @@
+0.4.20.2 (01/27/2017) - Only for SDK 6.0.2
+-------------------
+  * [TIMOB-24183] Failed to install WP 8.1 app
+
 0.4.20.1 (11/29/2016) - Only for SDK 6.0.1
 -------------------
   * [TIMOB-24157] Install certificate in new window

--- a/node_modules/windowslib/lib/wptool.js
+++ b/node_modules/windowslib/lib/wptool.js
@@ -719,7 +719,7 @@ function nativeLaunch(device, appid, options, callback) {
 			// Here's where we expect the failure that the app is not installed, which is right.
 			// We're explicitly telling to launch a bogus app, so we expect a very specific failure as "success" here...
 			// if (code == -2146233088 || code == 2148734208)
-			if (errmsg.indexOf('The application is not installed.') != -1) {
+			if (errmsg == '' || errmsg.indexOf('The application is not installed.') != -1) {
 				// we must be successful, right?
 				callback(null, device);
 			} else {
@@ -760,7 +760,7 @@ function nativeInstall(deployCmd, device, appPath, options, callback) {
 	child.on('close', function (code) {
 		clearTimeout(abortTimer);
 
-		if (code) {
+		if (out.trim() != '' && code) {
 			var errmsg = out.trim().split(/\r\n|\n/).shift(),
 				ex = new Error(/^Error: /.test(errmsg) ? errmsg.substring(7) : __('Failed to install app (code %s)', code));
 			callback(ex);


### PR DESCRIPTION
Cherry-pick https://github.com/appcelerator/windowslib/pull/64 for 6_0_X [TIMOB-24183](https://jira.appcelerator.org/browse/TIMOB-24183) manually because it's critical.

`appc run -p windows --target wp-device` fails to deploy apps to Windows Phone 8.1 device.

It turns out that deployment failed because outputs from Windows Phone deployment tools have been changed at some point of the installation, now it could output nothing but returns error code other than "0". As far as I can see it means deployment went successful and we can ignore the error code when output from tools are empty.

This PR intends to be a "manual fix" since we can not bump up the version simply. I'm pushing https://github.com/appcelerator/windowslib/pull/64 but it includes some fixes that is marked "6.1.0" (in 0.4.21 to 0.4.27), so we want to update certain file that is only related to SDK 6.0.2 without bumping up windowslib version. I did not actually bump up the version just like we did in https://github.com/appcelerator/titanium_mobile/pull/8641 .
