### PR TITLE
[TIMOB-24189] Update windowslib to 0.4.29

### DIFF
--- a/node_modules/windowslib/node_modules/uuid/package.json
+++ b/node_modules/windowslib/node_modules/uuid/package.json
@@ -10,12 +10,13 @@
         "spec": "3.0.0",
         "type": "version"
       },
-      "/Users/chris/appc/titanium_mobile/node_modules/windowslib"
+      "D:\\workspace\\titanium_mobile\\node_modules\\windowslib"
     ]
   ],
   "_from": "uuid@3.0.0",
   "_id": "uuid@3.0.0",
   "_inCache": true,
+  "_installable": true,
   "_location": "/windowslib/uuid",
   "_nodeVersion": "6.7.0",
   "_npmOperationalInternal": {
@@ -44,7 +45,7 @@
   "_shasum": "6728fc0459c450d796a99c31837569bdf672d728",
   "_shrinkwrap": null,
   "_spec": "uuid@3.0.0",
-  "_where": "/Users/chris/appc/titanium_mobile/node_modules/windowslib",
+  "_where": "D:\\workspace\\titanium_mobile\\node_modules\\windowslib",
   "bin": {
     "uuid": "./bin/uuid"
   },

--- a/node_modules/windowslib/package.json
+++ b/node_modules/windowslib/package.json
@@ -10,12 +10,13 @@
         "spec": "0.4.29",
         "type": "version"
       },
-      "/Users/chris/appc/titanium_mobile"
+      "C:\\Users\\gmathews\\github\\titanium_mobile"
     ]
   ],
   "_from": "windowslib@0.4.29",
   "_id": "windowslib@0.4.29",
   "_inCache": true,
+  "_installable": true,
   "_location": "/windowslib",
   "_nodeVersion": "4.6.1",
   "_npmOperationalInternal": {
@@ -44,7 +45,7 @@
   "_shasum": "62f8b7184862ac809b2ba7e15a6a1347e10a0f98",
   "_shrinkwrap": null,
   "_spec": "windowslib@0.4.29",
-  "_where": "/Users/chris/appc/titanium_mobile",
+  "_where": "C:\\Users\\gmathews\\github\\titanium_mobile",
   "author": {
     "name": "Appcelerator, Inc.",
     "email": "npmjs@appcelerator.com"


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-24189

- [TIMOB-24189](https://jira.appcelerator.org/browse/TIMOB-24189) Support Visual Studio 2017
- [TIMOB-24183](https://jira.appcelerator.org/browse/TIMOB-24183) Failed to install WP 8.1 app
- Require uuid instead of node-uuid because node-uuid is deprecated
