### PR TITLE
(7_0_X) [TIMOB-25766] Android: Ti.Utils.base64encode for cannot encode (Image) Ti.Blob anymore. Result = null

### DIFF
--- a/android/modules/network/src/java/ti/modules/titanium/network/TiHTTPClient.java
+++ b/android/modules/network/src/java/ti/modules/titanium/network/TiHTTPClient.java
@@ -901,14 +901,7 @@ public class TiHTTPClient
 				String mimeType = blob.getMimeType();
 				File tmpFile =
 					File.createTempFile("tixhr", "." + TiMimeTypeHelper.getFileExtensionFromMimeType(mimeType, "txt"));
-				if (blob.getType() == TiBlob.TYPE_STREAM_BASE64) {
-					FileOutputStream fos = new FileOutputStream(tmpFile);
-					TiBaseFile.copyStream(blob.getInputStream(),
-										  new Base64OutputStream(fos, android.util.Base64.DEFAULT));
-					fos.close();
-				} else {
-					createFileFromBlob(blob, tmpFile);
-				}
+				createFileFromBlob(blob, tmpFile);
 
 				tmpFiles.add(tmpFile);
 

--- a/android/modules/utils/src/java/ti/modules/titanium/utils/UtilsModule.java
+++ b/android/modules/utils/src/java/ti/modules/titanium/utils/UtilsModule.java
@@ -34,12 +34,17 @@ public class UtilsModule extends KrollModule
 		super();
 	}
 
