### PR TITLE
[TIMOB-25661] Android: Fix broken animation behaviour on Android 7.0+

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiBorderWrapperView.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiBorderWrapperView.java
@@ -47,6 +47,12 @@ public class TiBorderWrapperView extends FrameLayout
 
 		paint = new Paint(Paint.ANTI_ALIAS_FLAG);
 		bounds = new Rect();
+
+		// TIMOB-25661: disable hardware acceleration to prevent broken
+		// animation behaviour on Android 7.0 and above
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+			setLayerType(View.LAYER_TYPE_SOFTWARE, null);
+		}
 	}
 
 	@Override


### PR DESCRIPTION
- Disable hardware acceleration for `TiBorderWrapperView` to prevent broken animation behaviour on Android 7.0 and above

###### TEST CASE
```JS
var win = Ti.UI.createWindow({ backgroundColor: 'gray' }),
    base = Ti.UI.createView({
        backgroundColor: 'blue',
        width: 200,
        height: 200,
        borderRadius: 100
    })
    sqr = Ti.UI.createView({
        width: 140,
        height: 140,
        backgroundColor: 'red'
    }),
    animation = Ti.UI.createAnimation({
        duration : 3000,
        transform : Ti.UI.create2DMatrix().rotate(-45)
    });

win.addEventListener('open', function () {
    setTimeout(function () {
        base.animate(animation);
    }, 1000);
});

base.add(sqr);
win.add(base);
win.open();
```
<img src="https://jira.appcelerator.org/secure/attachment/63977/expected.png" width="300" />

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-25661)