### PR TITLE
[TIMOB-25188] Preserve file permissions for platform folder content

### DIFF
--- a/iphone/cli/commands/_buildModule.js
+++ b/iphone/cli/commands/_buildModule.js
@@ -606,7 +606,8 @@ iOSModuleBuilder.prototype.packageModule = function packageModule(next) {
 		// 3. platform folder
 		if (fs.existsSync(this.platformDir)) {
 			this.dirWalker(this.platformDir, function (file) {
-				dest.append(fs.createReadStream(file), { name: path.join(moduleFolders, 'platform', path.relative(this.platformDir, file)) });
+				var stat = fs.statSync(file);
+				dest.append(fs.createReadStream(file), { name: path.join(moduleFolders, 'platform', path.relative(this.platformDir, file)), mode: stat.mode });
 			}.bind(this));
 		}
 


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-25188

**Optional Description:**
In preparation for dynamic frameworks in modules it is important to store the correct file permissions in the .zip file. This ensures the extracted framework binaries have the +x flag set that is required by `swift-stdlib-tool` to properly detect Swift usage.
