### PR TITLE
[TIMOB-25397] Ti.Database.execute() should return null with no results

### DIFF
--- a/android/modules/database/src/java/ti/modules/titanium/database/TiDatabaseProxy.java
+++ b/android/modules/database/src/java/ti/modules/titanium/database/TiDatabaseProxy.java
@@ -111,7 +111,7 @@ public class TiDatabaseProxy extends KrollProxy
 					// PRAGMA do. If there are no results, just return null.
 					// Thanks to brion for working through the logic, based off of commit
 					// https://github.com/brion/titanium_mobile/commit/8d3251fca69e10df6a96a2a9ae513159494d17c3
-					if (c.getColumnCount() > 0) {
+					if (c.getCount() > 0) {
 						rs = new TiResultSetProxy(c);
 						if (rs.isValidRow()) {
 							rs.next(); // Position on first row if we have data.

--- a/iphone/Classes/TiDatabaseProxy.m
+++ b/iphone/Classes/TiDatabaseProxy.m
@@ -194,7 +194,7 @@
 
   PLSqliteResultSet *result = (PLSqliteResultSet *)[statement executeQuery];
 
-  if ([[result fieldNames] count] == 0) {
+  if ([result fullCount] == 0) {
     [result next]; // we need to do this to make sure lastInsertRowId and rowsAffected work
     [result close];
     return [NSNull null];


### PR DESCRIPTION
- `Titanium.Database.execute()` should return null when no results are found
- The tests are failing as it is counting the fields and not the rows returned; where default fields exist when the database is created. ([test](https://github.com/appcelerator/titanium-mobile-mocha-suite/blob/master/Resources/ti.database.test.js#L343))

###### TEST CASE
```JS
var db = Ti.Database.install('made.up.sqlite', 'category'),
    rows = db.execute('pragma table_info(\'category\');');

// rows should be `null` since there are no results
Ti.API.info('rows: ' + JSON.stringify(rows, null, 2));

db.remove();
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-25397)
