### PR TITLE
[TIMOB-25016] Bumped ioslib to 1.5.0 which bumps node-ios-device to 1…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1875,23 +1875,23 @@
       }
     },
     "ioslib": {
-      "version": "1.4.9",
-      "resolved": "https://registry.npmjs.org/ioslib/-/ioslib-1.4.9.tgz",
-      "integrity": "sha1-4U5lXd/Gn2quciJzaikZEmGwJOQ=",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/ioslib/-/ioslib-1.5.0.tgz",
+      "integrity": "sha512-wf5E8T38OSMwJpp4W+4SXlll2LMqm3iEzpNk6y76PTjeSr/pLoda94/IRAoUXbpYTUILJaWBVnaRPWj8Yf0K3Q==",
       "requires": {
         "always-tail": "0.2.0",
-        "async": "2.4.1",
+        "async": "2.5.0",
         "bplist-parser": "0.1.1",
         "debug": "2.6.8",
         "mkdirp": "0.5.1",
         "node-appc": "0.2.43",
-        "node-ios-device": "1.3.3"
+        "node-ios-device": "1.4.0"
       },
       "dependencies": {
         "async": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.4.1.tgz",
-          "integrity": "sha1-YqVrJ5yYoR0JhwlqAcw+6463u9c=",
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
+          "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
           "requires": {
             "lodash": "4.17.4"
           }
@@ -1902,13 +1902,6 @@
           "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
           "requires": {
             "ms": "2.0.0"
-          },
-          "dependencies": {
-            "ms": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-            }
           }
         },
         "mkdirp": {
@@ -1917,6 +1910,42 @@
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "requires": {
             "minimist": "0.0.8"
+          }
+        },
+        "node-ios-device": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/node-ios-device/-/node-ios-device-1.4.0.tgz",
+          "integrity": "sha1-2TRYWdgewIg2fKsW6v6/d8eMKlY=",
+          "requires": {
+            "debug": "2.6.8",
+            "nan": "2.6.2",
+            "node-pre-gyp": "0.6.36",
+            "node-pre-gyp-init": "1.0.0"
+          },
+          "dependencies": {
+            "node-pre-gyp": {
+              "version": "0.6.36",
+              "bundled": true,
+              "requires": {
+                "mkdirp": "0.5.1",
+                "nopt": "4.0.1",
+                "npmlog": "4.1.2",
+                "rc": "1.2.1",
+                "request": "2.81.0",
+                "rimraf": "2.6.1",
+                "semver": "5.3.0",
+                "tar": "2.2.1",
+                "tar-pack": "3.4.0"
+              }
+            }
+          }
+        },
+        "rimraf": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+          "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+          "requires": {
+            "glob": "7.1.1"
           }
         }
       }
@@ -2692,27 +2721,6 @@
         "uglify-js": "2.8.21",
         "wrench": "1.5.9",
         "xmldom": "0.1.22"
-      }
-    },
-    "node-ios-device": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/node-ios-device/-/node-ios-device-1.3.3.tgz",
-      "integrity": "sha512-LDn6Bg39Slyg6OvmaZTGAmGerXbMJaGlaDod/b1QkzeUJGMzOOqIedyQqq2EmJdcrY5rYy7DHQpPMiCrfTLXjQ==",
-      "requires": {
-        "debug": "2.6.8",
-        "nan": "2.6.2",
-        "node-pre-gyp": "0.6.36",
-        "node-pre-gyp-init": "1.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
       }
     },
     "node-pre-gyp": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "fields": "0.1.24",
     "glob": "7.1.1",
     "humanize": "0.0.9",
-    "ioslib": "^1.4.9",
+    "ioslib": "^1.5.0",
     "lodash.defaultsdeep": "4.6.0",
     "markdown": "0.5.0",
     "moment": "2.18.1",


### PR DESCRIPTION
[TIMOB-25016] Bumped ioslib to 1.5.0 which bumps node-ios-device to 1.4.0 which allows installing, but not building, on Windows and Linux.

**JIRA:** https://jira.appcelerator.org/browse/TIMOB-25016