### PR TITLE
(6_0_X)[TIMOB-24524] Android: module build fails for some native modules with 'mthodMap is not defined'

### DIFF
--- a/android/cli/commands/_buildModule.js
+++ b/android/cli/commands/_buildModule.js
@@ -618,7 +618,7 @@ AndroidModuleBuilder.prototype.generateV8Bindings = function (next) {
 			Object.keys(proxyMap.methods).forEach(function (method) {
 				var methodMap = proxyMap.methods[method];
 				if (methodMap.hasInvocation) {
-					invocationAPIs.push(mthodMap);
+					invocationAPIs.push(methodMap);
 				}
 			});
 		}


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-24524

Backport of #8898 