### PR TITLE
[TIMOB-25569] Reference Hyperloop 3.0.1

### DIFF
--- a/support/module/packaged/modules.json
+++ b/support/module/packaged/modules.json
@@ -20,6 +20,6 @@
 		"https://github.com/appcelerator-modules/ti.cloud/releases/download/3.2.11/ti.cloud-commonjs-3.2.11.zip"
 	],
 	"hyperloop": [
-		"https://github.com/appcelerator-modules/hyperloop-builds/releases/download/v3.0.0-beta.4/hyperloop-3.0.0-beta.4.zip"
+		"https://github.com/appcelerator-modules/hyperloop-builds/releases/download/v3.0.1/hyperloop-3.0.1.zip"
 	]
 }


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-25569

Highly recommending for 7.0.0 GA, but using `7.0.1` milestone for now to prevent unexpected new tickets 🙂.