### PR TITLE
[TIMOB-24479] Android: fix TiUILabel maxLines not working

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUILabel.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUILabel.java
@@ -234,6 +234,10 @@ public class TiUILabel extends TiUIView
 		if (d.containsKey(TiC.PROPERTY_LINES)) {
 			tv.setLines(TiConvert.toInt(d, TiC.PROPERTY_LINES));
 		}
+		if (d.containsKey(TiC.PROPERTY_WORD_WRAP)) {
+			wordWrap = TiConvert.toBoolean(d, TiC.PROPERTY_WORD_WRAP, true);
+			tv.setSingleLine(!wordWrap);
+		}
 		if (d.containsKey(TiC.PROPERTY_MAX_LINES)) {
 			tv.setMaxLines(TiConvert.toInt(d, TiC.PROPERTY_MAX_LINES));
 		}
@@ -290,12 +294,6 @@ public class TiUILabel extends TiUIView
 			}
 			tv.setEllipsize(ellipsize);
 		}
-
-		if (d.containsKey(TiC.PROPERTY_WORD_WRAP)) {
-			wordWrap = TiConvert.toBoolean(d, TiC.PROPERTY_WORD_WRAP, true);
-			tv.setSingleLine(!wordWrap);
-		}
-
 		if (d.containsKey(TiC.PROPERTY_SHADOW_OFFSET)) {
 			Object value = d.get(TiC.PROPERTY_SHADOW_OFFSET);
 			if (value instanceof HashMap) {


### PR DESCRIPTION
Test Case:
Expect the long string to be in one line meaning no word wraps.
```
var win = Ti.UI.createWindow({
	theme: "Theme.AppCompat.Fullscreen",
	backgroundColor: '#fff'
});
var longString = "Welcome to the Appcelerator Platform! The Appcelerator Platform extends Appcelerator's Titanium platform to help you manage the entire lifecycle of the application with debugging, testing, deployment, crash monitoring and analytic data collection.";
var bigLabel = Ti.UI.createLabel({
	text: longString,
	color: '#4d4d4d',
	width: "90%",
	top: 0,
	maxLines: 1
});
win.add(bigLabel);
win.open();
```
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-24479
