### PR TITLE
[TIMOB-17340] Android: Implement Ti.UI.ATTRIBUTE_BASELINE_OFFSET

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/AttributedStringProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/AttributedStringProxy.java
@@ -17,6 +17,7 @@ import org.appcelerator.titanium.util.TiConvert;
 import org.appcelerator.titanium.util.TiUIHelper;
 
 import android.app.Activity;
+import android.graphics.Paint;
 import android.graphics.Typeface;
 import android.os.Bundle;
 import android.text.Spannable;
@@ -25,6 +26,7 @@ import android.text.TextUtils;
 import android.text.style.AbsoluteSizeSpan;
 import android.text.style.BackgroundColorSpan;
 import android.text.style.ForegroundColorSpan;
+import android.text.style.LineHeightSpan;
 import android.text.style.StrikethroughSpan;
 import android.text.style.StyleSpan;
 import android.text.style.TypefaceSpan;
@@ -206,6 +208,16 @@ public class AttributedStringProxy extends KrollProxy
 												+ range[1], Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
 										}
 										results.putBoolean(TiC.PROPERTY_HAS_LINK, true);
+										break;
+									case UIModule.ATTRIBUTE_BASELINE_OFFSET:
+										final int offset = TiConvert.toInt(attrValue, 5);
+										spannableText.setSpan(new LineHeightSpan() {
+											@Override
+											public void chooseHeight(CharSequence charSequence, int i, int i1, int i2, int i3, Paint.FontMetricsInt fontMetricsInt) {
+												fontMetricsInt.bottom = offset * 2;
+												fontMetricsInt.descent = offset * 2;
+											}
+										}, range[0], range[0] + range[1], Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
 										break;
 								}
 							}

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/UIModule.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/UIModule.java
@@ -174,6 +174,7 @@ public class UIModule extends KrollModule implements Handler.Callback
 	@Kroll.constant public static final int ATTRIBUTE_UNDERLINE_COLOR = 6;
 	@Kroll.constant public static final int ATTRIBUTE_SUPERSCRIPT_STYLE = 7;
 	@Kroll.constant public static final int ATTRIBUTE_SUBSCRIPT_STYLE = 8;
+	@Kroll.constant public static final int ATTRIBUTE_BASELINE_OFFSET = 9;
 
 	@Kroll.constant public static final int INPUT_TYPE_CLASS_NUMBER = InputType.TYPE_CLASS_NUMBER;
 	@Kroll.constant public static final int INPUT_TYPE_CLASS_TEXT = InputType.TYPE_CLASS_TEXT;

--- a/apidoc/Titanium/UI/UI.yml
+++ b/apidoc/Titanium/UI/UI.yml
@@ -419,8 +419,8 @@ properties:
 
         See <Attribute> for more information.
     type: Number
-    platforms: [iphone, ipad]
-    since: "3.6.0"
+    platforms: [iphone, ipad, android]
+    since: {ios: "3.6.0", android: "7.0.0"}
     osver: {ios: {min: "7.0"}}
     permission: read-only
 


### PR DESCRIPTION
- Implement `Titanium.UI.ATTRIBUTE_BASELINE_OFFSET` for Android for parity with iOS

###### TEST CASE
```JS
var win = Ti.UI.createWindow({backgroundColor: 'gray'}),
    text = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent lobortis laoreet nibh in tempor. Mauris justo nibh, suscipit ut venenatis id, vehicula quis arcu. Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
    atr = Ti.UI.createAttributedString({
        text: text,
        attributes: [{
            type: Ti.UI.ATTRIBUTE_BASELINE_OFFSET,
            value: 50,
            range: [0, text.length]
        }]
    }),
    lbl = Ti.UI.createLabel({
        top: 5,
        left: 5,
        width: Ti.UI.FILL,
        height: Ti.UI.SIZE,
        attributedString: atr
    });

win.add(lbl);
win.open();
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-17340)