### PR TITLE
remove a very old property from the docs

### DIFF
--- a/apidoc/Titanium/App/App.yml
+++ b/apidoc/Titanium/App/App.yml
@@ -312,23 +312,6 @@ events:
         or <Titanium.UI.WebView>, because Apple does not call the `applicationDidBecomeActive` for
         URL-handling anymore. Instead, use the `handleurl` event in <Titanium.App.iOS>.
     platforms: [iphone, ipad]
-    
-  - name: keyboardFrameChanged
-    deprecated:
-        since: "3.0.0"
-        removed: "4.0.0"
-        notes: Use <Titanium.App.keyboardframechanged> instead.
-    summary: Fired when the soft keyboard is presented, on and off the screen.
-    description: |
-        This event fires when the application presents the soft keyboard on/off the screen . The 
-        event returns the dictionary containing `keyboardFrame.x`, `keyboardFrame.y`, 
-        `keyboardFrame.height` and `keyboardFrame.width` variables, corresponding to the frame of 
-        the keyboard with respect to the screen coordinates.
-        
-        Note that the keyboard `height` and `width` properties will not be accurate when the keyboard 
-        is being dissmissed.
-    platforms: [iphone, ipad]
-    since: '2.1.0'
 
   - name: keyboardframechanged
     summary: Fired when the soft keyboard is presented, on and off the screen.


### PR DESCRIPTION
property is deprecated since 3.0 and removed in 4.0. It sounds like time to go

**JIRA:** https://jira.appcelerator.org/browse/AC-5564