### PR TITLE
[TIMOB-24748] Fix logging of ready state in HTTPClient.

### DIFF
--- a/android/modules/network/src/java/ti/modules/titanium/network/TiHTTPClient.java
+++ b/android/modules/network/src/java/ti/modules/titanium/network/TiHTTPClient.java
@@ -447,7 +447,7 @@ public class TiHTTPClient
 
 	public void setReadyState(int readyState)
 	{
-		Log.d(TAG, "Setting ready state to " + readyState);
+		Log.d(TAG, "Setting ready state to " + readyState, Log.DEBUG_MODE);
 		this.readyState = readyState;
 		KrollDict data = new KrollDict();
 		data.put("readyState", Integer.valueOf(readyState));


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-24748?focusedCommentId=426933&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-426933

**Description:**
Fix logging of ready state, that was broken here:
https://github.com/appcelerator/titanium_mobile/pull/9104

**Test case:**
Application should not spam log messages when TiHTTPClient is used.