### PR TITLE
[TIMOB-26340] Android: Update V8 runtime to 6.9.x - V8 6.9.427.17 and NDK r16b

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,7 +59,7 @@ def unitTests(os, nodeVersion, npmVersion, testSuiteBranch) {
 					manager.addWarningBadge(msg)
 					throw e
 				}
-			}
+			} // dir
 			// copy over any overridden unit tests into this workspace
 			sh 'rm -rf tests'
 			unstash 'override-tests'
@@ -222,7 +222,7 @@ timestamps {
 					// TODO parallelize the iOS/Android/Mobileweb/Windows portions?
 					dir('build') {
 						timeout(15) {
-							sh "node scons.js build --android-ndk ${env.ANDROID_NDK_R12B} --android-sdk ${env.ANDROID_SDK}"
+							sh "node scons.js build --android-ndk ${env.ANDROID_NDK_R16B} --android-sdk ${env.ANDROID_SDK}"
 						} // timeout
 						ansiColor('xterm') {
 							timeout(15) {

--- a/android/kroll-apt/src/java/org/appcelerator/kroll/annotations/generator/ProxyBinding.fm
+++ b/android/kroll-apt/src/java/org/appcelerator/kroll/annotations/generator/ProxyBinding.fm
@@ -506,26 +506,9 @@ fails, a JS exception is returned.
 	} else {
 	</#if>
 <#t>
-	<#local current_arg = "arg_" + index>
-	<#if info.jsType == "Value">
-		<#local type = "Local<Value>">
-		<#local valueExpr = expr>
-	<#elseif info.jsType == "Number">
-		<#local type = "Local<Number>">
-		<#local valueExpr = expr + "->ToNumber(isolate)">
-		<#local stringExpr = expr + "->ToString(isolate)">
-	<#elseif info?keys?seq_contains("jsHandleCast")>
-		<#local type = "Local<" + info.jsType + ">">
-		<#local valueExpr = expr + ".As<" + info.jsType + ">()">
-	<#else>
-		<#local type = "Local<" + info.jsType + ">">
-		<#local valueExpr = expr + "->To" + info.jsType + "(isolate)">
-	</#if>
-
-<#t>
 	<#if info.jsType == "Number">
-		if ((titanium::V8Util::isNaN(isolate, ${expr}) && !${expr}->IsUndefined()) || ${stringExpr}->Length() == 0) {
-			const char *error = "Invalid value, expected type ${info.jsType}.";
+		if ((titanium::V8Util::isNaN(isolate, ${expr}) && !${expr}->IsUndefined()) || ${expr}->ToString(context).FromMaybe(String::Empty(isolate))->Length() == 0) {
+			const char *error = "Invalid value, expected type Number.";
 			LOGE(TAG, error);
 			<#if !(logOnly!false)>
 			titanium::JSException::Error(isolate, error);
@@ -534,7 +517,46 @@ fails, a JS exception is returned.
 		}
 	</#if>
 <#t>
+	<#local current_arg = "arg_" + index>
+	<#if info.jsType == "Value">
+		<#local coerced = false>
+		<#local type = "Local<Value>">
+		<#local valueExpr = expr>
+	<#elseif info.jsType == "Number">
+		<#local coerced = true>
+		<#local type = "MaybeLocal<Number>">
+		<#local valueExpr = expr + "->ToNumber(context)">
+	<#elseif info?keys?seq_contains("jsHandleCast")> // Array
+		<#local coerced = false>
+		<#local type = "Local<" + info.jsType + ">">
+		<#local valueExpr = expr + ".As<" + info.jsType + ">()">
+	<#else>
+		<#local coerced = true>
+		<#local type = "MaybeLocal<" + info.jsType + ">">
+		<#local valueExpr = expr + "->To" + info.jsType + "(context)">
+	</#if>
 	if (!${expr}->IsNull()) {
+	<#if coerced>
+		${type} ${current_arg} = ${valueExpr};
+		if (${current_arg}.IsEmpty()) {
+			const char *error = "Invalid argument at index ${index}, expected type ${info.jsType} and failed to coerce.";
+			LOGE(TAG, error);
+			<#if !(logOnly!false)>
+			titanium::JSException::Error(isolate, error);
+			return;
+			<#else>
+			jArguments[${index}].${info.jvalue} = NULL;
+			</#if>
+		} else {
+			jArguments[${index}].${info.jvalue} =
+				titanium::TypeConverter::${info.jsToJavaConverter}(
+			<#if info.jsToJavaConverter?matches("^js(Number|Date|String|Boolean)To.+")>
+			<#else>
+					isolate,
+			</#if>
+					env, ${current_arg}.ToLocalChecked()<#if checkNew>, &isNew_${index}</#if>);
+		}
+	<#else>
 		${type} ${current_arg} = ${valueExpr};
 		jArguments[${index}].${info.jvalue} =
 			titanium::TypeConverter::${info.jsToJavaConverter}(
@@ -543,6 +565,7 @@ fails, a JS exception is returned.
 				isolate,
 		</#if>
 				env, ${current_arg}<#if checkNew>, &isNew_${index}</#if>);
+	</#if>
 	} else {
 		jArguments[${index}].${info.jvalue} = NULL;
 	}
@@ -595,9 +618,9 @@ fails, a JS exception is returned.
 	</#list>
 
 	<#if method.hasInvocation>
-	Local<Object> scopeVars = args[0]->ToObject(isolate);
+	Local<Object> scopeVars = args[0]->ToObject(context).ToLocalChecked(); // FIXME handle when empty!
 	jstring sourceUrl = titanium::TypeConverter::jsValueToJavaString(isolate, env,
-		scopeVars->Get(Proxy::sourceUrlSymbol.Get(isolate)));
+		scopeVars->Get(context, Proxy::sourceUrlSymbol.Get(isolate)).FromMaybe(String::Empty(isolate).As<Value>())); // FIXME Default to app.js?
 	jArguments[0].l = env->NewObject(titanium::JNIUtil::krollInvocationClass,
 		titanium::JNIUtil::krollInvocationInitMethod, sourceUrl);
 	env->DeleteLocalRef(sourceUrl);
@@ -725,7 +748,7 @@ beprovided to handle the result.
 <#macro getHolder>
 	Local<Object> holder = args.Holder();
 	if (!JavaObject::isJavaObject(holder)) {
-		holder = holder->FindInstanceInPrototypeChain(getProxyTemplate(isolate));
+		holder = holder->FindInstanceInPrototypeChain(getProxyTemplate(context));
 	}
 	if (holder.IsEmpty() || holder->IsNull()) {
 		LOGE(TAG, "Couldn't obtain argument holder");

--- a/android/kroll-apt/src/java/org/appcelerator/kroll/annotations/generator/ProxyBindingV8.cpp.fm
+++ b/android/kroll-apt/src/java/org/appcelerator/kroll/annotations/generator/ProxyBindingV8.cpp.fm
@@ -1,6 +1,6 @@
 /**
  * Appcelerator Titanium Mobile
- * Copyright (c) 2011-2017 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2011-2018 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
@@ -50,7 +50,7 @@ void ${className}::bindProxy(Local<Object> exports, Local<Context> context)
 {
 	Isolate* isolate = context->GetIsolate();
 
-	Local<FunctionTemplate> pt = getProxyTemplate(isolate);
+	Local<FunctionTemplate> pt = getProxyTemplate(context);
 
 	v8::TryCatch tryCatch(isolate);
 	Local<Function> constructor;
@@ -68,9 +68,9 @@ void ${className}::bindProxy(Local<Object> exports, Local<Context> context)
 		titanium::V8Util::fatalException(isolate, tryCatch);
 		return;
 	}
-	exports->Set(nameSymbol, moduleInstance);
+	exports->Set(context, nameSymbol, moduleInstance);
 	<#else>
-	exports->Set(nameSymbol, constructor);
+	exports->Set(context, nameSymbol, constructor);
 	</#if>
 }
 
@@ -86,8 +86,9 @@ void ${className}::dispose(Isolate* isolate)
 	</#if>
 }
 
-Local<FunctionTemplate> ${className}::getProxyTemplate(Isolate* isolate)
+Local<FunctionTemplate> ${className}::getProxyTemplate(Local<Context> context)
 {
+	Isolate* isolate = context->GetIsolate();
 	if (!proxyTemplate.IsEmpty()) {
 		return proxyTemplate.Get(isolate);
 	}
@@ -101,16 +102,17 @@ Local<FunctionTemplate> ${className}::getProxyTemplate(Isolate* isolate)
 	// use symbol over string for efficiency
 	Local<String> nameSymbol = NEW_SYMBOL(isolate, "${proxyAttrs.name}");
 
-	Local<FunctionTemplate> t = titanium::Proxy::inheritProxyTemplate(isolate,
+	Local<FunctionTemplate> t = titanium::Proxy::inheritProxyTemplate(
+		isolate,
 	<#if superProxyClassName??>
-		<@Proxy.superNamespace/>${superProxyClassName}::getProxyTemplate(isolate)
+		<@Proxy.superNamespace/>${superProxyClassName}::getProxyTemplate(context),
 	<#else>
-		titanium::Proxy::baseProxyTemplate.Get(isolate)
-	</#if>, javaClass, nameSymbol);
+		titanium::Proxy::baseProxyTemplate.Get(isolate),
+	</#if>
+		javaClass,
+		nameSymbol);
 
 	proxyTemplate.Reset(isolate, t);
-	t->Set(titanium::Proxy::inheritSymbol.Get(isolate),
-		FunctionTemplate::New(isolate, titanium::Proxy::inherit<${className}>));
 
 	// Method bindings --------------------------------------------------------
 	<@Proxy.listMethods ; isFirst, name, method>
@@ -196,38 +198,42 @@ Local<FunctionTemplate> ${className}::getProxyTemplate(Isolate* isolate)
 
 	// Dynamic properties -----------------------------------------------------
 	<@Proxy.listDynamicProperties ; isFirst, name, property, getSignature, setSignature>
-	instanceTemplate->SetAccessor(NEW_SYMBOL(isolate, "${name}"),
-		<#if property.get>
-			${className}::getter_${name},
-		<#else>
-			titanium::Proxy::getProperty,
-		</#if>
-		<#if property.set>
-			${className}::setter_${name},
-		<#else>
-			titanium::Proxy::onPropertyChanged,
-		</#if>
-			Local<Value>(), DEFAULT,
-		<#if property.set>
-			static_cast<v8::PropertyAttribute>(v8::DontDelete)
-		<#else>
-			static_cast<v8::PropertyAttribute>(v8::ReadOnly | v8::DontDelete)
-		</#if>
-		);
+	instanceTemplate->SetAccessor(
+		NEW_SYMBOL(isolate, "${name}"),
+	<#if property.get>
+		${className}::getter_${name},
+	<#else>
+		titanium::Proxy::getProperty,
+	</#if>
+	<#if property.set>
+		${className}::setter_${name},
+	<#else>
+		titanium::Proxy::onPropertyChanged,
+	</#if>
+		Local<Value>(),
+		DEFAULT,
+	<#if property.set>
+		static_cast<v8::PropertyAttribute>(v8::DontDelete)
+	<#else>
+		static_cast<v8::PropertyAttribute>(v8::ReadOnly | v8::DontDelete)
+	</#if>
+	);
 	</@Proxy.listDynamicProperties>
 
 	// Accessors --------------------------------------------------------------
 	<@Proxy.listPropertyAccessors ; isFirst, name, getter, setter>
+	Local<String> ${name} = NEW_SYMBOL(isolate, "${name}");
 	instanceTemplate->SetAccessor(
-		NEW_SYMBOL(isolate, "${name}"),
+		${name},
 		titanium::Proxy::getProperty,
-		titanium::Proxy::onPropertyChanged);
-	DEFINE_PROTOTYPE_METHOD_DATA(isolate, t, "${getter}", titanium::Proxy::getProperty, NEW_SYMBOL(isolate, "${name}"));
-	DEFINE_PROTOTYPE_METHOD_DATA(isolate, t, "${setter}", titanium::Proxy::onPropertyChanged, NEW_SYMBOL(isolate, "${name}"));
-	</@Proxy.listPropertyAccessors>
+		titanium::Proxy::onPropertyChanged
+	);
+	DEFINE_PROTOTYPE_METHOD_DATA(isolate, t, "${getter}", titanium::Proxy::getProperty, ${name});
+	DEFINE_PROTOTYPE_METHOD_DATA(isolate, t, "${setter}", titanium::Proxy::onPropertyChanged, ${name});
 
+	</@Proxy.listPropertyAccessors>
 	<#if interceptor??>
-	instanceTemplate->SetNamedPropertyHandler(${className}::interceptor);
+	instanceTemplate->SetHandler(NamedPropertyHandlerConfiguration(${className}::interceptor, 0, 0, 0, 0, Local<Value>(), PropertyHandlerFlags::kOnlyInterceptStrings));
 	</#if>
 	return scope.Escape(t);
 }
@@ -238,6 +244,7 @@ void ${className}::${method.apiName}(const FunctionCallbackInfo<Value>& args)
 {
 	LOGD(TAG, "${method.apiName}()");
 	Isolate* isolate = args.GetIsolate();
+	Local<Context> context = isolate->GetCurrentContext();
 	HandleScope scope(isolate);
 
 	<@Proxy.initJNIEnv/>
@@ -292,6 +299,8 @@ void ${className}::getter_${name}(Local<Name> property, const PropertyCallbackIn
 	HandleScope scope(isolate);
 
 	<@Proxy.initJNIEnv/>
+
+	Local<Context> context = isolate->GetCurrentContext();
 	<@Proxy.initMethodID className=className name=property.getMethodName signature=getSignature logOnly=false/>
 
 	<@Proxy.getHolder/>
@@ -329,6 +338,8 @@ void ${className}::setter_${name}(Local<Name> property, Local<Value> value, cons
 		return;
 	}
 
+	Local<Context> context = isolate->GetCurrentContext();
+
 	<@Proxy.initMethodID className=className name=property.setMethodName signature=setSignature logOnly=true />
 
 	<@Proxy.getHolder/>
@@ -363,9 +374,10 @@ void ${className}::setter_${name}(Local<Name> property, Local<Value> value, cons
 </@Proxy.listDynamicProperties>
 
 <#if interceptor??>
-void ${className}::interceptor(Local<String> property, const v8::PropertyCallbackInfo<Value>& args)
+void ${className}::interceptor(Local<Name> property, const v8::PropertyCallbackInfo<Value>& args)
 {
 	Isolate* isolate = args.GetIsolate();
+	Local<Context> context = isolate->GetCurrentContext();
 	HandleScope scope(isolate);
 
 	<@Proxy.initJNIEnv/>
@@ -385,7 +397,7 @@ void ${className}::interceptor(Local<String> property, const v8::PropertyCallbac
 		return;
 	}
 
-	jstring javaProperty = titanium::TypeConverter::jsStringToJavaString(env, property);
+	jstring javaProperty = titanium::TypeConverter::jsStringToJavaString(isolate, env, property.As<String>());
 	jobject jResult = (jobject) env->CallObjectMethod(javaProxy, methodID, javaProperty);
 
 	proxy->unreferenceJavaObject(javaProxy);
@@ -407,9 +419,9 @@ void ${className}::interceptor(Local<String> property, const v8::PropertyCallbac
 	env->DeleteLocalRef(jResult);
 
 	if (v8Result->IsNumber()) {
-		int32_t intResult = v8Result->Int32Value();
+		Maybe<int32_t> intResult = v8Result->Int32Value(context);
 
-		if (intResult == titanium::JNIUtil::krollRuntimeDontIntercept) {
+		if (intResult.IsJust() && intResult.FromJust() == titanium::JNIUtil::krollRuntimeDontIntercept) {
 			args.GetReturnValue().Set(Local<Value>());
 			return;
 		}

--- a/android/kroll-apt/src/java/org/appcelerator/kroll/annotations/generator/ProxyBindingV8.h.fm
+++ b/android/kroll-apt/src/java/org/appcelerator/kroll/annotations/generator/ProxyBindingV8.h.fm
@@ -1,6 +1,6 @@
 /**
  * Appcelerator Titanium Mobile
- * Copyright (c) 2011-2016 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2011-2018 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
@@ -21,7 +21,7 @@ public:
 	explicit ${className}();
 
 	static void bindProxy(v8::Local<v8::Object>, v8::Local<v8::Context>);
-	static v8::Local<v8::FunctionTemplate> getProxyTemplate(v8::Isolate*);
+	static v8::Local<v8::FunctionTemplate> getProxyTemplate(v8::Local<v8::Context>);
 	static void dispose(v8::Isolate*);
 
 	static jclass javaClass;
@@ -45,7 +45,7 @@ private:
 	</@Proxy.listDynamicProperties>
 
 	<#if interceptor??>
-	static void interceptor(v8::Local<v8::String> property, const v8::PropertyCallbackInfo<v8::Value>& info);
+	static void interceptor(v8::Local<v8::Name> property, const v8::PropertyCallbackInfo<v8::Value>& info);
 	</#if>
 };
 

--- a/android/package.json
+++ b/android/package.json
@@ -11,11 +11,14 @@
 	"version": "__VERSION__",
 	"author": "Appcelerator, Inc. <info@appcelerator.com>",
 	"maintainers": [
-		"Chris Barber <cbarber@appcelerator.com>"
+		"Chris Williams <cwilliams@axway.com>",
+		"Gary Mathews <gmathews@axway.com>",
+		"Josh Quick <jquick@axway.com>",
+		"Chris Barber <cbarber@axway.com>"
 	],
 	"architectures": ["arm64-v8a", "armeabi-v7a", "x86"],
 	"v8": {
-		"version": "6.2.414.36",
+		"version": "7.0.276.9",
 		"mode": "release"
 	},
 	"minSDKVersion": "16",

--- a/android/runtime/v8/src/java/org/appcelerator/kroll/runtime/v8/V8Runtime.java
+++ b/android/runtime/v8/src/java/org/appcelerator/kroll/runtime/v8/V8Runtime.java
@@ -100,14 +100,6 @@ public final class V8Runtime extends KrollRuntime implements Handler.Callback
 
 		if (jsDebugger != null) {
 			jsDebugger.start();
-		} else if (deployData.isProfilerEnabled()) {
-			try {
-				Class<?> clazz = Class.forName("org.appcelerator.titanium.profiler.TiProfiler");
-				Method method = clazz.getMethod("startProfiler", new Class[0]);
-				method.invoke(clazz, new Object[0]);
-			} catch (Exception e) {
-				Log.e(TAG, "Unable to load profiler.", e);
-			}
 		}
 
 		loadExternalModules();
@@ -161,16 +153,6 @@ public final class V8Runtime extends KrollRuntime implements Handler.Callback
 	@Override
 	public void doDispose()
 	{
-		TiDeployData deployData = getKrollApplication().getDeployData();
-		if (deployData.isProfilerEnabled()) {
-			try {
-				Class<?> clazz = Class.forName("org.appcelerator.titanium.profiler.TiProfiler");
-				Method method = clazz.getMethod("stopProfiler", new Class[0]);
-				method.invoke(clazz, new Object[0]);
-			} catch (Exception e) {
-				Log.e(TAG, "Unable to stop profiler.", e);
-			}
-		}
 		nativeDispose();
 	}
 

--- a/android/runtime/v8/src/native/Android.mk
+++ b/android/runtime/v8/src/native/Android.mk
@@ -51,11 +51,7 @@ CFLAGS += -Os -ffunction-sections -fdata-sections
 LDLIBS += -Wl,--gc-sections,--strip-all
 
 # exclude v8 libraries
-LDLIBS += -Wl,--exclude-libs=libv8_libbase
-LDLIBS += -Wl,--exclude-libs=libv8_libplatform
-LDLIBS += -Wl,--exclude-libs=libv8_nosnapshot
-LDLIBS += -Wl,--exclude-libs=libv8_builtins_generators
-LDLIBS += -Wl,--exclude-libs=libv8_builtins_setup
+LDLIBS += -Wl,--exclude-libs=libv8_monolith
 
 # tune for common architectures
 ifeq ($(TARGET_ARCH_ABI),arm64-v8a)
@@ -79,8 +75,7 @@ LOCAL_CFLAGS := $(CFLAGS)
 LOCAL_LDLIBS := $(LDLIBS)
 LOCAL_SRC_FILES := $(SRC_FILES)
 
-# When setting v8_enable_i18n_support=0
-LOCAL_WHOLE_STATIC_LIBRARIES := libv8_libbase libv8_libplatform libv8_base libv8_nosnapshot libv8_builtins_generators libv8_builtins_setup
+LOCAL_WHOLE_STATIC_LIBRARIES := libv8_monolith
 
 include $(BUILD_SHARED_LIBRARY)
 

--- a/android/runtime/v8/src/native/Android.mk
+++ b/android/runtime/v8/src/native/Android.mk
@@ -51,7 +51,7 @@ CFLAGS += -Os -ffunction-sections -fdata-sections
 LDLIBS += -Wl,--gc-sections,--strip-all
 
 # exclude v8 libraries
-LDLIBS += -Wl,--exclude-libs=libv8_monolith
+#LDLIBS += -Wl,--exclude-libs=libv8_monolith
 
 # tune for common architectures
 ifeq ($(TARGET_ARCH_ABI),arm64-v8a)

--- a/android/runtime/v8/src/native/JSDebugger.cpp
+++ b/android/runtime/v8/src/native/JSDebugger.cpp
@@ -85,7 +85,7 @@ void JSDebugger::sendCommand(JNIEnv *env, jstring command)
 
 	v8::Local<v8::Value> stringValue = TypeConverter::javaStringToJsString(V8Runtime::v8_isolate, env, command);
 	v8::Local<v8::String> message = stringValue.As<v8::String>();
-	v8::String::Value buffer(message);
+	v8::String::Value buffer(V8Runtime::v8_isolate, message);
 	v8_inspector::StringView message_view(*buffer, buffer.length());
 	client__->sendMessage(message_view);
 
@@ -121,7 +121,7 @@ void JSDebugger::receive(v8::Local<v8::String> message)
 	JNIEnv *env = JNIUtil::getJNIEnv();
 	ASSERT(env != NULL);
 
-	jstring s = TypeConverter::jsStringToJavaString(env, message);
+	jstring s = TypeConverter::jsStringToJavaString(V8Runtime::v8_isolate, env, message);
 	env->CallVoidMethod(debugger__, handleMessage__, s);
 	env->DeleteLocalRef(s);
 }

--- a/android/runtime/v8/src/native/Proxy.cpp
+++ b/android/runtime/v8/src/native/Proxy.cpp
@@ -30,9 +30,6 @@ using namespace v8;
 namespace titanium {
 
 Persistent<FunctionTemplate> Proxy::baseProxyTemplate;
-Persistent<String> Proxy::javaClassSymbol;
-Persistent<String> Proxy::constructorSymbol;
-Persistent<String> Proxy::inheritSymbol;
 Persistent<String> Proxy::propertiesSymbol;
 Persistent<String> Proxy::lengthSymbol;
 Persistent<String> Proxy::sourceUrlSymbol;
@@ -45,22 +42,15 @@ Proxy::Proxy() :
 void Proxy::bindProxy(Local<Object> exports, Local<Context> context)
 {
 	Isolate* isolate = context->GetIsolate();
-	Local<String> javaClass = NEW_SYMBOL(isolate, "__javaClass__");
-	javaClassSymbol.Reset(isolate, javaClass);
-	constructorSymbol.Reset(isolate, NEW_SYMBOL(isolate, "constructor"));
-	inheritSymbol.Reset(isolate, NEW_SYMBOL(isolate, "inherit"));
 	propertiesSymbol.Reset(isolate, NEW_SYMBOL(isolate, "_properties"));
 	lengthSymbol.Reset(isolate, NEW_SYMBOL(isolate, "length"));
 	sourceUrlSymbol.Reset(isolate, NEW_SYMBOL(isolate, "sourceUrl"));
 
-	Local<FunctionTemplate> proxyTemplate = FunctionTemplate::New(isolate);
+	Local<FunctionTemplate> proxyTemplate = FunctionTemplate::New(isolate, 0, External::New(isolate, JNIUtil::krollProxyClass));
 	Local<String> proxySymbol = NEW_SYMBOL(isolate, "Proxy");
 	proxyTemplate->InstanceTemplate()->SetInternalFieldCount(kInternalFieldCount);
 	proxyTemplate->SetClassName(proxySymbol);
 	proxyTemplate->Inherit(EventEmitter::constructorTemplate.Get(isolate));
-
-	proxyTemplate->Set(javaClass, ProxyFactory::getJavaClassName(isolate, JNIUtil::krollProxyClass),
-		static_cast<PropertyAttribute>(DontDelete | DontEnum));
 
 	SetProtoMethod(isolate, proxyTemplate, "_hasListenersForEventType", hasListenersForEventType);
 	SetProtoMethod(isolate, proxyTemplate, "onPropertiesChanged", proxyOnPropertiesChanged);
@@ -72,7 +62,7 @@ void Proxy::bindProxy(Local<Object> exports, Local<Context> context)
 	Local<Function> constructor;
 	MaybeLocal<Function> maybeConstructor = proxyTemplate->GetFunction(context);
 	if (maybeConstructor.ToLocal(&constructor)) {
-		exports->Set(proxySymbol, constructor);
+		exports->Set(context, proxySymbol, constructor);
 	} else {
 		V8Util::fatalException(isolate, tryCatch);
 	}
@@ -80,47 +70,53 @@ void Proxy::bindProxy(Local<Object> exports, Local<Context> context)
 
 static Local<Value> getPropertyForProxy(Isolate* isolate, Local<Name> property, Local<Object> proxy)
 {
+	Local<Context> context = isolate->GetCurrentContext();
 	// Call getProperty on the Proxy to get the property.
 	// We define this method in JavaScript on the Proxy prototype.
-	Local<Value> getProperty = proxy->Get(STRING_NEW(isolate, "getProperty"));
-	if (!getProperty.IsEmpty() && getProperty->IsFunction()) {
-		Local<Value> argv[1] = { property };
-		MaybeLocal<Value> value = getProperty.As<Function>()->Call(isolate->GetCurrentContext(), proxy, 1, argv);
-		if (value.IsEmpty()) {
-			return Undefined(isolate);
-		}
-		return value.ToLocalChecked();
+	MaybeLocal<Value> maybeGetProperty = proxy->Get(context, STRING_NEW(isolate, "getProperty"));
+	if (maybeGetProperty.IsEmpty()) {
+		LOGE(TAG, "Unable to lookup Proxy.prototype.getProperty");
+		return Undefined(isolate);
 	}
 
-	LOGE(TAG, "Unable to lookup Proxy.prototype.getProperty");
-	return Undefined(isolate);
+	Local<Value> getProperty = maybeGetProperty.ToLocalChecked();
+	if (!getProperty->IsFunction()) {
+		LOGE(TAG, "Proxy.prototype.getProperty is not a Function!");
+		return Undefined(isolate);
+	}
+
+	Local<Value> argv[1] = { property };
+	MaybeLocal<Value> value = getProperty.As<Function>()->Call(context, proxy, 1, argv);
+	return value.FromMaybe(Undefined(isolate).As<Value>());
 }
 
 // This variant is used when accessing a property in standard JS fashion (i.e. obj.text or obj['text'])
 void Proxy::getProperty(Local<Name> property, const PropertyCallbackInfo<Value>& args)
 {
 	Isolate* isolate = args.GetIsolate();
-	args.GetReturnValue().Set(getPropertyForProxy(isolate, property->ToString(isolate), args.Holder()));
+	args.GetReturnValue().Set(getPropertyForProxy(isolate, property, args.Holder()));
 }
 
 // This variant is used when accessing a property through a getter method (i.e. obj.getText())
 void Proxy::getProperty(const FunctionCallbackInfo<Value>& args)
 {
 	Isolate* isolate = args.GetIsolate();
+	Local<Context> context = isolate->GetCurrentContext();
 	// The name of the property can be passed either as
 	// an argument or a data parameter.
-	Local<String> name;
-	if (args.Length() >= 1) {
-		name = args[0]->ToString(isolate);
-	} else if (args.Data()->IsString()) {
-		name = args.Data().As<String>();
+	// Only support symbols/Strings for now. I think we handle indices differently
+	Local<Name> name;
+	if (args.Length() >= 1 && args[0]->IsName()) { // already String/Symbol
+		name = args[0].As<Name>();
+	} else if (args.Data()->IsName()) {
+		name = args.Data().As<Name>();
 	} else {
-		JSException::Error(isolate, "Requires property name.");
+		JSException::Error(isolate, "Requires property name as Symbol or String.");
 		return;
 	}
 
 	// Spit out deprecation notice to use normal property getter
-	v8::String::Utf8Value propertyKey(name);
+	v8::String::Utf8Value propertyKey(isolate, name);
 	LOGW(TAG, "Automatic getter methods for properties are deprecated in SDK 8.0.0 and will be removed in SDK 9.0.0. Please access the property in standard JS style: obj.%s; or obj['%s'];", *propertyKey, *propertyKey);
 
 	args.GetReturnValue().Set(getPropertyForProxy(isolate, name, args.Holder()));
@@ -129,23 +125,29 @@ void Proxy::getProperty(const FunctionCallbackInfo<Value>& args)
 static void setPropertyOnProxy(Isolate* isolate, Local<Name> property, Local<Value> value, Local<Object> proxy)
 {
 	// Call Proxy.prototype.setProperty.
-	Local<Value> setProperty = proxy->Get(STRING_NEW(isolate, "setProperty"));
-	if (!setProperty.IsEmpty() && setProperty->IsFunction()) {
-		Local<Value> argv[2] = { property, value };
-		setProperty.As<Function>()->Call(isolate->GetCurrentContext(), proxy, 2, argv);
+	Local<Context> context = isolate->GetCurrentContext();
+	MaybeLocal<Value> maybeSetProperty = proxy->Get(context, STRING_NEW(isolate, "setProperty"));
+	if (maybeSetProperty.IsEmpty()) {
+		LOGE(TAG, "Unable to lookup Proxy.prototype.setProperty");
 		return;
 	}
 
-	LOGE(TAG, "Unable to lookup Proxy.prototype.setProperty");
+	Local<Value>setProperty = maybeSetProperty.ToLocalChecked();
+	if (!setProperty->IsFunction()) {
+		LOGE(TAG, "Proxy.prototype.setProperty isn't a function!!!");
+		return;
+	}
+	Local<Value> argv[2] = { property, value };
+	setProperty.As<Function>()->Call(context, proxy, 2, argv);
 }
 
 void Proxy::setProperty(Local<Name> property, Local<Value> value, const PropertyCallbackInfo<void>& info)
 {
 	Isolate* isolate = info.GetIsolate();
-	setPropertyOnProxy(isolate, property->ToString(isolate), value, info.This());
+	setPropertyOnProxy(isolate, property, value, info.This());
 }
 
-static void onPropertyChangedForProxy(Isolate* isolate, Local<String> property, Local<Value> value, Local<Object> proxyObject)
+static void onPropertyChangedForProxy(Isolate* isolate, Local<Name> property, Local<Value> value, Local<Object> proxyObject)
 {
 	Proxy* proxy = NativeObject::Unwrap<Proxy>(proxyObject);
 
@@ -154,8 +156,9 @@ static void onPropertyChangedForProxy(Isolate* isolate, Local<String> property, 
 		LOG_JNIENV_GET_ERROR(TAG);
 		return;
 	}
-
-	jstring javaProperty = TypeConverter::jsStringToJavaString(env, property);
+	// FIXME how can we handle symbols?
+	Local<Context> context = isolate->GetCurrentContext();
+	jstring javaProperty = TypeConverter::jsStringToJavaString(isolate, env, property->ToString(context).FromMaybe(String::Empty(isolate)));
 	bool javaValueIsNew;
 	jobject javaValue = TypeConverter::jsValueToJavaObject(isolate, env, value, &javaValueIsNew);
 
@@ -187,7 +190,7 @@ static void onPropertyChangedForProxy(Isolate* isolate, Local<String> property, 
 void Proxy::onPropertyChanged(Local<Name> property, Local<Value> value, const v8::PropertyCallbackInfo<void>& info)
 {
 	Isolate* isolate = info.GetIsolate();
-	onPropertyChangedForProxy(isolate, property->ToString(isolate), value, info.Holder());
+	onPropertyChangedForProxy(isolate, property, value, info.Holder());
 }
 
 // This variant is used when accessing a property through a getter method (i.e. setText('whatever'))
@@ -199,9 +202,9 @@ void Proxy::onPropertyChanged(const v8::FunctionCallbackInfo<v8::Value>& args)
 		return;
 	}
 
-	Local<String> name = args.Data()->ToString(isolate);
+	Local<Name> name = args.Data().As<Name>();
 	// Spit out deprecation notice to use normal property setter, not setX() style method.
-	v8::String::Utf8Value propertyKey(name);
+	v8::String::Utf8Value propertyKey(isolate, name);
 	LOGW(TAG, "Automatic setter methods for properties are deprecated in SDK 8.0.0 and will be removed in SDK 9.0.0. Please modify the property in standard JS style: obj.%s = value; or obj['%s'] = value;", *propertyKey, *propertyKey);
 
 	Local<Value> value = args[0];
@@ -287,12 +290,13 @@ void Proxy::hasListenersForEventType(const v8::FunctionCallbackInfo<v8::Value>& 
 	}
 	Proxy* proxy = NativeObject::Unwrap<Proxy>(holder);
 
-	Local<String> eventType = args[0]->ToString(isolate);
+	// TODO Support Symbols for event types?
+	Local<String> eventType = args[0].As<String>();
 	Local<Boolean> hasListeners = args[1]->ToBoolean(isolate);
 
 	jobject javaProxy = proxy->getJavaObject();
 	jobject krollObject = env->GetObjectField(javaProxy, JNIUtil::krollProxyKrollObjectField);
-	jstring javaEventType = TypeConverter::jsStringToJavaString(env, eventType);
+	jstring javaEventType = TypeConverter::jsStringToJavaString(isolate, env, eventType);
 
 	proxy->unreferenceJavaObject(javaProxy);
 
@@ -327,13 +331,14 @@ void Proxy::onEventFired(const v8::FunctionCallbackInfo<v8::Value>& args)
 	}
 	Proxy* proxy = NativeObject::Unwrap<Proxy>(holder);
 
-	Local<String> eventType = args[0]->ToString(isolate);
+	// TODO Support Symbols for event types?
+	Local<String> eventType = args[0].As<String>();
 	Local<Value> eventData = args[1];
 
 	jobject javaProxy = proxy->getJavaObject();
 	jobject krollObject = env->GetObjectField(javaProxy, JNIUtil::krollProxyKrollObjectField);
 
-	jstring javaEventType = TypeConverter::jsStringToJavaString(env, eventType);
+	jstring javaEventType = TypeConverter::jsStringToJavaString(isolate, env, eventType);
 	bool isNew;
 	jobject javaEventData = TypeConverter::jsValueToJavaObject(isolate, env, eventData, &isNew);
 
@@ -359,14 +364,12 @@ void Proxy::onEventFired(const v8::FunctionCallbackInfo<v8::Value>& args)
 
 Local<FunctionTemplate> Proxy::inheritProxyTemplate(Isolate* isolate,
 	Local<FunctionTemplate> superTemplate, jclass javaClass,
-	Local<String> className, Local<Function> callback)
+	Local<String> className)
 {
 	EscapableHandleScope scope(isolate);
 
-	Local<FunctionTemplate> inheritedTemplate = FunctionTemplate::New(isolate, proxyConstructor, callback);
-	inheritedTemplate->Set(javaClassSymbol.Get(isolate),
-		ProxyFactory::getJavaClassName(isolate, javaClass),
-		static_cast<PropertyAttribute>(DontDelete | DontEnum));
+	// Wrap the java class in an External and we can access it via FunctionCallbackInfo.Data() in #proxyConstructor
+	Local<FunctionTemplate> inheritedTemplate = FunctionTemplate::New(isolate, proxyConstructor, External::New(isolate, javaClass));
 
 	inheritedTemplate->InstanceTemplate()->SetInternalFieldCount(kInternalFieldCount);
 	inheritedTemplate->SetClassName(className);
@@ -384,34 +387,31 @@ void Proxy::proxyConstructor(const v8::FunctionCallbackInfo<v8::Value>& args)
 	JNIEnv *env = JNIScope::getEnv();
 	Local<Object> jsProxy = args.This();
 
+	TryCatch tryCatch(isolate);
+
 	// First things first, we need to wrap the object in case future calls need to unwrap proxy!
 	Proxy* proxy = new Proxy();
 	proxy->Wrap(jsProxy);
 	proxy->Ref(); // force a reference so we don't get GC'd before we can attach the Java object
 
+	Local<Context> context = isolate->GetCurrentContext();
+
 	// every instance gets a special "_properties" object for us to use internally for get/setProperty
-	jsProxy->DefineOwnProperty(isolate->GetCurrentContext(), propertiesSymbol.Get(isolate), Object::New(isolate), static_cast<PropertyAttribute>(DontEnum));
+	jsProxy->DefineOwnProperty(context, propertiesSymbol.Get(isolate), Object::New(isolate), static_cast<PropertyAttribute>(DontEnum));
 
 	// Now we hook up a java Object from the JVM...
 	jobject javaProxy = Proxy::unwrapJavaProxy(args); // do we already have one that got passed in?
 	bool deleteRef = false;
 	if (!javaProxy) {
-		// No passed in java object, so let's create an instance
-		// Look up java class from prototype...
-		Local<Object> prototype = jsProxy->GetPrototype()->ToObject(isolate);
-		Local<Function> constructor = prototype->Get(constructorSymbol.Get(isolate)).As<Function>();
-		Local<String> javaClassName = constructor->Get(javaClassSymbol.Get(isolate)).As<String>();
-		v8::String::Utf8Value javaClassNameVal(javaClassName);
-		std::string javaClassNameString(*javaClassNameVal);
-		std::replace( javaClassNameString.begin(), javaClassNameString.end(), '.', '/');
-		// Create a copy of the char* since I'm seeing it get mangled when passed on to findClass later
-		const char* jniName = strdup(javaClassNameString.c_str());
-		jclass javaClass = JNIUtil::findClass(jniName);
+		if (args.Data().IsEmpty() || !args.Data()->IsExternal()) {
+			String::Utf8Value jsClassName(isolate, jsProxy->GetConstructorName());
+			LOGE(TAG, "No JNI Java Class reference set for proxy java proxy type %s", *jsClassName);
+			return;
+		}
 
+		jclass javaClass = (jclass) args.Data().As<External>()->Value();
 		// Now we create an instance of the class and hook it up
-		LOGD(TAG, "Creating java proxy for class %s", jniName);
 		javaProxy = ProxyFactory::createJavaProxy(javaClass, jsProxy, args);
-		env->DeleteGlobalRef(javaClass); // JNIUtil::findClass returns a global reference to a class
 		deleteRef = true;
 	}
 	proxy->attach(javaProxy);
@@ -423,11 +423,11 @@ void Proxy::proxyConstructor(const v8::FunctionCallbackInfo<v8::Value>& args)
 		bool extend = true;
 		Local<Object> createProperties = args[0].As<Object>();
 		Local<String> constructorName = createProperties->GetConstructorName();
-		if (strcmp(*v8::String::Utf8Value(constructorName), "Arguments") == 0) {
+		if (strcmp(*v8::String::Utf8Value(isolate, constructorName), "Arguments") == 0) {
 			extend = false;
-			int32_t argsLength = createProperties->Get(STRING_NEW(isolate, "length"))->Int32Value();
+			int32_t argsLength = createProperties->Get(context, lengthSymbol.Get(isolate)).FromMaybe(Integer::New(isolate, 0).As<Value>())->Int32Value(context).FromMaybe(0);
 			if (argsLength > 1) {
-				Local<Value> properties = createProperties->Get(1);
+				Local<Value> properties = createProperties->Get(context, 1).FromMaybe(Undefined(isolate).As<Value>());
 				if (properties->IsObject()) {
 					extend = true;
 					createProperties = properties.As<Object>();
@@ -436,37 +436,42 @@ void Proxy::proxyConstructor(const v8::FunctionCallbackInfo<v8::Value>& args)
 		}
 
 		if (extend) {
-			Local<Array> names = createProperties->GetOwnPropertyNames();
-			int length = names->Length();
-			Local<Object> properties = jsProxy->Get(propertiesSymbol.Get(isolate))->ToObject(isolate);
+			MaybeLocal<Array> maybePropertyNames = createProperties->GetOwnPropertyNames(context);
+			if (!maybePropertyNames.IsEmpty()) { // FIXME Handle when empty!
+				Local<Array> names = maybePropertyNames.ToLocalChecked();
+				int length = names->Length();
+				MaybeLocal<Value> maybeProperties = jsProxy->Get(context, propertiesSymbol.Get(isolate));
+				if (!maybeProperties.IsEmpty()) { // FIXME Handle when empty!
+					Local<Object> properties = maybeProperties.ToLocalChecked().As<Object>();
 
-			for (int i = 0; i < length; ++i) {
-				Local<Value> name = names->Get(i);
-				Local<Value> value = createProperties->Get(name);
-				bool isProperty = true;
-				if (name->IsString()) {
-					Local<String> nameString = name.As<String>();
-					if (!jsProxy->HasRealNamedCallbackProperty(nameString)
-						&& !jsProxy->HasRealNamedProperty(nameString)) {
-						jsProxy->Set(name, value);
-						isProperty = false;
+					for (int i = 0; i < length; ++i) {
+						MaybeLocal<Value> maybeName = names->Get(context, i);
+						if (maybeName.IsEmpty()) {
+							continue;
+						}
+						Local<Value> name = maybeName.ToLocalChecked();
+						MaybeLocal<Value> maybeValue = createProperties->Get(context, name);
+						if (maybeValue.IsEmpty()) {
+							continue;
+						}
+
+						Local<Value> value = maybeValue.ToLocalChecked();
+						bool isProperty = true;
+						if (name->IsName()) {
+							Local<Name> nameStringOrSymbol = name.As<Name>();
+							if (!jsProxy->HasRealNamedCallbackProperty(context, nameStringOrSymbol).FromMaybe(false)
+								&& !jsProxy->HasRealNamedProperty(context, nameStringOrSymbol).FromMaybe(false)) {
+								jsProxy->Set(context, name, value);
+								isProperty = false;
+							}
+						}
+						if (isProperty) {
+							properties->Set(context, name, value);
+						}
 					}
-				}
-				if (isProperty) {
-					properties->Set(name, value);
 				}
 			}
 		}
-	}
-
-
-	if (!args.Data().IsEmpty() && args.Data()->IsFunction()) {
-		Local<Function> proxyFn = args.Data().As<Function>();
-		Local<Value> *fnArgs = new Local<Value>[length];
-		for (int i = 0; i < length; ++i) {
-			fnArgs[i] = args[i];
-		}
-		proxyFn->Call(isolate->GetCurrentContext(), jsProxy, length, fnArgs);
 	}
 
 	if (deleteRef) {
@@ -502,19 +507,21 @@ void Proxy::proxyOnPropertiesChanged(const v8::FunctionCallbackInfo<v8::Value>& 
 		return;
 	}
 
+	Local<Context> context = isolate->GetCurrentContext();
 	Local<Array> changes = args[0].As<Array>();
 	uint32_t length = changes->Length();
 	jobjectArray jChanges = env->NewObjectArray(length, JNIUtil::objectClass, NULL);
 
 	for (uint32_t i = 0; i < length; ++i) {
-		Local<Array> change = changes->Get(i).As<Array>();
-		Local<String> name = change->Get(INDEX_NAME)->ToString(isolate);
-		Local<Value> oldValue = change->Get(INDEX_OLD_VALUE);
-		Local<Value> value = change->Get(INDEX_VALUE);
+		// FIXME Actually handle possible empty values
+		Local<Array> change = changes->Get(context, i).ToLocalChecked().As<Array>();
+		Local<String> name = change->Get(context, INDEX_NAME).ToLocalChecked()->ToString(context).ToLocalChecked();
+		Local<Value> oldValue = change->Get(context, INDEX_OLD_VALUE).ToLocalChecked();
+		Local<Value> value = change->Get(context, INDEX_VALUE).ToLocalChecked();
 
 		jobjectArray jChange = env->NewObjectArray(3, JNIUtil::objectClass, NULL);
 
-		jstring jName = TypeConverter::jsStringToJavaString(env, name);
+		jstring jName = TypeConverter::jsStringToJavaString(isolate, env, name);
 		env->SetObjectArrayElement(jChange, INDEX_NAME, jName);
 		env->DeleteLocalRef(jName);
 
@@ -550,9 +557,6 @@ void Proxy::proxyOnPropertiesChanged(const v8::FunctionCallbackInfo<v8::Value>& 
 void Proxy::dispose(Isolate* isolate)
 {
 	baseProxyTemplate.Reset();
-	javaClassSymbol.Reset();
-	constructorSymbol.Reset();
-	inheritSymbol.Reset();
 	propertiesSymbol.Reset();
 	lengthSymbol.Reset();
 	sourceUrlSymbol.Reset();

--- a/android/runtime/v8/src/native/Proxy.h
+++ b/android/runtime/v8/src/native/Proxy.h
@@ -1,6 +1,6 @@
 /*
  * Appcelerator Titanium Mobile
- * Copyright (c) 2011-2017 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2011-2018 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
@@ -20,15 +20,13 @@ class Proxy : public JavaObject
 public:
 	enum {
 		kJavaObject = 0,
-		kJavaClass,
-		kPropertyCache,
-		kInternalFieldCount
+		kInternalFieldCount // Just one internal field on proxies, and it wraps the java object
 	};
 
 	static v8::Persistent<v8::FunctionTemplate> baseProxyTemplate;
-	static v8::Persistent<v8::String> javaClassSymbol, constructorSymbol;
-	static v8::Persistent<v8::String> inheritSymbol, propertiesSymbol;
-	static v8::Persistent<v8::String> lengthSymbol, sourceUrlSymbol;
+	static v8::Persistent<v8::String> propertiesSymbol;
+	static v8::Persistent<v8::String> lengthSymbol;
+	static v8::Persistent<v8::String> sourceUrlSymbol;
 
 	Proxy();
 
@@ -113,28 +111,6 @@ public:
 	 */
 	static void onEventFired(const v8::FunctionCallbackInfo<v8::Value>& args);
 
-	// This provides Javascript a way to extend one of our native / wrapped
-	// templates without needing to know about the internal java class.
-	//
-	// An example of what this might look like from JS:
-	// var MyProxy = Ti.UI.View.inherit(function MyView(options) {
-	//     // constructor code goes here.. (optional)
-	// });
-	template<typename ProxyClass>
-	static void inherit(const v8::FunctionCallbackInfo<v8::Value>& args)
-	{
-		v8::Isolate* isolate = args.GetIsolate();
-		v8::HandleScope scope(isolate);
-		v8::Local<v8::Function> fn = args[0].As<v8::Function>();
-
-		v8::Local<v8::FunctionTemplate> newType = inheritProxyTemplate(
-			isolate,
-			ProxyClass::getProxyTemplate(isolate),
-			ProxyClass::javaClass,
-			fn->GetName()->ToString(isolate), fn);
-		args.GetReturnValue().Set(newType->GetFunction());
-	}
-
 	/**
 	 * Inherit a built-in proxy template for use in Javascript (used by generated code)
 	 */
@@ -142,8 +118,7 @@ public:
 		v8::Isolate* isolate,
 		v8::Local<v8::FunctionTemplate> superTemplate,
 		jclass javaClass,
-		v8::Local<v8::String> className,
-		v8::Local<v8::Function> callback = v8::Local<v8::Function>());
+		v8::Local<v8::String> className);
 
 	static void dispose(v8::Isolate* isolate);
 
@@ -154,12 +129,10 @@ private:
 	 * Here we typically:
 	 * - wrap the js object in a Proxy instance
 	 * - define an own property "_properties" used for #getProperty and #setProperty callbacks
-	 * -
-	 * - look up the prototype of the JS object, grab the constructor, then ask for the __javaClass__ property.
-	 *   (See #javaClassPropertyCallback below) to get the jclass we need to instantiate
+	 * - Grab the Java class inside an External from the Data() value.
+	 * This got set back in #inheritProxyTemplate when we generate the FunctionTemplate
 	 * - attach the Java Proxy instantiated to this native Proxy.
 	 * - Deal with argunents passed
-	 * - If using the inherit function, look for that hanging as the Data() of args and invoke it.
 	 *
 	 * @param args The constructor arguments.
 	 */

--- a/android/runtime/v8/src/native/ProxyFactory.cpp
+++ b/android/runtime/v8/src/native/ProxyFactory.cpp
@@ -42,32 +42,44 @@ Local<Object> ProxyFactory::createV8Proxy(v8::Isolate* isolate, Local<Value> cla
 		return Local<Object>();
 	}
 
+	Local<Context> context = isolate->GetCurrentContext();
 	v8::EscapableHandleScope scope(isolate);
 
-	Local<Object> exports = KrollBindings::getBinding(isolate, className->ToString(isolate));
+	Local<Object> exports = KrollBindings::getBinding(isolate, className->ToString(context).FromMaybe(String::Empty(isolate)));
 
 	if (exports.IsEmpty()) {
-		v8::String::Utf8Value classStr(className);
+		v8::String::Utf8Value classStr(isolate, className);
 		LOGE(TAG, "Failed to find class for %s", *classStr);
 		LOG_JNIENV_ERROR("while creating V8 Proxy.");
 		return Local<Object>();
 	}
 
 	// FIXME: We pick the first item in exports as the constructor. We should do something more intelligent (for ES6 look at default export?)
-	Local<Array> names = exports->GetPropertyNames();
-	if (names->Length() < 1) {
-		v8::String::Utf8Value classStr(className);
-		LOGE(TAG, "Failed to find class for %s", *classStr);
+	Local<Array> names;
+	MaybeLocal<Array> possibleNames = exports->GetPropertyNames(context);
+	if (!possibleNames.ToLocal(&names) || names->Length() < 1) {
+		v8::String::Utf8Value classStr(isolate, className);
+		LOGE(TAG, "Failed to find constructor in exports for %s", *classStr);
 		LOG_JNIENV_ERROR("while creating V8 Proxy.");
 		return Local<Object>();
 	}
-	Local<Function> creator = exports->Get(names->Get(0)).As<Function>();
+	MaybeLocal<Value> possibleConstructor = exports->Get(context, names->Get(context, 0).ToLocalChecked());
+	if (possibleConstructor.IsEmpty()) {
+		v8::String::Utf8Value classStr(isolate, className);
+		LOGE(TAG, "Failed to get constructor in exports for %s", *classStr);
+		LOG_JNIENV_ERROR("while creating V8 Proxy.");
+		return Local<Object>();
+	}
+
+	Local<Function> creator = possibleConstructor.ToLocalChecked().As<Function>();
 
 	Local<Value> javaObjectExternal = External::New(isolate, javaProxy);
 	TryCatch tryCatch(isolate);
 	Local<Value> argv[1] = { javaObjectExternal };
-	Local<Object> v8Proxy = creator->NewInstance(1, argv);
-	if (tryCatch.HasCaught()) {
+
+	Local<Object> v8Proxy;
+	MaybeLocal<Object> maybeV8Proxy = creator->NewInstance(context, 1, argv);
+	if (!maybeV8Proxy.ToLocal(&v8Proxy)) {
 		LOGE(TAG, "Exception thrown while creating V8 proxy.");
 		V8Util::reportException(isolate, tryCatch);
 		return Local<Object>();
@@ -97,21 +109,12 @@ jobject ProxyFactory::createJavaProxy(jclass javaClass, Local<Object> v8Proxy, c
 		return NULL;
 	}
 
+	Local<Context> context = isolate->GetCurrentContext();
+
 	// Grab the Proxy pointer from the JSObject that wraps it,
 	// pass along the address of the Proxy to use a pointer to get it back later when we deal with this object
 	titanium::Proxy* proxy = NativeObject::Unwrap<titanium::Proxy>(v8Proxy); // v8Proxy holds pointer to Proxy object in internal field
 	jlong pv8Proxy = (jlong) proxy; // So now we store pointer to the Proxy on Java side.
-
-	// We also pass the creation URL of the proxy so we can track relative URLs
-	Local<Value> sourceUrl = args.Callee()->GetScriptOrigin().ResourceName();
-	v8::String::Utf8Value sourceUrlValue(sourceUrl);
-
-	const char *url = "app://app.js";
-	jstring javaSourceUrl = NULL;
-	if (sourceUrlValue.length() > 0) {
-		url = *sourceUrlValue;
-		javaSourceUrl = env->NewStringUTF(url);
-	}
 
 	// Determine if this constructor call was made within
 	// the createXYZ() wrapper function. This can be tested by checking
@@ -123,27 +126,39 @@ jobject ProxyFactory::createJavaProxy(jclass javaClass, Local<Object> v8Proxy, c
 		}
 	}
 
+
+	// We also pass the creation URL of the proxy so we can track relative URLs
+	// First see if this is getting passed in for us already
+	jstring javaSourceUrl = NULL;
+
 	// Convert the V8 arguments into Java types so they can be
 	// passed to the Java creator method. Which converter we use
 	// depends how this constructor was called.
 	jobjectArray javaArgs;
 	if (calledFromCreate) {
-		Local<Object> arguments = args[0]->ToObject(isolate);
-		int length = arguments->Get(Proxy::lengthSymbol.Get(isolate))->Int32Value();
+		Local<Object> arguments = args[0].As<Object>();
+		MaybeLocal<Value> lengthValue = arguments->Get(context, Proxy::lengthSymbol.Get(isolate));
+		Maybe<int32_t> length = Nothing<int32_t>();
+		if (!lengthValue.IsEmpty()) {
+			length = lengthValue.ToLocalChecked()->Int32Value(context);
+		}
 		int start = 0;
 
 		// Get the scope variables if provided and extract the source URL.
 		// We need to send that to the Java side when creating the proxy.
-		if (length > 0) {
-			Local<Object> scopeVars = arguments->Get(0)->ToObject(isolate);
-			if (V8Util::constructorNameMatches(isolate, scopeVars, "ScopeVars")) {
-				Local<Value> sourceUrl = scopeVars->Get(Proxy::sourceUrlSymbol.Get(isolate));
-				javaSourceUrl = TypeConverter::jsValueToJavaString(isolate, env, sourceUrl);
-				start = 1;
+		if (length.FromMaybe(0) > 0) {
+			MaybeLocal<Value> maybeFirstArgument = arguments->Get(context, 0);
+			if (!maybeFirstArgument.IsEmpty()) {
+				MaybeLocal<Object> scopeVars = maybeFirstArgument.ToLocalChecked()->ToObject(context);
+				if (!scopeVars.IsEmpty() && V8Util::constructorNameMatches(isolate, scopeVars.ToLocalChecked(), "ScopeVars")) {
+					MaybeLocal<Value> sourceUrl = scopeVars.ToLocalChecked()->Get(context, Proxy::sourceUrlSymbol.Get(isolate));
+					javaSourceUrl = TypeConverter::jsValueToJavaString(isolate, env, sourceUrl.FromMaybe(String::Empty(isolate).As<Value>()));
+					start = 1;
+				}
 			}
 		}
 
-		javaArgs = TypeConverter::jsObjectIndexPropsToJavaArray(isolate, env, arguments, start, length);
+		javaArgs = TypeConverter::jsObjectIndexPropsToJavaArray(isolate, env, arguments, start, length.FromMaybe(0));
 	} else {
 		javaArgs = TypeConverter::jsArgumentsToJavaArray(env, args);
 	}
@@ -151,6 +166,18 @@ jobject ProxyFactory::createJavaProxy(jclass javaClass, Local<Object> v8Proxy, c
 	// This does: Object javaV8Object = new V8Object(pv8Proxy);
 	jobject javaV8Object = env->NewObject(JNIUtil::v8ObjectClass,
 		JNIUtil::v8ObjectInitMethod, pv8Proxy);
+
+	// Crap, we didn't get passed the sourceURL in context. So let's hack this and grab from current stack
+	// So far in every case this was logged in our unit test suite, the URL was either:
+	// - a ti:/whatever.js runtime file
+	// - a module.id/bootstrap.js file
+	// So, I think we can just skip this hack altogether? Or maybe just assume "app://app.js"?
+	if (javaSourceUrl == NULL) {
+		Local<String> sourceUrl = v8::StackTrace::CurrentStackTrace(isolate, 1, v8::StackTrace::kScriptName)->GetFrame(isolate, 0)->GetScriptNameOrSourceURL();
+		// v8::String::Utf8Value sourceUrlThing(isolate, sourceUrl);
+		// LOGE(TAG, "Was given no sourceURL. Trying to hack one from stack trace: %s", *sourceUrlThing);
+		javaSourceUrl = TypeConverter::jsValueToJavaString(isolate, env, sourceUrl);
+	}
 
 	// This does: KrollProxy.createProxy(javaClass, javaV8Object, javaArgs, javaSourceUrl);
 	// Which creates a new instance of the class using default no-arg constructor,

--- a/android/runtime/v8/src/native/TypeConverter.cpp
+++ b/android/runtime/v8/src/native/TypeConverter.cpp
@@ -1,6 +1,6 @@
 /**
  * Appcelerator Titanium Mobile
- * Copyright (c) 2011-2016 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2011-2018 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
@@ -25,85 +25,85 @@ using namespace titanium;
 // Ideally we should "wrap around" when we reach max, but are we really expecting to go through more than 18,446,744,073,709,551,615 functions?
 int64_t TypeConverter::functionIndex = std::numeric_limits<int64_t>::min();
 // The global map to hold persistent functions. We use the index as our "pointer" to store and retrieve the function
-std::map<int64_t, v8::Persistent<v8::Function, v8::CopyablePersistentTraits<v8::Function>>> TypeConverter::functions;
+std::map<int64_t, Persistent<Function, CopyablePersistentTraits<Function>>> TypeConverter::functions;
 
 /****************************** public methods ******************************/
-jshort TypeConverter::jsNumberToJavaShort(v8::Local<v8::Number> jsNumber)
+jshort TypeConverter::jsNumberToJavaShort(Local<Number> jsNumber)
 {
 	return ((jshort) jsNumber->Value());
 }
 
-v8::Local<v8::Number> TypeConverter::javaShortToJsNumber(v8::Isolate* isolate, jshort javaShort)
+Local<Number> TypeConverter::javaShortToJsNumber(Isolate* isolate, jshort javaShort)
 {
-	return v8::Number::New(isolate, (double) javaShort);
+	return Number::New(isolate, (double) javaShort);
 }
 
-jint TypeConverter::jsNumberToJavaInt(v8::Local<v8::Number> jsNumber)
+jint TypeConverter::jsNumberToJavaInt(Local<Number> jsNumber)
 {
 	return ((jint) jsNumber->Value());
 }
 
-v8::Local<v8::Number> TypeConverter::javaIntToJsNumber(v8::Isolate* isolate, jint javaInt)
+Local<Number> TypeConverter::javaIntToJsNumber(Isolate* isolate, jint javaInt)
 {
-	return v8::Number::New(isolate, (double) javaInt);
+	return Number::New(isolate, (double) javaInt);
 }
 
-jlong TypeConverter::jsNumberToJavaLong(v8::Local<v8::Number> jsNumber)
+jlong TypeConverter::jsNumberToJavaLong(Local<Number> jsNumber)
 {
 	return ((jlong) jsNumber->Value());
 }
 
-v8::Local<v8::Number> TypeConverter::javaLongToJsNumber(v8::Isolate* isolate, jlong javaLong)
+Local<Number> TypeConverter::javaLongToJsNumber(Isolate* isolate, jlong javaLong)
 {
-	return v8::Number::New(isolate, (double) javaLong);
+	return Number::New(isolate, (double) javaLong);
 }
 
-jfloat TypeConverter::jsNumberToJavaFloat(v8::Local<v8::Number> jsNumber)
+jfloat TypeConverter::jsNumberToJavaFloat(Local<Number> jsNumber)
 {
 	return ((jfloat) jsNumber->Value());
 }
 
-v8::Local<v8::Number> TypeConverter::javaFloatToJsNumber(v8::Isolate* isolate, jfloat javaFloat)
+Local<Number> TypeConverter::javaFloatToJsNumber(Isolate* isolate, jfloat javaFloat)
 {
-	return v8::Number::New(isolate, (double) javaFloat);
+	return Number::New(isolate, (double) javaFloat);
 }
 
-jdouble TypeConverter::jsNumberToJavaDouble(v8::Local<v8::Number> jsNumber)
+jdouble TypeConverter::jsNumberToJavaDouble(Local<Number> jsNumber)
 {
 	return ((jdouble) jsNumber->Value());
 }
 
-v8::Local<v8::Number> TypeConverter::javaDoubleToJsNumber(v8::Isolate* isolate, jdouble javaDouble)
+Local<Number> TypeConverter::javaDoubleToJsNumber(Isolate* isolate, jdouble javaDouble)
 {
-	return v8::Number::New(isolate, javaDouble);
+	return Number::New(isolate, javaDouble);
 }
 
-jboolean TypeConverter::jsBooleanToJavaBoolean(v8::Local<v8::Boolean> jsBoolean)
+jboolean TypeConverter::jsBooleanToJavaBoolean(Local<Boolean> jsBoolean)
 {
 	return (jsBoolean->Value()) == JNI_TRUE;
 }
 
-v8::Local<v8::Boolean> TypeConverter::javaBooleanToJsBoolean(v8::Isolate* isolate, jboolean javaBoolean)
+Local<Boolean> TypeConverter::javaBooleanToJsBoolean(Isolate* isolate, jboolean javaBoolean)
 {
-	return v8::Boolean::New(isolate, (bool) javaBoolean);
+	return Boolean::New(isolate, (bool) javaBoolean);
 }
 
-jstring TypeConverter::jsStringToJavaString(v8::Local<v8::String> jsString)
+jstring TypeConverter::jsStringToJavaString(Isolate* isolate, Local<String> jsString)
 {
 	JNIEnv *env = JNIScope::getEnv();
 	if (env == NULL) {
 		return NULL;
 	}
-	return TypeConverter::jsStringToJavaString(env, jsString);
+	return TypeConverter::jsStringToJavaString(isolate, env, jsString);
 }
 
-jstring TypeConverter::jsStringToJavaString(JNIEnv *env, v8::Local<v8::String> jsString)
+jstring TypeConverter::jsStringToJavaString(Isolate* isolate, JNIEnv *env, Local<String> jsString)
 {
-	v8::String::Value string(jsString);
+	String::Value string(isolate, jsString);
 	return env->NewString(reinterpret_cast<const jchar*>(*string), string.length());
 }
 
-jstring TypeConverter::jsValueToJavaString(v8::Isolate* isolate, v8::Local<v8::Value> jsValue)
+jstring TypeConverter::jsValueToJavaString(Isolate* isolate, Local<Value> jsValue)
 {
 	JNIEnv *env = JNIScope::getEnv();
 	if (env == NULL) {
@@ -112,39 +112,40 @@ jstring TypeConverter::jsValueToJavaString(v8::Isolate* isolate, v8::Local<v8::V
 	return TypeConverter::jsValueToJavaString(isolate, env, jsValue);
 }
 
-jstring TypeConverter::jsValueToJavaString(v8::Isolate* isolate, JNIEnv *env, v8::Local<v8::Value> jsValue)
+jstring TypeConverter::jsValueToJavaString(Isolate* isolate, JNIEnv *env, Local<Value> jsValue)
 {
 	if (jsValue.IsEmpty() || jsValue->IsNullOrUndefined()) {
 		return NULL;
 	}
 
-	return TypeConverter::jsStringToJavaString(env, jsValue->ToString(isolate));
+	return TypeConverter::jsStringToJavaString(isolate, env, jsValue->ToString(isolate));
 }
 
-v8::Local<v8::Value> TypeConverter::javaStringToJsString(v8::Isolate* isolate, jstring javaString)
+Local<Value> TypeConverter::javaStringToJsString(Isolate* isolate, jstring javaString)
 {
 	JNIEnv *env = JNIScope::getEnv();
 	if (env == NULL) {
-		return v8::String::Empty(isolate);
+		return String::Empty(isolate);
 	}
 	return TypeConverter::javaStringToJsString(isolate, env, javaString);
 }
 
-v8::Local<v8::Value> TypeConverter::javaStringToJsString(v8::Isolate* isolate, JNIEnv *env, jstring javaString)
+Local<Value> TypeConverter::javaStringToJsString(Isolate* isolate, JNIEnv *env, jstring javaString)
 {
 	if (!javaString) {
-		return v8::Null(isolate);
+		return Null(isolate);
 	}
 
 	int nativeStringLength = env->GetStringLength(javaString);
 	const jchar *nativeString = env->GetStringChars(javaString, NULL);
-	v8::Local<v8::String> jsString = v8::String::NewFromTwoByte(isolate, nativeString, v8::String::kNormalString, nativeStringLength);
+	// FIXME Propagate MaybeLocal to caller?
+	Local<String> jsString = String::NewFromTwoByte(isolate, nativeString, NewStringType::kNormal, nativeStringLength).ToLocalChecked();
 	env->ReleaseStringChars(javaString, nativeString);
 
 	return jsString;
 }
 
-jobject TypeConverter::jsDateToJavaDate(v8::Local<v8::Date> jsDate)
+jobject TypeConverter::jsDateToJavaDate(Local<Date> jsDate)
 {
 	JNIEnv *env = JNIScope::getEnv();
 	if (env == NULL) {
@@ -153,21 +154,21 @@ jobject TypeConverter::jsDateToJavaDate(v8::Local<v8::Date> jsDate)
 	return TypeConverter::jsDateToJavaDate(env, jsDate);
 }
 
-jobject TypeConverter::jsDateToJavaDate(JNIEnv *env, v8::Local<v8::Date> jsDate)
+jobject TypeConverter::jsDateToJavaDate(JNIEnv *env, Local<Date> jsDate)
 {
 	return env->NewObject(JNIUtil::dateClass, JNIUtil::dateInitMethod, (jlong) jsDate->ValueOf());
 }
 
-jlong TypeConverter::jsDateToJavaLong(v8::Local<v8::Date> jsDate)
+jlong TypeConverter::jsDateToJavaLong(Local<Date> jsDate)
 {
 	return (jlong) jsDate->ValueOf();
 }
 
-v8::Local<v8::Date> TypeConverter::javaDateToJsDate(v8::Isolate* isolate, jobject javaDate)
+Local<Date> TypeConverter::javaDateToJsDate(Isolate* isolate, jobject javaDate)
 {
 	JNIEnv *env = JNIScope::getEnv();
 	if (env == NULL) {
-		return v8::Local<v8::Date>();
+		return Local<Date>();
 	}
 	return TypeConverter::javaDateToJsDate(isolate, env, javaDate);
 }
@@ -183,7 +184,7 @@ Local<Date> TypeConverter::javaLongToJsDate(Isolate* isolate, jlong javaLong)
 	return Date::New(isolate, (double) javaLong).As<Date>(); // perversely, the date constructor returns Local<value> so we need to cast it
 }
 
-jobject TypeConverter::jsObjectToJavaFunction(v8::Isolate* isolate, v8::Local<v8::Object> jsObject)
+jobject TypeConverter::jsObjectToJavaFunction(Isolate* isolate, Local<Object> jsObject)
 {
 	JNIEnv *env = JNIScope::getEnv();
 	if (!env) {
@@ -192,7 +193,7 @@ jobject TypeConverter::jsObjectToJavaFunction(v8::Isolate* isolate, v8::Local<v8
 	return TypeConverter::jsObjectToJavaFunction(isolate, env, jsObject);
 }
 
-jobject TypeConverter::jsObjectToJavaFunction(v8::Isolate* isolate, JNIEnv *env, v8::Local<v8::Object> jsObject)
+jobject TypeConverter::jsObjectToJavaFunction(Isolate* isolate, JNIEnv *env, Local<Object> jsObject)
 {
 	Local<Function> func = jsObject.As<Function>();
 	Persistent<Function, CopyablePersistentTraits<Function>> jsFunction(isolate, func);
@@ -211,16 +212,16 @@ jobject TypeConverter::jsObjectToJavaFunction(v8::Isolate* isolate, JNIEnv *env,
 	return env->NewObject(JNIUtil::v8FunctionClass, JNIUtil::v8FunctionInitMethod, ptr);
 }
 
-v8::Local<v8::Function> TypeConverter::javaObjectToJsFunction(Isolate* isolate, jobject javaObject)
+Local<Function> TypeConverter::javaObjectToJsFunction(Isolate* isolate, jobject javaObject)
 {
 	JNIEnv *env = JNIScope::getEnv();
 	if (!env) {
-		return v8::Local<v8::Function>();
+		return Local<Function>();
 	}
 	return TypeConverter::javaObjectToJsFunction(isolate, env, javaObject);
 }
 
-v8::Local<v8::Function> TypeConverter::javaObjectToJsFunction(Isolate* isolate, JNIEnv *env, jobject javaObject)
+Local<Function> TypeConverter::javaObjectToJsFunction(Isolate* isolate, JNIEnv *env, jobject javaObject)
 {
 	jlong v8ObjectPointer = env->GetLongField(javaObject, JNIUtil::v8ObjectPtrField);
 	Persistent<Function, CopyablePersistentTraits<Function>> persistentV8Object = TypeConverter::functions.at(v8ObjectPointer);
@@ -283,7 +284,7 @@ Local<Value>* TypeConverter::javaObjectArrayToJsArguments(Isolate* isolate, JNIE
 	return jsArguments;
 }
 
-jarray TypeConverter::jsArrayToJavaArray(v8::Isolate* isolate, v8::Local<v8::Array> jsArray)
+jarray TypeConverter::jsArrayToJavaArray(Isolate* isolate, Local<Array> jsArray)
 {
 	JNIEnv *env = JNIScope::getEnv();
 	if (env == NULL) {
@@ -292,7 +293,7 @@ jarray TypeConverter::jsArrayToJavaArray(v8::Isolate* isolate, v8::Local<v8::Arr
 	return TypeConverter::jsArrayToJavaArray(isolate, env, jsArray);
 }
 
-jarray TypeConverter::jsArrayToJavaArray(v8::Isolate* isolate, JNIEnv *env, v8::Local<v8::Array> jsArray)
+jarray TypeConverter::jsArrayToJavaArray(Isolate* isolate, JNIEnv *env, Local<Array> jsArray)
 {
 	int arrayLength = jsArray->Length();
 	jobjectArray javaArray = env->NewObjectArray(arrayLength, JNIUtil::objectClass, NULL);
@@ -301,22 +302,26 @@ jarray TypeConverter::jsArrayToJavaArray(v8::Isolate* isolate, JNIEnv *env, v8::
 		return NULL;
 	}
 
+	Local<Context> context = isolate->GetCurrentContext();
 	for (int i = 0; i < arrayLength; i++) {
-		v8::Local<v8::Value> element = jsArray->Get(i);
-		bool isNew;
-
-		jobject javaObject = jsValueToJavaObject(isolate, element, &isNew);
-		env->SetObjectArrayElement(javaArray, i, javaObject);
-
-		if (isNew) {
-			env->DeleteLocalRef(javaObject);
+		MaybeLocal<Value> element = jsArray->Get(context, i);
+		if (element.IsEmpty()) {
+			LOGE(TAG, "Failed to get element at index %d, inserting null", i);
+			env->SetObjectArrayElement(javaArray, i, NULL);
+		} else {
+			bool isNew;
+			jobject javaObject = jsValueToJavaObject(isolate, element.ToLocalChecked(), &isNew);
+			env->SetObjectArrayElement(javaArray, i, javaObject);
+			if (isNew) {
+				env->DeleteLocalRef(javaObject);
+			}
 		}
 	}
 
 	return javaArray;
 }
 
-jobjectArray TypeConverter::jsArrayToJavaStringArray(v8::Isolate* isolate, v8::Local<v8::Array> jsArray)
+jobjectArray TypeConverter::jsArrayToJavaStringArray(Isolate* isolate, Local<Array> jsArray)
 {
 	JNIEnv *env = JNIScope::getEnv();
 	if (env == NULL) {
@@ -325,7 +330,7 @@ jobjectArray TypeConverter::jsArrayToJavaStringArray(v8::Isolate* isolate, v8::L
 	return TypeConverter::jsArrayToJavaStringArray(isolate, env, jsArray);
 }
 
-jobjectArray TypeConverter::jsArrayToJavaStringArray(v8::Isolate* isolate, JNIEnv *env, v8::Local<v8::Array> jsArray)
+jobjectArray TypeConverter::jsArrayToJavaStringArray(Isolate* isolate, JNIEnv *env, Local<Array> jsArray)
 {
 	int arrayLength = jsArray->Length();
 	jobjectArray javaArray = env->NewObjectArray(arrayLength, JNIUtil::stringClass, NULL);
@@ -334,34 +339,46 @@ jobjectArray TypeConverter::jsArrayToJavaStringArray(v8::Isolate* isolate, JNIEn
 		return NULL;
 	}
 
+	Local<Context> context = isolate->GetCurrentContext();
 	for (int i = 0; i < arrayLength; i++) {
-		v8::Local<v8::Value> element = jsArray->Get(i);
-		jstring javaObject = jsStringToJavaString(env, element->ToString(isolate));
-		env->SetObjectArrayElement(javaArray, i, javaObject);
-
-		env->DeleteLocalRef(javaObject);
+		MaybeLocal<Value> element = jsArray->Get(context, i);
+		if (element.IsEmpty()) {
+			LOGE(TAG, "Failed to get element at index %d, inserting null", i);
+			env->SetObjectArrayElement(javaArray, i, NULL);
+		} else {
+			MaybeLocal<String> stringValue = element.ToLocalChecked()->ToString(context);
+			if (stringValue.IsEmpty()) {
+				LOGE(TAG, "Failed to coerce element at index %d into a string, inserting null", i);
+				env->SetObjectArrayElement(javaArray, i, NULL);
+			} else {
+				jstring javaObject = jsStringToJavaString(isolate, env, stringValue.ToLocalChecked());
+				env->SetObjectArrayElement(javaArray, i, javaObject);
+				env->DeleteLocalRef(javaObject);
+			}
+		}
 	}
 
 	return javaArray;
 }
 
-v8::Local<v8::Array> TypeConverter::javaArrayToJsArray(v8::Isolate* isolate, jbooleanArray javaBooleanArray)
+Local<Array> TypeConverter::javaArrayToJsArray(Isolate* isolate, jbooleanArray javaBooleanArray)
 {
 	JNIEnv *env = JNIScope::getEnv();
 	if (env == NULL) {
-		return v8::Array::New(isolate);
+		return Array::New(isolate);
 	}
 	return TypeConverter::javaArrayToJsArray(isolate, env, javaBooleanArray);
 }
 
 Local<Array> TypeConverter::javaArrayToJsArray(Isolate* isolate, JNIEnv *env, jbooleanArray javaBooleanArray)
 {
+	Local<Context> context = isolate->GetCurrentContext();
 	int arrayLength = env->GetArrayLength(javaBooleanArray);
-	v8::Local<v8::Array> jsArray = v8::Array::New(isolate, arrayLength);
+	Local<Array> jsArray = Array::New(isolate, arrayLength);
 
 	jboolean *arrayElements = env->GetBooleanArrayElements(javaBooleanArray, 0);
 	for (int i = 0; i < arrayLength; i++) {
-		jsArray->Set((uint32_t) i, v8::Boolean::New(isolate, arrayElements[i]));
+		jsArray->Set(context, (uint32_t) i, Boolean::New(isolate, arrayElements[i]));
 	}
 
 	return jsArray;
@@ -385,27 +402,39 @@ jshortArray TypeConverter::jsArrayToJavaShortArray(Isolate* isolate, JNIEnv *env
 		return NULL;
 	}
 
+	Local<Context> context = isolate->GetCurrentContext();
 	jshort* shortBuffer = new jshort[arrayLength];
 	for (int i = 0; i < arrayLength; i++) {
-		Local<Value> element = jsArray->Get(i);
-		shortBuffer[i] = TypeConverter::jsNumberToJavaShort(element->ToNumber(isolate));
+		MaybeLocal<Value> element = jsArray->Get(context, i);
+		if (element.IsEmpty()) {
+			LOGE(TAG, "Failed to get element at index %d, inserting 0", i);
+			shortBuffer[i] = 0;
+		} else {
+			MaybeLocal<Number> number = element.ToLocalChecked()->ToNumber(context);
+			if (element.IsEmpty()) {
+				LOGE(TAG, "Failed to coerce element at index %d into a Number, inserting 0", i);
+				shortBuffer[i] = 0;
+			} else {
+				shortBuffer[i] = TypeConverter::jsNumberToJavaShort(number.ToLocalChecked());
+			}
+		}
 	}
 	env->SetShortArrayRegion(javaShortArray, 0, arrayLength, shortBuffer);
 
 	return javaShortArray;
 }
 
-v8::Local<v8::Array> TypeConverter::javaArrayToJsArray(v8::Isolate* isolate, jshortArray javaShortArray)
+Local<Array> TypeConverter::javaArrayToJsArray(Isolate* isolate, jshortArray javaShortArray)
 {
 	return javaShortArrayToJsNumberArray(isolate, javaShortArray);
 }
 
-v8::Local<v8::Array> TypeConverter::javaArrayToJsArray(v8::Isolate* isolate, JNIEnv *env, jshortArray javaShortArray)
+Local<Array> TypeConverter::javaArrayToJsArray(Isolate* isolate, JNIEnv *env, jshortArray javaShortArray)
 {
 	return javaShortArrayToJsNumberArray(isolate, env, javaShortArray);
 }
 
-jintArray TypeConverter::jsArrayToJavaIntArray(v8::Isolate* isolate, v8::Local<v8::Array> jsArray)
+jintArray TypeConverter::jsArrayToJavaIntArray(Isolate* isolate, Local<Array> jsArray)
 {
 	JNIEnv *env = JNIScope::getEnv();
 	if (env == NULL) {
@@ -414,7 +443,7 @@ jintArray TypeConverter::jsArrayToJavaIntArray(v8::Isolate* isolate, v8::Local<v
 	return TypeConverter::jsArrayToJavaIntArray(isolate, env, jsArray);
 }
 
-jintArray TypeConverter::jsArrayToJavaIntArray(v8::Isolate* isolate, JNIEnv *env, v8::Local<v8::Array> jsArray)
+jintArray TypeConverter::jsArrayToJavaIntArray(Isolate* isolate, JNIEnv *env, Local<Array> jsArray)
 {
 	int arrayLength = jsArray->Length();
 	jintArray javaIntArray = env->NewIntArray(arrayLength);
@@ -423,39 +452,52 @@ jintArray TypeConverter::jsArrayToJavaIntArray(v8::Isolate* isolate, JNIEnv *env
 		return NULL;
 	}
 
+	Local<Context> context = isolate->GetCurrentContext();
 	jint* intBuffer = new jint[arrayLength];
 	for (int i = 0; i < arrayLength; i++) {
-		v8::Local<v8::Value> element = jsArray->Get(i);
-		intBuffer[i] = TypeConverter::jsNumberToJavaInt(element->ToNumber(isolate));
+		MaybeLocal<Value> element = jsArray->Get(context, i);
+		if (element.IsEmpty()) {
+			LOGE(TAG, "Failed to get element at index %d, inserting 0", i);
+			intBuffer[i] = 0;
+		} else {
+			MaybeLocal<Number> number = element.ToLocalChecked()->ToNumber(context);
+			if (element.IsEmpty()) {
+				LOGE(TAG, "Failed to coerce element at index %d into a Number, inserting 0", i);
+				intBuffer[i] = 0;
+			} else {
+				intBuffer[i] = TypeConverter::jsNumberToJavaInt(number.ToLocalChecked());
+			}
+		}
 	}
 	env->SetIntArrayRegion(javaIntArray, 0, arrayLength, intBuffer);
 
 	return javaIntArray;
 }
 
-v8::Local<v8::Array> TypeConverter::javaArrayToJsArray(v8::Isolate* isolate, jintArray javaIntArray)
+Local<Array> TypeConverter::javaArrayToJsArray(Isolate* isolate, jintArray javaIntArray)
 {
 	JNIEnv *env = JNIScope::getEnv();
 	if (env == NULL) {
-		return v8::Local<v8::Array>();
+		return Local<Array>();
 	}
 	return TypeConverter::javaArrayToJsArray(isolate, env, javaIntArray);
 }
 
-v8::Local<v8::Array> TypeConverter::javaArrayToJsArray(v8::Isolate* isolate, JNIEnv *env, jintArray javaIntArray)
+Local<Array> TypeConverter::javaArrayToJsArray(Isolate* isolate, JNIEnv *env, jintArray javaIntArray)
 {
 	int arrayLength = env->GetArrayLength(javaIntArray);
-	v8::Local<v8::Array> jsArray = v8::Array::New(isolate, arrayLength);
+	Local<Array> jsArray = Array::New(isolate, arrayLength);
 
+	Local<Context> context = isolate->GetCurrentContext();
 	jint *arrayElements = env->GetIntArrayElements(javaIntArray, 0);
 	for (int i = 0; i < arrayLength; i++) {
-		jsArray->Set((uint32_t) i, v8::Integer::New(isolate, arrayElements[i]));
+		jsArray->Set(context, (uint32_t) i, Integer::New(isolate, arrayElements[i]));
 	}
 
 	return jsArray;
 }
 
-jlongArray TypeConverter::jsArrayToJavaLongArray(v8::Isolate* isolate, v8::Local<v8::Array> jsArray)
+jlongArray TypeConverter::jsArrayToJavaLongArray(Isolate* isolate, Local<Array> jsArray)
 {
 	JNIEnv *env = JNIScope::getEnv();
 	if (env == NULL) {
@@ -464,7 +506,7 @@ jlongArray TypeConverter::jsArrayToJavaLongArray(v8::Isolate* isolate, v8::Local
 	return TypeConverter::jsArrayToJavaLongArray(isolate, env, jsArray);
 }
 
-jlongArray TypeConverter::jsArrayToJavaLongArray(v8::Isolate* isolate, JNIEnv *env, v8::Local<v8::Array> jsArray)
+jlongArray TypeConverter::jsArrayToJavaLongArray(Isolate* isolate, JNIEnv *env, Local<Array> jsArray)
 {
 	int arrayLength = jsArray->Length();
 	jlongArray javaLongArray = env->NewLongArray(arrayLength);
@@ -473,17 +515,29 @@ jlongArray TypeConverter::jsArrayToJavaLongArray(v8::Isolate* isolate, JNIEnv *e
 		return NULL;
 	}
 
+	Local<Context> context = isolate->GetCurrentContext();
 	jlong* longBuffer = new jlong[arrayLength];
 	for (int i = 0; i < arrayLength; i++) {
-		v8::Local<v8::Value> element = jsArray->Get(i);
-		longBuffer[i] = TypeConverter::jsNumberToJavaLong(element->ToNumber(isolate));
+		MaybeLocal<Value> element = jsArray->Get(context, i);
+		if (element.IsEmpty()) {
+			LOGE(TAG, "Failed to get element at index %d, inserting 0", i);
+			longBuffer[i] = 0;
+		} else {
+			MaybeLocal<Number> number = element.ToLocalChecked()->ToNumber(context);
+			if (element.IsEmpty()) {
+				LOGE(TAG, "Failed to coerce element at index %d into a Number, inserting 0", i);
+				longBuffer[i] = 0;
+			} else {
+				longBuffer[i] = TypeConverter::jsNumberToJavaLong(number.ToLocalChecked());
+			}
+		}
 	}
 	env->SetLongArrayRegion(javaLongArray, 0, arrayLength, longBuffer);
 
 	return javaLongArray;
 }
 
-jfloatArray TypeConverter::jsArrayToJavaFloatArray(v8::Isolate* isolate, v8::Local<v8::Array> jsArray)
+jfloatArray TypeConverter::jsArrayToJavaFloatArray(Isolate* isolate, Local<Array> jsArray)
 {
 	JNIEnv *env = JNIScope::getEnv();
 	if (env == NULL) {
@@ -492,7 +546,7 @@ jfloatArray TypeConverter::jsArrayToJavaFloatArray(v8::Isolate* isolate, v8::Loc
 	return TypeConverter::jsArrayToJavaFloatArray(isolate, env, jsArray);
 }
 
-jfloatArray TypeConverter::jsArrayToJavaFloatArray(v8::Isolate* isolate, JNIEnv *env, v8::Local<v8::Array> jsArray)
+jfloatArray TypeConverter::jsArrayToJavaFloatArray(Isolate* isolate, JNIEnv *env, Local<Array> jsArray)
 {
 	int arrayLength = jsArray->Length();
 	jfloatArray javaFloatArray = env->NewFloatArray(arrayLength);
@@ -501,37 +555,49 @@ jfloatArray TypeConverter::jsArrayToJavaFloatArray(v8::Isolate* isolate, JNIEnv 
 		return NULL;
 	}
 
+	Local<Context> context = isolate->GetCurrentContext();
 	jfloat* floatBuffer = new jfloat[arrayLength];
 	for (int i = 0; i < arrayLength; i++) {
-		v8::Local<v8::Value> element = jsArray->Get(i);
-		floatBuffer[i] = TypeConverter::jsNumberToJavaFloat(element->ToNumber(isolate));
+		MaybeLocal<Value> element = jsArray->Get(context, i);
+		if (element.IsEmpty()) {
+			LOGE(TAG, "Failed to get element at index %d, inserting 0", i);
+			floatBuffer[i] = 0;
+		} else {
+			MaybeLocal<Number> number = element.ToLocalChecked()->ToNumber(context);
+			if (element.IsEmpty()) {
+				LOGE(TAG, "Failed to coerce element at index %d into a Number, inserting 0", i);
+				floatBuffer[i] = 0;
+			} else {
+				floatBuffer[i] = TypeConverter::jsNumberToJavaFloat(number.ToLocalChecked());
+			}
+		}
 	}
 	env->SetFloatArrayRegion(javaFloatArray, 0, arrayLength, floatBuffer);
 
 	return javaFloatArray;
 }
 
-v8::Local<v8::Array> TypeConverter::javaArrayToJsArray(v8::Isolate* isolate, jlongArray javaLongArray)
+Local<Array> TypeConverter::javaArrayToJsArray(Isolate* isolate, jlongArray javaLongArray)
 {
 	return javaLongArrayToJsNumberArray(isolate, javaLongArray);
 }
 
-v8::Local<v8::Array> TypeConverter::javaArrayToJsArray(v8::Isolate* isolate, JNIEnv *env, jlongArray javaLongArray)
+Local<Array> TypeConverter::javaArrayToJsArray(Isolate* isolate, JNIEnv *env, jlongArray javaLongArray)
 {
 	return javaLongArrayToJsNumberArray(isolate, env, javaLongArray);
 }
 
-v8::Local<v8::Array> TypeConverter::javaArrayToJsArray(v8::Isolate* isolate, jfloatArray javaFloatArray)
+Local<Array> TypeConverter::javaArrayToJsArray(Isolate* isolate, jfloatArray javaFloatArray)
 {
 	return javaFloatArrayToJsNumberArray(isolate, javaFloatArray);
 }
 
-v8::Local<v8::Array> TypeConverter::javaArrayToJsArray(v8::Isolate* isolate, JNIEnv *env, jfloatArray javaFloatArray)
+Local<Array> TypeConverter::javaArrayToJsArray(Isolate* isolate, JNIEnv *env, jfloatArray javaFloatArray)
 {
 	return javaFloatArrayToJsNumberArray(isolate, env, javaFloatArray);
 }
 
-jdoubleArray TypeConverter::jsArrayToJavaDoubleArray(v8::Isolate* isolate, v8::Local<v8::Array> jsArray)
+jdoubleArray TypeConverter::jsArrayToJavaDoubleArray(Isolate* isolate, Local<Array> jsArray)
 {
 	JNIEnv *env = JNIScope::getEnv();
 	if (env == NULL) {
@@ -540,7 +606,7 @@ jdoubleArray TypeConverter::jsArrayToJavaDoubleArray(v8::Isolate* isolate, v8::L
 	return TypeConverter::jsArrayToJavaDoubleArray(isolate, env, jsArray);
 }
 
-jdoubleArray TypeConverter::jsArrayToJavaDoubleArray(v8::Isolate* isolate, JNIEnv *env, v8::Local<v8::Array> jsArray)
+jdoubleArray TypeConverter::jsArrayToJavaDoubleArray(Isolate* isolate, JNIEnv *env, Local<Array> jsArray)
 {
 	int arrayLength = jsArray->Length();
 	jdoubleArray javaDoubleArray = env->NewDoubleArray(arrayLength);
@@ -549,44 +615,57 @@ jdoubleArray TypeConverter::jsArrayToJavaDoubleArray(v8::Isolate* isolate, JNIEn
 		return NULL;
 	}
 
+	Local<Context> context = isolate->GetCurrentContext();
 	jdouble* doubleBuffer = new jdouble[arrayLength];
 	for (int i = 0; i < arrayLength; i++) {
-		v8::Local<v8::Value> element = jsArray->Get(i);
-		doubleBuffer[i] = TypeConverter::jsNumberToJavaDouble(element->ToNumber(isolate));
+		MaybeLocal<Value> element = jsArray->Get(context, i);
+		if (element.IsEmpty()) {
+			LOGE(TAG, "Failed to get element at index %d, inserting 0", i);
+			doubleBuffer[i] = 0;
+		} else {
+			MaybeLocal<Number> number = element.ToLocalChecked()->ToNumber(context);
+			if (element.IsEmpty()) {
+				LOGE(TAG, "Failed to coerce element at index %d into a Number, inserting 0", i);
+				doubleBuffer[i] = 0;
+			} else {
+				doubleBuffer[i] = TypeConverter::jsNumberToJavaDouble(number.ToLocalChecked());
+			}
+		}
 	}
 	env->SetDoubleArrayRegion(javaDoubleArray, 0, arrayLength, doubleBuffer);
 
 	return javaDoubleArray;
 }
 
-v8::Local<v8::Array> TypeConverter::javaArrayToJsArray(v8::Isolate* isolate, jdoubleArray javaDoubleArray)
+Local<Array> TypeConverter::javaArrayToJsArray(Isolate* isolate, jdoubleArray javaDoubleArray)
 {
 	return javaDoubleArrayToJsNumberArray(isolate, javaDoubleArray);
 }
 
-v8::Local<v8::Array> TypeConverter::javaArrayToJsArray(v8::Isolate* isolate, JNIEnv *env, jdoubleArray javaDoubleArray)
+Local<Array> TypeConverter::javaArrayToJsArray(Isolate* isolate, JNIEnv *env, jdoubleArray javaDoubleArray)
 {
 	return javaDoubleArrayToJsNumberArray(isolate, env, javaDoubleArray);
 }
 
-v8::Local<v8::Array> TypeConverter::javaArrayToJsArray(v8::Isolate* isolate, jobjectArray javaObjectArray)
+Local<Array> TypeConverter::javaArrayToJsArray(Isolate* isolate, jobjectArray javaObjectArray)
 {
 	JNIEnv *env = JNIScope::getEnv();
 	if (env == NULL) {
-		return v8::Array::New(isolate);
+		return Array::New(isolate);
 	}
 	return TypeConverter::javaArrayToJsArray(isolate, env, javaObjectArray);
 }
 
-v8::Local<v8::Array> TypeConverter::javaArrayToJsArray(v8::Isolate* isolate, JNIEnv *env, jobjectArray javaObjectArray)
+Local<Array> TypeConverter::javaArrayToJsArray(Isolate* isolate, JNIEnv *env, jobjectArray javaObjectArray)
 {
 	int arrayLength = env->GetArrayLength(javaObjectArray);
-	v8::Local<v8::Array> jsArray = v8::Array::New(isolate, arrayLength);
+	Local<Array> jsArray = Array::New(isolate, arrayLength);
 
+	Local<Context> context = isolate->GetCurrentContext();
 	for (int i = 0; i < arrayLength; i++) {
 		jobject javaArrayElement = env->GetObjectArrayElement(javaObjectArray, i);
-		v8::Local<v8::Value> jsArrayElement = TypeConverter::javaObjectToJsValue(isolate, env, javaArrayElement);
-		jsArray->Set((uint32_t) i, jsArrayElement);
+		Local<Value> jsArrayElement = TypeConverter::javaObjectToJsValue(isolate, env, javaArrayElement);
+		jsArray->Set(context, (uint32_t) i, jsArrayElement);
 		env->DeleteLocalRef(javaArrayElement);
 	}
 
@@ -595,7 +674,7 @@ v8::Local<v8::Array> TypeConverter::javaArrayToJsArray(v8::Isolate* isolate, JNI
 
 // converts js value to java object and recursively converts sub objects if this
 // object is a container type
-jobject TypeConverter::jsValueToJavaObject(v8::Isolate* isolate, v8::Local<v8::Value> jsValue, bool *isNew)
+jobject TypeConverter::jsValueToJavaObject(Isolate* isolate, Local<Value> jsValue, bool *isNew)
 {
 	JNIEnv *env = JNIScope::getEnv();
 	if (env == NULL) {
@@ -604,7 +683,7 @@ jobject TypeConverter::jsValueToJavaObject(v8::Isolate* isolate, v8::Local<v8::V
 	return TypeConverter::jsValueToJavaObject(isolate, env, jsValue, isNew);
 }
 
-jobject TypeConverter::jsValueToJavaObject(v8::Isolate* isolate, JNIEnv *env, v8::Local<v8::Value> jsValue, bool *isNew)
+jobject TypeConverter::jsValueToJavaObject(Isolate* isolate, JNIEnv *env, Local<Value> jsValue, bool *isNew)
 {
 	if (jsValue->IsNumber()) {
 		*isNew = true;
@@ -623,7 +702,7 @@ jobject TypeConverter::jsValueToJavaObject(v8::Isolate* isolate, JNIEnv *env, v8
 
 	} else if (jsValue->IsString()) {
 		*isNew = true;
-		return TypeConverter::jsStringToJavaString(env, jsValue.As<String>());
+		return TypeConverter::jsStringToJavaString(isolate, env, jsValue.As<String>());
 
 	} else if (jsValue->IsDate()) {
 		return TypeConverter::jsDateToJavaDate(env, jsValue.As<Date>());
@@ -637,18 +716,33 @@ jobject TypeConverter::jsValueToJavaObject(v8::Isolate* isolate, JNIEnv *env, v8
 		return TypeConverter::jsObjectToJavaFunction(isolate, env, jsValue.As<Function>());
 
 	} else if (jsValue->IsObject()) {
-		v8::Local<v8::Object> jsObject = jsValue.As<Object>();
+		Local<Object> jsObject = jsValue.As<Object>();
 
 		if (JavaObject::isJavaObject(jsObject)) {
 			*isNew = true;
 			JavaObject *javaObject = JavaObject::Unwrap<JavaObject>(jsObject);
 			return javaObject->getJavaObject();
 		} else {
+
+			Local<Context> context = isolate->GetCurrentContext();
 			// Unwrap hyperloop JS wrappers to get native java proxy
-			v8::Local<String> nativeString = STRING_NEW(isolate, "$native");
-			if (jsObject->HasOwnProperty(nativeString)) {
-				v8::Local<v8::Value> nativeObject = jsObject->GetRealNamedProperty(nativeString);
-				jsObject = nativeObject->ToObject(isolate);
+			Local<String> nativeString = STRING_NEW(isolate, "$native");
+			if (jsObject->HasOwnProperty(context, nativeString).FromMaybe(false)) {
+
+				TryCatch tryCatch(isolate);
+				Local<Value> nativeObject;
+				MaybeLocal<Value> maybeNativeObject = jsObject->GetRealNamedProperty(context, nativeString);
+				if (!maybeNativeObject.ToLocal(&nativeObject)) {
+					V8Util::fatalException(isolate, tryCatch);
+					return NULL;
+				}
+
+				MaybeLocal<Object> maybeObject = nativeObject->ToObject(context);
+				if (!maybeObject.ToLocal(&jsObject)) {
+					V8Util::fatalException(isolate, tryCatch);
+					return NULL;
+				}
+
 				if (JavaObject::isJavaObject(jsObject)) {
 					*isNew = true;
 					JavaObject *javaObject = JavaObject::Unwrap<JavaObject>(jsObject);
@@ -656,16 +750,19 @@ jobject TypeConverter::jsValueToJavaObject(v8::Isolate* isolate, JNIEnv *env, v8
 				}
 			}
 
-			v8::Local<v8::Array> objectKeys = jsObject->GetOwnPropertyNames();
+			// FIXME Handle when empty!
+			Local<Array> objectKeys = jsObject->GetOwnPropertyNames(context).ToLocalChecked();
 			int numKeys = objectKeys->Length();
 			*isNew = true;
 			jobject javaHashMap = env->NewObject(JNIUtil::hashMapClass, JNIUtil::hashMapInitMethod, numKeys);
 
 			for (int i = 0; i < numKeys; i++) {
-				v8::Local<v8::Value> jsObjectPropertyKey = objectKeys->Get((uint32_t) i);
+				// FIXME Handle when empty!
+				Local<Value> jsObjectPropertyKey = objectKeys->Get(context, (uint32_t) i).ToLocalChecked();
 				bool valueIsNew;
 				jstring javaStringPropertyKey = TypeConverter::jsValueToJavaString(isolate, env, jsObjectPropertyKey);
-				v8::Local<v8::Value> jsObjectPropertyValue = jsObject->Get(jsObjectPropertyKey);
+				// FIXME Handle when empty!
+				Local<Value> jsObjectPropertyValue = jsObject->Get(context, jsObjectPropertyKey).ToLocalChecked();
 				jobject javaObjectPropertyValue = TypeConverter::jsValueToJavaObject(isolate, env, jsObjectPropertyValue, &valueIsNew);
 
 				jobject result = env->CallObjectMethod(javaHashMap,
@@ -692,7 +789,7 @@ jobject TypeConverter::jsValueToJavaObject(v8::Isolate* isolate, JNIEnv *env, v8
 
 // converts js object to kroll dict and recursively converts sub objects if this
 // object is a container type
-jobject TypeConverter::jsObjectToJavaKrollDict(v8::Isolate* isolate, v8::Local<v8::Value> jsValue, bool *isNew)
+jobject TypeConverter::jsObjectToJavaKrollDict(Isolate* isolate, Local<Value> jsValue, bool *isNew)
 {
 	JNIEnv *env = JNIScope::getEnv();
 	if (env == NULL) {
@@ -701,21 +798,25 @@ jobject TypeConverter::jsObjectToJavaKrollDict(v8::Isolate* isolate, v8::Local<v
 	return TypeConverter::jsObjectToJavaKrollDict(isolate, env,jsValue,isNew);
 }
 
-jobject TypeConverter::jsObjectToJavaKrollDict(v8::Isolate* isolate, JNIEnv *env, v8::Local<v8::Value> jsValue, bool *isNew)
+jobject TypeConverter::jsObjectToJavaKrollDict(Isolate* isolate, JNIEnv *env, Local<Value> jsValue, bool *isNew)
 {
 	if (jsValue->IsObject())
 	{
-		v8::Local<v8::Object> jsObject = jsValue.As<Object>();
-		v8::Local<v8::Array> objectKeys = jsObject->GetOwnPropertyNames();
+		Local<Context> context = isolate->GetCurrentContext();
+		Local<Object> jsObject = jsValue.As<Object>();
+		// FIXME Handle when empty/getting own property names fails!
+		Local<Array> objectKeys = jsObject->GetOwnPropertyNames(context).ToLocalChecked();
 		int numKeys = objectKeys->Length();
 		*isNew = true;
 		jobject javaKrollDict = env->NewObject(JNIUtil::krollDictClass, JNIUtil::krollDictInitMethod, numKeys);
 
 		for (int i = 0; i < numKeys; i++) {
-			v8::Local<v8::Value> jsObjectPropertyKey = objectKeys->Get((uint32_t) i);
+			// FIXME Handle when empty!
+			Local<Value> jsObjectPropertyKey = objectKeys->Get(context, (uint32_t) i).ToLocalChecked();
 			bool valueIsNew;
 			jstring javaStringPropertyKey = TypeConverter::jsValueToJavaString(isolate, env, jsObjectPropertyKey);
-			v8::Local<v8::Value> jsObjectPropertyValue = jsObject->Get(jsObjectPropertyKey);
+			// FIXME Handle when empty!
+			Local<Value> jsObjectPropertyValue = jsObject->Get(context, jsObjectPropertyKey).ToLocalChecked();
 			jobject javaObjectPropertyValue = TypeConverter::jsValueToJavaObject(isolate, env, jsObjectPropertyValue, &valueIsNew);
 
 			jobject result = env->CallObjectMethod(javaKrollDict,
@@ -741,7 +842,7 @@ jobject TypeConverter::jsObjectToJavaKrollDict(v8::Isolate* isolate, JNIEnv *env
 
 
 // converts js value to java error
-jobject TypeConverter::jsValueToJavaError(v8::Isolate* isolate, v8::Local<v8::Value> jsValue, bool* isNew)
+jobject TypeConverter::jsValueToJavaError(Isolate* isolate, Local<Value> jsValue, bool* isNew)
 {
 	JNIEnv *env = JNIScope::getEnv();
 	if (env == NULL) {
@@ -750,20 +851,23 @@ jobject TypeConverter::jsValueToJavaError(v8::Isolate* isolate, v8::Local<v8::Va
 	return TypeConverter::jsValueToJavaError(isolate, env, jsValue, isNew);
 }
 
-jobject TypeConverter::jsValueToJavaError(v8::Isolate* isolate, JNIEnv *env, v8::Local<v8::Value> jsValue, bool* isNew)
+jobject TypeConverter::jsValueToJavaError(Isolate* isolate, JNIEnv *env, Local<Value> jsValue, bool* isNew)
 {
 	if (jsValue->IsObject()) {
-		v8::Local<v8::Object> jsObject = jsValue.As<Object>();
+		Local<Object> jsObject = jsValue.As<Object>();
 
 		// If it's a java object, we just return null for now.
 		if (!JavaObject::isJavaObject(jsObject)) {
 
-			Local<String> stackString = STRING_NEW(isolate, "stack"), messageString = STRING_NEW(isolate, "message");
-			if (jsObject->HasOwnProperty(stackString) || jsObject->HasOwnProperty(messageString)) {
-				bool keyIsNew, valueIsNew;
+			Local<Context> context = isolate->GetCurrentContext();
+			Local<String> stackString = STRING_NEW(isolate, "stack");
+			Local<String> messageString = STRING_NEW(isolate, "message");
+			if (jsObject->HasOwnProperty(context, stackString).FromMaybe(false) || jsObject->HasOwnProperty(context, messageString).FromMaybe(false)) {
 				*isNew = true;
-				v8::Local<v8::Value> jsObjectMessageProperty = jsObject->GetRealNamedProperty(messageString);
-				v8::Local<v8::Value> jsObjectStackProperty = jsObject->GetRealNamedProperty(stackString);
+
+				// Potentially empty, default to Null so we return Java NULL to KrollException
+				Local<Value> jsObjectMessageProperty = jsObject->GetRealNamedProperty(context, messageString).FromMaybe(Null(isolate).As<Value>());
+				Local<Value> jsObjectStackProperty = jsObject->GetRealNamedProperty(context, stackString).FromMaybe(Null(isolate).As<Value>());
 
 				return env->NewObject(JNIUtil::krollExceptionClass, JNIUtil::krollExceptionInitMethod,
 							TypeConverter::jsValueToJavaString(isolate, env, jsObjectMessageProperty), TypeConverter::jsValueToJavaString(isolate, env, jsObjectStackProperty));
@@ -784,9 +888,9 @@ jobject TypeConverter::jsValueToJavaError(v8::Isolate* isolate, JNIEnv *env, v8:
 
 // converts java hashmap to js value and recursively converts sub objects if this
 // object is a container type. If javaObject is NULL, an empty object is created.
-v8::Local<v8::Object> TypeConverter::javaHashMapToJsValue(v8::Isolate* isolate, JNIEnv *env, jobject javaObject)
+Local<Object> TypeConverter::javaHashMapToJsValue(Isolate* isolate, JNIEnv *env, jobject javaObject)
 {
-	v8::Local<v8::Object> jsObject = v8::Object::New(isolate);
+	Local<Object> jsObject = Object::New(isolate);
 	if (!javaObject || !env) {
 		return jsObject;
 	}
@@ -800,7 +904,7 @@ v8::Local<v8::Object> TypeConverter::javaHashMapToJsValue(v8::Isolate* isolate, 
 
 	for (int i = 0; i < hashMapKeysLength; i++) {
 		jobject javaPairKey = env->GetObjectArrayElement(hashMapKeys, i);
-		v8::Local<v8::Value> jsPairKey;
+		Local<Value> jsPairKey;
 		if (isStringHashMap) {
 			jsPairKey = TypeConverter::javaStringToJsString(isolate, env, (jstring)javaPairKey);
 		} else {
@@ -824,29 +928,29 @@ v8::Local<v8::Object> TypeConverter::javaHashMapToJsValue(v8::Isolate* isolate, 
 Local<Value> TypeConverter::javaObjectToJsValue(Isolate* isolate, jobject javaObject)
 {
 	if (!javaObject) {
-		return v8::Null(isolate);
+		return Null(isolate);
 	}
 
 	JNIEnv *env = JNIScope::getEnv();
 	if (!env) {
-		return v8::Undefined(isolate);
+		return Undefined(isolate);
 	}
 	return TypeConverter::javaObjectToJsValue(isolate, env, javaObject);
 }
 
-v8::Local<v8::Value> TypeConverter::javaObjectToJsValue(v8::Isolate* isolate, JNIEnv *env, jobject javaObject)
+Local<Value> TypeConverter::javaObjectToJsValue(Isolate* isolate, JNIEnv *env, jobject javaObject)
 {
 	if (!javaObject) {
-		return v8::Null(isolate);
+		return Null(isolate);
 	}
 
 	if (env->IsInstanceOf(javaObject, JNIUtil::booleanClass)) {
 		jboolean javaBoolean = env->CallBooleanMethod(javaObject, JNIUtil::booleanBooleanValueMethod);
-		return javaBoolean ? v8::True(isolate) : v8::False(isolate);
+		return javaBoolean ? True(isolate) : False(isolate);
 
 	} else if (env->IsInstanceOf(javaObject, JNIUtil::numberClass)) {
 		jdouble javaDouble = env->CallDoubleMethod(javaObject, JNIUtil::numberDoubleValueMethod);
-		return v8::Number::New(isolate, (double) javaDouble);
+		return Number::New(isolate, (double) javaDouble);
 
 	} else if (env->IsInstanceOf(javaObject, JNIUtil::stringClass)) {
 		return TypeConverter::javaStringToJsString(isolate, env, (jstring) javaObject);
@@ -864,7 +968,7 @@ v8::Local<v8::Value> TypeConverter::javaObjectToJsValue(v8::Isolate* isolate, JN
 
 			if (v8ObjectPointer != 0) {
 				titanium::Proxy* proxy = (titanium::Proxy*) v8ObjectPointer;
-				v8::Local<v8::Object> v8Object = proxy->handle(isolate);
+				Local<Object> v8Object = proxy->handle(isolate);
 				// This is an ugly HACK
 				// We're basically just temporarily calling ClearWeak and MakeWeak again hoping to extend the lifetime of this object
 				// so it doesn't get GC'd
@@ -875,7 +979,7 @@ v8::Local<v8::Value> TypeConverter::javaObjectToJsValue(v8::Isolate* isolate, JN
 		}
 
 		jclass javaObjectClass = env->GetObjectClass(javaObject);
-		v8::Local<v8::Object> proxyHandle = ProxyFactory::createV8Proxy(isolate, javaObjectClass, javaObject);
+		Local<Object> proxyHandle = ProxyFactory::createV8Proxy(isolate, javaObjectClass, javaObject);
 		env->DeleteLocalRef(javaObjectClass);
 		return proxyHandle;
 
@@ -904,14 +1008,14 @@ v8::Local<v8::Value> TypeConverter::javaObjectToJsValue(v8::Isolate* isolate, JN
 		return javaArrayToJsArray(isolate, (jbooleanArray) javaObject);
 
 	} else if (env->IsSameObject(JNIUtil::undefinedObject, javaObject)) {
-		return v8::Undefined(isolate);
+		return Undefined(isolate);
 	}
 
 	jclass javaObjectClass = env->GetObjectClass(javaObject);
 	JNIUtil::logClassName("!!! Unable to convert unknown Java object class '%s' to JS value !!!", javaObjectClass, true);
 	env->DeleteLocalRef(javaObjectClass);
 
-	return v8::Undefined(isolate);
+	return Undefined(isolate);
 }
 
 jobjectArray TypeConverter::jsObjectIndexPropsToJavaArray(Isolate* isolate, Local<Object> jsObject, int start, int length)
@@ -931,15 +1035,19 @@ jobjectArray TypeConverter::jsObjectIndexPropsToJavaArray(Isolate* isolate, JNIE
 	jobjectArray javaArray = env->NewObjectArray(arrayLength, JNIUtil::objectClass, NULL);
 	int index = 0;
 
+	Local<Context> context = isolate->GetCurrentContext();
 	for (int index = start; index < length; ++index) {
-		v8::Local<Value> prop = jsObject->Get(index);
-		bool isNew;
-
-		jobject javaObject = jsValueToJavaObject(isolate, prop, &isNew);
-		env->SetObjectArrayElement(javaArray, index - start, javaObject);
-
-		if (isNew) {
-			env->DeleteLocalRef(javaObject);
+		MaybeLocal<Value> prop = jsObject->Get(context, index);
+		if (prop.IsEmpty()) {
+			LOGE(TAG, "Failed to get element at index %d, inserting NULL", index);
+			env->SetObjectArrayElement(javaArray, index - start, NULL);
+		} else {
+			bool isNew;
+			jobject javaObject = jsValueToJavaObject(isolate, prop.ToLocalChecked(), &isNew);
+			env->SetObjectArrayElement(javaArray, index - start, javaObject);
+			if (isNew) {
+				env->DeleteLocalRef(javaObject);
+			}
 		}
 	}
 
@@ -950,89 +1058,93 @@ jobjectArray TypeConverter::jsObjectIndexPropsToJavaArray(Isolate* isolate, JNIE
 
 // used mainly by the array conversion methods when converting java numeric types
 // arrays to to the generic js number type
-v8::Local<v8::Array> TypeConverter::javaDoubleArrayToJsNumberArray(v8::Isolate* isolate, jdoubleArray javaDoubleArray)
+Local<Array> TypeConverter::javaDoubleArrayToJsNumberArray(Isolate* isolate, jdoubleArray javaDoubleArray)
 {
 	JNIEnv *env = JNIScope::getEnv();
 	if (env == NULL) {
-		return v8::Array::New(isolate);
+		return Array::New(isolate);
 	}
 	return TypeConverter::javaDoubleArrayToJsNumberArray(isolate, env, javaDoubleArray);
 }
 
-v8::Local<v8::Array> TypeConverter::javaDoubleArrayToJsNumberArray(v8::Isolate* isolate, JNIEnv *env, jdoubleArray javaDoubleArray)
+Local<Array> TypeConverter::javaDoubleArrayToJsNumberArray(Isolate* isolate, JNIEnv *env, jdoubleArray javaDoubleArray)
 {
 	int arrayLength = env->GetArrayLength(javaDoubleArray);
-	v8::Local<v8::Array> jsArray = v8::Array::New(isolate, arrayLength);
+	Local<Array> jsArray = Array::New(isolate, arrayLength);
 
+	Local<Context> context = isolate->GetCurrentContext();
 	jdouble *arrayElements = env->GetDoubleArrayElements(javaDoubleArray, 0);
 	for (int i = 0; i < arrayLength; i++) {
-		jsArray->Set((uint32_t) i, v8::Number::New(isolate, arrayElements[i]));
+		jsArray->Set(context, (uint32_t) i, Number::New(isolate, arrayElements[i]));
 	}
 	env->ReleaseDoubleArrayElements(javaDoubleArray, arrayElements, JNI_ABORT);
 	//Since we were only reading, there is no need to copy back. Thus, Abort.
 	return jsArray;
 }
 
-v8::Local<v8::Array> TypeConverter::javaLongArrayToJsNumberArray(v8::Isolate* isolate, jlongArray javaLongArray)
+Local<Array> TypeConverter::javaLongArrayToJsNumberArray(Isolate* isolate, jlongArray javaLongArray)
 {
 	JNIEnv *env = JNIScope::getEnv();
 	if (env == NULL) {
-		return v8::Array::New(isolate);
+		return Array::New(isolate);
 	}
 	return TypeConverter::javaLongArrayToJsNumberArray(isolate, env, javaLongArray);
 }
 
-v8::Local<v8::Array> TypeConverter::javaLongArrayToJsNumberArray(v8::Isolate* isolate, JNIEnv *env, jlongArray javaLongArray)
+Local<Array> TypeConverter::javaLongArrayToJsNumberArray(Isolate* isolate, JNIEnv *env, jlongArray javaLongArray)
 {
 	int arrayLength = env->GetArrayLength(javaLongArray);
-	v8::Local<v8::Array> jsArray = v8::Array::New(isolate, arrayLength);
+	Local<Array> jsArray = Array::New(isolate, arrayLength);
 
+	Local<Context> context = isolate->GetCurrentContext();
 	jlong *arrayElements = env->GetLongArrayElements(javaLongArray, 0);
 	for (int i = 0; i < arrayLength; i++) {
-		jsArray->Set((uint32_t) i, v8::Number::New(isolate, arrayElements[i]));
+		jsArray->Set(context, (uint32_t) i, Number::New(isolate, arrayElements[i]));
 	}
 	return jsArray;
 }
 
-v8::Local<v8::Array> TypeConverter::javaFloatArrayToJsNumberArray(v8::Isolate* isolate, jfloatArray javaFloatArray)
+Local<Array> TypeConverter::javaFloatArrayToJsNumberArray(Isolate* isolate, jfloatArray javaFloatArray)
 {
 	JNIEnv *env = JNIScope::getEnv();
 	if (env == NULL) {
-		return v8::Array::New(isolate);
+		return Array::New(isolate);
 	}
 	return TypeConverter::javaFloatArrayToJsNumberArray(isolate, env, javaFloatArray);
 }
 
-v8::Local<v8::Array> TypeConverter::javaFloatArrayToJsNumberArray(v8::Isolate* isolate, JNIEnv *env, jfloatArray javaFloatArray)
+Local<Array> TypeConverter::javaFloatArrayToJsNumberArray(Isolate* isolate, JNIEnv *env, jfloatArray javaFloatArray)
 {
 	int arrayLength = env->GetArrayLength(javaFloatArray);
-	v8::Local<v8::Array> jsArray = v8::Array::New(isolate, arrayLength);
+	Local<Array> jsArray = Array::New(isolate, arrayLength);
 
+	Local<Context> context = isolate->GetCurrentContext();
 	jfloat *arrayElements = env->GetFloatArrayElements(javaFloatArray, 0);
 	for (int i = 0; i < arrayLength; i++) {
-		jsArray->Set((uint32_t) i, v8::Number::New(isolate, arrayElements[i]));
+		jsArray->Set(context, (uint32_t) i, Number::New(isolate, arrayElements[i]));
 	}
 	env->ReleaseFloatArrayElements(javaFloatArray, arrayElements, JNI_ABORT);
 	return jsArray;
 }
 
-v8::Local<v8::Array> TypeConverter::javaShortArrayToJsNumberArray(v8::Isolate* isolate, jshortArray javaShortArray)
+Local<Array> TypeConverter::javaShortArrayToJsNumberArray(Isolate* isolate, jshortArray javaShortArray)
 {
 	JNIEnv *env = JNIScope::getEnv();
 	if (env == NULL) {
-		return v8::Array::New(isolate);
+		return Array::New(isolate);
 	}
 	return TypeConverter::javaShortArrayToJsNumberArray(isolate, env, javaShortArray);
 }
 
-v8::Local<v8::Array> TypeConverter::javaShortArrayToJsNumberArray(v8::Isolate* isolate, JNIEnv *env, jshortArray javaShortArray)
+Local<Array> TypeConverter::javaShortArrayToJsNumberArray(Isolate* isolate, JNIEnv *env, jshortArray javaShortArray)
 {
 	int arrayLength = env->GetArrayLength(javaShortArray);
-	v8::Local<v8::Array> jsArray = v8::Array::New(isolate, arrayLength);
+	Local<Array> jsArray = Array::New(isolate, arrayLength);
 
+	Local<Context> context = isolate->GetCurrentContext();
 	jshort *arrayElements = env->GetShortArrayElements(javaShortArray, 0);
 	for (int i = 0; i < arrayLength; i++) {
-		jsArray->Set((uint32_t) i, v8::Number::New(isolate, arrayElements[i]));
+		jsArray->Set(context, (uint32_t) i, Number::New(isolate, arrayElements[i]));
 	}
 	env->ReleaseShortArrayElements(javaShortArray, arrayElements, JNI_ABORT);
 	return jsArray;

--- a/android/runtime/v8/src/native/TypeConverter.h
+++ b/android/runtime/v8/src/native/TypeConverter.h
@@ -1,6 +1,6 @@
 /*
  * Appcelerator Titanium Mobile
- * Copyright (c) 2011-2017 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2011-2018 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
@@ -88,11 +88,11 @@ public:
 	}
 
 	// string convert methods
-	static jstring jsStringToJavaString(v8::Local<v8::String> jsString);
+	static jstring jsStringToJavaString(v8::Isolate* isolate, v8::Local<v8::String> jsString);
 	static jstring jsValueToJavaString(v8::Isolate* isolate, v8::Local<v8::Value> jsValue);
 	static v8::Local<v8::Value> javaStringToJsString(v8::Isolate* isolate, jstring javaString);
 
-	static jstring jsStringToJavaString(JNIEnv *env, v8::Local<v8::String> jsString);
+	static jstring jsStringToJavaString(v8::Isolate* isolate, JNIEnv *env, v8::Local<v8::String> jsString);
 	static jstring jsValueToJavaString(v8::Isolate* isolate, JNIEnv *env, v8::Local<v8::Value> jsValue);
 	static v8::Local<v8::Value> javaStringToJsString(v8::Isolate* isolate, JNIEnv *env, jstring javaString);
 

--- a/android/runtime/v8/src/native/V8Function.cpp
+++ b/android/runtime/v8/src/native/V8Function.cpp
@@ -1,6 +1,6 @@
 /**
  * Appcelerator Titanium Mobile
- * Copyright (c) 2011-2016 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2011-2018 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
@@ -60,7 +60,7 @@ JNIEXPORT jobject JNICALL Java_org_appcelerator_kroll_runtime_v8_V8Function_nati
 
 	// call into the JS function with the provided argument
 	TryCatch tryCatch(V8Runtime::v8_isolate);
-	v8::MaybeLocal<v8::Value> object = jsFunction->Call(V8Runtime::v8_isolate->GetCurrentContext(), thisObject, length, jsFunctionArguments);
+	MaybeLocal<Value> object = jsFunction->Call(V8Runtime::v8_isolate->GetCurrentContext(), thisObject, length, jsFunctionArguments);
 
 	// make sure to delete the arguments since the arguments array is built on the heap
 	if (jsFunctionArguments) {
@@ -70,8 +70,8 @@ JNIEXPORT jobject JNICALL Java_org_appcelerator_kroll_runtime_v8_V8Function_nati
 	if (tryCatch.HasCaught()) {
 		V8Util::openJSErrorDialog(V8Runtime::v8_isolate, tryCatch);
 		V8Util::reportException(V8Runtime::v8_isolate, tryCatch);
-		return JNIUtil::undefinedObject;
-	} else if (object.IsEmpty()) {
+	} // if exception, object should be empty handle...so returns undefined
+	if (object.IsEmpty()) {
 		return JNIUtil::undefinedObject;
 	}
 

--- a/android/runtime/v8/src/native/V8Runtime.cpp
+++ b/android/runtime/v8/src/native/V8Runtime.cpp
@@ -1,6 +1,6 @@
 /**
  * Appcelerator Titanium Mobile
- * Copyright (c) 2011-2016 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2011-2018 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
@@ -103,11 +103,11 @@ static void krollLog(const FunctionCallbackInfo<Value>& args)
 	Local<String> message = args[1].As<String>();
 	Local<String> space = STRING_NEW(isolate, " ");
 	for (uint32_t i = 2; i < len; ++i) {
-		message = String::Concat(String::Concat(message, space), args[i].As<String>());
+		message = String::Concat(isolate, String::Concat(isolate, message, space), args[i].As<String>());
 	}
 
-	v8::String::Utf8Value tagValue(tag);
-	v8::String::Utf8Value messageValue(message);
+	String::Utf8Value tagValue(isolate, tag);
+	String::Utf8Value messageValue(isolate, message);
 	__android_log_print(ANDROID_LOG_DEBUG, *tagValue, *messageValue);
 }
 
@@ -124,7 +124,7 @@ void V8Runtime::bootstrap(Local<Context> context)
 
 	KrollBindings::initFunctions(kroll, context);
 
-	SetMethod(isolate, kroll, "log", krollLog);
+	SetMethod(context, isolate, kroll, "log", krollLog);
 	// Move this into the EventEmitter::initTemplate call?
 	Local<FunctionTemplate> eect = Local<FunctionTemplate>::New(isolate, EventEmitter::constructorTemplate);
 	{
@@ -135,17 +135,17 @@ void V8Runtime::bootstrap(Local<Context> context)
 			titanium::V8Util::fatalException(isolate, tryCatch);
 			return;
 		}
-		kroll->Set(NEW_SYMBOL(isolate, "EventEmitter"), eventEmitterConstructor);
+		kroll->Set(context, NEW_SYMBOL(isolate, "EventEmitter"), eventEmitterConstructor);
 	}
 
-	kroll->Set(NEW_SYMBOL(isolate, "runtime"), STRING_NEW(isolate, "v8"));
-	kroll->Set(NEW_SYMBOL(isolate, "DBG"), v8::Boolean::New(isolate, V8Runtime::DBG));
-	kroll->Set(NEW_SYMBOL(isolate, "moduleContexts"), mc);
+	kroll->Set(context, NEW_SYMBOL(isolate, "runtime"), STRING_NEW(isolate, "v8"));
+	kroll->Set(context, NEW_SYMBOL(isolate, "DBG"), v8::Boolean::New(isolate, V8Runtime::DBG));
+	kroll->Set(context, NEW_SYMBOL(isolate, "moduleContexts"), mc);
 
 	LOG_TIMER(TAG, "Executing kroll.js");
 
 	TryCatch tryCatch(isolate);
-	Local<Value> result = V8Util::executeString(isolate, KrollBindings::getMainSource(isolate), STRING_NEW(isolate, "ti:/kroll.js"));
+	Local<Value> result = V8Util::executeString(context, KrollBindings::getMainSource(isolate), STRING_NEW(isolate, "ti:/kroll.js"));
 
 	if (tryCatch.HasCaught()) {
 		V8Util::reportException(isolate, tryCatch, true);
@@ -160,7 +160,7 @@ void V8Runtime::bootstrap(Local<Context> context)
 
 	// Expose the global object as a property on itself
 	// (Allows you to set stuff on `global` from anywhere in JavaScript.)
-	global->Set(NEW_SYMBOL(isolate, "global"), global);
+	global->Set(context, NEW_SYMBOL(isolate, "global"), global);
 
 	// Set the __dirname and __filename for the app.js.
 	// For other files, it will be injected via the `NativeModule` JavaScript class
@@ -180,13 +180,14 @@ void V8Runtime::bootstrap(Local<Context> context)
 static void logV8Exception(Local<Message> msg, Local<Value> data)
 {
 	HandleScope scope(V8Runtime::v8_isolate);
-
+	Local<Context> context = V8Runtime::v8_isolate->GetCurrentContext();
 	// Log reason and location of the error.
-	LOGD(TAG, *v8::String::Utf8Value(msg->Get()));
+	LOGD(TAG, *String::Utf8Value(V8Runtime::v8_isolate, msg->Get()));
 	LOGD(TAG, "%s @ %d >>> %s",
-		*v8::String::Utf8Value(msg->GetScriptResourceName()),
-		msg->GetLineNumber(),
-		*v8::String::Utf8Value(msg->GetSourceLine()));
+		*String::Utf8Value(V8Runtime::v8_isolate, msg->GetScriptResourceName()),
+		msg->GetLineNumber(context).FromMaybe(-1),
+		*String::Utf8Value(V8Runtime::v8_isolate,
+		msg->GetSourceLine(context).FromMaybe(-1)));
 }
 
 } // namespace titanium
@@ -204,8 +205,6 @@ JNIEXPORT void JNICALL Java_org_appcelerator_kroll_runtime_v8_V8Runtime_nativeIn
 {
 	if (!V8Runtime::initialized) {
 		// Initialize V8.
-		V8::InitializeICU();
-
 		// TODO Enable this when we use snapshots?
 		//V8::InitializeExternalStartupData(argv[0]);
 		V8Runtime::platform = platform::CreateDefaultPlatform();
@@ -325,16 +324,23 @@ JNIEXPORT jobject JNICALL Java_org_appcelerator_kroll_runtime_v8_V8Runtime_nativ
 	Local<Value> jsFilename = TypeConverter::javaStringToJsString(V8Runtime::v8_isolate, env, filename);
 
 	TryCatch tryCatch(V8Runtime::v8_isolate);
-	Local<Script> script = Script::Compile(jsSource.As<String>(), jsFilename.As<String>());
-	Local<Value> result = script->Run();
-
+	Local<Context> context = V8Runtime::v8_isolate->GetCurrentContext();
+	ScriptOrigin origin(jsFilename);
+	MaybeLocal<Script> maybeScript = Script::Compile(context, jsSource.As<String>(), &origin);
+	if (maybeScript.IsEmpty()) {
+		V8Util::openJSErrorDialog(V8Runtime::v8_isolate, tryCatch);
+		V8Util::reportException(V8Runtime::v8_isolate, tryCatch, true);
+		return NULL;
+	}
+	Local<Script> script = maybeScript.ToLocalChecked();
+	MaybeLocal<Value> result = script->Run(context);
 	if (tryCatch.HasCaught()) {
 		V8Util::openJSErrorDialog(V8Runtime::v8_isolate, tryCatch);
 		V8Util::reportException(V8Runtime::v8_isolate, tryCatch, true);
 		return NULL;
 	}
 
-	return TypeConverter::jsValueToJavaObject(V8Runtime::v8_isolate, env, result);
+	return TypeConverter::jsValueToJavaObject(V8Runtime::v8_isolate, env, result.ToLocalChecked());
 }
 
 JNIEXPORT jboolean JNICALL Java_org_appcelerator_kroll_runtime_v8_V8Runtime_nativeIdle(JNIEnv *env, jobject self)
@@ -410,17 +416,19 @@ JNIEXPORT void JNICALL Java_org_appcelerator_kroll_runtime_v8_V8Runtime_nativeDi
 		// Array and expose it on kroll above in nativeInit, and
 		// module.js will insert module contexts into this array in
 		// Module.prototype._runScript
+		Local<Context> context = V8Runtime::v8_isolate->GetCurrentContext();
 		uint32_t length = V8Runtime::ModuleContexts()->Length();
 		for (uint32_t i = 0; i < length; ++i) {
-			Local<Value> moduleContext = V8Runtime::ModuleContexts()->Get(i);
+			MaybeLocal<Value> moduleContext = V8Runtime::ModuleContexts()->Get(context, i);
+			if (!moduleContext.IsEmpty()) {
+				// WrappedContext is simply a C++ wrapper for the V8 Context object,
+				// and is used to expose the Context to javascript. See ScriptsModule for
+				// implementation details
+				WrappedContext *wrappedContext = WrappedContext::Unwrap(V8Runtime::v8_isolate, moduleContext.ToLocalChecked().As<Object>());
+				ASSERT(wrappedContext != NULL);
 
-			// WrappedContext is simply a C++ wrapper for the V8 Context object,
-			// and is used to expose the Context to javascript. See ScriptsModule for
-			// implementation details
-			WrappedContext *wrappedContext = WrappedContext::Unwrap(V8Runtime::v8_isolate, moduleContext.As<Object>());
-			ASSERT(wrappedContext != NULL);
-
-			wrappedContext->Dispose();
+				wrappedContext->Dispose();
+			}
 		}
 
 		// KrollBindings

--- a/android/runtime/v8/src/native/V8Util.cpp
+++ b/android/runtime/v8/src/native/V8Util.cpp
@@ -1,6 +1,6 @@
 /**
  * Appcelerator Titanium Mobile
- * Copyright (c) 2011-2017 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2011-2018 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
@@ -20,121 +20,101 @@ using namespace v8;
 
 #define TAG "V8Util"
 
-// DEPRECATED: Use v8::String::Utf8Value. Remove in SDK 8.0
-Utf8Value::Utf8Value(v8::Local<v8::Value> value) : length_(0), str_(str_st_)
+Local<Value> V8Util::executeString(Local<Context> context, Local<String> source, Local<Value> filename)
 {
-	if (value.IsEmpty()) return;
-
-	v8::Local<v8::String> string = value->ToString();
-	if (string.IsEmpty()) return;
-
-	// Allocate enough space to include the null terminator
-	size_t len = (3 * string->Length()) + 1;
-	if (len > sizeof(str_st_)) {
-		str_ = static_cast<char*>(malloc(len));
-		//CHECK_NE(str_, nullptr);
-	}
-
-	const int flags = v8::String::NO_NULL_TERMINATION | v8::String::REPLACE_INVALID_UTF8;
-	length_ = string->WriteUtf8(str_, len, 0, flags);
-	str_[length_] = '\0';
-}
-
-Local<Value> V8Util::executeString(Isolate* isolate, Local<String> source, Local<Value> filename)
-{
+	Isolate* isolate = context->GetIsolate();
 	EscapableHandleScope scope(isolate);
 	TryCatch tryCatch(isolate);
 
-	Local<Script> script = Script::Compile(source, filename.As<String>());
-	if (script.IsEmpty()) {
+	ScriptOrigin origin(filename);
+	MaybeLocal<Script> maybeScript = Script::Compile(context, source, &origin);
+	if (maybeScript.IsEmpty()) {
 		LOGF(TAG, "Script source is empty");
 		reportException(isolate, tryCatch, true);
 		return scope.Escape(Undefined(isolate));
 	}
 
-	Local<Value> result = script->Run();
+	Local<Script> script = maybeScript.ToLocalChecked();
+	MaybeLocal<Value> result = script->Run(context);
 	if (result.IsEmpty()) {
 		LOGF(TAG, "Script result is empty");
 		reportException(isolate, tryCatch, true);
 		return scope.Escape(Undefined(isolate));
 	}
 
-	return scope.Escape(result);
+	return scope.Escape(result.ToLocalChecked());
 }
 
 Local<Value> V8Util::newInstanceFromConstructorTemplate(Persistent<FunctionTemplate>& t, const FunctionCallbackInfo<Value>& args)
 {
 	Isolate* isolate = args.GetIsolate();
 	EscapableHandleScope scope(isolate);
-	const int argc = args.Length();
-	Local<Value>* argv = new Local<Value> [argc];
 
+	const int argc = args.Length();
+	Local<Value>* argv = new Local<Value>[argc];
 	for (int i = 0; i < argc; ++i) {
 		argv[i] = args[i];
 	}
 
-	Local<Object> instance = t.Get(isolate)->GetFunction()->NewInstance(argc, argv);
+	Local<Context> context = isolate->GetCurrentContext();
+
+	TryCatch tryCatch(isolate);
+	Local<Value> nativeObject;
+	Local<Object> instance;
+	MaybeLocal<Object> maybeInstance = t.Get(isolate)->GetFunction()->NewInstance(context, argc, argv);
 	delete[] argv;
-	return scope.Escape(instance);
-}
-
-void V8Util::objectExtend(Local<Object> dest, Local<Object> src)
-{
-	Local<Array> names = src->GetOwnPropertyNames();
-	int length = names->Length();
-
-	for (int i = 0; i < length; ++i) {
-		Local<Value> name = names->Get(i);
-		Local<Value> value = src->Get(name);
-		dest->Set(name, value);
+	if (!maybeInstance.ToLocal(&instance)) {
+		V8Util::fatalException(isolate, tryCatch);
+		return scope.Escape(Undefined(isolate));
 	}
+	return scope.Escape(instance);
 }
 
 #define EXC_TAG "V8Exception"
 
-static Persistent<String> nameSymbol, messageSymbol;
-
 void V8Util::reportException(Isolate* isolate, TryCatch &tryCatch, bool showLine)
 {
 	HandleScope scope(isolate);
+	Local<Context> context = isolate->GetCurrentContext();
 	Local<Message> message = tryCatch.Message();
 
-	if (nameSymbol.IsEmpty()) {
-		nameSymbol.Reset(isolate, NEW_SYMBOL(isolate, "name"));
-		messageSymbol.Reset(isolate, NEW_SYMBOL(isolate, "message"));
+	if (showLine && !message.IsEmpty()) {
+		String::Utf8Value filename(isolate, message->GetScriptResourceName());
+		String::Utf8Value msg(isolate, message->Get());
+		Maybe<int> linenum = message->GetLineNumber(context);
+		LOGE(EXC_TAG, "Exception occurred at %s:%i: %s", *filename, linenum.FromMaybe(-1), *msg);
 	}
 
-	if (showLine) {
-		if (!message.IsEmpty()) {
-			v8::String::Utf8Value filename(message->GetScriptResourceName());
-			v8::String::Utf8Value msg(message->Get());
-			int linenum = message->GetLineNumber();
-			LOGE(EXC_TAG, "Exception occurred at %s:%i: %s", *filename, linenum, *msg);
+	// Log the stack trace if we have one
+	MaybeLocal<Value> maybeStackTrace = tryCatch.StackTrace(context);
+	if (!maybeStackTrace.IsEmpty()) {
+		Local<Value> stack = maybeStackTrace.ToLocalChecked();
+		String::Utf8Value trace(isolate, stack);
+		if (trace.length() > 0 && !stack->IsUndefined()) {
+			LOGD(EXC_TAG, *trace);
+			return;
 		}
 	}
 
-	Local<Value> stackTrace = tryCatch.StackTrace();
-	v8::String::Utf8Value trace(stackTrace);
+	// no/empty stack trace, so if the exception is an object,
+	// try to get the 'message' and 'name' properties
+	Local<Value> exception = tryCatch.Exception();
+	if (exception->IsObject()) {
+		Local<Object> exceptionObj = exception.As<Object>();
+		MaybeLocal<Value> message = exceptionObj->Get(context, NEW_SYMBOL(isolate, "message"));
+		MaybeLocal<Value> name = exceptionObj->Get(context, NEW_SYMBOL(isolate, "name"));
 
-	if (trace.length() > 0 && !stackTrace->IsUndefined()) {
-		LOGD(EXC_TAG, *trace);
-	} else {
-		Local<Value> exception = tryCatch.Exception();
-		if (exception->IsObject()) {
-			Local<Object> exceptionObj = exception.As<Object>();
-			Local<Value> message = exceptionObj->Get(messageSymbol.Get(isolate));
-			Local<Value> name = exceptionObj->Get(nameSymbol.Get(isolate));
-
-			if (!message->IsUndefined() && !name->IsUndefined()) {
-				v8::String::Utf8Value nameValue(name);
-				v8::String::Utf8Value messageValue(message);
-				LOGE(EXC_TAG, "%s: %s", *nameValue, *messageValue);
-			}
-		} else {
-			v8::String::Utf8Value error(exception);
-			LOGE(EXC_TAG, *error);
+		if (!message.IsEmpty() && !message.ToLocalChecked()->IsUndefined() && !name.IsEmpty() && !name.ToLocalChecked()->IsUndefined()) {
+			String::Utf8Value nameValue(isolate, name.ToLocalChecked());
+			String::Utf8Value messageValue(isolate, message.ToLocalChecked());
+			LOGE(EXC_TAG, "%s: %s", *nameValue, *messageValue);
+			return;
 		}
 	}
+
+	// Fall back to logging exception as a string
+	String::Utf8Value error(isolate, exception);
+	LOGE(EXC_TAG, *error);
 }
 
 void V8Util::openJSErrorDialog(Isolate* isolate, TryCatch &tryCatch)
@@ -167,7 +147,7 @@ void V8Util::openJSErrorDialog(Isolate* isolate, TryCatch &tryCatch)
 			frames = StackTrace::CurrentStackTrace(isolate, MAX_STACK);
 		}
 		if (!frames.IsEmpty()) {
-			std::string stackString = V8Util::stackTraceString(frames);
+			std::string stackString = V8Util::stackTraceString(isolate, frames);
 			if (!stackString.empty()) {
 				jsStack = String::NewFromUtf8(isolate, stackString.c_str()).As<Value>();
 			}
@@ -177,22 +157,20 @@ void V8Util::openJSErrorDialog(Isolate* isolate, TryCatch &tryCatch)
 	jstring title = env->NewStringUTF("Runtime Error");
 	jstring errorMessage = TypeConverter::jsValueToJavaString(isolate, env, message->Get());
 	jstring resourceName = TypeConverter::jsValueToJavaString(isolate, env, message->GetScriptResourceName());
-	jstring sourceLine = TypeConverter::jsValueToJavaString(isolate, env, message->GetSourceLine());
+	jstring sourceLine = TypeConverter::jsValueToJavaString(isolate, env, message->GetSourceLine(context).FromMaybe(Null(isolate).As<Value>()));
 	jstring jsStackString = TypeConverter::jsValueToJavaString(isolate, env, jsStack);
 	jstring javaStackString = TypeConverter::jsValueToJavaString(isolate, env, javaStack);
-
 	env->CallStaticVoidMethod(
 		JNIUtil::krollRuntimeClass,
 		JNIUtil::krollRuntimeDispatchExceptionMethod,
 		title,
 		errorMessage,
 		resourceName,
-		message->GetLineNumber(),
+		message->GetLineNumber(context).FromMaybe(-1),
 		sourceLine,
-		message->GetEndColumn(),
+		message->GetEndColumn(context).FromMaybe(-1),
 		jsStackString,
 		javaStackString);
-
 	env->DeleteLocalRef(title);
 	env->DeleteLocalRef(errorMessage);
 	env->DeleteLocalRef(resourceName);
@@ -220,23 +198,37 @@ Local<String> V8Util::jsonStringify(Isolate* isolate, Local<Value> value)
 	EscapableHandleScope scope(isolate);
 	Local<Context> context = isolate->GetCurrentContext();
 
-	Local<Object> json = context->Global()->Get(STRING_NEW(isolate, "JSON")).As<Object>();
-	Local<Function> stringify = json->Get(STRING_NEW(isolate, "stringify")).As<Function>();
+	TryCatch tryCatch(isolate);
+
+	MaybeLocal<Value> jsonGlobal = context->Global()->Get(context, STRING_NEW(isolate, "JSON"));
+	if (jsonGlobal.IsEmpty()) {
+		LOGE(TAG, "!!!! JSON global not found/accessible !!!");
+		return scope.Escape(STRING_NEW(isolate, "ERROR"));
+	}
+
+	Local<Object> jsonObject = jsonGlobal.ToLocalChecked().As<Object>();
+	MaybeLocal<Value> stringifyValue = jsonObject->Get(context, STRING_NEW(isolate, "stringify"));
+	if (stringifyValue.IsEmpty()) {
+		LOGE(TAG, "!!!! JSON.stringifyValue not found/accessible !!!");
+		return scope.Escape(STRING_NEW(isolate, "ERROR"));
+	}
+
+	Local<Function> stringify = stringifyValue.ToLocalChecked().As<Function>();
 	Local<Value> args[] = { value };
-	MaybeLocal<Value> result = stringify->Call(context, json, 1, args);
+	MaybeLocal<Value> result = stringify->Call(context, jsonObject, 1, args);
 	if (result.IsEmpty()) {
 		LOGE(TAG, "!!!! JSON.stringify() result is null/undefined.!!!");
 		return scope.Escape(STRING_NEW(isolate, "ERROR"));
-	} else {
-		return scope.Escape(result.ToLocalChecked().As<String>());
 	}
+
+	return scope.Escape(result.ToLocalChecked().As<String>());
 }
 
 bool V8Util::constructorNameMatches(Isolate* isolate, Local<Object> object, const char* name)
 {
 	HandleScope scope(isolate);
 	Local<String> constructorName = object->GetConstructorName();
-	return strcmp(*v8::String::Utf8Value(constructorName), name) == 0;
+	return strcmp(*String::Utf8Value(isolate, constructorName), name) == 0;
 }
 
 static Persistent<Function> isNaNFunction;
@@ -248,26 +240,25 @@ bool V8Util::isNaN(Isolate* isolate, Local<Value> value)
 	Local<Object> global = context->Global();
 
 	if (isNaNFunction.IsEmpty()) {
-		Local<Value> isNaNValue = global->Get(NEW_SYMBOL(isolate, "isNaN"));
-		isNaNFunction.Reset(isolate, isNaNValue.As<Function>());
+		MaybeLocal<Value> isNaNValue = global->Get(context, NEW_SYMBOL(isolate, "isNaN"));
+		if (isNaNValue.IsEmpty()) {
+			LOGE(TAG, "!!!! global isNaN function not found/inaccessible. !!!");
+			return false;
+		}
+		isNaNFunction.Reset(isolate, isNaNValue.ToLocalChecked().As<Function>());
 	}
 
 	Local<Value> args[] = { value };
 	MaybeLocal<Value> result = isNaNFunction.Get(isolate)->Call(context, global, 1, args);
-	if (result.IsEmpty()) {
-		return false;
-	}
-	return result.ToLocalChecked()->BooleanValue();
+	return result.FromMaybe(False(isolate).As<Value>())->BooleanValue(context).FromMaybe(false);
 }
 
 void V8Util::dispose()
 {
-	nameSymbol.Reset();
-	messageSymbol.Reset();
 	isNaNFunction.Reset();
 }
 
-std::string V8Util::stackTraceString(Local<StackTrace> frames) {
+std::string V8Util::stackTraceString(v8::Isolate* isolate, Local<StackTrace> frames) {
 	if (frames.IsEmpty()) {
 		return std::string();
 	}
@@ -275,12 +266,12 @@ std::string V8Util::stackTraceString(Local<StackTrace> frames) {
 	std::stringstream stack;
 
 	for (int i = 0, count = frames->GetFrameCount(); i < count; i++) {
-		v8::Local<v8::StackFrame> frame = frames->GetFrame(i);
+		v8::Local<v8::StackFrame> frame = frames->GetFrame(isolate, i);
 
-		v8::String::Utf8Value jsFunctionName(frame->GetFunctionName());
+		v8::String::Utf8Value jsFunctionName(isolate, frame->GetFunctionName());
 		std::string functionName = std::string(*jsFunctionName, jsFunctionName.length());
 
-		v8::String::Utf8Value jsScriptName(frame->GetScriptName());
+		v8::String::Utf8Value jsScriptName(isolate, frame->GetScriptName());
 		std::string scriptName = std::string(*jsScriptName, jsScriptName.length());
 
 		stack << "    at " << functionName << "(" << scriptName << ":" << frame->GetLineNumber() << ":" << frame->GetColumn() << ")" << std::endl;

--- a/android/runtime/v8/src/native/V8Util.h
+++ b/android/runtime/v8/src/native/V8Util.h
@@ -1,6 +1,6 @@
 /**
  * Appcelerator Titanium Mobile
- * Copyright (c) 2011-2016 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2011-2018 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
@@ -17,10 +17,10 @@
 	v8::String::NewExternalOneByte(isolate, new v8::ExternalOneByteStringResourceImpl(string_literal, length)).ToLocalChecked()
 
 #define NEW_SYMBOL(isolate, string_literal) \
-	v8::String::NewFromUtf8(isolate, string_literal "", v8::String::kInternalizedString)
+	v8::String::NewFromUtf8(isolate, string_literal "", v8::NewStringType::kInternalized).ToLocalChecked()
 
 #define STRING_NEW(isolate, string_literal) \
-	v8::String::NewFromUtf8(isolate, string_literal "")
+	v8::String::NewFromUtf8(isolate, string_literal "", v8::NewStringType::kNormal).ToLocalChecked()
 
 #define DEFINE_CONSTANT(isolate, target, name, value) \
 	(target)->Set(NEW_SYMBOL(isolate, name), \
@@ -88,11 +88,9 @@ inline v8::Local<v8::FunctionTemplate> NewFunctionTemplate(v8::Isolate* isolate,
 	return v8::FunctionTemplate::New(isolate, callback, v8::Local<v8::Value>(), signature);
 }
 
-inline void SetMethod(v8::Isolate* isolate, v8::Local<v8::Object> that, const char* name, v8::FunctionCallback callback) {
-	v8::Local<v8::Function> function = NewFunctionTemplate(isolate, callback)->GetFunction();
-	// kInternalized strings are created in the old space.
-	const v8::NewStringType type = v8::NewStringType::kInternalized;
-	v8::Local<v8::String> name_string = v8::String::NewFromUtf8(isolate, name, type).ToLocalChecked();
+inline void SetMethod(v8::Local<v8::Context> context, v8::Isolate* isolate, v8::Local<v8::Object> that, const char* name, v8::FunctionCallback callback) {
+	v8::Local<v8::Function> function = NewFunctionTemplate(isolate, callback)->GetFunction(context).ToLocalChecked();
+	v8::Local<v8::String> name_string = v8::String::NewFromUtf8(isolate, name, v8::NewStringType::kInternalized).ToLocalChecked();
 	that->Set(name_string, function);
 	function->SetName(name_string); // NODE_SET_METHOD() compatibility.
 }
@@ -100,56 +98,23 @@ inline void SetMethod(v8::Isolate* isolate, v8::Local<v8::Object> that, const ch
 inline void SetProtoMethod(v8::Isolate* isolate, v8::Local<v8::FunctionTemplate> that, const char* name, v8::FunctionCallback callback) {
 	v8::Local<v8::Signature> signature = v8::Signature::New(isolate, that);
 	v8::Local<v8::FunctionTemplate> t = NewFunctionTemplate(isolate, callback);
-	// kInternalized strings are created in the old space.
-	const v8::NewStringType type = v8::NewStringType::kInternalized;
-	v8::Local<v8::String> name_string = v8::String::NewFromUtf8(isolate, name, type).ToLocalChecked();
+	v8::Local<v8::String> name_string = v8::String::NewFromUtf8(isolate, name, v8::NewStringType::kInternalized).ToLocalChecked();
 	that->PrototypeTemplate()->Set(name_string, t);
 	t->SetClassName(name_string); // NODE_SET_PROTOTYPE_METHOD() compatibility.
 }
 
 inline void SetTemplateMethod(v8::Isolate* isolate, v8::Local<v8::FunctionTemplate> that, const char* name, v8::FunctionCallback callback) {
 	v8::Local<v8::FunctionTemplate> t = NewFunctionTemplate(isolate, callback);
-	// kInternalized strings are created in the old space.
-	const v8::NewStringType type = v8::NewStringType::kInternalized;
-	v8::Local<v8::String> name_string = v8::String::NewFromUtf8(isolate, name, type).ToLocalChecked();
+	v8::Local<v8::String> name_string = v8::String::NewFromUtf8(isolate, name, v8::NewStringType::kInternalized).ToLocalChecked();
 	that->Set(name_string, t);
 	t->SetClassName(name_string); // NODE_SET_METHOD() compatibility.
 }
 
-// DEPRECATED: Use v8::String::Utf8Value. Remove in SDK 8.0
-// class [[deprecated("Replaced by v8::String::Utf8Value, which is now official V8 API")]] Utf8Value {
-class Utf8Value {
-	public:
-	explicit Utf8Value(v8::Local<v8::Value> value);
-
-	~Utf8Value() {
-		if (str_ != str_st_) free(str_);
-	}
-
-	char* operator*() {
-		return str_;
-	};
-
-	const char* operator*() const {
-		return str_;
-	};
-
-	size_t length() const {
-		return length_;
-	};
-
-	private:
-	size_t length_;
-	char* str_;
-	char str_st_[1024];
-};
-
 class V8Util {
 public:
-	static v8::Local<v8::Value> executeString(v8::Isolate* isolate, v8::Local<v8::String> source, v8::Local<v8::Value> filename);
+	static v8::Local<v8::Value> executeString(v8::Local<v8::Context> context, v8::Local<v8::String> source, v8::Local<v8::Value> filename);
 	static v8::Local<v8::Value> newInstanceFromConstructorTemplate(v8::Persistent<v8::FunctionTemplate>& t,
-	const v8::FunctionCallbackInfo<v8::Value>& args);
-	static void objectExtend(v8::Local<v8::Object> dest, v8::Local<v8::Object> src);
+		const v8::FunctionCallbackInfo<v8::Value>& args);
 	static void reportException(v8::Isolate* isolate, v8::TryCatch &tryCatch, bool showLine = true);
 	static void openJSErrorDialog(v8::Isolate* isolate, v8::TryCatch &tryCatch);
 	static void fatalException(v8::Isolate* isolate, v8::TryCatch &tryCatch);
@@ -157,7 +122,7 @@ public:
 	static bool constructorNameMatches(v8::Isolate* isolate, v8::Local<v8::Object>, const char* name);
 	static bool isNaN(v8::Isolate* isolate, v8::Local<v8::Value> value);
 	static void dispose();
-	static std::string stackTraceString(v8::Local<v8::StackTrace> frames);
+	static std::string stackTraceString(v8::Isolate* isolate, v8::Local<v8::StackTrace> frames);
 };
 
 }

--- a/android/runtime/v8/src/native/modules/APIModule.cpp
+++ b/android/runtime/v8/src/native/modules/APIModule.cpp
@@ -7,7 +7,6 @@
 
 #include <android/log.h>
 #include <v8.h>
-#include <v8-debug.h>
 #include <cstring>
 #include <signal.h>
 #include <unistd.h>
@@ -18,6 +17,7 @@
 #include "V8Runtime.h"
 #include "V8Util.h"
 #include "org.appcelerator.kroll.KrollModule.h"
+#include "JSDebugger.h"
 
 namespace titanium {
 
@@ -71,7 +71,7 @@ void APIModule::Initialize(Local<Object> target, Local<Context> context)
 	// TODO Use a constant here?
 	Local<ObjectTemplate> instanceTemplate = constructor->InstanceTemplate();
 	instanceTemplate->SetAccessor(NEW_SYMBOL(isolate, "apiName"), APIModule::getter_apiName);
-	
+
 	instanceTemplate->SetAccessor(NEW_SYMBOL(isolate, "bubbleParent"), APIModule::getter_undefined);
 	instanceTemplate->SetAccessor(NEW_SYMBOL(isolate, "lifecycleContainer"), APIModule::getter_undefined);
 
@@ -83,7 +83,7 @@ void APIModule::Initialize(Local<Object> target, Local<Context> context)
 		SetProtoMethod(isolate, constructor, "debugBreak", debugBreak);
 	}
 	// Make API extend from KrollModule
-	constructor->Inherit(KrollModule::getProxyTemplate(isolate));
+	constructor->Inherit(KrollModule::getProxyTemplate(context));
 
 	// export an instance of API as "API" (basically make a static singleton)
 	v8::TryCatch tryCatch(isolate);
@@ -104,57 +104,65 @@ void APIModule::Initialize(Local<Object> target, Local<Context> context)
 
 void APIModule::logDebug(const FunctionCallbackInfo<Value>& args)
 {
-	HandleScope scope(args.GetIsolate());
-	v8::String::Utf8Value message(APIModule::combineLogMessages(args));
+	Isolate* isolate = args.GetIsolate();
+	HandleScope scope(isolate);
+	v8::String::Utf8Value message(isolate, APIModule::combineLogMessages(args));
 	APIModule::logInternal(LOG_LEVEL_DEBUG, LCAT, *message);
 }
 
 void APIModule::logInfo(const FunctionCallbackInfo<Value>& args)
 {
-	HandleScope scope(args.GetIsolate());
-	v8::String::Utf8Value message(APIModule::combineLogMessages(args));
+	Isolate* isolate = args.GetIsolate();
+	HandleScope scope(isolate);
+	v8::String::Utf8Value message(isolate, APIModule::combineLogMessages(args));
 	APIModule::logInternal(LOG_LEVEL_INFO, LCAT, *message);
 }
 
 void APIModule::logWarn(const FunctionCallbackInfo<Value>& args)
 {
-	HandleScope scope(args.GetIsolate());
-	v8::String::Utf8Value message(APIModule::combineLogMessages(args));
+	Isolate* isolate = args.GetIsolate();
+	HandleScope scope(isolate);
+	v8::String::Utf8Value message(isolate, APIModule::combineLogMessages(args));
 	APIModule::logInternal(LOG_LEVEL_WARN, LCAT, *message);
 }
 
 void APIModule::logError(const FunctionCallbackInfo<Value>& args)
 {
-	HandleScope scope(args.GetIsolate());
-	v8::String::Utf8Value message(APIModule::combineLogMessages(args));
+	Isolate* isolate = args.GetIsolate();
+	HandleScope scope(isolate);
+	v8::String::Utf8Value message(isolate, APIModule::combineLogMessages(args));
 	APIModule::logInternal(LOG_LEVEL_ERROR, LCAT, *message);
 }
 
 void APIModule::logTrace(const FunctionCallbackInfo<Value>& args)
 {
-	HandleScope scope(args.GetIsolate());
-	v8::String::Utf8Value message(APIModule::combineLogMessages(args));
+	Isolate* isolate = args.GetIsolate();
+	HandleScope scope(isolate);
+	v8::String::Utf8Value message(isolate, APIModule::combineLogMessages(args));
 	APIModule::logInternal(LOG_LEVEL_TRACE, LCAT, *message);
 }
 
 void APIModule::logNotice(const FunctionCallbackInfo<Value>& args)
 {
-	HandleScope scope(args.GetIsolate());
-	v8::String::Utf8Value message(APIModule::combineLogMessages(args));
+	Isolate* isolate = args.GetIsolate();
+	HandleScope scope(isolate);
+	v8::String::Utf8Value message(isolate, APIModule::combineLogMessages(args));
 	APIModule::logInternal(LOG_LEVEL_NOTICE, LCAT, *message);
 }
 
 void APIModule::logCritical(const FunctionCallbackInfo<Value>& args)
 {
-	HandleScope scope(args.GetIsolate());
-	v8::String::Utf8Value message(APIModule::combineLogMessages(args));
+	Isolate* isolate = args.GetIsolate();
+	HandleScope scope(isolate);
+	v8::String::Utf8Value message(isolate, APIModule::combineLogMessages(args));
 	APIModule::logInternal(LOG_LEVEL_CRITICAL, LCAT, *message);
 }
 
 void APIModule::logFatal(const FunctionCallbackInfo<Value>& args)
 {
-	HandleScope scope(args.GetIsolate());
-	v8::String::Utf8Value message(args[0]);
+	Isolate* isolate = args.GetIsolate();
+	HandleScope scope(isolate);
+	v8::String::Utf8Value message(isolate, args[0]);
 	APIModule::logInternal(LOG_LEVEL_FATAL, LCAT, *message);
 }
 
@@ -201,13 +209,14 @@ void APIModule::logInternal(int logLevel, const char *messageTag, const char *me
 
 void APIModule::log(const FunctionCallbackInfo<Value>& args)
 {
-	HandleScope scope(args.GetIsolate());
+	Isolate* isolate = args.GetIsolate();
+	HandleScope scope(isolate);
 	if (args.Length()  == 1) {
-		v8::String::Utf8Value message(args[0]);
+		v8::String::Utf8Value message(isolate, args[0]);
 		APIModule::logInternal(LOG_LEVEL_INFO, LCAT, *message);
 	} else {
-		v8::String::Utf8Value level(args[0]);
-		v8::String::Utf8Value message(APIModule::combineLogMessages(args, 1));
+		v8::String::Utf8Value level(isolate, args[0]);
+		v8::String::Utf8Value message(isolate, APIModule::combineLogMessages(args, 1));
 
 		if (strcasecmp(*level, "TRACE") == 0) {
 			APIModule::logInternal(LOG_LEVEL_TRACE, LCAT, *message);
@@ -237,19 +246,20 @@ void APIModule::log(const FunctionCallbackInfo<Value>& args)
 
 Local<String> APIModule::combineLogMessages(const FunctionCallbackInfo<Value>& args, int startIndex)
 {
-    // Unfortunately there is no really reasonable way to do this in a memory
-    // and speed-efficient manner. Instead what we have is a series of string
-    // object concatenations, which is a rough emulation of what the + op would
-    // do in JS. Requiring the whitespace between arguments complicates matters
-    // by introducing the " " token.
-    Isolate* isolate = args.GetIsolate();
-    Local<String> space = NEW_SYMBOL(isolate, " ");
-    Local<String> message = String::Empty(isolate);
-    for (int i=startIndex; i < args.Length(); i++) {
-        message = String::Concat(message, String::Concat(space, args[i]->ToString(isolate)));
-    }
-
-    return message;
+	// Unfortunately there is no really reasonable way to do this in a memory
+	// and speed-efficient manner. Instead what we have is a series of string
+	// object concatenations, which is a rough emulation of what the + op would
+	// do in JS. Requiring the whitespace between arguments complicates matters
+	// by introducing the " " token.
+	Isolate* isolate = args.GetIsolate();
+	Local<Context> context = isolate->GetCurrentContext();
+	Local<String> space = NEW_SYMBOL(isolate, " ");
+	Local<String> message = String::Empty(isolate);
+	Local<String> empty = String::Empty(isolate);
+	for (int i=startIndex; i < args.Length(); i++) {
+		message = String::Concat(isolate, message, String::Concat(isolate, space, args[i]->ToString(context).FromMaybe(empty)));
+	}
+	return message;
 }
 
 void APIModule::getApiName(const FunctionCallbackInfo<Value>& args)
@@ -274,7 +284,7 @@ void APIModule::terminate(const FunctionCallbackInfo<Value>& args)
 
 void APIModule::debugBreak(const FunctionCallbackInfo<Value>& args)
 {
-	Debug::DebugBreak(args.GetIsolate());
+	JSDebugger::debugBreak();
 }
 
 void APIModule::undefined(const FunctionCallbackInfo<Value>& args)

--- a/android/runtime/v8/src/ndk-modules/libv8/Android.mk
+++ b/android/runtime/v8/src/ndk-modules/libv8/Android.mk
@@ -1,6 +1,6 @@
 #
 # Appcelerator Titanium Mobile
-# Copyright (c) 2011-2017 by Appcelerator, Inc. All Rights Reserved.
+# Copyright (c) 2011-2018 by Appcelerator, Inc. All Rights Reserved.
 # Licensed under the terms of the Apache Public License
 # Please see the LICENSE included with this distribution for details.
 #
@@ -39,57 +39,9 @@ ifeq ($(TARGET_ARCH_ABI),arm64-v8a)
 SIMPLIFIED_ARCH := arm64
 endif
 
-# v8_libbase
+# v8_monolith
 include $(CLEAR_VARS)
-LOCAL_MODULE    := libv8_libbase
+LOCAL_MODULE    := libv8_monolith
 LOCAL_SRC_FILES := $(LIBV8_DIR)/libs/$(SIMPLIFIED_ARCH)/$(LOCAL_MODULE).a
 LOCAL_EXPORT_C_INCLUDES := $(LIBV8_DIR)/include
-include $(PREBUILT_STATIC_LIBRARY)
-
-# v8_libsampler
-include $(CLEAR_VARS)
-LOCAL_MODULE    := libv8_libsampler
-LOCAL_SRC_FILES := $(LIBV8_DIR)/libs/$(SIMPLIFIED_ARCH)/$(LOCAL_MODULE).a
-LOCAL_EXPORT_C_INCLUDES := $(LIBV8_DIR)/include
-LOCAL_STATIC_LIBRARIES := libv8_libbase
-include $(PREBUILT_STATIC_LIBRARY)
-
-# v8_base
-include $(CLEAR_VARS)
-LOCAL_MODULE := libv8_base
-LOCAL_SRC_FILES := $(LIBV8_DIR)/libs/$(SIMPLIFIED_ARCH)/$(LOCAL_MODULE).a
-LOCAL_EXPORT_C_INCLUDES := $(LIBV8_DIR)/include
-LOCAL_STATIC_LIBRARIES := libv8_libbase libv8_libsampler
-include $(PREBUILT_STATIC_LIBRARY)
-
-# v8_libplatform
-include $(CLEAR_VARS)
-LOCAL_MODULE    := libv8_libplatform
-LOCAL_SRC_FILES := $(LIBV8_DIR)/libs/$(SIMPLIFIED_ARCH)/$(LOCAL_MODULE).a
-LOCAL_EXPORT_C_INCLUDES := $(LIBV8_DIR)/include
-LOCAL_STATIC_LIBRARIES := libv8_libbase
-include $(PREBUILT_STATIC_LIBRARY)
-
-# v8_nosnapshot
-include $(CLEAR_VARS)
-LOCAL_MODULE    := libv8_nosnapshot
-LOCAL_SRC_FILES := $(LIBV8_DIR)/libs/$(SIMPLIFIED_ARCH)/$(LOCAL_MODULE).a
-LOCAL_EXPORT_C_INCLUDES := $(LIBV8_DIR)/include
-LOCAL_STATIC_LIBRARIES := libv8_base
-include $(PREBUILT_STATIC_LIBRARY)
-
-# v8_builtins_generators
-include $(CLEAR_VARS)
-LOCAL_MODULE    := libv8_builtins_generators
-LOCAL_SRC_FILES := $(LIBV8_DIR)/libs/$(SIMPLIFIED_ARCH)/$(LOCAL_MODULE).a
-LOCAL_EXPORT_C_INCLUDES := $(LIBV8_DIR)/include
-LOCAL_STATIC_LIBRARIES := libv8_base
-include $(PREBUILT_STATIC_LIBRARY)
-
-# v8_builtins_setup
-include $(CLEAR_VARS)
-LOCAL_MODULE    := libv8_builtins_setup
-LOCAL_SRC_FILES := $(LIBV8_DIR)/libs/$(SIMPLIFIED_ARCH)/$(LOCAL_MODULE).a
-LOCAL_EXPORT_C_INCLUDES := $(LIBV8_DIR)/include
-LOCAL_STATIC_LIBRARIES := libv8_builtins_generators
 include $(PREBUILT_STATIC_LIBRARY)

--- a/android/templates/module/generated/{{ModuleIdAsIdentifier}}Bootstrap.cpp.ejs
+++ b/android/templates/module/generated/{{ModuleIdAsIdentifier}}Bootstrap.cpp.ejs
@@ -50,7 +50,7 @@ static void <%- className %>_getBinding(const FunctionCallbackInfo<Value>& args)
 		return;
 	}
 
-	v8::String::Utf8Value bindingValue(binding);
+	v8::String::Utf8Value bindingValue(isolate, binding);
 	LOGD(TAG, "Looking up binding: %s", *bindingValue);
 
 	titanium::bindings::BindEntry *extBinding = titanium::bindings::<%- className %>Bindings::lookupGeneratedInit(
@@ -98,7 +98,7 @@ static void <%- className %>_dispose(Isolate* isolate)
 	uint32_t length = propertyNames->Length();
 
 	for (uint32_t i = 0; i < length; ++i) {
-		v8::String::Utf8Value binding(propertyNames->Get(i));
+		v8::String::Utf8Value binding(isolate, propertyNames->Get(i));
 		int bindingLength = binding.length();
 
 		titanium::bindings::BindEntry *extBinding =

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "8.0.0",
   "moduleApiVersion": {
     "iphone": "2",
-    "android": "4",
+    "android": "5",
     "windows": "6"
   },
   "keywords": [

--- a/support/module/packaged/modules.json
+++ b/support/module/packaged/modules.json
@@ -43,20 +43,20 @@
 			"integrity": "sha512-fIR52VyFEFFr5HmJfnAQc6n1QCpZFifNa9ONrXWuZYd1f97PeEfmq/ggJztexe4NvMutQheWbysunkv2qZMCRA=="
 		},
 		"ti.map": {
-			"url": "https://github.com/appcelerator-modules/ti.map/releases/download/android-4.3.1/ti.map-android-4.3.1.zip",
-			"integrity": "sha512-g36WuxrRzdwi8DRbyLmJyiF53aUefDeExhNEc6POVi8elbbX17phtKwiMdF3foifxUdpdMTo31CVJQXnfxc75w=="
+			"url": "https://s3.amazonaws.com/builds.appcelerator.com/mobile/custom/ti.map-android-5.0.0.zip",
+			"integrity": "sha512-OIDe/EJR0Us1Y9L8/XJ9bGHqxwufXzeU3iQmqoxVEu3uuT89kRPDp8T5yW52RbrG9vc/AXyHtHmRvOzvyrQlaA=="
 		},
 		"ti.webdialog": {
 			"url": "https://github.com/appcelerator-modules/titanium-web-dialog/releases/download/android-1.1.0/ti.webdialog-android-1.1.0.zip",
 			"integrity": "sha512-aE5Y3Ll3yXyO7oo9RdbMRNpFfnxrfhHzddIJS0KPJ+eZyNtK/h2S7BstSkQkiQt4GBaGFALaEaWqyMCSuvailA=="
 		},
 		"ti.touchid": {
-			"url": "https://github.com/appcelerator-modules/ti.touchid/releases/download/android-3.0.1/ti.touchid-android-3.0.1.zip",
-			"integrity": "sha512-G30ZTwV1VI+GI5FmRWJLGZUQgckvMYTiX7mYhWDLCGZac8cSQDpG4xylJlSp6B/isNqa6TBX4ZPE3ieJ50p0mA=="
+			"url": "https://s3.amazonaws.com/builds.appcelerator.com/mobile/custom/ti.touchid-android-4.0.0.zip",
+			"integrity": "sha512-KW6yIGJUfhFBI2J2ZMEdWLi0EFr4wHW/PRHsr3dWbONvaVSnDksrv+eTpoetcKVPCPwWlB46NJMsv0p2KAoKaw=="
 		},
 		"ti.playservices": {
-			"url": "https://github.com/appcelerator-modules/ti.playservices/releases/download/android-11.0.40/ti.playservices-android-11.0.40.zip",
-			"integrity": "sha512-bLhpzOjnmiTWFRjMuFfvqf0ePd1kbTdXLMVZJ+EsPrfn4JmxvkINS9Nu6ivjV+fmH9cBYVjZ5k9nGCeUdqZOlQ=="
+			"url": "https://s3.amazonaws.com/builds.appcelerator.com/mobile/custom/ti.playservices-android-11.0.40.zip",
+			"integrity": "sha512-IvNvAGM8xX6PQPEauHaN6oPtxvEhng4n23j0wCTzaHdEnwF6Ek9sBOSHyH44aEVyCHj6dOrrCw3qtKU5pi3BVg=="
 		},
 		"ti.identity": {
 			"url": "https://github.com/appcelerator-modules/titanium-identity/releases/download/android-2.1.0/ti.identity-android-2.1.0.zip",


### PR DESCRIPTION
**JIRA**: https://jira.appcelerator.org/browse/TIMOB-26340

**Description**
This is a PR/branch to keep us up to date with the latest V8 stable branch. This will get updated over time as we approach 8.0 being target of master branch.

Here's how we can track stable branch: https://omahaproxy.appspot.com

So far the update required:
- Compiling with Android NDK r16b
- bumping the native module api version for android to `5` (we will need to rebuild the bundled native modules against a new SDK now)
- Changing from gyp to ninja/gn to build v8 (which also resulted in an easier to consume single static library)
- tweaks around the fallback sourceURL we pass to Java proxies. In most cases we get the url passed in a context object behind the scenes. But there are/were cases we grabbed the url from the function args `Callee()` method which is now removed (and was long deprecated). I can achieve the same thing using a stack trace hack, and I have done so. I also moved it to happen only when we *don't* get the url passed in. In these cases I'm not even sure we need to hack the url from the stack trace. Every instance I saw was a ti:/whatever.js internal runtime file or a "module.id/bootstrap.js" file. We may be able to keep null, or fall back to app://app.js. Or maybe we need to look up the stack higher?
- `HasOwnProperty()` and `GetRealNamedProperty()` calls now require a `Local<Context>` first argument.
- Some APIs Now return `MaybeLocal<T>` and need to be handled more carefully (i.e. actual try/catch or safe conversions to `Local<T>` as they have been doing over time to almost all APIs)
- Changing a reference to the legacy debug API on our APIModule.cpp to delegate to `JSDebugger::debugBreak()` instead to handle `Ti.API.debugBreak();`
- Move away from deprecated APIs that took an `Isolate` and now take a `Context` (typically coercion calls like `ToString()`, `ToObject`, `Int32Value()`, etc on `Local<Value>`).
- Move to APIs taking a first-argument `Context` now, such as `Get` and `Set` calls on `Local<Object>`.

TODO:
- [ ] Rebuild the pre-packaged android native modules against this SDK (there's a bit of a chicken and egg problem to do so. The builds here fail during unit testing until the modules are rebuilt, bu the modules need to pick up a built SDK to build against). This likely means I'll need to move/change this PR to be a long running feature branch on the original repo that actually get published. Maybe wait until we branch for 8.0 and we get it automatically...