### PR TITLE
[TIMOB-24367] Android: Fix TabGroupProxy.handlePostOpen()

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TabGroupProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TabGroupProxy.java
@@ -393,7 +393,11 @@ public class TabGroupProxy extends TiWindowProxy implements TiActivityWindow
 		// Load any tabs added before the tab group opened.
 		TiUIAbstractTabGroup tg = (TiUIAbstractTabGroup) view;
 		for (TabProxy tab : tabs) {
-			tg.addTab(tab);
+			if (tab != null) {
+				tg.addTab(tab);
+			} else {
+				tabs.remove(tab);
+			}
 		}
 
 		TabProxy activeTab = handleGetActiveTab();

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIActionBarTabGroup.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIActionBarTabGroup.java
@@ -335,9 +335,16 @@ public class TiUIActionBarTabGroup extends TiUIAbstractTabGroup implements TabLi
 			pendingDisableTabs = true;
 			checkAndDisableTabsIfRequired();
 		}
-		ColorDrawable drawable = (tabProxy.getProperty(TiC.PROPERTY_BACKGROUND_COLOR) != null) ? TiConvert.toColorDrawable((String) tabProxy.getProperty(TiC.PROPERTY_BACKGROUND_COLOR)) : TiConvert.toColorDrawable((String) tabProxy.getTabGroup().getProperty(TiC.PROPERTY_TABS_BACKGROUND_COLOR));
-		actionBar.setStackedBackgroundDrawable(drawable);
-		actionBar.setBackgroundDrawable(drawable);
+		ColorDrawable drawable = null;
+		if (tabProxy.getProperty(TiC.PROPERTY_BACKGROUND_COLOR) != null) {
+			drawable = TiConvert.toColorDrawable((String) tabProxy.getProperty(TiC.PROPERTY_BACKGROUND_COLOR));
+		} else if (tabProxy.getTabGroup() != null) {
+			drawable = TiConvert.toColorDrawable((String) tabProxy.getTabGroup().getProperty(TiC.PROPERTY_TABS_BACKGROUND_COLOR));
+		}
+		if (drawable != null) {
+			actionBar.setStackedBackgroundDrawable(drawable);
+			actionBar.setBackgroundDrawable(drawable);
+		}
 	}
 
 	@Override


### PR DESCRIPTION
- Guard against `null` `TabProxy` in `handlePostOpen()`

###### TEST CASE
```Javascript
var win1 = Ti.UI.createWindow({
    backgroundColor: 'blue',
    title: 'Blue'
});
 
var lbl = Ti.UI.createLabel({text: 'I am a blue window.'});
 
lbl.addEventListener('click', function(){
	Ti.UI.createWindow().open();	
});
 
win1.add(lbl);
 
var win2 = Ti.UI.createWindow({
    backgroundColor: 'red',
    title: 'Red'
});
 
win2.add(Ti.UI.createLabel({text: 'I am a red window.'}));
 
var tab1 = Ti.UI.createTab({
    window: win1,
    title: 'Blue'
}),
tab2 = Ti.UI.createTab({
    window: win2,
    title: 'Red'
}),
tabGroup = Ti.UI.createTabGroup({
    tabs: [tab1, tab2]
});
tabGroup.open();
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-24367)