### PR TITLE
[TIMOB-25216] Include Windows Modules docs

### DIFF
--- a/build/docs.js
+++ b/build/docs.js
@@ -26,7 +26,8 @@ Documentation.prototype.generateParityReport = function (next) {
 	if (this.hasWindows) {
 		args = args.concat([
 			'-a', path.join(ROOT_DIR, 'windows', 'doc', 'Titanium'),
-			'-a', path.join(ROOT_DIR, 'windows', 'doc', 'WindowsOnly')
+			'-a', path.join(ROOT_DIR, 'windows', 'doc', 'WindowsOnly'),
+			'-a', path.join(ROOT_DIR, 'windows', 'doc', 'Modules')
 		]);
 	}
 


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-25216

When generating the parity report, include the Modules dir under the windows dist

## Verification

1. Grab the dist from the Jenkins build of appcelerator/titanium_mobile_windows/pull/1091
2. Whack the contents under /windows
3. Run node build/scons.js cleanbuild ios (or whatever takes your fancy)
4. Check dist/parity.html, ti.cloud should be green and noted as supported

The change at appcelerator/titanium_mobile_windows/pull/1091 will also mean that Windows only APIs are now actually in the parity report so you may see the numbers for Android and iOS fluctuate a little