### PR TITLE
[7_1_X][TIMOB-25895] Update module apiversion

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "moduleApiVersion": {
     "iphone": "2",
     "android": "4",
-    "windows": "4"
+    "windows": "5"
   },
   "keywords": [
     "appcelerator",


### PR DESCRIPTION
Cherry-pick #9956 for 7_1_X

**JIRA:** https://jira.appcelerator.org/browse/TIMOB-25895

Update Windows module `apiversion` due to [TIMOB-25895](https://jira.appcelerator.org/browse/TIMOB-25895). This works together with https://github.com/appcelerator/titanium_mobile_windows/pull/1213