### PR TITLE
[TIMOB-12145] kroll.writeSnapshot method for heap dump

### DIFF
--- a/android/runtime/v8/src/native/JSException.h
+++ b/android/runtime/v8/src/native/JSException.h
@@ -12,7 +12,7 @@
 #include <v8.h>
 
 #define THROW(isolate, msg) \
-	isolate->ThrowException(v8::String::NewFromUtf8(isolate, msg))
+	isolate->ThrowException(v8::Exception::Error(v8::String::NewFromUtf8(isolate, msg)))
 
 namespace titanium {
 


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-12145

```javascript
var path = Ti.Filesystem.tempDirectory.replace('file://', '') +
  '/' + Date.now() + '.heapsnapshot';
if (kroll.writeSnapshot(path)) {
  console.log('Heap snapshot successfully dumped to', path);
} else {
  console.error('Failed to dump heap snapshot to', path);
}
```