### PR TITLE
[TIMOB-25176] Fix node 4 compatibility

### DIFF
--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -14,6 +14,8 @@
  * Please see the LICENSE included with this distribution for details.
  */
 
+'use strict';
+
 const ADB = require('node-titanium-sdk/lib/adb'),
 	AdmZip = require('adm-zip'),
 	android = require('node-titanium-sdk/lib/android'),

--- a/android/cli/commands/_buildModule.js
+++ b/android/cli/commands/_buildModule.js
@@ -11,6 +11,8 @@
 * Please see the LICENSE included with this distribution for details.
 */
 
+'use strict';
+
 const AdmZip = require('adm-zip'),
 	androidDetect = require('../lib/detect').detect,
 	appc = require('node-appc'),

--- a/android/cli/hooks/package.js
+++ b/android/cli/hooks/package.js
@@ -5,6 +5,8 @@
  * See the LICENSE file for more information.
  */
 
+'use strict';
+
 const appc = require('node-appc'),
 	fs = require('fs'),
 	path = require('path'),

--- a/android/cli/hooks/run.js
+++ b/android/cli/hooks/run.js
@@ -5,6 +5,8 @@
  * See the LICENSE file for more information.
  */
 
+'use strict';
+
 const ADB = require('node-titanium-sdk/lib/adb'),
 	appc = require('node-appc'),
 	async = require('async'),

--- a/android/cli/lib/AndroidManifest.js
+++ b/android/cli/lib/AndroidManifest.js
@@ -4,6 +4,8 @@
  * Please see the LICENSE file for information about licensing.
  */
 
+'use strict';
+
 const appc = require('node-appc'),
 	DOMParser = require('xmldom').DOMParser,
 	fs = require('fs'),

--- a/android/cli/lib/base-builder.js
+++ b/android/cli/lib/base-builder.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const appc = require('node-appc'),
 	Builder = require('node-titanium-sdk/lib/builder'),
 	DOMParser = require('xmldom').DOMParser,

--- a/android/cli/lib/detect.js
+++ b/android/cli/lib/detect.js
@@ -11,6 +11,8 @@
  * Please see the LICENSE included with this distribution for details.
  */
 
+'use strict';
+
 const android = require('node-titanium-sdk/lib/android'),
 	ADB = require('node-titanium-sdk/lib/adb'),
 	EmulatorManager = require('node-titanium-sdk/lib/emulator'),

--- a/android/cli/lib/info.js
+++ b/android/cli/lib/info.js
@@ -1,3 +1,4 @@
+'use strict';
 const appc = require('node-appc'),
 	__ = appc.i18n(__dirname).__,
 	fs = require('fs'),

--- a/cli/commands/build.js
+++ b/cli/commands/build.js
@@ -5,6 +5,8 @@
  * See the LICENSE file for more information.
  */
 
+'use strict';
+
 const appc = require('node-appc'),
 	fields = require('fields'),
 	fs = require('fs'),

--- a/cli/commands/clean.js
+++ b/cli/commands/clean.js
@@ -5,6 +5,8 @@
  * See the LICENSE file for more information.
  */
 
+'use strict';
+
 const appc = require('node-appc'),
 	i18n = appc.i18n(__dirname),
 	__ = i18n.__,

--- a/cli/commands/create.js
+++ b/cli/commands/create.js
@@ -11,6 +11,8 @@
  * Please see the LICENSE included with this distribution for details.
  */
 
+'use strict';
+
 const appc = require('node-appc'),
 	async = require('async'),
 	fields = require('fields'),

--- a/cli/commands/project.js
+++ b/cli/commands/project.js
@@ -4,6 +4,8 @@
  * Copyright (c) 2012-2017, Appcelerator, Inc.  All Rights Reserved.
  * See the LICENSE file for more information.
  */
+'use strict';
+
 const path = require('path'),
 	ti = require('node-titanium-sdk'),
 	appc = require('node-appc'),

--- a/cli/lib/creator.js
+++ b/cli/lib/creator.js
@@ -12,6 +12,8 @@
  * Please see the LICENSE included with this distribution for details.
  */
 
