### PR TITLE
[TIMOB-25223] Android: Fix remaining height calculation

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiCompositeLayout.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiCompositeLayout.java
@@ -286,6 +286,7 @@ public class TiCompositeLayout extends ViewGroup
         int wRemain = w;
         int wMode = MeasureSpec.getMode(widthMeasureSpec);
         int h = Math.max(hFromSpec, hSuggested);
+        int hRemain = h;
         int hMode = MeasureSpec.getMode(heightMeasureSpec);
 
         int maxWidth = 0;
@@ -298,7 +299,7 @@ public class TiCompositeLayout extends ViewGroup
         for (int i = 0; i < childCount; i++) {
             View child = getChildAt(i);
             if (child.getVisibility() != View.GONE) {
-                constrainChild(child, w, wMode, h, hMode, wRemain, h - maxHeight);
+                constrainChild(child, w, wMode, h, hMode, wRemain, hRemain);
             }
 
             int childWidth = child.getMeasuredWidth();
@@ -336,6 +337,7 @@ public class TiCompositeLayout extends ViewGroup
                     // the widths since it doesn't wrap
                     maxWidth += childWidth;
                 }
+                hRemain = h - maxHeight;
                 horizontalRowHeight = Math.max(horizontalRowHeight, childHeight);
 
             } else {


### PR DESCRIPTION
- Fix remaining height calculation of child views

###### TEST CASE
```JS
var win = Ti.UI.createWindow({
		backgroundColor: 'gray'
	}),
	list = Ti.UI.createListView(),
	section = Ti.UI.createListSection({
		items: [
			{properties: {title: 'Square'}},
			{properties: {title: 'Circle'}},
			{properties: {title: 'Triangle'}}
		]
	}),
	view = Ti.UI.createView({
		width: Ti.UI.FILL,
		height: Ti.UI.FILL,
		backgroundColor: 'green'
	});

list.setSections([section]);
win.add([list, view]);

win.open();
```
- Should see a green square

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-25223)