### PR TITLE
[TIMOB-25676] (7_0_X) iOS: Fix Ti.Network.HTTPClient states to pass unit-tests

### DIFF
--- a/iphone/Classes/TiNetworkHTTPClientProxy.m
+++ b/iphone/Classes/TiNetworkHTTPClientProxy.m
@@ -373,7 +373,12 @@ extern NSString *const TI_APPLICATION_GUID;
 - (void)request:(APSHTTPRequest *)request onReadyStateChange:(APSHTTPResponse *)response
 {
   if (hasOnreadystatechange) {
-    [self fireCallback:@"onreadystatechange" withArg:[NSDictionary dictionaryWithObjectsAndKeys:NUMINT(response.readyState), @"readyState", nil] withSource:self];
+    // Perform state changes serial to prevent the race conditions
+    // e.g. duplicate states, missing states
+    TiThreadPerformOnMainThread(^{
+      [self fireCallback:@"onreadystatechange" withArg:[NSDictionary dictionaryWithObjectsAndKeys:NUMINT(response.readyState), @"readyState", nil] withSource:self];
+    },
+        YES);
   }
 }
 


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-25676

`no tests` because it fixes an existing unit-test.