### PR TITLE
[TIMOB-24451] Android: Fix Ti.UI.ListView.getSectionCount()

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/ListViewProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/ListViewProxy.java
@@ -154,7 +154,7 @@ public class ListViewProxy extends TiViewProxy {
 		if (listView != null) {
 			return ((TiListView) listView).getSectionCount();
 		}
-		return 0;
+		return preloadSections.size();
 	}
 
 	@Kroll.method


### PR DESCRIPTION
- Fix `handleSectionCount()` to return pre-loaded section count when a view has not been assigned

###### TEST CASE
- [Project on JIRA](https://jira.appcelerator.org/secure/attachment/61783/TIMOB-24451.zip)

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-24451)