### PR TITLE
[TIMOB-24898] Android: Guard against null backgroundColor

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiUIView.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiUIView.java
@@ -876,7 +876,7 @@ public abstract class TiUIView
 
 					// TIMOB-24898: disable HW acceleration to allow transparency
 					// when the backgroundColor alpha channel has been set
-					if ((byte)(bgColor >> 24) < 0xFF) {
+					if (bgColor != null && (byte)(bgColor >> 24) < 0xFF) {
 						disableHWAcceleration();
 					}
 				}
@@ -1428,7 +1428,7 @@ public abstract class TiUIView
 
 			// TIMOB-24898: disable HW acceleration to allow transparency
 			// when the backgroundColor alpha channel has been set
-			if ((byte)(bgColor >> 24) < 0xFF) {
+			if (bgColor != null && (byte)(bgColor >> 24) < 0xFF) {
 				disableHWAcceleration();
 			}
 		}


### PR DESCRIPTION
- Fix for https://github.com/appcelerator/titanium_mobile/pull/9179
- Guard against `backgroundColor: null/undefined`
- Jenkins tests should [not fail](https://jenkins.appcelerator.org/blue/organizations/jenkins/titanium-sdk%2Ftitanium_mobile/detail/PR-9207/2/pipeline/#step-121-log-301)

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-24898)