### PR TITLE
[TIMOB-24943] Fixed "node scons install" where it fails to overwrite last install.

### DIFF
--- a/build/scons-install.js
+++ b/build/scons-install.js
@@ -42,7 +42,7 @@ function install(versionTag, next) {
 	zipfile = path.join(__dirname, '..', 'dist', 'mobilesdk-' + versionTag + '-' + osName + '.zip');
 	console.log('Installing %s...', zipfile);
 
-	appc.zip.unzip(zipfile, dest, { overwrite:true }, next);
+	appc.zip.unzip(zipfile, dest, {}, next);
 }
 
 install(versionTag, function (err) {


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-24943

**Description:**
The `titanium_mobile/build`folder's `node scons.js install` command no longer overwrites the last installed package of the same version. Since this issue only happens on the master branch, that means the 7.0.0 version at the time of this writing.

**Notes:**
- Bug was introduced on Mac and Windows as of PR #9198.
- This issue does not happen with the `node scons.js cleanbuild` command.

**Test:**

1. At the command line, go to directory: `titanium_mobile/build`
2. At the command line, run: `node scons.js cleanbuild`
3. Modify file `titanium_mobile/CREDITS`. (**Ex:** Add "Hello World" to first line in file.)
4. At the command line, run: `node scons.js package`
5. At the command line, run: `node scons.js install`
6. On Mac, go to folder: `~/Library/Application Support/Titanium/mobilesdk/osx/7.0.0`
7. Check if the "CREDITS" file contains your change.
