### PR TITLE
[TIMOB-24906] Bump node-titanium-sdk to 0.4.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3475,9 +3475,9 @@
       }
     },
     "node-titanium-sdk": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/node-titanium-sdk/-/node-titanium-sdk-0.4.4.tgz",
-      "integrity": "sha512-2MsK6nf59opShtG2t29wuZiPSAnKq5HFiZwNvwhUtLIbYqGReFucXblZg+ue/XXxbZrGwQ85bqFYYH1wSmTH0A==",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/node-titanium-sdk/-/node-titanium-sdk-0.4.5.tgz",
+      "integrity": "sha512-ophB1i1eYkH9Tw+cl80xJyeK37LGJdyxY9G2G9l09Tu+3Zk0eyt8wD4lT2uOn5sekjzTaFHqxE8rGCgFxQnLpg==",
       "requires": {
         "async": "2.6.0",
         "babel-core": "6.25.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "markdown": "0.5.0",
     "moment": "2.18.1",
     "node-appc": "0.2.43",
-    "node-titanium-sdk": "^0.4.4",
+    "node-titanium-sdk": "^0.4.5",
     "node-uuid": "1.4.8",
     "pngjs": "3.0.1",
     "request": "2.81.0",


### PR DESCRIPTION
- Update `node-titanium-sdk` to version `0.4.5`
- Android: Wait for response when parsing devices https://github.com/appcelerator/node-titanium-sdk/pull/18

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-24906)