### PR TITLE
Android: Lowered min "targetSdkVersion" from 25 to 23.

### DIFF
--- a/android/package.json
+++ b/android/package.json
@@ -16,7 +16,7 @@
 	"minSDKVersion": "16",
 	"compileSDKVersion": "26",
 	"vendorDependencies": {
-		"android sdk": "25.x",
+		"android sdk": ">=23.x <=25.x",
 		"android build tools": "26.x",
 		"android platform tools": "26.x",
 		"android tools": "<=26.x",


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-25510

**Summary:**
The Android min "targetSdkVersion" was bumped up from 23 to 25 in Titanium 6.2.2, but developers need the ability to target API Level 23 (aka: Android 6.0) in order to work-around Android 7.0's breaking changes (not all of them have been resolved yet). This change brings back API Level 23 targeting support.

**Test:**
1. Add the below Android settings to your project's "tiapp.xml" file.
2. Build the app for Android.
3. Open the file:  `./<YourProject>/build/android/AndroidManifest.xml`
4. Verify that the XML `<uses-sdk>` element's `targetSdkVersion` is set to `23`.

```xml
<?xml version="1.0" encoding="UTF-8"?>
<ti:app xmlns:ti="http://ti.appcelerator.org">
	<android xmlns:android="http://schemas.android.com/apk/res/android">
		<manifest>
			<uses-sdk android:minSdkVersion="16" android:targetSdkVersion="23"/>
		</manifest>
	</android>
</ti:app>
```
