### PR TITLE
[TIMOB-25259] Android: Use ContentProvider to obtain image preview

### DIFF
--- a/android/modules/media/src/java/ti/modules/titanium/media/MediaModule.java
+++ b/android/modules/media/src/java/ti/modules/titanium/media/MediaModule.java
@@ -1227,13 +1227,15 @@ public class MediaModule extends KrollModule implements Handler.Callback
 		TiActivitySupport activitySupport = (TiActivitySupport) activity;
 
 		Intent intent = new Intent(Intent.ACTION_VIEW);
+		intent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
 		TiIntentWrapper previewIntent = new TiIntentWrapper(intent);
 		String mimeType = image.getMimeType();
+		Uri imageUri = TiFileProvider.createUriFrom(f.getNativeFile());
 
 		if (mimeType != null && mimeType.length() > 0) {
-			intent.setDataAndType(Uri.parse(f.nativePath()), mimeType);
+			intent.setDataAndType(imageUri, mimeType);
 		} else {
-			intent.setData(Uri.parse(f.nativePath()));
+			intent.setData(imageUri);
 		}
 
 		previewIntent.setWindowId(TiIntentWrapper.createActivityName("PREVIEW"));

--- a/tests/Resources/ti.media.test.js
+++ b/tests/Resources/ti.media.test.js
@@ -1,0 +1,66 @@
+/*
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2017 Axway, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+/* eslint-env mocha */
+/* global Ti */
+/* eslint no-unused-expressions: "off" */
+'use strict';
+var should = require('./utilities/assertions'),
+	utilities = require('./utilities/utilities');
+
+describe('Titanium.Media', function () {
+
+	it('apiName', function () {
+		var media = Ti.Media;
+		should(media).have.readOnlyProperty('apiName').which.is.a.String;
+		should(media.apiName).be.eql('Ti.Media');
+	});
+
+	it('takeScreenshot', function (finish) {
+		should(Ti.Media.takeScreenshot).not.be.undefined;
+		should(Ti.Media.takeScreenshot).be.a.Function;
+
+		// take a screenshot
+		Ti.Media.takeScreenshot(function (image) {
+			if (image && image.media) {
+				finish();
+			} else {
+				finish(new Error('failed to obtain screenshot'));
+			}
+		});
+	});
+
+	it.android('previewImage', function () {
+		should(Ti.Media.previewImage).not.be.undefined;
+		should(Ti.Media.previewImage).be.a.Function;
+	});
+
+	it.android('preview image read/write external storage', function (finish) {
+
+		// take a screenshot
+		Ti.Media.takeScreenshot(function (image) {
+			if (image && image.media) {
+				var tmp = Ti.Filesystem.getFile(Ti.Filesystem.externalStorageDirectory, 'temp.png');
+
+				// write to external storage
+				tmp.write(image.media);
+
+				// preview image from external storage
+				Ti.Media.previewImage({
+					success: function () {
+						finish();
+					},
+					error: function (e) {
+						finish(e);
+					},
+					image: tmp.read()
+				});
+			} else {
+				finish(new Error('failed to obtain screenshot'));
+			}
+		});
+	});
+});

--- a/tests/Resources/ti.network.httpclient.test.js
+++ b/tests/Resources/ti.network.httpclient.test.js
@@ -387,6 +387,7 @@ describe('Titanium.Network.HTTPClient', function () {
 				} else {
 					if (attempts-- > 0) {
 						Ti.API.warn('failed, attempting to retry request...');
+						xhr.abort();
 						xhr.send();
 					} else {
 						finish(new Error('onreadystatechange done fired before 100% progress'));
@@ -405,6 +406,7 @@ describe('Titanium.Network.HTTPClient', function () {
 		xhr.onerror = function (e) {
 			if (attempts-- > 0) {
 				Ti.API.warn('failed, attempting to retry request...');
+				xhr.abort();
 				xhr.send();
 			} else {
 				Ti.API.debug(JSON.stringify(e, null , 2));


### PR DESCRIPTION
- Use `TiFileProvider` to obtain the `Uri` for the image preview for compatibility with Android 7.0+

###### TEST CASE
```XML
<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
```
```JS
var win = Ti.UI.createWindow({backgroundColor: 'grey'}),
    btn = Ti.UI.createButton({title : 'SCREENSHOT'});

btn.addEventListener('click', function() {
    Ti.Media.takeScreenshot(function(image) {
        if (image && image.media) {
            var tmp = Ti.Filesystem.getFile(Ti.Filesystem.externalStorageDirectory, 'temp.png');

            tmp.write(image.media);
            Ti.API.info('temp file: ' + tmp.resolve());

            Ti.Media.previewImage({
                success : function() {
                    Ti.API.info('preview success');
                },
                error : function(e) {
                    alert('preview failed: ' + e.message);
                    Ti.API.error(e.message);
                },
                image : tmp.read()
            });
        } else {
            alert('failed to obtain screenshot');
        }
    });
});

win.add(btn);
win.open();
```

##### NOTE: Also test this on KitKat (4.4) and below devices, there could be a separate issue writing to external storage. But I do not have a device with 4.4 to verify this.

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-25259)