### PR TITLE
[TIDOC-2664] Updated Android.yml regarding deprecations

### DIFF
--- a/apidoc/Titanium/Android/Android.yml
+++ b/apidoc/Titanium/Android/Android.yml
@@ -2240,7 +2240,7 @@ properties:
   - name: NAVIGATION_MODE_STANDARD
     summary: Standard Action Bar navigation mode
     description: |
-        Use with the <Titanium.Android.ActionBar.navigationMode> property.
+        Use with the <Titanium.Android.ActionBar.navigationMode> property. Note: NAVIGATION_MODE_STANDARD has been depricated in API level 21 and up.
     type: Number
     permission: read-only
     since: "3.2.0"
@@ -2248,7 +2248,7 @@ properties:
   - name: NAVIGATION_MODE_TABS
     summary: Action Bar tab navigation mode
     description: |
-        Use with the <Titanium.Android.ActionBar.navigationMode> property.
+        Use with the <Titanium.Android.ActionBar.navigationMode> property. Note: NAVIGATION_MODE_TABS has been depricated in API level 21 and up.
     type: Number
     permission: read-only
     since: "3.2.0"

--- a/apidoc/Titanium/Android/Android.yml
+++ b/apidoc/Titanium/Android/Android.yml
@@ -2240,7 +2240,7 @@ properties:
   - name: NAVIGATION_MODE_STANDARD
     summary: Standard Action Bar navigation mode
     description: |
-        Use with the <Titanium.Android.ActionBar.navigationMode> property. Note: NAVIGATION_MODE_STANDARD has been depricated in API level 21 and up.
+        Use with the <Titanium.Android.ActionBar.navigationMode> property. Note: NAVIGATION_MODE_STANDARD has been deprecated in API level 21 and up.
     type: Number
     permission: read-only
     since: "3.2.0"
@@ -2248,7 +2248,7 @@ properties:
   - name: NAVIGATION_MODE_TABS
     summary: Action Bar tab navigation mode
     description: |
-        Use with the <Titanium.Android.ActionBar.navigationMode> property. Note: NAVIGATION_MODE_TABS has been depricated in API level 21 and up.
+        Use with the <Titanium.Android.ActionBar.navigationMode> property. Note: NAVIGATION_MODE_TABS has been deprecated in API level 21 and up.
     type: Number
     permission: read-only
     since: "3.2.0"


### PR DESCRIPTION
Added the following notes to two properties:
* NAVIGATION_MODE_STANDARD:  "Note: NAVIGATION_MODE_STANDARD has been deprecated in API level 21 and up."
* NAVIGATION_MODE_TABS: Note: NAVIGATION_MODE_TABS has been deprecated in API level 21 and up.

**JIRA:** https://jira.appcelerator.org/browse/TIDOC-2664