### PR TITLE
[TIMOB-16005] Android: option for no full screen mode for textfield

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TextFieldProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TextFieldProxy.java
@@ -38,6 +38,7 @@ import android.os.Message;
 	TiC.PROPERTY_INPUT_TYPE,
 	TiC.PROPERTY_KEYBOARD_TYPE,
 	TiC.PROPERTY_MAX_LENGTH,
+	TiC.PROPERTY_NO_FULLSCREEN,
 	TiC.PROPERTY_PASSWORD_MASK,
 	TiC.PROPERTY_TEXT_ALIGN,
 	TiC.PROPERTY_VALUE,
@@ -56,6 +57,7 @@ public class TextFieldProxy extends TiViewProxy
 		super();
 		defaultValues.put(TiC.PROPERTY_VALUE, "");
 		defaultValues.put(TiC.PROPERTY_MAX_LENGTH, -1);
+		defaultValues.put(TiC.PROPERTY_NO_FULLSCREEN, false);
 	}
 
 	@Override

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIText.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIText.java
@@ -220,6 +220,9 @@ public class TiUIText extends TiUIView
 			setTextPadding((HashMap)d.get(TiC.PROPERTY_PADDING));
 		}
 		
+		if (d.containsKey(TiC.PROPERTY_NO_FULLSCREEN) && (Boolean) d.get(TiC.PROPERTY_NO_FULLSCREEN)) {
+				tv.setImeOptions(EditorInfo.IME_FLAG_NO_FULLSCREEN);
+		}
 	}
 
 	private void setTextPadding(HashMap<String, Object> d)

--- a/android/modules/xml/src/java/ti/modules/titanium/xml/TextProxy.java
+++ b/android/modules/xml/src/java/ti/modules/titanium/xml/TextProxy.java
@@ -7,7 +7,6 @@
 package ti.modules.titanium.xml;
 
 import org.appcelerator.kroll.annotations.Kroll;
-import org.appcelerator.kroll.common.Log;
 import org.w3c.dom.DOMException;
 import org.w3c.dom.Node;
 import org.w3c.dom.Text;

--- a/android/titanium/src/java/org/appcelerator/titanium/TiC.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiC.java
@@ -1955,6 +1955,11 @@ public class TiC
 	/**
 	 * @module.api
 	 */
+	public static final String PROPERTY_NO_FULLSCREEN = "noFullScreen";
+
+	/**
+	 * @module.api
+	 */
 	public static final String PROPERTY_NOTE = "note";
 
 	/**

--- a/apidoc/Titanium/UI/TextField.yml
+++ b/apidoc/Titanium/UI/TextField.yml
@@ -416,6 +416,13 @@ properties:
     type: Number
     platforms: [iphone, ipad]
     
+  - name: noFullScreen
+    summary: |
+        If set to true then the text field will be not go into full screen mode when focused.
+    type: Boolean
+    platforms: [android]
+    since: 6.1.0
+    
   - name: padding
     summary: Sets the padding of this text field. 
     type: TextFieldPadding


### PR DESCRIPTION
**Test Case**
```
var win = Ti.UI.createWindow({
	backgroundColor: "#fff"
});
var textfield = Ti.UI.createTextField({
	top: 10,
	height: Titanium.UI.SIZE,
	width: Titanium.UI.FILL,
	noFullScreen: false,
	color: '#000',
	hintText: "input",
	softKeyboardOnFocus: Ti.UI.Android.SOFT_KEYBOARD_DEFAULT_ON_FOCUS, // Android only
	keyboardType: Ti.UI.KEYBOARD_DEFAULT,
	returnKeyType: Ti.UI.RETURNKEY_DEFAULT,
	borderStyle: Ti.UI.INPUT_BORDERSTYLE_ROUNDED
});
win.add(textfield);
win.open();
```

**JIRA:** https://jira.appcelerator.org/browse/TIMOB-16005