### PR TITLE
[TIMOB-16257] Android: Fixed crashed caused by setting ScrollView.scrollingEnabled on non-UI thread

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/ActivityIndicatorProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/ActivityIndicatorProxy.java
@@ -7,7 +7,6 @@
 package ti.modules.titanium.ui;
 
 import org.appcelerator.kroll.KrollDict;
-import org.appcelerator.kroll.KrollProxy;
 import org.appcelerator.kroll.annotations.Kroll;
 import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.proxy.TiViewProxy;
@@ -30,7 +29,7 @@ import android.os.Message;
 })
 public class ActivityIndicatorProxy extends TiViewProxy
 {
-	private static final int MSG_FIRST_ID = KrollProxy.MSG_LAST_ID + 1;
+	private static final int MSG_FIRST_ID = TiViewProxy.MSG_LAST_ID + 1;
 	private static final int MSG_SHOW = MSG_FIRST_ID + 100;
 
 	boolean visible = false;

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/LabelProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/LabelProxy.java
@@ -7,7 +7,6 @@
 package ti.modules.titanium.ui;
 
 import org.appcelerator.kroll.KrollDict;
-import org.appcelerator.kroll.KrollProxy;
 import org.appcelerator.kroll.annotations.Kroll;
 import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.proxy.TiViewProxy;
@@ -40,7 +39,7 @@ import android.app.Activity;
 })
 public class LabelProxy extends TiViewProxy
 {
-	private static final int MSG_FIRST_ID = KrollProxy.MSG_LAST_ID + 1;
+	private static final int MSG_FIRST_ID = TiViewProxy.MSG_LAST_ID + 1;
 	protected static final int MSG_LAST_ID = MSG_FIRST_ID + 999;
 
 	public LabelProxy()

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/ScrollViewProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/ScrollViewProxy.java
@@ -7,7 +7,6 @@
 package ti.modules.titanium.ui;
 
 import org.appcelerator.kroll.KrollDict;
-import org.appcelerator.kroll.KrollProxy;
 import org.appcelerator.kroll.annotations.Kroll;
 import org.appcelerator.kroll.common.AsyncResult;
 import org.appcelerator.kroll.common.TiMessenger;
@@ -36,7 +35,7 @@ import java.util.HashMap;
 public class ScrollViewProxy extends TiViewProxy
 	implements Handler.Callback
 {
-	private static final int MSG_FIRST_ID = KrollProxy.MSG_LAST_ID + 1;
+	private static final int MSG_FIRST_ID = TiViewProxy.MSG_LAST_ID + 1;
 
 	private static final int MSG_SCROLL_TO = MSG_FIRST_ID + 100;
 	private static final int MSG_SCROLL_TO_BOTTOM = MSG_FIRST_ID + 101;

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/WindowProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/WindowProxy.java
@@ -22,7 +22,6 @@ import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.TiDimension;
 import org.appcelerator.titanium.TiTranslucentActivity;
 import org.appcelerator.titanium.proxy.ActivityProxy;
-import org.appcelerator.titanium.proxy.TiViewProxy;
 import org.appcelerator.titanium.proxy.TiWindowProxy;
 import org.appcelerator.titanium.util.TiConvert;
 import org.appcelerator.titanium.util.TiRHelper;
@@ -64,7 +63,7 @@ public class WindowProxy extends TiWindowProxy implements TiActivityWindow
 	private static final String TAG = "WindowProxy";
 	private static final String PROPERTY_POST_WINDOW_CREATED = "postWindowCreated";
 
-	private static final int MSG_FIRST_ID = TiViewProxy.MSG_LAST_ID + 1;
+	private static final int MSG_FIRST_ID = TiWindowProxy.MSG_LAST_ID + 1;
 	private static final int MSG_SET_PIXEL_FORMAT = MSG_FIRST_ID + 100;
 	private static final int MSG_SET_TITLE = MSG_FIRST_ID + 101;
 	private static final int MSG_SET_WIDTH_HEIGHT = MSG_FIRST_ID + 102;

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/android/CardViewProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/android/CardViewProxy.java
@@ -6,7 +6,6 @@
  */
 package ti.modules.titanium.ui.android;
 
-import org.appcelerator.kroll.KrollProxy;
 import org.appcelerator.kroll.annotations.Kroll;
 import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.proxy.TiViewProxy;
@@ -29,7 +28,7 @@ import android.app.Activity;
 })
 public class CardViewProxy extends TiViewProxy
 {
-	private static final int MSG_FIRST_ID = KrollProxy.MSG_LAST_ID + 1;
+	private static final int MSG_FIRST_ID = TiViewProxy.MSG_LAST_ID + 1;
 	protected static final int MSG_LAST_ID = MSG_FIRST_ID + 999;
 
 	public CardViewProxy()

--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/TiWindowProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/TiWindowProxy.java
@@ -53,7 +53,7 @@ public abstract class TiWindowProxy extends TiViewProxy
 	private static final String TAG = "TiWindowProxy";
 	protected static final boolean LOLLIPOP_OR_GREATER = (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP);
 	
-	private static final int MSG_FIRST_ID = KrollProxy.MSG_LAST_ID + 1;
+	private static final int MSG_FIRST_ID = TiViewProxy.MSG_LAST_ID + 1;
 	private static final int MSG_OPEN = MSG_FIRST_ID + 100;
 	private static final int MSG_CLOSE = MSG_FIRST_ID + 101;
 	protected static final int MSG_LAST_ID = MSG_FIRST_ID + 999;

--- a/tests/Resources/ti.ui.scrollview.test.js
+++ b/tests/Resources/ti.ui.scrollview.test.js
@@ -103,6 +103,8 @@ describe('Titanium.UI.ScrollView', function () {
 	it('scrollingEnabled', function () {
 		var bar = Ti.UI.createScrollView({});
 		should(bar.scrollingEnabled).be.a.Boolean;
+		bar.scrollingEnabled = false;
+		should(bar.scrollingEnabled).be.eql(false);
 	});
 
 	// Android-only property


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-16257

**Notes:**
- Caused by Android message ID collision with super class' IDs.
- Also resolved potential ID collision with the following features:
  * Ti.UI.ActivityIndicator
  * Ti.UI.CardView
  * Ti.UI.Label
  * Ti.UI.Window

**Test:**

1. Set up a classic app project using the below files. _(Note that the app must be to **not** run JavaScript on the main thread.)_
2. Run the project on an Android device.
3. Verify that the app does crash on startup.

---

tiapp.xml

```xml
<?xml version="1.0" encoding="UTF-8"?>
<ti:app xmlns:ti="http://ti.appcelerator.org">
    <property name="run-on-main-thread" type="bool">false</property>
</ti:app>
```

---

app.js

```javascript
var scrollView = Ti.UI.createScrollView({});
scrollView.scrollingEnabled = true;
```
