### PR TITLE
[TIMOB-24793] Android: Fix Ti.UI.View.center calculation

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiCompositeLayout.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiCompositeLayout.java
@@ -663,10 +663,10 @@ public class TiCompositeLayout extends ViewGroup
             int leftOrTopPixels = leftOrTop.getAsPixels(parent);
             pos[0] = layoutPosition0 + leftOrTopPixels;
             pos[1] = layoutPosition0 + leftOrTopPixels + measuredSize;
-        } else if (optionCenter != null && optionCenter.getValue() != 0.0) {
-            // Don't calculate position based on center dimension if it's 0.0
+        } else if (optionCenter != null) {
             int halfSize = measuredSize / 2;
-            pos[0] = layoutPosition0 + optionCenter.getAsPixels(parent) - halfSize;
+            int centerPixels = optionCenter.getAsPixels(parent);
+            pos[0] = layoutPosition0 + centerPixels - halfSize;
             pos[1] = pos[0] + measuredSize;
         } else if (rightOrBottom != null) {
             // peg right/bottom

--- a/apidoc/Titanium/UI/View.yml
+++ b/apidoc/Titanium/UI/View.yml
@@ -104,7 +104,7 @@ description: |
     
     For more details see: 
     
-    * [UI Composite Layout Spec](http://docs.appcelerator.com/platform/latest/!/guide/UI_Composite_Layout_Behavior_Spec)
+    * [UI Composite Layout Spec](http://docs.appcelerator.com/platform/latest/#!/guide/UI_Composite_Layout_Behavior_Spec)
     
     #### Size and Position
     


### PR DESCRIPTION
- Fix `Ti.UI.View.center` property when `{x: 0, y: 0}` is used

###### TEST CASE
```JS
var window = Ti.UI.createWindow({backgroundColor: 'gray'}),
    a = Ti.UI.createView({backgroundColor: 'red', width: 200, height: 200, top: 0, left: 0}),
    b = Ti.UI.createView({backgroundColor: 'blue', width: 100, height: 100, center: {x: 150, y: 150}}),
    btn_a = Ti.UI.createButton({title: 'TOP LEFT', bottom: 0, left: 0, width: '50%'}),
    btn_b = Ti.UI.createButton({title: 'ZERO', bottom: 0, right: 0, width: '50%'});

btn_a.addEventListener('click', function(){
    b.center = {x: 50, y: 50};
});

btn_b.addEventListener('click', function(){
    b.center = {x: 0, y: 0};
});

window.add([btn_a, btn_b, a, b]);
window.open();
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-24793)