### PR TITLE
[TIMOB-25244] Pass correct framework path to builder

### DIFF
--- a/iphone/cli/hooks/frameworks.js
+++ b/iphone/cli/hooks/frameworks.js
@@ -99,7 +99,7 @@ class FrameworkManager {
 					this._frameworks.forEach(frameworkInfo => {
 						frameworkObject[frameworkInfo.name] = {
 							name: frameworkInfo.name,
-							path: frameworkInfo.name,
+							path: frameworkInfo.path,
 							type: frameworkInfo.type,
 							architectures: Array.from(frameworkInfo.architectures)
 						};


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-25244

**Optional Description:**
Fixes a property mix-up that resulted in wrong framework data being passed back to the builder which is meant to be consumed by other hooks.