### PR TITLE
[TIMOB-25849] Android: Always specify image mime-type

### DIFF
--- a/android/modules/media/src/java/ti/modules/titanium/media/MediaModule.java
+++ b/android/modules/media/src/java/ti/modules/titanium/media/MediaModule.java
@@ -1113,6 +1113,7 @@ public class MediaModule extends KrollModule implements Handler.Callback
 	{
 		String[] parts = { path };
 		TiBlob imageData;
+
 		// Workaround for TIMOB-19910. Image is in the Google Photos cloud and not on device.
 		if (path.startsWith("content://com.google.android.apps.photos.contentprovider")) {
 			ParcelFileDescriptor parcelFileDescriptor;
@@ -1125,14 +1126,14 @@ public class MediaModule extends KrollModule implements Handler.Callback
 				parcelFileDescriptor.close();
 				imageData = TiBlob.blobFromImage(image);
 			} catch (FileNotFoundException e) {
-				imageData = createImageData(parts, MIME_IMAGE);
+				imageData = createImageData(parts, null);
 			} catch (IOException e) {
-				imageData = createImageData(parts, MIME_IMAGE);
+				imageData = createImageData(parts, null);
 			}
 		} else {
-			imageData = createImageData(parts, MIME_IMAGE);
+			imageData = createImageData(parts, null);
 		}
-		return createDictForImage(imageData, MIME_IMAGE);
+		return createDictForImage(imageData, null);
 	}
 
 	public static TiBlob createImageData(String[] parts, String mimeType)

--- a/android/modules/media/src/java/ti/modules/titanium/media/MediaModule.java
+++ b/android/modules/media/src/java/ti/modules/titanium/media/MediaModule.java
@@ -180,6 +180,8 @@ public class MediaModule extends KrollModule implements Handler.Callback
 	private static String extension = ".jpg";
 	private TiTempFileHelper tempFileHelper;
 
+	private static final String MIME_IMAGE = "image/*";
+
 	private static class ApiLevel16
 	{
 		private ApiLevel16()
@@ -1002,7 +1004,7 @@ public class MediaModule extends KrollModule implements Handler.Callback
 
 		TiIntentWrapper galleryIntent = new TiIntentWrapper(new Intent());
 		galleryIntent.getIntent().setAction(Intent.ACTION_GET_CONTENT);
-		galleryIntent.getIntent().setType("image/*");
+		galleryIntent.getIntent().setType(MIME_IMAGE);
 		galleryIntent.getIntent().addCategory(Intent.CATEGORY_DEFAULT);
 		galleryIntent.setWindowId(TiIntentWrapper.createActivityName("GALLERY"));
 
@@ -1123,14 +1125,14 @@ public class MediaModule extends KrollModule implements Handler.Callback
 				parcelFileDescriptor.close();
 				imageData = TiBlob.blobFromImage(image);
 			} catch (FileNotFoundException e) {
-				imageData = createImageData(parts, null);
+				imageData = createImageData(parts, MIME_IMAGE);
 			} catch (IOException e) {
-				imageData = createImageData(parts, null);
+				imageData = createImageData(parts, MIME_IMAGE);
 			}
 		} else {
-			imageData = createImageData(parts, null);
+			imageData = createImageData(parts, MIME_IMAGE);
 		}
-		return createDictForImage(imageData, null);
+		return createDictForImage(imageData, MIME_IMAGE);
 	}
 
 	public static TiBlob createImageData(String[] parts, String mimeType)
@@ -1190,7 +1192,7 @@ public class MediaModule extends KrollModule implements Handler.Callback
 		cropRect.put("height", height);
 		d.put("cropRect", cropRect);
 		d.put("mediaType", mediaType);
-		d.put("media", TiBlob.blobFromData(data, "image/png"));
+		d.put("media", TiBlob.blobFromData(data, MIME_IMAGE));
 
 		return d;
 	}

--- a/android/titanium/src/java/org/appcelerator/titanium/TiBlob.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiBlob.java
@@ -514,7 +514,6 @@ public class TiBlob extends KrollProxy
 			return null;
 		}
 		if (this.type != TYPE_FILE) {
-			Log.w(TAG, "getNativePath not supported for non-file blob types.");
 			return null;
 		} else if (!(data instanceof TiBaseFile)) {
 			Log.w(TAG, "getNativePath unable to return value: underlying data is not file, rather "

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiMimeTypeHelper.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiMimeTypeHelper.java
@@ -8,7 +8,10 @@ package org.appcelerator.titanium.util;
 
 import java.util.HashMap;
 
+import android.net.Uri;
 import android.webkit.MimeTypeMap;
+
+import org.appcelerator.titanium.TiApplication;
 
 public class TiMimeTypeHelper
 {
@@ -54,6 +57,14 @@ public class TiMimeTypeHelper
 
 	public static String getMimeType(String url, String defaultType)
 	{
+		// attempt to obtain mime-type from content provider
+		if (url.startsWith("content://")) {
+			final String mimeType = TiApplication.getInstance().getContentResolver().getType(Uri.parse(url));
+			if (mimeType != null) {
+				return mimeType;
+			}
+		}
+
 		String extension = "";
 		int pos = url.lastIndexOf('.');
 		if (pos > 0) {


### PR DESCRIPTION
- Always specify image mime-type to obtain image information correctly
- Remove annoying warning from `TiBlob`

###### NOTE: `no tests` as this test case requires user input

##### TEST CASE
```JS
var win = Ti.UI.createWindow(),
    btn = Ti.UI.createButton({
        title: 'OPEN GALLERY',
    });

btn.addEventListener('click', function(){
    Ti.Media.openPhotoGallery({
        mediaTypes: [ Titanium.Media.MEDIA_TYPE_PHOTO ],
        success: function (e) {
            var msg = 'media.width: ' + e.media.width
                + '\nmedia.height: ' + e.media.height
                + '\nmedia.length: ' + e.media.length
                + '\nmedia.mimeType: ' + e.media.mimeType
                + '\nmedia.nativePath: ' + e.media.nativePath;
            alert(msg);
        },
        error: function (e) {
            alert('error opening image: ' + e.error);
        }
    });
});

win.add(btn);
win.open();
```
- Should see `width height` and `mimeType` populated after selecting an image

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-25849)