### PR TITLE
[TIMOB-25363] Android: Use ContentProvider for Intent data

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/io/TiFileProvider.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/io/TiFileProvider.java
@@ -24,20 +24,23 @@ public class TiFileProvider extends ContentProvider {
 		return true;
 	}
 
-	public static Uri createUriFrom(File file) {
+	public static Uri createUriFrom(String filePath) {
 		final TiApplication tiApp = TiApplication.getInstance();
 		if (tiApp == null) {
 			return null;
 		}
-
 		try {
-			String path = getUriPrefix() + file.getAbsolutePath();
+			String path = getUriPrefix() + filePath.replaceAll("^file://(/android_asset)?", "");
 			return Uri.parse(path);
 		} catch (Exception e) {
 			// ignore exception
 		}
 
 		return null;
+	}
+
+	public static Uri createUriFrom(File file) {
+		return createUriFrom(file.getAbsolutePath());
 	}
 
 	@Override

--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/IntentProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/IntentProxy.java
@@ -17,6 +17,7 @@ import org.appcelerator.kroll.KrollDict;
 import org.appcelerator.kroll.KrollProxy;
 import org.appcelerator.kroll.annotations.Kroll;
 import org.appcelerator.kroll.common.Log;
+import org.appcelerator.titanium.io.TiFileProvider;
 import org.appcelerator.titanium.TiApplication;
 import org.appcelerator.titanium.TiBlob;
 import org.appcelerator.titanium.TiC;
@@ -191,12 +192,14 @@ public class IntentProxy extends KrollProxy
 		if (type != null) {
 			Log.d(TAG, "Setting type: " + type, Log.DEBUG_MODE);
 			if (data != null) {
-				intent.setDataAndType(Uri.parse(data), type);
+				intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+				intent.setDataAndType(TiFileProvider.createUriFrom(data), type);
 			} else {
 				intent.setType(type);
 			}
 		} else if (data != null) {
-			intent.setData(Uri.parse(data));
+			intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+			intent.setData(TiFileProvider.createUriFrom(data));
 		}
 	}
 


### PR DESCRIPTION
- Use `ContentProvider` for `Intent` `DATA`

###### TEST CASE
```JS
var extFile = Ti.Filesystem.getFile(Ti.Filesystem.externalStorageDirectory, 'test.pdf'),
    openPDF = function(pdf) {
        Ti.Android.currentActivity.startActivity(
            Ti.Android.createIntent({
                action : Ti.Android.ACTION_VIEW,
                type : 'application/pdf',
                data : pdf.nativePath
            })
        );
    };

if (extFile.exists()) {
    openPDF(extFile);
} else {
    var httpClient = Titanium.Network.createHTTPClient({
        onload: function() {
            extFile.createFile();
            extFile.write(this.responseData);
            openPDF(extFile);
        }
    });
    httpClient.open('GET','https://github.com/mozilla/pdf.js/raw/master/examples/helloworld/helloworld.pdf');
    httpClient.send();
}
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-25363)