### PR TITLE
[TIMOB-24349]:iOS Ti.UI.AlertDialog Not Firing Events Consistently (run-on-main-thread)

### DIFF
--- a/iphone/Classes/TiUIAlertDialogProxy.m
+++ b/iphone/Classes/TiUIAlertDialogProxy.m
@@ -83,6 +83,11 @@ static BOOL alertShowing = NO;
         // alert show should block the JS thread like the browser
         TiThreadPerformOnMainThread(^{[self show:args];}, YES);
     } else {
+#ifndef TI_USE_KROLL_THREAD
+        //TIMOB-24349: Force the heap to be GC'd to avoid Ti.UI.AlertDialog references to grow much.
+        KrollContext *krollContext = [self.pageContext krollContext];
+        [krollContext forceGarbageCollectNow];
+#endif
         persistentFlag = [TiUtils boolValue:[self valueForKey:@"persistent"] def:NO];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(suspended:) name:kTiSuspendNotification object:nil];
         NSMutableArray *buttonNames = [self valueForKey:@"buttonNames"];


### PR DESCRIPTION
 https://jira.appcelerator.org/browse/TIMOB-24349
