### PR TITLE
[TIMOB-24442] Android: Fix Ti.UI.View.rect x and y properties

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/TiViewProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/TiViewProxy.java
@@ -316,10 +316,13 @@ public abstract class TiViewProxy extends KrollProxy implements Handler.Callback
 				if (view != null) {
 					View v = view.getOuterView();
 					if (v != null) {
+						int position[] = new int[2];
+						v.getLocationInWindow(position);
+
 						TiDimension nativeWidth = new TiDimension(v.getWidth(), TiDimension.TYPE_WIDTH);
 						TiDimension nativeHeight = new TiDimension(v.getHeight(), TiDimension.TYPE_HEIGHT);
-						TiDimension nativeLeft = new TiDimension(v.getLeft(), TiDimension.TYPE_LEFT);
-						TiDimension nativeTop = new TiDimension(v.getTop(), TiDimension.TYPE_TOP);
+						TiDimension nativeLeft = new TiDimension(position[0], TiDimension.TYPE_LEFT);
+						TiDimension nativeTop = new TiDimension(position[1], TiDimension.TYPE_TOP);
 
 						// TiDimension needs a view to grab the window manager, so we'll just use the decorview of the current window
 						View decorView = TiApplication.getAppCurrentActivity().getWindow().getDecorView();


### PR DESCRIPTION
- Use component position for `x` and `y` properties of `Titanium.UI.View.rect`

###### TEST CASE
```JS
var win = Ti.UI.createWindow({backgroundColor: 'gray'}),
    view = Ti.UI.createView({
        left: 100,
        top: 100,
        width: 100,
        height: 100,
        backgroundColor: 'red'
    });

win.addEventListener('open', function() {
    Ti.API.info('Initial');
    Ti.API.info('  rect.x: ' + view.rect.x);
    Ti.API.info('  rect.y: ' + view.rect.y);

    view.animate({
        top: 200,
        left: 200,
        duration: 1000
    }, function() {
        Ti.API.info('After Animation');
        Ti.API.info('  rect.x: ' + view.rect.x);
        Ti.API.info('  rect.y: ' + view.rect.y);
    });
})
win.add(view);
win.open();
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-24442)