### PR TITLE
[TIMOB-24917] Android: Fix application theming

### DIFF
--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -3346,6 +3346,7 @@ AndroidBuilder.prototype.generateTheme = function generateTheme(next) {
 			if (theme.startsWith('@style/') && theme !== '@style/Theme.Titanium') {
 				flags = theme.replace('@style/', '');
 			}
+			delete this.tiappAndroidManifest.application.theme;
 		}
 
 		fs.writeFileSync(themeFile, ejs.render(fs.readFileSync(path.join(this.templatesDir, 'theme.xml')).toString(), {

--- a/android/templates/build/AndroidManifest.xml
+++ b/android/templates/build/AndroidManifest.xml
@@ -14,7 +14,7 @@
 	<application android:icon="@drawable/appicon"
 		android:label="<%- tiapp.name %>" android:name="<%- classname %>Application"
 		android:debuggable="false"
-		android:theme="@style/Theme.AppCompat<% if (tiapp.fullscreen || tiapp['statusbar-hidden'] || tiapp['navbar-hidden']) { %>.NoTitleBar<% if (tiapp.fullscreen || tiapp['statusbar-hidden']) { %>.Fullscreen<% } %><% } %>">
+		android:theme="@style/Theme.Titanium<% if (tiapp.fullscreen || tiapp['statusbar-hidden'] || tiapp['navbar-hidden']) { %>.NoTitleBar<% if (tiapp.fullscreen || tiapp['statusbar-hidden']) { %>.Fullscreen<% } %><% } %>">
 
 		<activity android:name=".<%- classname %>Activity"
 			android:label="@string/app_name" android:theme="@style/Theme.Titanium"


### PR DESCRIPTION
- Always use `Theme.Titanium` for the application theme which inherits the theme set in `tiapp.xml`
- This is to make sure Titanium specific properties are set when a custom theme is defined (such as splash screen)

###### TEST CASE
- See JIRA

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-24917)