### PR TITLE
(6_0_X) [TIMOB-24480] Android: appc run based module builds fail due to double-namespaced classes in KrollGeneratedBindings.gperf

### DIFF
--- a/android/cli/commands/_buildModule.js
+++ b/android/cli/commands/_buildModule.js
@@ -733,7 +733,7 @@ AndroidModuleBuilder.prototype.generateV8Bindings = function (next) {
 					return s.toLowerCase();
 				});
 
-				if (!(moduleNamespace in namespaces)) {
+				if (namespaces.indexOf(moduleNamespace) == -1) {
 					namespaces.unshift(moduleNamespace.split('.').join('::'));
 				}
 


### PR DESCRIPTION
This is attempt number 2 for this fix. I apparently had tweaked my SDK installs with fixes I never ported back into the repo here!

**JIRA:** https://jira.appcelerator.org/browse/TIMOB-24480

