### PR TITLE
[6_1_X] Android: Modified default API Level to only target 23.

### DIFF
--- a/android/package.json
+++ b/android/package.json
@@ -15,7 +15,7 @@
 	],
 	"minSDKVersion": "14",
 	"vendorDependencies": {
-		"android sdk": ">=23 <=25.x",
+		"android sdk": "23.x",
 		"android build tools": ">=17 <=25.x",
 		"android platform tools": ">=17 <=25.x",
 		"android tools": "<=26.x",


### PR DESCRIPTION
**Summary:**
Fixed build system to not target Android API Levels higher than 23 yet.
(We can't target higher API level until Android 7 breaking changes have been resolved first.)

**Test Case:**

1. Go to a machine having an Android SDK with API Level 24 or 25 installed.
2. Create a new classic app project.
3. Build for Android.
4. Go to the project folder in Windows Explorer or Finder on Mac.
5. Go to the "./build/android" directory.
6. Open the "AndroidManifest.xml" file.
7. Verify that the "targetSdkVersion" attribute is set to 23.
