### PR TITLE
[TIMOB-24941] Android: Fix /modules packaging on Android.

### DIFF
--- a/build/android.js
+++ b/build/android.js
@@ -129,7 +129,7 @@ Android.prototype.package = function (packager, next) {
 		},
 		// Copy over module resources
 		function (cb) {
-			filterRegExp = new RegExp('\\' + path.sep  + 'android(\\' + path.sep + 'titanium\-(.+)?\.(jar|res\.zip|respackage))?$');
+			var filterRegExp = new RegExp('\\' + path.sep  + 'android(\\' + path.sep + 'titanium\-(.+)?\.(jar|res\.zip|respackage))?$');
 			fs.copy(DIST_ANDROID, ANDROID_MODULES, { filter: filterRegExp}, cb);
 		}
 	], next);

--- a/build/android.js
+++ b/build/android.js
@@ -129,7 +129,8 @@ Android.prototype.package = function (packager, next) {
 		},
 		// Copy over module resources
 		function (cb) {
-			fs.copy(DIST_ANDROID, ANDROID_MODULES, { filter: /\/android(\/titanium\-(.+)?\.(jar|res\.zip|respackage))?$/ }, cb);
+			filterRegExp = new RegExp('\\' + path.sep  + 'android(\\' + path.sep + 'titanium\-(.+)?\.(jar|res\.zip|respackage))?$');
+			fs.copy(DIST_ANDROID, ANDROID_MODULES, { filter: filterRegExp}, cb);
 		}
 	], next);
 };


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-24941

**Optional Description:**
Scons 'package' creates an archive without 'modules' folder. 

Changed the regular expression to work with platform specific path separators.
