### PR TITLE
[6_2_X][TIMOB-24748] Fix logging of ready state in HTTPClient.

### DIFF
--- a/android/modules/network/src/java/ti/modules/titanium/network/TiHTTPClient.java
+++ b/android/modules/network/src/java/ti/modules/titanium/network/TiHTTPClient.java
@@ -447,7 +447,7 @@ public class TiHTTPClient
 
 	public void setReadyState(int readyState)
 	{
-		Log.d(TAG, "Setting ready state to " + readyState);
+		Log.d(TAG, "Setting ready state to " + readyState, Log.DEBUG_MODE);
 		this.readyState = readyState;
 		KrollDict data = new KrollDict();
 		data.put("readyState", Integer.valueOf(readyState));


### PR DESCRIPTION
Backport of: https://github.com/appcelerator/titanium_mobile/pull/9342

