### PR TITLE
[TIMOB-24527] Android: Intents using FLAG_ACTIVITY_NEW_DOCUMENT can cause issues with KrollRuntime

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/TiRootActivity.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiRootActivity.java
@@ -78,6 +78,19 @@ public class TiRootActivity extends TiLaunchActivity
 
 		if (intent != null) {
 			if (rootActivity != null) {
+
+				// TIMOB-24527: FLAG_ACTIVITY_NEW_DOCUMENT creates a new activity instance
+				// which overrides any previous event handlers and prevents resumed instances
+				// from functioning correctly. We need to ignore this flag.
+				if ((intent.getFlags() & Intent.FLAG_ACTIVITY_NEW_DOCUMENT) != 0) {
+					intent.setFlags(intent.getFlags() & ~Intent.FLAG_ACTIVITY_NEW_DOCUMENT);
+					finish();
+					startActivity(intent);
+
+					KrollRuntime.incrementActivityRefCount();
+					activityOnCreate(savedInstanceState);
+					return;
+				}
 				rootActivity.setIntent(intent);
 			} else {
 


### PR DESCRIPTION
**WARNING: https://github.com/appcelerator/titanium_mobile/pull/8897 must be merged first!**

- New activity instances created using `FLAG_ACTIVITY_NEW_DOCUMENT` (e.g: when launched from Gmail) can cause issues with KrollRuntime and override the event listeners.
- Prevent `FLAG_ACTIVITY_NEW_DOCUMENT` from taking effect

###### TEST CASE
##### tiapp.xml
```XML
<android ...>
    ...
   <manifest ...>
       ...
        <intent-filter>
            <action android:name="android.intent.action.VIEW" />
            <category android:name="android.intent.category.DEFAULT" />
            <category android:name="android.intent.category.BROWSABLE" />
            <data android:scheme="http" />
            <data android:scheme="https" />
            <data android:host="www.android.com" />
        </intent-filter>
        ...
    </manifest>
</android>
```
##### app.js
```JS
var win = Ti.UI.createWindow({
        layout: 'vertical'
    }),
    bar = Ti.UI.createView({
        layout: 'horizontal',
        width: Ti.UI.FILL,
        height: Ti.UI.SIZE
    })
    currentData = Ti.UI.createButton({
        title: 'CURRENT DATA',
        left: 0
    }),
    clear = Ti.UI.createButton({
        title: 'CLEAR',
        right: 0
    }),
    scrollView = Ti.UI.createScrollView({
        layout: 'vertical',
        height: Ti.UI.FILL,
        backgroundColor: 'white'
    });

// show current data
currentData.addEventListener('click', () => {
    alert(Ti.Android.currentActivity.getIntent().data);
});

// clear intent log
clear.addEventListener('click', function (e) {
    scrollView.removeAllChildren();
});

// launch intent
scrollView.add(Ti.UI.createLabel({
    top: 10,
    color: 'black',
    text: 'LAUNCH INTENT ' + JSON.stringify(Ti.Android.currentActivity.getIntent()) + ' WITH DATA: ' + Ti.Android.currentActivity.getIntent().data
}));

bar.add(currentData);
bar.add(clear);
win.add(bar);
win.add(scrollView);
win.open();
```
1. Launch app via a link in Gmail: `www.android.com/0`
2. Press 'CURRENT DATA', should display `www.android.com/0`
3. Open recent apps menu and resume Gmail
4. Launch app via link in Gmail: `www.android.com/1`
5. Press 'CURRENT DATA', should display `www.android.com/1`
6. Open recent apps menu and resume Gmail
7. Launch app via a link in Gmail: `www.android.com/0`
8. Press 'CURRENT DATA', should display `www.android.com/0` but does not

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-24527)