### PR TITLE
[TIMOB-25459] Android: toImage method needs parity with iOS

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/TiViewProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/TiViewProxy.java
@@ -991,7 +991,9 @@ public abstract class TiViewProxy extends KrollProxy implements Handler.Callback
 			blob  = TiBlob.blobFromImage(Bitmap.createBitmap(1, 1, Config.ARGB_8888));
 			Runnable renderRunnable = new Runnable() {
 				public void run() {
-					callback.callAsync(getKrollObject(), new Object[] {handleToImage()});
+					KrollDict callbackResult = new KrollDict();
+					callbackResult.put("blob", handleToImage());
+					callback.callAsync(getKrollObject(), callbackResult);
 				}
 			};
 

--- a/apidoc/Titanium/UI/View.yml
+++ b/apidoc/Titanium/UI/View.yml
@@ -858,7 +858,7 @@ methods:
         summary: |
             Function to be invoked upon completion. If non-null, this method will be performed
             asynchronously. If null, it will be performed immediately.
-        type: Callback<Titanium.Blob>
+        type: Callback<ToImageCallback>
         optional: true
 
       - name: honorScaleFactor
@@ -1872,3 +1872,11 @@ properties:
     type: Boolean
     default: false
     osver: {android: {min: 5.0}}
+
+---
+name: ToImageCallback
+summary: Dictionary with the Ti.Blob result of toImage() call.
+properties:
+  - name: blob
+    summary: Result of the toImage() call.
+    type: Titanium.Blob

