### PR TITLE
[TIMOB-25284] Android: Fixed bug where images from "res" folder fail to load. (Introduced in 6.2.0.)

### DIFF
--- a/android/modules/android/src/java/ti/modules/titanium/android/notificationmanager/BigPictureStyleProxy.java
+++ b/android/modules/android/src/java/ti/modules/titanium/android/notificationmanager/BigPictureStyleProxy.java
@@ -81,7 +81,7 @@ public class BigPictureStyleProxy extends StyleProxy {
 	@Kroll.method @Kroll.setProperty
 	public void setBigPicture(Object picture)
 	{
-		TiDrawableReference source = TiDrawableReference.fromObject(this.getActivity(), picture);
+		TiDrawableReference source = TiDrawableReference.fromObject(this, picture);
 
 		// Check for decodeRetries
 		if (hasProperty(TiC.PROPERTY_DECODE_RETRIES)) {

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiToolbar.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiToolbar.java
@@ -234,7 +234,7 @@ public class TiToolbar extends TiUIView implements Handler.Callback{
 	 */
 	private void handleSetLogo(Object object) {
 		logo = object;
-		TiDrawableReference tiDrawableReference = TiDrawableReference.fromObject(proxy.getActivity(), object);
+		TiDrawableReference tiDrawableReference = TiDrawableReference.fromObject(proxy, object);
 		((Toolbar) getNativeView()).setLogo(tiDrawableReference.getDrawable());
 	}
 
@@ -264,7 +264,7 @@ public class TiToolbar extends TiUIView implements Handler.Callback{
 	 */
 	private void handleSetNavigationIcon(Object object) {
 		navigationIcon = object;
-		TiDrawableReference tiDrawableReference = TiDrawableReference.fromObject(proxy.getActivity(), object);
+		TiDrawableReference tiDrawableReference = TiDrawableReference.fromObject(proxy, object);
 		((Toolbar) getNativeView()).setNavigationIcon(tiDrawableReference.getDrawable());
 	}
 
@@ -294,7 +294,7 @@ public class TiToolbar extends TiUIView implements Handler.Callback{
 	 */
 	private void handleSetOverflowMenuIcon(Object object) {
 		overflowMenuIcon = object;
-		TiDrawableReference tiDrawableReference = TiDrawableReference.fromObject(proxy.getActivity(), object);
+		TiDrawableReference tiDrawableReference = TiDrawableReference.fromObject(proxy, object);
 		((Toolbar) getNativeView()).setOverflowIcon(tiDrawableReference.getDrawable());
 	}
 

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIImageView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIImageView.java
@@ -669,10 +669,10 @@ public class TiUIImageView extends TiUIView implements OnLifecycleEvent, Handler
 		imageSources = new ArrayList<TiDrawableReference>();
 		if (object instanceof Object[]) {
 			for (Object o : (Object[]) object) {
-				imageSources.add(TiDrawableReference.fromObject(getProxy().getActivity(), o));
+				imageSources.add(TiDrawableReference.fromObject(getProxy(), o));
 			}
 		} else {
-			imageSources.add(TiDrawableReference.fromObject(getProxy().getActivity(), object));
+			imageSources.add(TiDrawableReference.fromObject(getProxy(), object));
 		}
 	}
 
@@ -689,7 +689,7 @@ public class TiUIImageView extends TiUIView implements OnLifecycleEvent, Handler
 		} else if (object instanceof String) {
 			defaultImageSource = TiDrawableReference.fromUrl(proxy, (String) object);
 		} else {
-			defaultImageSource = TiDrawableReference.fromObject(proxy.getActivity(), object);
+			defaultImageSource = TiDrawableReference.fromObject(proxy, object);
 		}
 	}
 	
@@ -809,7 +809,7 @@ public class TiUIImageView extends TiUIView implements OnLifecycleEvent, Handler
 			// processProperties is also called from TableView, we need check if we changed before re-creating the
 			// bitmap
 			boolean changeImage = true;
-			TiDrawableReference source = TiDrawableReference.fromObject(getProxy().getActivity(), d.get(TiC.PROPERTY_IMAGE));
+			TiDrawableReference source = TiDrawableReference.fromObject(getProxy(), d.get(TiC.PROPERTY_IMAGE));
 			if (imageSources != null && imageSources.size() == 1) {
 				if (imageSources.get(0).equals(source)) {
 					changeImage = false;
@@ -861,7 +861,7 @@ public class TiUIImageView extends TiUIView implements OnLifecycleEvent, Handler
 			view.setEnableZoomControls(TiConvert.toBoolean(newValue));
 		} else if (key.equals(TiC.PROPERTY_IMAGE)) {
 			if ((oldValue == null && newValue != null) || (oldValue != null && !oldValue.equals(newValue))) {
-				TiDrawableReference source = TiDrawableReference.fromObject(getProxy().getActivity(), newValue);
+				TiDrawableReference source = TiDrawableReference.fromObject(getProxy(), newValue);
 				Object autoRotate = proxy.getProperty(TiC.PROPERTY_AUTOROTATE);
 				if (autoRotate != null && TiConvert.toBoolean(autoRotate)) {
 					view.setOrientation(source.getOrientation());

--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiDrawableReference.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiDrawableReference.java
@@ -216,6 +216,35 @@ public class TiDrawableReference
 			return fromObject(activity, null);
 		}
 	}
+
+	/**
+	 * Does its best to determine the type of reference (url, blob, etc) based on object parameter.
+	 * <p>
+	 * Uses the given proxy to resolve relative paths to an image file, if applicable.
+	 * @param proxy Used to acquire an activty and resolve relative paths if given object is a string path.
+	 * @param object Reference to the image to be loaded such as a file, path, blob, etc.
+	 * @return Returns an instance of TiDrawableReference wrapping the given object.
+	 * @module.api
+	 */
+	public static TiDrawableReference fromObject(KrollProxy proxy, Object object)
+	{
+		// Attempt to fetch an activity from the given proxy.
+		Activity activity = null;
+		if (proxy != null) {
+			activity = proxy.getActivity();
+		}
+
+		// If given object is a string:
+		// - Resolve its relative path, if applicable.
+		// - Convert the string to a URL.
+		if ((proxy != null) && (object instanceof String)) {
+			object = proxy.resolveUrl(null, (String)object);
+		}
+
+		// Create a drawable reference from the given object.
+		return TiDrawableReference.fromObject(activity, object);
+	}
+
 	/**
 	 * Does its best to determine the type of reference (url, blob, etc) based on object parameter.
 	 * @param activity the referenced activity.


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-25284

**Notes:**
This bug prevented density scaled images from being loaded from the APK's "res" folder via the following features:
- ImageView.image property
- NotificationManager "BigPictureStyle"
- Toolbar

Caused by string paths to the image files not being passed to `KrollProxy.resolveUrl()` which is used to resolve relative paths and to convert to URLs.

**Testing:**
To be tested by @lokeshchdhry with his regression test projects.
