### PR TITLE
[TIMOB-25805] Android: Remove 'appc info' output typo at 'NDK Path'

### DIFF
--- a/android/cli/lib/info.js
+++ b/android/cli/lib/info.js
@@ -55,7 +55,7 @@ exports.render = function (logger, config, rpad, styleHeading, styleValue, style
 	);
 
 	logger.log(styleHeading(__('Android NDK')) + '\n'
-		+ +'  ' + rpad(__('NDK Path'))           + ' = ' + styleValue(data.ndk && data.ndk.path || __('not found')) + '\n'
+		+ '  ' + rpad(__('NDK Path'))           + ' = ' + styleValue(data.ndk && data.ndk.path || __('not found')) + '\n'
 		+ '  ' + rpad(__('NDK Version'))        + ' = ' + styleValue(data.ndk && data.ndk.version || __('not found')) + '\n'
 	);
 


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-25805

**Optional Description:**

Current output of `appc info android`
```
Android NDK
  0NDK Path                    = /home/miga/tools/android-ndk
  NDK Version                 = 12.1.2977051
```

with the fix:
```
Android NDK
  NDK Path                    = /home/miga/tools/android-ndk
  NDK Version                 = 12.1.2977051
```
