### PR TITLE
TIDOC-3183: Update to latest js-yaml

### DIFF
--- a/apidoc/Titanium/Android/QuickSettingsService.yml
+++ b/apidoc/Titanium/Android/QuickSettingsService.yml
@@ -82,12 +82,12 @@ methods:
     returns:
         type: String
 
-    name: isLocked
+  - name: isLocked
     summary: Returns 'true' if the device is currently locked, 'false' otherwise.
     returns:
         type: Boolean
 
-    name: isSecure
+  - name: isSecure
     summary: Returns 'true' if the device is in secure state, 'false' otherwise.
     returns:
         type: Boolean

--- a/apidoc/Titanium/UI/DashboardView.yml
+++ b/apidoc/Titanium/UI/DashboardView.yml
@@ -68,8 +68,6 @@ events:
       - name: item
         summary: Item that was dragged.
         type: Titanium.UI.DashboardItem
-    deprecated:
-        since: "3.0.0"
         
   - name: dragStart
     deprecated:
@@ -80,8 +78,6 @@ events:
       - name: item
         summary: Item that was dragged.
         type: Titanium.UI.DashboardItem
-    deprecated:
-        since: "3.0.0"
         
   - name: dragend
     summary: Fired when an item finishes being dragged in edit mode.

--- a/apidoc/Titanium/UI/iOS/SystemButtonStyle.yml
+++ b/apidoc/Titanium/UI/iOS/SystemButtonStyle.yml
@@ -46,7 +46,6 @@ properties:
         
         When used with [ButtonBar](Titanium.UI.ButtonBar) or [TabbedBar](Titanium.UI.iOS.TabbedBar), 
         specifies a standard bar with a heavier border.
-    description: |
     type: Number
     permission: read-only
     

--- a/apidoc/Titanium/UI/iPhone/ActivityIndicatorStyle.yml
+++ b/apidoc/Titanium/UI/iPhone/ActivityIndicatorStyle.yml
@@ -9,9 +9,6 @@ extends: Titanium.Proxy
 since: "0.9"
 platforms: [iphone, ipad]
 createable: false
-deprecated:
-    since: "5.1.0"
-    notes: Use <Titanium.UI.ActivityIndicatorStyle> instead.
 properties:
   - name: BIG
     summary: Large white spinning indicator.

--- a/apidoc/Titanium/UI/iPhone/SystemButtonStyle.yml
+++ b/apidoc/Titanium/UI/iPhone/SystemButtonStyle.yml
@@ -65,7 +65,6 @@ properties:
         
         When used with [ButtonBar](Titanium.UI.ButtonBar) or [TabbedBar](Titanium.UI.iOS.TabbedBar), 
         specifies a standard bar with a heavier border.
-    description: |
     type: Number
     permission: read-only
     

--- a/package-lock.json
+++ b/package-lock.json
@@ -3219,7 +3219,7 @@
         "bplist-parser": "0.1.1",
         "debug": "2.6.9",
         "mkdirp": "0.5.1",
-        "node-appc": "0.2.45",
+        "node-appc": "0.2.43",
         "node-ios-device": "1.4.0"
       },
       "dependencies": {
@@ -3246,6 +3246,41 @@
           "requires": {
             "minimist": "0.0.8"
           }
+        },
+        "node-appc": {
+          "version": "0.2.43",
+          "resolved": "https://registry.npmjs.org/node-appc/-/node-appc-0.2.43.tgz",
+          "integrity": "sha1-s6/A3B4kGUrZ7h/Ww2qSoaOqoJ4=",
+          "requires": {
+            "adm-zip": "0.4.7",
+            "async": "2.3.0",
+            "colors": "1.1.2",
+            "diff": "3.2.0",
+            "node-uuid": "1.4.8",
+            "optimist": "0.6.1",
+            "request": "2.81.0",
+            "semver": "5.3.0",
+            "sprintf": "0.1.5",
+            "temp": "0.8.3",
+            "uglify-js": "2.8.21",
+            "wrench": "1.5.9",
+            "xmldom": "0.1.22"
+          },
+          "dependencies": {
+            "async": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-2.3.0.tgz",
+              "integrity": "sha1-EBPRBRBH3TIP4k5JTVxm7K9hR9k=",
+              "requires": {
+                "lodash": "4.17.4"
+              }
+            }
+          }
+        },
+        "semver": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
         }
       }
     },
@@ -3360,19 +3395,19 @@
       "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
     },
     "js-yaml": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.2.7.tgz",
-      "integrity": "sha1-ECeQ8mXZhv6VpNDyp5Lnp72Ibuw=",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
+      "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
       "dev": true,
       "requires": {
         "argparse": "1.0.9",
-        "esprima": "2.0.0"
+        "esprima": "4.0.0"
       },
       "dependencies": {
         "esprima": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.0.0.tgz",
-          "integrity": "sha1-YJrFwmZ+rlQztB657OziMxtBSY8=",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+          "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "grunt-cli": "^1.2.0",
     "grunt-contrib-clean": "^1.0.0",
     "grunt-mocha-test": "^0.13.2",
-    "js-yaml": "~3.2.2",
+    "js-yaml": "^3.11.0",
     "mocha": "*",
     "optimist": "^0.6.1",
     "pagedown": "~1.1.0",


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIDOC-3183

This PR updates the js-yaml package to the latest version (3.11.0) from 3.2.7.

I'm proposing this because having used the latest js-yaml package on our docs for something else and it had picked up a fair few errors (like duplicate entries, bad syntax) that seem to be causing problems in the publication process (like the Ti.UI.Toolbar dupe). I've trawled through JIRA and GitHub and haven't seen any specific reason for us being pinned to 3.2.x

There's a few errors currently, but I'm pushing now as I wanna check how Jenkins reports the validation errors.

This PR will reinstate the pages for the following docs:

* Ti.Android.QuickSettingsService
* Ti.UI.DashboardView
* Ti.UI.iOS.SystemButtonStyle
* Ti.UI.iPhone.ActivityIndicatorStyle
* Ti.UI.iPhone.SystemButtonStyle