### PR TITLE
Android: Update supported source version to Java 7

### DIFF
--- a/android/kroll-apt/src/java/org/appcelerator/kroll/annotations/generator/KrollJSONGenerator.java
+++ b/android/kroll-apt/src/java/org/appcelerator/kroll/annotations/generator/KrollJSONGenerator.java
@@ -39,7 +39,7 @@ import org.json.simple.JSONValue;
 @SupportedAnnotationTypes({
 	KrollJSONGenerator.Kroll_proxy,
 	KrollJSONGenerator.Kroll_module})
-@SupportedSourceVersion(SourceVersion.RELEASE_6)
+@SupportedSourceVersion(SourceVersion.RELEASE_7)
 @SupportedOptions({KrollJSONGenerator.PROPERTY_JSON_PACKAGE, KrollJSONGenerator.PROPERTY_JSON_FILE})
 @SuppressWarnings("unchecked")
 public class KrollJSONGenerator extends AbstractProcessor {


### PR DESCRIPTION
- Update `KrollJSONGenerator` reference from `6` to `7` to prevent

```
[javac] warning: Supported source version 'RELEASE_6' from annotation processor 'org.appcelerator.kroll.annotations.generator.KrollJSONGenerator' less than -source '1.7'
```