### PR TITLE
[6_1_0][TIMOB-8430]Android: fix google issue with am/pm

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/picker/TiUITimePicker.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/picker/TiUITimePicker.java
@@ -163,12 +163,11 @@ public class TiUITimePicker extends TiUIView
 		Calendar calendar = Calendar.getInstance();
 		calendar.set(Calendar.HOUR_OF_DAY, hourOfDay);
 		calendar.set(Calendar.MINUTE, minute);
+		proxy.setProperty("value", calendar.getTime());
 		if (!suppressChangeEvent) {
 			KrollDict data = new KrollDict();
 			data.put("value", calendar.getTime());
-			fireEvent("change", data);		
+			fireEvent("change", data);
 		}
-		// Make sure .value is readable by user
-		proxy.setProperty("value", calendar.getTime());
 	}
 }

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/picker/TiUITimePicker.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/picker/TiUITimePicker.java
@@ -13,6 +13,7 @@ import org.appcelerator.kroll.KrollDict;
 import org.appcelerator.kroll.KrollProxy;
 import org.appcelerator.kroll.common.Log;
 import org.appcelerator.titanium.proxy.TiViewProxy;
+import org.appcelerator.titanium.TiApplication;
 import org.appcelerator.titanium.util.TiConvert;
 import org.appcelerator.titanium.util.TiRHelper;
 import org.appcelerator.titanium.util.TiUIHelper;
@@ -20,7 +21,9 @@ import org.appcelerator.titanium.util.TiRHelper.ResourceNotFoundException;
 import org.appcelerator.titanium.view.TiUIView;
 
 import android.app.Activity;
+import android.content.res.Resources;
 import android.os.Build;
+import android.view.View;
 import android.widget.TimePicker;
 import android.widget.TimePicker.OnTimeChangedListener;
 
@@ -32,6 +35,9 @@ public class TiUITimePicker extends TiUIView
 	
 	protected Date minDate, maxDate;
 	protected int minuteInterval;
+
+	private static int id_am = 0;
+	private static int id_pm = 0;
 	
 	public TiUITimePicker(TiViewProxy proxy)
 	{
@@ -42,7 +48,7 @@ public class TiUITimePicker extends TiUIView
 		this(proxy);
 		Log.d(TAG, "Creating a time picker", Log.DEBUG_MODE);
 		
-		TimePicker picker;
+		final TimePicker picker;
 		// If it is not API Level 21 (Android 5.0), create picker normally.
 		// If not, it will inflate a spinner picker to address a bug.
 		if (Build.VERSION.SDK_INT != Build.VERSION_CODES.LOLLIPOP) {
@@ -55,6 +61,36 @@ public class TiUITimePicker extends TiUIView
 					TiUIHelper.firePostLayoutEvent(proxy);
 				}
 			};
+
+			// TIMOB-8430: https://issuetracker.google.com/issues/36931448
+			if (Build.VERSION.SDK_INT > Build.VERSION_CODES.LOLLIPOP && Build.VERSION.SDK_INT <= Build.VERSION_CODES.M) {
+				Resources resources = TiApplication.getInstance().getResources();
+				if (id_am == 0) {
+					id_am = resources.getIdentifier("android:id/am_label", "drawable", "android.widget.TimePicker");
+				}
+				if (id_pm == 0) {
+					id_pm = resources.getIdentifier("android:id/pm_label", "drawable", "android.widget.TimePicker");
+				}
+				View am = (View) picker.findViewById(id_am);
+				View pm = (View) picker.findViewById(id_pm);
+				View.OnClickListener listener = new View.OnClickListener() {
+					@Override
+					public void onClick(View v) {
+						if (Build.VERSION.SDK_INT >= 23) {
+							picker.setHour((picker.getHour() + 12) % 24);
+						} else {
+							picker.setCurrentHour((picker.getCurrentHour() + 12) % 24);
+						}
+					}
+				};
+				if (am != null) {
+					am.setOnClickListener(listener);
+				}
+				if (pm != null) {
+					pm.setOnClickListener(listener);
+				}
+			}
+
 		} else {
 			// A bug where PickerCalendarDelegate does not send events to the
 			// listener on API Level 21 (Android 5.0) for TIMOB-19192


### PR DESCRIPTION
**Test Case**
label should show the same time, in 24 hour format, as the time picker when toggling "AM" or "PM".
```
var win = Titanium.UI.createWindow();
var lbl = Titanium.UI.createLabel({
	color: '#999',
	text: 'Set the time below',
	font: {fontSize: 20, fontFamily: 'Helvetica Neue'},
	textAlign: 'center',
	width: 'auto',
	top: '0'
});
var pkr = Titanium.UI.createPicker({
	type: Ti.UI.PICKER_TYPE_TIME,
	top: '40',
	backgroundColor: "red",
	format24: false
});
pkr.addEventListener('change', function (e) {
	lbl.text = pkr.value;
	console.log("test msg picker value: " + pkr.value);
});
win.add(lbl);
win.add(pkr);
win.open();
```
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-8430
