### PR TITLE
[TIMOB-24958] Update to windowslib@0.5.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3097,9 +3097,9 @@
       }
     },
     "node-titanium-sdk": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/node-titanium-sdk/-/node-titanium-sdk-0.4.2.tgz",
-      "integrity": "sha512-cKheUBKTyVIS8tm1u1ImE1YAMPZXFB/d/zTlX34IhO+EZaDoAWJq2qdc5SDnnAN2Ngk4hcZxDZX2lXRg4WTxBQ==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/node-titanium-sdk/-/node-titanium-sdk-0.4.3.tgz",
+      "integrity": "sha512-lSRq0rUFEpOKNTT/mrU2r2TwpY2fRgSGl8Hgz2YJkrvqqQXY9WqHJV5JI91q/uXbmRgDJHrDK6wxGBu2Ph38rw==",
       "requires": {
         "async": "2.5.0",
         "babel-core": "6.25.0",
@@ -4304,9 +4304,9 @@
       "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0="
     },
     "windowslib": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/windowslib/-/windowslib-0.5.3.tgz",
-      "integrity": "sha1-VDu1H2SaUqbwTTeAV8QL96q1tPM=",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/windowslib/-/windowslib-0.5.4.tgz",
+      "integrity": "sha512-a6+eRue6okjSSD4tSjL3vpqVLuiks/PMPUhgEnpgxVledvz6s62lMrUrdrKDqRWHHyeaG5EFu2D64bQEJpgdWQ==",
       "requires": {
         "async": "1.5.2",
         "moment": "2.11.2",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "request": "2.81.0",
     "sprintf": "0.1.5",
     "temp": "0.8.3",
-    "windowslib": "0.5.3",
+    "windowslib": "0.5.4",
     "wrench": "1.5.9",
     "xcode": "0.9.2",
     "xmldom": "0.1.22"


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-24958

Update to windowslib@0.5.4 to support winappdeploycmd detection in latest windows SDKs, also updates package-lock.json with changes from the node-titanium-sdk updates
