### PR TITLE
[TIMOB-24610] Make transpiling off by default

### DIFF
--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -916,7 +916,7 @@ AndroidBuilder.prototype.validate = function validate(logger, config, cli) {
 	this.dxMaxIdxNumber = cli.tiapp.properties['android.dx.maxIdxNumber'] && cli.tiapp.properties['android.dx.maxIdxNumber'].value || config.get('android.dx.maxIdxNumber', '65536');
 
 	// Transpilation details
-	this.transpile = cli.tiapp['transpile'] !== false; // FIXME Does this properly default to true?
+	this.transpile = cli.tiapp['transpile'] === true; // Transpiling is an opt-in process for now
 	// We get a string here like 6.2.414.36, we need to convert it to 62 (integer)
 	const v8Version = this.packageJson.v8.version;
 	const found = v8Version.match(V8_STRING_VERSION_REGEXP);

--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -1825,7 +1825,7 @@ iOSBuilder.prototype.validate = function validate(logger, config, cli) {
 		this.initTiappSettings();
 
 		// Transpilation details
-		this.transpile = cli.tiapp['transpile'] !== false; // FIXME Does this properly default to true?
+		this.transpile = cli.tiapp['transpile'] === true; // Transpiling is an opt-in process for now
 		// this.minSupportedIosSdk holds the target ios version to transpile down to
 
 		// check for blacklisted files in the Resources directory


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-24610 (do we need another one?)

Make babel transpilation an opt in process by using the `<transpile>true</transpile>` flag in the tiapp.xml

Test steps

1. Add the following to an app.js
```js
var undefined = 'This will error in strict mode as we are overwriting undefined';
```
2. Build for iOS/Android 
3. Add `<transpile>true</transpile>` to your tiapp.xml
4. Build for iOS/Android again

## Expected

The app should throw an error similar to below the second time

```
[ERROR] Script Error {
[ERROR]     column = 16;
[ERROR]     line = 5;
[ERROR]     message = "Attempted to assign to readonly property.";
[ERROR]     sourceURL = "file:///Users/eharris/Library/Developer/CoreSimulator/Devices/19A348C6-7F86-4096-AEDE-90BB291BC971/data/Containers/Bundle/Application/2FCEAB2E-C77B-4CAC-9DA3-301B781DDD62/testbabelstuff.app/app.js";
[ERROR] }
```