### PR TITLE
[TIMOB-24778] Update minimum android build tools

### DIFF
--- a/android/package.json
+++ b/android/package.json
@@ -16,7 +16,7 @@
 	"minSDKVersion": "14",
 	"vendorDependencies": {
 		"android sdk": ">=23 <=25.x",
-		"android build tools": ">=17 <=25.x",
+		"android build tools": ">=23 <=25.x",
 		"android platform tools": ">=17 <=25.x",
 		"android tools": "<=26.x",
 		"android ndk": ">=r8e <=r9",


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-24778

Due to [TIMOB-24733](https://jira.appcelerator.org/browse/TIMOB-24733) the minimum build tools is now 23 and up.

While fixing this I also filed, [TIMOB-24779](https://jira.appcelerator.org/browse/TIMOB-24779) as (to me) the error message if confusing)