### PR TITLE
[TIMOB-24949] Android: Remove unnecessary % escapes from logs

### DIFF
--- a/android/cli/hooks/run.js
+++ b/android/cli/hooks/run.js
@@ -245,7 +245,7 @@ exports.init = function (logger, config, cli) {
 
 						// start of a new log message
 						if (device.appPidRegExp.test(line)) {
-							line = line.trim().replace(/\%/g, '%%').replace(device.appPidRegExp, ':');
+							line = line.trim().replace(device.appPidRegExp, ':');
 							logLevel = line.charAt(0).toLowerCase();
 							if (tiapiRegExp.test(line)) {
 								line = line.replace(tiapiRegExp, '').trim();


### PR DESCRIPTION
- Remove unnecessary escape characters `%%` from logs

###### TEST CASE
```JS
console.log('%');
```
```
%
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-24949)