### PR TITLE
[7_1_X][TIMOB-25903] Android: TableView.updateRow method doesn't work on 7.1 if run-on-main-thread is off

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TableViewProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TableViewProxy.java
@@ -886,6 +886,7 @@ public class TableViewProxy extends TiViewProxy
 		Object asyncResult = null;
 		switch (msg.what) {
 			case MSG_UPDATE_VIEW:
+				setModelDirtyIfNecessary();
 				result = (AsyncResult) msg.obj;
 				if (tableNativeViewCreated) {
 					tableNativeView.updateView();


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-25903

**Back-port of:** #9962 