### PR TITLE
(7_1_X) [TIMOB-25766][TIMOB-25727] Android: Ti.Utils.base64encode fixes

### DIFF
--- a/android/modules/network/src/java/ti/modules/titanium/network/TiHTTPClient.java
+++ b/android/modules/network/src/java/ti/modules/titanium/network/TiHTTPClient.java
@@ -895,14 +895,7 @@ public class TiHTTPClient
 				String mimeType = blob.getMimeType();
 				File tmpFile =
 					File.createTempFile("tixhr", "." + TiMimeTypeHelper.getFileExtensionFromMimeType(mimeType, "txt"));
-				if (blob.getType() == TiBlob.TYPE_STREAM_BASE64) {
-					FileOutputStream fos = new FileOutputStream(tmpFile);
-					TiBaseFile.copyStream(blob.getInputStream(),
-										  new Base64OutputStream(fos, android.util.Base64.DEFAULT));
-					fos.close();
-				} else {
-					createFileFromBlob(blob, tmpFile);
-				}
+				createFileFromBlob(blob, tmpFile);
 
 				tmpFiles.add(tmpFile);
 

--- a/android/modules/utils/src/java/ti/modules/titanium/utils/UtilsModule.java
+++ b/android/modules/utils/src/java/ti/modules/titanium/utils/UtilsModule.java
@@ -34,12 +34,17 @@ public class UtilsModule extends KrollModule
 		super();
 	}
 
