### PR TITLE
[6_1_X][TIMOB-24265] Android: Fix unsupported relaunch for Marshmallow and above

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
@@ -608,9 +608,15 @@ public abstract class TiBaseActivity extends AppCompatActivity
 		// lost (TiActivityWindows.dispose()). In this case, we have to restart the app.
 		if (TiBaseActivity.isUnsupportedReLaunch(this, savedInstanceState)) {
 			Log.w(TAG, "Runtime has been disposed or app has been killed. Finishing.");
-			super.onCreate(savedInstanceState);
-			tiApp.scheduleRestart(250);
-			finish();
+			activityOnCreate(savedInstanceState);
+			TiApplication.terminateActivityStack();
+			if (Build.VERSION.SDK_INT < 23) {
+				finish();
+				tiApp.scheduleRestart(300);
+				return;
+			}
+			KrollRuntime.incrementActivityRefCount();
+			finishAndRemoveTask();
 			return;
 		}
 


### PR DESCRIPTION
- Cherry-pick of https://github.com/appcelerator/titanium_mobile/pull/8843
- Fix addresses crash seen in [TIMOB-24710](https://jira.appcelerator.org/browse/TIMOB-24710)

###### TEST CASE
- On Android 6.0+
1. Set background process limit to `1`
2. Deploy default alloy application
3. Press home and launch another app
4. Use recents menu to resume alloy application

- Should not see crash

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-24710)