### PR TITLE
[TIMOB-24524] Android: module build fails for some native modules with 'mthodMap is not defined'

### DIFF
--- a/android/cli/commands/_buildModule.js
+++ b/android/cli/commands/_buildModule.js
@@ -619,7 +619,7 @@ AndroidModuleBuilder.prototype.generateV8Bindings = function (next) {
 			Object.keys(proxyMap.methods).forEach(function (method) {
 				var methodMap = proxyMap.methods[method];
 				if (methodMap.hasInvocation) {
-					invocationAPIs.push(mthodMap);
+					invocationAPIs.push(methodMap);
 				}
 			});
 		}


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-24524

Note that of all our modules, I only ran into this issue with appcelerator.encrypteddatabase.