### PR TITLE
[TIMOB-25321] iOS: Replace "iTunes Sync" with "Export .ipa" option

### DIFF
--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -408,10 +408,10 @@ iOSBuilder.prototype.config = function config(logger, config, cli) {
 
 			this.iosInfo = iosInfo;
 
-			// add itunes sync
+			// add "Export .ipa"
 			iosInfo.devices.push({
-				udid: 'itunes',
-				name: 'iTunes Sync'
+				udid: 'export-ipa',
+				name: 'Export .ipa'
 			});
 
 			// we have more than 1 device plus itunes, so we should show 'all'
@@ -543,7 +543,7 @@ iOSBuilder.prototype.configOptionDeviceID = function configOptionDeviceID(order)
 	return {
 		abbr: 'C',
 		desc: __('the udid of the iOS simulator or iOS device to install the application to; for %s builds %s',
-			'device'.cyan, ('[' + 'itunes'.bold + ', <udid>, all]').grey),
+			'device'.cyan, ('[' + 'export-ipa'.bold + ', <udid>, all]').grey),
 		hint: __('udid'),
 		order: order,
 		helpNoPrompt: function (logger, msg) {
@@ -1965,7 +1965,7 @@ iOSBuilder.prototype.validate = function validate(logger, config, cli) {
 
 				if (cli.argv.target === 'device') {
 					if (!cli.argv['build-only'] && !cli.argv['device-id']) {
-						cli.argv['device-id'] = this.iosInfo.devices.length ? this.iosInfo.devices[0].udid : 'itunes';
+						cli.argv['device-id'] = this.iosInfo.devices.length ? this.iosInfo.devices[0].udid : 'export-ipa';
 					}
 					return next();
 				}
@@ -2080,7 +2080,7 @@ iOSBuilder.prototype.validate = function validate(logger, config, cli) {
 				// check the min-ios-ver for the device we're installing to
 				if (this.target === 'device') {
 					this.getDeviceInfo().devices.forEach(function (device) {
-						if (device.udid !== 'all' && device.udid !== 'itunes' && (cli.argv['device-id'] === 'all' || cli.argv['device-id'] === device.udid) && version.lt(device.productVersion, this.minIosVer)) {
+						if (device.udid !== 'all' && device.udid !== 'export-ipa' && (cli.argv['device-id'] === 'all' || cli.argv['device-id'] === device.udid) && version.lt(device.productVersion, this.minIosVer)) {
 							logger.error(__('This app does not support the device "%s"', device.name) + '\n');
 							logger.log(__('The device is running iOS %s, however the app\'s the minimum iOS version is set to %s', device.productVersion.cyan, version.format(this.minIosVer, 2, 3).cyan));
 							logger.log(__('In order to install this app on this device, lower the %s to %s in the tiapp.xml:', '<min-ios-ver>'.cyan, version.format(device.productVersion, 2, 2).cyan));
@@ -4080,15 +4080,6 @@ iOSBuilder.prototype.writeInfoPlist = function writeInfoPlist() {
 	} else {
 		this.logger.warn(__('ATS enabled, however *.appcelerator.com are not whitelisted'));
 		this.logger.warn(__('Consider setting the "ios.whitelist.appcelerator.com" property in the tiapp.xml to "true"'));
-	}
-
-	if (this.target === 'device' && this.deviceId === 'itunes') {
-		// device builds require an additional token to ensure uniqueness so that iTunes will detect an updated app to sync.
-		// we drop the milliseconds from the current time so that we still have a unique identifier, but is less than 10
-		// characters so iTunes 11.2 doesn't get upset.
-		plist.CFBundleVersion = String(+new Date());
-		this.logger.debug(__('Building for iTunes sync which requires us to set the CFBundleVersion to a unique number to trigger iTunes to update your app'));
-		this.logger.debug(__('Setting Info.plist CFBundleVersion to current epoch time %s', plist.CFBundleVersion.cyan));
 	}
 
 	// scan for ttf and otf font files


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-25321

Replaces the `iTunes Sync` option with `Export .ipa` as the latest iTunes is not able to manage apps anymore (Titanium unrelated). So we want to give our developers an alternative when sending .ipa files to clients or MDM's.

This is the basic idea I had to have "something". Probably this will be replaced by something else, but it works so let's discuss it!