### PR TITLE
[TIMOB-24400] Android: Support saving video files to gallery

### DIFF
--- a/apidoc/Titanium/Media/Media.yml
+++ b/apidoc/Titanium/Media/Media.yml
@@ -96,7 +96,7 @@ methods:
         but `video1.tmp` does not. Currently, the `.mp4` extension is not supported, but MP4
         files may be imported by saving them with the `.mov` extension.
 
-        On Android this method *only supports saving images* to the device gallery.
+        On Android this method *only supports saving images* to the device gallery prior to Titanium SDK 6.1.0.
 
     platforms: [iphone, ipad, android]
     parameters:


### PR DESCRIPTION
- Amended `createExternalStorageFile()`
- Removed duplicate code for `createGalleryImageFile()`
- Added video support for `Ti.Media.saveToPhotoGallery()` to maintain parity with iOS
- Updated documentation

###### TEST CASE
- Download [BigBuckBunny_320x180.mp4](http://download.blender.org/peach/bigbuckbunny_movies/BigBuckBunny_320x180.mp4) and place into your project `Resources` folder
```Javascript
var videoFile = Ti.Filesystem.getFile('BigBuckBunny_320x180.mp4');

Ti.Media.saveToPhotoGallery(videoFile.read(), {
    success : function(e) {
        console.log('-> SUCCESS');
    },
    error : function(e) {
        console.log('-> ERROR', e)
    }
});
```
- `BigBuckBunny_320x180.mp4` should be visible in the Android Gallery

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-24400)
