### PR TITLE
Updated CloudPush.yml

### DIFF
--- a/apidoc/Modules/CloudPush/CloudPush.yml
+++ b/apidoc/Modules/CloudPush/CloudPush.yml
@@ -123,17 +123,6 @@ methods:
         get the device token again.
     since: 3.1.2
 
-  - name: isGooglePlayServicesAvailable
-    returns:
-        type: Number
-        summary: |
-            One of the following status codes:
-            <Modules.CloudPush.SUCCESS>, <Modules.CloudPush.SERVICE_MISSING>,
-            <Modules.CloudPush.SERVICE_VERSION_UPDATE_REQUIRED>,
-            <Modules.CloudPush.SERVICE_DISABLED> or <Modules.CloudPush.SERVICE_INVALID>.
-    summary: Returns a code to indicate whether Google Play Services is available on the device.
-    since: 3.4.1
-    platforms: [android]
 properties:
   - name: enabled
     summary: Whether or not this device will receive push notifications.


### PR DESCRIPTION
Removed isGooglePlayServicesAvailable() as it has been moved to https://docs.appcelerator.com/platform/latest/#!/api/Modules.PlayServices-method-isGooglePlayServicesAvailable. 

See https://jira.appcelerator.org/browse/TIDOC-3120 for more details.