### PR TITLE
[6_2_X][TIMOB-24218] Update to Android ti.touchid 2.2.0

### DIFF
--- a/support/module/packaged/modules.json
+++ b/support/module/packaged/modules.json
@@ -11,7 +11,7 @@
 		"https://github.com/appcelerator-modules/ti.facebook/releases/download/android-6.2.0/facebook-android-6.2.0.zip",
 		"https://s3.amazonaws.com/timobile.appcelerator.com/modules/ti.cloudpush-android-4.0.3.zip",
 		"https://github.com/appcelerator-modules/ti.map/releases/download/android-3.3.0/ti.map-android-3.3.0.zip",
-		"https://github.com/appcelerator-modules/ti.touchid/releases/download/android-2.1.0/ti.touchid-android-2.1.0.zip"
+		"https://github.com/appcelerator-modules/ti.touchid/releases/download/android-2.2.0/ti.touchid-android-2.2.0.zip"
 	],
 	"commonjs": [
 		"https://github.com/appcelerator-modules/ti.cloud/releases/download/3.2.11/ti.cloud-commonjs-3.2.11.zip"


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-24218

Did not take 2.2.1 as it is marked as prerelease and not merged yet, lmk if that is preferred.