### PR TITLE
[TIMOB-24842] Android: Fix Ti.UI.View.opacity property change

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiUIView.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiUIView.java
@@ -830,20 +830,7 @@ public abstract class TiUIView
 							applyTouchFeedback(bgColor, d.containsKey(TiC.PROPERTY_TOUCH_FEEDBACK_COLOR) ? TiConvert.toColor(d, TiC.PROPERTY_TOUCH_FEEDBACK_COLOR) : null);
 						} else {
 							nativeView.setBackgroundColor(bgColor);
-							// A bug only on Android 2.3 (TIMOB-14311).
-							if (Build.VERSION.SDK_INT < TiC.API_LEVEL_HONEYCOMB && proxy.hasProperty(TiC.PROPERTY_OPACITY)) {
-								setOpacity(TiConvert.toFloat(proxy.getProperty(TiC.PROPERTY_OPACITY), 1f));
-							}
 						}
-						nativeView.postInvalidate();
-					}
-				} else {
-					if (key.equals(TiC.PROPERTY_OPACITY)) {
-						setOpacity(TiConvert.toFloat(newValue, 1f));
-					}
-					if (!nativeViewNull) {
-						nativeView.setBackgroundDrawable(null);
-						nativeView.postInvalidate();
 					}
 				}
 			} else {
@@ -889,14 +876,9 @@ public abstract class TiUIView
 				}
 
 				applyCustomBackground();
-
-				if (key.equals(TiC.PROPERTY_OPACITY)) {
-					setOpacity(TiConvert.toFloat(newValue, 1f));
-				} else if (Build.VERSION.SDK_INT < TiC.API_LEVEL_HONEYCOMB && proxy.hasProperty(TiC.PROPERTY_OPACITY)) {
-					// A bug only on Android 2.3 (TIMOB-14311).
-					setOpacity(TiConvert.toFloat(proxy.getProperty(TiC.PROPERTY_OPACITY), 1f));
-				}
-
+			}
+			if (key.equals(TiC.PROPERTY_OPACITY)) {
+				setOpacity(TiConvert.toFloat(newValue, 1f));
 			}
 			if (!nativeViewNull) {
 				nativeView.postInvalidate();


### PR DESCRIPTION
- Fix `Titanium.UI.View` `opacity` property change
- Remove redundant code

###### TEST CASE
```JS
var win = Ti.UI.createWindow({backgroundColor: 'gray'}),
    view = Ti.UI.createView({
        backgroundColor: 'blue', width: 200, height: 200
    });

view.addEventListener('click', function(e) {
	view.opacity = 0.5;
});

win.add(view);
win.open();
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-24842)