### PR TITLE
[TIMOB-25210] Fixed bug where the new iOS Marketing app icon was bein…

### DIFF
--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -4928,10 +4928,10 @@ iOSBuilder.prototype.copyResources = function copyResources(next) {
 
 			// remove all unnecessary icons from the lookup
 			Object.keys(lookup).forEach(function (key) {
-				if (deviceFamily === 'iphone' && lookup[key].idioms.indexOf('iphone') === -1) {
+				if (deviceFamily === 'iphone' && lookup[key].idioms.indexOf('iphone') === -1 && lookup[key].idioms.indexOf('ios-marketing') === -1) {
 					// remove ipad only
 					delete lookup[key];
-				} else if (deviceFamily === 'ipad' && lookup[key].idioms.indexOf('ipad') === -1) {
+				} else if (deviceFamily === 'ipad' && lookup[key].idioms.indexOf('ipad') === -1 && lookup[key].idioms.indexOf('ios-marketing') === -1) {
 					// remove iphone only
 					delete lookup[key];
 				} else if (lookup[key].minXcodeVer && appc.version.lt(this.xcodeEnv.version, lookup[key].minXcodeVer)) {


### PR DESCRIPTION
[TIMOB-25210] Fixed bug where the new iOS Marketing app icon was being negated when specifying an iphone or ipad device family.

**JIRA:** https://jira.appcelerator.org/browse/TIMOB-25210