### PR TITLE
Hook up new tests, fix up suite

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,8 +2,8 @@
 library 'pipeline-library'
 currentBuild.result = 'SUCCESS'
 
-// Keep logs/reports/etc of last 5 builds, only keep build artifacts of last 3 builds
-properties([buildDiscarder(logRotator(numToKeepStr: '5', artifactNumToKeepStr: '3'))])
+// Keep logs/reports/etc of last 15 builds, only keep build artifacts of last 3 builds
+properties([buildDiscarder(logRotator(numToKeepStr: '15', artifactNumToKeepStr: '3'))])
 
 // Variables which we assign and share between nodes
 // Don't modify these yourself

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/ToolbarProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/ToolbarProxy.java
@@ -134,4 +134,9 @@ public class ToolbarProxy extends TiToolbarProxy {
 	}
 	//endregion
 
+	@Override
+	public String getApiName()
+	{
+		return "Ti.UI.Toolbar";
+	}
 }

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/android/DrawerLayoutProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/android/DrawerLayoutProxy.java
@@ -27,6 +27,7 @@ public class DrawerLayoutProxy extends TiViewProxy
     @Kroll.constant public static final int LOCK_MODE_LOCKED_CLOSED = DrawerLayout.LOCK_MODE_LOCKED_CLOSED;
     @Kroll.constant public static final int LOCK_MODE_LOCKED_OPEN = DrawerLayout.LOCK_MODE_LOCKED_OPEN;
     @Kroll.constant public static final int LOCK_MODE_UNLOCKED = DrawerLayout.LOCK_MODE_UNLOCKED;
+    @Kroll.constant public static final int LOCK_MODE_UNDEFINED = DrawerLayout.LOCK_MODE_UNDEFINED;
 
     private static final String TAG = "DrawerLayoutProxy";
 
@@ -46,56 +47,68 @@ public class DrawerLayoutProxy extends TiViewProxy
 
     @Kroll.method(runOnUiThread=true)
     public void toggleLeft() {
-        drawer.toggleLeft();
+        if (drawer != null) {
+            drawer.toggleLeft();
+        }
     }
 
     @Kroll.method(runOnUiThread=true)
     public void openLeft() {
-        drawer.openLeft();
+        if (drawer != null) {
+            drawer.openLeft();
+        }
     }
 
     @Kroll.method(runOnUiThread=true)
     public void closeLeft() {
-        drawer.closeLeft();
+        if (drawer != null) {
+            drawer.closeLeft();
+        }
     }
 
     @Kroll.method(runOnUiThread=true)
     public void toggleRight() {
-        drawer.toggleRight();
+        if (drawer != null) {
+            drawer.toggleRight();
+        }
     }
 
     @Kroll.method(runOnUiThread=true)
     public void openRight() {
-        drawer.openRight();
+        if (drawer != null) {
+            drawer.openRight();
+        }
     }
 
     @Kroll.method(runOnUiThread=true)
     public void closeRight() {
-        drawer.closeRight();
+        if (drawer != null) {
+            drawer.closeRight();
+        }
     }
 
     @Kroll.method
     @Kroll.getProperty
     public boolean getIsLeftOpen() {
-        return drawer.isLeftOpen();
+        return drawer != null && drawer.isLeftOpen();
     }
 
     @Kroll.method
     @Kroll.getProperty
     public boolean getIsRightOpen() {
-        return drawer.isRightOpen();
+        return drawer != null && drawer.isRightOpen();
     }
 
     @Kroll.method
     @Kroll.getProperty
     public boolean getIsLeftVisible() {
-        return drawer.isLeftVisible();
+        return drawer != null && drawer.isLeftVisible();
     }
 
     @Kroll.method
     @Kroll.getProperty
     public boolean getIsRightVisible() {
-        return drawer.isRightVisible();
+        return drawer != null && drawer.isRightVisible();
     }
 
     @Kroll.method
@@ -129,9 +142,27 @@ public class DrawerLayoutProxy extends TiViewProxy
     }
 
     @Kroll.method
+    @Kroll.getProperty
+    public boolean getDrawerIndicatorEnabled() {
+        if (hasProperty(TiC.PROPERTY_DRAWER_INDICATOR_ENABLED)) {
+            return (Boolean) getProperty(TiC.PROPERTY_DRAWER_INDICATOR_ENABLED);
+        }
+        return true;
+    }
+
+    @Kroll.method
     @Kroll.setProperty
     public void setDrawerIndicatorEnabled(Object arg) {
         setPropertyAndFire(TiC.PROPERTY_DRAWER_INDICATOR_ENABLED, arg);
+    }
+
+    @Kroll.method
+    @Kroll.getProperty
+    public int getDrawerLockMode() {
+        if (hasProperty(TiC.PROPERTY_DRAWER_LOCK_MODE)) {
+            return (Integer) getProperty(TiC.PROPERTY_DRAWER_LOCK_MODE);
+        }
+        return LOCK_MODE_UNDEFINED;
     }
 
     @Kroll.method
@@ -143,6 +174,15 @@ public class DrawerLayoutProxy extends TiViewProxy
     @Kroll.method
     public void interceptTouchEvent (TiViewProxy view, Boolean disallowIntercept){
         view.getOrCreateView().getOuterView().getParent().requestDisallowInterceptTouchEvent(disallowIntercept);
+    }
+
+    @Kroll.method
+    @Kroll.getProperty
+    public boolean getToolbarEnabled() {
+        if (hasProperty(TiC.PROPERTY_TOOLBAR_ENABLED)) {
+            return (Boolean) getProperty(TiC.PROPERTY_TOOLBAR_ENABLED);
+        }
+        return true;
     }
 
     @Kroll.method

--- a/apidoc/Titanium/UI/Android/DrawerLayout.yml
+++ b/apidoc/Titanium/UI/Android/DrawerLayout.yml
@@ -16,37 +16,64 @@ since: "6.2.0"
 platforms: [android]
 
 properties:
+  - name: LOCK_MODE_LOCKED_CLOSED
+    summary: |
+        Use with [DrawerLayout.drawerLockMode](Titanium.UI.Android.DrawerLayout.drawerLockMode) to specify the drawer is locked closed.
+    type: Number
+    permission: read-only
+
+  - name: LOCK_MODE_LOCKED_OPEN
+    summary: |
+        Use with [DrawerLayout.drawerLockMode](Titanium.UI.Android.DrawerLayout.drawerLockMode) to specify the drawer is locked opened.
+    type: Number
+    permission: read-only
+
+  - name: LOCK_MODE_UNDEFINED
+    summary: |
+        Use with [DrawerLayout.drawerLockMode](Titanium.UI.Android.DrawerLayout.drawerLockMode) to specify the drawer is reset to default lock state.
+    type: Number
+    permission: read-only
+
+  - name: LOCK_MODE_UNLOCKED
+    summary: |
+        Use with [DrawerLayout.drawerLockMode](Titanium.UI.Android.DrawerLayout.drawerLockMode) to specify the drawer is unlocked.
+    type: Number
+    permission: read-only
 
   - name: isLeftOpen
     summary: Determine whether the left drawer is open
     type: Boolean
+    default: false
 
   - name: isRightOpen
     summary: Determine whether the right drawer is open
     type: Boolean
+    default: false
 
   - name: isLeftVisible
     summary: Determine whether the left drawer is visible
     type: Boolean
+    default: false
 
   - name: isRightVisible
     summary: Determine whether the right drawer is visible
     type: Boolean
+    default: false
 
   - name: leftWidth
-    summary: Get or set the width of the left draw
+    summary: Get or set the width of the left drawer
     type: Number
 
   - name: rightWidth
