### PR TITLE
[TIMOB-24943] CLI: Fix 'cleanbuild' command

### DIFF
--- a/build/scons-cleanbuild.js
+++ b/build/scons-cleanbuild.js
@@ -10,6 +10,7 @@ var exec = require('child_process').exec,
 	Documentation = require('./docs'),
 	git = require('./git'),
 	Packager = require('./packager'),
+	appc = require('node-appc'),
 	platforms = [],
 	oses = [],
 	// TODO Move common constants somewhere?
@@ -49,26 +50,23 @@ function install(versionTag, next) {
 		osName = os.platform();
 
 	if (osName === 'win32') {
-		return next('Unable to unzip files on Windows currently. FIXME!');
+		dest = path.join(process.env.ProgramData, 'Titanium');
 	}
 
 	if (osName === 'darwin') {
 		osName = 'osx';
 		dest = path.join(process.env.HOME, 'Library', 'Application Support', 'Titanium');
 	}
-	// TODO Where should we install on Windows?
+
+	if (osName === 'linux') {
+		osName = 'linux';
+		dest = path.join(process.env.HOME, '.titanium');
+	}
 
 	zipfile = path.join(__dirname, '..', 'dist', 'mobilesdk-' + versionTag + '-' + osName + '.zip');
 	console.log('Installing %s...', zipfile);
 
-	// TODO Combine with unzip method in packager.js?
-	// TODO Support unzipping on windows
-	exec('/usr/bin/unzip -q -o -d "' + dest + '" "' + zipfile + '"', function (err, stdout, stderr) {
-		if (err) {
-			return next(err);
-		}
-		return next();
-	});
+	appc.zip.unzip(zipfile, dest, {}, next);
 }
 
 var versionTag = program.versionTag || program.sdkVersion;

--- a/build/scons-install.js
+++ b/build/scons-install.js
@@ -42,7 +42,7 @@ function install(versionTag, next) {
 	zipfile = path.join(__dirname, '..', 'dist', 'mobilesdk-' + versionTag + '-' + osName + '.zip');
 	console.log('Installing %s...', zipfile);
 
-	appc.zip.unzip(zipfile, dest, { overwrite:true }, next);
+	appc.zip.unzip(zipfile, dest, {}, next);
 }
 
 install(versionTag, function (err) {


### PR DESCRIPTION
Fix unzipping in 'cleanbuild' command.
Remove overwrite parameter.

**JIRA:** https://jira.appcelerator.org/browse/TIMOB-24943

**Description:**
Includes the fix from: https://github.com/appcelerator/titanium_mobile/pull/9244