### PR TITLE
[TIMOB-20448] Android: Adding text color to a singular row adds the color to multiple down the list

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TableViewRowProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TableViewRowProxy.java
@@ -9,6 +9,7 @@ package ti.modules.titanium.ui;
 import java.util.ArrayList;
 import java.util.HashMap;
 
+import android.graphics.Color;
 import org.appcelerator.kroll.KrollDict;
 import org.appcelerator.kroll.annotations.Kroll;
 import org.appcelerator.kroll.common.Log;
@@ -48,7 +49,6 @@ public class TableViewRowProxy extends TiViewProxy
 	public TableViewRowProxy()
 	{
 		super();
-
 		// TIMOB-24058: Prevent setOnClickListener() from being set allowing
 		// backgroundSelectedColor and backgroundSelectedImage to function
 		defaultValues.put(TiC.PROPERTY_TOUCH_ENABLED, false);
@@ -76,6 +76,18 @@ public class TableViewRowProxy extends TiViewProxy
 		if (options.containsKey(TiC.PROPERTY_SELECTED_BACKGROUND_IMAGE)) {
 			Log.w(TAG, "selectedBackgroundImage is deprecated, use backgroundSelectedImage instead");
 			setProperty(TiC.PROPERTY_BACKGROUND_SELECTED_IMAGE, options.get(TiC.PROPERTY_SELECTED_BACKGROUND_IMAGE));
+		}
+		if (!options.containsKey(TiC.PROPERTY_COLOR)) {
+			if (options.containsKey(TiC.PROPERTY_BACKGROUND_COLOR)) {
+				int color = Color.parseColor((String) options.get(TiC.PROPERTY_BACKGROUND_COLOR));
+				if (Math.abs(color - Color.WHITE) < Math.abs(color - Color.BLACK)) {
+					options.put(TiC.PROPERTY_COLOR, "black");
+				} else {
+					options.put(TiC.PROPERTY_COLOR, "white");
+				}
+			} else {
+				options.put(TiC.PROPERTY_COLOR, "white");
+			}
 		}
 	}
 

--- a/apidoc/Titanium/UI/TableViewRow.yml
+++ b/apidoc/Titanium/UI/TableViewRow.yml
@@ -245,6 +245,8 @@ properties:
   - name: color
     summary: Default text color of the row when not selected, as a color name or hex triplet.
     description: |
+        Default text color is black if background color is closer to white otherwise default text color is white.
+        
         For information about color values, see the "Colors" section of <Titanium.UI>. 
         
         On Android, `selectedColor` is not supported, so the text is always displayed in this color.

--- a/apidoc/Titanium/UI/TableViewRow.yml
+++ b/apidoc/Titanium/UI/TableViewRow.yml
@@ -245,11 +245,11 @@ properties:
   - name: color
     summary: Default text color of the row when not selected, as a color name or hex triplet.
     description: |
-        Default text color is black if background color is closer to white otherwise default text color is white.
-        
         For information about color values, see the "Colors" section of <Titanium.UI>. 
         
-        On Android, `selectedColor` is not supported, so the text is always displayed in this color.
+        On Android, the default text color is black if the background color is closer to white
+        otherwise the default text color is white also `selectedColor` is not supported
+        so the text is always displayed in this color.
     type: String
 
   - name: deleteButtonTitle


### PR DESCRIPTION
Test Case:
Toggle color and background color values. Expect sane behaviour => White text color if background is dark else black. Only row 0 has color green and other rows do not change colors when scrolling.
```
var win = Ti.UI.createWindow();
var array = [];
for (var i = 0; i < 20; i++) {
	var obj = {
		title : "Row "+ i,
		backgroundColor: "black"
		// backgroundColor: "white"
	};
	array.push(obj);
}
array[0].color =  "green";
var tableView = Titanium.UI.createTableView({
	data: array
});
win.add(tableView);
win.open();
```
**JIRA:** https://jira.appcelerator.org/browse/timob-20448

