### PR TITLE
[TIMOB-24308] Android: Use Math.floor() when converting percentage values

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiCompositeLayout.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiCompositeLayout.java
@@ -231,7 +231,7 @@ public class TiCompositeLayout extends ViewGroup
 
     private static int getAsPercentageValue(double percentage, int value)
     {
-        return (int) Math.round((percentage / 100.0) * value);
+        return (int) Math.floor((percentage / 100.0) * value);
     }
 
     protected int getViewWidthPadding(View child, int parentWidth)


### PR DESCRIPTION
- Fix rounding of percentage conversion for horizontal wrapping

###### TEST CASE
```Javascript
var win = Ti.UI.createWindow(),
    view = Ti.UI.createView({
        height: Ti.UI.FILL,
        width: Ti.UI.FILL,
        layout: 'horizontal',
        backgroundColor: 'gray'
    }),
    a = Ti.UI.createView({
        width: '25%',
        height: Ti.UI.FILL,
        backgroundColor: 'red'
    }),
    b = Ti.UI.createView({
        width: '25%',
        height: Ti.UI.FILL,
        backgroundColor: 'green'
    }),
    c = Ti.UI.createView({
        width: '25%',
        height: Ti.UI.FILL,
        backgroundColor: 'blue'
    }),
    d = Ti.UI.createView({
        width: '25%',
        height: Ti.UI.FILL,
        backgroundColor: 'yellow'
    });

view.add(a);
view.add(b);
view.add(c);
view.add(d);

win.add(view);

win.open();
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-24308)