### PR TITLE
[TIMOB-24404] Expose global object on iOS

### DIFF
--- a/iphone/Classes/KrollBridge.m
+++ b/iphone/Classes/KrollBridge.m
@@ -552,6 +552,10 @@ CFMutableSetRef krollBridgeRegistry = nil;
   prop = TiStringCreateWithCFString((CFStringRef) @"console");
   TiObjectSetProperty(jsContext, globalRef, prop, [KrollObject toValue:kroll value:console], kTiPropertyAttributeNone, NULL);
 
+  // Make the global object itself available under the name "global"
+  TiStringRef globalPropertyName = TiStringCreateWithCFString((CFStringRef) @"global");
+  TiObjectSetProperty(jsContext, globalRef, globalPropertyName, globalRef, kTiPropertyAttributeDontEnum | kTiPropertyAttributeReadOnly | kTiPropertyAttributeDontDelete, NULL);
+
   //if we have a preload dictionary, register those static key/values into our namespace
   if (preload != nil) {
     for (NSString *name in preload) {


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-24404

**Optional Description:**
Exposes the global object as a node like `global` variable. Allows the following code to be run:
```
global.testVar = 1;
console.log(testVar); // prints "1" to the log
```
This already works in Alloy apps in Android, but not in classic apps.