### PR TITLE
[TIMOB-24407] Android: Fix TiUIDatePicker for API 21 and above

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/picker/TiUIDatePicker.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/picker/TiUIDatePicker.java
@@ -46,7 +46,7 @@ public class TiUIDatePicker extends TiUIView
 		DatePicker picker;
 		// If it is not API Level 21 (Android 5.0), create picker normally.
 		// If not, it will inflate a spinner picker to address a bug.
-		if (Build.VERSION.SDK_INT != Build.VERSION_CODES.LOLLIPOP) {
+		if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
 			picker = new DatePicker(activity)
 			{
 				@Override


### PR DESCRIPTION
- Fix TiUIDatePicker version check

###### TEST CASE
```Javascript
var win = Titanium.UI.createWindow({
        title: 'TIMOB-24407',
        backgroundColor: 'gray'
    }),
    picker = Ti.UI.createPicker({
        calendarViewShown: false,
        type: Ti.UI.PICKER_TYPE_DATE
    });

win.add(picker);
win.open();
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-24407)