### PR TITLE
Fixed deprecated since values for Geolocation.yml

### DIFF
--- a/apidoc/Titanium/Geolocation/Geolocation.yml
+++ b/apidoc/Titanium/Geolocation/Geolocation.yml
@@ -429,7 +429,7 @@ properties:
     permission: read-only
     platforms: [android, iphone, ipad]
     deprecated:
-        since: {android: "2.0.0"}
+        since: "2.0.0"
 
   - name: ACCURACY_HUNDRED_METERS
     summary: |
@@ -442,7 +442,7 @@ properties:
     permission: read-only
     platforms: [android, iphone, ipad]
     deprecated:
-        since: {android: "2.0.0"}
+        since: "2.0.0"
 
   - name: ACCURACY_KILOMETER
     summary: |
@@ -455,7 +455,7 @@ properties:
     permission: read-only
     platforms: [android, iphone, ipad]
     deprecated:
-        since: {android: "2.0.0"}
+        since: "2.0.0"
 
   - name: ACCURACY_NEAREST_TEN_METERS
     summary: |
@@ -468,7 +468,7 @@ properties:
     permission: read-only
     platforms: [android, iphone, ipad]
     deprecated:
-        since: {android: "2.0.0"}
+        since: "2.0.0"
 
   - name: ACCURACY_THREE_KILOMETERS
     summary: |
@@ -481,7 +481,7 @@ properties:
     permission: read-only
     platforms: [android, iphone, ipad]
     deprecated:
-        since: {android: "2.0.0"}
+        since: "2.0.0"
 
   - name: ACCURACY_HIGH
     summary: |


### PR DESCRIPTION
At this time, the docgen script cannot handle objects passed as values in deprecated since. Please don't pass {<platform>: <version>} as a value for the since property.

See https://jira.appcelerator.org/browse/TIDOC-3124 for details.