### PR TITLE
try to hack in a shared git reference clone across all PRs/branches. …

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,12 +71,29 @@ timestamps {
 	try {
 		node('git && android-sdk && android-ndk && ant && gperf && osx') {
 			stage('Checkout') {
+				// Update our shared reference repo for all branches/PRs
+				dir('..') {
+					sh 'mkdir -p titanium_mobile'
+					dir('titanium_mobile') {
+						checkout([
+							$class: 'GitSCM',
+							branches: [[name: '**']],
+							extensions: [
+								[$class: 'CloneOption', depth: 0, noTags: true, reference: '', shallow: false, timeout: 60]
+							],
+							userRemoteConfigs: scm.userRemoteConfigs
+						])
+					}
+				}
+
 				// checkout scm
 				// Hack for JENKINS-37658 - see https://support.cloudbees.com/hc/en-us/articles/226122247-How-to-Customize-Checkout-for-Pipeline-Multibranch
 				checkout([
 					$class: 'GitSCM',
 					branches: scm.branches,
-					extensions: scm.extensions + [[$class: 'CleanBeforeCheckout'], [$class: 'CloneOption', honorRefspec: true, noTags: true, reference: '', shallow: true, depth: 30, timeout: 30]],
+					extensions: scm.extensions + [
+						[$class: 'CleanBeforeCheckout'],
+						[$class: 'CloneOption', honorRefspec: true, noTags: true, reference: "${pwd()}/../titanium_mobile", shallow: true, depth: 30, timeout: 30]],
 					userRemoteConfigs: scm.userRemoteConfigs
 				])
 				// FIXME: Workaround for missing env.GIT_COMMIT: http://stackoverflow.com/questions/36304208/jenkins-workflow-checkout-accessing-branch-name-and-git-commit


### PR DESCRIPTION
…Each job will attempt to update/clone the repo to a shared location and then use that clone as a reference for it's own. This _should_ mean less full clones are necessary
