### PR TITLE
[TIMOB-24459] Android: Allow automatic permissions to be overriden

### DIFF
--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -3698,10 +3698,12 @@ AndroidBuilder.prototype.generateAndroidManifest = function generateAndroidManif
 	}
 
 	// add permissions
-	Array.isArray(finalAndroidManifest['uses-permission']) || (finalAndroidManifest['uses-permission'] = []);
-	Object.keys(permissions).forEach(function (perm) {
-		finalAndroidManifest['uses-permission'].indexOf(perm) == -1 && finalAndroidManifest['uses-permission'].push(perm);
-	});
+	if (!this.tiapp['override-permissions']) {
+		Array.isArray(finalAndroidManifest['uses-permission']) || (finalAndroidManifest['uses-permission'] = []);
+		Object.keys(permissions).forEach(function (perm) {
+			finalAndroidManifest['uses-permission'].indexOf(perm) == -1 && finalAndroidManifest['uses-permission'].push(perm);
+		});
+	}
 
 	// if the AndroidManifest.xml already exists, remove it so that we aren't updating the original file (if it's symlinked)
 	fs.existsSync(this.androidManifestFile) && fs.unlinkSync(this.androidManifestFile);


### PR DESCRIPTION
- Allow `override-permissions` in `tiapp.xml` to prevent automatic permissions from being defined in `AndroidManifest.xml`

```XML
<ti:app xmlns:ti="http://ti.appcelerator.org">
    ...
    <override-permissions>true</override-permissions>
    ...
</ti:app>
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-24459)