### PR TITLE
[TIMOB-24451] Fix init of ListView in ListViewProxy

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/ListViewProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/ListViewProxy.java
@@ -150,7 +150,11 @@ public class ListViewProxy extends TiViewProxy {
 	}
 	
 	public int handleSectionCount () {
+		if (peekView() == null && getParent() != null) {
+			getParent().getOrCreateView();
+		}
 		TiUIView listView = peekView();
+		
 		if (listView != null) {
 			return ((TiListView) listView).getSectionCount();
 		}
@@ -471,6 +475,9 @@ public class ListViewProxy extends TiViewProxy {
 	
 	private ListSectionProxy[] handleSections()
 	{
+		if (peekView() == null && getParent() != null) {
+			getParent().getOrCreateView();
+		}
 		TiUIView listView = peekView();
 
 		if (listView != null) {


### PR DESCRIPTION
- In some cases property getter events are fired before `TiListView` has been initialised by its parent
- Make sure the view is available before returning section data

###### TEST CASE
- [Project on JIRA](https://jira.appcelerator.org/secure/attachment/61783/TIMOB-24451.zip)

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-24451)