### PR TITLE
[TIMOB-24429] Android: Only disable HW-acceleration for borderView below Jelly Bean

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiUIView.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiUIView.java
@@ -88,6 +88,7 @@ public abstract class TiUIView
 
 	private static final boolean HONEYCOMB_OR_GREATER = (Build.VERSION.SDK_INT >= 11);
 	private static final boolean LOLLIPOP_OR_GREATER = (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP);
+	private static final boolean LOWER_THAN_JELLYBEAN = (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN);
 
 	private static final int LAYER_TYPE_SOFTWARE = 1;
 	private static final String TAG = "TiUIView";
@@ -1412,7 +1413,7 @@ public abstract class TiUIView
 					if (radiusDim != null) {
 						radius = (float) radiusDim.getPixels(getNativeView());
 					}
-					if (radius > 0f && HONEYCOMB_OR_GREATER) {
+					if (radius > 0f && HONEYCOMB_OR_GREATER && LOWER_THAN_JELLYBEAN) {
 						disableHWAcceleration();
 					}
 					borderView.setRadius(radius);
@@ -1455,7 +1456,7 @@ public abstract class TiUIView
 			if (radiusDim != null) {
 				radius = (float) radiusDim.getPixels(getNativeView());
 			}
-			if (radius > 0f && HONEYCOMB_OR_GREATER) {
+			if (radius > 0f && HONEYCOMB_OR_GREATER && LOWER_THAN_JELLYBEAN) {
 				disableHWAcceleration();
 			}
 			borderView.setRadius(radius);


### PR DESCRIPTION
- Disables HW acceleration for Views with `borderRadius` only on Android versions below Jelly Bean and above Honeycomb

###### TEST CASE
```Javascript
var win = Ti.UI.createWindow();
	view = Ti.UI.createView({
	    height: Ti.UI.FILL,
	    width: Ti.UI.FILL
	}),
	mapView = require('ti.map').createView({
	    height: Ti.UI.FILL,
	    width: Ti.UI.FILL,
	    borderRadius: 50
	});

view.add(mapView);
win.add(view);
win.open();
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-24429)