### PR TITLE
[TIMOB-24834] Escape path separator in regex

### DIFF
--- a/android/cli/lib/base-builder.js
+++ b/android/cli/lib/base-builder.js
@@ -57,7 +57,7 @@ AndroidBaseBuilder.prototype.writeXmlFile = function writeXmlFile(srcOrDoc, dest
 	} else {
 		// Resource sets under a qualifier all need to be merged into a single values
 		// file so we adjust the destination path here if necessary
-		const valueResourcesPattern = new RegExp('(values(?:-[^' + path.sep + ']+)?)' + path.sep + '[^' + path.sep + ']+$', 'i');
+		const valueResourcesPattern = new RegExp('(values(?:-[^\\' + path.sep + ']+)?)\\' + path.sep + '[^\\' + path.sep + ']+$', 'i');
 		const match = dest.match(valueResourcesPattern);
 		if (match !== null) {
 			const resourceQualifier = match[1];


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-24834

Fixes a regression on Windows where the unescaped path separator would result in an invalid regex.
