### PR TITLE
[TIMOB-25903] Android: TableView.updateRow method doesn't work on 7.1 if run-on-main-thread is off

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TableViewProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TableViewProxy.java
@@ -886,6 +886,7 @@ public class TableViewProxy extends TiViewProxy
 		Object asyncResult = null;
 		switch (msg.what) {
 			case MSG_UPDATE_VIEW:
+				setModelDirtyIfNecessary();
 				result = (AsyncResult) msg.obj;
 				if (tableNativeViewCreated) {
 					tableNativeView.updateView();


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-25903

**Description:**
Update model when the row updated from another thread.

**Test case:**
1. Open the "tiapp.xml" file.
2. Set XML property `run-on-main-thread` to `false`.
3. Run the below code on Android.
4. Tap on the "Update Row" button.
5. Verify that text `ROW #00` changes to `NEW ROW`.

---
```xml
<?xml version="1.0" encoding="UTF-8"?>
<ti:app xmlns:ti="http://ti.appcelerator.org">
   <property name="run-on-main-thread" type="bool">false</property>
</ti:app>
```

---
```javascript
var win = Ti.UI.createWindow({backgroundColor: 'gray'});
var rowData = [];
var row = Ti.UI.createTableViewRow({
height: 120,
title: 'ROW #00'
});
rowData.push(row);
 
var table = Ti.UI.createTableView({
top: 50,
height: 120,
data: rowData
});
table.addEventListener( 'click', function(e) {
console.log(' ***** click on table ');
});
win.add(table);
 
var bt = Ti.UI.createButton({
top: 200,
title: 'UPDATE ROW'
});
 
bt.addEventListener('click',function(e){
var newRow = Ti.UI.createTableViewRow({
height: 120,
title: 'NEW ROW'
});
table.updateRow(0,newRow);
});
win.add(bt);
 
win.open();
```

---
**Note:** I am not sure if our unit tests should be considering `run-on-ui-thread` property.  It will be significantly more time consuming to handle both set ups, but maybe it is worth thinking in that direction? What do you think?