### PR TITLE
[TIMOB-25201](7_1_X): iOS tintColor doesn't work on imageView if dimensions (height, width) are provided

### DIFF
--- a/iphone/Classes/TiUIImageViewProxy.m
+++ b/iphone/Classes/TiUIImageViewProxy.m
@@ -30,7 +30,7 @@ static NSArray *imageKeySequence;
 - (NSArray *)keySequence
 {
   if (imageKeySequence == nil) {
-    imageKeySequence = [[NSArray arrayWithObjects:@"width", @"height", nil] retain];
+    imageKeySequence = [[NSArray arrayWithObjects:@"width", @"height", @"image", @"tintColor", nil] retain];
   }
   return imageKeySequence;
 }


### PR DESCRIPTION
 https://jira.appcelerator.org/browse/TIMOB-25201