-	private String convertToString(Object obj)
+	private byte[] convertToBytes(Object obj)
 	{
 		if (obj instanceof String) {
-			return (String) obj;
+			try {
+				return ((String) obj).getBytes("UTF-8");
+			} catch (UnsupportedEncodingException e) {
+				Log.e(TAG, "UTF-8 is not a supported encoding type");
+			}
+			return ((String) obj).getBytes(); // should never fall back here!
 		} else if (obj instanceof TiBlob) {
-			return ((TiBlob) obj).getText();
+			return ((TiBlob) obj).getBytes();
 		} else {
 			throw new IllegalArgumentException("Invalid type for argument");
 		}
@@ -48,22 +53,14 @@ public class UtilsModule extends KrollModule
 	@Kroll.method
 	public TiBlob base64encode(Object obj)
 	{
-		if (obj instanceof TiBlob) {
-			return TiBlob.blobFromString(((TiBlob) obj).toBase64());
-		} else if (obj instanceof TiFileProxy) {
-			try {
-				return TiBlob.blobFromStreamBase64(
-					((TiFileProxy) obj).getInputStream(),
-					TiMimeTypeHelper.getMimeType(((TiFileProxy) obj).getBaseFile().nativePath()));
-			} catch (IOException e) {
-				Log.e(TAG, "Problem reading file");
-			}
+		if (obj instanceof TiFileProxy) {
+			// recursively call base64encode after converting Ti.Filesystem.File to a Ti.Blob wrapping it
+			return base64encode(TiBlob.blobFromFile(((TiFileProxy) obj).getBaseFile()));
 		}
-		String data = convertToString(obj);
+		byte[] data = convertToBytes(obj);
 		if (data != null) {
 			try {
-				return TiBlob.blobFromString(
-					new String(Base64.encode(data.getBytes("UTF-8"), Base64.NO_WRAP), "UTF-8"));
+				return TiBlob.blobFromString(new String(Base64.encode(data, Base64.NO_WRAP), "UTF-8"));
 			} catch (UnsupportedEncodingException e) {
 				Log.e(TAG, "UTF-8 is not a supported encoding type");
 			}
@@ -74,13 +71,13 @@ public class UtilsModule extends KrollModule
 	@Kroll.method
 	public TiBlob base64decode(Object obj)
 	{
-		String data = convertToString(obj);
+		if (obj instanceof TiFileProxy) {
+			// recursively call base64decode after converting Ti.Filesystem.File to a Ti.Blob wrapping it
+			return base64decode(TiBlob.blobFromFile(((TiFileProxy) obj).getBaseFile()));
+		}
+		byte[] data = convertToBytes(obj);
 		if (data != null) {
-			try {
-				return TiBlob.blobFromData(Base64.decode(data.getBytes("UTF-8"), Base64.NO_WRAP));
-			} catch (UnsupportedEncodingException e) {
-				Log.e(TAG, "UTF-8 is not a supported encoding type");
-			}
+			return TiBlob.blobFromData(Base64.decode(data, Base64.NO_WRAP));
 		}
 		return null;
 	}
@@ -88,10 +85,7 @@ public class UtilsModule extends KrollModule
 	@Kroll.method
 	public String md5HexDigest(Object obj)
 	{
-		if (obj instanceof TiBlob) {
-			return DigestUtils.md5Hex(((TiBlob) obj).getBytes());
-		}
-		String data = convertToString(obj);
+		byte[] data = convertToBytes(obj);
 		if (data != null) {
 			return DigestUtils.md5Hex(data);
 		}
@@ -101,10 +95,7 @@ public class UtilsModule extends KrollModule
 	@Kroll.method
 	public String sha1(Object obj)
 	{
-		if (obj instanceof TiBlob) {
-			return DigestUtils.shaHex(((TiBlob) obj).getBytes());
-		}
-		String data = convertToString(obj);
+		byte[] data = convertToBytes(obj);
 		if (data != null) {
 			return DigestUtils.shaHex(data);
 		}
@@ -123,13 +114,7 @@ public class UtilsModule extends KrollModule
 		// NOTE: DigestUtils with the version before 1.4 doesn't have the function sha256Hex,
 		// so we deal with it ourselves
 		try {
-			byte[] b = null;
-			if (obj instanceof TiBlob) {
-				b = ((TiBlob) obj).getBytes();
-			} else {
-				String data = convertToString(obj);
-				b = data.getBytes();
-			}
+			byte[] b = convertToBytes(obj);
 			MessageDigest algorithm = MessageDigest.getInstance("SHA-256");
 			algorithm.reset();
 			algorithm.update(b);
@@ -141,33 +126,6 @@ public class UtilsModule extends KrollModule
 			return result.toString();
 		} catch (NoSuchAlgorithmException e) {
 			Log.e(TAG, "SHA256 is not a supported algorithm");
-		}
-		return null;
-	}
-
-	public String transcodeString(String orig, String inEncoding, String outEncoding)
-	{
-		try {
-
-			Charset charsetOut = Charset.forName(outEncoding);
-			Charset charsetIn = Charset.forName(inEncoding);
-
-			ByteBuffer bufferIn = ByteBuffer.wrap(orig.getBytes(charsetIn.name()));
-			CharBuffer dataIn = charsetIn.decode(bufferIn);
-			bufferIn.clear();
-			bufferIn = null;
-
-			ByteBuffer bufferOut = charsetOut.encode(dataIn);
-			dataIn.clear();
-			dataIn = null;
-			byte[] dataOut = bufferOut.array();
-			bufferOut.clear();
-			bufferOut = null;
-
-			return new String(dataOut, charsetOut.name());
-
-		} catch (UnsupportedEncodingException e) {
-			Log.e(TAG, "Unsupported encoding: " + e.getMessage(), e);
 		}
 		return null;
 	}

--- a/build/scons-test.js
+++ b/build/scons-test.js
@@ -17,6 +17,7 @@ program
 	.option('-C, --device-id [id]', 'Titanium device id to run the unit tests on. Only valid when there is a target provided')
 	.option('-T, --target [target]', 'Titanium platform target to run the unit tests on. Only valid when there is a single platform provided')
 	.option('-s, --skip-sdk-install', 'Skip the SDK installation step')
+	.option('-b, --branch [branch]', 'Which branch of the test suite to use', 'master')
 	.parse(process.argv);
 
 let platforms = program.args;
@@ -44,9 +45,10 @@ if (!program.skipSdkInstall && !fs.existsSync(zipfile)) {
  * SDK zipfile in dist against the supplied platforms.
  *
  * @param  {String[]}   platforms [description]
+ * @param  {String}   branch [description]
  * @param  {Function} next      [description]
  */
-function runTests(platforms, next) {
+function runTests(platforms, branch, next) {
 	async.series([
 		function (cb) {
 			// If we have a clone of the tests locally, wipe it...
@@ -56,7 +58,7 @@ function runTests(platforms, next) {
 			}
 			// clone the common test suite shallow
 			// FIXME Determine the correct branch of the suite to clone like we do in the Jenkinsfile
-			exec('git clone --depth 1 https://github.com/appcelerator/titanium-mobile-mocha-suite.git', { cwd: path.join(__dirname, '..') }, cb);
+			exec('git clone --depth 1 https://github.com/appcelerator/titanium-mobile-mocha-suite.git -b ' + branch, { cwd: path.join(__dirname, '..') }, cb);
 		},
 		function (cb) {
 			// Make sure it's dependencies are installed
@@ -88,7 +90,7 @@ function runTests(platforms, next) {
 	], next);
 }
 
-runTests(platforms, function (err) {
+runTests(platforms, program.branch, function (err) {
 	if (err) {
 		console.error(err.toString());
 		process.exit(1);

--- a/tests/Resources/ti.utils.test.js
+++ b/tests/Resources/ti.utils.test.js
@@ -1,0 +1,249 @@
+/*
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2015-Present by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+/* eslint-env mocha */
+/* global Ti */
+/* eslint no-unused-expressions: "off" */
+'use strict';
+var should = require('./utilities/assertions'),
+	utilities = require('./utilities/utilities');
+
+// handy tool: https://www.fileformat.info/tool/hash.htm
+
+describe('Titanium.Utils', function () {
+	var win;
+
+	afterEach(function () {
+		if (win) {
+			win.close();
+		}
+		win = null;
+	});
+
+	it('exists', function () {
+		should(Ti.Utils).not.be.undefined;
+		should(Ti.Utils).be.an.Object;
+	});
+
+	it('apiName', function () {
+		should(Ti.Utils).have.readOnlyProperty('apiName').which.is.a.String;
+		should(Ti.Utils.apiName).be.eql('Ti.Utils');
+	});
+
+	it('#base64decode(String)', function () {
+		var test;
+		// Basic tests
+		should(Ti.Utils.base64decode).be.a.Function;
+		test = Ti.Utils.base64decode('dGVzdA==');
+		should(test).be.a.Object;
+		should(test.apiName).eql('Ti.Blob');
+		should(test.getText()).be.eql('test');
+
+		// Test string without padding
+		should(!Ti.Utils.base64decode('eyJzdWIiOiJ0ZXN0IiwiZW1haWwiOiJ0ZXN0IiwiYXVkIjoidGVzdCIsImp0aSI6ImxvTHM4d2o5aWxBQUtWckNxbzhaMFMiLCJpc3MiOiJodHRwczpcL1wvc3NvLmV4YW1wbGUuY29tIiwiaWF0IjoxNTI2MTY3NDc3LCJleHAiOjE1MjYxNjc0NzcsInBpLnRlc3QiOiJMSTRmMW81Q2pqU2tHU2xTanM0bHlPeVlROCJ9')).not.be.null;
+
+		// More padding tests
+		should(Ti.Utils.base64decode('Zg').text).eql('f');
+		should(Ti.Utils.base64decode('Zm8').text).eql('fo');
+		should(Ti.Utils.base64decode('Zm9v').text).eql('foo');
+		should(Ti.Utils.base64decode('Zm9vYg').text).eql('foob');
+		should(Ti.Utils.base64decode('Zm9vYmE').text).eql('fooba');
+		should(Ti.Utils.base64decode('Zm9vYmFy').text).eql('foobar');
+	});
+
+	// FIXME Windows gives: 'base64decode: attempt to decode a value not in base64 char set'
+	it.windowsBroken('#base64decode(Ti.Blob with text data)', function () {
+		var f = Ti.Filesystem.getFile(Ti.Filesystem.resourcesDirectory, 'txtFiles/encodedFile.txt'),
+			blob = Ti.Utils.base64decode(f.read());
+		should(blob.toString()).eql('Decoding successful!');
+	});
+
+	it('#base64encode(String)', function () {
+		var test;
+		should(Ti.Utils.base64encode).be.a.Function;
+		test = Ti.Utils.base64encode('test');
+		should(test).be.a.Object;
+		should(test.apiName).eql('Ti.Blob');
+		should(test.getText()).be.eql('dGVzdA==');
+	});
+
+	it('#base64encode(Ti.Blob#TYPE_FILE)', function () {
+		var f = Ti.Filesystem.getFile(Ti.Filesystem.resourcesDirectory, 'txtFiles/decodedFile.txt'),
+			contents = f.read();
+		should(Ti.Utils.base64encode(contents).toString()).eql('SSBhbSBub3QgZW5jb2RlZCB5ZXQu');
+	});
+
+	it('#base64encode(Ti.Blob#TYPE_DATA from Ti.UI.View.toImage() async)', function (finish) {
+		var win,
+			label;
+		this.timeout(5000);
+		win = Ti.UI.createWindow();
+		label = Ti.UI.createLabel({ text: 'test' });
+		win.add(label);
+		win.addEventListener('focus', function () {
+			// Get a Ti.Blob from view.toImage()
+			label.toImage(function (blob) {
+				var result;
+				try {
+					if (utilities.isAndroid()) {
+						should(blob.type).eql(2); // Android-specific property, value of 2 indicates TYPE_DATA
+					}
+					result = Ti.Utils.base64encode(blob);
+					// result here is a Ti.Blob
+					should(result).be.a.Object; // Fails here
+					should(result.apiName).eql('Ti.Blob');
+					// should(blob.text).eql('aGVsbG8gd29ybGQ='); // FIXME What sanity check can we do here?
+					finish();
+				} catch (err) {
+					finish(err);
+				}
+			});
+		});
+		win.open();
+	});
+
+	it('#base64encode(Ti.Blob#TYPE_DATA from Ti.Buffer.toBlob())', function () {
+		var blob,
+			buffer = Ti.createBuffer({ value: 'hello world' }); // Easiest way to get a TYPE_DATA Blob is from Ti.Buffer.toBlob()
+		blob = Ti.Utils.base64encode(buffer.toBlob());
+		// result here is a Ti.Blob
+		should(blob).be.a.Object;
+		should(blob.apiName).eql('Ti.Blob');
+		should(blob.text).eql('aGVsbG8gd29ybGQ=');
+	});
+
+	it('#base64encode(Ti.Blob#TYPE_STRING)', function () {
+		// Only way to get a blob of type string is the result of base64encode(String) on Android!
+		var blob,
+			test = Ti.Utils.base64encode('test');
+		should(test).be.a.Object;
+		should(test.apiName).eql('Ti.Blob');
+		if (utilities.isAndroid()) {
+			should(test.type).eql(3); // Android-specific property, value of 3 indicates TYPE_STRING
+		}
+		should(test.getText()).be.eql('dGVzdA==');
+
+		blob = Ti.Utils.base64encode(test);
+		// result here is a Ti.Blob
+		should(blob).be.a.Object;
+		should(blob.apiName).eql('Ti.Blob');
+		should(blob.text).eql('ZEdWemRBPT0=');
+	});
+
+	// FIXME: base64encode accepts Ti.File as a parameter on iOS/Android, but not on Windows.
+	it.windowsBroken('#base64encode(Ti.Filesystem.File)', function () {
+		var f = Ti.Filesystem.getFile(Ti.Filesystem.resourcesDirectory, 'txtFiles/decodedFile.txt');
+		var blob = Ti.Utils.base64encode(f);
+
+		// result here is a Ti.Blob
+		should(blob).be.a.Object;
+		should(blob.apiName).eql('Ti.Blob');
+		should(blob.text).eql('SSBhbSBub3QgZW5jb2RlZCB5ZXQu');
+	});
+
+	// FIXME: base64decode accepts Ti.File as a parameter on iOS/Android, but not on Windows.
+	it.windowsBroken('#base64decode(Ti.Filesystem.File with text data)', function () {
+		var f = Ti.Filesystem.getFile(Ti.Filesystem.resourcesDirectory, 'txtFiles/encodedFile.txt');
+		var blob = Ti.Utils.base64decode(f);
+
+		// result here is a Ti.Blob
+		should(blob).be.a.Object;
+		should(blob.apiName).eql('Ti.Blob');
+		should(blob.toString()).eql('Decoding successful!');
+	});
+
+	// FIXME: How can I make this valid? The input needs to be valid base64...
+	// An image can't be right. Maybe we can validate in UtilsModule that a given blob is non-binary?
+	// it.windowsBroken('#base64decode(Ti.Filesystem.File with binary data)', function () {
+	// 	var binaryFile = Ti.Filesystem.getFile(Ti.Filesystem.resourcesDirectory, 'Logo.png'),
+	// 		blob = Ti.Utils.base64decode(binaryFile);
+	//
+	// 	// result here is a Ti.Blob
+	// 	should(blob).be.a.Object;
+	// 	should(blob.apiName).eql('Ti.Blob');
+	// 	// ignore the actual decoded value...
+	// });
+
+	it('#md5HexDigest(String)', function () {
+		var test;
+		should(Ti.Utils.md5HexDigest).be.a.Function;
+		test = Ti.Utils.md5HexDigest('test');
+		should(test).be.a.String;
+		should(test).be.eql('098f6bcd4621d373cade4e832627b4f6');
+	});
+
+	// FIXME Windows gives different md5 hash! Maybe line ending difference?
+	it.windowsBroken('#md5HexDigest(Ti.Blob with text data)', function () {
+		var f = Ti.Filesystem.getFile(Ti.Filesystem.resourcesDirectory, 'txtFiles/file.txt'),
+			contents = f.read(),
+			test;
+		should(Ti.Utils.md5HexDigest).be.a.Function;
+		test = Ti.Utils.md5HexDigest(contents);
+		should(test).be.a.String;
+		should(test).be.eql('4fe8a693c64f93f65c5faf42dc49ab23'); // Windows Desktop gives: 'ab1600f840b927f80a3dc000c510d1d3'
+	});
+
+	it.windowsBroken('#md5HexDigest(Ti.Blob with binary data)', function () {
+		var binaryFile = Ti.Filesystem.getFile(Ti.Filesystem.resourcesDirectory, 'Logo.png'),
+			blob = binaryFile.read(),
+			result;
+		should(Ti.Utils.md5HexDigest).be.a.Function;
+		result = Ti.Utils.md5HexDigest(blob);
+		should(result).be.a.String;
+		should(result).be.eql('803fd0b8dd9a3ca5238390732db54062');
+	});
+
+	it('#sha1(String)', function () {
+		var test;
+		should(Ti.Utils.sha1).be.a.Function;
+		test = Ti.Utils.sha1('test');
+		should(test).be.a.String;
+		should(test).be.eql('a94a8fe5ccb19ba61c4c0873d391e987982fbbd3');
+	});
+
+	it('#sha1(Ti.Blob with text data)', function () {
+		var textFile = Ti.Filesystem.getFile(Ti.Filesystem.resourcesDirectory, 'txtFiles/decodedFile.txt'),
+			blob = textFile.read();
+		should(Ti.Utils.sha1(blob)).eql('ddbb50fb5beea93d1d4913fc22355c84f22d43ed');
+	});
+
+	it('#sha1(Ti.Blob with binary data)', function () {
+		var binaryFile = Ti.Filesystem.getFile(Ti.Filesystem.resourcesDirectory, 'Logo.png'),
+			blob = binaryFile.read();
+		should(Ti.Utils.sha1(blob)).eql('668e98c66d8a11ef38ab442d9d6d4a21d8593645');
+	});
+
+	it('#sha256(String)', function () {
+		var test;
+		should(Ti.Utils.sha256).be.a.Function;
+		test = Ti.Utils.sha256('test');
+		should(test).be.a.String;
+		should(test).be.eql('9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08');
+	});
+
+	it('#sha256(Ti.Blob with text data)', function () {
+		var textFile = Ti.Filesystem.getFile(Ti.Filesystem.resourcesDirectory, 'txtFiles/decodedFile.txt'),
+			blob = textFile.read();
+		should(Ti.Utils.sha256(blob)).eql('9f81cd4f510080f1da92386b391cf2539b21f6363df491b89787e50fbc33b2c3');
+	});
+
+	it('#sha256(Ti.Blob with binary data)', function () {
+		var binaryFile = Ti.Filesystem.getFile(Ti.Filesystem.resourcesDirectory, 'Logo.png'),
+			blob = binaryFile.read();
+		should(Ti.Utils.sha256(blob)).eql('54be80ae48e4242d56170248e730ffac60a2828d07260a048e2ac0fd62386234');
+	});
+
+	// FIXME Android and iOS do no newlines for longer output, Windows does. Need to get parity
+	it.windowsBroken('TIMOB-25513', function () {
+		var shortString = 'ABCDEFGHIJ1234567890ABCDEFGHIJ12|psndemo2|abcd:1',
+			longString = 'ABCDEFGHIJ1234567890ABCDEFGHIJ12|psndemo2|abcd:12345678901234567890',
+			tiBase64ShortResult = Ti.Utils.base64encode(shortString),
+			tiBase64LongResult  = Ti.Utils.base64encode(longString);
+
+		should(tiBase64ShortResult.getText()).be.eql('QUJDREVGR0hJSjEyMzQ1Njc4OTBBQkNERUZHSElKMTJ8cHNuZGVtbzJ8YWJjZDox');
+		should(tiBase64LongResult.getText()).be.eql('QUJDREVGR0hJSjEyMzQ1Njc4OTBBQkNERUZHSElKMTJ8cHNuZGVtbzJ8YWJjZDoxMjM0NTY3ODkwMTIzNDU2Nzg5MA==');
+	});
+});


### PR DESCRIPTION
**JIRA:** 
- https://jira.appcelerator.org/browse/TIMOB-25766
- https://jira.appcelerator.org/browse/TIMOB-25727

**Description:**
back port of #9885

This is a fix for both listed tickets. Our previous "fix" was to revert the changes to avoid a regression caused by the fix to the other ticket. But then we never re-opened the original ticket when it was reverted.

This fix attempts to add more comprehensive Ti.Utils tests and fix both cases properly.

- Add more comprehensive unit tests around base64encode
- Avoid regression while still adding support for Ti.Filesystem.File argument on Android
- Remove no longer used Ti.Blob type STREAM_BASE64 code.
- Fix stream content type sniffing to only happen when the stream supports mark/reset, actually properly reset, and only sniff number of bytes we actually look at
* Remove reference to unused TiBlob type
* Add tests for hashing/encoding binary data. Update Utils module to support that and clean up the code.
* Fix iOS to support sha256/sha1 of Ti.Blob with binary data.
* Refactor code for turning args into NSData for Utils