### PR TITLE
[TIMOB-25252] Android: Only prevent duplicates of TiTableViewRowProxyItem

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiTableView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiTableView.java
@@ -203,7 +203,7 @@ public class TiTableView extends TiSwipeRefreshLayout
 				// TIMOB-24560: prevent duplicate TableViewRowProxyItem on Android N
 				if (Build.VERSION.SDK_INT > 23) {
 					ArrayList<Item> models = viewModel.getViewModel();
-					if (models != null && models.contains(v.getRowData())) {
+					if (models != null && v instanceof TiTableViewRowProxyItem && models.contains(v.getRowData())) {
 						v = null;
 						sameView = true;
 					}

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiTableViewHeaderItem.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiTableViewHeaderItem.java
@@ -102,7 +102,10 @@ public class TiTableViewHeaderItem extends TiBaseTableViewItem
 
 	public Item getRowData()
 	{
-		return rowView.getRowData();
+		if (rowView != null) {
+			return rowView.getRowData();
+		}
+		return null;
 	}
 
 	@Override


### PR DESCRIPTION
- Add validation to prevent `TiTableViewHeaderItem` being processed when preventing duplicate rows on Android 7.0+

###### TEST CASE
```JS
var win = Ti.UI.createWindow({backgroundColor: 'gray'}),
    section = Ti.UI.createTableViewSection({
        headerView: Ti.UI.createView({
            backgroundColor: 'orange',
            height: '10%'
        })
    }),
    table = Ti.UI.createTableView({
      data: [section]
    });

for (var i = 1; i <= 12; ++i) {
    section.add(Ti.UI.createTableViewRow({title: 'ROW ' + i}));
}

win.add(table);
win.open();
```
- Scroll past the orange header and scroll back to the top
- Should not observe any crashes

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-25252)