### PR TITLE
titanium_ui_drawer_layout.xml fixes: background, elevation and fitsSy…

### DIFF
--- a/android/modules/ui/res/layout/titanium_ui_drawer_layout.xml
+++ b/android/modules/ui/res/layout/titanium_ui_drawer_layout.xml
@@ -15,10 +15,11 @@
                android:layout_height="wrap_content"
                android:layout_width="match_parent"
                android:minHeight="?attr/actionBarSize"
-               android:background="#222299"
+               android:background="@color/primary"
                android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
                app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
-               android:elevation="4dp"/>
+               android:elevation="0dp"
+               android:fitsSystemWindows="true"/>
 
            <org.appcelerator.titanium.view.TiCompositeLayout
                android:layout_below="@id/drawer_layout_toolbar"


### PR DESCRIPTION
The background color was hardcoded so was not possible to change the color via theme; also the property android:fitsSystemWindows="true" was added to avoid that the status bar overlaps the App bar; and the elevation was set to 0 which looks nicer especially when using navigation tabs.