### PR TITLE
[TIMOB-25277] Android: Implement onLink callback for Ti.UI.WebView

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiWebViewClient.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiWebViewClient.java
@@ -97,20 +97,6 @@ public class TiWebViewClient extends WebViewClientClassicExt
 		if (proxy == null) {
 			return;
 		}
-		if (proxy.hasProperty(TiC.PROPERTY_ON_LINK)) {
-			Object onLink = proxy.getProperty(TiC.PROPERTY_ON_LINK);
-			if (onLink instanceof KrollFunction) {
-				KrollFunction onLinkFunction = (KrollFunction) onLink;
-				KrollDict args = new KrollDict();
-				args.put(TiC.EVENT_PROPERTY_URL, url);
-				Object result = onLinkFunction.call(proxy.getKrollObject(), args);
-				if (result == null || (result instanceof Boolean && ((Boolean) result) == false)) {
-					webView.stopLoading();
-					return;
-				}
-			}
-		}
-
 		KrollDict data = new KrollDict();
 		data.put("url", url);
 		proxy.fireEvent("beforeload", data);
@@ -139,6 +125,19 @@ public class TiWebViewClient extends WebViewClientClassicExt
 		WebViewProxy proxy = (WebViewProxy) webView.getProxy();
 		if (proxy == null) {
 			return super.shouldOverrideUrlLoading(view, url);
+		}
+		if (proxy.hasProperty(TiC.PROPERTY_ON_LINK)) {
+			Object onLink = proxy.getProperty(TiC.PROPERTY_ON_LINK);
+			if (onLink instanceof KrollFunction) {
+				KrollFunction onLinkFunction = (KrollFunction) onLink;
+				KrollDict args = new KrollDict();
+				args.put(TiC.EVENT_PROPERTY_URL, url);
+				Object result = onLinkFunction.call(proxy.getKrollObject(), args);
+				if (result == null || (result instanceof Boolean && ((Boolean) result) == false)) {
+					webView.stopLoading();
+					return true;
+				}
+			}
 		}
 		if (proxy.hasProperty(TiC.PROPERTY_BLACKLISTED_URLS)) {
 			String[] blacklistedSites =

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiWebViewClient.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiWebViewClient.java
@@ -7,6 +7,7 @@
 package ti.modules.titanium.ui.widget.webview;
 
 import org.appcelerator.kroll.KrollDict;
+import org.appcelerator.kroll.KrollFunction;
 import org.appcelerator.kroll.common.Log;
 import org.appcelerator.titanium.TiApplication;
 import org.appcelerator.titanium.TiC;
@@ -96,6 +97,20 @@ public class TiWebViewClient extends WebViewClientClassicExt
 		if (proxy == null) {
 			return;
 		}
+		if (proxy.hasProperty(TiC.PROPERTY_ON_LINK)) {
+			Object onLink = proxy.getProperty(TiC.PROPERTY_ON_LINK);
+			if (onLink instanceof KrollFunction) {
+				KrollFunction onLinkFunction = (KrollFunction) onLink;
+				KrollDict args = new KrollDict();
+				args.put(TiC.EVENT_PROPERTY_URL, url);
+				Object result = onLinkFunction.call(proxy.getKrollObject(), args);
+				if (result == null || (result instanceof Boolean && ((Boolean) result) == false)) {
+					webView.stopLoading();
+					return;
+				}
+			}
+		}
+
 		KrollDict data = new KrollDict();
 		data.put("url", url);
 		proxy.fireEvent("beforeload", data);

--- a/android/titanium/src/java/org/appcelerator/titanium/TiC.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiC.java
@@ -2432,7 +2432,7 @@ public class TiC
 	/**
 	 * @module.api
 	 */
-	public static final String PROPERTY_ON_LINK = "onLink";
+	public static final String PROPERTY_ON_LINK = "onlink";
 
 	/**
 	 * @module.api

--- a/android/titanium/src/java/org/appcelerator/titanium/TiC.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiC.java
@@ -2432,6 +2432,11 @@ public class TiC
 	/**
 	 * @module.api
 	 */
+	public static final String PROPERTY_ON_LINK = "onLink";
+
+	/**
+	 * @module.api
+	 */
 	public static final String PROPERTY_ON_PREPARE_OPTIONS_MENU = "onPrepareOptionsMenu";
 
 	/**

--- a/apidoc/Titanium/UI/WebView.yml
+++ b/apidoc/Titanium/UI/WebView.yml
@@ -560,10 +560,10 @@ properties:
   - name: onlink
     summary: Fired before navigating to a link.
     description: |
-        Android only. The callback will be called before navigating to the link. The Boolean return value of the
-        callback will determine if the link will be navigated.
-    type: Callback<Boolean>
-    platforms: [android]
+        The callback will be called before navigating to the link. The Boolean return value of the
+        callback will determine if the link will be navigated or discarded.
+    type: Callback<OnLinkURLResponse>
+    platforms: [iphone, ipad, android]
     since: "7.4.0"
 
   - name: overScrollMode
@@ -756,7 +756,8 @@ examples:
 ---
 name: OnLinkURLResponse
 summary: An object returned when the <Titanium.UI.WebView.onlink> callback is fired.
+platforms: [iphone, ipad, android]
 properties:
   - name: url
-    summary: The url of the link.
+    summary: The url of the link that should be navigated to.
     type: String

--- a/apidoc/Titanium/UI/WebView.yml
+++ b/apidoc/Titanium/UI/WebView.yml
@@ -564,7 +564,7 @@ properties:
         callback will determine if the link will be navigated or discarded.
     type: Callback<OnLinkURLResponse>
     platforms: [iphone, ipad, android]
-    since: "7.4.0"
+    since: "7.5.0"
 
   - name: overScrollMode
     summary: Determines the behavior when the user overscrolls the view.

--- a/apidoc/Titanium/UI/WebView.yml
+++ b/apidoc/Titanium/UI/WebView.yml
@@ -557,6 +557,15 @@ properties:
     platforms: [android]
     since: "2.1.0"
 
+  - name: onlink
+    summary: Fired before navigating to a link.
+    description: |
+        Android only. The callback will be called before navigating to the link. The Boolean return value of the
+        callback will determine if the link will be navigated.
+    type: Callback<Boolean>
+    platforms: [android]
+    since: "7.4.0"
+
   - name: overScrollMode
     summary: Determines the behavior when the user overscrolls the view.
     type: Number
@@ -743,3 +752,11 @@ examples:
                     <WebView id="webview" url="http://www.appcelerator.com" />
                 </Window>
             </Alloy>
+
+---
+name: OnLinkURLResponse
+summary: An object returned when the <Titanium.UI.WebView.onlink> callback is fired.
+properties:
+  - name: url
+    summary: The url of the link.
+    type: String


### PR DESCRIPTION
- Implement `onlink` callback property for `Titanium.UI.WebView`
- Callback must return `true` or `false` as a condition for loading the link
- Fixed issue where events from new windows would not fire

###### TEST CASE
```JS
var window = Ti.UI.createWindow(),
    webView = Ti.UI.createWebView({
        url: 'https://india.gov.in/website-ministry-commerce-and-industry',
        onlink: function(e) {
            if (e.url.endsWith('.pdf')) {
                alert('PDF: ' + e.url);
                return false;
            }
            return true;
        }
    });

window.add(webView);
window.open();
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-25277)