### PR TITLE
[TIMOB-24406] Android: Fix Ti.UI.View.center property setter

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/TiViewProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/TiViewProxy.java
@@ -59,7 +59,7 @@ import android.view.ViewAnimationUtils;
 	"borderColor", "borderRadius", "borderWidth",
 
 	// layout / dimension (size/width/height have custom accessors)
-	"left", "top", "right", "bottom", "layout", "zIndex",
+	"left", "top", "right", "bottom", "layout", "zIndex", TiC.PROPERTY_CENTER,
 
 	// accessibility
 	TiC.PROPERTY_ACCESSIBILITY_HINT, TiC.PROPERTY_ACCESSIBILITY_LABEL, TiC.PROPERTY_ACCESSIBILITY_VALUE,


### PR DESCRIPTION
- Define accessors for `Titanium.UI.View.center` property

###### TEST CASE
```JS
var win = Ti.UI.createWindow({backgroundColor: 'gray'}),
    view = Ti.UI.createView({
        backgroundColor : 'red',
        width: 100, height: 100,
        center: {x: 0, y: 0}
    });

view.addEventListener('click', function() {
    Ti.API.info('set view center');
    view.center = {
        x: Math.floor(Math.random() * 100) + 100,
        y: Math.floor(Math.random() * 100) + 100
    };
});

win.add(view);
win.open();
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-24428)