### PR TITLE
[TIMOB-23898] Android: Fixed mime-type identifiction

### DIFF
--- a/android/modules/media/src/java/ti/modules/titanium/media/MediaModule.java
+++ b/android/modules/media/src/java/ti/modules/titanium/media/MediaModule.java
@@ -949,12 +949,11 @@ public class MediaModule extends KrollModule
 						if (requestCode == PICK_IMAGE_MULTIPLE && Build.VERSION.SDK_INT >= 18) {
 							ClipData clipdata = data.getClipData();
 							if (clipdata != null) {
-
 								int count = clipdata.getItemCount();
 								KrollDict[] selectedPhotos = new KrollDict[count];
 								for (int i=0; i<count; i++) {
 									ClipData.Item item = clipdata.getItemAt(i);
-									selectedPhotos[i] = createDictForImage(item.getUri().toString(), "image/jpeg");
+									selectedPhotos[i] = createDictForImage(item.getUri().toString());
 								}
 
 								if (fSuccessCallback != null) {
@@ -965,9 +964,8 @@ public class MediaModule extends KrollModule
 								}
 
 							} else if (path != null) {
-
 							    KrollDict[] selectedPhotos = new KrollDict[1];
-							    selectedPhotos[0] = createDictForImage(path, "image/jpeg");
+							    selectedPhotos[0] = createDictForImage(path);
 							    if (fSuccessCallback != null) {
 							        KrollDict d = new KrollDict();
 							        d.putCodeAndMessage(NO_ERROR, null);
@@ -990,7 +988,7 @@ public class MediaModule extends KrollModule
 								return;
 							}
 							if (fSuccessCallback != null) {
-								fSuccessCallback.callAsync(getKrollObject(), createDictForImage(path, "image/jpeg"));
+								fSuccessCallback.callAsync(getKrollObject(), createDictForImage(path));
 							}
 
 						} catch (OutOfMemoryError e) {
@@ -1017,7 +1015,7 @@ public class MediaModule extends KrollModule
 			});
 	}
 
-	protected static KrollDict createDictForImage(String path, String mimeType) {
+	protected static KrollDict createDictForImage(String path) {
 		String[] parts = { path };
 		TiBlob imageData;
 		// Workaround for TIMOB-19910. Image is in the Google Photos cloud and not on device.
@@ -1031,14 +1029,14 @@ public class MediaModule extends KrollModule
 		        parcelFileDescriptor.close();
 		        imageData = TiBlob.blobFromImage(image);
 		    } catch (FileNotFoundException e) {
-		        imageData = createImageData(parts, mimeType);
+		        imageData = createImageData(parts, null);
 		    } catch (IOException e) {
-		        imageData = createImageData(parts, mimeType);
+		        imageData = createImageData(parts, null);
 		    }
 		} else {
-		    imageData = createImageData(parts, mimeType);
+		    imageData = createImageData(parts, null);
 		}
-		return createDictForImage(imageData, mimeType);
+		return createDictForImage(imageData, null);
 	}
 
 	public static TiBlob createImageData(String[] parts, String mimeType){

--- a/android/titanium/src/java/org/appcelerator/titanium/TiBlob.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiBlob.java
@@ -158,8 +158,7 @@ public class TiBlob extends KrollProxy
 				data = bos.toByteArray();
 				mimeType = "image/png";
 			}
-		}
-		else {
+		} else {
 			if (image.compress(CompressFormat.JPEG, 100, bos)) {
 				data = bos.toByteArray();
 				mimeType = "image/jpeg";
@@ -239,7 +238,6 @@ public class TiBlob extends KrollProxy
 				is.mark(64);
 				byte[] bytes = new byte[64];
 				int length = is.read(bytes);
-				is.reset();
 				if (length == -1) {
 					return null;
 				}
@@ -259,7 +257,7 @@ public class TiBlob extends KrollProxy
 					}
 				}
 			} catch (Exception e) {
-				Log.e(TAG, e.getMessage(), e, Log.DEBUG_MODE);
+				Log.e(TAG, e.getMessage(), e);
 			}
 		}
 		return mt;


### PR DESCRIPTION
- Removed forced exception from `guessAdditionalContentTypeFromStream()` preventing the method from running correctly
- Remove the Hardcoded MIME-Types of `image/jpeg` which resulted in `guessAdditionalContentTypeFromStream()` being invoked which then found the extension of the image selected

## Test Case app.js
```Javascript
// this sets the background color of the master UIView (when there are no windows/tab groups on it)
Titanium.UI.setBackgroundColor('#000');

// create tab group
var tabGroup = Titanium.UI.createTabGroup();


//
// create base UI tab and root window
//
var win1 = Titanium.UI.createWindow({  
    title:'Tab 1',
    backgroundColor:'#fff'
});
var tab1 = Titanium.UI.createTab({  
    icon:'KS_nav_views.png',
    title:'Tab 1',
    window:win1
});

var label1 = Titanium.UI.createLabel({
	color:'#999',
	text:'I am Window 1',
	font:{fontSize:20,fontFamily:'Helvetica Neue'},
	textAlign:'center',
	width:'auto'
});

win1.add(label1);

//
// create controls tab and root window
//
var win2 = Titanium.UI.createWindow({  
    title:'Tab 2',
    backgroundColor:'#fff'
});
var tab2 = Titanium.UI.createTab({  
    icon:'KS_nav_ui.png',
    title:'Tab 2',
    window:win2
});

var label2 = Titanium.UI.createLabel({
	color:'#999',
	text:'I am Window 2',
	font:{fontSize:20,fontFamily:'Helvetica Neue'},
	textAlign:'center',
	width:'auto'
});

win2.add(label2);



//
//  add tabs
//
tabGroup.addTab(tab1);  
tabGroup.addTab(tab2);  


// open tab group
tabGroup.open();
```

[TIMOB-23898](https://jira.appcelerator.org/browse/TIMOB-23898)