### PR TITLE
[TIMOB-25220] Android: Fix FileProxy compatibility with TiDrawableReference

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiDrawableReference.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiDrawableReference.java
@@ -24,6 +24,7 @@ import org.appcelerator.kroll.common.Log;
 import org.appcelerator.titanium.TiApplication;
 import org.appcelerator.titanium.TiBlob;
 import org.appcelerator.titanium.TiDimension;
+import org.appcelerator.titanium.TiFileProxy;
 import org.appcelerator.titanium.io.TiBaseFile;
 import org.appcelerator.titanium.util.TiConvert;
 import org.appcelerator.titanium.util.TiDownloadListener;
@@ -238,6 +239,8 @@ public class TiDrawableReference
 			return fromBlob(activity, TiConvert.toBlob(object));
 		} else if (object instanceof Number) {
 			return fromResourceId(activity, ((Number)object).intValue());
+		} else if  (object instanceof TiFileProxy) {
+			return fromFile(activity, ((TiFileProxy)object).getBaseFile());
 		} else {
 			Log.w(TAG, "Unknown image resource type: " + object.getClass().getSimpleName()
 				+ ". Returning null drawable reference");


### PR DESCRIPTION
- Fix `FileProxy` compatibility with `TiDrawableReference`
- Caused by https://github.com/appcelerator/titanium_mobile/pull/9147/commits/9ccebb209164a5459e74d403a4c758c458a39e98

###### TEST CASE
```JS
var win = Ti.UI.createWindow({backgroundColor: 'white'}),
    file = Ti.Filesystem.getFile('DefaultIcon.png'),
    img = Ti.UI.createImageView({image: file});

win.add(img);
win.open();
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-25220)