### PR TITLE
[TIMOB-24655] Android: Disable HW-acceleration when opacity is defined

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiUIView.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiUIView.java
@@ -89,6 +89,7 @@ public abstract class TiUIView
 	private static final boolean HONEYCOMB_OR_GREATER = (Build.VERSION.SDK_INT >= 11);
 	private static final boolean LOLLIPOP_OR_GREATER = (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP);
 	private static final boolean LOWER_THAN_JELLYBEAN = (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR2);
+	private static final boolean LOWER_THAN_MARSHMALLOW = (Build.VERSION.SDK_INT < Build.VERSION_CODES.M);
 
 	private static final int LAYER_TYPE_SOFTWARE = 1;
 	private static final String TAG = "TiUIView";
@@ -1409,7 +1410,8 @@ public abstract class TiUIView
 					if (radiusDim != null) {
 						radius = (float) radiusDim.getPixels(getNativeView());
 					}
-					if (radius > 0f && HONEYCOMB_OR_GREATER && LOWER_THAN_JELLYBEAN) {
+					if (radius > 0f && HONEYCOMB_OR_GREATER &&
+							(LOWER_THAN_JELLYBEAN || (d.containsKey(TiC.PROPERTY_OPACITY) && LOWER_THAN_MARSHMALLOW))) {
 						disableHWAcceleration();
 					}
 					borderView.setRadius(radius);
@@ -1455,7 +1457,8 @@ public abstract class TiUIView
 			if (radiusDim != null) {
 				radius = (float) radiusDim.getPixels(getNativeView());
 			}
-			if (radius > 0f && HONEYCOMB_OR_GREATER && LOWER_THAN_JELLYBEAN) {
+			if (radius > 0f && HONEYCOMB_OR_GREATER &&
+					(LOWER_THAN_JELLYBEAN || (proxy.hasProperty(TiC.PROPERTY_OPACITY) && LOWER_THAN_MARSHMALLOW))) {
 				disableHWAcceleration();
 			}
 			borderView.setRadius(radius);


### PR DESCRIPTION
- Disable hardware-acceleration when `opacity` is defined on Android 5.1 or lower

##### TEST CASE
```JS
var win = Titanium.UI.createWindow({backgroundColor: 'white', layout: 'vertical'}),
    a = Ti.UI.createView({
        top: 10,
        backgroundColor: 'blue',
        width: 200, height: 200
    }),
    b = Ti.UI.createView({
        top: 10,
        backgroundColor: 'orange',
        width: 100, height: 100,
        borderWidth: 3,
        borderRadius: 50,
        borderColor: 'red'
    }),
    c = Ti.UI.createView({
        top: 10,
        backgroundColor: 'red',
        width: 100, height: 100,
        opacity: 0.5,
        borderRadius: 35
    });

a.add(require('ti.map').createView({
    height: Ti.UI.FILL,
    width: Ti.UI.FILL,
    borderRadius: 10
}));

win.add([a, b, c]);
win.open();
```
- Test on Android versions `4.1, 4.2, 4.3, 5.0, 5.1 and 6.0`

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-24655)