### PR TITLE
[TIMOB-25654] Remove duplicate key from Geolocation logging

### DIFF
--- a/iphone/Classes/GeolocationModule.m
+++ b/iphone/Classes/GeolocationModule.m
@@ -828,8 +828,8 @@ MAKE_SYSTEM_PROP(ACTIVITYTYPE_OTHER_NAVIGATION, CLActivityTypeOtherNavigation);
     } else if ([TiUtils isIOS11OrGreater]) {
       errorMessage = [[NSString alloc] initWithFormat:
                                            @"The %@, %@ and %@ key must be defined in your tiapp.xml in order to request this permission.",
-                                       kTiGeolocationUsageDescriptionAlwaysAndWhenInUse,
                                        kTiGeolocationUsageDescriptionAlways,
+                                       kTiGeolocationUsageDescriptionWhenInUse,
                                        kTiGeolocationUsageDescriptionAlwaysAndWhenInUse];
     } else {
       errorMessage = [[NSString alloc] initWithFormat:


### PR DESCRIPTION
**JIRA**: https://jira.appcelerator.org/browse/TIMOB-25654

#### Steps to reproduce

- Add the code below to an app.js and build to iOS
```js
Ti.Geolocation.requestLocationPermissions(Ti.Geolocation.AUTHORIZATION_ALWAYS, function(e) {
    console.log(e);
});
```

#### Expected

`[ERROR] The NSLocationAlwaysUsageDescription, NSLocationWhenInUseUsageDescription and NSLocationAlwaysAndWhenInUseUsageDescription key must be defined in your tiapp.xml in order to request this permission.` should be logged


#### Current

`[ERROR] The NSLocationAlwaysAndWhenInUseUsageDescription, NSLocationAlwaysUsageDescription and NSLocationAlwaysAndWhenInUseUsageDescription key must be defined in your tiapp.xml in order to request this permission.` is logged
  
  
  