### PR TITLE
[TIMOB-24344] Android: Fix getDensity() for tvdpi

### DIFF
--- a/android/modules/platform/src/java/ti/modules/titanium/platform/DisplayCapsProxy.java
+++ b/android/modules/platform/src/java/ti/modules/titanium/platform/DisplayCapsProxy.java
@@ -62,7 +62,7 @@ public class DisplayCapsProxy extends KrollProxy
 			case DisplayMetrics.DENSITY_MEDIUM :
 				return "medium";
 			case 213: //TV
-				return "high";
+				return "tvdpi";
 			case 280: //Introduce in API 22.
 				return "xhigh";
 			case 320:


### PR DESCRIPTION
- Fix `getDensity()` of `213dp`to `tvdpi`

###### TEST CASE
```Javascript
Ti.API.info('density: ' + Ti.Platform.displayCaps.getDensity());
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-24344)