### PR TITLE
(6_1_X) [TIMOB-24608] Android: respackage value in native module's manifest is ignored

### DIFF
--- a/android/cli/commands/_buildModule.js
+++ b/android/cli/commands/_buildModule.js
@@ -1772,6 +1772,11 @@ AndroidModuleBuilder.prototype.packageZip = function (next) {
 					}.bind(this));
 				}
 
+				// respackageinfo file
+				if (this.manifest.respackage) {
+					dest.append(this.manifest.respackage, { name: path.join(moduleFolder,'respackageinfo') });
+				}
+
 				dest.append(fs.createReadStream(this.licenseFile), { name: path.join(moduleFolder,'LICENSE') });
 				dest.append(fs.createReadStream(this.manifestFile), { name: path.join(moduleFolder,'manifest') });
 				dest.append(fs.createReadStream(this.moduleJarFile), { name: path.join(moduleFolder, this.moduleJarName) });


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-24608

**Description:**
Backport of #9063