### PR TITLE
[TIMOB-25680] (7_0_X) iOS: Workaround the iOS 11.2+ document-viewer issue

### DIFF
--- a/apidoc/Titanium/UI/iOS/DocumentViewer.yml
+++ b/apidoc/Titanium/UI/iOS/DocumentViewer.yml
@@ -59,8 +59,8 @@ description: |
           
         // Check if the current device runs iOS 11.2+
         function isiOS11_2() {
-        	var version = Ti.Platform.version.split(".");	
-        	return (parseInt(version[0]) >= 11 && parseInt(version[1]) >= 2);
+          var version = Ti.Platform.version.split(".");	
+          return (parseInt(version[0]) >= 11 && parseInt(version[1]) >= 2);
         }
 
         // Create a temporary file with the contents of the old file

--- a/apidoc/Titanium/UI/iOS/DocumentViewer.yml
+++ b/apidoc/Titanium/UI/iOS/DocumentViewer.yml
@@ -36,6 +36,59 @@ description: |
     using either a document from the `Resources` directory (classic Titanium) or `app/assets` (Alloy). 
     Alternatively, documents can also be stored in the <Titanium.Filesystem.applicationCacheDirectory> 
     or <Titanium.Filesystem.applicationDataDirectory>.
+    
+    **Note for iOS 11.2 and later**
+    Apple introduced a regression in iOS 11.2 that forces **all** files to be in the application data
+    directory or temporary directory. We handle this workaround for you in Titanium SDK 7.0.2+, but you
+    can also work around it without an SDK update. Here is an example:
+      
+        var fileName = 'example.pdf';
+        
+        // For iOS 11.2, workaround the Apple issue by creating a temporary file and
+        // reference it. It will be removed from filesystem once the app closes.
+        // Read more here: http://nshipster.com/nstemporarydirectory/
+        if (isiOS11_2()) {
+          fileName = fileInTemporaryDirectory(fileName);
+        }
+        
+        var docViewer = Ti.UI.iOS.createDocumentViewer({
+          url: fileName
+        });
+       
+        docViewer.show();
+          
+        // Check if the current device runs iOS 11.2+
+        function isiOS11_2() {
+        	var version = Ti.Platform.version.split(".");	
+        	return (parseInt(version[0]) >= 11 && parseInt(version[1]) >= 2);
+        }
+
+        // Create a temporary file with the contents of the old file
+        // Expects the file to be in the resources directory. If you receive the file 
+        // from an API-call, receive pass the Ti.Blob/Ti.File/text to "write" directly.
+        function fileInTemporaryDirectory(fileName) {
+          var file = Ti.Filesystem.getFile(Ti.Filesystem.resourcesDirectory, fileName);
+          
+          if (!file.exists()) {
+            alert('File does not exist in resources!');
+            return;
+          }
+          
+          var newFile = Titanium.Filesystem.getFile(Ti.Filesystem.tempDirectory, fileName);
+          newFile.createFile();
+          
+          if (!newFile.exists()) {
+            alert('New file could not be created in temporary directory!');
+            return;
+          }
+          
+          newFile.write(file);
+          
+          return newFile.nativePath;
+        }
+        
+    Read more about the issue in [TIMOB-25680](https://jira.appcelerator.org/browse/TIMOB-25680).
+
 extends: Titanium.UI.View
 platforms: [iphone,ipad]
 since: "2.1.1"
@@ -50,6 +103,11 @@ properties:
 
   - name: url
     summary: URL of the document being previewed.
+    description: |
+        Important note: For iOS 11.2 and later, you need to reference this URL
+        from either the application data directory or temporary directory. Read
+        more about this change in the "Note for iOS 11.2 and later" pargraph of 
+        the API summary.
     type: String
 
 methods:
@@ -137,4 +195,3 @@ properties:
         If this property is not specified, the `show` method launches the document in the viewer
         without showing the options menu.
     type: Titanium.UI.View
-

--- a/apidoc/Titanium/UI/iOS/DocumentViewer.yml
+++ b/apidoc/Titanium/UI/iOS/DocumentViewer.yml
@@ -106,7 +106,7 @@ properties:
     description: |
         Important note: For iOS 11.2 and later, you need to reference this URL
         from either the application data directory or temporary directory. Read
-        more about this change in the "Note for iOS 11.2 and later" pargraph of 
+        more about this change in the "Note for iOS 11.2 and later" paragraph of 
         the API summary.
     type: String
 


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-25680

`no tests` because it's a change unit-tests cannot measure.