### PR TITLE
Updated CardView.yml per TIDOC-2865

### DIFF
--- a/apidoc/Titanium/UI/Android/CardView.yml
+++ b/apidoc/Titanium/UI/Android/CardView.yml
@@ -18,7 +18,7 @@ description: |
     For design guidelines, see
     [Google Design Guidelines: Cards](http://www.google.com/design/spec/components/cards.html)
 
-    CardView does not support <Titanium.UI.View.backgroundImage> & <Titanium.UI.View.borderColor>.
+    CardView does not support <Titanium.UI.View.backgroundImage>, <Titanium.UI.View.borderColor>, or <Titanium.UI.View.backgroundGradient>.
 extends: Titanium.UI.View
 since: "5.1.0"
 platforms: [android]


### PR DESCRIPTION
Updated line 21 to include the following:

CardView does not support <Titanium.UI.View.backgroundImage>, <Titanium.UI.View.borderColor>, or <Titanium.UI.View.backgroundGradient>.

https://jira.appcelerator.org/browse/TIDOC-2865

Added the backgroundGradient method to the list of items not supported by CardView.
