### PR TITLE
[TIMOB-25010] Fix ioslib dependency for Windows and Linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "fields": "0.1.24",
     "glob": "7.1.1",
     "humanize": "0.0.9",
-    "ioslib": "^1.4.9",
     "lodash.defaultsdeep": "4.6.0",
     "markdown": "0.5.0",
     "moment": "2.18.1",
@@ -50,6 +49,9 @@
     "wrench": "1.5.9",
     "xcode": "0.9.2",
     "xmldom": "0.1.22"
+  },
+  "optionalDependencies":{
+    "ioslib": "^1.4.9"
   },
   "devDependencies": {
     "commander": "*",


### PR DESCRIPTION
- `ioslib` cannot compile under `Windows` and `Linux`
- Move `ioslib` to `optionalDependencies`

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-25010)