### PR TITLE
[TIMOB-25658] Android: TableView NullPointerException on getOuterView Titanium 7.0.1 Android

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/TiViewProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/TiViewProxy.java
@@ -538,7 +538,9 @@ public abstract class TiViewProxy extends KrollProxy implements Handler.Callback
 	public TiUIView getOrCreateView()
 	{
 		TiBaseActivity activity = (TiBaseActivity) getActivity();
-		if (activity == null || activity.isDestroyed() || view != null) {
+
+		if (view != null && (activity == null || activity.isDestroyed())) {
+			view.getProxy().setActivity(TiApplication.getAppCurrentActivity());
 			return view;
 		}
 


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-25658

**Description:**
Setting the current activity as one for proxies that are linked with destroyed activity.

**Test case:**
Alloy project in the JIRA ticket. 
Also the samples provided in this ticket:
https://jira.appcelerator.org/browse/TIMOB-25656