### PR TITLE
Remove "needs cla" label

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -13,7 +13,6 @@ const github = danger.github;
 const Label = {
 	NEEDS_JIRA: 'needs jira 🚨',
 	NEEDS_TESTS: 'needs tests 🚨',
-	NEEDS_CLA: 'needs cla 🚨',
 	NO_TESTS: 'no tests',
 	IOS: 'ios',
 	ANDROID: 'android',
@@ -92,12 +91,10 @@ if (modifiedApiDocs.length > 0) {
 // Check PR author to see if it's community, etc
 if (github.pr.author_association === 'FIRST_TIMER') {
 	labels.add(Label.COMMUNITY);
-	labels.add(Label.NEEDS_CLA);
 	// Thank them profusely! This is their first ever github commit!
 	message(`:rocket: Wow, ${github.pr.user.login}, your first contribution to GitHub and it's to help us make Titanium better! You rock! :guitar:`);
 } else if (github.pr.author_association === 'FIRST_TIME_CONTRIBUTOR') {
 	labels.add(Label.COMMUNITY);
-	labels.add(Label.NEEDS_CLA);
 	// Thank them, this is their first contribution to this repo!
 	message(`:confetti_ball: Welcome to the Titanium SDK community, ${github.pr.user.login}! Thank you so much for your PR, you're helping us make Titanium better. :gift:`);
 } else if (github.pr.author_association === 'CONTRIBUTOR') {


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/JIRA-0000

The "needs cla" label should not be generated by Danger.js, since its already checked in an own pull request hook and it doesn't actually check if the developer signed it or not. That caused confusion lately, so it should be removed.
