### PR TITLE
(6_1_X) [TIMOB-24932] Android Hybrid modules: cannot instantiate a proxy in a js file that is packaged in the same module

### DIFF
--- a/android/runtime/common/src/js/module.js
+++ b/android/runtime/common/src/js/module.js
@@ -166,7 +166,9 @@ Module.prototype.createModuleWrapper = function(externalModule, sourceUrl) {
 function extendModuleWithCommonJs(externalModule, id, thiss, context) {
 	if (kroll.isExternalCommonJsModule(id)) {
 		var jsModule = new Module(id + ".commonjs", thiss, context);
-		jsModule.load(id, kroll.getExternalCommonJsModule(id));
+		// Load under fake name, or the commonjs side of the native module gets cached in place of the native module!
+		// See TIMOB-24932
+		jsModule.load(id + ".commonjs", kroll.getExternalCommonJsModule(id));
 		if (jsModule.exports) {
 			if (kroll.DBG) {
 				kroll.log(TAG, "Extending native module '" + id + "' with the CommonJS module that was packaged with it.");
@@ -339,7 +341,6 @@ Module.prototype.loadCoreModule = function (id, context) {
 				// found it
 				// FIXME Re-use loadAsJavaScriptText?
 				var module = new Module(id, this, context);
-				Module.cache[id] = module;
 				module.load(id, externalCommonJsContents);
 				return module.exports;
 			}


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-24932

**Description:**
Calling `require('module.id')` from inside a JS file in that module's assets folder would fail (specifically this is when you're creating "hybrid" native modules for Android that combine Java proxies and JS code). See the ticket for steps to reproduce.

The fix here was to avoid clobbering the native half of the hybrid module in our cache object. Before we'd insert the CommonJS half of the hybrid API into our require cache over top the native module. We need to keep just the native half and recreate the combination of both when required from different files since apparently it's context specific (and so the combined wrapper is cached per-module).