### PR TITLE
[TIMOB-25359] Android: Fix Ti.UI.ScrollView when keyboard is active

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIScrollView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIScrollView.java
@@ -188,6 +188,17 @@ public class TiUIScrollView extends TiUIView
 		public TiVerticalScrollView(Context context, LayoutArrangement arrangement)
 		{
 			super(context);
+
+			// TIMOB-25359: allow window to re-size when keyboard is shown
+			if (context instanceof TiBaseActivity) {
+				Window window = ((TiBaseActivity) context).getWindow();
+				int softInputMode = window.getAttributes().softInputMode;
+
+				if ((softInputMode & WindowManager.LayoutParams.SOFT_INPUT_ADJUST_PAN) == 0) {
+					window.setSoftInputMode(softInputMode | WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE);
+				}
+			}
+
 			setScrollBarStyle(SCROLLBARS_INSIDE_OVERLAY);
 
 			layout = new TiScrollViewLayout(context, arrangement);

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIScrollView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIScrollView.java
@@ -15,9 +15,11 @@ import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.TiDimension;
 import org.appcelerator.titanium.proxy.TiViewProxy;
 import org.appcelerator.titanium.util.TiConvert;
+import org.appcelerator.titanium.TiBaseActivity;
 import org.appcelerator.titanium.view.TiCompositeLayout;
 import org.appcelerator.titanium.view.TiCompositeLayout.LayoutArrangement;
 import org.appcelerator.titanium.view.TiUIView;
+
 import ti.modules.titanium.ui.RefreshControlProxy;
 
 import android.content.Context;
@@ -28,6 +30,8 @@ import android.view.GestureDetector;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.Window;
+import android.view.WindowManager;
 import android.widget.FrameLayout;
 import android.widget.HorizontalScrollView;
 


### PR DESCRIPTION
- Allow `Titanium.UI.ScrollView` to scroll by default when the keyboard is active

###### TEST CASE
```JS
var win = Ti.UI.createWindow({
        backgroundColor: 'white',
        windowSoftInputMode: Ti.UI.Android.SOFT_INPUT_STATE_HIDDEN
    }),
    scrollView = Ti.UI.createScrollView({
        layout: 'vertical'
    }),
    userField = Ti.UI.createTextField({
        hintText: 'USERNAME',
        hintTextColor: 'grey',
        top: '250dp',
        left: '10%', right: '10%',
        backgroundColor: 'transparent',
        width: Titanium.UI.FILL
    }),
    passwordField = Ti.UI.createTextField({
        hintText: 'PASSWORD',
        hintTextColor: 'grey',
        passwordMask: true,
        left: '10%', right: '10%',
        backgroundColor: 'transparent',
        width: Titanium.UI.FILL
    }),
    loginButton = Ti.UI.createButton({
        width: '80%',
        title: 'LOGIN'
    });

scrollView.add([userField, passwordField, loginButton]);

win.add(scrollView);
win.open();
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-25359)