### PR TITLE
[TIMOB-24765] Android: Implement Ti.UI.ShortcutItem pinning

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/ShortcutItemProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/ShortcutItemProxy.java
@@ -140,6 +140,25 @@ public class ShortcutItemProxy extends KrollProxy
 		}
 	}
 
+	@Kroll.method
+	public void pin()
+	{
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && shortcut != null) {
+			if (shortcutManager.isRequestPinShortcutSupported()) {
+				boolean shortcutExists = false;
+				for (ShortcutInfo shortcut : shortcutManager.getPinnedShortcuts()) {
+					if (shortcut.getId().equals(this.shortcut.getId())) {
+						shortcutExists = true;
+						break;
+					}
+				}
+				if (!shortcutExists) {
+					shortcutManager.requestPinShortcut(this.shortcut, null);
+				}
+			}
+		}
+	}
+
 	@Kroll.getProperty
 	public String getId()
 	{

--- a/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
@@ -1337,6 +1337,19 @@ public abstract class TiBaseActivity extends AppCompatActivity implements TiActi
 		tiApp.setCurrentActivity(this, this);
 		TiApplication.updateActivityTransitionState(false);
 
+		// handle shortcut intents
+		Intent intent = getIntent();
+		String shortcutId =
+			intent.hasExtra(TiC.EVENT_PROPERTY_SHORTCUT) ? intent.getStringExtra(TiC.EVENT_PROPERTY_SHORTCUT) : null;
+		if (shortcutId != null) {
+			KrollModule appModule = TiApplication.getInstance().getModuleByName("App");
+			if (appModule != null) {
+				KrollDict data = new KrollDict();
+				data.put(TiC.PROPERTY_ID, shortcutId);
+				appModule.fireEvent(TiC.EVENT_SHORTCUT_ITEM_CLICK, data);
+			}
+		}
+
 		if (activityProxy != null) {
 			activityProxy.fireEvent(TiC.EVENT_RESUME, null);
 		}

--- a/apidoc/Titanium/App/Android/Android.yml
+++ b/apidoc/Titanium/App/Android/Android.yml
@@ -35,6 +35,15 @@ properties:
     permission: read-only
     since: 3.3.0
 
+events:
+  - name: shortcutitemclick
+    summary: Fired when a <Titanium.UI.ShortcutItem> is clicked.
+    properties:
+      - name: id
+        summary: Identifier of the clicked shortcut item.
+        type: String
+    since: 7.5.0
+
 examples:
   - title: Custom String Resource
     example: |

--- a/apidoc/Titanium/UI/ShortcutItem.yml
+++ b/apidoc/Titanium/UI/ShortcutItem.yml
@@ -8,7 +8,7 @@ description: |
     Use the <Titanium.UI.createShortcutItem> method to create a shortcut.
 
 extends: Titanium.Proxy
-since: "7.4.0"
+since: "7.5.0"
 methods:
   - name: show
     summary: Allow the shortcut to show.
@@ -17,6 +17,11 @@ methods:
   - name: hide
     summary: Hide the shortcut.
     platforms: [android, iphone, ipad]
+
+  - name: pin
+    description: Pin shortcut to launcher.
+    platforms: [android]
+    osver: {android: {min: "8.0"}}
 
 properties:
   - name: id


### PR DESCRIPTION
### https://github.com/appcelerator/titanium_mobile/pull/9426 MUST BE MERGED FIRST

- Implement `Titanium.UI.ShortcutItem.pin()` to pin shortcuts to the launcher

###### TEST CASE
```JS
var win = Ti.UI.createWindow({backgroundColor: 'grey'}),
    btn = Ti.UI.createButton({title: 'PIN SHORTCUT'}),
    shortcut = Ti.UI.createShortcutItem({
        id: 'test_shortcut',
        icon: Ti.Android.R.drawable.ic_dialog_info,
        title: 'TEST',
        description: 'DESCRIPTION'
    });

Ti.App.addEventListener('shortcutitemclick', function() {
    win.backgroundColor = 'blue';
});

btn.addEventListener('click', () => {
    win.backgroundColor = 'red';
    shortcut.pin();
});

win.add(btn);
win.open();
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-24765)