### PR TITLE
[TIMOB-25739] iOS 11: Fix typo in Ti.Geolocation error message

### DIFF
--- a/iphone/Classes/GeolocationModule.m
+++ b/iphone/Classes/GeolocationModule.m
@@ -827,8 +827,8 @@ MAKE_SYSTEM_PROP(ACTIVITYTYPE_OTHER_NAVIGATION, CLActivityTypeOtherNavigation);
           NO);
     } else if ([TiUtils isIOS11OrGreater]) {
       errorMessage = [[NSString alloc] initWithFormat:
-                                           @"The %@, %@ and %@ key must be defined in your tiapp.xml in order to request this permission.",
-                                       kTiGeolocationUsageDescriptionAlwaysAndWhenInUse,
+                                           @"The %@, %@ and %@ (iOS 11+) key must be defined in your tiapp.xml in order to request this permission.",
+                                       kTiGeolocationUsageDescriptionWhenInUse,
                                        kTiGeolocationUsageDescriptionAlways,
                                        kTiGeolocationUsageDescriptionAlwaysAndWhenInUse];
     } else {

--- a/iphone/iphone/Titanium.plist
+++ b/iphone/iphone/Titanium.plist
@@ -50,7 +50,11 @@
 	<key>NSContactsUsageDescription</key>
 	<string>Can we use to your contacts?</string>
 	<key>NSLocationAlwaysUsageDescription</key>
-	<string>Can we use your location</string>
+	<string>Can we always access your location</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>Can we access your location?</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>Can we access your location when using the app?</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Can we use your microphone?</string>
 	<key>NSPhotoLibraryUsageDescription</key>


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-25739

`no tests` because it's a UI-related change (rather for our Appium test suite).