-	private String convertToString(Object obj)
+	private byte[] convertToBytes(Object obj)
 	{
 		if (obj instanceof String) {
-			return (String) obj;
+			try {
+				return ((String) obj).getBytes("UTF-8");
+			} catch (UnsupportedEncodingException e) {
+				Log.e(TAG, "UTF-8 is not a supported encoding type");
+			}
+			return ((String) obj).getBytes(); // should never fall back here!
 		} else if (obj instanceof TiBlob) {
-			return ((TiBlob) obj).getText();
+			return ((TiBlob) obj).getBytes();
 		} else {
 			throw new IllegalArgumentException("Invalid type for argument");
 		}
@@ -48,16 +53,14 @@ public class UtilsModule extends KrollModule
 	@Kroll.method
 	public TiBlob base64encode(Object obj)
 	{
-		if (obj instanceof TiBlob) {
-			return TiBlob.blobFromString(((TiBlob) obj).toBase64());
-		} else if (obj instanceof TiFileProxy) {
+		if (obj instanceof TiFileProxy) {
 			// recursively call base64encode after converting Ti.Filesystem.File to a Ti.Blob wrapping it
 			return base64encode(TiBlob.blobFromFile(((TiFileProxy) obj).getBaseFile()));
 		}
-		String data = convertToString(obj);
+		byte[] data = convertToBytes(obj);
 		if (data != null) {
 			try {
-				return TiBlob.blobFromString(new String(Base64.encode(data.getBytes("UTF-8"), Base64.NO_WRAP), "UTF-8"));
+				return TiBlob.blobFromString(new String(Base64.encode(data, Base64.NO_WRAP), "UTF-8"));
 			} catch (UnsupportedEncodingException e) {
 				Log.e(TAG, "UTF-8 is not a supported encoding type");
 			}
@@ -72,13 +75,9 @@ public class UtilsModule extends KrollModule
 			// recursively call base64decode after converting Ti.Filesystem.File to a Ti.Blob wrapping it
 			return base64decode(TiBlob.blobFromFile(((TiFileProxy) obj).getBaseFile()));
 		}
-		String data = convertToString(obj);
+		byte[] data = convertToBytes(obj);
 		if (data != null) {
-			try {
-				return TiBlob.blobFromData(Base64.decode(data.getBytes("UTF-8"), Base64.NO_WRAP));
-			} catch (UnsupportedEncodingException e) {
-				Log.e(TAG, "UTF-8 is not a supported encoding type");
-			}
+			return TiBlob.blobFromData(Base64.decode(data, Base64.NO_WRAP));
 		}
 		return null;
 	}
@@ -86,10 +85,7 @@ public class UtilsModule extends KrollModule
 	@Kroll.method
 	public String md5HexDigest(Object obj)
 	{
-		if (obj instanceof TiBlob) {
-			return DigestUtils.md5Hex(((TiBlob) obj).getBytes());
-		}
-		String data = convertToString(obj);
+		byte[] data = convertToBytes(obj);
 		if (data != null) {
 			return DigestUtils.md5Hex(data);
 		}
@@ -99,10 +95,7 @@ public class UtilsModule extends KrollModule
 	@Kroll.method
 	public String sha1(Object obj)
 	{
-		if (obj instanceof TiBlob) {
-			return DigestUtils.shaHex(((TiBlob) obj).getBytes());
-		}
-		String data = convertToString(obj);
+		byte[] data = convertToBytes(obj);
 		if (data != null) {
 			return DigestUtils.shaHex(data);
 		}
@@ -121,13 +114,7 @@ public class UtilsModule extends KrollModule
 		// NOTE: DigestUtils with the version before 1.4 doesn't have the function sha256Hex,
 		// so we deal with it ourselves
 		try {
-			byte[] b = null;
-			if (obj instanceof TiBlob) {
-				b = ((TiBlob) obj).getBytes();
-			} else {
-				String data = convertToString(obj);
-				b = data.getBytes();
-			}
+			byte[] b = convertToBytes(obj);
 			MessageDigest algorithm = MessageDigest.getInstance("SHA-256");
 			algorithm.reset();
 			algorithm.update(b);
@@ -139,33 +126,6 @@ public class UtilsModule extends KrollModule
 			return result.toString();
 		} catch (NoSuchAlgorithmException e) {
 			Log.e(TAG, "SHA256 is not a supported algorithm");
-		}
-		return null;
-	}
-
-	public String transcodeString(String orig, String inEncoding, String outEncoding)
-	{
-		try {
-
-			Charset charsetOut = Charset.forName(outEncoding);
-			Charset charsetIn = Charset.forName(inEncoding);
-
-			ByteBuffer bufferIn = ByteBuffer.wrap(orig.getBytes(charsetIn.name()) );
-			CharBuffer dataIn = charsetIn.decode(bufferIn);
-			bufferIn.clear();
-			bufferIn = null;
-
-			ByteBuffer bufferOut = charsetOut.encode(dataIn);
-			dataIn.clear();
-			dataIn = null;
-			byte[] dataOut = bufferOut.array();
-			bufferOut.clear();
-			bufferOut = null;
-
-			return new String(dataOut, charsetOut.name());
-
-		} catch (UnsupportedEncodingException e) {
-			Log.e(TAG, "Unsupported encoding: " + e.getMessage(), e);
 		}
 		return null;
 	}

--- a/android/modules/utils/src/java/ti/modules/titanium/utils/UtilsModule.java
+++ b/android/modules/utils/src/java/ti/modules/titanium/utils/UtilsModule.java
@@ -51,13 +51,8 @@ public class UtilsModule extends KrollModule
 		if (obj instanceof TiBlob) {
 			return TiBlob.blobFromString(((TiBlob) obj).toBase64());
 		} else if (obj instanceof TiFileProxy) {
-			try {
-				return TiBlob.blobFromStreamBase64(
-					((TiFileProxy) obj).getInputStream(),
-					TiMimeTypeHelper.getMimeType(((TiFileProxy) obj).getBaseFile().nativePath()));
-			} catch (IOException e) {
-				Log.e(TAG, "Problem reading file");
-			}
+			// recursively call base64encode after converting Ti.Filesystem.File to a Ti.Blob wrapping it
+			return base64encode(TiBlob.blobFromFile(((TiFileProxy) obj).getBaseFile()));
 		}
 		String data = convertToString(obj);
 		if (data != null) {
@@ -73,6 +68,10 @@ public class UtilsModule extends KrollModule
 	@Kroll.method
 	public TiBlob base64decode(Object obj)
 	{
+		if (obj instanceof TiFileProxy) {
+			// recursively call base64decode after converting Ti.Filesystem.File to a Ti.Blob wrapping it
+			return base64decode(TiBlob.blobFromFile(((TiFileProxy) obj).getBaseFile()));
+		}
 		String data = convertToString(obj);
 		if (data != null) {
 			try {

--- a/build/scons-test.js
+++ b/build/scons-test.js
@@ -17,6 +17,7 @@ program
 	.option('-C, --device-id [id]', 'Titanium device id to run the unit tests on. Only valid when there is a target provided')
 	.option('-T, --target [target]', 'Titanium platform target to run the unit tests on. Only valid when there is a single platform provided')
 	.option('-s, --skip-sdk-install', 'Skip the SDK installation step')
+	.option('-b, --branch [branch]', 'Which branch of the test suite to use', 'master')
 	.parse(process.argv);
 
 let platforms = program.args;
@@ -44,9 +45,10 @@ if (!program.skipSdkInstall && !fs.existsSync(zipfile)) {
  * SDK zipfile in dist against the supplied platforms.
  *
  * @param  {String[]}   platforms [description]
+ * @param  {String}   branch [description]
  * @param  {Function} next      [description]
  */
-function runTests(platforms, next) {
+function runTests(platforms, branch, next) {
 	async.series([
 		function (cb) {
 			// If we have a clone of the tests locally, wipe it...
@@ -56,7 +58,7 @@ function runTests(platforms, next) {
 			}
 			// clone the common test suite shallow
 			// FIXME Determine the correct branch of the suite to clone like we do in the Jenkinsfile
-			exec('git clone --depth 1 https://github.com/appcelerator/titanium-mobile-mocha-suite.git', { cwd: path.join(__dirname, '..') }, cb);
+			exec('git clone --depth 1 https://github.com/appcelerator/titanium-mobile-mocha-suite.git -b ' + branch, { cwd: path.join(__dirname, '..') }, cb);
 		},
 		function (cb) {
 			// Make sure it's dependencies are installed
@@ -88,7 +90,7 @@ function runTests(platforms, next) {
 	], next);
 }
 
-runTests(platforms, function (err) {
+runTests(platforms, program.branch, function (err) {
 	if (err) {
 		console.error(err.toString());
 		process.exit(1);

--- a/iphone/Classes/UtilsModule.m
+++ b/iphone/Classes/UtilsModule.m
@@ -90,20 +90,32 @@
 - (id)sha1:(id)args
 {
   ENSURE_SINGLE_ARG(args, NSObject);
-  NSString *nstr = [self convertToString:args];
-  const char *cStr = [nstr UTF8String];
+
+  NSData *data;
+  if ([args isKindOfClass:[TiBlob class]]) {
+    data = [(TiBlob *)args data];
+  } else {
+    data = [[self convertToString:args] dataUsingEncoding:NSUTF8StringEncoding];
+  }
+
   unsigned char result[CC_SHA1_DIGEST_LENGTH];
-  CC_SHA1(cStr, (CC_LONG)[nstr lengthOfBytesUsingEncoding:NSUTF8StringEncoding], result);
+  CC_SHA1(data.bytes, data.length, result);
   return [TiUtils convertToHex:(unsigned char *)&result length:CC_SHA1_DIGEST_LENGTH];
 }
 
 - (id)sha256:(id)args
 {
   ENSURE_SINGLE_ARG(args, NSObject);
-  NSString *nstr = [self convertToString:args];
-  const char *cStr = [nstr UTF8String];
+
+  NSData *data;
+  if ([args isKindOfClass:[TiBlob class]]) {
+    data = [(TiBlob *)args data];
+  } else {
+    data = [[self convertToString:args] dataUsingEncoding:NSUTF8StringEncoding];
+  }
+
   unsigned char result[CC_SHA256_DIGEST_LENGTH];
-  CC_SHA256(cStr, (CC_LONG)[nstr lengthOfBytesUsingEncoding:NSUTF8StringEncoding], result);
+  CC_SHA256(data.bytes, data.length, result);
   return [TiUtils convertToHex:(unsigned char *)&result length:CC_SHA256_DIGEST_LENGTH];
 }
 

--- a/iphone/Classes/UtilsModule.m
+++ b/iphone/Classes/UtilsModule.m
@@ -27,6 +27,17 @@
   THROW_INVALID_ARG(@"Invalid type");
 }
 
+- (NSData *)convertToData:(id)arg
+{
+  if ([arg isKindOfClass:[TiBlob class]]) {
+    return [(TiBlob *)arg data];
+  } else if ([arg isKindOfClass:[TiFile class]]) {
+    // Support TiFile with possibly binary data by converting to TiBlob and recursing
+    return [self convertToData:[(TiFile *)arg blob]];
+  }
+  return [[self convertToString:arg] dataUsingEncoding:NSUTF8StringEncoding];
+}
+
 - (NSString *)apiName
 {
   return @"Ti.Utils";
@@ -37,16 +48,8 @@
 - (TiBlob *)base64encode:(id)args
 {
   ENSURE_SINGLE_ARG(args, NSObject);
-  NSData *data;
-
-  if ([args isKindOfClass:[TiBlob class]]) {
-    data = [(TiBlob *)args data];
-  } else {
-    data = [[self convertToString:args] dataUsingEncoding:NSUTF8StringEncoding];
-  }
-
+  NSData *data = [self convertToData:args];
   NSString *base64Encoded = [data base64EncodedStringWithOptions:0];
-
   if (base64Encoded != nil) {
     return [[[TiBlob alloc] _initWithPageContext:[self pageContext]
                                          andData:[base64Encoded dataUsingEncoding:NSUTF8StringEncoding]
@@ -76,14 +79,7 @@
 {
   ENSURE_SINGLE_ARG(args, NSObject);
 
-  NSData *data = nil;
-  NSString *nstr = [self convertToString:args];
-  if (nstr) {
-    const char *s = [nstr UTF8String];
-    data = [NSData dataWithBytes:s length:strlen(s)];
-  } else if ([args respondsToSelector:@selector(data)]) {
-    data = [args data];
-  }
+  NSData *data = [self convertToData:args];
   return [TiUtils md5:data];
 }
 
@@ -91,15 +87,10 @@
 {
   ENSURE_SINGLE_ARG(args, NSObject);
 
-  NSData *data;
-  if ([args isKindOfClass:[TiBlob class]]) {
-    data = [(TiBlob *)args data];
-  } else {
-    data = [[self convertToString:args] dataUsingEncoding:NSUTF8StringEncoding];
-  }
+  NSData *data = [self convertToData:args];
 
   unsigned char result[CC_SHA1_DIGEST_LENGTH];
-  CC_SHA1(data.bytes, data.length, result);
+  CC_SHA1([data bytes], [data length], result);
   return [TiUtils convertToHex:(unsigned char *)&result length:CC_SHA1_DIGEST_LENGTH];
 }
 
@@ -107,15 +98,10 @@
 {
   ENSURE_SINGLE_ARG(args, NSObject);
 
-  NSData *data;
-  if ([args isKindOfClass:[TiBlob class]]) {
-    data = [(TiBlob *)args data];
-  } else {
-    data = [[self convertToString:args] dataUsingEncoding:NSUTF8StringEncoding];
-  }
+  NSData *data = [self convertToData:args];
 
   unsigned char result[CC_SHA256_DIGEST_LENGTH];
-  CC_SHA256(data.bytes, data.length, result);
+  CC_SHA256([data bytes], [data length], result);
   return [TiUtils convertToHex:(unsigned char *)&result length:CC_SHA256_DIGEST_LENGTH];
 }
 

--- a/tests/Resources/ti.utils.test.js
+++ b/tests/Resources/ti.utils.test.js
@@ -11,6 +11,8 @@
 var should = require('./utilities/assertions'),
 	utilities = require('./utilities/utilities');
 
+// handy tool: https://www.fileformat.info/tool/hash.htm
+
 describe('Titanium.Utils', function () {
 	var win;
 
@@ -53,7 +55,7 @@ describe('Titanium.Utils', function () {
 	});
 
 	// FIXME Windows gives: 'base64decode: attempt to decode a value not in base64 char set'
-	it.windowsBroken('#base64decode(Ti.Blob)', function () {
+	it.windowsBroken('#base64decode(Ti.Blob with text data)', function () {
 		var f = Ti.Filesystem.getFile(Ti.Filesystem.resourcesDirectory, 'txtFiles/encodedFile.txt'),
 			blob = Ti.Utils.base64decode(f.read());
 		should(blob.toString()).eql('Decoding successful!');
@@ -143,7 +145,7 @@ describe('Titanium.Utils', function () {
 	});
 
 	// FIXME: base64decode accepts Ti.File as a parameter on iOS/Android, but not on Windows.
-	it.windowsBroken('#base64decode(Ti.Filesystem.File)', function () {
+	it.windowsBroken('#base64decode(Ti.Filesystem.File with text data)', function () {
 		var f = Ti.Filesystem.getFile(Ti.Filesystem.resourcesDirectory, 'txtFiles/encodedFile.txt');
 		var blob = Ti.Utils.base64decode(f);
 
@@ -152,6 +154,18 @@ describe('Titanium.Utils', function () {
 		should(blob.apiName).eql('Ti.Blob');
 		should(blob.toString()).eql('Decoding successful!');
 	});
+
+	// FIXME: How can I make this valid? The input needs to be valid base64...
+	// An image can't be right. Maybe we can validate in UtilsModule that a given blob is non-binary?
+	// it.windowsBroken('#base64decode(Ti.Filesystem.File with binary data)', function () {
+	// 	var binaryFile = Ti.Filesystem.getFile(Ti.Filesystem.resourcesDirectory, 'Logo.png'),
+	// 		blob = Ti.Utils.base64decode(binaryFile);
+  //
+	// 	// result here is a Ti.Blob
+	// 	should(blob).be.a.Object;
+	// 	should(blob.apiName).eql('Ti.Blob');
+	// 	// ignore the actual decoded value...
+	// });
 
 	it('#md5HexDigest(String)', function () {
 		var test;
@@ -162,7 +176,7 @@ describe('Titanium.Utils', function () {
 	});
 
 	// FIXME Windows gives different md5 hash! Maybe line ending difference?
-	it.windowsBroken('#md5HexDigest(Ti.Blob)', function () {
+	it.windowsBroken('#md5HexDigest(Ti.Blob with text data)', function () {
 		var f = Ti.Filesystem.getFile(Ti.Filesystem.resourcesDirectory, 'txtFiles/file.txt'),
 			contents = f.read(),
 			test;
@@ -170,6 +184,16 @@ describe('Titanium.Utils', function () {
 		test = Ti.Utils.md5HexDigest(contents);
 		should(test).be.a.String;
 		should(test).be.eql('4fe8a693c64f93f65c5faf42dc49ab23'); // Windows Desktop gives: 'ab1600f840b927f80a3dc000c510d1d3'
+	});
+
+	it.windowsBroken('#md5HexDigest(Ti.Blob with binary data)', function () {
+		var binaryFile = Ti.Filesystem.getFile(Ti.Filesystem.resourcesDirectory, 'Logo.png'),
+			blob = binaryFile.read(),
+			result;
+		should(Ti.Utils.md5HexDigest).be.a.Function;
+		result = Ti.Utils.md5HexDigest(blob);
+		should(result).be.a.String;
+		should(result).be.eql('803fd0b8dd9a3ca5238390732db54062');
 	});
 
 	it('#sha1(String)', function () {
@@ -180,10 +204,16 @@ describe('Titanium.Utils', function () {
 		should(test).be.eql('a94a8fe5ccb19ba61c4c0873d391e987982fbbd3');
 	});
 
-	it('#sha1(Ti.Blob)', function () {
-		var f = Ti.Filesystem.getFile(Ti.Filesystem.resourcesDirectory, 'txtFiles/decodedFile.txt'),
-			contents = f.read();
-		should(Ti.Utils.sha1(contents).toString()).eql('ddbb50fb5beea93d1d4913fc22355c84f22d43ed');
+	it('#sha1(Ti.Blob with text data)', function () {
+		var textFile = Ti.Filesystem.getFile(Ti.Filesystem.resourcesDirectory, 'txtFiles/decodedFile.txt'),
+			blob = textFile.read();
+		should(Ti.Utils.sha1(blob)).eql('ddbb50fb5beea93d1d4913fc22355c84f22d43ed');
+	});
+
+	it('#sha1(Ti.Blob with binary data)', function () {
+		var binaryFile = Ti.Filesystem.getFile(Ti.Filesystem.resourcesDirectory, 'Logo.png'),
+			blob = binaryFile.read();
+		should(Ti.Utils.sha1(blob)).eql('668e98c66d8a11ef38ab442d9d6d4a21d8593645');
 	});
 
 	it('#sha256(String)', function () {
@@ -194,10 +224,16 @@ describe('Titanium.Utils', function () {
 		should(test).be.eql('9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08');
 	});
 
-	it('#sha256(Ti.Blob)', function () {
-		var f = Ti.Filesystem.getFile(Ti.Filesystem.resourcesDirectory, 'txtFiles/decodedFile.txt'),
-			contents = f.read();
-		should(Ti.Utils.sha256(contents).toString()).eql('9f81cd4f510080f1da92386b391cf2539b21f6363df491b89787e50fbc33b2c3');
+	it('#sha256(Ti.Blob with text data)', function () {
+		var textFile = Ti.Filesystem.getFile(Ti.Filesystem.resourcesDirectory, 'txtFiles/decodedFile.txt'),
+			blob = textFile.read();
+		should(Ti.Utils.sha256(blob)).eql('9f81cd4f510080f1da92386b391cf2539b21f6363df491b89787e50fbc33b2c3');
+	});
+
+	it('#sha256(Ti.Blob with binary data)', function () {
+		var binaryFile = Ti.Filesystem.getFile(Ti.Filesystem.resourcesDirectory, 'Logo.png'),
+			blob = binaryFile.read();
+		should(Ti.Utils.sha256(blob)).eql('54be80ae48e4242d56170248e730ffac60a2828d07260a048e2ac0fd62386234');
 	});
 
 	// FIXME Android and iOS do no newlines for longer output, Windows does. Need to get parity


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-25766

**Description:**
Follow-on to #9812 

- Add more comprehensive unit tests around base64encode
- Avoid regression while still adding support for Ti.Filesystem.File argument on Android
- Remove no longer used Ti.Blob type STREAM_BASE64 code.
- Fix stream content type sniffing to only happen when the stream supports mark/reset, actually properly reset, and only sniff number of bytes we actually look at