### PR TITLE
[TIMOB-25733] Android: Auto-size TiBorderWrapperView drawing cache

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiBorderWrapperView.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiBorderWrapperView.java
@@ -58,6 +58,17 @@ public class TiBorderWrapperView extends FrameLayout
 	@Override
 	protected void onDraw(Canvas canvas)
 	{
+		// TIMOB-25733: attempt to prevent 'View too large to fit into drawing cache' by creating
+		// an auto-sized drawing cache
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && isDrawingCacheEnabled() && getDrawingCache() == null) {
+			buildDrawingCache(true);
+
+			// failed to use drawing cache, disable
+			if (getDrawingCache() == null) {
+				setDrawingCacheEnabled(false);
+			}
+		}
+
 		getDrawingRect(bounds);
 
 		int maxPadding = (int) Math.min(bounds.right / 2, bounds.bottom / 2);


### PR DESCRIPTION
- Attempt to prevent `View too large to fit into drawing cache` by creating an auto-sized drawing cache

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-25733)