### PR TITLE
[TIMOB-25621] Android: Do not delete third-party native libraries

### DIFF
--- a/android/cli/commands/_buildModule.js
+++ b/android/cli/commands/_buildModule.js
@@ -548,7 +548,6 @@ AndroidModuleBuilder.prototype.loginfo = function loginfo(next) {
 
 AndroidModuleBuilder.prototype.cleanup = function cleanup(next) {
 	fs.emptyDirSync(this.buildDir);
-	fs.emptyDirSync(this.libsDir);
 
 	this.requiredArchitectures.forEach(function (architecture) {
 		fs.mkdirsSync(path.join(this.libsDir, architecture));

--- a/android/cli/commands/_buildModule.js
+++ b/android/cli/commands/_buildModule.js
@@ -549,6 +549,15 @@ AndroidModuleBuilder.prototype.loginfo = function loginfo(next) {
 AndroidModuleBuilder.prototype.cleanup = function cleanup(next) {
 	fs.emptyDirSync(this.buildDir);
 
+	// remove old module libraries
+	fs.existsSync(this.libsDir) && this.dirWalker(this.libsDir, function (file) {
+		const libExp = new RegExp('lib' + this.manifest.moduleid + '.so$', 'i');
+		if (libExp.test(file) && fs.existsSync(file)) {
+			this.logger.debug(__('Removing %s', file.cyan));
+			fs.removeSync(file);
+		}
+	}.bind(this));
+
 	this.requiredArchitectures.forEach(function (architecture) {
 		fs.mkdirsSync(path.join(this.libsDir, architecture));
 	}, this);


### PR DESCRIPTION
- Do not clean third-party native libraries from Titanium modules
- Caused by the changes in https://github.com/appcelerator/titanium_mobile/pull/9670

###### TEST CASE
- Compile the appcelerator.encrypteddatabase module
- Verify the appropriate *.so libraries are included in the .zip output

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-25621)
  