### PR TITLE
[6_3_X][TIMOB-25363] Android: Set type when data is not defined

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/IntentProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/IntentProxy.java
@@ -205,6 +205,8 @@ public class IntentProxy extends KrollProxy
 			} else {
 				intent.setData(dataUri);
 			}
+		} else {
+			intent.setType(type);
 		}
 	}
 


### PR DESCRIPTION
- Set `type` when data is not defined

###### TEST CASE
```JS
var win = Ti.UI.createWindow({backgroundColor: 'gray'}),
    btn = Ti.UI.createButton({
	    title: 'SEND',
    });

btn.addEventListener('click', function(e) {
	var img = 'appicon.png',
	    src = Ti.Filesystem.getFile(img),
	    dst = Ti.Filesystem.getFile(Ti.Filesystem.applicationDataDirectory, img),
        intent = Ti.Android.createIntent({
            action: Ti.Android.ACTION_SEND,
            type: 'image/*'
        });

	dst.write(src, false);

	intent.putExtraUri(Ti.Android.EXTRA_STREAM, dst.nativePath);
	intent = Ti.Android.createIntentChooser(intent, 'Choose');
	Ti.Android.currentActivity.startActivity(intent);
});

win.add(btn);
win.open();
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-25363)