### PR TITLE
[TIMOB-25728] Android: TableView can crash using setData()

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiTableViewRowProxyItem.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiTableViewRowProxyItem.java
@@ -25,6 +25,7 @@ import ti.modules.titanium.ui.LabelProxy;
 import ti.modules.titanium.ui.TableViewProxy;
 import ti.modules.titanium.ui.TableViewRowProxy;
 import ti.modules.titanium.ui.widget.TiUILabel;
+import ti.modules.titanium.ui.widget.TiUITableView;
 import ti.modules.titanium.ui.widget.tableview.TableViewModel.Item;
 import android.app.Activity;
 import android.graphics.drawable.BitmapDrawable;
@@ -357,7 +358,16 @@ public class TiTableViewRowProxyItem extends TiBaseTableViewItem
 		}
 		selectorSource = newSelectorSource;
 		if (selectorSource != null) {
-			rp.getTable().getTableView().getTableView().enableCustomSelector();
+			TableViewProxy tableViewProxy = rp.getTable();
+			if (tableViewProxy != null) {
+				TiUITableView tableView = tableViewProxy.getTableView();
+				if (tableViewProxy != null) {
+					TiTableView view = tableView.getTableView();
+					if (view != null) {
+						view.enableCustomSelector();
+					}
+				}
+			}
 		}
 
 		setBackgroundFromProxy(rp);

--- a/tests/Resources/ti.ui.tableview.addontest.js
+++ b/tests/Resources/ti.ui.tableview.addontest.js
@@ -1,0 +1,39 @@
+/*
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2011-Present by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+/* eslint-env mocha */
+/* global Ti */
+/* eslint no-unused-expressions: "off" */
+'use strict';
+
+describe('Ti.UI.TableView', function () {
+	it('set and clear data', function (finish) {
+		var data_a = [
+				{ title: 'Square', backgroundSelectedColor: 'red' },
+				{ title: 'Circle', backgroundSelectedColor: 'blue' },
+				{ title: 'Triangle', backgroundSelectedColor: 'purple' }
+			],
+			data_b = [
+				{ title: 'Red', backgroundSelectedColor: 'red' },
+				{ title: 'Green', backgroundSelectedColor: 'green' },
+				{ title: 'Blue', backgroundSelectedColor: 'blue' }
+			],
+			tv = Ti.UI.createTableView(),
+			error;
+
+		try {
+			tv.data = [];
+			tv.setData(data_a);
+			tv.data = [];
+			tv.setData(data_b);
+			tv.data = [];
+			tv.setData(data_a);
+		} catch (e) {
+			error = e;
+		}
+		finish(error);
+	});
+});


### PR DESCRIPTION
- Improve the validation for selectors in `setRowData()`

###### TEST CASE
```JS
var win = Ti.UI.createWindow({ backgroundColor: 'gray' }),
    data_a = [
        { title: 'Square', backgroundSelectedColor: 'red' },
        { title: 'Circle', backgroundSelectedColor: 'blue' },
        { title: 'Triangle', backgroundSelectedColor: 'purple' }
    ],
    data_b = [
        { title: 'Red', backgroundSelectedColor: 'red' },
        { title: 'Green', backgroundSelectedColor: 'green' },
        { title: 'Blue', backgroundSelectedColor: 'blue' }
    ],
    tv = Ti.UI.createTableView();

tv.data = [];
tv.setData(data_a);
tv.data = [];
tv.setData(data_b);
tv.data = [];
tv.setData(data_a);

win.add(tv);
win.open();
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-25728)