### PR TITLE
(6_1_X) [TIMOB-24654] Android native module build fails with multiple commonjs assets

### DIFF
--- a/android/cli/commands/_buildModule.js
+++ b/android/cli/commands/_buildModule.js
@@ -1179,7 +1179,7 @@ AndroidModuleBuilder.prototype.compileJsClosure = function (next) {
 		}),
 		closureJarFile = path.join(this.platformPath, 'lib', 'closure-compiler.jar');
 
-	jsFilesToEncrypt.forEach(function (file) {
+	async.each(jsFilesToEncrypt, function(file, callback) {
 
 		var outputDir = path.dirname(path.join(this.buildGenJsDir, file)),
 			filePath = path.join(this.assetsDir, file);
@@ -1204,11 +1204,9 @@ AndroidModuleBuilder.prototype.compileJsClosure = function (next) {
 				'--jscomp_off=internetExplorerChecks'
 			],
 			{},
-			next
+			callback
 		);
-
-	}, this);
-
+	}.bind(this), next);
 };
 
 /*

--- a/android/cli/commands/_buildModule.js
+++ b/android/cli/commands/_buildModule.js
@@ -1179,7 +1179,8 @@ AndroidModuleBuilder.prototype.compileJsClosure = function (next) {
 		}),
 		closureJarFile = path.join(this.platformPath, 'lib', 'closure-compiler.jar');
 
-	async.each(jsFilesToEncrypt, function(file, callback) {
+	// Limit to 5 instances of Java in parallel at max, to be careful/conservative
+	async.eachLimit(jsFilesToEncrypt, 5, function(file, callback) {
 
 		var outputDir = path.dirname(path.join(this.buildGenJsDir, file)),
 			filePath = path.join(this.assetsDir, file);


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-24654

**Description:**
This is a follow-on fix to TIMOB-24654, reported by a user and seen when trying to compile syncserver native module for Android. When there are multiple JS files in the native module's assets folder, the CLI build would choke because it tried to call the same callback for each file rather than after all of them.

The master branch fix for same issue is #9116 