### PR TITLE
Warn and handle when the docs for a given type had an empty/null listing and we're appending create* methods to it.

### DIFF
--- a/apidoc/docgen.js
+++ b/apidoc/docgen.js
@@ -455,7 +455,16 @@ function processAPIs (api) {
 					'__subtype': 'method'
 				};
 				api.__creatable = true;
-				'methods' in doc[cls] ? doc[cls].methods.push(createMethod) : doc[cls].methods = [createMethod];
+				if ('methods' in doc[cls]) {
+					if (!doc[cls].methods) {
+						common.log(common.LOG_WARN, 'Empty \'methods\' listing for class: %s', cls);
+						doc[cls].methods = [createMethod];
+					} else {
+						doc[cls].methods.push(createMethod);
+					}
+				} else {
+					doc[cls].methods = [createMethod];
+				}
 			}
 		}
 	}


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIDOC-2860?focusedCommentId=419212&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-419212

**Description:**
CoreMotion's main module xml had an empty 'methods' listing which broke our docgen tool. We assumed if the type had a 'methods' property it'd be non-null. But if it's empty it exists and is null. I modified docgen to handle this case and spit out a warning about the empty methods listing on the type (this happened when adding create* methods on the module from the createable flags on other types in the module).