### PR TITLE
[TIMOB-25948] Android: Update hyperloop to v3.0.5

### DIFF
--- a/support/module/packaged/modules.json
+++ b/support/module/packaged/modules.json
@@ -63,8 +63,8 @@
 	},
 	"hyperloop": {
 		"hyperloop": {
-			"url": "https://github.com/appcelerator-modules/hyperloop-builds/releases/download/v3.0.4/hyperloop-3.0.4.zip",
-			"integrity": "sha512-uy7fj7uvudIksIi4lnH7q4Un323DSJYStOrHz+YRuC1Nt5wOj5aGgYYr+LsP1TUzfqupjHt3zxN3t4cVKefjFQ=="
+			"url": "https://github.com/appcelerator-modules/hyperloop-builds/releases/download/v3.0.5/hyperloop-3.0.5.zip",
+			"integrity": "sha512-hXUzZIEs7IBnD5f7rBzEULhl1+0oJN1gJyi+2SpVds7jXjJ5MxblWkTQYjJAcEr1NdBpA70m0w5nLncDQU6avQ=="
 		}
 	}
 }


### PR DESCRIPTION
- Update `hyperloop` to version `3.0.5`
  - Compile using Android NDK r12b
    - Fix compatibility on Android 7.0/7.1

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-25948)