-    summary: Get or set the width of the right draw
+    summary: Get or set the width of the right drawer
     type: Number
 
   - name: leftView
-    summary: Get or set the view of the left draw
+    summary: Get or set the view of the left drawer
     type: Titanium.UI.View
 
   - name: rightView
-    summary: Get or set the view of the right draw
+    summary: Get or set the view of the right drawer
     type: Titanium.UI.View
 
   - name: centerView
@@ -56,14 +83,18 @@ properties:
   - name: drawerIndicatorEnabled
     summary: Determine the drawer indicator status
     type: Boolean
+    default: true
 
   - name: drawerLockMode
     summary: Get or set the drawerLockMode
     type: Number
+    constants: Titanium.UI.Android.DrawerLayout.LOCK_MODE_*
+    default: <Titanium.UI.Android.DrawerLayout.LOCK_MODE_UNDEFINED>
 
   - name: toolbarEnabled
     summary: Determine whether to enable the toolbar
     type: Boolean
+    default: true
 
 methods:
   - name: toggleLeft

--- a/package-lock.json
+++ b/package-lock.json
@@ -121,6 +121,35 @@
         }
       }
     },
+    "appc-tasks": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/appc-tasks/-/appc-tasks-1.0.1.tgz",
+      "integrity": "sha1-aOG8cq/leLYloW5imalMWtMtmAY=",
+      "requires": {
+        "file-state-monitor": "1.0.0",
+        "fs-extra": "4.0.1"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.1.tgz",
+          "integrity": "sha1-f8DGyJV/mD9X8waiTlud3Y0N2IA=",
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "jsonfile": "3.0.1",
+            "universalify": "0.1.1"
+          }
+        },
+        "jsonfile": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
+          "integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
+          "requires": {
+            "graceful-fs": "4.1.11"
+          }
+        }
+      }
+    },
     "aproba": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.2.tgz",
