### PR TITLE
[TIMOB-24528] Android: Fixed issue where images (such as camera photos) will fail to load if too big to be shown by the GPU. Now auto-downscales to fit.

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIButton.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIButton.java
@@ -72,7 +72,7 @@ public class TiUIButton extends TiUIView
 			}
 
 			if (drawableRef != null) {
-				Drawable image = drawableRef.getDensityScaledDrawable();
+				Drawable image = drawableRef.getDrawable();
 				btn.setCompoundDrawablesWithIntrinsicBounds(image, null, null, null);
 			}
 		} else if (d.containsKey(TiC.PROPERTY_BACKGROUND_COLOR)) {

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIImageView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIImageView.java
@@ -47,6 +47,7 @@ import android.os.Handler;
 import android.os.Looper;
 import android.os.Message;
 import android.os.Bundle;
+import android.util.DisplayMetrics;
 import android.view.View;
 import android.view.ViewParent;
 
@@ -261,10 +262,20 @@ public class TiUIImageView extends TiUIView implements OnLifecycleEvent, Handler
 
 	private void handleSetImage(final Bitmap bitmap)
 	{
+		// Fetch the image view.
 		TiImageView view = getView();
-		if (view != null) {
-			view.setImageBitmap(bitmap);
+		if (view == null) {
+			return;
 		}
+
+		// Clear the DPI/density setting from the bitmap.
+		// This makes the view display the bitmap pixel perfect, without density scaling.
+		if (bitmap != null) {
+			bitmap.setDensity(Bitmap.DENSITY_NONE);
+		}
+
+		// Show the given bitmap in the view.
+		view.setImageBitmap(bitmap);
 	}
 
 	private class BitmapWithIndex

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiNinePatchHelper.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiNinePatchHelper.java
@@ -50,13 +50,13 @@ public class TiNinePatchHelper
 				if ((ninePatchChunk != null) && NinePatch.isNinePatchChunk(ninePatchChunk)) {
 					// The bitmap already has 9-patch pixels extracted from the image. Use it as-is.
 					// Note: This is typically the case for image's under the APK's "res/drawable" directories.
-			        nd = new NinePatchDrawable(resources, b, ninePatchChunk, new Rect(1,1,1,1), "");
+					nd = new NinePatchDrawable(resources, b, ninePatchChunk, new Rect(1,1,1,1), "");
 				}
 				else if (isNinePatch(b)) {
 					// The bitmap has 9-patch pixels on the edges. Extract it and crop the pixels off.
 					// Note: This is typically the case for images under the APK's "assets" directory.
-			        ninePatchChunk = createChunk(b);
-			        nd = new NinePatchDrawable(resources, cropNinePatch(b), ninePatchChunk, new Rect(1,1,1,1), "");
+					ninePatchChunk = createChunk(b);
+					nd = new NinePatchDrawable(resources, cropNinePatch(b), ninePatchChunk, new Rect(1,1,1,1), "");
 				}
 			}
 		}
@@ -88,8 +88,8 @@ public class TiNinePatchHelper
 			else if (isNinePatch(b)) {
 				// The bitmap has 9-patch pixels on the edges. Extract it and crop the pixels off.
 				// Note: This is typically the case for images under the APK's "assets" directory.
-		        ninePatchChunk = createChunk(b);
-		        nd = new NinePatchDrawable(resources, cropNinePatch(b), ninePatchChunk, new Rect(1,1,1,1), "");
+				ninePatchChunk = createChunk(b);
+				nd = new NinePatchDrawable(resources, cropNinePatch(b), ninePatchChunk, new Rect(1,1,1,1), "");
 			}
 			else {
 				// The given bitmap is not a 9-patch image. Display it in a drawable as-is.
@@ -164,17 +164,17 @@ public class TiNinePatchHelper
 		return (c == 0 || (c == Color.BLACK));
 	}
 
-    private Bitmap cropNinePatch(Bitmap b) {
-    	Bitmap cb = null;
+	private Bitmap cropNinePatch(Bitmap b) {
+		Bitmap cb = null;
 
-    	cb = Bitmap.createBitmap(b.getWidth()-2, b.getHeight()-2, b.getConfig());
-    	int[] pixels = new int[cb.getWidth() * cb.getHeight()];
-    	b.getPixels(pixels, 0, cb.getWidth(), 1, 1, cb.getWidth(), cb.getHeight());
-    	cb.setPixels(pixels, 0, cb.getWidth(), 0, 0, cb.getWidth(), cb.getHeight());
+		cb = Bitmap.createBitmap(b.getWidth()-2, b.getHeight()-2, b.getConfig());
+		int[] pixels = new int[cb.getWidth() * cb.getHeight()];
+		b.getPixels(pixels, 0, cb.getWidth(), 1, 1, cb.getWidth(), cb.getHeight());
+		cb.setPixels(pixels, 0, cb.getWidth(), 0, 0, cb.getWidth(), cb.getHeight());
 		cb.setDensity(b.getDensity());
 
-    	return cb;
-    }
+		return cb;
+	}
 
     byte[] createChunk(Bitmap b) {
     	byte[] chunk = null;

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiUIHelper.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiUIHelper.java
@@ -948,7 +948,8 @@ public class TiUIHelper
 	
 	public static Drawable getResourceDrawable(int res_id)
 	{
-		return TiApplication.getInstance().getResources().getDrawable(res_id);
+		Activity activity = TiApplication.getInstance().getCurrentActivity();
+		return TiDrawableReference.fromResourceId(activity, res_id).getDrawable();
 	}
 
 	public static Drawable getResourceDrawable(Object path)


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-24528

**Testing:**
See JIRA case above for steps to reproduce this issue.

**Notes:**

- Most image loading code has been re-routed to the TiDrawableReference class which now automatically down-samples images if larger than GPU max texture size or 100 MB drawable bitmap limit.
- Fixed TiDrawableReference.getDensityScaledBitmap() which was wrongly upscaling non-resource bitmaps in RAM and then shrinking the drawable back to the image's original pixel size, causing no size changes onscreen, wasting memory, and increasing chance of out-of-memory exceptions. It now loads images as-is and scales the drawable.
- Changes made to TiUIImage and TiUIButton are not breaking changes. They will still size/scale images the same as before. They were changed because TiDrawableReference was returning incorrectly scaled drawables (were defaulting to MDPI on all devices), which is now fixed.
- Fixed caching bugs in TiDrawableReference.peekBounds() method. It was incorrectly using hash-codes as a key (not guaranteed to be unique). Plus, it shouldn't have been caching the bounds of mutable images, such as files under external storage.
- Fixed 9-patch handling code which incorrectly scaled based on MDPI on all devices. (Also, bitmap loading fixes made TiDrawableReference impacted TiNinePatchHelper class.)
