### PR TITLE
[TIMOB-24610] Follow-on - support disabling transpile via tiapp.xml tag <transpile>false</transpile>. Move transpilation to node-titanium-sdk.

### DIFF
--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -916,7 +916,7 @@ AndroidBuilder.prototype.validate = function validate(logger, config, cli) {
 	this.dxMaxIdxNumber = cli.tiapp.properties['android.dx.maxIdxNumber'] && cli.tiapp.properties['android.dx.maxIdxNumber'].value || config.get('android.dx.maxIdxNumber', '65536');
 
 	// Transpilation details
-	this.transpile = cli.tiapp['transpile'].transpile !== false; // FIXME Does this properly default to true?
+	this.transpile = cli.tiapp['transpile'] !== false; // FIXME Does this properly default to true?
 	// We get a string here like 6.2.414.36, we need to convert it to 62 (integer)
 	const v8Version = this.packageJson.v8.version;
 	const found = v8Version.match(V8_STRING_VERSION_REGEXP);

--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -1638,13 +1638,9 @@ process.exit(1);
 					for (let dependency of timodule.modules) {
 						if (!dependency.platform || /^android$/.test(dependency.platform)) {
 
-							let missing = true;
-							for (let module of this.nativeLibModules) {
-								if (module.id === dependency.id) {
-									missing = false;
-									break;
-								}
-							}
+							let missing = !this.nativeLibModules.some(function (mod) {
+								return mod.id === dependency.id;
+							});
 							if (missing) {
 								dependency.depended = module;
 

--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -5796,6 +5796,9 @@ iOSBuilder.prototype.copyResources = function copyResources(next) {
 								symbols: []
 							};
 							this.cli.createHook('build.ios.compileJsFile', this, function (r, from, to, cb2) {
+								// Read the possibly modified file contents
+								const source = r.contents;
+								// Analyze Ti API usage, possibly also minify/transpile
 								const analyzeOptions = {
 									filename: from,
 									minify: this.minifyJS,
@@ -5806,8 +5809,7 @@ iOSBuilder.prototype.copyResources = function copyResources(next) {
 									analyzeOptions.targets = { 'ios': this.minSupportedIosSdk }; // if using jscore, target our min ios version
 								} // if not jscore, just transpile everything down (no target)
 
-								// Analyze Ti API usage, possibly also minify/transpile
-								const modified = jsanalyze.analyzeJs(originalContents, analyzeOptions);
+								const modified = jsanalyze.analyzeJs(source, analyzeOptions);
 								const newContents = modified.contents;
 
 								// we want to sort by the "to" filename so that we correctly handle file overwriting
@@ -5821,7 +5823,7 @@ iOSBuilder.prototype.copyResources = function copyResources(next) {
 								if (!exists || newContents !== fs.readFileSync(to).toString()) {
 									this.logger.debug(__('Copying and minifying %s => %s', from.cyan, to.cyan));
 									exists && fs.unlinkSync(to);
-									fs.writeFileSync(to, r.contents);
+									fs.writeFileSync(to, newContents);
 									this.jsFilesChanged = true;
 								} else {
 									this.logger.trace(__('No change, skipping %s', to.cyan));

--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -1825,7 +1825,7 @@ iOSBuilder.prototype.validate = function validate(logger, config, cli) {
 		this.initTiappSettings();
 
 		// Transpilation details
-		this.transpile = cli.tiapp['transpile'].transpile !== false; // FIXME Does this properly default to true?
+		this.transpile = cli.tiapp['transpile'] !== false; // FIXME Does this properly default to true?
 		// this.minSupportedIosSdk holds the target ios version to transpile down to
 
 		// check for blacklisted files in the Resources directory

--- a/package-lock.json
+++ b/package-lock.json
@@ -938,6 +938,15 @@
         "babel-types": "6.26.0"
       }
     },
+    "babel-plugin-transform-strict-mode": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
+      "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
     "babel-plugin-transform-undefined-to-void": {
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.9.0.tgz",
@@ -1050,13 +1059,13 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "requires": {
         "core-js": "2.5.0",
-        "regenerator-runtime": "0.11.0"
+        "regenerator-runtime": "0.11.1"
       },
       "dependencies": {
         "regenerator-runtime": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-          "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -938,15 +938,6 @@
         "babel-types": "6.26.0"
       }
     },
-    "babel-plugin-transform-strict-mode": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
-      "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
-      }
-    },
     "babel-plugin-transform-undefined-to-void": {
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.9.0.tgz",

--- a/package.json
+++ b/package.json
@@ -26,8 +26,6 @@
     "appc-tasks": "^1.0.1",
     "archiver": "2.1.0",
     "async": "2.3.0",
-    "babel-core": "^6.26.0",
-    "babel-preset-env": "^1.6.1",
     "buffer-equal": "1.0.0",
     "clean-css": "4.0.11",
     "colors": "1.1.2",


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-24610

**Description:**
Now that node-titanium-sdk supports transpiling (via appcelerator/node-titanium-sdk#20), we can rely on that.

This also allows developers to explicitly turn off transpilation by adding a `<transpile>false</transpile>` tag into your tiapp.xml.