### PR TITLE
[6_1_X] [TIMOB-24853] Update Windows module apiversion

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "iphone": "2",
     "android": "3",
     "mobileweb": "2",
-    "windows": "2"
+    "windows": "3"
   },
   "keywords": [
     "appcelerator",


### PR DESCRIPTION
Cherry-pick #9164 for 6_1_X

JIRA: [TIMOB-24853](https://jira.appcelerator.org/browse/TIMOB-24853)

Update Windows module `apiversion` due to [TIMOB-24786](https://jira.appcelerator.org/browse/TIMOB-24786). This works together with https://github.com/appcelerator/titanium_mobile_windows/pull/1016.