### PR TITLE
[TIMOB-23863] Item Template in List View blocks Android 5 ripple animation

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/TiBaseListViewItem.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/TiBaseListViewItem.java
@@ -10,7 +10,6 @@ package ti.modules.titanium.ui.widget.listview;
 import java.util.HashMap;
 
 import org.appcelerator.kroll.KrollDict;
-import org.appcelerator.titanium.TiDimension;
 import org.appcelerator.titanium.view.TiCompositeLayout;
 import org.appcelerator.titanium.view.TiUIView;
 

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/TiListView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/TiListView.java
@@ -293,12 +293,12 @@ public class TiListView extends TiUIView implements OnSearchChangeListener {
 				TiBaseListViewItem itemContent = (TiBaseListViewItem) content.findViewById(listContentId);
 				section.populateViews(data, itemContent, template, sectionItemIndex, sectionIndex, content);
 				//Manually add drawable for ripple touch feedback
-				if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+				if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
 					try {
 						TypedValue typedValue = new TypedValue();
 						context.getTheme().resolveAttribute(android.R.attr.selectableItemBackground, typedValue, true);
 						itemContent.setClickable(true);
-						itemContent.setBackground(context.getResources().getDrawable(typedValue.resourceId, context.getTheme()));
+						itemContent.setForeground(context.getResources().getDrawable(typedValue.resourceId, context.getTheme()));
 					} catch (Exception ex) {
 						ex.printStackTrace();
 					}
@@ -311,12 +311,12 @@ public class TiListView extends TiUIView implements OnSearchChangeListener {
 				itemContent.setLayoutParams(params);
 				section.generateCellContent(sectionIndex, data, template, itemContent, sectionItemIndex, content);
 				//Manually add drawable for ripple touch feedback
-				if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+				if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
 					try {
 						TypedValue typedValue = new TypedValue();
 						context.getTheme().resolveAttribute(android.R.attr.selectableItemBackground, typedValue, true);
 						itemContent.setClickable(true);
-						itemContent.setBackground(context.getResources().getDrawable(typedValue.resourceId, context.getTheme()));
+						itemContent.setForeground(context.getResources().getDrawable(typedValue.resourceId, context.getTheme()));
 					} catch (Exception ex) {
 						ex.printStackTrace();
 					}

--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiUIView.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiUIView.java
@@ -1902,7 +1902,6 @@ public abstract class TiUIView
 				view.setOnClickListener(null); // This will set clickable to true in the view, so make sure it stays here so the next line turns it off.
 			}
 			view.setClickable(false);
-			view.setOnClickListener(null);
 			view.setOnLongClickListener(null);
 			view.setLongClickable(false);
 		} else if ( ! (view instanceof AdapterView) ) {


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-23863

**Description:**
Unblocks the ripple touch effect for items in ListView for Android API 23 and above.

Reverts the change from: https://github.com/appcelerator/titanium_mobile/pull/9143
in order to prevent regression.
QE, if you could try the test case from here:
https://jira.appcelerator.org/browse/TIMOB-11856
to make sure it is fine, it would be great.

**Test case:**
```
var win = Ti.UI.createWindow({backgroundColor: '#232323'});
var listView = Ti.UI.createListView();
var sections = [];

var fruitSection = Ti.UI.createListSection({ headerTitle: 'Fruits'});
var fruitDataSet = [
    {properties: { title: 'Apple', image: 'logo.png', backgroundColor: '#232323'}},
    {properties: { title: 'Banana'}}
];
fruitSection.setItems(fruitDataSet);
sections.push(fruitSection);

var vegSection = Ti.UI.createListSection({ headerTitle: 'Vegetables'});
var vegDataSet = [
    {properties: { title: 'Carrots'}},
    {properties: { title: 'Potatoes'}},
];
vegSection.setItems(vegDataSet);
sections.push(vegSection);

listView.sections = sections;
win.add(listView);
win.open();


var fishSection = Ti.UI.createListSection({ headerTitle: 'Fish'});
var fishDataSet = [
    {properties: { title: 'Cod'}},
    {properties: { title: 'Haddock'}},
];
fishSection.setItems(fishDataSet);
listView.appendSection(fishSection);
listView.addEventListener('itemclick', function (e) {
    Ti.API.info('Clicked item with index ' + e.itemIndex)
});
```