### PR TITLE
[TIMOB-25487] Android: Prevent kroll from removing null proxy object pointer

### DIFF
--- a/android/runtime/v8/src/native/JNIUtil.cpp
+++ b/android/runtime/v8/src/native/JNIUtil.cpp
@@ -272,7 +272,7 @@ void JNIUtil::logClassName(const char *format, jclass javaClass, bool errorLevel
 bool JNIUtil::removePointer(jobject javaObject)
 {
 	JNIEnv *env = JNIScope::getEnv();
-	if (!env) {
+	if (!env || env->IsSameObject(javaObject, NULL)) {
 		return false;
 	}
 	if (env->IsInstanceOf(javaObject, JNIUtil::krollProxyClass)) {


### PR DESCRIPTION
- There is no `null` object reference check when removing a proxy object pointer, causing a crash on garbage collection

###### TEST CASE
- Repeatedly view and back-out from the map until crash
- This will be re-producible in other cases, but can consistently be reproduced with `ti.map` due to its heavy memory usage
```JS
var MapModule = require('ti.map'),
    win = Titanium.UI.createWindow({backgroundColor: 'gray'}),
    btn = Ti.UI.createButton({title: 'VIEW MAP'});

function viewMap () {
    var win = Ti.UI.createWindow({backgroundColor: 'gray'}),
        mapView = MapModule.createView({
            userLocation: true,
            mapType: MapModule.NORMAL_TYPE,
            animate: true,
            region: {latitude: -33.87365, longitude: 151.20689, latitudeDelta: 0.1, longitudeDelta: 0.1 }
        });
    win.add(mapView);
    win.open();
}

btn.addEventListener('click', function (e) {
	if (Ti.Geolocation.hasLocationPermissions()) {
        viewMap();
    } else {
        Ti.Geolocation.requestLocationPermissions(function (e) {
            if (e.success === true) {
                viewMap();
            } else {
                alert('permissions denied: ' + e.error);
            }
        });
	}
});

win.add(btn);
win.open();
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-25487)