### PR TITLE
[TIMOB-25288]Android: addAnnotations in Ti.Map crashes app

### DIFF
--- a/support/module/packaged/modules.json
+++ b/support/module/packaged/modules.json
@@ -10,7 +10,7 @@
 	"android": [
 		"https://github.com/appcelerator-modules/ti.facebook/releases/download/android-6.2.0/facebook-android-6.2.0.zip",
 		"https://s3.amazonaws.com/timobile.appcelerator.com/modules/ti.cloudpush-android-4.0.3.zip",
-		"https://github.com/appcelerator-modules/ti.map/releases/download/android-3.3.0/ti.map-android-3.3.0.zip",
+		"https://github.com/appcelerator-modules/ti.map/releases/download/android-3.3.0/ti.map-android-3.3.1.zip",
 		"https://github.com/appcelerator-modules/ti.touchid/releases/download/android-2.2.0/ti.touchid-android-2.2.0.zip"
 	],
 	"commonjs": [

--- a/support/module/packaged/modules.json
+++ b/support/module/packaged/modules.json
@@ -10,7 +10,7 @@
 	"android": [
 		"https://github.com/appcelerator-modules/ti.facebook/releases/download/android-6.2.0/facebook-android-6.2.0.zip",
 		"https://s3.amazonaws.com/timobile.appcelerator.com/modules/ti.cloudpush-android-4.0.3.zip",
-		"https://github.com/appcelerator-modules/ti.map/releases/download/android-3.3.0/ti.map-android-3.3.1.zip",
+		"https://github.com/appcelerator-modules/ti.map/releases/download/android-3.3.1/ti.map-android-3.3.1.zip",
 		"https://github.com/appcelerator-modules/ti.touchid/releases/download/android-2.2.0/ti.touchid-android-2.2.0.zip"
 	],
 	"commonjs": [


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-25288

**Description:**
Bundled module looks for non-existing method. Rebuild against latest sources.
Attached Module archive should be added as a release version.

**Test case:**
In JIRA ticket.

[ti.map-android-3.3.1.zip](https://github.com/appcelerator/titanium_mobile/files/1312220/ti.map-android-3.3.1.zip)

