### PR TITLE
[TIMOB-25963] Android: Improve KrollRuntime error output

### DIFF
--- a/android/runtime/common/src/java/org/appcelerator/kroll/KrollExceptionHandler.java
+++ b/android/runtime/common/src/java/org/appcelerator/kroll/KrollExceptionHandler.java
@@ -34,11 +34,12 @@ package org.appcelerator.kroll;
 public interface KrollExceptionHandler {
 	public class ExceptionMessage
 	{
-		public String title, message, sourceName, lineSource;
+		public String title, message, sourceName, lineSource, jsStack, javaStack;
 		public int line, lineOffset;
 
 		public ExceptionMessage(final String title, final String message, final String sourceName, final int line,
-								final String lineSource, final int lineOffset)
+								final String lineSource, final int lineOffset, final String jsStack,
+								final String javaStack)
 		{
 			this.title = title;
 			this.message = message;
@@ -46,6 +47,8 @@ public interface KrollExceptionHandler {
 			this.lineSource = lineSource;
 			this.line = line;
 			this.lineOffset = lineOffset;
+			this.jsStack = jsStack;
+			this.javaStack = javaStack;
 		}
 	}
 

--- a/android/runtime/common/src/java/org/appcelerator/kroll/KrollRuntime.java
+++ b/android/runtime/common/src/java/org/appcelerator/kroll/KrollRuntime.java
@@ -518,25 +518,26 @@ public abstract class KrollRuntime implements Handler.Callback
 	}
 
 	public static void dispatchException(final String title, final String message, final String sourceName,
-										 final int line, final String lineSource, final int lineOffset)
+										 final int line, final String lineSource, final int lineOffset,
+										 final String stack)
 	{
 		if (instance != null) {
 			HashMap<String, KrollExceptionHandler> handlers = instance.exceptionHandlers;
 			KrollExceptionHandler currentHandler;
+			ExceptionMessage exceptionMessage =
+				new ExceptionMessage(title, message, sourceName, line, lineSource, lineOffset, stack);
 
 			if (!handlers.isEmpty()) {
 				for (String key : handlers.keySet()) {
 					currentHandler = handlers.get(key);
 					if (currentHandler != null) {
-						currentHandler.handleException(
-							new ExceptionMessage(title, message, sourceName, line, lineSource, lineOffset));
+						currentHandler.handleException(exceptionMessage);
 					}
 				}
 			}
 
 			// Handle exception with defaultExceptionHandler
-			instance.primaryExceptionHandler.handleException(
-				new ExceptionMessage(title, message, sourceName, line, lineSource, lineOffset));
+			instance.primaryExceptionHandler.handleException(exceptionMessage);
 		}
 	}
 

