### PR TITLE
[TIMOB-24363] Android: Always filter .jar assets folder

### DIFF
--- a/android/cli/commands/_buildModule.js
+++ b/android/cli/commands/_buildModule.js
@@ -1280,8 +1280,7 @@ AndroidModuleBuilder.prototype.packageZip = function (next) {
 				jarArgs = [
 					'cf',
 					this.moduleJarFile,
-					'-C', this.buildClassesDir, '.',
-					'-C', path.join(this.assetsDir, '..'), 'assets'
+					'-C', this.buildClassesDir, '.'
 				],
 				createJarHook = this.cli.createHook('build.android.java', this, function (exe, args, opts, done) {
 					this.logger.info(__('Generate module JAR: %s', (exe + ' "' + args.join('" "') + '"').cyan));
@@ -1303,7 +1302,6 @@ AndroidModuleBuilder.prototype.packageZip = function (next) {
 					jarArgs.push(assetsParentDir);
 					jarArgs.push(path.relative(assetsParentDir, file));
 				}
-
 			}.bind(this));
 
 			createJarHook(


### PR DESCRIPTION
- Always filter `assets` files to prevent copying `README` into the `.jar`

###### TEST CASE
- Create native Android module
- Create\Copy an asset into `android\assets`
- Compile module, open `dist\<module>.jar` to make sure `README` is not included in the `assets` folder but all other assets exist

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-24363)