### PR TITLE
[TIMOB-25347] Android: Fix Ti.UI.Android.DrawerLayout layout

### DIFF
--- a/android/modules/ui/res/layout/titanium_ui_drawer_layout.xml
+++ b/android/modules/ui/res/layout/titanium_ui_drawer_layout.xml
@@ -15,10 +15,8 @@
                android:layout_height="wrap_content"
                android:layout_width="match_parent"
                android:minHeight="?attr/actionBarSize"
-               android:background="@color/primary"
-               android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
+               android:background="?attr/colorPrimary"
                app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
-               android:elevation="0dp"
                android:fitsSystemWindows="true"/>
 
            <org.appcelerator.titanium.view.TiCompositeLayout


### PR DESCRIPTION
- Do not hard-code theme, use applications theme
- Use application theme `colorPrimary` for background
- Remove unnecessary `elevation` attribute

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-25347)