--- a/android/runtime/common/src/java/org/appcelerator/kroll/KrollRuntime.java
+++ b/android/runtime/common/src/java/org/appcelerator/kroll/KrollRuntime.java
@@ -519,13 +519,13 @@ public abstract class KrollRuntime implements Handler.Callback
 
 	public static void dispatchException(final String title, final String message, final String sourceName,
 										 final int line, final String lineSource, final int lineOffset,
-										 final String stack)
+										 final String jsStack, final String javaStack)
 	{
 		if (instance != null) {
 			HashMap<String, KrollExceptionHandler> handlers = instance.exceptionHandlers;
 			KrollExceptionHandler currentHandler;
 			ExceptionMessage exceptionMessage =
-				new ExceptionMessage(title, message, sourceName, line, lineSource, lineOffset, stack);
+				new ExceptionMessage(title, message, sourceName, line, lineSource, lineOffset, jsStack, javaStack);
 
 			if (!handlers.isEmpty()) {
 				for (String key : handlers.keySet()) {
@@ -544,7 +544,6 @@ public abstract class KrollRuntime implements Handler.Callback
 	public abstract void doDispose();
 	public abstract void doRunModule(String source, String filename, KrollProxySupport activityProxy);
 	public abstract Object doEvalString(String source, String filename);
-	public abstract String getStackTrace();
 
 	public abstract String getRuntimeName();
 	public abstract void initRuntime();

--- a/android/runtime/common/src/java/org/appcelerator/kroll/KrollRuntime.java
+++ b/android/runtime/common/src/java/org/appcelerator/kroll/KrollRuntime.java
@@ -543,6 +543,7 @@ public abstract class KrollRuntime implements Handler.Callback
 	public abstract void doDispose();
 	public abstract void doRunModule(String source, String filename, KrollProxySupport activityProxy);
 	public abstract Object doEvalString(String source, String filename);
+	public abstract String getStackTrace();
 
 	public abstract String getRuntimeName();
 	public abstract void initRuntime();

--- a/android/runtime/v8/src/java/org/appcelerator/kroll/runtime/v8/V8Runtime.java
+++ b/android/runtime/v8/src/java/org/appcelerator/kroll/runtime/v8/V8Runtime.java
@@ -166,6 +166,12 @@ public final class V8Runtime extends KrollRuntime implements Handler.Callback
 	}
 
 	@Override
+	public String getStackTrace()
+	{
+		return nativeStackTrace();
+	}
+
+	@Override
 	public void doDispose()
 	{
 		TiDeployData deployData = getKrollApplication().getDeployData();
@@ -239,4 +245,6 @@ public final class V8Runtime extends KrollRuntime implements Handler.Callback
 	private native void nativeDispose();
 
 	private native void nativeAddExternalCommonJsModule(String moduleName, KrollSourceCodeProvider sourceProvider);
+
+	private native String nativeStackTrace();
 }

--- a/android/runtime/v8/src/java/org/appcelerator/kroll/runtime/v8/V8Runtime.java
+++ b/android/runtime/v8/src/java/org/appcelerator/kroll/runtime/v8/V8Runtime.java
@@ -166,12 +166,6 @@ public final class V8Runtime extends KrollRuntime implements Handler.Callback
 	}
 
 	@Override
-	public String getStackTrace()
-	{
-		return nativeStackTrace();
-	}
-
-	@Override
 	public void doDispose()
 	{
 		TiDeployData deployData = getKrollApplication().getDeployData();
@@ -245,6 +239,4 @@ public final class V8Runtime extends KrollRuntime implements Handler.Callback
 	private native void nativeDispose();
 
 	private native void nativeAddExternalCommonJsModule(String moduleName, KrollSourceCodeProvider sourceProvider);
-
-	private native String nativeStackTrace();
 }

--- a/android/runtime/v8/src/native/JNIUtil.cpp
+++ b/android/runtime/v8/src/native/JNIUtil.cpp
@@ -401,7 +401,7 @@ void JNIUtil::initCache()
 	krollProxyOnPropertiesChangedMethod = getMethodID(krollProxyClass, "onPropertiesChanged",
 		"([[Ljava/lang/Object;)V", false);
 
-	krollRuntimeDispatchExceptionMethod = getMethodID(krollRuntimeClass, "dispatchException", "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;I)V",true);
+	krollRuntimeDispatchExceptionMethod = getMethodID(krollRuntimeClass, "dispatchException", "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;ILjava/lang/String;)V",true);
 	krollAssetHelperReadAssetMethod = getMethodID(krollAssetHelperClass, "readAsset", "(Ljava/lang/String;)Ljava/lang/String;", true);
 
 	krollLoggingLogWithDefaultLoggerMethod = getMethodID(krollLoggingClass, "logWithDefaultLogger", "(ILjava/lang/String;)V", true);

--- a/android/runtime/v8/src/native/JNIUtil.cpp
+++ b/android/runtime/v8/src/native/JNIUtil.cpp
@@ -401,7 +401,7 @@ void JNIUtil::initCache()
 	krollProxyOnPropertiesChangedMethod = getMethodID(krollProxyClass, "onPropertiesChanged",
 		"([[Ljava/lang/Object;)V", false);
 
-	krollRuntimeDispatchExceptionMethod = getMethodID(krollRuntimeClass, "dispatchException", "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;ILjava/lang/String;)V",true);
+	krollRuntimeDispatchExceptionMethod = getMethodID(krollRuntimeClass, "dispatchException", "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;ILjava/lang/String;Ljava/lang/String;)V",true);
 	krollAssetHelperReadAssetMethod = getMethodID(krollAssetHelperClass, "readAsset", "(Ljava/lang/String;)Ljava/lang/String;", true);
 
 	krollLoggingLogWithDefaultLoggerMethod = getMethodID(krollLoggingClass, "logWithDefaultLogger", "(ILjava/lang/String;)V", true);

--- a/android/runtime/v8/src/native/JNIUtil.cpp
+++ b/android/runtime/v8/src/native/JNIUtil.cpp
@@ -43,6 +43,7 @@ jclass JNIUtil::setClass = NULL;
 jclass JNIUtil::outOfMemoryError = NULL;
 jclass JNIUtil::nullPointerException = NULL;
 jclass JNIUtil::throwableClass = NULL;
+jclass JNIUtil::stackTraceElementClass = NULL;
 
 jclass JNIUtil::v8ObjectClass = NULL;
 jclass JNIUtil::v8FunctionClass = NULL;
@@ -79,7 +80,11 @@ jmethodID JNIUtil::booleanInitMethod = NULL;
 jmethodID JNIUtil::booleanBooleanValueMethod = NULL;
 jmethodID JNIUtil::longInitMethod = NULL;
 jmethodID JNIUtil::numberDoubleValueMethod = NULL;
+
 jmethodID JNIUtil::throwableGetMessageMethod = NULL;
+jmethodID JNIUtil::throwableGetStackTraceMethod = NULL;
+
+jmethodID JNIUtil::stackTraceElementToStringMethod = NULL;
 
 jfieldID JNIUtil::v8ObjectPtrField = NULL;
 jmethodID JNIUtil::v8ObjectInitMethod = NULL;
@@ -318,6 +323,7 @@ void JNIUtil::initCache()
 	outOfMemoryError = findClass("java/lang/OutOfMemoryError");
 	nullPointerException = findClass("java/lang/NullPointerException");
 	throwableClass = findClass("java/lang/Throwable");
+	stackTraceElementClass = findClass("java/lang/StackTraceElement");
 
 	v8ObjectClass = findClass("org/appcelerator/kroll/runtime/v8/V8Object");
 	v8FunctionClass = findClass("org/appcelerator/kroll/runtime/v8/V8Function");
@@ -355,6 +361,8 @@ void JNIUtil::initCache()
 	longInitMethod = getMethodID(longClass, "<init>", "(J)V", false);
 	numberDoubleValueMethod = getMethodID(numberClass, "doubleValue", "()D", false);
 	throwableGetMessageMethod = getMethodID(throwableClass, "getMessage", "()Ljava/lang/String;", false);
+	throwableGetStackTraceMethod = getMethodID(throwableClass, "getStackTrace", "()[Ljava/lang/StackTraceElement;", false);
+	stackTraceElementToStringMethod = getMethodID(stackTraceElementClass, "toString", "()Ljava/lang/String;", false);
 
 	v8ObjectPtrField = getFieldID(v8ObjectClass, "ptr", "J");
 	v8ObjectInitMethod = getMethodID(v8ObjectClass, "<init>", "(J)V", false);

--- a/android/runtime/v8/src/native/JNIUtil.h
+++ b/android/runtime/v8/src/native/JNIUtil.h
@@ -91,6 +91,7 @@ public:
 	static jclass setClass;
 	static jclass outOfMemoryError;
 	static jclass throwableClass;
+	static jclass stackTraceElementClass;
 	static jclass nullPointerException;
 
 	// Titanium classes
@@ -128,6 +129,8 @@ public:
 	static jmethodID longInitMethod;
 	static jmethodID numberDoubleValueMethod;
 	static jmethodID throwableGetMessageMethod;
+	static jmethodID throwableGetStackTraceMethod;
+	static jmethodID stackTraceElementToStringMethod;
 
 	// Titanium methods and fields
 	static jfieldID v8ObjectPtrField;

--- a/android/runtime/v8/src/native/JSException.cpp
+++ b/android/runtime/v8/src/native/JSException.cpp
@@ -73,7 +73,7 @@ Local<Value> JSException::fromJavaException(v8::Isolate* isolate, jthrowable jav
 
 	// Now explicitly assign our properly generated stacktrace
 	Local<String> javaStack = String::NewFromUtf8(isolate, stackStream.str().c_str());
-	error->Set(context, STRING_NEW(isolate, "javaStack"), javaStack);
+	error->Set(context, STRING_NEW(isolate, "nativeStack"), javaStack);
 
 	// throw it
 	return isolate->ThrowException(error);

--- a/android/runtime/v8/src/native/JSException.cpp
+++ b/android/runtime/v8/src/native/JSException.cpp
@@ -16,8 +16,6 @@
 
 #include "JSException.h"
 
-#define MAX_STACK 10
-
 using namespace v8;
 
 namespace titanium {

--- a/android/runtime/v8/src/native/JSException.cpp
+++ b/android/runtime/v8/src/native/JSException.cpp
@@ -42,6 +42,8 @@ Local<Value> JSException::fromJavaException(v8::Isolate* isolate, jthrowable jav
 	const char* messagePtr = env->GetStringUTFChars(javaMessage, NULL);
 	std::stringstream message;
 	message << messagePtr;
+	env->ReleaseStringUTFChars(javaMessage, messagePtr);
+	env->DeleteLocalRef(javaMessage);
 
 	jobjectArray frames = (jobjectArray) env->CallObjectMethod(javaException, JNIUtil::throwableGetStackTraceMethod);
 	jsize frames_length = env->GetArrayLength(frames);
@@ -57,8 +59,6 @@ Local<Value> JSException::fromJavaException(v8::Isolate* isolate, jthrowable jav
 	}
 	message << std::endl;
 
-	env->ReleaseStringUTFChars(javaMessage, messagePtr);
-	env->DeleteLocalRef(javaMessage);
 	if (deleteRef) {
 		env->DeleteLocalRef(javaException);
 	}

--- a/android/runtime/v8/src/native/JSException.h
+++ b/android/runtime/v8/src/native/JSException.h
@@ -11,6 +11,8 @@
 #include <jni.h>
 #include <v8.h>
 
+#define MAX_STACK 10
+
 #define THROW(isolate, msg) \
 	isolate->ThrowException(v8::String::NewFromUtf8(isolate, msg))
 

--- a/android/runtime/v8/src/native/Proxy.cpp
+++ b/android/runtime/v8/src/native/Proxy.cpp
@@ -166,6 +166,12 @@ static void onPropertyChangedForProxy(Isolate* isolate, Local<String> property, 
 		env->DeleteLocalRef(javaValue);
 	}
 
+	if (env->ExceptionCheck()) {
+		JSException::fromJavaException(isolate);
+		env->ExceptionClear();
+		return;
+	}
+
 	// Store new property value on JS internal map.
 	setPropertyOnProxy(isolate, property, value, proxyObject);
 }
@@ -206,6 +212,12 @@ void Proxy::getIndexedProperty(uint32_t index, const PropertyCallbackInfo<Value>
 
 	proxy->unreferenceJavaObject(javaProxy);
 
+	if (env->ExceptionCheck()) {
+		JSException::fromJavaException(isolate);
+		env->ExceptionClear();
+		return;
+	}
+
 	Local<Value> result = TypeConverter::javaObjectToJsValue(isolate, env, value);
 	env->DeleteLocalRef(value);
 
@@ -235,6 +247,12 @@ void Proxy::setIndexedProperty(uint32_t index, Local<Value> value, const Propert
 	proxy->unreferenceJavaObject(javaProxy);
 	if (javaValueIsNew) {
 		env->DeleteLocalRef(javaValue);
+	}
+
+	if (env->ExceptionCheck()) {
+		JSException::fromJavaException(isolate);
+		env->ExceptionClear();
+		return;
 	}
 
 	info.GetReturnValue().Set(value);
@@ -272,6 +290,12 @@ void Proxy::hasListenersForEventType(const v8::FunctionCallbackInfo<v8::Value>& 
 
 	env->DeleteLocalRef(krollObject);
 	env->DeleteLocalRef(javaEventType);
+
+	if (env->ExceptionCheck()) {
+		JSException::fromJavaException(isolate);
+		env->ExceptionClear();
+		return;
+	}
 }
 
 void Proxy::onEventFired(const v8::FunctionCallbackInfo<v8::Value>& args)
@@ -311,6 +335,12 @@ void Proxy::onEventFired(const v8::FunctionCallbackInfo<v8::Value>& args)
 	env->DeleteLocalRef(javaEventType);
 	if (isNew) {
 		env->DeleteLocalRef(javaEventData);
+	}
+
+	if (env->ExceptionCheck()) {
+		JSException::fromJavaException(isolate);
+		env->ExceptionClear();
+		return;
 	}
 }
 
@@ -498,7 +528,10 @@ void Proxy::proxyOnPropertiesChanged(const v8::FunctionCallbackInfo<v8::Value>& 
 
 	proxy->unreferenceJavaObject(javaProxy);
 
-	return;
+	if (env->ExceptionCheck()) {
+		JSException::fromJavaException(isolate);
+		env->ExceptionClear();
+	}
 }
 
 void Proxy::dispose(Isolate* isolate)

--- a/android/runtime/v8/src/native/ProxyFactory.cpp
+++ b/android/runtime/v8/src/native/ProxyFactory.cpp
@@ -13,6 +13,7 @@
 #include "AndroidUtil.h"
 #include "JavaObject.h"
 #include "JNIUtil.h"
+#include "JSException.h"
 #include "KrollBindings.h"
 #include "Proxy.h"
 #include "TypeConverter.h"
@@ -165,6 +166,12 @@ jobject ProxyFactory::createJavaProxy(jclass javaClass, Local<Object> v8Proxy, c
 	env->DeleteLocalRef(javaV8Object);
 	env->DeleteLocalRef(javaArgs);
 	// We don't delete the global jclass reference...
+
+	if (env->ExceptionCheck()) {
+		JSException::fromJavaException(isolate);
+		env->ExceptionClear();
+		return NULL;
+	}
 
 	return javaProxy;
 }

--- a/android/runtime/v8/src/native/TypeConverter.cpp
+++ b/android/runtime/v8/src/native/TypeConverter.cpp
@@ -114,7 +114,7 @@ jstring TypeConverter::jsValueToJavaString(v8::Isolate* isolate, v8::Local<v8::V
 
 jstring TypeConverter::jsValueToJavaString(v8::Isolate* isolate, JNIEnv *env, v8::Local<v8::Value> jsValue)
 {
-	if (jsValue->IsNull()) {
+	if (jsValue.IsEmpty() || jsValue->IsNullOrUndefined()) {
 		return NULL;
 	}
 

--- a/android/runtime/v8/src/native/V8Runtime.cpp
+++ b/android/runtime/v8/src/native/V8Runtime.cpp
@@ -38,6 +38,7 @@ Persistent<Object> V8Runtime::krollGlobalObject;
 Persistent<Array> V8Runtime::moduleContexts;
 Persistent<Object> V8Runtime::moduleObject;
 Persistent<Function> V8Runtime::runModuleFunction;
+Persistent<StackTrace> V8Runtime::exceptionStackTrace;
 
 jobject V8Runtime::javaInstance;
 Platform* V8Runtime::platform = nullptr;

--- a/android/runtime/v8/src/native/V8Runtime.cpp
+++ b/android/runtime/v8/src/native/V8Runtime.cpp
@@ -469,15 +469,19 @@ JNIEXPORT void JNICALL Java_org_appcelerator_kroll_runtime_v8_V8Runtime_nativeDi
 
 JNIEXPORT jstring JNICALL Java_org_appcelerator_kroll_runtime_v8_V8Runtime_nativeStackTrace(JNIEnv *env, jobject self)
 {
-	v8::Local<v8::StackTrace> frames = v8::StackTrace::CurrentStackTrace(V8Runtime::v8_isolate, 10);
-	if (!frames->GetFrameCount()) {
+	HandleScope scope(V8Runtime::v8_isolate);
+
+	Local<StackTrace> frames = StackTrace::CurrentStackTrace(V8Runtime::v8_isolate, 10);
+	if (frames.IsEmpty() || !frames->GetFrameCount()) {
 		frames = V8Runtime::exceptionStackTrace.Get(V8Runtime::v8_isolate);
 	}
-
-	std::string stack = V8Util::stackTraceString(frames);
-	if (!stack.empty()) {
-		return env->NewStringUTF(stack.c_str());
+	if (!frames.IsEmpty()) {
+		std::string stack = V8Util::stackTraceString(frames);
+		if (!stack.empty()) {
+			return env->NewStringUTF(stack.c_str());
+		}
 	}
+
 	return NULL;
 }
 

--- a/android/runtime/v8/src/native/V8Runtime.cpp
+++ b/android/runtime/v8/src/native/V8Runtime.cpp
@@ -38,7 +38,6 @@ Persistent<Object> V8Runtime::krollGlobalObject;
 Persistent<Array> V8Runtime::moduleContexts;
 Persistent<Object> V8Runtime::moduleObject;
 Persistent<Function> V8Runtime::runModuleFunction;
-Persistent<StackTrace> V8Runtime::exceptionStackTrace;
 
 jobject V8Runtime::javaInstance;
 Platform* V8Runtime::platform = nullptr;
@@ -433,7 +432,6 @@ JNIEXPORT void JNICALL Java_org_appcelerator_kroll_runtime_v8_V8Runtime_nativeDi
 	V8Util::dispose();
 	ProxyFactory::dispose();
 
-	V8Runtime::exceptionStackTrace.Reset();
 	V8Runtime::moduleObject.Reset();
 	V8Runtime::runModuleFunction.Reset();
 	V8Runtime::krollGlobalObject.Reset();
@@ -465,24 +463,6 @@ JNIEXPORT void JNICALL Java_org_appcelerator_kroll_runtime_v8_V8Runtime_nativeDi
 	//V8::Dispose();
 	//V8::ShutdownPlatform();
 	//delete V8Runtime::platform;
-}
-
-JNIEXPORT jstring JNICALL Java_org_appcelerator_kroll_runtime_v8_V8Runtime_nativeStackTrace(JNIEnv *env, jobject self)
-{
-	HandleScope scope(V8Runtime::v8_isolate);
-
-	Local<StackTrace> frames = StackTrace::CurrentStackTrace(V8Runtime::v8_isolate, 10);
-	if (frames.IsEmpty() || !frames->GetFrameCount()) {
-		frames = V8Runtime::exceptionStackTrace.Get(V8Runtime::v8_isolate);
-	}
-	if (!frames.IsEmpty()) {
-		std::string stack = V8Util::stackTraceString(frames);
-		if (!stack.empty()) {
-			return env->NewStringUTF(stack.c_str());
-		}
-	}
-
-	return NULL;
 }
 
 jint JNI_OnLoad(JavaVM *vm, void *reserved)

--- a/android/runtime/v8/src/native/V8Runtime.h
+++ b/android/runtime/v8/src/native/V8Runtime.h
@@ -19,6 +19,8 @@ public:
 	static Persistent<Context> globalContext;
 	static Persistent<Object> krollGlobalObject;
 	static Persistent<Array> moduleContexts;
+	static Persistent<StackTrace> exceptionStackTrace;
+	
 	static Isolate* v8_isolate;
 	static Platform* platform;
 

--- a/android/runtime/v8/src/native/V8Runtime.h
+++ b/android/runtime/v8/src/native/V8Runtime.h
@@ -19,7 +19,6 @@ public:
 	static Persistent<Context> globalContext;
 	static Persistent<Object> krollGlobalObject;
 	static Persistent<Array> moduleContexts;
-	static Persistent<StackTrace> exceptionStackTrace;
 	
 	static Isolate* v8_isolate;
 	static Platform* platform;

--- a/android/runtime/v8/src/native/V8Util.cpp
+++ b/android/runtime/v8/src/native/V8Util.cpp
@@ -238,6 +238,10 @@ void V8Util::dispose()
 }
 
 std::string V8Util::stackTraceString(Local<StackTrace> frames) {
+	if (frames.IsEmpty()) {
+		return NULL;
+	}
+
 	std::stringstream stack;
 
 	for (int i = 0, count = frames->GetFrameCount(); i < count; i++) {

--- a/android/runtime/v8/src/native/V8Util.cpp
+++ b/android/runtime/v8/src/native/V8Util.cpp
@@ -155,8 +155,8 @@ void V8Util::openJSErrorDialog(Isolate* isolate, TryCatch &tryCatch)
 
 	if (exception->IsObject()) {
 		Local<Object> error = exception.As<Object>();
-		jsStack = exception.As<Object>()->Get(STRING_NEW(isolate, "stack"));
-		javaStack = exception.As<Object>()->Get(STRING_NEW(isolate, "javaStack"));
+		jsStack = error->Get(context, STRING_NEW(isolate, "stack")).ToLocalChecked();
+		javaStack = error->Get(context, STRING_NEW(isolate, "nativeStack")).ToLocalChecked();
 	}
 
 	// obtain javascript stack trace

--- a/android/runtime/v8/src/native/V8Util.h
+++ b/android/runtime/v8/src/native/V8Util.h
@@ -84,90 +84,71 @@
 
 namespace titanium {
 
-inline v8::Local<v8::FunctionTemplate>
-    NewFunctionTemplate(v8::Isolate* isolate,
-    					v8::FunctionCallback callback,
-                        v8::Local<v8::Signature> signature = v8::Local<v8::Signature>()) {
-  return v8::FunctionTemplate::New(isolate, callback, v8::Local<v8::Value>(), signature);
+inline v8::Local<v8::FunctionTemplate> NewFunctionTemplate(v8::Isolate* isolate, v8::FunctionCallback callback, v8::Local<v8::Signature> signature = v8::Local<v8::Signature>()) {
+	return v8::FunctionTemplate::New(isolate, callback, v8::Local<v8::Value>(), signature);
 }
 
-inline void SetMethod(v8::Isolate* isolate,
-					  v8::Local<v8::Object> that,
-                      const char* name,
-                      v8::FunctionCallback callback) {
-  v8::Local<v8::Function> function =
-      NewFunctionTemplate(isolate, callback)->GetFunction();
-  // kInternalized strings are created in the old space.
-  const v8::NewStringType type = v8::NewStringType::kInternalized;
-  v8::Local<v8::String> name_string =
-      v8::String::NewFromUtf8(isolate, name, type).ToLocalChecked();
-  that->Set(name_string, function);
-  function->SetName(name_string);  // NODE_SET_METHOD() compatibility.
+inline void SetMethod(v8::Isolate* isolate, v8::Local<v8::Object> that, const char* name, v8::FunctionCallback callback) {
+	v8::Local<v8::Function> function = NewFunctionTemplate(isolate, callback)->GetFunction();
+	// kInternalized strings are created in the old space.
+	const v8::NewStringType type = v8::NewStringType::kInternalized;
+	v8::Local<v8::String> name_string = v8::String::NewFromUtf8(isolate, name, type).ToLocalChecked();
+	that->Set(name_string, function);
+	function->SetName(name_string); // NODE_SET_METHOD() compatibility.
 }
 
-inline void SetProtoMethod(v8::Isolate* isolate,
-						   v8::Local<v8::FunctionTemplate> that,
-                           const char* name,
-                           v8::FunctionCallback callback) {
-  v8::Local<v8::Signature> signature = v8::Signature::New(isolate, that);
-  v8::Local<v8::FunctionTemplate> t =
-      NewFunctionTemplate(isolate, callback);
-  // kInternalized strings are created in the old space.
-  const v8::NewStringType type = v8::NewStringType::kInternalized;
-  v8::Local<v8::String> name_string =
-      v8::String::NewFromUtf8(isolate, name, type).ToLocalChecked();
-  that->PrototypeTemplate()->Set(name_string, t);
-  t->SetClassName(name_string);  // NODE_SET_PROTOTYPE_METHOD() compatibility.
+inline void SetProtoMethod(v8::Isolate* isolate, v8::Local<v8::FunctionTemplate> that, const char* name, v8::FunctionCallback callback) {
+	v8::Local<v8::Signature> signature = v8::Signature::New(isolate, that);
+	v8::Local<v8::FunctionTemplate> t = NewFunctionTemplate(isolate, callback);
+	// kInternalized strings are created in the old space.
+	const v8::NewStringType type = v8::NewStringType::kInternalized;
+	v8::Local<v8::String> name_string = v8::String::NewFromUtf8(isolate, name, type).ToLocalChecked();
+	that->PrototypeTemplate()->Set(name_string, t);
+	t->SetClassName(name_string); // NODE_SET_PROTOTYPE_METHOD() compatibility.
 }
 
-inline void SetTemplateMethod(v8::Isolate* isolate,
-							  v8::Local<v8::FunctionTemplate> that,
-                              const char* name,
-                              v8::FunctionCallback callback) {
-  v8::Local<v8::FunctionTemplate> t =
-      NewFunctionTemplate(isolate, callback);
-  // kInternalized strings are created in the old space.
-  const v8::NewStringType type = v8::NewStringType::kInternalized;
-  v8::Local<v8::String> name_string =
-      v8::String::NewFromUtf8(isolate, name, type).ToLocalChecked();
-  that->Set(name_string, t);
-  t->SetClassName(name_string);  // NODE_SET_METHOD() compatibility.
+inline void SetTemplateMethod(v8::Isolate* isolate, v8::Local<v8::FunctionTemplate> that, const char* name, v8::FunctionCallback callback) {
+	v8::Local<v8::FunctionTemplate> t = NewFunctionTemplate(isolate, callback);
+	// kInternalized strings are created in the old space.
+	const v8::NewStringType type = v8::NewStringType::kInternalized;
+	v8::Local<v8::String> name_string = v8::String::NewFromUtf8(isolate, name, type).ToLocalChecked();
+	that->Set(name_string, t);
+	t->SetClassName(name_string); // NODE_SET_METHOD() compatibility.
 }
 
 // DEPRECATED: Use v8::String::Utf8Value. Remove in SDK 8.0
 // class [[deprecated("Replaced by v8::String::Utf8Value, which is now official V8 API")]] Utf8Value {
 class Utf8Value {
-  public:
-    explicit Utf8Value(v8::Local<v8::Value> value);
+	public:
+	explicit Utf8Value(v8::Local<v8::Value> value);
 
-    ~Utf8Value() {
-      if (str_ != str_st_)
-        free(str_);
-    }
+	~Utf8Value() {
+		if (str_ != str_st_) free(str_);
+	}
 
-    char* operator*() {
-      return str_;
-    };
+	char* operator*() {
+		return str_;
+	};
 
-    const char* operator*() const {
-      return str_;
-    };
+	const char* operator*() const {
+		return str_;
+	};
 
-    size_t length() const {
-      return length_;
-    };
+	size_t length() const {
+		return length_;
+	};
 
-  private:
-    size_t length_;
-    char* str_;
-    char str_st_[1024];
+	private:
+	size_t length_;
+	char* str_;
+	char str_st_[1024];
 };
 
 class V8Util {
 public:
 	static v8::Local<v8::Value> executeString(v8::Isolate* isolate, v8::Local<v8::String> source, v8::Local<v8::Value> filename);
 	static v8::Local<v8::Value> newInstanceFromConstructorTemplate(v8::Persistent<v8::FunctionTemplate>& t,
-		const v8::FunctionCallbackInfo<v8::Value>& args);
+	const v8::FunctionCallbackInfo<v8::Value>& args);
 	static void objectExtend(v8::Local<v8::Object> dest, v8::Local<v8::Object> src);
 	static void reportException(v8::Isolate* isolate, v8::TryCatch &tryCatch, bool showLine = true);
 	static void openJSErrorDialog(v8::Isolate* isolate, v8::TryCatch &tryCatch);
@@ -176,6 +157,7 @@ public:
 	static bool constructorNameMatches(v8::Isolate* isolate, v8::Local<v8::Object>, const char* name);
 	static bool isNaN(v8::Isolate* isolate, v8::Local<v8::Value> value);
 	static void dispose();
+	static std::string stackTraceString(v8::Local<v8::StackTrace> frames);
 };
 
 }

--- a/android/titanium/src/java/org/appcelerator/titanium/TiApplication.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiApplication.java
@@ -369,14 +369,17 @@ public abstract class TiApplication extends Application implements KrollApplicat
 			{
 
 				// obtain java stack trace
-				String javaStack = "";
+				String javaStack = null;
 				StackTraceElement[] frames = e.getCause() != null ? e.getCause().getStackTrace() : e.getStackTrace();
-				for (StackTraceElement frame : frames) {
-					javaStack += "\n    " + frame.toString();
+				if (frames != null && frames.length > 0) {
+					javaStack = "";
+					for (StackTraceElement frame : frames) {
+						javaStack += "\n    " + frame.toString();
+					}
 				}
 
 				// throw exception as KrollException
-				KrollRuntime.dispatchException("Runtime Error", e.getMessage(), null, 0, null, 0, javaStack);
+				KrollRuntime.dispatchException("Runtime Error", e.getMessage(), null, 0, null, 0, null, javaStack);
 			}
 		});
 

--- a/android/titanium/src/java/org/appcelerator/titanium/TiApplication.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiApplication.java
@@ -362,20 +362,27 @@ public abstract class TiApplication extends Application implements KrollApplicat
 		super.onCreate();
 		Log.d(TAG, "Application onCreate", Log.DEBUG_MODE);
 
-		final UncaughtExceptionHandler defaultHandler = Thread.getDefaultUncaughtExceptionHandler();
+		// handle uncaught java exceptions
 		Thread.setDefaultUncaughtExceptionHandler(new UncaughtExceptionHandler() {
+			@Override
 			public void uncaughtException(Thread t, Throwable e)
 			{
-				if (isAnalyticsEnabled()) {
-					String tiVer = buildVersion + "," + buildTimestamp + "," + buildHash;
-					Log.e(TAG,
-						  "Sending event: exception on thread: " + t.getName() + " msg:" + e.toString() + "; Titanium "
-							  + tiVer,
-						  e);
-					TiPlatformHelper.getInstance().postAnalyticsEvent(
-						TiAnalyticsEventFactory.createErrorEvent(t, e, tiVer));
+
+				// obtain java stack trace
+				String javaStack = "";
+				StackTraceElement[] frames = e.getCause() != null ? e.getCause().getStackTrace() : e.getStackTrace();
+				for (StackTraceElement frame : frames) {
+					javaStack += "\n    " + frame.toString();
 				}
-				defaultHandler.uncaughtException(t, e);
+
+				// construct exception message
+				String message = e.getMessage();
+				if (!javaStack.isEmpty()) {
+					message += javaStack;
+				}
+
+				// throw exception as KrollException
+				KrollRuntime.dispatchException("Runtime Error", message, null, 0, null, 0);
 			}
 		});
 

--- a/android/titanium/src/java/org/appcelerator/titanium/TiApplication.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiApplication.java
@@ -375,14 +375,8 @@ public abstract class TiApplication extends Application implements KrollApplicat
 					javaStack += "\n    " + frame.toString();
 				}
 
-				// construct exception message
-				String message = e.getMessage();
-				if (!javaStack.isEmpty()) {
-					message += javaStack;
-				}
-
 				// throw exception as KrollException
-				KrollRuntime.dispatchException("Runtime Error", message, null, 0, null, 0);
+				KrollRuntime.dispatchException("Runtime Error", e.getMessage(), null, 0, null, 0, javaStack);
 			}
 		});
 

--- a/android/titanium/src/java/org/appcelerator/titanium/TiExceptionHandler.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiExceptionHandler.java
@@ -52,7 +52,8 @@ public class TiExceptionHandler implements Handler.Callback, KrollExceptionHandl
 	private static final String ERROR_LINE = "line";
 	private static final String ERROR_LINESOURCE = "lineSource";
 	private static final String ERROR_LINEOFFSET = "lineOffset";
-	private static final String ERROR_STACK = "stack";
+	private static final String ERROR_JS_STACK = "javascriptStack";
+	private static final String ERROR_JAVA_STACK = "javaStack";
 
 	private static final String fill(int count)
 	{
@@ -70,7 +71,8 @@ public class TiExceptionHandler implements Handler.Callback, KrollExceptionHandl
 		dict.put(ERROR_LINE, error.line);
 		dict.put(ERROR_LINESOURCE, error.lineSource);
 		dict.put(ERROR_LINEOFFSET, error.lineOffset);
-		dict.put(ERROR_STACK, KrollRuntime.getInstance().getStackTrace());
+		dict.put(ERROR_JS_STACK, KrollRuntime.getInstance().getStackTrace());
+		dict.put(ERROR_JAVA_STACK, error.stack);
 		return dict;
 	}
 
@@ -82,7 +84,8 @@ public class TiExceptionHandler implements Handler.Callback, KrollExceptionHandl
 		final int line = error.getInt(ERROR_LINE);
 		final String lineSource = error.getString(ERROR_LINESOURCE);
 		final int lineOffset = error.getInt(ERROR_LINEOFFSET);
-		final String stack = error.getString(ERROR_STACK);
+		final String jsStack = error.getString(ERROR_JS_STACK);
+		final String javaStack = error.getString(ERROR_JAVA_STACK);
 		final String message = error.getString(ERROR_MESSAGE);
 
 		if (sourceName != null) {
@@ -92,10 +95,13 @@ public class TiExceptionHandler implements Handler.Callback, KrollExceptionHandl
 			output += lineSource + "\n";
 			output += fill(lineOffset - 1) + "^\n";
 		}
-		if (stack != null) {
-			output += stack + "\n";
-		}
 		output += message + "\n";
+		if (jsStack != null) {
+			output += jsStack;
+		}
+		if (javaStack != null) {
+			output += javaStack;
+		}
 
 		return output;
 	}

--- a/android/titanium/src/java/org/appcelerator/titanium/TiExceptionHandler.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiExceptionHandler.java
@@ -95,12 +95,13 @@ public class TiExceptionHandler implements Handler.Callback, KrollExceptionHandl
 			output += lineSource + "\n";
 			output += fill(lineOffset - 1) + "^\n";
 		}
-		output += message + "\n";
 		if (jsStack != null) {
 			output += jsStack;
+		} else {
+			output += message;
 		}
 		if (javaStack != null) {
-			output += javaStack;
+			output += "\n" + javaStack;
 		}
 
 		return output;

--- a/android/titanium/src/java/org/appcelerator/titanium/TiExceptionHandler.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiExceptionHandler.java
@@ -71,8 +71,8 @@ public class TiExceptionHandler implements Handler.Callback, KrollExceptionHandl
 		dict.put(ERROR_LINE, error.line);
 		dict.put(ERROR_LINESOURCE, error.lineSource);
 		dict.put(ERROR_LINEOFFSET, error.lineOffset);
-		dict.put(ERROR_JS_STACK, KrollRuntime.getInstance().getStackTrace());
-		dict.put(ERROR_JAVA_STACK, error.stack);
+		dict.put(ERROR_JS_STACK, error.jsStack);
+		dict.put(ERROR_JAVA_STACK, error.javaStack);
 		return dict;
 	}
 

--- a/android/titanium/src/java/org/appcelerator/titanium/TiExceptionHandler.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiExceptionHandler.java
@@ -1,11 +1,12 @@
 /**
  * Appcelerator Titanium Mobile
- * Copyright (c) 2009-2015 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2009-2018 by Axway, Inc. All Rights Reserved.
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
 package org.appcelerator.titanium;
 
+import java.util.Arrays;
 import java.util.LinkedList;
 
 import org.appcelerator.kroll.KrollApplication;
@@ -22,12 +23,17 @@ import android.app.AlertDialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.DialogInterface.OnClickListener;
-import android.graphics.Color;
+import android.graphics.Rect;
+import android.graphics.Typeface;
 import android.os.Handler;
 import android.os.Message;
 import android.os.Process;
-import android.widget.FrameLayout;
+import android.text.InputType;
+import android.text.method.ScrollingMovementMethod;
+import android.view.Window;
 import android.widget.LinearLayout;
+import android.widget.RelativeLayout;
+import android.widget.Scroller;
 import android.widget.TextView;
 
 /**
@@ -41,12 +47,26 @@ public class TiExceptionHandler implements Handler.Callback, KrollExceptionHandl
 	private static boolean dialogShowing = false;
 	private static Handler mainHandler;
 
-	public void printError(String title, String message, String sourceName, int line, String lineSource, int lineOffset)
+	private static final String fill(int count)
 	{
-		Log.e(TAG, "----- Titanium Javascript " + title + " -----");
-		Log.e(TAG, "- In " + sourceName + ":" + line + "," + lineOffset);
-		Log.e(TAG, "- Message: " + message);
-		Log.e(TAG, "- Source: " + lineSource);
+		char[] string = new char[count];
+		Arrays.fill(string, ' ');
+		return new String(string);
+	}
+
+	private static String getError(KrollDict error)
+	{
+		String message = new String();
+		message += error.getString("sourceName") + ":" + error.getString("line") + "\n";
+		if (error.containsKeyAndNotNull("lineSource")) {
+			message += error.getString("lineSource") + "\n";
+			message += fill(Integer.parseInt(error.getString("lineOffset")) - 1) + "^\n";
+		}
+		message += error.getString("message") + "\n";
+		if (error.containsKeyAndNotNull("stack")) {
+			message += error.getString("stack");
+		}
+		return message;
 	}
 
 	public TiExceptionHandler()
@@ -63,43 +83,41 @@ public class TiExceptionHandler implements Handler.Callback, KrollExceptionHandl
 		}
 	}
 
-	protected void handleOpenErrorDialog(ExceptionMessage error)
+	protected static void handleOpenErrorDialog(final ExceptionMessage error)
 	{
-		KrollApplication application = KrollRuntime.getInstance().getKrollApplication();
-		if (application == null) {
+		TiApplication tiApp = TiApplication.getInstance();
+		if (tiApp == null) {
 			return;
 		}
 
-		Activity activity = application.getCurrentActivity();
+		Activity activity = tiApp.getRootOrCurrentActivity();
 		if (activity == null || activity.isFinishing()) {
-			Log.w(TAG, "Activity is null or already finishing, skipping dialog.");
 			return;
 		}
 
-		KrollDict dict = new KrollDict();
+		final KrollDict dict = new KrollDict();
 		dict.put("title", error.title);
 		dict.put("message", error.message);
 		dict.put("sourceName", error.sourceName);
 		dict.put("line", error.line);
 		dict.put("lineSource", error.lineSource);
 		dict.put("lineOffset", error.lineOffset);
-		TiApplication.getInstance().fireAppEvent("uncaughtException", dict);
+		dict.put("stack", KrollRuntime.getInstance().getStackTrace());
+		tiApp.fireAppEvent("uncaughtException", dict);
 
-		printError(error.title, error.message, error.sourceName, error.line, error.lineSource, error.lineOffset);
+		Log.e(TAG, getError(dict));
 
-		TiApplication tiApplication = TiApplication.getInstance();
-		if (tiApplication.getDeployType().equals(TiApplication.DEPLOY_TYPE_PRODUCTION)) {
+		if (tiApp.getDeployType().equals(TiApplication.DEPLOY_TYPE_PRODUCTION)) {
 			return;
 		}
 
 		if (!dialogShowing) {
 			dialogShowing = true;
-			final ExceptionMessage fError = error;
-			application.waitForCurrentActivity(new CurrentActivityListener() {
-				// TODO @Override
+			tiApp.waitForCurrentActivity(new CurrentActivityListener() {
+				@Override
 				public void onCurrentActivityReady(Activity activity)
 				{
-					createDialog(fError);
+					createDialog(dict);
 				}
 			});
 		} else {
@@ -107,110 +125,66 @@ public class TiExceptionHandler implements Handler.Callback, KrollExceptionHandl
 		}
 	}
 
-	protected static void createDialog(final ExceptionMessage error)
+	protected static void createDialog(final KrollDict error)
 	{
-		KrollApplication application = KrollRuntime.getInstance().getKrollApplication();
-		if (application == null) {
+		final KrollApplication tiApp = KrollRuntime.getInstance().getKrollApplication();
+		if (tiApp == null) {
 			return;
 		}
 
-		Context context = application.getCurrentActivity();
-		FrameLayout layout = new FrameLayout(context);
-		layout.setBackgroundColor(Color.rgb(128, 0, 0));
+		final Context context = tiApp.getCurrentActivity();
 
-		LinearLayout vlayout = new LinearLayout(context);
-		vlayout.setOrientation(LinearLayout.VERTICAL);
-		vlayout.setPadding(10, 10, 10, 10);
-		layout.addView(vlayout);
+		final TextView errorView = new TextView(context);
+		errorView.setBackgroundColor(0xFFF5F5F5);
+		errorView.setTextColor(0xFFE53935);
+		errorView.setPadding(5, 5, 5, 5);
+		errorView.setLayoutParams(new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT,
+																LinearLayout.LayoutParams.MATCH_PARENT));
+		errorView.setInputType(InputType.TYPE_TEXT_FLAG_MULTI_LINE);
+		errorView.setSingleLine(false);
+		errorView.setScroller(new Scroller(context));
+		errorView.setVerticalScrollBarEnabled(true);
+		errorView.setHorizontallyScrolling(true);
+		errorView.setHorizontalScrollBarEnabled(true);
+		errorView.setMovementMethod(new ScrollingMovementMethod());
+		errorView.setTypeface(Typeface.MONOSPACE);
+		errorView.setText(getError(error));
 
-		TextView sourceInfoView = new TextView(context);
-		sourceInfoView.setBackgroundColor(Color.WHITE);
-		sourceInfoView.setTextColor(Color.BLACK);
-		sourceInfoView.setPadding(4, 5, 4, 0);
-		sourceInfoView.setText("[" + error.line + "," + error.lineOffset + "] " + error.sourceName);
+		final RelativeLayout layout = new RelativeLayout(context);
+		layout.setPadding(0, 50, 0, 0);
+		RelativeLayout.LayoutParams layoutParams = new RelativeLayout.LayoutParams(
+			RelativeLayout.LayoutParams.MATCH_PARENT, RelativeLayout.LayoutParams.MATCH_PARENT);
+		layout.setLayoutParams(layoutParams);
+		layout.addView(errorView);
 
-		TextView messageView = new TextView(context);
-		messageView.setBackgroundColor(Color.WHITE);
-		messageView.setTextColor(Color.BLACK);
-		messageView.setPadding(4, 5, 4, 0);
-		messageView.setText(error.message);
-
-		TextView sourceView = new TextView(context);
-		sourceView.setBackgroundColor(Color.WHITE);
-		sourceView.setTextColor(Color.BLACK);
-		sourceView.setPadding(4, 5, 4, 0);
-		sourceView.setText(error.lineSource);
-
-		TextView infoLabel = new TextView(context);
-		infoLabel.setText("Location: ");
-		infoLabel.setTextColor(Color.WHITE);
-		infoLabel.setTextScaleX(1.5f);
-
-		TextView messageLabel = new TextView(context);
-		messageLabel.setText("Message: ");
-		messageLabel.setTextColor(Color.WHITE);
-		messageLabel.setTextScaleX(1.5f);
-
-		TextView sourceLabel = new TextView(context);
-		sourceLabel.setText("Source: ");
-		sourceLabel.setTextColor(Color.WHITE);
-		sourceLabel.setTextScaleX(1.5f);
-
-		vlayout.addView(infoLabel);
-		vlayout.addView(sourceInfoView);
-		vlayout.addView(messageLabel);
-		vlayout.addView(messageView);
-		vlayout.addView(sourceLabel);
-		vlayout.addView(sourceView);
-
-		OnClickListener clickListener = new OnClickListener() {
+		final OnClickListener clickListener = new OnClickListener() {
 			public void onClick(DialogInterface dialog, int which)
 			{
 				if (which == DialogInterface.BUTTON_POSITIVE) {
-					// Kill Process
 					Process.killProcess(Process.myPid());
-
-				} else if (which == DialogInterface.BUTTON_NEUTRAL) {
-					// Continue
-				} else if (which == DialogInterface.BUTTON_NEGATIVE) {
-					// TODO: Reload (Fastdev)
-					// if (error.tiContext != null && error.tiContext.get() != null) {
-					// reload(error.sourceName);
-					// }
 				}
 				if (!errorMessages.isEmpty()) {
-					createDialog(errorMessages.removeFirst());
-
+					handleOpenErrorDialog(errorMessages.removeFirst());
 				} else {
 					dialogShowing = false;
 				}
 			}
 		};
 
-		AlertDialog.Builder builder = new AlertDialog.Builder(context)
-										  .setTitle(error.title)
-										  .setView(layout)
-										  .setPositiveButton("Kill", clickListener)
-										  .setNeutralButton("Continue", clickListener)
-										  .setCancelable(false);
+		final AlertDialog.Builder builder = new AlertDialog.Builder(context)
+												.setTitle(error.getString("title"))
+												.setView(layout)
+												.setPositiveButton("Kill", clickListener)
+												.setNeutralButton("Continue", clickListener)
+												.setCancelable(false);
 
-		// TODO: Enable when we have fastdev working
-		// if (TiFastDev.isFastDevEnabled()) {
-		// builder.setNegativeButton("Reload", clickListener);
-		// }
-		builder.create().show();
-	}
+		final AlertDialog dialog = builder.create();
+		dialog.show();
 
-	protected static void reload(String sourceName)
-	{
-		// try {
-		// TODO: Enable this when we have fastdev
-		// KrollContext.getKrollContext().evalFile(sourceName);
-		/*
-		 * } catch (IOException e) {
-		 * Log.e(TAG, e.getMessage(), e);
-		 * }
-		 */
+		Window window = ((Activity) context).getWindow();
+		Rect displayRect = new Rect();
+		window.getDecorView().getWindowVisibleDisplayFrame(displayRect);
+		dialog.getWindow().setLayout(displayRect.width(), (int) (displayRect.height() * 0.95));
 	}
 
 	public boolean handleMessage(Message msg)

--- a/tests/Resources/ti.addontest.js
+++ b/tests/Resources/ti.addontest.js
@@ -8,16 +8,28 @@
 /* global Ti */
 /* eslint no-unused-expressions: "off" */
 'use strict';
-var should = require('./utilities/assertions');
+var should = require('./utilities/assertions'); // eslint-disable-line no-unused-vars
 
-describe('Titanium', function () {
-	it.android('validate exception stack trace output', function () {
+describe('Error', function () {
+	it.android('JS error thrown', function () {
 		var e = {};
 
 		try {
 			Ti.API.info(e.test.crash);
+			should.fail('Expected to throw exception');
 		} catch (ex) {
-			ex.toString().includes('Cannot read property \'crash\' of undefined').should.be.true();
+			ex.message.should.equal('Cannot read property \'crash\' of undefined');
+		}
+	});
+
+	it.android('Java exception surfaced', function () {
+		try {
+			Ti.Geolocation.accuracy = null;
+			should.fail('Expected to throw exception');
+		} catch (ex) {
+			ex.message.should.equal('Unable to convert null'); // message property is undefined now, so this will fail
+			// stack property is also undefined so this will fail
+			ex.stack.should.containEql('org.appcelerator.titanium.util.TiConvert.toInt(TiConvert.java:'); // points to Java code in stack
 		}
 	});
 });

--- a/tests/Resources/ti.addontest.js
+++ b/tests/Resources/ti.addontest.js
@@ -18,7 +18,13 @@ describe('Error', function () {
 			Ti.API.info(e.test.crash);
 			should.fail('Expected to throw exception');
 		} catch (ex) {
+			ex.should.have.property('message');
 			ex.message.should.equal('Cannot read property \'crash\' of undefined');
+			// has typical stack property
+			ex.should.have.property('stack');
+			ex.stack.should.containEql('TypeError: Cannot read property \'crash\' of undefined');
+			// does not have java stack trace
+			ex.should.not.have.property('javaStack');
 		}
 	});
 
@@ -27,9 +33,25 @@ describe('Error', function () {
 			Ti.Geolocation.accuracy = null;
 			should.fail('Expected to throw exception');
 		} catch (ex) {
-			ex.message.should.equal('Unable to convert null'); // message property is undefined now, so this will fail
-			// stack property is also undefined so this will fail
-			ex.stack.should.containEql('org.appcelerator.titanium.util.TiConvert.toInt(TiConvert.java:'); // points to Java code in stack
+			ex.should.have.property('message');
+			ex.message.should.equal('Unable to convert null');
+			// has typical stack property for JS
+			ex.should.have.property('stack');
+			ex.stack.should.containEql('Error: Unable to convert null'); // TODO Verify app.js in stack?
+			// has special javaStack property for java stacktrace
+			ex.should.have.property('javaStack');
+			ex.javaStack.should.containEql('org.appcelerator.titanium.util.TiConvert.toInt(TiConvert.java:'); // points to Java code in stack
+		}
+	});
+
+	it.android('throw(String)', function () {
+		try {
+			throw ('this is my error string'); // eslint-disable-line no-throw-literal
+		} catch (ex) {
+			ex.should.equal('this is my error string');
+			ex.should.not.have.property('message');
+			ex.should.not.have.property('stack');
+			ex.should.not.have.property('javaStack');
 		}
 	});
 });

--- a/tests/Resources/ti.addontest.js
+++ b/tests/Resources/ti.addontest.js
@@ -1,0 +1,23 @@
+/*
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2011-Present by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+/* eslint-env mocha */
+/* global Ti */
+/* eslint no-unused-expressions: "off" */
+'use strict';
+var should = require('./utilities/assertions');
+
+describe('Titanium', function () {
+	it.android('validate exception stack trace output', function () {
+		var e = {};
+
+		try {
+			Ti.API.info(e.test.crash);
+		} catch (ex) {
+			ex.toString().includes('Cannot read property \'crash\' of undefined').should.be.true();
+		}
+	});
+});

--- a/tests/Resources/ti.addontest.js
+++ b/tests/Resources/ti.addontest.js
@@ -24,7 +24,7 @@ describe('Error', function () {
 			ex.should.have.property('stack');
 			ex.stack.should.containEql('TypeError: Cannot read property \'crash\' of undefined');
 			// does not have java stack trace
-			ex.should.not.have.property('javaStack');
+			ex.should.not.have.property('nativeStack');
 		}
 	});
 
@@ -39,8 +39,8 @@ describe('Error', function () {
 			ex.should.have.property('stack');
 			ex.stack.should.containEql('Error: Unable to convert null'); // TODO Verify app.js in stack?
 			// has special javaStack property for java stacktrace
-			ex.should.have.property('javaStack');
-			ex.javaStack.should.containEql('org.appcelerator.titanium.util.TiConvert.toInt(TiConvert.java:'); // points to Java code in stack
+			ex.should.have.property('nativeStack');
+			ex.nativeStack.should.containEql('org.appcelerator.titanium.util.TiConvert.toInt(TiConvert.java:'); // points to Java code in stack
 		}
 	});
 
@@ -51,7 +51,7 @@ describe('Error', function () {
 			ex.should.equal('this is my error string');
 			ex.should.not.have.property('message');
 			ex.should.not.have.property('stack');
-			ex.should.not.have.property('javaStack');
+			ex.should.not.have.property('nativeStack');
 		}
 	});
 });


