### PR TITLE
[TIMOB-24943] CLI: Install command patch for Windows platform.

### DIFF
--- a/build/scons-install.js
+++ b/build/scons-install.js
@@ -5,7 +5,8 @@ var exec = require('child_process').exec,
 	path = require('path'),
 	async = require('async'),
 	program = require('commander'),
-	version = require('../package.json').version;
+	version = require('../package.json').version,
+	appc = require('node-appc');
 
 program
 	.option('-v, --sdk-version [version]', 'Override the SDK version we report', process.env.PRODUCT_VERSION || version)
@@ -36,14 +37,7 @@ function install(versionTag, next) {
 	zipfile = path.join(__dirname, '..', 'dist', 'mobilesdk-' + versionTag + '-' + osName + '.zip');
 	console.log('Installing %s...', zipfile);
 
-	// TODO Combine with unzip method in packager.js?
-	// TODO Support unzipping on windows
-	exec('unzip -q -o -d "' + dest + '" "' + zipfile + '"', function (err, stdout, stderr) {
-		if (err) {
-			return next(err);
-		}
-		return next();
-	});
+	appc.zip.unzip(zipfile, dest, { overwrite:true }, next);
 }
 
 install(versionTag, function (err) {

--- a/build/scons-install.js
+++ b/build/scons-install.js
@@ -24,7 +24,7 @@ function install(versionTag, next) {
 		osName = os.platform();
 
 	if (osName === 'win32') {
-		return next('Unable to unzip files on Windows currently. FIXME!');
+		dest = path.join(process.env.ProgramData, 'Titanium');
 	}
 
 	if (osName === 'darwin') {
@@ -38,7 +38,7 @@ function install(versionTag, next) {
 
 	// TODO Combine with unzip method in packager.js?
 	// TODO Support unzipping on windows
-	exec('/usr/bin/unzip -q -o -d "' + dest + '" "' + zipfile + '"', function (err, stdout, stderr) {
+	exec('unzip -q -o -d "' + dest + '" "' + zipfile + '"', function (err, stdout, stderr) {
 		if (err) {
 			return next(err);
 		}


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-24943

**Description:**
Installing a built from sources SDK fails on Windows. 

Here I am not sure if stripping the 'unizp' command would work fine on OS X.
