### PR TITLE
[6_3_X] Android: Fix module versions

### DIFF
--- a/support/module/packaged/modules.json
+++ b/support/module/packaged/modules.json
@@ -10,7 +10,7 @@
 	"android": [
 		"https://github.com/appcelerator-modules/ti.facebook/releases/download/android-6.2.0/facebook-android-6.2.0.zip",
 		"https://s3.amazonaws.com/timobile.appcelerator.com/modules/ti.cloudpush-android-4.0.3.zip",
-		"https://github.com/appcelerator-modules/ti.map/releases/download/android-3.3.0/ti.map-android-3.3.0.zip",
+		"https://github.com/appcelerator-modules/ti.map/releases/download/android-3.3.1/ti.map-android-3.3.1.zip",
 		"https://github.com/appcelerator-modules/ti.touchid/releases/download/android-2.2.0/ti.touchid-android-2.2.0.zip"
 	],
 	"commonjs": [

--- a/support/module/packaged/modules.json
+++ b/support/module/packaged/modules.json
@@ -9,7 +9,7 @@
 	],
 	"android": [
 		"https://github.com/appcelerator-modules/ti.facebook/releases/download/android-6.2.0/facebook-android-6.2.0.zip",
-		"https://s3.amazonaws.com/timobile.appcelerator.com/modules/ti.cloudpush-android-4.0.3.zip",
+		"https://s3.amazonaws.com/timobile.appcelerator.com/modules/ti.cloudpush-android-4.0.4.zip",
 		"https://github.com/appcelerator-modules/ti.map/releases/download/android-3.3.1/ti.map-android-3.3.1.zip",
 		"https://github.com/appcelerator-modules/ti.touchid/releases/download/android-2.2.0/ti.touchid-android-2.2.0.zip"
 	],


### PR DESCRIPTION
- Fix module versioning for `ti.map` and `ti.cloudpush`