### PR TITLE
[6_3_X][TIMOB-25363] Android: Use ContentProvider in EmailDialog

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/EmailDialogProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/EmailDialogProxy.java
@@ -21,6 +21,7 @@ import org.appcelerator.titanium.TiBlob;
 import org.appcelerator.titanium.io.TiBaseFile;
 import org.appcelerator.titanium.io.TiFile;
 import org.appcelerator.titanium.io.TiFileFactory;
+import org.appcelerator.titanium.io.TiFileProvider;
 import org.appcelerator.titanium.proxy.TiViewProxy;
 import org.appcelerator.titanium.util.TiActivityResultHandler;
 import org.appcelerator.titanium.util.TiActivitySupport;
@@ -240,19 +241,19 @@ public class EmailDialogProxy extends TiViewProxy implements ActivityTransitionL
 				if (isPrivateData(fileProxy)) {
 					File file = privateFileToTemp(fileProxy);
 					if (file != null) {
-						return Uri.fromFile(file);
+						return TiFileProvider.createUriFrom(file);
 					} else {
 						return null;
 					}
 				} else {
 					File nativeFile = fileProxy.getBaseFile().getNativeFile();
-					return Uri.fromFile(nativeFile);
+					return Uri.TiFileProvider.createUriFrom(nativeFile);
 				}
 			}
 		} else if (attachment instanceof TiBlob) {
 			File file = blobToFile((TiBlob)attachment);
 			if (file != null) {
-				return Uri.fromFile(file);
+				return TiFileProvider.createUriFrom(file);
 			}
 		}
 		return null;


### PR DESCRIPTION
Fixing the issue with EmailDialog file attachments being sent as direct URI's. This update replaces them with ContentProvider URI's

**JIRA:** https://jira.appcelerator.org/browse/TIMOB-25363