### PR TITLE
[TIMOB-20363] Fix Android: Buttons inside views appear on top of all other children

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIButton.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIButton.java
@@ -8,6 +8,7 @@ package ti.modules.titanium.ui.widget;
 
 import java.util.HashMap;
 
+import android.os.Build;
 import android.text.TextUtils;
 import org.appcelerator.kroll.KrollDict;
 import org.appcelerator.kroll.KrollProxy;
@@ -54,6 +55,10 @@ public class TiUIButton extends TiUIView
 		defaultColor = btn.getCurrentTextColor();
 		btn.setEllipsize(TextUtils.TruncateAt.MIDDLE);
 		btn.setMaxLines(1);
+		// Fixed for TIMOB-20363. Buttons inside views appear on top of all other children
+		if (Build.VERSION.SDK_INT >= 21) {
+			btn.setStateListAnimator(null);
+		}
 		setNativeView(btn);
 	}
 


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-20363

````js

Titanium.UI.setBackgroundColor('#000');

var window = Titanium.UI.createWindow({
backgroundColor:'#fff'
});
 
// create a main view which will contain the button and the view
var mainViewContainer = Ti.UI.createView({
top: 0,
left: 0,
right: 0,
bottom:0,
backgroundColor: 'red'
});
 
// create a view which will obscure the button
var shouldObscureButton = Ti.UI.createView({
top: 0,
left: 0,
width: 200,
bottom: 0,
backgroundColor: 'blue'
});
 
// create a button which is wider than the obscure view
var button = Ti.UI.createButton({
height: 350,
width: 350,
left: 0,
backgroundImage: 'buttonTest.png',
backgroundColor: 'yellow'
});
 
// add the button to the main view container before the obscure view
mainViewContainer.add(button);
 
// add a view that should obscure the button after the button has been added
mainViewContainer.add(shouldObscureButton);
 
// add the main view to the window and open it
window.add(mainViewContainer);
window.open();


