### PR TITLE
Update the pre-packaged module JSON listing to use integrity hashes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,8 +15,8 @@ def isMainlineBranch = true // used to determine if we should publish to S3 (and
 def isFirstBuildOnBranch = false // calculated by looking at S3's branches.json
 
 // Variables we can change
-def nodeVersion = '6.10.3' // NOTE that changing this requires we set up the desired version on jenkins master first!
-def npmVersion = '5.4.1' // We can change this without any changes to Jenkins.
+def nodeVersion = '8.9.1' // NOTE that changing this requires we set up the desired version on jenkins master first!
+def npmVersion = '5.6.0' // We can change this without any changes to Jenkins.
 
 def unitTests(os, nodeVersion, testSuiteBranch) {
 	return {

--- a/build/ios.js
+++ b/build/ios.js
@@ -13,7 +13,8 @@ const exec = require('child_process').exec, // eslint-disable-line security/dete
 	ROOT_DIR = path.join(__dirname, '..'),
 	IOS_ROOT = path.join(ROOT_DIR, 'iphone'),
 	IOS_LIB = path.join(IOS_ROOT, 'lib'),
-	TI_CORE_VERSION = 24;
+	TI_CORE_VERSION = 24,
+	TI_CORE_INTEGRITY = 'sha512-iTyrzaMs6SfPlyEgO70pg8EW08mn211tjpAI5hAmRHQaZGu1ieuBnT8uEkEYcsO8hdzAFbouqPPEaXWcJH5SLA==';
 
 function gunzip(gzFile, destFile, next) {
 	console.log('Gunzipping ' + gzFile + ' to ' + destFile);
@@ -55,7 +56,7 @@ IOS.prototype.fetchLibTiCore = function (next) {
 	console.log('You don\'t seem to have the appropriate thirdparty files. I\'ll fetch them.');
 	console.log('This could take awhile.. Might want to grab a cup of Joe or make fun of Nolan.');
 
-	downloadURL(url, function (err, file) {
+	downloadURL(url, TI_CORE_INTEGRITY, function (err, file) {
 		if (err) {
 			return next(err);
 		}

--- a/build/packager.js
+++ b/build/packager.js
@@ -2,7 +2,6 @@
 
 const path = require('path');
 const os = require('os');
-const ssri = require('ssri');
 const exec = require('child_process').exec; // eslint-disable-line security/detect-child-process
 const spawn = require('child_process').spawn; // eslint-disable-line security/detect-child-process
 const async = require('async');

--- a/build/packager.js
+++ b/build/packager.js
@@ -1,17 +1,18 @@
 'use strict';
 
-const path = require('path'),
-	os = require('os'),
-	exec = require('child_process').exec, // eslint-disable-line security/detect-child-process
-	spawn = require('child_process').spawn, // eslint-disable-line security/detect-child-process
-	async = require('async'),
-	fs = require('fs-extra'),
-	utils = require('./utils'),
-	copyFile = utils.copyFile,
-	copyFiles = utils.copyFiles,
-	downloadURL = utils.downloadURL,
-	ROOT_DIR = path.join(__dirname, '..'),
-	SUPPORT_DIR = path.join(ROOT_DIR, 'support');
+const path = require('path');
+const os = require('os');
+const ssri = require('ssri');
+const exec = require('child_process').exec; // eslint-disable-line security/detect-child-process
+const spawn = require('child_process').spawn; // eslint-disable-line security/detect-child-process
+const async = require('async');
+const fs = require('fs-extra');
+const utils = require('./utils');
+const copyFile = utils.copyFile;
+const copyFiles = utils.copyFiles;
+const downloadURL = utils.downloadURL;
+const ROOT_DIR = path.join(__dirname, '..');
+const SUPPORT_DIR = path.join(ROOT_DIR, 'support');
 
 /**
  * Given a folder we'd like to zip up and the destination filename, this will zip up the directory contents.
@@ -189,21 +190,25 @@ Packager.prototype.includePackagedModules = function (next) {
 	// that will download the all-in-one distribution.
 	supportedPlatforms = supportedPlatforms.concat([ 'hyperloop' ]);
 
-	let urls = []; // urls of module zips to grab
+	let modules = []; // module objects holding url/integrity
 	// Read modules.json, grab the object for each supportedPlatform
 	const contents = fs.readFileSync(path.join(SUPPORT_DIR, 'module', 'packaged', 'modules.json')).toString(),
 		modulesJSON = JSON.parse(contents);
 	for (let x = 0; x < supportedPlatforms.length; x++) {
-		const newModuleURLS = modulesJSON[supportedPlatforms[x]];
-		urls = urls.concat(newModuleURLS || []);
+		const modulesForPlatform = modulesJSON[supportedPlatforms[x]];
+		if (modulesForPlatform) {
+			modules = modules.concat(Object.values(modulesForPlatform));
+		}
 	}
+	// remove duplicates
+	modules = Array.from(new Set(modules));
 
 	// Fetch the listed modules from URLs...
 	const outDir = this.zipDir,
 		zipFiles = [];
-	async.each(urls, function (url, cb) {
+	async.each(modules, function (moduleObject, cb) {
 		// FIXME Don't show progress bars, because they clobber each other
-		downloadURL(url, function (err, file) {
+		downloadURL(moduleObject.url, moduleObject.integrity, function (err, file) {
 			if (err) {
 				return cb(err);
 			}

--- a/build/scons-modules-integrity.js
+++ b/build/scons-modules-integrity.js
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+'use strict';
+
+const async = require('async'),
+	program = require('commander'),
+	utils = require('./utils'),
+	modules = require('../support/module/packaged/modules.json');
+
+const platforms = Object.keys(modules);
+async.map(platforms, (platform, platformNext) => {
+	const platformModuleNames = Object.keys(modules[platform]);
+	async.map(platformModuleNames, (modName, modNext) => {
+		const modObj = modules[platform][modName];
+		utils.generateSSRIHashFromURL(modObj.url, function (e, hash) {
+			if (e) {
+				return modNext(e);
+			}
+			const obj = {};
+			modObj.integrity = hash;
+			obj[modName] = modObj;
+			modNext(null, obj);
+		});
+	}, (e, mods) => {
+		if (e) {
+			return platformNext(e);
+		}
+		// Merge the modules array into a single object
+		const merged = Object.assign({}, ...mods);
+		const platformObj = {};
+		platformObj[platform] = merged;
+		return platformNext(null, platformObj);
+	});
+}, (e, results) => {
+	if (e) {
+		console.error(e);
+		process.exit(1);
+	}
+	// Merge the platforms array into a single object
+	const merged = Object.assign({}, ...results);
+	console.log(JSON.stringify(merged));
+});

--- a/build/scons-modules-integrity.js
+++ b/build/scons-modules-integrity.js
@@ -2,7 +2,6 @@
 'use strict';
 
 const async = require('async'),
-	program = require('commander'),
 	utils = require('./utils'),
 	modules = require('../support/module/packaged/modules.json');
 

--- a/build/scons-ssri.js
+++ b/build/scons-ssri.js
@@ -24,7 +24,7 @@ async.each(urls, function (url, next) {
 		};
 		console.log(JSON.stringify(obj));
 		return next(null, hash);
-	})
+	});
 }, function (err) {
 	if (err) {
 		process.exit(1);

--- a/build/scons-ssri.js
+++ b/build/scons-ssri.js
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+'use strict';
+
+const async = require('async'),
+	program = require('commander'),
+	utils = require('./utils');
+
+program.parse(process.argv);
+
+let urls = program.args;
+if (urls.length <= 0) {
+	console.log('Please provide one or more URLs as arguments to this command to generate SSRI "integrity" values for.');
+	process.exit(1);
+}
+console.log(urls);
+async.each(urls, function (url, next) {
+	utils.generateSSRIHashFromURL(url, function (e, hash) {
+		if (e) {
+			return next(e);
+		}
+		const obj = {
+			url: url,
+			integrity: hash
+		};
+		console.log(JSON.stringify(obj));
+		return next(null, hash);
+	})
+}, function (err) {
+	if (err) {
+		process.exit(1);
+	}
+	process.exit(0);
+});

--- a/build/scons.js
+++ b/build/scons.js
@@ -13,4 +13,6 @@ commander
 	.command('build [platforms]', 'build one or more platforms')
 	.command('test [platforms]', 'Runs our unit tests')
 	.command('update-node-deps', 'deletes and reinstalls node dependencies')
+	.command('ssri [urls]', 'generates ssri integrity hashes for URLs')
+	.command('modules-integrity', 'Regenerates ssri integrity hashes for all the modules in our pre-packaged listing under support/module/packged/modules.json given the current url values')
 	.parse(process.argv);

--- a/build/utils.js
+++ b/build/utils.js
@@ -119,8 +119,8 @@ function downloadWithIntegrity(url, downloadPath, integrity, callback) {
 			return callback(err);
 		}
 		// Verify integrity!
-		ssri.checkStream(fs.createReadStream(downloadPath), integrity).then((hash) => {
-			callback(null, downloadPath);
+		ssri.checkStream(fs.createReadStream(file), integrity).then(() => {
+			callback(null, file);
 		}).catch((e) => {
 			callback(e);
 		});
@@ -137,7 +137,7 @@ function cachedDownloadPath(url) {
 	return path.join(cacheDir, filename);
 }
 
-Utils.generateSSRIHashFromURL = function(url, callback) {
+Utils.generateSSRIHashFromURL = function (url, callback) {
 	const downloadPath = cachedDownloadPath(url);
 	fs.removeSync(downloadPath);
 	download(url, downloadPath, function (err, file) {
@@ -145,13 +145,13 @@ Utils.generateSSRIHashFromURL = function(url, callback) {
 			return callback(err);
 		}
 		// Generate integrity hash!
-		ssri.fromStream(fs.createReadStream(downloadPath)).then(integrity => {
+		ssri.fromStream(fs.createReadStream(file)).then(integrity => {
 			callback(null, integrity.toString());
 		}).catch(e => {
 			callback(e);
 		});
 	});
-}
+};
 
 Utils.downloadURL = function downloadURL(url, integrity, callback) {
 	const downloadPath = cachedDownloadPath(url);
@@ -162,7 +162,7 @@ Utils.downloadURL = function downloadURL(url, integrity, callback) {
 	// Check if file already exists and passes integrity check!
 	if (fs.existsSync(downloadPath)) {
 		// if it passes integrity check, we're all good, return path to file
-		ssri.checkStream(fs.createReadStream(downloadPath), integrity).then((hash) => {
+		ssri.checkStream(fs.createReadStream(downloadPath), integrity).then(() => {
 			// cached copy is still valid, integrity hash matches
 			callback(null, downloadPath);
 		}).catch(() => {

--- a/build/utils.js
+++ b/build/utils.js
@@ -6,7 +6,9 @@ const path = require('path'),
 	glob = require('glob'),
 	appc = require('node-appc'),
 	request = require('request'),
-	temp = require('temp'),
+	os = require('os'),
+	ssri = require('ssri'),
+	tempDir = os.tmpdir(),
 	util = require('util'),
 	Utils = {};
 
@@ -54,20 +56,16 @@ Utils.copyAndModifyFiles = function (srcFolder, destFolder, files, substitutions
 	}, next);
 };
 
-Utils.downloadURL = function (url, callback) {
+function download(url, destination, callback) {
 	console.log('Downloading %s', url);
 
-	const tempName = temp.path({ suffix: '.gz' }),
-		tempDir = path.dirname(tempName);
-	fs.existsSync(tempDir) || fs.mkdirsSync(tempDir);
-
-	const tempStream = fs.createWriteStream(tempName),
-		req = request({ url: url });
+	const tempStream = fs.createWriteStream(destination);
+	const req = request({ url: url });
 
 	req.pipe(tempStream);
 
 	req.on('error', function (err) {
-		fs.existsSync(tempName) && fs.unlinkSync(tempName);
+		fs.existsSync(destination) && fs.unlinkSync(destination);
 		console.log();
 		console.error('Failed to download: %s', err.toString());
 		callback(err);
@@ -99,7 +97,7 @@ Utils.downloadURL = function (url, callback) {
 					bar.tick(total);
 					console.log('\n');
 				}
-				callback(null, tempName);
+				callback(null, destination);
 			});
 		} else {
 			// we don't know how big the file is, display a spinner
@@ -109,10 +107,73 @@ Utils.downloadURL = function (url, callback) {
 			tempStream.on('close', function () {
 				busy && busy.stop();
 				console.log();
-				callback(null, tempName);
+				callback(null, destination);
 			});
 		}
 	});
+}
+
+function downloadWithIntegrity(url, downloadPath, integrity, callback) {
+	download(url, downloadPath, function (err, file) {
+		if (err) {
+			return callback(err);
+		}
+		// Verify integrity!
+		ssri.checkStream(fs.createReadStream(downloadPath), integrity).then((hash) => {
+			callback(null, downloadPath);
+		}).catch((e) => {
+			callback(e);
+		});
+	});
+}
+
+function cachedDownloadPath(url) {
+	// Use some consistent name so we can cache files!
+	const cacheDir = path.join(tempDir, 'timob-build');
+	fs.existsSync(cacheDir) || fs.mkdirsSync(cacheDir);
+
+	const filename = url.slice(url.lastIndexOf('/') + 1);
+	// Place to download file
+	return path.join(cacheDir, filename);
+}
+
+Utils.generateSSRIHashFromURL = function(url, callback) {
+	const downloadPath = cachedDownloadPath(url);
+	fs.removeSync(downloadPath);
+	download(url, downloadPath, function (err, file) {
+		if (err) {
+			return callback(err);
+		}
+		// Generate integrity hash!
+		ssri.fromStream(fs.createReadStream(downloadPath)).then(integrity => {
+			callback(null, integrity.toString());
+		}).catch(e => {
+			callback(e);
+		});
+	});
+}
+
+Utils.downloadURL = function downloadURL(url, integrity, callback) {
+	const downloadPath = cachedDownloadPath(url);
+
+	if (!integrity) {
+		return callback(new Error('No "integrity" value given for %s, may need to run "scons update-modules-integrity" to generate new module listing with updated integrity hashes.', url));
+	}
+	// Check if file already exists and passes integrity check!
+	if (fs.existsSync(downloadPath)) {
+		// if it passes integrity check, we're all good, return path to file
+		ssri.checkStream(fs.createReadStream(downloadPath), integrity).then((hash) => {
+			// cached copy is still valid, integrity hash matches
+			callback(null, downloadPath);
+		}).catch(() => {
+			// hash doesn't match. Wipe the cached version and re-download
+			fs.removeSync(downloadPath);
+			downloadWithIntegrity(url, downloadPath, integrity, callback);
+		});
+	} else {
+		// download and verify integrity
+		downloadWithIntegrity(url, downloadPath, integrity, callback);
+	}
 };
 
 module.exports = Utils;

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -1,4 +1,4 @@
-/* global danger, fail, warn, markdown, message, schedule */
+/* global danger, fail, warn, markdown, message */
 'use strict';
 // requires
 const fs = require('fs-extra');

--- a/package-lock.json
+++ b/package-lock.json
@@ -4379,6 +4379,15 @@
         }
       }
     },
+    "ssri": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-5.0.0.tgz",
+      "integrity": "sha512-728D4yoQcQm1ooZvSbywLkV1RjfITZXh0oWrhM/lnsx3nAHx7LsRGJWB/YyvoceAYRq98xqbstiN4JBv1/wNHg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
     "stream-buffers": {
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-0.2.6.tgz",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
     "mocha": "*",
     "optimist": "^0.6.1",
     "pagedown": "~1.1.0",
-    "should": "^11.2.1"
+    "should": "^11.2.1",
+    "ssri": "^5.0.0"
   },
   "repository": {
     "type": "git",

--- a/support/module/packaged/README.md
+++ b/support/module/packaged/README.md
@@ -1,1 +1,5 @@
-These modules will be bundled with the SDK.
+The modules listed inside modules.json will be bundled with the SDK.
+
+The easiest way to update this properly is to add/edit the url listing for a module and then run 'scons update-modules-integrity'. That command will re-generate JSON content with the integrity hashes filled in. The result can be copy/pasted into modules.json.
+
+We use integrity hashes now to verify that the remote file contents match our expectations as well as to make use of local cached copies of the modules to avoid unnecessarily re-downloading them. If we've downloaded them once before and have cleared our OS temp folder location, and they match the integrity hash, we'll re-use the cached file.

--- a/support/module/packaged/modules.json
+++ b/support/module/packaged/modules.json
@@ -1,25 +1,70 @@
 {
-	"ios": [
-		"https://github.com/appcelerator-modules/ti.urlsession/releases/download/v2.1.0/com.appcelerator.urlSession-iphone-2.1.0.zip",
-		"https://github.com/appcelerator-modules/ti.facebook/releases/download/ios-5.6.0/facebook-iphone-5.6.0.zip",
-		"https://github.com/appcelerator-modules/ti.coremotion/releases/download/v2.0.1/ti.coremotion-iphone-2.0.1.zip",
-		"https://github.com/appcelerator-modules/ti.map/releases/download/ios-3.0.1/ti.map-iphone-3.0.1.zip",
-		"https://github.com/appcelerator-modules/ti.safaridialog/releases/download/iOS-1.1.1/ti.safaridialog-iphone-1.1.1.zip",
-		"https://github.com/appcelerator-modules/ti.touchid/releases/download/ios-2.1.4/ti.touchid-iphone-2.1.4.zip",
-		"https://github.com/appcelerator-modules/titanium-identity/releases/download/ios-1.0.3/ti.identity-iphone-1.0.3.zip"
-	],
-	"android": [
-		"https://github.com/appcelerator-modules/ti.facebook/releases/download/android-7.0.0/facebook-android-7.0.0.zip",
-		"https://s3.amazonaws.com/timobile.appcelerator.com/modules/ti.cloudpush-android-5.0.1.zip",
-		"https://github.com/appcelerator-modules/ti.map/releases/download/android-4.0.0/ti.map-android-4.0.0.zip",
-		"https://github.com/appcelerator-modules/ti.touchid/releases/download/android-3.0.0/ti.touchid-android-3.0.0.zip",
-		"https://github.com/appcelerator-modules/ti.playservices/releases/download/android-11.0.40/ti.playservices-android-11.0.40.zip",
-		"https://github.com/appcelerator-modules/titanium-identity/releases/download/android-2.0.0/ti.identity-android-2.0.0.zip"
-	],
-	"commonjs": [
-		"https://github.com/appcelerator-modules/ti.cloud/releases/download/3.2.11/ti.cloud-commonjs-3.2.11.zip"
-	],
-	"hyperloop": [
-		"https://github.com/appcelerator-modules/hyperloop-builds/releases/download/v3.0.1/hyperloop-3.0.1.zip"
-	]
+	"ios": {
+		"urlSession": {
+			"url": "https://github.com/appcelerator-modules/ti.urlsession/releases/download/v2.1.0/com.appcelerator.urlSession-iphone-2.1.0.zip",
+			"integrity": "sha512-q7IPaAjg8wpQH5lRyABMpZpQT5HxUgbHmdYT91Be0zGFOtqiQ0VUAn396gnp90+dTOnlKVWVsJQ9EyVHwtotCw=="
+		},
+		"facebook": {
+			"url": "https://github.com/appcelerator-modules/ti.facebook/releases/download/ios-5.6.0/facebook-iphone-5.6.0.zip",
+			"integrity": "sha512-4G8irvO8L2rXGxmqbWSrFYD02Y1tt5AGlm0AU0gGufT79IVq8mvYQH9ow8sUBXr6p9dNuGsrASlMi0o27wWYhQ=="
+		},
+		"ti.coremotion": {
+			"url": "https://github.com/appcelerator-modules/ti.coremotion/releases/download/v2.0.1/ti.coremotion-iphone-2.0.1.zip",
+			"integrity": "sha512-h1wM7mE/cgpk2n1YOYBNMNBQq5ViLxil6+GRnVqSaFB3LY3ubGSZVkZQ5rzC74anLlNXJVpsH/bP98AQ6zzXbA=="
+		},
+		"ti.map": {
+			"url": "https://github.com/appcelerator-modules/ti.map/releases/download/ios-3.0.1/ti.map-iphone-3.0.1.zip",
+			"integrity": "sha512-vD9DLBQgRpmkt8FBbEzRKWKFuJkUTwjwK2ijvRTR9lebGmsgRa9uA2uOLltR8w27b4mbtREZowAEYcVvkQ01Dw=="
+		},
+		"ti.safaridialog": {
+			"url": "https://github.com/appcelerator-modules/ti.safaridialog/releases/download/iOS-1.1.1/ti.safaridialog-iphone-1.1.1.zip",
+			"integrity": "sha512-6g3Qi9RUCl3uf06OnrThm9fpxhcxhtRzyoFRE5PJpenTFN45QYGRZeEQAqgTKcvEB0ardUfGMOyZcA8WoCfWTw=="
+		},
+		"ti.touchid": {
+			"url": "https://github.com/appcelerator-modules/ti.touchid/releases/download/ios-2.1.4/ti.touchid-iphone-2.1.4.zip",
+			"integrity": "sha512-3lJKS4miCleBbX0k4vjNV65MOZ2IPKQSRjUqPpuY0g2Wen14DwVDyphkkgVCG0cXmiVj8BHXp1ATzxwWeKw8yw=="
+		},
+		"ti.identity": {
+			"url": "https://github.com/appcelerator-modules/titanium-identity/releases/download/ios-1.0.3/ti.identity-iphone-1.0.3.zip",
+			"integrity": "sha512-AoydjJEHAgYmD5O0YbhzmRvofb/zvAeoMUFz5X+oiEay//Y0zsNSLV24IYjmqkZnrt0rvilDrmoUIOwzZjW/ww=="
+		}
+	},
+	"android": {
+		"facebook": {
+			"url": "https://github.com/appcelerator-modules/ti.facebook/releases/download/android-7.0.0/facebook-android-7.0.0.zip",
+			"integrity": "sha512-NNMLoAt7iptWWLL+JVMW5IDSWgO6he2dtGVaUWWTixROD07KyQ4wgNwa6nC22vQ59+dRH8PU06JClN7mmS6QFA=="
+		},
+		"ti.cloudpush": {
+			"url": "https://s3.amazonaws.com/timobile.appcelerator.com/modules/ti.cloudpush-android-5.0.1.zip",
+			"integrity": "sha512-77XgM2VNKrpZAKHTx2IAN2iTswzGh9Qgwj1vA01fsEQPC7PEGY27VwL14SXplwM3cJYOfOZmdz7j59Eammrr3Q=="
+		},
+		"ti.map": {
+			"url": "https://github.com/appcelerator-modules/ti.map/releases/download/android-4.0.0/ti.map-android-4.0.0.zip",
+			"integrity": "sha512-LAaoM/tBsaCux5X79JllOsXIASF8L7bSZs2RT+UwK51pCtSDn5o+WXZ5BS6ivb1ZauqqHul8ibVubf9WRCWB0Q=="
+		},
+		"ti.touchid": {
+			"url": "https://github.com/appcelerator-modules/ti.touchid/releases/download/android-3.0.0/ti.touchid-android-3.0.0.zip",
+			"integrity": "sha512-lYC2D9QRGlQs4+/GEbBPtq0FelbKWPpuoRkihEWyQHHIBxYIy6Ok/paWnIuyvfqwhUD3wGRbhhIKap5LH9e2Zg=="
+		},
+		"ti.playservices": {
+			"url": "https://github.com/appcelerator-modules/ti.playservices/releases/download/android-11.0.40/ti.playservices-android-11.0.40.zip",
+			"integrity": "sha512-bLhpzOjnmiTWFRjMuFfvqf0ePd1kbTdXLMVZJ+EsPrfn4JmxvkINS9Nu6ivjV+fmH9cBYVjZ5k9nGCeUdqZOlQ=="
+		},
+		"ti.identity": {
+			"url": "https://github.com/appcelerator-modules/titanium-identity/releases/download/android-2.0.0/ti.identity-android-2.0.0.zip",
+			"integrity": "sha512-IPR1u8XnTXWbugKWwKe2Cg5Km4ayKaQMNWwVVkTDX+HHsgJSomEN18BJwiLr1ClSTHnf8xz8EC8pZbKGEcYAXQ=="
+		}
+	},
+	"commonjs": {
+		"ti.cloud": {
+			"url": "https://github.com/appcelerator-modules/ti.cloud/releases/download/3.2.11/ti.cloud-commonjs-3.2.11.zip",
+			"integrity": "sha512-QL0mbMwNIigmXimPVaBzckIJizQyoMpvAkotqh2FSv9NkqTGhK2DtQ3rKpDTKNgxyRU607brE3grc0L30bRlMQ=="
+		}
+	},
+	"hyperloop": {
+		"hyperloop": {
+			"url": "https://github.com/appcelerator-modules/hyperloop-builds/releases/download/v3.0.1/hyperloop-3.0.1.zip",
+			"integrity": "sha512-TyX82FJ7EZ2Xf0bGh4Z2Z0Yi/2MwXX7UZ4j9icVifNFBAThiNToRqa3VWpI9N/ly2TyeGIeEwaA57g/2ZrCuLg=="
+		}
+	}
 }


### PR DESCRIPTION
**Description:**
This is more secure as we can verify the contents haven't been changed unexpectedly, and it also allows us to retain cached copies of the module zips in the OS temp folder. This should avoid the need to constantly re-download modules when the listing changes so infrequently.

This was driven by a desire to avoid re-downloading module zips constantly, particularly to avoid saturating the office network due to CI builds.

I also added two developer `scons` commands to generate these integrity hashes.
`scons ssri <url-list>` will generate integrity hashes for one or more URLs (space separated cmd line args).
`scone modules-integrity` will read the support/module/packaged/modules.json listing and spit out JSON output with the correct integrity hashes filled in. This is useful to pre-populate the value when a module url has changed. (or much rarer, when the url stayed the same but the contents changed and we're ok with the new contents).

We use the same `ssri` library for integrity hashes as that used by npm.