### PR TITLE
[TIMOB-24733](6_1_X) Add missing --no-version-vectors option to aapt

### DIFF
--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -3700,7 +3700,8 @@ AndroidBuilder.prototype.packageApp = function packageApp(next) {
 			'-S', this.buildResDir,
 			'-I', this.androidTargetSDK.androidJar,
 			'-F', this.ap_File,
-			'--output-text-symbols', bundlesPath
+			'--output-text-symbols', bundlesPath,
+			'--no-version-vectors'
 		];
 
 	var runAapt = function runAapt() {


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-24733

**Optional Description:**
6_1_X backport of #9084 