### PR TITLE
Fix extensions not including enterprise provisioning profiles

### DIFF
--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -1594,7 +1594,7 @@ iOSBuilder.prototype.initTiappSettings = function initTiappSettings() {
 					pps = this.iosInfo.provisioning.development;
 					pp = getPPbyUUID();
 				} else if (cli.argv.target === 'dist-appstore' || cli.argv.target === 'dist-adhoc') {
-					pps = [].concat(this.iosInfo.provisioning.distribution, this.iosInfo.provisioning.adhoc);
+					pps = [].concat.apply([], [this.iosInfo.provisioning.distribution, this.iosInfo.provisioning.adhoc, this.iosInfo.provisioning.enterprise]);
 					pp = getPPbyUUID();
 				}
 


### PR DESCRIPTION
Contributions guidelines are a little much. Copy this fix over if you want and delete the request. 
