### PR TITLE
[TIMOB-24834] Android: Merge value resources into single file

### DIFF
--- a/android/cli/lib/base-builder.js
+++ b/android/cli/lib/base-builder.js
@@ -54,6 +54,16 @@ AndroidBaseBuilder.prototype.writeXmlFile = function writeXmlFile(srcOrDoc, dest
 		}
 		fs.writeFileSync(dest, '<?xml version="1.0" encoding="UTF-8"?>\n' + srcDoc.toString());
 		return;
+	} else {
+		// Resource sets under a qualifier all need to be merged into a single values
+		// file so we adjust the destination path here if necessary
+		var valueResourcesPattern = /res\/(values(?:-[^/]+)?)\/.*/i;
+		var match = dest.match(valueResourcesPattern);
+		if (match !== null) {
+			var resourceQualifier = match[1];
+			dest = path.join(destDir, resourceQualifier + '.xml');
+			destExists = fs.existsSync(dest);
+		}
 	}
 
 	if (destExists) {


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-24834

**Optional Description:**
Resource sets under the values folder can be split into different files. Those need to be merged back into a single values file so Android library resources and the app's resources can be properly merged together.

See: https://android.googlesource.com/platform/tools/base/+/android-7.1.1_r43/sdk-common/src/main/java/com/android/ide/common/res2/MergedResourceWriter.java
