### PR TITLE
[TIMOB-23556] Android: Updated the package json vendor dependency for android build tools

### DIFF
--- a/android/package.json
+++ b/android/package.json
@@ -16,7 +16,7 @@
 	"minSDKVersion": "14",
 	"vendorDependencies": {
 		"android sdk": "23",
-		"android build tools": ">=17 <=23.x",
+		"android build tools": ">=17 <=25",
 		"android platform tools": ">=17 <=23.x",
 		"android tools": "<=24.3.x",
 		"android ndk": ">=r8e <=r9",

--- a/android/package.json
+++ b/android/package.json
@@ -16,7 +16,7 @@
 	"minSDKVersion": "14",
 	"vendorDependencies": {
 		"android sdk": "23",
-		"android build tools": ">=17 <=25",
+		"android build tools": ">=17 <=25.x",
 		"android platform tools": ">=17 <=23.x",
 		"android tools": "<=24.3.x",
 		"android ndk": ">=r8e <=r9",


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-23556

**Optional Description:**
Updated the dependency for one of the vendors in the package json, due to a warning about support with android build tools.

### Test Case

- Create new classic application
- Run application in default state and check the logs 
- Logs should not have the following warning:

`[WARN] :   Android Build Tools 24 are too new and may or may not work with Titanium.`
`[WARN] :   If you encounter problems, select a supported version with:`
`[WARN] :   ti config android.buildTools.selectedVersion ##.##.##`