+'use strict';
+
 const appc = require('node-appc'),
 	async = require('async'),
 	ejs = require('ejs'),

--- a/cli/lib/creators/app.js
+++ b/cli/lib/creators/app.js
@@ -10,6 +10,8 @@
  * Please see the LICENSE included with this distribution for details.
  */
 
+'use strict';
+
 const appc = require('node-appc'),
 	Creator = require('../creator'),
 	fs = require('fs'),

--- a/cli/lib/creators/applewatch.js
+++ b/cli/lib/creators/applewatch.js
@@ -13,6 +13,8 @@
  * Please see the LICENSE included with this distribution for details.
  */
 
+'use strict';
+
 const appc = require('node-appc'),
 	Creator = require('../creator'),
 	DOMParser = require('xmldom').DOMParser,

--- a/cli/lib/creators/module.js
+++ b/cli/lib/creators/module.js
@@ -10,6 +10,8 @@
  * Please see the LICENSE included with this distribution for details.
  */
 
+'use strict';
+
 const appc = require('node-appc'),
 	Creator = require('../creator'),
 	fs = require('fs'),

--- a/cli/lib/info.js
+++ b/cli/lib/info.js
@@ -5,8 +5,9 @@
  * See the LICENSE file for more information.
  */
 
-const
-	appc = require('node-appc'),
+'use strict';
+
+const appc = require('node-appc'),
 	fs = require('fs'),
 	path = require('path'),
 	genymotion = require('node-titanium-sdk/lib/emulators/genymotion'),

--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -11,6 +11,8 @@
  * Please see the LICENSE included with this distribution for details.
  */
 
+'use strict';
+
 const appc = require('node-appc'),
 	async = require('async'),
 	bufferEqual = require('buffer-equal'),

--- a/iphone/cli/commands/_buildModule.js
+++ b/iphone/cli/commands/_buildModule.js
@@ -11,6 +11,8 @@
 * Please see the LICENSE included with this distribution for details.
 */
 
+'use strict';
+
 const appc = require('node-appc'),
 	AdmZip = require('adm-zip'),
 	archiver = require('archiver'),

--- a/iphone/cli/hooks/hyperloop.js
+++ b/iphone/cli/hooks/hyperloop.js
@@ -4,6 +4,8 @@
  * @author Jeff Haynie
  * @date 02/06/2014
  */
+'use strict';
+
 const fs = require('fs'),
 	path = require('path'),
 	os = require('os'),

--- a/iphone/cli/hooks/install.js
+++ b/iphone/cli/hooks/install.js
@@ -5,6 +5,8 @@
  * See the LICENSE file for more information.
  */
 
+'use strict';
+
 const appc = require('node-appc'),
 	async = require('async'),
 	fs = require('fs'),

--- a/iphone/cli/hooks/package.js
+++ b/iphone/cli/hooks/package.js
@@ -5,6 +5,8 @@
  * See the LICENSE file for more information.
  */
 
+'use strict';
+
 const appc = require('node-appc'),
 	__ = appc.i18n(__dirname).__,
 	afs = appc.fs,

--- a/iphone/cli/hooks/run.js
+++ b/iphone/cli/hooks/run.js
@@ -5,6 +5,8 @@
  * See the LICENSE file for more information.
  */
 
+'use strict';
+
 const appc = require('node-appc'),
 	ioslib = require('ioslib'),
 	i18n = appc.i18n(__dirname),

--- a/iphone/cli/lib/info.js
+++ b/iphone/cli/lib/info.js
@@ -11,6 +11,8 @@
  * Please see the LICENSE included with this distribution for details.
  */
 
+'use strict';
+
 const appc = require('node-appc'),
 	fs = require('fs'),
 	ioslib = require('ioslib'),


### PR DESCRIPTION
JIRA: https://jira.appcelerator.org/browse/TIMOB-25176

This PR add node 4 compatibility back, I only added 'use strict' to the files we distribute, so files in apidoc/, build/ and Gruntfile.js will still break on node 4. 

If we want that it's just a matter of me running [the relevant jscodemod](https://github.com/cpojer/js-codemod/blob/master/transforms/use-strict.js) again so no biggy, just let me know