### PR TITLE
[TIMOB-25913] Android: Update gradle for Java 9 compatibility

### DIFF
--- a/android/templates/gradle/gradle/wrapper/gradle-wrapper.properties
+++ b/android/templates/gradle/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-4.6-all.zip


### PR DESCRIPTION
- Update `gradle` to `4.6` for Java 9 compatibility

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-25913)