### PR DESCRIPTION
- ~Provide access to current stack trace using `KrollRuntime.getInstance().getStackTrace()`~
- Update error output to match [node.js](https://nodejs.org/api/errors.html#errors_error_stack)
- Update exception dialog to show more details including stack trace
- Include Javascript stack trace with Java exceptions

###### TEST CASE \#1
```JS
var win = Ti.UI.createWindow({ backgroundColor: 'gray' });

win.addEventListener('open', function (e) {
   Ti.API.info(e.test.crash);
});

win.open();
```
```
/app.js:12
Ti.API.info(e.test.crash);
                   ^
Uncaught TypeError: Cannot read property 'crash' of undefined
    at (/app.js:12:23)
    at value(ti:/events.js:49:21)
    at value(ti:/events.js:101:19)
```
<img src="https://jira.appcelerator.org/secure/attachment/65048/exception_new.png" width="300"/>

###### TEST CASE \#2
```JS
var win = Ti.UI.createWindow({ backgroundColor: 'gray' });

win.addEventListener('open', function (e) {
   Ti.Geolocation.accuracy = null;
});

win.open();
```
```
/app.js:4
  Ti.Geolocation.accuracy = null;
                          ^
   at (/app.js:4:28)
   at value(ti:/events.js:49:21)
   at value(ti:/events.js:101:19)

Uncaught Unable to convert null
   org.appcelerator.titanium.util.TiConvert.toInt(TiConvert.java:415)
   ti.modules.titanium.geolocation.GeolocationModule.propertyChangedAccuracy(GeolocationModule.java:414)
   ti.modules.titanium.geolocation.GeolocationModule.propertyChanged(GeolocationModule.java:384)
   org.appcelerator.kroll.KrollProxy.firePropertyChanged(KrollProxy.java:969)
   org.appcelerator.kroll.KrollProxy.onPropertyChanged(KrollProxy.java:1058)
   org.appcelerator.kroll.runtime.v8.V8Object.nativeFireEvent(Native Method)
   org.appcelerator.kroll.runtime.v8.V8Object.fireEvent(V8Object.java:63)
   org.appcelerator.kroll.KrollProxy.doFireEvent(KrollProxy.java:962)
   org.appcelerator.kroll.KrollProxy.handleMessage(KrollProxy.java:1186)
   org.appcelerator.titanium.proxy.TiViewProxy.handleMessage(TiViewProxy.java:394)
```

<img src="https://jira.appcelerator.org/secure/attachment/65059/exception_new2.png" width="300"/>

[TIMOB-25963](https://jira.appcelerator.org/browse/TIMOB-25963)
[TIMOB-25965](https://jira.appcelerator.org/browse/TIMOB-25965)