### PR TITLE
[TIMOB-24737] Android: Fix Ti.UI.WebView.disableContextMenu getter

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/WebViewProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/WebViewProxy.java
@@ -74,6 +74,7 @@ public class WebViewProxy extends ViewProxy
 		defaultValues.put(TiC.PROPERTY_LIGHT_TOUCH_ENABLED, true);
 		defaultValues.put(TiC.PROPERTY_ENABLE_JAVASCRIPT_INTERFACE, true);
 		defaultValues.put(TiC.PROPERTY_BORDER_RADIUS, 0);
+		defaultValues.put(TiC.PROPERTY_DISABLE_CONTEXT_MENU, false);
 	}
 
 	@Override
@@ -349,7 +350,10 @@ public class WebViewProxy extends ViewProxy
 	@Kroll.method @Kroll.getProperty
 	public boolean getDisableContextMenu()
 	{
-		return TiConvert.toBoolean(getProperty(TiC.PROPERTY_DISABLE_CONTEXT_MENU));
+		if (hasPropertyAndNotNull(TiC.PROPERTY_DISABLE_CONTEXT_MENU)) {
+			return TiConvert.toBoolean(getProperty(TiC.PROPERTY_DISABLE_CONTEXT_MENU));
+		}
+		return false;
 	}
 
 	@Kroll.method @Kroll.setProperty


### PR DESCRIPTION
- Set default value for `disableContextMenu`
- Guard against `null` value in `TiConvert.toBoolean`

##### TEST CASE
```JS
var win = Ti.UI.createWindow({layout: 'horizontal'}),
    wv = Ti.UI.createWebView({
        scalesPageToFit: true,
        height: Ti.UI.SIZE,
        url: 'http://bit.ly/2qrpV4L'
    }),
    btn = Ti.UI.createButton({
        title: 'GET disableContextMenu',
        width: '100%'
    });

btn.addEventListener('click', function() {
    alert('disableContextMenu: ' + wv.getDisableContextMenu());
});

win.add([btn, wv]);
win.open();
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-24737)