--- a/tests/Resources/ti.blob.test.js
+++ b/tests/Resources/ti.blob.test.js
@@ -1,0 +1,288 @@
+/*
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2011-Present by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+/* eslint-env mocha */
+/* global Ti */
+/* eslint no-unused-expressions: "off" */
+'use strict';
+var should = require('./utilities/assertions'),
+	utilities = require('./utilities/utilities');
+
+describe('Titanium.Blob', function () {
+	var win;
+
+	afterEach(function () {
+		if (win) {
+			win.close();
+		}
+		win = null;
+	});
+
+	it('apiName', function () {
+		// FIXME Should be able to do Ti.Blob.apiName
+		var blob = Ti.Filesystem.getFile('app.js').read();
+		should(blob).have.a.readOnlyProperty('apiName').which.is.a.String;
+		should(blob.apiName).be.eql('Ti.Blob');
+	});
+
+	it('constructed from File.read()', function () {
+		var blob = Ti.Filesystem.getFile('app.js').read();
+		should(blob).be.an.Object;
+		// should(blob).be.an.instanceof(Ti.Blob); // Crashes Windows, throws uncaught error on iOS & Android
+	});
+
+	// Windows crashes on instanceof check TIMOB-25012
+	// Windows also crashes if we uncomment this now, I think closing the window (or failing the test) in the blob callback is causing Desktop crash
+	// Android is sometimes timing out... Trying an open event now...
+	// TODO: Test is tempermental, skipping for now...
+	it.skip('constructed from image', function (finish) {
+		var label;
+		win = Ti.UI.createWindow();
+		label = Ti.UI.createLabel({ text: 'test' });
+		win.add(label);
+		win.addEventListener('open', function () {
+			label.toImage(function (e) {
+				should(e.blob).be.an.Object;
+				// should(blob).be.an.instanceof(Ti.Blob); // FIXME Crashes Windows, throws uncaught error on iOS & Android
+				// should(blob.getText()).equal(null); // FIXME 'blob.getText is not a function' on iOS
+				// should(blob.text).equal(null); // FIXME this is undefined on iOS, docs say it should be null
+				should(e.blob.text).not.exist;
+				Ti.API.info(e.blob.width);
+				should(e.blob.width).be.a.Number; // FIXME Undefined on iOS
+				should(e.blob.width).be.above(0); // 0 on Windows
+				should(e.blob.height).be.a.Number;
+				should(e.blob.height).be.above(0);
+				should(e.blob.length).be.a.Number;
+				// FIXME Parity issue, no size property on Android
+				if (!utilities.isAndroid()) {
+					should(e.blob.size).be.a.Number;
+					should(e.blob.size).equal(e.blob.width * blob.height);
+				}
+				finish();
+			});
+		});
+		win.open();
+	});
+
+	it('text', function () {
+		var blob = Ti.Filesystem.getFile('app.js').read();
+		should(blob.text).be.a.String;
+		should(blob.text.length).be.above(0);
+		should(blob.text).equal(blob.toString());
+		// TODO Test that it's read-only
+	});
+
+	// FIXME Add to iOS API
+	it.iosMissing('append', function () {
+		var blob = Ti.Filesystem.getFile('app.js').read();
+		should(blob.append).be.a.Function;
+		// TODO Test actually appending data to it
+	});
+
+	it('nativePath', function () {
+		var blob = Ti.Filesystem.getFile('app.js').read();
+		should(blob.nativePath).be.a.String;
+		should(blob.nativePath.length).be.above(0);
+		// TODO Test that it's read-only
+	});
+
+	it.windowsDesktopBroken('mimeType with text/javascript', function () {
+		var blob = Ti.Filesystem.getFile('app.js').read();
+		should(blob.mimeType).be.a.String;
+		should(blob.mimeType.length).be.above(0); // Windows desktop returns 0 here
+		should(blob.mimeType).be.eql('text/javascript');
+		// TODO Test that it's read-only
+	});
+
+	it('mimeType with image/png', function () {
+		var blob = Ti.Filesystem.getFile('Logo.png').read();
+		should(blob.mimeType).be.a.String;
+		should(blob.mimeType.length).be.above(0);
+		should(blob.mimeType).be.eql('image/png');
+		// TODO Test that it's read-only
+	});
+
+	it('length', function () {
+		var blob = Ti.Filesystem.getFile('app.js').read();
+		should(blob.length).be.a.Number;
+		should(blob.length).be.above(0);
+		// TODO Test that it's read-only
+	});
+
+	// Parity issue, add to Android API
+	it.androidMissing('size in bytes', function () {
+		var blob = Ti.Filesystem.getFile('app.js').read();
+		should(blob.size).be.a.Number;
+		should(blob.size).be.above(0);
+		// TODO Test that it's read-only
+	});
+
+	// FIXME Missing API on Android, parity issue
+	// FIXME Returns 801 on Windows
+	it.androidMissingAndWindowsBroken('size in pixels', function () {
+		var blob = Ti.Filesystem.getFile('Logo.png').read();
+		should(blob.size).be.a.Number;
+		should(blob.size).be.eql(22500);
+		// TODO Test that it's read-only
+	});
+
+	// FIXME Get working for iOS - I think app thinning is getting rid of Logo.png
+	it.iosBroken('width', function () {
+		var blob = Ti.Filesystem.getFile('Logo.png').read();
+		should(blob.width).be.a.Number;
+		should(blob.width).be.eql(150);
+		// TODO Test that it's read-only
+	});
+
+	// FIXME Get working for iOS - I think app thinning is getting rid of Logo.png
+	it.iosBroken('height', function () {
+		var blob = Ti.Filesystem.getFile('Logo.png').read();
+		should(blob.height).be.a.Number;
+		should(blob.height).be.eql(150);
+		// TODO Test that it's read-only
+	});
+
+	it('width of non-image', function () {
+		var blob = Ti.Filesystem.getFile('app.js').read();
+		should(blob.width).be.a.Number;
+		should(blob.width).be.eql(0);
+		// TODO Test that it's read-only
+	});
+
+	it('height of non-image', function () {
+		var blob = Ti.Filesystem.getFile('app.js').read();
+		should(blob.height).be.a.Number;
+		should(blob.height).be.eql(0);
+		// TODO Test that it's read-only
+	});
+
+	it('file', function () {
+		var blob = Ti.Filesystem.getFile('app.js').read();
+		var file = blob.file;
+		should(file.toString()).be.a.String;
+		should(file.nativePath).be.eql(blob.nativePath);
+		// TODO Test that it's read-only
+	});
+
+	// TODO Test file property is null for non-file backed Blobs!
+
+	// FIXME Get working for iOS - I think app thinning is getting rid of Logo.png
+	it.iosBroken('imageAsCropped', function () {
+		var blob = Ti.Filesystem.getFile('Logo.png').read();
+		should(blob.imageAsCropped).be.a.Function;
+		should(function () {
+			var b = blob.imageAsCropped({ width: 50, height: 60, x: 0, y: 0 });
+			should(b).be.an.Object;
+			should(b.width).be.eql(50);
+			should(b.height).be.eql(60);
+		}).not.throw();
+	});
+
+	// FIXME Get working for iOS - I think app thinning is getting rid of Logo.png
+	it.iosBroken('imageAsResized', function () {
+		var blob = Ti.Filesystem.getFile('Logo.png').read();
+		should(blob.imageAsResized).be.a.Function;
+		should(function () {
+			var b = blob.imageAsResized(50, 60);
+			should(b).be.an.Object;
+			should(b.width).be.eql(50);
+			should(b.height).be.eql(60);
+		}).not.throw();
+	});
+
+	// FIXME Get working for iOS - I think app thinning is getting rid of Logo.png
+	it.iosBroken('imageAsThumbnail', function () {
+		var blob = Ti.Filesystem.getFile('Logo.png').read();
+		should(blob.imageAsThumbnail).be.a.Function;
+		should(function () {
+			var b = blob.imageAsThumbnail(50);
+			should(b).be.an.Object;
+			should(b.width).eql(50);
+			should(b.height).eql(50);
+		}).not.throw();
+	});
+
+	// FIXME Get working for iOS - I think app thinning is getting rid of Logo.png
+	it.iosBroken('imageWithAlpha', function () {
+		var blob = Ti.Filesystem.getFile('Logo.png').read();
+		should(blob.imageWithAlpha).be.a.Function;
+		should(function () {
+			blob.imageWithAlpha();
+		}).not.throw();
+	});
+
+	// FIXME Get working for iOS - I think app thinning is getting rid of Logo.png
+	it.iosBroken('imageWithRoundedCorner', function () {
+		var blob = Ti.Filesystem.getFile('Logo.png').read();
+		should(blob.imageWithRoundedCorner).be.a.Function;
+		should(function () {
+			blob.imageWithRoundedCorner(1);
+		}).not.throw();
+	});
+
+	// FIXME Get working for iOS - I think app thinning is getting rid of Logo.png
+	it.iosBroken('imageWithTransparentBorder', function () {
+		var blob = Ti.Filesystem.getFile('Logo.png').read();
+		should(blob.imageWithTransparentBorder).be.a.Function;
+		should(function () {
+			blob.imageWithTransparentBorder(1);
+		}).not.throw();
+	});
+
+	it('imageAsCropped of non-image', function () {
+		var blob = Ti.Filesystem.getFile('app.js').read();
+		should(blob.imageAsCropped).be.a.Function;
+		should(function () {
+			var b = blob.imageAsCropped({ width: 50, height: 60, x: 0, y: 0 });
+			should(b).not.exist;
+		}).not.throw();
+	});
+
+	it('imageAsResized of non-image', function () {
+		var blob = Ti.Filesystem.getFile('app.js').read();
+		should(blob.imageAsCropped).be.a.Function;
+		should(function () {
+			var b = blob.imageAsResized(50, 60);
+			should(b).not.exist;
+		}).not.throw();
+	});
+
+	it('imageAsThumbnail of non-image', function () {
+		var blob = Ti.Filesystem.getFile('app.js').read();
+		should(blob.imageAsCropped).be.a.Function;
+		should(function () {
+			var b = blob.imageAsThumbnail(50);
+			should(b).not.exist;
+		}).not.throw();
+	});
+
+	it('imageWithAlpha of non-image', function () {
+		var blob = Ti.Filesystem.getFile('app.js').read();
+		should(blob.imageAsCropped).be.a.Function;
+		should(function () {
+			var b = blob.imageWithAlpha();
+			should(b).not.exist;
+		}).not.throw();
+	});
+
+	it('imageWithRoundedCorner of non-image', function () {
+		var blob = Ti.Filesystem.getFile('app.js').read();
+		should(blob.imageAsCropped).be.a.Function;
+		should(function () {
+			var b = blob.imageWithRoundedCorner(1);
+			should(b).not.exist;
+		}).not.throw();
+	});
+
+	it('imageWithTransparentBorder of non-image', function () {
+		var blob = Ti.Filesystem.getFile('app.js').read();
+		should(blob.imageAsCropped).be.a.Function;
+		should(function () {
+			var b = blob.imageWithTransparentBorder(1);
+			should(b).not.exist;
+		}).not.throw();
+	});
+});

