### PR TITLE
[6_0_X][TIMOB-24304] Android: Use application context for permissions

### DIFF
--- a/android/modules/android/src/java/ti/modules/titanium/android/AndroidModule.java
+++ b/android/modules/android/src/java/ti/modules/titanium/android/AndroidModule.java
@@ -351,8 +351,8 @@ public class AndroidModule extends KrollModule
 		if (Build.VERSION.SDK_INT < 23) {
 			return true;
 		}
-		Activity currentActivity  = TiApplication.getInstance().getCurrentActivity();
-		if (currentActivity.checkSelfPermission(permission) == PackageManager.PERMISSION_GRANTED) {
+		Context context = TiApplication.getInstance().getApplicationContext();
+		if (context.checkSelfPermission(permission) == PackageManager.PERMISSION_GRANTED) {
 			return true;
 		}
 		return false;

--- a/android/modules/contacts/src/java/ti/modules/titanium/contacts/CommonContactsApi.java
+++ b/android/modules/contacts/src/java/ti/modules/titanium/contacts/CommonContactsApi.java
@@ -17,6 +17,7 @@ import org.appcelerator.titanium.TiC;
 
 import android.Manifest;
 import android.app.Activity;
+import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.database.Cursor;
@@ -65,10 +66,10 @@ public abstract class CommonContactsApi
 		if (Build.VERSION.SDK_INT < 23) {
 			return true;
 		}
-		Activity currentActivity = TiApplication.getAppCurrentActivity();
+		Context context = TiApplication.getInstance().getApplicationContext();
 		// If READ_CONTACTS is granted, WRITE_CONTACTS is also granted if the permission is included in manifest.
-		if (currentActivity != null &&
-				currentActivity.checkSelfPermission(Manifest.permission.READ_CONTACTS) == PackageManager.PERMISSION_GRANTED) {
+		if (context != null &&
+				context.checkSelfPermission(Manifest.permission.READ_CONTACTS) == PackageManager.PERMISSION_GRANTED) {
 			return true;
 		}
 		Log.w(TAG, "Contact permissions are missing");

--- a/android/modules/filesystem/src/java/ti/modules/titanium/filesystem/FilesystemModule.java
+++ b/android/modules/filesystem/src/java/ti/modules/titanium/filesystem/FilesystemModule.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 
 import android.app.Activity;
+import android.content.Context;
 import android.content.pm.PackageManager;
 import android.os.Build;
 import org.appcelerator.kroll.KrollFunction;
@@ -89,8 +90,8 @@ public class FilesystemModule extends KrollModule
 		if (Build.VERSION.SDK_INT < 23) {
 			return true;
 		}
-		Activity currentActivity = TiApplication.getInstance().getCurrentActivity();
-		if (currentActivity.checkSelfPermission(android.Manifest.permission.READ_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED) {
+		Context context = TiApplication.getInstance().getApplicationContext();
+		if (context.checkSelfPermission(android.Manifest.permission.READ_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED) {
 			return true;
 		}
 		return false;

--- a/android/modules/geolocation/src/java/ti/modules/titanium/geolocation/GeolocationModule.java
+++ b/android/modules/geolocation/src/java/ti/modules/titanium/geolocation/GeolocationModule.java
@@ -30,6 +30,7 @@ import ti.modules.titanium.geolocation.android.LocationProviderProxy.LocationPro
 import ti.modules.titanium.geolocation.android.LocationRuleProxy;
 import android.Manifest;
 import android.app.Activity;
+import android.content.Context;
 import android.content.pm.PackageManager;
 import android.location.Location;
 import android.location.LocationManager;
@@ -618,8 +619,8 @@ public class GeolocationModule extends KrollModule
 		if (Build.VERSION.SDK_INT < 23) {
 			return true;
 		}
-		Activity currentActivity  = TiApplication.getInstance().getCurrentActivity();
-		if (currentActivity.checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED) {
+		Context context = TiApplication.getInstance().getApplicationContext();
+		if (context.checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED) {
 			return true;
 		}
 		return false;

--- a/android/modules/media/src/java/ti/modules/titanium/media/MediaModule.java
+++ b/android/modules/media/src/java/ti/modules/titanium/media/MediaModule.java
@@ -355,9 +355,9 @@ public class MediaModule extends KrollModule
 		if (Build.VERSION.SDK_INT < 23) {
 			return true;
 		}
-		Activity currentActivity  = TiApplication.getInstance().getCurrentActivity();
-		if (currentActivity.checkSelfPermission(Manifest.permission.CAMERA) == PackageManager.PERMISSION_GRANTED &&
-				currentActivity.checkSelfPermission(Manifest.permission.READ_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED) {
+		Context context = TiApplication.getInstance().getApplicationContext();
+		if (context.checkSelfPermission(Manifest.permission.CAMERA) == PackageManager.PERMISSION_GRANTED &&
+				context.checkSelfPermission(Manifest.permission.READ_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED) {
 			return true;
 		}
 		return false;
@@ -367,8 +367,8 @@ public class MediaModule extends KrollModule
 	    if (Build.VERSION.SDK_INT < 23) {
 	        return true;
 	    }
-	    Activity currentActivity  = TiApplication.getInstance().getCurrentActivity();
-	    if (currentActivity.checkSelfPermission(Manifest.permission.CAMERA) == PackageManager.PERMISSION_GRANTED) {
+	    Context context = TiApplication.getInstance().getApplicationContext();
+	    if (context.checkSelfPermission(Manifest.permission.CAMERA) == PackageManager.PERMISSION_GRANTED) {
 	        return true;
 	    }
 	    return false;
@@ -378,8 +378,8 @@ public class MediaModule extends KrollModule
 	    if (Build.VERSION.SDK_INT < 23) {
 	        return true;
 	    }
-	    Activity currentActivity = TiApplication.getInstance().getCurrentActivity();
-	    if (currentActivity.checkSelfPermission(Manifest.permission.READ_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED) {
+	    Context context = TiApplication.getInstance().getApplicationContext();
+	    if (context.checkSelfPermission(Manifest.permission.READ_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED) {
 	        return true;
 	    }
 	    return false;

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiFileHelper2.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiFileHelper2.java
@@ -7,6 +7,7 @@
 package org.appcelerator.titanium.util;
 
 import android.app.Activity;
+import android.content.Context;
 import android.content.pm.PackageManager;
 import android.os.Build;
 import org.appcelerator.titanium.TiApplication;
@@ -85,12 +86,12 @@ public class TiFileHelper2
 		if (Build.VERSION.SDK_INT < 23) {
 			return true;
 		}
-		Activity currentActivity = TiApplication.getInstance().getCurrentActivity();
+		Context context = TiApplication.getInstance().getApplicationContext();
 		// Fix for TIMOB-20434 where activity is null
-		if (currentActivity == null) {
+		if (context == null) {
 		    return false;
 		}
-		if (currentActivity.checkSelfPermission(android.Manifest.permission.READ_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED) {
+		if (context.checkSelfPermission(android.Manifest.permission.READ_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED) {
 			return true;
 		}
 		return false;


### PR DESCRIPTION
- Use application context instead of activity context for permissions

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-24304)