### PR TITLE
[TIMOB-23757] Android: Fix TextField keyboard overlap

### DIFF
--- a/android/modules/ui/res/layout/titanium_ui_edittext.xml
+++ b/android/modules/ui/res/layout/titanium_ui_edittext.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<EditText xmlns:android="http://schemas.android.com/apk/res/android"
+<ti.modules.titanium.ui.widget.TiUIEditText xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/titanium_ui_edittext"
     android:layout_height="wrap_content"
     android:layout_width="wrap_content"

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIEditText.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIEditText.java
@@ -1,0 +1,27 @@
+package ti.modules.titanium.ui.widget;
+
+import android.content.Context;
+import android.os.Build;
+import android.util.AttributeSet;
+import android.view.Gravity;
+import android.view.KeyEvent;
+import android.view.ViewGroup;
+import android.widget.EditText;
+
+public class TiUIEditText extends EditText {
+
+	public TiUIEditText(Context context, AttributeSet attributeSet) {
+		super(context, attributeSet);
+	}
+
+	@Override
+	public boolean onKeyPreIme(int keyCode, KeyEvent event) {
+		// TIMOB-23757: https://code.google.com/p/android/issues/detail?id=182191
+		if (Build.VERSION.SDK_INT < 24 && (getGravity() & Gravity.LEFT) != Gravity.LEFT && keyCode == KeyEvent.KEYCODE_BACK) {
+			ViewGroup view = (ViewGroup) getParent();
+			view.setFocusableInTouchMode(true);
+			view.requestFocus();
+		}
+		return super.onKeyPreIme(keyCode, event);
+	}
+}

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIText.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIText.java
@@ -21,6 +21,7 @@ import org.appcelerator.titanium.util.TiUIHelper;
 import org.appcelerator.titanium.view.TiUIView;
 
 import ti.modules.titanium.ui.AttributedStringProxy;
+import android.content.Context;
 import android.graphics.Rect;
 import android.graphics.Typeface;
 import android.os.Build;
@@ -40,6 +41,8 @@ import android.view.Gravity;
 import android.view.KeyEvent;
 import android.view.View;
 import android.view.View.OnFocusChangeListener;
+import android.view.ViewGroup;
+import android.view.inputmethod.InputMethodManager;
 import android.view.inputmethod.EditorInfo;
 import android.widget.EditText;
 import android.widget.TextView;
@@ -84,7 +87,7 @@ public class TiUIText extends TiUIView
 	private boolean isTruncatingText = false;
 	private boolean disableChangeEvent = false;
 
-	protected EditText tv;
+	protected TiUIEditText tv;
 
 	public TiUIText(final TiViewProxy proxy, boolean field)
 	{
@@ -102,7 +105,7 @@ public class TiUIText extends TiUIView
 			}
 			return;
 		}
-		tv = (EditText) TiApplication.getAppCurrentActivity().getLayoutInflater().inflate(tvId, null);
+		tv = (TiUIEditText) TiApplication.getAppCurrentActivity().getLayoutInflater().inflate(tvId, null);
 
 		tv.addOnLayoutChangeListener(new View.OnLayoutChangeListener()
 		{
@@ -433,6 +436,18 @@ public class TiUIText extends TiUIView
 	@Override
 	public boolean onEditorAction(TextView v, int actionId, KeyEvent keyEvent)
 	{
+		// TIMOB-23757: https://code.google.com/p/android/issues/detail?id=182191
+		if (Build.VERSION.SDK_INT < 24 && (tv.getGravity() & Gravity.LEFT) != Gravity.LEFT) {
+			if (getNativeView() != null) {
+				ViewGroup view = (ViewGroup) getNativeView().getParent();
+				view.setFocusableInTouchMode(true);
+				view.requestFocus();
+			}
+			Context context = TiApplication.getInstance().getApplicationContext();
+			InputMethodManager inputManager = (InputMethodManager) context.getSystemService(Context.INPUT_METHOD_SERVICE);
+			inputManager.hideSoftInputFromWindow(tv.getWindowToken(), 0);
+		}
+
 		String value = tv.getText().toString();
 		KrollDict data = new KrollDict();
 		data.put(TiC.PROPERTY_VALUE, value);


### PR DESCRIPTION
- Fix Android issue [182191](https://code.google.com/p/android/issues/detail?id=182191)

###### TEST CASE
```Javascript
var win = Ti.UI.createWindow({
        backgroundColor : 'white'
    }),
    a = Ti.UI.createTextField({
        bottom : 10,
        width: '90%',
        textAlign : Titanium.UI.TEXT_ALIGNMENT_RIGHT,
        color: 'black'
    });

win.add(a);
win.open();
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-23757)