@@ -1635,6 +1664,34 @@
       "requires": {
         "flat-cache": "1.2.2",
         "object-assign": "4.1.1"
+      }
+    },
+    "file-state-monitor": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-state-monitor/-/file-state-monitor-1.0.0.tgz",
+      "integrity": "sha512-Tmn8VmqNW++Vyd0aMgNPR1F+56gp4GE9iY1rpM5X4YrN1yDxLVBfL2Q7qr6FCyoYyNiyOHCFidK1Mpl5t58BSA==",
+      "requires": {
+        "fs-extra": "4.0.1"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.1.tgz",
+          "integrity": "sha1-f8DGyJV/mD9X8waiTlud3Y0N2IA=",
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "jsonfile": "3.0.1",
+            "universalify": "0.1.1"
+          }
+        },
+        "jsonfile": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
+          "integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
+          "requires": {
+            "graceful-fs": "4.1.11"
+          }
+        }
       }
     },
     "find-up": {
@@ -4227,6 +4284,11 @@
       "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.2.3.tgz",
       "integrity": "sha1-gGmSYzZl1eX8tNsfs6hi62jp5to=",
       "dev": true
+    },
+    "universalify": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
+      "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc="
     },
     "unorm": {
       "version": "1.4.1",

--- a/tests/Resources/app.js
+++ b/tests/Resources/app.js
@@ -1,0 +1,152 @@
+/*
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2011-2017 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+'use strict';
+
+var win = Ti.UI.createWindow({
+		backgroundColor: 'yellow'
+	}),
+	$results = [],
+	failed = false;
+win.open();
+
+require('./ti-mocha');
+
+// ============================================================================
+// Add the tests here using "require"
+// ES6 syntax/compatability tests
+require('./es6.arrows.test');
+require('./es6.default.args.test');
+require('./es6.rest.args.test');
+require('./es6.spread.args.test');
+require('./es6.string.interpolation.test');
+// Titanium APIs
+require('./ti.accelerometer.test');
+require('./ti.api.test');
+require('./ti.app.test');
+require('./ti.app.properties.test');
+require('./ti.app.windows.backgroundservice.test');
+require('./ti.blob.test');
+require('./ti.builtin.test');
+require('./ti.buffer.test');
+require('./ti.codec.test');
+require('./ti.contacts.test');
+require('./ti.contacts.group.test');
+require('./ti.contacts.person.test');
+require('./ti.database.test');
+require('./ti.filesystem.test');
+require('./ti.filesystem.file.test');
+require('./ti.filesystem.filestream.test');
+require('./ti.geolocation.test');
+require('./ti.gesture.test');
+require('./ti.internal.test');
+require('./ti.locale.test');
+require('./ti.map.test');
+require('./ti.media.audioplayer.test');
+require('./ti.media.sound.test');
+require('./ti.network.test');
+require('./ti.network.httpclient.test');
+require('./ti.platform.test');
+require('./ti.platform.displaycaps.test');
+require('./ti.require.test');
+require('./ti.stream.test');
+require('./ti.test');
+require('./ti.ui.test');
+require('./ti.ui.2dmatrix.test');
+require('./ti.ui.activityindicator.test');
+require('./ti.ui.alertdialog.test');
+require('./ti.ui.android.drawerlayout.test');
+require('./ti.ui.button.test');
+require('./ti.ui.constants.test');
+require('./ti.ui.emaildialog.test');
+require('./ti.ui.imageview.test');
+require('./ti.ui.ios.test');
+require('./ti.ui.ios.previewcontext.test');
+require('./ti.ui.label.test');
+require('./ti.ui.layout.test');
+require('./ti.ui.listview.test');
+require('./ti.ui.optiondialog.test');
+require('./ti.ui.picker.test');
+require('./ti.ui.progressbar.test');
+require('./ti.ui.scrollableview.test');
+require('./ti.ui.scrollview.test');
+require('./ti.ui.searchbar.test');
+require('./ti.ui.switch.test');
+require('./ti.ui.tab.test');
+require('./ti.ui.tableview.test');
+require('./ti.ui.textfield.test');
+require('./ti.ui.toolbar.test');
+require('./ti.ui.view.test');
+require('./ti.ui.webview.test');
+require('./ti.ui.window.test');
+require('./ti.ui.windows.commandbar.test');
+require('./ti.utils.test');
+require('./ti.xml.test');
+// ============================================================================
+
+// add a special mocha reporter that will time each test run using
+// our microsecond timer
+function $Reporter(runner) {
+	var started,
+		title;
+
+	runner.on('suite', function (suite) {
+		title = suite.title;
+	});
+
+	runner.on('test', function (test) {
+		Ti.API.info('!TEST_START: ' + test.title);
+		started = new Date().getTime();
+	});
+
+	runner.on('pending', function () {
+		// TODO Spit out something like !TEST_SKIP:  ?
+		started = new Date().getTime(); // reset timer. pending/skipped tests basically start and end immediately
+	});
+
+	// 'pending' hook for skipped tests? Does 'pending', then immediate 'test end'. No 'test' event
+
+	runner.on('fail', function (test, err) {
+		test.err = err;
+		failed = true;
+	});
+
+	runner.on('test end', function (test) {
+		var tdiff = new Date().getTime() - started,
+			result = {
+				state: test.state || 'skipped',
+				duration: tdiff,
+				suite: title,
+				title: test.title,
+				error: test.err // TODO Include the message property on Windows!
+			},
+			stringified = JSON.stringify(result);
+
+		stringified = stringified.replace(/\\n/g, '\\n')
+			.replace(/\\'/g, '\\\'')
+			.replace(/\\"/g, '\\"')
+			.replace(/\\&/g, '\\&')
+			.replace(/\\r/g, '\\r')
+			.replace(/\\t/g, '\\t')
+			.replace(/\\b/g, '\\b')
+			.replace(/\\f/g, '\\f');
+		// remove non-printable and other non-valid JSON chars
+		stringified = stringified.replace(/[\u0000-\u0019]+/g, '');
+		Ti.API.info('!TEST_END: ' + stringified);
+		$results.push(result);
+	});
+}
+
+mocha.setup({
+	reporter: $Reporter,
+	quiet: true
+});
+
+// dump the output, which will get interpreted above in the logging code
+mocha.run(function () {
+	win.backgroundColor = failed ? 'red' : 'green';
+	Ti.API.info('!TEST_RESULTS_STOP!');
+});

--- a/tests/Resources/mocha-filter.js
+++ b/tests/Resources/mocha-filter.js
@@ -1,0 +1,119 @@
+/**
+ * The following code is for adding mocha filters, these filters
+ * will add a clean way to skip tests based on a predefined scenario.
+ *
+ * Add commonly used filters to the checks variable below, and any other
+ * test-specific filters should be defined in the applicable test using
+ * the addFilter() method.
+ */
+
+// Predefined additional filters
+var checks = {
+		ignore: function () {
+			return false;
+		}
+	},
+	originalChecks = Object.keys(checks);
+
+module.exports = function (defaults) {
+	if (typeof defaults !== 'undefined' && typeof defaults !== 'object') {
+		throw new Error('Error: default filters should be an object');
+	}
+	// Add the ignore filter to the provided defaults object if it isn't already defined in it
+	!defaults.ignore && (defaults.ignore = checks.ignore);
+	checks = defaults;
+	module.exports.setupMocha();
+};
+
+/**
+ * Adding filters to mocha tests does not persist across test
+ * files, so any tests making use of the functions must call
+ * this function to set them.
+ */
+module.exports.setupMocha = function (_checks, skipOriginals) {
+	if (!_checks) {
+		_checks = checks;
+	} else if (!skipOriginals) {
+		for (var key in checks) {
+			_checks[key] = checks[key];
+		}
+	}
+
+	var functions = [ describe, it, before, after, beforeEach, afterEach ];
+
+	/**
+	 * Process the checks
+	 */
+	function ext(func, notFailed) {
+		var check = this,
+			returnFunction = {};
+
+		/**
+		 * Parse the provided functions
+		 */
+		var parseFunctions = function (_key) {
+			/**
+			 * Function to return when the checks have been processed
+			 */
+			returnFunction[_key] = function () {
+				var passed = _checks[_key]();
+				if (arguments.length > 0) {
+					if (passed === 'skip' && notFailed) {
+						func.skip.apply(null, arguments);
+					} else if (passed && notFailed) {
+						func.apply(null, arguments);
+					}
+				} else {
+					return ext(func, passed && notFailed);
+				}
+			};
+		};
+
+		for (var key in _checks) {
+			parseFunctions(key);
+		}
+		return returnFunction;
+	}
+
+	/**
+	 * Populate the functions with the new checks
+	 */
+	var populateFunctions = function (_i, _extension) {
+		functions[_i][_extension] = extensions[_extension];
+	};
+
+	for (var i in functions) {
+		var extensions = ext(functions[i], true);
+		for (var extension in extensions) {
+			populateFunctions(i, extension);
+		}
+	}
+};
+
+/**
+ * Add a new filter to the mocha functions. The predefined filters
+ * cannot be overwritten, but user-defined ones can.
+ *
+ * @param name      The name of the filter, which will be used in the test
+ * @param filter    The function that will determine whether to run the test
+ */
+module.exports.addFilter = function (name, filter) {
+	if (originalChecks.indexOf(name) > -1) {
+		return false;
+	}
+	checks[name] = filter;
+	var obj;
+	module.exports.setupMocha((obj = {}, obj[name] = filter, obj), true);
+};
+
+/**
+ * Add mutliple filters at once
+ *
+ * @param filters    Object containing the filters to add
+ */
+module.exports.addFilters = function (filters) {
+	var keys = Object.keys(filters);
+	for (var i = 0; i < keys.length; i++) {
+		module.exports.addFilter(keys[i], filters[keys[i]]);
+	}
+};

--- a/tests/Resources/ti.accelerometer.test.js
+++ b/tests/Resources/ti.accelerometer.test.js
@@ -1,0 +1,24 @@
+/*
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2011-Present by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+/* eslint-env mocha */
+/* global Ti */
+/* eslint no-unused-expressions: "off" */
+'use strict';
+var should = require('./utilities/assertions');
+
+describe('Titanium.Accelerometer', function () {
+	it('apiName', function () {
+		should(Ti.Accelerometer).have.readOnlyProperty('apiName').which.is.a.String;
+		should(Ti.Accelerometer.apiName).be.eql('Ti.Accelerometer');
+	});
+
+	it('exists', function () {
+		should(Ti.Accelerometer).exist;
+		should(Ti.Accelerometer.addEventListener).be.a.Function;
+		should(Ti.Accelerometer.removeEventListener).be.a.Function;
+	});
+});

--- a/tests/Resources/ti.api.test.js
+++ b/tests/Resources/ti.api.test.js
@@ -1,0 +1,58 @@
+/*
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2011-Present by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+/* eslint-env mocha */
+/* global Ti */
+/* eslint no-unused-expressions: "off" */
+'use strict';
+var should = require('./utilities/assertions');
+
+describe('Titanium.API', function () {
+
+	// FIXME Get working on Android, not sure why it doesn't!
+	it.androidBroken('apiName', function () {
+		should(Ti.API).have.readOnlyProperty('apiName').which.is.a.String;
+		should(Ti.API.apiName).be.eql('Ti.API');
+	});
+
+	it('debug()', function () {
+		should(Ti.API.debug).be.a.Function;
+		// return value is void/undefined
+		// TODO How can we verify behavior, accepting array of string args, or accepting/rejecting non string args?
+		should(Ti.API.debug('debug')).be.undefined;
+	});
+
+	it('error()', function () {
+		should(Ti.API.error).be.a.Function;
+		should(Ti.API.debug('error')).be.undefined;
+	});
+
+	it('info()', function () {
+		should(Ti.API.info).be.a.Function;
+		should(Ti.API.debug('info')).be.undefined;
+	});
+
+	it('log()', function () {
+		should(Ti.API.log).be.a.Function;
+		should(Ti.API.debug('log')).be.undefined;
+	});
+
+	// TODO Should timestamp function be available on other platforms?
+	it.ios('timestamp()', function () {
+		should(Ti.API.timestamp).be.a.Function;
+		should(Ti.API.debug('timestamp')).be.undefined;
+	});
+
+	it('trace()', function () {
+		should(Ti.API.trace).be.a.Function;
+		should(Ti.API.trace('trace')).be.undefined;
+	});
+
+	it('warn()', function () {
+		should(Ti.API.warn).be.a.Function;
+		should(Ti.API.warn('warn')).be.undefined;
+	});
+});

--- a/tests/Resources/ti.test.js
+++ b/tests/Resources/ti.test.js
@@ -1,0 +1,118 @@
+/*
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2011-Present by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+/* eslint-env mocha */
+/* global Ti */
+/* eslint no-unused-expressions: "off" */
+'use strict';
+var should = require('./utilities/assertions');
+
+describe('Titanium', function () {
+
+	it('apiName', function () {
+		should(Ti).have.readOnlyProperty('apiName').which.is.a.String;
+		should(Ti.apiName).be.eql('Ti');
+	});
+
+	// FIXME Get working on IOS!
+	it.iosBroken('version', function () {
+		should(Ti.version).not.eql('__TITANIUM_VERSION__');
+		should(Ti).have.readOnlyProperty('version').which.is.a.String;
+	});
+
+	it('#getVersion()', function () {
+		should(Ti.getVersion).be.a.Function;
+		should(Ti.getVersion()).be.a.String;
+		should(Ti.getVersion()).not.eql('__TITANIUM_VERSION__');
+		// TODO Test format of the version string. what should we expect? Something like: /\d\.\d\.\d(\.(v\d+|GA))/
+	});
+
+	// FIXME Get working on IOS!
+	it.iosBroken('buildDate', function () {
+		should(Ti.buildDate).not.eql('__TITANIUM_BUILD_DATE__');
+		should(Ti).have.readOnlyProperty('buildDate').which.is.a.String;
+		// TODO Test format of the date string. what should we expect? Android gives us: '2016/06/02 08:45'
+	});
+
+	it('#getBuildDate()', function () {
+		should(Ti.getBuildDate).be.a.Function;
+		should(Ti.getBuildDate()).be.a.String;
+		should(Ti.getBuildDate()).not.eql('__TITANIUM_BUILD_DATE__');
+	});
+
+	// FIXME Get working on IOS!
+	it.iosBroken('buildHash', function () {
+		should(Ti.buildHash).not.eql('__TITANIUM_BUILD_HASH__');
+		should(Ti).have.readOnlyProperty('buildHash').which.is.a.String;
+		// TODO Test format of the buildHash string. what should we expect? Android gives us: 'c012548'
+	});
+
+	it('#getBuildHash()', function () {
+		should(Ti.getBuildHash).be.a.Function;
+		should(Ti.getBuildHash()).be.a.String;
+		should(Ti.getBuildHash()).not.eql('__TITANIUM_BUILD_HASH__');
+	});
+
+	// FIXME File a ticket in JIRA. Updating V8 fixes the property read/write issues, but exposes bug in that we set userAgent as read-only on Android and it shouldn't be
+	it.androidBroken('userAgent', function () {
+		should(Ti.userAgent).be.a.String;
+
+		var save = Ti.userAgent;
+		Ti.userAgent = 'Titanium_Mocha_Test';
+		should(Ti.userAgent).be.eql('Titanium_Mocha_Test');
+		Ti.userAgent = save;
+		should(Ti.userAgent).be.eql(save);
+	});
+
+	it('#getUserAgent()', function () {
+		should(Ti.getUserAgent).be.a.Function;
+		should(Ti.getUserAgent()).be.a.String;
+	});
+
+	// FIXME Get working on IOS/Android!
+	it.androidAndIosBroken('#setUserAgent()', function () {
+		should(Ti.setUserAgent).be.a.Function;
+		var save = Ti.getUserAgent();
+		Ti.setUserAgent('Titanium_Mocha_Test');
+		should(Ti.getUserAgent()).be.eql('Titanium_Mocha_Test');
+		should(Ti.userAgent).be.eql('Titanium_Mocha_Test');
+		Ti.setUserAgent(save);
+		should(Ti.getUserAgent()).be.eql(save);
+		should(Ti.userAgent).be.eql(save);
+	});
+
+	it('#addEventListener()', function () {
+		should(Ti.addEventListener).be.a.Function;
+	});
+
+	it('#removeEventListener()', function () {
+		should(Ti.removeEventListener).be.a.Function;
+	});
+
+	// FIXME Get working on IOS/Android!
+	it.androidAndIosBroken('#applyProperties()', function () {
+		should(Ti.applyProperties).be.a.Function;
+		Ti.mocha_test = undefined;
+		should(Ti.applyProperties({ mocha_test: 'mocha_test_value' }));
+		should(Ti.mocha_test !== undefined);
+		should(Ti.mocha_test).be.eql('mocha_test_value');
+		Ti.mocha_test = undefined;
+	});
+
+	it('#createBuffer()', function () {
+		should(Ti.createBuffer).be.a.Function;
+	});
+
+	// FIXME Is this really a method we want to expose on our API? Seems like it shouldn't be
+	// Undefined on Android, but there on iOS!
+	it.skip('#createProxy()', function () {
+		should(Ti.createProxy).be.a.Function;
+	});
+
+	it('#fireEvent()', function () {
+		should(Ti.fireEvent).be.a.Function;
+	});
+});

--- a/tests/Resources/ti.ui.alertdialog.test.js
+++ b/tests/Resources/ti.ui.alertdialog.test.js
@@ -4,8 +4,11 @@
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
-var should = require('./utilities/assertions'),
-	utilities = require('./utilities/utilities');
+/* eslint-env mocha */
+/* global Ti */
+/* eslint no-unused-expressions: "off" */
+'use strict';
+var should = require('./utilities/assertions');
 
 describe('Titanium.UI.AlertDialog', function () {
 	it('apiName', function () {
@@ -28,7 +31,7 @@ describe('Titanium.UI.AlertDialog', function () {
 	});
 
 	// FIXME titleid doesn't seem to set title on iOS?
-	(utilities.isIOS() ? it.skip : it)('titleid', function () {
+	it.iosBroken('titleid', function () {
 		var bar = Ti.UI.createAlertDialog({
 			titleid: 'this_is_my_key'
 		});
@@ -58,20 +61,20 @@ describe('Titanium.UI.AlertDialog', function () {
 
 	// FIXME Get working on iOS - defaults to undefined, should be ['OK']
 	// FIXME Get working on Android - defaults to undefined, should be ['OK']
-	((utilities.isIOS() || utilities.isAndroid()) ? it.skip : it)('buttonNames', function () {
+	it.androidAndIosBroken('buttonNames', function () {
 		var bar = Ti.UI.createAlertDialog({});
 		should(bar.buttonNames).be.an.Array; // undefined on iOS and Android
 		should(bar.getButtonNames).be.a.Function;
 		should(bar.buttonNames).be.empty;
 		should(bar.getButtonNames()).be.empty;
-		bar.buttonNames = ['this','other'];
+		bar.buttonNames = [ 'this', 'other' ];
 		should(bar.buttonNames.length).eql(2);
 		should(bar.getButtonNames().length).eql(2);
 	});
 
 	// FIXME Get working on iOS - defaults to undefined, should be -1
 	// FIXME Get working on Android - defaults to undefined, should be -1
-	((utilities.isIOS() || utilities.isAndroid()) ? it.skip : it)('cancel', function (finish) {
+	it.androidAndIosBroken('cancel', function () {
 		var bar = Ti.UI.createAlertDialog({});
 		should(bar.cancel).be.a.Number; // undefined on iOS and Android
 		should(bar.getCancel).be.a.Function;
@@ -79,26 +82,25 @@ describe('Titanium.UI.AlertDialog', function () {
 		should(bar.cancel).eql(1);
 		should(bar.getCancel()).eql(1);
 	});
-	
-	// Skip on other platforms, since it's an iOS-only property
-	(utilities.isIOS() ? it : it.skip)('tintColor', function () {
+
+	it.ios('tintColor', function () {
 		var bar = Ti.UI.createAlertDialog({
 			tintColor: 'red'
 		});
-		
+
 		// Check getter
 		should(bar.tintColor).be.a.String;
 		should(bar.getTintColor).be.a.Function;
 		should(bar.tintColor).eql('red');
 		should(bar.getTintColor()).eql('red');
-		
+
 		// Set new value
 		bar.tintColor = '#f00';
-		
+
 		// Check getter again
 		should(bar.tintColor).eql('#f00');
 		should(bar.getTintColor()).eql('#f00');
-		
+
 		// Check setter
 		should(bar.setTintColor).be.a.Function;
 		bar.setTintColor('#0f0');

--- a/tests/Resources/ti.ui.android.drawerlayout.test.js
+++ b/tests/Resources/ti.ui.android.drawerlayout.test.js
@@ -4,92 +4,113 @@
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
-var should = require('./utilities/assertions'),
-	utilities = require('./utilities/utilities');
+/* eslint-env mocha */
+/* global Titanium */
+/* eslint no-unused-expressions: "off" */
+'use strict';
 
-describe('Titanium.UI.Android.DrawerLayout', function () {
+var should = require('./utilities/assertions');
 
-	(utilities.isAndroid() ? it : it.skip)('isLeftOpen', function () {
+describe.android('Titanium.UI.Android', function () {
+	it('#createDrawerLayout', function () {
+		var drawerLayout;
 		should(Titanium.UI.Android.createDrawerLayout).be.a.Function;
-		var drawerLayout = Titanium.UI.Android.createDrawerLayout();
+		drawerLayout = Titanium.UI.Android.createDrawerLayout();
 		should(drawerLayout).be.a.Object;
+	});
+});
+
+describe.android('Titanium.UI.Android.DrawerLayout', function () {
+	// constants
+	it('LOCK_MODE_LOCKED_CLOSED', function () {
+		should(Titanium.UI.Android.DrawerLayout).have.constant('LOCK_MODE_LOCKED_CLOSED').which.is.a.Number;
+	});
+	it('LOCK_MODE_LOCKED_OPEN', function () {
+		should(Titanium.UI.Android.DrawerLayout).have.constant('LOCK_MODE_LOCKED_OPEN').which.is.a.Number;
+	});
+	it('LOCK_MODE_UNLOCKED', function () {
+		should(Titanium.UI.Android.DrawerLayout).have.constant('LOCK_MODE_UNLOCKED').which.is.a.Number;
+	});
+	it('LOCK_MODE_UNDEFINED', function () {
+		should(Titanium.UI.Android.DrawerLayout).have.constant('LOCK_MODE_UNDEFINED').which.is.a.Number;
+	});
+
+	// properties
+	it('isLeftOpen', function () {
+		var drawerLayout = Titanium.UI.Android.createDrawerLayout();
 		should(drawerLayout.isLeftOpen).be.a.Boolean;
+		should(drawerLayout.isLeftOpen).be.false; // default value
 	});
 
-	(utilities.isAndroid() ? it : it.skip)('isRightOpen', function () {
-		should(Titanium.UI.Android.createDrawerLayout).be.a.Function;
+	it('isRightOpen', function () {
 		var drawerLayout = Titanium.UI.Android.createDrawerLayout();
-		should(drawerLayout).be.a.Object;
 		should(drawerLayout.isRightOpen).be.a.Boolean;
+		should(drawerLayout.isRightOpen).be.false; // default value
 	});
 
-	(utilities.isAndroid() ? it : it.skip)('isLeftVisible', function () {
-		should(Titanium.UI.Android.createDrawerLayout).be.a.Function;
+	it('isLeftVisible', function () {
 		var drawerLayout = Titanium.UI.Android.createDrawerLayout();
-		should(drawerLayout).be.a.Object;
 		should(drawerLayout.isLeftVisible).be.a.Boolean;
+		should(drawerLayout.isLeftVisible).be.false; // default value
 	});
 
-	(utilities.isAndroid() ? it : it.skip)('isRightVisible', function () {
-		should(Titanium.UI.Android.createDrawerLayout).be.a.Function;
+	it('isRightVisible', function () {
 		var drawerLayout = Titanium.UI.Android.createDrawerLayout();
-		should(drawerLayout).be.a.Object;
 		should(drawerLayout.isRightVisible).be.a.Boolean;
+		should(drawerLayout.isRightVisible).be.false; // default value
 	});
 
-	(utilities.isAndroid() ? it : it.skip)('leftWidth', function () {
-		should(Titanium.UI.Android.createDrawerLayout).be.a.Function;
+	it('leftWidth', function () {
 		var drawerLayout = Titanium.UI.Android.createDrawerLayout();
-		should(drawerLayout).be.a.Object;
-		should(drawerLayout.leftWidth).be.a.Number;
+		// should(drawerLayout.leftWidth).be.a.Number;
+		// FIXME Default value is undefined, can't verify it's supposed to be a number unless we've opened the left drawer
+		should(drawerLayout.leftWidth).be.undefined;
 	});
 
-	(utilities.isAndroid() ? it : it.skip)('rightWidth', function () {
-		should(Titanium.UI.Android.createDrawerLayout).be.a.Function;
+	it('rightWidth', function () {
 		var drawerLayout = Titanium.UI.Android.createDrawerLayout();
-		should(drawerLayout).be.a.Object;
-		should(drawerLayout.rightWidth).be.a.Number;
+		// should(drawerLayout.rightWidth).be.a.Number;
+		// FIXME Default value is undefined, can't verify it's supposed to be a number unless we've opened the right drawer
+		should(drawerLayout.rightWidth).be.undefined;
 	});
 
-	(utilities.isAndroid() ? it : it.skip)('leftView', function () {
-		should(Titanium.UI.Android.createDrawerLayout).be.a.Function;
+	it('leftView', function () {
 		var drawerLayout = Titanium.UI.Android.createDrawerLayout();
-		should(drawerLayout).be.a.Object;
-		should(drawerLayout.leftView).be.a.Object;
+		// should(drawerLayout.leftView).be.a.Object;
+		// FIXME Default value is undefined, can't verify it's supposed to be an object unless we've set a value
+		should(drawerLayout.leftView).be.undefined;
 	});
 
-	(utilities.isAndroid() ? it : it.skip)('rightView', function () {
-		should(Titanium.UI.Android.createDrawerLayout).be.a.Function;
+	it('rightView', function () {
 		var drawerLayout = Titanium.UI.Android.createDrawerLayout();
-		should(drawerLayout).be.a.Object;
-		should(drawerLayout.rightView).be.a.Object;
+		// should(drawerLayout.rightView).be.a.Object;
+		// FIXME Default value is undefined, can't verify it's supposed to be an object unless we've set a value
+		should(drawerLayout.rightView).be.undefined;
 	});
 
-	(utilities.isAndroid() ? it : it.skip)('centerView', function () {
-		should(Titanium.UI.Android.createDrawerLayout).be.a.Function;
+	it('centerView', function () {
 		var drawerLayout = Titanium.UI.Android.createDrawerLayout();
-		should(drawerLayout).be.a.Object;
-		should(drawerLayout.centerView).be.a.Object;
+		// should(drawerLayout.centerView).be.a.Object;
+		// FIXME Default value is undefined, can't verify it's supposed to be an object unless we've set a value
+		should(drawerLayout.centerView).be.undefined;
 	});
 
-	(utilities.isAndroid() ? it : it.skip)('drawerIndicatorEnabled', function () {
-		should(Titanium.UI.Android.createDrawerLayout).be.a.Function;
+	it('drawerIndicatorEnabled', function () {
 		var drawerLayout = Titanium.UI.Android.createDrawerLayout();
-		should(drawerLayout).be.a.Object;
 		should(drawerLayout.drawerIndicatorEnabled).be.a.Boolean;
+		should(drawerLayout.drawerIndicatorEnabled).be.true; // default value
 	});
 
-	(utilities.isAndroid() ? it : it.skip)('drawerLockMode', function () {
-		should(Titanium.UI.Android.createDrawerLayout).be.a.Function;
+	it('drawerLockMode', function () {
 		var drawerLayout = Titanium.UI.Android.createDrawerLayout();
-		should(drawerLayout).be.a.Object;
 		should(drawerLayout.drawerLockMode).be.a.Number;
+		should(drawerLayout.drawerLockMode).eql(Titanium.UI.Android.DrawerLayout.LOCK_MODE_UNDEFINED); // default value
+		// TODO Add tests that we enforce lock mode must be one of the constants defined!
 	});
 
-	(utilities.isAndroid() ? it : it.skip)('toolbarEnabled', function () {
-		should(Titanium.UI.Android.createDrawerLayout).be.a.Function;
+	it('toolbarEnabled', function () {
 		var drawerLayout = Titanium.UI.Android.createDrawerLayout();
-		should(drawerLayout).be.a.Object;
 		should(drawerLayout.toolbarEnabled).be.a.Boolean;
+		should(drawerLayout.toolbarEnabled).be.true; // default value
 	});
 });

--- a/tests/Resources/ti.ui.ios.previewcontext.test.js
+++ b/tests/Resources/ti.ui.ios.previewcontext.test.js
@@ -1,0 +1,32 @@
+/*
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2011-Present by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+/* eslint-env mocha */
+/* global Ti */
+/* eslint no-unused-expressions: "off" */
+'use strict';
+var should = require('./utilities/assertions');
+
+describe.ios('Titanium.UI.iOS', function () {
+	// TIMOB-23542 test previewContext
+	it('#createPreviewContext()', function () {
+		var previewContext;
+		should(Ti.UI.iOS.createPreviewContext).not.be.undefined;
+		should(Ti.UI.iOS.createPreviewContext).be.a.Function;
+		previewContext = Ti.UI.iOS.createPreviewContext({
+			preview: Ti.UI.createView({
+				backgroundColor: "red"
+			}),
+			contentHeight: 300
+		});
+		should(previewContext.preview).be.an.Object;
+		should(previewContext.contentHeight).be.eql(300);
+	});
+});
+
+// describe.ios('Titanium.UI.iOS.PreviewContext', function () {
+// TODO Add tests for PreviewContext type!
+// });

--- a/tests/Resources/ti.ui.ios.test.js
+++ b/tests/Resources/ti.ui.ios.test.js
@@ -1,0 +1,52 @@
+/*
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2011-Present by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+/* eslint-env mocha */
+/* global Ti */
+/* eslint no-unused-expressions: "off" */
+'use strict';
+var should = require('./utilities/assertions');
+
+describe.ios('Titanium.UI.iOS', function () {
+
+	// TODO Add tests for all the constants in this namespace!
+
+	// --- properties ---
+	it('appBadge', function () {
+		should(Ti.UI.iOS.appBadge).be.undefined;
+		// TODO Set the value and test it got set
+	});
+
+	it('appSupportsShakeToEdit', function () {
+		should(Ti.UI.iOS.appSupportsShakeToEdit).be.true; // TODO Set default to true in docs?
+		// TODO Set the value and test it got set
+	});
+
+	it('forceTouchSupported', function () {
+		should(Ti.UI.iOS).have.readOnlyProperty('forceTouchSupported').which.is.a.Boolean;
+		// TODO Validate the value based on the device?
+	});
+
+	it('statusBarBackgroundColor', function () {
+		should(Ti.UI.iOS.statusBarBackgroundColor).be.undefined;
+		// TODO Test that this accepts normal color values (names, hex, etc)
+	});
+
+	// --- methods ---
+
+	// TIMOB-23542 test livePhotoBadge
+	it('#createLivePhotoBadge()', function () {
+		var livePhotoBadge;
+		should(Ti.UI.iOS.createLivePhotoBadge).not.be.undefined;
+		should(Ti.UI.iOS.createLivePhotoBadge).be.a.Function;
+		livePhotoBadge = Ti.UI.iOS.createLivePhotoBadge(Ti.UI.iOS.LIVEPHOTO_BADGE_OPTIONS_OVER_CONTENT);
+		should(livePhotoBadge).be.an.Object;
+		// TODO Test that we created a Ti.Blob!
+	});
+
+	// TODO Add tests for createTransitionAnimation
+	it('#createTransitionAnimation(Object)');
+});

--- a/tests/Resources/ti.ui.test.js
+++ b/tests/Resources/ti.ui.test.js
@@ -1,0 +1,26 @@
+/*
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2011-Present by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+/* eslint-env mocha */
+/* global Ti */
+/* eslint no-unused-expressions: "off" */
+'use strict';
+var should = require('./utilities/assertions');
+
+describe('Titanium.UI', function () {
+
+	// TODO Write some tests for converting various units back and forth!
+	it('#convertUnits(String, Number)');
+
+	// Constants are tested in ti.ui.constants.test.js
+
+	// TODO Write tests for Ti.UI.global properties below!
+	it('backgroundColor');
+	it('backgroundImage');
+	it('currentTab');
+	it('currentWindow');
+	it.ios('tintColor');
+});

--- a/tests/Resources/ti.ui.textfield.test.js
+++ b/tests/Resources/ti.ui.textfield.test.js
@@ -1,16 +1,20 @@
 /*
  * Appcelerator Titanium Mobile
- * Copyright (c) 2011-2016 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2011-2017 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
+/* eslint-env mocha */
+/* global Ti, Titanium */
+/* eslint no-unused-expressions: "off" */
+'use strict';
 var should = require('./utilities/assertions'),
 	utilities = require('./utilities/utilities'),
 	didFocus = false;
 
 describe('Titanium.UI.TextField', function () {
 
-	beforeEach(function() {
+	beforeEach(function () {
 		didFocus = false;
 	});
 
@@ -36,7 +40,7 @@ describe('Titanium.UI.TextField', function () {
 	});
 
 	// Skip on Windows Phone since not available, yet
-	(!(utilities.isIOS() || utilities.isAndroid()) ? it.skip : it)('padding', function () {
+	it.windowsMissing('padding', function () {
 		var textfield = Ti.UI.createTextField({
 			value: 'this is some text',
 			padding: {
@@ -69,6 +73,7 @@ describe('Titanium.UI.TextField', function () {
 			value: 'this is some text',
 			textAlign: Titanium.UI.TEXT_ALIGNMENT_CENTER
 		});
+		// FIXME Parity issue!
 		if (utilities.isAndroid()) {
 			should(textfield.textAlign).be.a.String;
 		} else {
@@ -87,6 +92,7 @@ describe('Titanium.UI.TextField', function () {
 			value: 'this is some text',
 			verticalAlign: Titanium.UI.TEXT_VERTICAL_ALIGNMENT_BOTTOM
 		});
+		// FIXME Parity issue!
 		if (utilities.isAndroid()) {
 			should(textfield.verticalAlign).be.a.String;
 		} else {
@@ -101,7 +107,7 @@ describe('Titanium.UI.TextField', function () {
 	});
 
 	// FIXME Defaults to undefined on Android. Docs say default is false
-	(utilities.isAndroid() ? it.skip : it)('passwordMask', function () {
+	it.androidBroken('passwordMask', function () {
 		var text = 'this is some text',
 			textfield = Ti.UI.createTextField({
 				value: text
@@ -154,7 +160,7 @@ describe('Titanium.UI.TextField', function () {
 		should(textfield.getHintTextColor()).eql('blue');
 	});
 
-	(utilities.isIOS() ? it.skip : it)('hintType', function () {
+	it.iosBroken('hintType', function () {
 		var textfield = Ti.UI.createTextField({
 			hintText: 'Enter E-Mail ...',
 			hintType: Ti.UI.HINT_TYPE_ANIMATED
@@ -167,15 +173,16 @@ describe('Titanium.UI.TextField', function () {
 		should(textfield.getHintType()).eql(Ti.UI.HINT_TYPE_STATIC);
 	});
 
-	it.skip('width', function (finish) {
+	// FIXME win.width is undefined on Android and iOS here. Test needs to be rewritten
+	it.androidAndIosBroken('width', function (finish) {
 		this.timeout(5000);
 		var textfield = Ti.UI.createTextField({
-			value: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec nec ullamcorper massa, eget tempor sapien. Phasellus nisi metus, tempus a magna nec, ultricies rutrum lacus. Aliquam sit amet augue suscipit, dignissim tellus eu, consectetur elit. Praesent ligula velit, blandit vel urna sit amet, suscipit euismod nunc.',
-			width: Ti.UI.SIZE
-		});
-		var win = Ti.UI.createWindow({
-			backgroundColor: '#ddd'
-		});
+				value: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec nec ullamcorper massa, eget tempor sapien. Phasellus nisi metus, tempus a magna nec, ultricies rutrum lacus. Aliquam sit amet augue suscipit, dignissim tellus eu, consectetur elit. Praesent ligula velit, blandit vel urna sit amet, suscipit euismod nunc.',
+				width: Ti.UI.SIZE
+			}),
+			win = Ti.UI.createWindow({
+				backgroundColor: '#ddd'
+			});
 		win.add(textfield);
 		win.addEventListener('focus', function () {
 			var error;
@@ -187,7 +194,7 @@ describe('Titanium.UI.TextField', function () {
 				error = err;
 			}
 
-			setTimeout(function() {
+			setTimeout(function () {
 				win.close();
 				finish(error);
 			}, 3000);
@@ -196,7 +203,7 @@ describe('Titanium.UI.TextField', function () {
 	});
 
 	// FIXME Intermittently failing on Android on build machine, I think due to test timeout
-	(utilities.isAndroid() ? it.skip : it)('height', function (finish) {
+	it.androidBroken('height', function (finish) {
 		this.timeout(5000);
 		var textfield = Ti.UI.createTextField({
 				value: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec nec ullamcorper massa, eget tempor sapien. Phasellus nisi metus, tempus a magna nec, ultricies rutrum lacus. Aliquam sit amet augue suscipit, dignissim tellus eu, consectetur elit. Praesent ligula velit, blandit vel urna sit amet, suscipit euismod nunc.',
@@ -218,7 +225,9 @@ describe('Titanium.UI.TextField', function () {
 		win.addEventListener('focus', function () {
 			var error;
 
-			if (didFocus) return;
+			if (didFocus) {
+				return;
+			}
 			didFocus = true;
 
 			try {
@@ -228,7 +237,7 @@ describe('Titanium.UI.TextField', function () {
 				error = err;
 			}
 
-			setTimeout(function() {
+			setTimeout(function () {
 				win.close();
 				finish(error);
 			}, 3000);

--- a/tests/Resources/ti.ui.toolbar.test.js
+++ b/tests/Resources/ti.ui.toolbar.test.js
@@ -4,67 +4,64 @@
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
+/* eslint-env mocha */
+/* global Ti */
+/* eslint no-unused-expressions: "off" */
+'use strict';
 
 var should = require('./utilities/assertions'),
-	utilities = require('./utilities/utilities'),
 	win = null;
 
-describe('Titanium.UI.Toolbar', function() {
+describe('Titanium.UI.Toolbar', function () {
 	this.timeout(10000);
 
-	afterEach(function() {
+	afterEach(function () {
 		if (win) {
 			win.close();
 		}
 		win = null;
 	});
-	
-	it('SimpleToolbar', function(finish) {
-		win = Ti.UI.createWindow();
 
+	it('SimpleToolbar', function () {
 		var send = Ti.UI.createButton({
-		    title: 'Send',
-		});
+				title: 'Send',
+			}),
+			camera = Ti.UI.createButton({
+				title: 'Camera'
+			}),
+			toolbar = Ti.UI.createToolbar({
+				items: [ send, camera ],
+				bottom: 0
+			});
 
-		var camera = Ti.UI.createButton({
-		    title: 'Camera'
-		});
-
-		var toolbar = Ti.UI.createToolbar({
-		    items: [send, camera],
-		    bottom: 0
-		});
-		
 		should(toolbar).have.readOnlyProperty('apiName').which.is.a.String;
 		should(toolbar.apiName).be.eql('Ti.UI.Toolbar');
 		should(toolbar.items).be.an.Array;
 		should(toolbar.items.length).eql(2);
 
+		win = Ti.UI.createWindow();
 		win.add(toolbar);
 		win.open();
 	});
-	
-	it('SimpleiOSToolbarDeprecated', function(finish) {
-		win = Ti.UI.createWindow();
 
+	it.ios('SimpleiOSToolbarDeprecated', function () {
 		var send = Ti.UI.createButton({
 				title: 'Send',
-		});
-
-		var camera = Ti.UI.createButton({
+			}),
+			camera = Ti.UI.createButton({
 				title: 'Camera'
-		});
-
-		var toolbar = Ti.UI.iOS.createToolbar({
-				items: [send, camera],
+			}),
+			toolbar = Ti.UI.iOS.createToolbar({
+				items: [ send, camera ],
 				bottom: 0
-		});
-		
+			});
+
 		should(toolbar).have.readOnlyProperty('apiName').which.is.a.String;
 		should(toolbar.apiName).be.eql('Ti.UI.iOS.Toolbar');
 		should(toolbar.items).be.an.Array;
 		should(toolbar.items.length).eql(2);
 
+		win = Ti.UI.createWindow();
 		win.add(toolbar);
 		win.open();
 	});

--- a/tests/Resources/ti.utils.test.js
+++ b/tests/Resources/ti.utils.test.js
@@ -1,0 +1,126 @@
+/*
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2015-Present by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+/* eslint-env mocha */
+/* global Ti */
+/* eslint no-unused-expressions: "off" */
+'use strict';
+var should = require('./utilities/assertions');
+
+describe('Titanium.Utils', function () {
+	it('exists', function () {
+		should(Ti.Utils).not.be.undefined;
+		should(Ti.Utils).be.an.Object;
+	});
+
+	it('apiName', function () {
+		should(Ti.Utils).have.readOnlyProperty('apiName').which.is.a.String;
+		should(Ti.Utils.apiName).be.eql('Ti.Utils');
+	});
+
+	it('#base64decode(String)', function () {
+		var test;
+		should(Ti.Utils.base64decode).be.a.Function;
+		test = Ti.Utils.base64decode('dGVzdA==');
+		should(test).be.a.Object;
+		should(test.apiName).eql('Ti.Blob');
+		should(test.getText()).be.eql('test');
+	});
+
+	it('#base64decode(Ti.Blob)', function () {
+		var f = Titanium.Filesystem.getFile(Titanium.Filesystem.resourcesDirectory, 'txtFiles/encodedFile.txt'),
+			blob = Ti.Utils.base64decode(f.read());
+		should(blob.toString()).eql('Decoding successful!');
+	});
+
+	it('#base64encode(String)', function () {
+		var test;
+		should(Ti.Utils.base64encode).be.a.Function;
+		test = Ti.Utils.base64encode('test');
+		should(test).be.a.Object;
+		should(test.apiName).eql('Ti.Blob');
+		should(test.getText()).be.eql('dGVzdA==');
+	});
+
+	it('#base64encode(Ti.Blob)', function () {
+		var f = Titanium.Filesystem.getFile(Titanium.Filesystem.resourcesDirectory, 'txtFiles/decodedFile.txt'),
+			contents = f.read();
+		should(Ti.Utils.base64encode(contents).toString()).eql('SSBhbSBub3QgZW5jb2RlZCB5ZXQu');
+	});
+
+	// TODO According to docs, File is only accepted on Android. Should this be cross-platform?
+	// For now, the only impl is Android, and there is no way to actually use the result without an error getting thrown
+	// #toString() and #toBase64() (undocumented API) both end up throwing errors
+	// Why can't this just be treated similarly to how passing in a Ti.Blob that's wrapping a file is
+	it.skip('#base64encode(Ti.Filesystem.File)', function () { // it.androidBroken // this is broken, see above for why
+		var f = Titanium.Filesystem.getFile(Titanium.Filesystem.resourcesDirectory, 'txtFiles/decodedFile.txt'),
+			blob = Ti.Utils.base64encode(f),
+			string;
+
+		// result here is a Ti.Blob
+		should(blob).be.a.Object;
+		should(blob.apiName).eql('Ti.Blob'); // toString() fails...
+		string = blob.toBase64(); // undocumented API, still fails because calls getBytes() which calls getLength() which fails
+		should(result).eql('SSBhbSBub3QgZW5jb2RlZCB5ZXQu');
+	});
+
+	it('#md5HexDigest(String)', function () {
+		var test;
+		should(Ti.Utils.md5HexDigest).be.a.Function;
+		test = Ti.Utils.md5HexDigest('test');
+		should(test).be.a.String;
+		should(test).be.eql('098f6bcd4621d373cade4e832627b4f6');
+	});
+
+	it('#md5HexDigest(Ti.Blob)', function () {
+		var f = Titanium.Filesystem.getFile(Titanium.Filesystem.resourcesDirectory, 'txtFiles/file.txt'),
+			contents = f.read(),
+			test;
+		should(Ti.Utils.md5HexDigest).be.a.Function;
+		test = Ti.Utils.md5HexDigest(contents);
+		should(test).be.a.String;
+		should(test).be.eql('4fe8a693c64f93f65c5faf42dc49ab23');
+	});
+
+	it('#sha1(String)', function () {
+		var test;
+		should(Ti.Utils.sha1).be.a.Function;
+		test = Ti.Utils.sha1('test');
+		should(test).be.a.String;
+		should(test).be.eql('a94a8fe5ccb19ba61c4c0873d391e987982fbbd3');
+	});
+
+	it('#sha1(Ti.Blob)', function () {
+		var f = Titanium.Filesystem.getFile(Titanium.Filesystem.resourcesDirectory, 'txtFiles/decodedFile.txt'),
+			contents = f.read();
+		should(Ti.Utils.sha1(contents).toString()).eql('ddbb50fb5beea93d1d4913fc22355c84f22d43ed');
+	});
+
+	it('#sha256(String)', function () {
+		var test;
+		should(Ti.Utils.sha256).be.a.Function;
+		test = Ti.Utils.sha256('test');
+		should(test).be.a.String;
+		should(test).be.eql('9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08');
+	});
+
+	it('#sha256(Ti.Blob)', function () {
+		var f = Titanium.Filesystem.getFile(Titanium.Filesystem.resourcesDirectory, 'txtFiles/decodedFile.txt'),
+			contents = f.read();
+		should(Ti.Utils.sha256(contents).toString()).eql('9f81cd4f510080f1da92386b391cf2539b21f6363df491b89787e50fbc33b2c3');
+	});
+
+	// FIXME Android does no newlines for longer output, both iOS and Windows do. Need to get parity
+	it.skip('TIMOB-9111', function () {
+		var shortString = 'ABCDEFGHIJ1234567890ABCDEFGHIJ12|psndemo2|abcd:1',
+			longString = 'ABCDEFGHIJ1234567890ABCDEFGHIJ12|psndemo2|abcd:12345678901234567890',
+			tiBase64ShortResult = Ti.Utils.base64encode(shortString),
+			tiBase64LongResult  = Ti.Utils.base64encode(longString);
+
+		should(tiBase64ShortResult.getText()).be.eql('QUJDREVGR0hJSjEyMzQ1Njc4OTBBQkNERUZHSElKMTJ8cHNuZGVtbzJ8YWJjZDox');
+		should(tiBase64LongResult.getText()).be.eql('QUJDREVGR0hJSjEyMzQ1Njc4OTBBQkNERUZHSElKMTJ8cHNuZGVtbzJ8YWJjZDoxMjM0NTY3ODkwMTIzNDU2Nzg5MA==');
+	});
+});

--- a/tests/Resources/utilities/utilities.js
+++ b/tests/Resources/utilities/utilities.js
@@ -1,0 +1,89 @@
+'use strict';
+var filter = require('../mocha-filter'),
+	filters = {},
+	Utility = {};
+
+Utility.isIPhone = function () {
+	return Ti.Platform.osname === 'iphone';
+};
+
+Utility.isIPad = function () {
+	return Ti.Platform.osname === 'ipad';
+};
+
+Utility.isIOS = function () {
+	return this.isIPhone() || this.isIPad();
+};
+
+Utility.isAndroid = function () {
+	return (Ti.Platform.osname === 'android');
+};
+
+Utility.isWindowsPhone = function () {
+	return Ti.Platform.osname === 'windowsphone';
+};
+
+Utility.isWindowsDesktop = function () {
+	return Ti.Platform.osname === 'windowsstore';
+};
+
+Utility.isWindows = function () {
+	return this.isWindowsPhone() || this.isWindowsDesktop();
+};
+
+Utility.isWindows10 = function () {
+	return this.isWindows() && Ti.Platform.version.indexOf('10.0') === 0;
+};
+
+Utility.isWindows8_1 = function () {
+	// We've seen 6.3.9600 and 6.3.9651.0 - so assume 6.3.x is Windows 8.1.x
+	return this.isWindows() && Ti.Platform.version.indexOf('6.3.') === 0;
+};
+
+// Use custom mocha filters for platform-specific tests
+filters = {
+	android: function () {
+		return Utility.isAndroid();
+	},
+	ios: function () {
+		return Utility.isIOS();
+	},
+	windows: function () {
+		return Utility.isWindows();
+	},
+	// To mark APIs meant to be cross-platform but missing from a given platform
+	androidMissing: function () {
+		if (Utility.isAndroid()) {
+			return 'skip';
+		}
+		return true;
+	},
+	iosMissing: function () {
+		if (Utility.isIOS()) {
+			return 'skip';
+		}
+		return true;
+	},
+	windowsMissing: function () {
+		if (Utility.isWindows()) {
+			return 'skip';
+		}
+		return true;
+	},
+	// to mark when there's a bug in both iOS and Android impl
+	androidAndIosBroken: function () {
+		if (Utility.isAndroid() || Utility.isIOS()) {
+			return 'skip';
+		}
+		return true;
+	}
+};
+// Alias broken tests on a given platform to "missing" filter for that platform.
+// This is just handy to try and label where we have gaps in our APIs versus where we have bugs in our impl for a given platform
+filters.androidBroken = filters.androidMissing;
+filters.iosBroken = filters.iosMissing;
+filters.windowsBroken = filters.windowsMissing;
+// Add our custom filters
+filter.addFilters(filters);
+
+module.exports = Utility;


### PR DESCRIPTION
**Description:**
The new ti.ui.toolbar and ti.ui.android.drawerlayout test suites were not hooked into our app.js unit test suite, so never got run. This adds them in and fixes them so that they pass.

I'm also attempting to start differentiate between skipping tests due to bugs/parity issues (effectively known issues we should address); versus not running or skipping or reporting certain tests on some platforms. If we have platform-specific APIs/properties/etc, the tests should only be run on those platforms and shouldn't even get reported as skipped on the others (as we've decided to explicitly limit the impl to certain platforms).

This should allow us over time to tease out the parity issues we need to address with existing APIs not working the same across platforms versus the platform-specific APIs that should remain as-is, or possibly move out to native modules/namespaces.

This is a work in progress.