### PR TITLE
Revert "[TIMOB-24679] Remove invalid constant definitions"

### DIFF
--- a/android/kroll-apt/src/java/org/appcelerator/kroll/annotations/generator/ProxyBindingV8.cpp.fm
+++ b/android/kroll-apt/src/java/org/appcelerator/kroll/annotations/generator/ProxyBindingV8.cpp.fm
@@ -146,10 +146,16 @@ Local<FunctionTemplate> ${className}::getProxyTemplate(Isolate* isolate)
 		<#else>
 			<#if constant.type = "java.lang.String">
 			DEFINE_STRING_CONSTANT(isolate, t, "${name}", "${constant.value}");
+			// TODO: deprecate in 7.0.0
+			DEFINE_STRING_CONSTANT(isolate, prototypeTemplate, "${name}", "${constant.value}");
 			<#elseif constant.type = "int" || constant.type = "long" || constant.type = "short">
 			DEFINE_INT_CONSTANT(isolate, t, "${name}", ${constant.value?c});
+			// TODO: deprecate in 7.0.0
+			DEFINE_INT_CONSTANT(isolate, prototypeTemplate, "${name}", ${constant.value?c});
 			<#else>
 			DEFINE_NUMBER_CONSTANT(isolate, t, "${name}", ${constant.value?c});
+			// TODO: deprecate in 7.0.0
+			DEFINE_NUMBER_CONSTANT(isolate, prototypeTemplate, "${name}", ${constant.value?c});
 			</#if>
 		</#if>
 	<#else>


### PR DESCRIPTION
- Revert 2c3bae459f37502d14173db441e808a5b4832988 which causes a difference in behaviour between iOS and Windows
- Should fix numerous Jenkins test failures