### PR TITLE
[TIMOB-24478] Android: Fix postlayout event in TiCompositeLayout

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiCompositeLayout.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiCompositeLayout.java
@@ -646,9 +646,10 @@ public class TiCompositeLayout extends ViewGroup
             }
         }
 
-        TiViewProxy viewProxy = (proxy == null ? null : proxy.get());
-        TiUIHelper.firePostLayoutEvent(viewProxy);
-
+        if (changed) {
+            TiViewProxy viewProxy = (proxy == null ? null : proxy.get());
+            TiUIHelper.firePostLayoutEvent(viewProxy);
+        }
     }
 
     // option0 is left/top, option1 is right/bottom


### PR DESCRIPTION
- Fire `postlayout` when a change has happened to the underlying view
- `postlayout` event should only fire once after loading application

###### TEST CASE
```Javascript
var win = Ti.UI.createWindow({backgroundColor: 'gray'});
 
win.addEventListener('open', function() {
    win.backgroundColor = 'orange';
    Ti.API.info('open event fired.');
});
 
win.addEventListener('postlayout', function() {
    if (win.backgroundColor == 'green') {
        win.backgroundColor = 'red';
    } else {
        win.backgroundColor = 'green';
    }
    Ti.API.info('postlayout event fired.');
});
 
win.open();
```
```
I/TiAPI:  open event fired.
I/TiAPI:  postlayout event fired.
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-24478)