### PR TITLE
[TIMOB-24496]:iOS Camera overlay does not fill the entire screen when orientation is changed on iPad, Titanium SDK 6.0.0 and later

### DIFF
--- a/iphone/Classes/MediaModule.m
+++ b/iphone/Classes/MediaModule.m
@@ -1704,7 +1704,6 @@ MAKE_SYSTEM_PROP(VIDEO_TIME_OPTION_EXACT,MPMovieTimeOptionExact);
             
             [cameraView windowWillOpen];
             [picker setCameraOverlayView:view];
-            [view setAutoresizingMask:UIViewAutoresizingNone];
             
             [cameraView windowDidOpen];
             [cameraView layoutChildren:NO];


### PR DESCRIPTION
 https://jira.appcelerator.org/browse/TIMOB-24496
