### PR TITLE
[TIMOB-24703] Generate R classes for modules

### DIFF
--- a/android/cli/commands/_buildModule.js
+++ b/android/cli/commands/_buildModule.js
@@ -1754,6 +1754,11 @@ AndroidModuleBuilder.prototype.packageZip = function (next) {
 					dest.append(fs.createReadStream(this.metaDataFile), { name: path.join(moduleFolder,'metadata.json') });
 				}
 
+				var symbolOutputPathAndFilename = path.join(this.buildIntermediatesDir, 'bundles/R.txt');
+				if (fs.existsSync(symbolOutputPathAndFilename)) {
+					dest.append(fs.createReadStream(symbolOutputPathAndFilename), {name: path.join(moduleFolder, 'R.txt')});
+				}
+
 				this.logger.info(__('Writing module zip: %s', moduleZipPath));
 				dest.finalize();
 			} catch (ex) {


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-24703

**Optional Description:**
Fixes a bug in the new R.java class generation where the R class for a module was not generated.