### PR TITLE
[TIMOB-24659] Android: Add support for the roundIcon attribute

### DIFF
--- a/android/cli/lib/AndroidManifest.js
+++ b/android/cli/lib/AndroidManifest.js
@@ -23,7 +23,7 @@ var appc = require('node-appc'),
 	},
 
 	tagAttrs = {
-		'application': /^(allowTaskReparenting|allowBackup|backupAgent|debuggable|description|enabled|hasCode|hardwareAccelerated|icon|killAfterRestore|largeHeap|label|logo|manageSpaceActivity|name|permission|persistent|process|restoreAnyVersion|requiredAccountType|restrictedAccountType|supportsRtl|taskAffinity|testOnly|theme|uiOptions|vmSafeMode)$/,
+		'application': /^(allowTaskReparenting|allowBackup|backupAgent|debuggable|description|enabled|hasCode|hardwareAccelerated|icon|roundIcon|killAfterRestore|largeHeap|label|logo|manageSpaceActivity|name|permission|persistent|process|restoreAnyVersion|requiredAccountType|restrictedAccountType|supportsRtl|taskAffinity|testOnly|theme|uiOptions|vmSafeMode)$/,
 		'activity': /^(allowTaskReparenting|alwaysRetainTaskState|clearTaskOnLaunch|configChanges|enabled|excludeFromRecents|exported|finishOnTaskLaunch|hardwareAccelerated|icon|label|launchMode|multiprocess|name|noHistory|parentActivityName|permission|process|screenOrientation|stateNotNeeded|taskAffinity|theme|uiOptions|windowSoftInputMode)$/,
 		'activity-alias': /^(enabled|exported|icon|label|name|permission|targetActivity)$/,
 		'data': /^(host|mimeType|path|pathPattern|pathPrefix|port|scheme)$/,


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-24659

**Optional Description:**
Android 7.1 allow applications to show a circular icon in the launcher, for devices that supports them (ex. Pixel & Pixel XL).
Titanium should support the android:roundIcon attribute in AndroidManifest.xml.