### PR TITLE
Add grunt task to auto-fix JS files

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -132,6 +132,8 @@ module.exports = function (grunt) {
 	// register tasks
 	grunt.registerTask('format', [ 'clangFormat' ]);
 
+	grunt.registerTask('fixJs', [ 'appcJs:src:lint:fix' ]);
+
 	// register tasks
 	grunt.registerTask('default', [ 'lint' ]);
 };


### PR DESCRIPTION
Requires https://github.com/appcelerator-modules/grunt-appc-js/pull/11

Add a grunt task that automatically fixes JS files for people, ran with `grunt fixJs`, happy to bikeshed over the naming if anyone prefers anything else :) The task only runs the linting (no retire etc.), I was going to hang it off `grunt format` but it seemed pointless to lint all iOS/Android source as well.

Do we need a ticket for this?