--- a/tests/Resources/ti.ui.view.test.js
+++ b/tests/Resources/ti.ui.view.test.js
@@ -1,0 +1,632 @@
+/*
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2015-Present by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+/* eslint-env mocha */
+/* global Ti */
+/* eslint no-unused-expressions: "off" */
+'use strict';
+var should = require('./utilities/assertions'),
+	utilities = require('./utilities/utilities');
+
+describe('Titanium.UI.View', function () {
+	var win,
+		didFocus = false,
+		didPostLayout = false;
+
+	this.timeout(5000);
+
+	beforeEach(function () {
+		didFocus = false;
+		didPostLayout = false;
+	});
+
+	afterEach(function () {
+		if (win) {
+			win.close();
+		}
+		win = null;
+	});
+
+	it('backgroundColor/Image', function (finish) {
+		var view;
+		win = Ti.UI.createWindow({ backgroundColor: 'blue' });
+		view = Ti.UI.createView({ width:Ti.UI.FILL, height:Ti.UI.FILL });
+		win.add(view);
+		win.addEventListener('focus', function () {
+			if (didFocus) {
+				return;
+			}
+			didFocus = true;
+
+			try {
+				view.backgroundColor = 'white';
+				view.backgroundImage = 'Logo.png';
+				should(view.backgroundColor).be.a.String;
+				should(view.backgroundImage).be.a.String;
+				should(view.backgroundColor).be.eql('white');
+				should(view.backgroundImage).be.eql('Logo.png');
+
+				finish();
+			} catch (err) {
+				finish(err);
+			}
+		});
+		win.open();
+	});
+
+	// FIXME Get working on iOS and Android
+	(((utilities.isWindows8_1() && utilities.isWindowsDesktop()) || utilities.isIOS() || utilities.isAndroid()) ? it.skip : it)('backgroundFocusedColor/Image', function (finish) {
+		var view;
+		win = Ti.UI.createWindow({ backgroundColor: 'blue' });
+		view = Ti.UI.createView({ width:Ti.UI.FILL, height:Ti.UI.FILL });
+		win.add(view);
+		win.addEventListener('focus', function () {
+			if (didFocus) {
+				return;
+			}
+			didFocus = true;
+
+			try {
+				should(view.backgroundFocusedColor).be.a.String; // undefined on iOS and Android
+				should(view.backgroundFocusedImage).be.a.String;
+				view.backgroundFocusedColor = 'white';
+				view.backgroundFocusedImage = 'Logo.png';
+				should(view.backgroundFocusedColor).be.eql('white');
+				should(view.backgroundFocusedImage).be.eql('Logo.png');
+
+				finish();
+			} catch (err) {
+				finish(err);
+			}
+		});
+		win.open();
+	});
+
+	// FIXME Get working on iOS
+	(((utilities.isWindows8_1() && utilities.isWindowsDesktop()) || utilities.isIOS() || utilities.isAndroid()) ? it.skip : it)('backgroundSelectedColor/Image', function (finish) {
+		var view;
+		win = Ti.UI.createWindow({ backgroundColor: 'blue' });
+		view = Ti.UI.createView({ width:Ti.UI.FILL, height:Ti.UI.FILL });
+		win.add(view);
+		win.addEventListener('focus', function () {
+			if (didFocus) {
+				return;
+			}
+			didFocus = true;
+
+			try {
+				should(view.backgroundSelectedColor).be.a.String; // undefined on iOS and Android
+				should(view.backgroundSelectedImage).be.a.String;
+				view.backgroundSelectedColor = 'white';
+				view.backgroundSelectedImage = 'Logo.png';
+				should(view.backgroundSelectedColor).be.eql('white');
+				should(view.backgroundSelectedImage).be.eql('Logo.png');
+
+				finish();
+			} catch (err) {
+				finish(err);
+			}
+		});
+		win.open();
+	});
+
+	// FIXME Get working on iOS and Android
+	(((utilities.isWindows8_1() && utilities.isWindowsDesktop()) || utilities.isIOS() || utilities.isAndroid()) ? it.skip : it)('backgroundDisabledColor/Image', function (finish) {
+		var view;
+		win = Ti.UI.createWindow({ backgroundColor: 'blue' });
+		view = Ti.UI.createView({ width:Ti.UI.FILL, height:Ti.UI.FILL });
+		win.add(view);
+		win.addEventListener('focus', function () {
+			if (didFocus) {
+				return;
+			}
+			didFocus = true;
+
+			try {
+				should(view.backgroundDisabledColor).be.a.String; // undefined on iOS and Android
+				should(view.backgroundDisabledImage).be.a.String;
+				view.backgroundDisabledColor = 'white';
+				view.backgroundDisabledImage = 'Logo.png';
+				should(view.backgroundDisabledColor).be.eql('white');
+				should(view.backgroundDisabledImage).be.eql('Logo.png');
+
+				finish();
+			} catch (err) {
+				finish(err);
+			}
+		});
+		win.open();
+	});
+
+	// FIXME Get working on iOS
+	it.iosBroken('backgroundGradient', function (finish) {
+		var view;
+		this.timeout(10000);
+
+		win = Ti.UI.createWindow({ backgroundColor: 'blue' });
+		view = Ti.UI.createView({ width:Ti.UI.FILL, height:Ti.UI.FILL });
+		view.backgroundGradient = {
+			type: 'linear',
+			startPoint: { x: '0%', y: '50%' },
+			endPoint: { x: '100%', y: '100%' },
+			colors: [ { color: 'red', offset: 0.0 }, { color: 'blue', offset: 0.25 }, { color: 'red', offset: 1.0 } ],
+		};
+		win.add(view);
+		win.addEventListener('focus', function () {
+			if (didFocus) {
+				return;
+			}
+			didFocus = true;
+
+			try {
+				should(view.backgroundGradient.type).be.eql('linear');
+				should(view.backgroundGradient.startPoint).be.an.Object;
+				should(view.backgroundGradient.endPoint).be.an.Object;
+				should(view.backgroundGradient.colors).be.an.Array; // undefined on iOS
+
+				finish();
+			} catch (err) {
+				finish(err);
+			}
+		});
+		win.open();
+	});
+
+	// FIXME Get working on iOS and Android
+	it.allBroken('border', function (finish) {
+		var view;
+		win = Ti.UI.createWindow({ backgroundColor: 'blue' });
+		view = Ti.UI.createView({ width:Ti.UI.FILL, height:Ti.UI.FILL });
+		win.add(view);
+		win.addEventListener('focus', function () {
+			if (didFocus) {
+				return;
+			}
+			didFocus = true;
+
+			try {
+				should(view.borderColor).be.a.String; // undefined on iOS and Android
+				should(view.borderWidth).be.a.Number; // Windows gives: expected '0' to be a number
+				view.borderColor = 'blue';
+				view.borderWidth = 2;
+				should(view.borderColor).be.eql('blue');
+				should(view.borderWidth).be.eql(2);
+
+				finish();
+			} catch (err) {
+				finish(err);
+			}
+		});
+		win.open();
+	});
+
+	// FIXME fails on Android because Ti.UI.View doesn't fire postlayout
+	// FIXME Times out on iOS. Never fires postlayout?
+	(((utilities.isWindows8_1() && utilities.isWindowsDesktop()) || utilities.isAndroid() || utilities.isIOS()) ? it.skip : it)('rect and size', function (finish) {
+		var view;
+		win = Ti.UI.createWindow({ backgroundColor: 'blue' });
+		view = Ti.UI.createView({ width:Ti.UI.FILL, height:Ti.UI.FILL });
+		win.add(view);
+
+		view.addEventListener('postlayout', function () {
+			if (didPostLayout) {
+				return;
+			}
+			didPostLayout = true;
+
+			try {
+				Ti.API.info('Got postlayout event');
+				Ti.API.info(JSON.stringify(view.rect));
+				Ti.API.info(JSON.stringify(view.size));
+				should(view.rect).be.an.Object;
+				should(view.rect.width).be.above(0);
+				should(view.rect.height).be.above(0);
+				should(view.rect.x).be.a.Number;
+				should(view.rect.y).be.a.Number;
+				should(view.size.width).be.above(0);
+				should(view.size.height).be.above(0);
+
+				finish();
+			} catch (err) {
+				finish(err);
+			}
+		});
+		win.open();
+	});
+
+	// FIXME Get working on iOS! After #hide() call, visible still returns true)
+	(((utilities.isWindows8_1() && utilities.isWindowsDesktop()) || utilities.isIOS()) ? it.skip : it)('hide() and show() change visible property value', function (finish) {
+		this.slow(2000);
+		this.timeout(7500);
+
+		win = Ti.UI.createWindow({
+			backgroundColor: 'blue'
+		});
+
+		win.addEventListener('focus', function () {
+			if (didFocus) {
+				return;
+			}
+			didFocus = true;
+
+			try {
+				Ti.API.info('Got focus event');
+				should(win.visible).be.true;
+				win.hide();
+				should(win.visible).be.false; // iOS returns true
+				win.show();
+				should(win.visible).be.true;
+
+				finish();
+			} catch (err) {
+				finish(err);
+			}
+		});
+		win.open();
+	});
+
+	// FIXME: Windows 10 Store app fails for this...need to figure out why.
+	// FIXME Android reports view.rect.y to be 100, others report 150
+	(((utilities.isWindows10() && utilities.isWindowsDesktop()) || utilities.isAndroid()) ? it.skip : it)('animate (top)', function (finish) {
+		var view;
+		win = Ti.UI.createWindow();
+		view = Ti.UI.createView({
+			backgroundColor:'red',
+			width: 100, height: 100,
+			left: 100,  top: 100
+		});
+
+		win.addEventListener('open', function () {
+			var animation = Ti.UI.createAnimation({
+				top: 150,
+				duration: 1000,
+			});
+
+			animation.addEventListener('complete', function () {
+				// make sure to give it a time to layout
+				setTimeout(function () {
+					try {
+						should(view.rect.x).be.eql(100);
+						should(view.rect.y).be.eql(150); // Android reports 100
+						should(view.left).be.eql(100);
+						should(view.top).be.eql(100);
+
+						finish();
+					} catch (err) {
+						finish(err);
+					}
+				}, 500);
+			});
+
+			view.animate(animation);
+
+		});
+		win.add(view);
+		win.open();
+	});
+
+	// FIXME: Windows 10 Store app fails for this...need to figure out why.
+	// FIXME Android reports view.rect.x to be 100, others report 150
+	(((utilities.isWindows10() && utilities.isWindowsDesktop()) || utilities.isAndroid()) ? it.skip : it)('animate (left)', function (finish) {
+		var view;
+		win = Ti.UI.createWindow();
+		view = Ti.UI.createView({
+			backgroundColor:'red',
+			width: 100, height: 100,
+			left: 100,  top: 100
+		});
+
+		win.addEventListener('open', function () {
+			var animation = Ti.UI.createAnimation({
+				left: 150,
+				duration: 1000,
+			});
+
+			animation.addEventListener('complete', function () {
+				// make sure to give it a time to layout
+				setTimeout(function () {
+
+					try {
+						should(view.rect.x).be.eql(150); // Android reports 100
+						should(view.rect.y).be.eql(100);
+						should(view.left).be.eql(100);
+						should(view.top).be.eql(100);
+
+						finish();
+					} catch (err) {
+						finish(err);
+					}
+				}, 500);
+			});
+
+			view.animate(animation);
+
+		});
+		win.add(view);
+		win.open();
+	});
+
+	// FIXME: Android view.rect.y is not the same as view.top
+	// FIXME: iOS fails with 'New layout set while view [object TiUIView] animating'
+	it.androidAndIosBroken('TIMOB-20598', function (finish) {
+		this.timeout(10000);
+		var view = Ti.UI.createView({
+				backgroundColor:'red',
+				width: 100, height: 100,
+				left: 100,  top: 100
+			}),
+			left = 150,
+			count = 0;
+
+		win = Ti.UI.createWindow();
+
+		function start() {
+			var animation = Ti.UI.createAnimation({
+				left: left,
+				duration: 1000
+			});
+
+			animation.addEventListener('complete', function() {
+				setTimeout(function() {
+					try {
+						should(view.rect.x).be.eql(left);
+						should(view.rect.y).be.eql(100);
+						should(view.left).be.eql(100);
+						should(view.top).be.eql(100);
+
+						if (count++ > 1) {
+							win.close();
+							finish();
+							return;
+						}
+						left += 50;
+						start();
+					} catch (e) {
+						finish(e);
+					}
+				}, 1000);
+			});
+
+			view.animate(animation);
+		}
+
+		win.addEventListener('open', function() {
+			start();
+		});
+
+		win.add(view);
+		win.open();
+	});
+
+	// FIXME: Windows 10 Store app fails for this...need to figure out why.
+	// FIXME Android reports 90% for one of comparisons to 0 (view.left?)
+	(((utilities.isWindows10() && utilities.isWindowsDesktop()) || utilities.isAndroid()) ? it.skip : it)('animate (left %)', function (finish) {
+		var view;
+		win = Ti.UI.createWindow();
+		view = Ti.UI.createView({
+			backgroundColor: 'red',
+			width: '10%', height: '10%',
+			left: 0, top: 0
+		});
+		win.addEventListener('open', function () {
+			var animation = Ti.UI.createAnimation({
+				left: '90%',
+				duration: 1000
+			});
+			animation.addEventListener('complete', function () {
+				// make sure to give it a time to layout
+				setTimeout(function () {
+					try {
+						should(view.rect.x).be.approximately(view.rect.width * 9, 10);
+						should(view.rect.y).be.eql(0);
+						should(view.left).be.eql(0);
+						should(view.top).be.eql(0);
+
+						finish();
+					} catch (err) {
+						finish(err);
+					}
+				}, 500);
+			});
+			view.animate(animation);
+		});
+		win.add(view);
+		win.open();
+	});
+
+	// FIXME: Windows 10 Store app fails for this...need to figure out why.
+	// FIXME Android reports 90% for one of comparisons to 0 (view.top?)
+	(((utilities.isWindows10() && utilities.isWindowsDesktop()) || utilities.isAndroid()) ? it.skip : it)('animate (top %)', function (finish) {
+		var view;
+		win = Ti.UI.createWindow();
+		view = Ti.UI.createView({
+			backgroundColor: 'red',
+			width: '10%', height: '10%',
+			left: 0, top: 0
+		});
+		win.addEventListener('open', function () {
+			var animation = Ti.UI.createAnimation({
+				top: '90%',
+				duration: 1000
+			});
+			animation.addEventListener('complete', function () {
+				// make sure to give it a time to layout
+				setTimeout(function () {
+					try {
+						should(view.rect.x).be.eql(0);
+						should(view.rect.y).be.approximately(view.rect.height * 9, 10);
+						should(view.left).be.eql(0);
+						should(view.top).be.eql(0);
+
+						finish();
+					} catch (err) {
+						finish(err);
+					}
+				}, 500);
+			});
+			view.animate(animation);
+		});
+		win.add(view);
+		win.open();
+	});
+
+	// FIXME: Windows 10 Store app fails for this...need to figure out why.
+	// FIXME Android reports 90% for one of comparisons to 10% (view.width?)
+	it.androidAndWindowsBroken('animate (width %)', function (finish) {
+		var view;
+		win = Ti.UI.createWindow();
+		view = Ti.UI.createView({
+			backgroundColor: 'red',
+			width: '10%', height: '10%',
+			left: '10%', top: 0
+		});
+		win.addEventListener('open', function () {
+			var animation = Ti.UI.createAnimation({
+				width: '90%',
+				duration: 1000
+			});
+			animation.addEventListener('complete', function () {
+				// make sure to give it a time to layout
+				setTimeout(function () {
+					try {
+						should(view.width).be.eql('10%');
+						should(view.height).be.eql('10%');
+						should(view.rect.width).be.approximately(view.rect.x * 9, 10); // Windows Phone gives: expected 32 to be approximately 288 ±10
+						should(view.left).be.eql('10%');
+						should(view.top).be.eql(0);
+
+						finish();
+					} catch (err) {
+						finish(err);
+					}
+				}, 500);
+			});
+			view.animate(animation);
+		});
+		win.add(view);
+		win.open();
+	});
+
+	// FIXME: Windows 10 Store app fails for this...need to figure out why.
+	// FIXME Android reports 90% for one of comparisons to 10% (view.height?)
+	it.androidAndWindowsBroken('animate (height %)', function (finish) {
+		var view;
+		win = Ti.UI.createWindow();
+		view = Ti.UI.createView({
+			backgroundColor: 'red',
+			width: '10%', height: '10%',
+			left: 0, top: '10%'
+		});
+		win.addEventListener('open', function () {
+			var animation = Ti.UI.createAnimation({
+				height: '90%',
+				duration: 1000
+			});
+			animation.addEventListener('complete', function () {
+				// make sure to give it a time to layout
+				setTimeout(function () {
+					try {
+						should(view.width).be.eql('10%');
+						should(view.height).be.eql('10%');
+						should(view.rect.height).be.approximately(view.rect.y * 9, 10); // Windows Phone: expected 53 to be approximately 477 ±10
+						should(view.left).be.eql(0);
+						should(view.top).be.eql('10%');
+
+						finish();
+					} catch (err) {
+						finish(err);
+					}
+				}, 500);
+			});
+			view.animate(animation);
+		});
+		win.add(view);
+		win.open();
+	});
+
+	// FIXME Android reports 223 for one of the values we expect 123 (result.y?)
+	it.androidAndWindowsBroken('convertPointToView', function (finish) {
+		var a,
+			b;
+		win = Ti.UI.createWindow();
+		a = Ti.UI.createView({ backgroundColor:'red' });
+		b = Ti.UI.createView({ top: '100', backgroundColor: 'blue' });
+
+		a.add(b);
+		win.add(a);
+
+		b.addEventListener('postlayout', function () {
+			var result;
+			if (didPostLayout) {
+				return;
+			}
+			didPostLayout = true;
+
+			try {
+				Ti.API.info('Got postlayout event');
+				result = b.convertPointToView({ x: 123, y: 23 }, a);
+				should(result).be.an.Object;
+				should(result.x).be.a.Number; // Windows: expected '123.000000' to be a number
+				should(result.y).be.a.Number;
+				should(result.x).eql(123);
+				should(result.y).eql(123);
+
+				finish();
+			} catch (err) {
+				finish(err);
+			}
+		});
+		win.open();
+	});
+
+	// FIXME one of the getters or setter for parent isn't there on Android. I can't find the property or accessors in our docs!
+	(utilities.isAndroid() ? it.skip : it)('parent', function (finish) {
+		var view;
+		win = Ti.UI.createWindow({ backgroundColor: 'blue' });
+		view = Ti.UI.createView({ width:Ti.UI.FILL, height:Ti.UI.FILL });
+		win.add(view);
+
+		win.addEventListener('open', function () {
+			try {
+				should(view.parent).be.an.Object;
+				should(view.parent).eql(win);
+				should(view.getParent).be.a.Function;
+				should(view.setParent).be.a.Function;
+				should(view.getParent()).eql(win);
+
+				// parent is not read-only
+				view.setParent(null);
+				should(view.parent).not.exist;
+
+				finish();
+			} catch (err) {
+				finish(err);
+			}
+		});
+
+		win.open();
+	});
+
+	// Test for callback result structure parity - TIMOB-25459
+	it('toImage callback structure', function(finish) {
+		var win = Ti.UI.createWindow();
+		var view = Ti.UI.createView({backgroundColor: 'green', width: 150, height: 150, top: 100});
+		var content = Ti.UI.createView({backgroundColor: 'blue', width: 45, height: 45});
+		var imageView = Ti.UI.createImageView({width: 150, height: 150, top: 300});
+		view.add(content);
+		win.add(view);
+		win.addEventListener('postlayout', function() {
+			view.toImage(function(e) {
+				imageView.setImage(e.blob);
+				should(imageView.getImage()).eql(e.blob);
+				finish();
+			});
+		})
+		win.add(imageView);
+		win.open();
+	});
+
+});


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-25459

**Description:**
Result from calling toImage is returned directly to the callback function. Should be in a dictionary with "blob" key to match iOS behavior.

**Test case:**
app.js
```
var win = Ti.UI.createWindow();
var view = Ti.UI.createView({backgroundColor: 'green', width: 150, height: 150, top: 100});
var content = Ti.UI.createView({backgroundColor: 'blue', width: 45, height: 45});
var imageView = Ti.UI.createImageView({width: 150, height: 150, top: 300});
view.add(content);
win.add(view);
win.addEventListener('postlayout', function() {
	view.toImage(function(e) {
		imageView.setImage(e.blob);
	});
})
win.add(imageView);
win.open();
```