### PR TITLE
[TIMOB-25021] Android: Fix deletion of weak global reference

### DIFF
--- a/android/runtime/v8/src/native/JavaObject.cpp
+++ b/android/runtime/v8/src/native/JavaObject.cpp
@@ -220,7 +220,11 @@ void JavaObject::DeleteJavaRef()
 		ASSERT(javaObject_ != NULL);
 		// Wipe the V8Object ptr value back to 0, to denote that the native C++ proxy is gone
 		JNIUtil::removePointer(javaObject_);
-		env->DeleteGlobalRef(javaObject_);
+		if (isWeakRef_) {
+			env->DeleteWeakGlobalRef(javaObject_);
+		} else {
+			env->DeleteGlobalRef(javaObject_);
+		}
 		javaObject_ = NULL;
 	} else {
 		LOGD(TAG, "Deleting ref in ReferenceTable for key: %d, pointer: %p", refTableKey_, this);


### PR DESCRIPTION
- Fix deletion of weak global references

###### TEST CASE
```JS
var win = Ti.UI.createWindow({backgroundColor: 'gray', exitOnClose: true});
win.open();
```
1. Launch application
2. Press back to exit the application
3. Quickly re-launch the application by pressing the application icon (you may want to add a shortcut to your homescreen)
4. This may take a few attempts

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-25021)