### PR TITLE
[TIMOB-25028][6_2_X] Fix issue where node-ios-device is not hoisted

### DIFF
--- a/build/packager.js
+++ b/build/packager.js
@@ -257,15 +257,31 @@ Packager.prototype.package = function (next) {
 		}.bind(this),
 		// Now include all the pre-built node-ios-device bindings/binaries
 		function (cb) {
-			if (this.targetOS == 'osx') {
-				exec('node bin/download-all.js', {cwd: path.join(this.zipSDKDir, 'node_modules', 'node-ios-device')}, function (err, stdout, stderr) {
-					if (err) {
-						console.log(stdout);
-						console.error(stderr);
-						return cb(err);
-					}
-					cb();
-				});
+			if (this.targetOS === 'osx') {
+				console.log(path.join(this.zipSDKDir, 'node_modules', 'node-ios-device'));
+				const hoistedPath = path.join(this.zipSDKDir, 'node_modules', 'node-ios-device');
+				const normalPath = path.join(this.zipSDKDir, 'node_modules', 'ioslib', 'node_modules', 'node-ios-device');
+				if (fs.existsSync(hoistedPath)) {
+					exec('node bin/download-all.js', {cwd: hoistedPath}, function (err, stdout, stderr) {
+						if (err) {
+							console.log(stdout);
+							console.error(stderr);
+							return cb(err);
+						}
+						cb();
+					});
+				} else if (fs.existsSync(normalPath)) {
+					exec('node bin/download-all.js', {cwd: normalPath}, function (err, stdout, stderr) {
+						if (err) {
+							console.log(stdout);
+							console.error(stderr);
+							return cb(err);
+						}
+						cb();
+					});
+				} else {
+					return cb(new Error('Unable to find node-ios-device module'))
+				}
 			} else {
 				cb();
 			}

--- a/build/packager.js
+++ b/build/packager.js
@@ -258,30 +258,18 @@ Packager.prototype.package = function (next) {
 		// Now include all the pre-built node-ios-device bindings/binaries
 		function (cb) {
 			if (this.targetOS === 'osx') {
-				console.log(path.join(this.zipSDKDir, 'node_modules', 'node-ios-device'));
-				const hoistedPath = path.join(this.zipSDKDir, 'node_modules', 'node-ios-device');
-				const normalPath = path.join(this.zipSDKDir, 'node_modules', 'ioslib', 'node_modules', 'node-ios-device');
-				if (fs.existsSync(hoistedPath)) {
-					exec('node bin/download-all.js', {cwd: hoistedPath}, function (err, stdout, stderr) {
-						if (err) {
-							console.log(stdout);
-							console.error(stderr);
-							return cb(err);
-						}
-						cb();
-					});
-				} else if (fs.existsSync(normalPath)) {
-					exec('node bin/download-all.js', {cwd: normalPath}, function (err, stdout, stderr) {
-						if (err) {
-							console.log(stdout);
-							console.error(stderr);
-							return cb(err);
-						}
-						cb();
-					});
-				} else {
-					return cb(new Error('Unable to find node-ios-device module'))
+				var dir = path.join(this.zipSDKDir, 'node_modules', 'node-ios-device');
+
+				if (!fs.existsSync(dir)) {
+				    dir = path.join(this.zipSDKDir, 'node_modules', 'ioslib', 'node_modules', 'node-ios-device');
 				}
+
+				if (!fs.existsSync(dir)) {
+				    return cb(new Error('Unable to find node-ios-device module'));
+				}
+
+				exec('node bin/download-all.js', { cwd: dir, stdio: 'inherit' }, cb);
+
 			} else {
 				cb();
 			}


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-25028

Backport of #9260


node-ios-device can be in `node_modules` or `node_modules/ioslib/node_modules` we should consider that when executing the script.


Verification

1. Run node build/scon.js package ios
    - It should not error out
2. Let Jenkins run
     - It should be happy
