### PR TITLE
[TIMOB-25231] Android: List encrypted assets

### DIFF
--- a/android/runtime/common/src/java/org/appcelerator/kroll/util/KrollAssetHelper.java
+++ b/android/runtime/common/src/java/org/appcelerator/kroll/util/KrollAssetHelper.java
@@ -26,6 +26,7 @@ public class KrollAssetHelper
 
 	public interface AssetCrypt {
 		String readAsset(String path);
+		String[] getAssets();
 	}
 
 	public static void setAssetCrypt(AssetCrypt assetCrypt)
@@ -74,6 +75,14 @@ public class KrollAssetHelper
 			Log.e(TAG, "Error while reading asset \"" + path + "\":", e);
 		}
 
+		return null;
+	}
+
+	public static String[] getEncryptedAssets()
+	{
+		if (assetCrypt != null) {
+			return assetCrypt.getAssets();
+		}
 		return null;
 	}
 

--- a/android/runtime/common/src/java/org/appcelerator/kroll/util/KrollAssetHelper.java
+++ b/android/runtime/common/src/java/org/appcelerator/kroll/util/KrollAssetHelper.java
@@ -26,7 +26,7 @@ public class KrollAssetHelper
 
 	public interface AssetCrypt {
 		String readAsset(String path);
-		String[] getAssets();
+		String[] getAssetPaths();
 	}
 
 	public static void setAssetCrypt(AssetCrypt assetCrypt)
@@ -78,10 +78,10 @@ public class KrollAssetHelper
 		return null;
 	}
 
-	public static String[] getEncryptedAssets()
+	public static String[] getEncryptedAssetPaths()
 	{
 		if (assetCrypt != null) {
-			return assetCrypt.getAssets();
+			return assetCrypt.getAssetPaths();
 		}
 		return null;
 	}

--- a/android/templates/build/AssetCryptImpl.java
+++ b/android/templates/build/AssetCryptImpl.java
@@ -48,6 +48,10 @@ public class AssetCryptImpl implements KrollAssetHelper.AssetCrypt
 		return new String(filterDataInRange(assetsBytes, range.offset, range.length));
 	}
 
+	public String[] getAssets() {
+		return assets.keySet().toArray(new String[assets.size()]);
+	}
+
 	private static byte[] filterDataInRange(byte[] data, int offset, int length)
 	{
 		try {

--- a/android/templates/build/AssetCryptImpl.java
+++ b/android/templates/build/AssetCryptImpl.java
@@ -48,7 +48,7 @@ public class AssetCryptImpl implements KrollAssetHelper.AssetCrypt
 		return new String(filterDataInRange(assetsBytes, range.offset, range.length));
 	}
 
-	public String[] getAssets() {
+	public String[] getAssetPaths() {
 		return assets.keySet().toArray(new String[assets.size()]);
 	}
 

--- a/android/titanium/src/java/org/appcelerator/titanium/io/TiResourceFile.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/io/TiResourceFile.java
@@ -238,7 +238,7 @@ public class TiResourceFile extends TiBaseFile
 			}
 
 			// list encrypted assets
-			String[] assets = KrollAssetHelper.getEncryptedAssets();
+			String[] assets = KrollAssetHelper.getEncryptedAssetPaths();
 			if (assets != null) {
 				for (String asset : assets) {
 					if (asset.startsWith(path)) {
@@ -280,7 +280,7 @@ public class TiResourceFile extends TiBaseFile
 				this.typeDir = true;
 				this.exists = true;
 
-			// does not exist; neither file or directory
+				// does not exist; neither file or directory
 			} else {
 				this.typeDir = false;
 				this.exists = false;

--- a/android/titanium/src/java/org/appcelerator/titanium/io/TiResourceFile.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/io/TiResourceFile.java
@@ -30,7 +30,7 @@ public class TiResourceFile extends TiBaseFile
 {
 	private static final String TAG = "TiResourceFile";
 
-	private final String path;
+	private String path;
 	private boolean statsFetched = false;
 	private boolean exists = false;
 
@@ -191,6 +191,9 @@ public class TiResourceFile extends TiBaseFile
 
 	public String toURL()
 	{
+		if (!path.isEmpty() && !path.endsWith("/") && isDirectory()) {
+			path += "/";
+		}
 		return TiC.URL_ANDROID_ASSET_RESOURCES + path;
 	}
 
@@ -273,6 +276,7 @@ public class TiResourceFile extends TiBaseFile
 			this.typeDir = false;
 			this.typeFile = true;
 			this.exists = true;
+
 		} else {
 			this.typeFile = false;
 

--- a/android/titanium/src/java/org/appcelerator/titanium/io/TiResourceFile.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/io/TiResourceFile.java
@@ -269,32 +269,21 @@ public class TiResourceFile extends TiBaseFile
 
 	private void fetchStats()
 	{
-		InputStream is = null;
-		try {
-			is = getInputStream();
+		if (KrollAssetHelper.assetExists(TiFileHelper2.getResourcesPath(path))) {
 			this.typeDir = false;
 			this.typeFile = true;
 			this.exists = true;
-		} catch (IOException e) {
-			this.typeFile = false; // definitely not a file
-			// getInputStream() will throw a FileNotFoundException if it is a
-			// directory. We check if there are directory listings. If there is,
-			// we can assume it is a directory and it exists.
+		} else {
+			this.typeFile = false;
+
 			if (!getDirectoryListing().isEmpty()) {
 				this.typeDir = true;
 				this.exists = true;
+
+			// does not exist; neither file or directory
 			} else {
-				// doesn't exist so neither file nor directory
 				this.typeDir = false;
 				this.exists = false;
-			}
-		} finally {
-			if (is != null) {
-				try {
-					is.close();
-				} catch (IOException e) {
-					// Ignore
-				}
 			}
 		}
 		statsFetched = true;

--- a/android/titanium/src/java/org/appcelerator/titanium/io/TiResourceFile.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/io/TiResourceFile.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.appcelerator.kroll.common.Log;
+import org.appcelerator.kroll.util.KrollAssetHelper;
 import org.appcelerator.titanium.TiApplication;
 import org.appcelerator.titanium.TiBlob;
 import org.appcelerator.titanium.TiC;
@@ -222,10 +223,12 @@ public class TiResourceFile extends TiBaseFile
 	{
 		List<String> listing = new ArrayList<String>();
 		try {
-			String lpath = TiFileHelper2.joinSegments("Resources", path);
+			String lpath = TiFileHelper2.getResourcesPath(path);
 			if (lpath.endsWith("/")) {
 				lpath = lpath.substring(0, lpath.lastIndexOf("/"));
 			}
+
+			// list application assets
 			String[] names = TiApplication.getInstance().getAssets().list(lpath);
 			if (names != null) {
 				int len = names.length;
@@ -233,6 +236,26 @@ public class TiResourceFile extends TiBaseFile
 					listing.add(names[i]);
 				}
 			}
+
+			// list encrypted assets
+			String[] assets = KrollAssetHelper.getEncryptedAssets();
+			if (assets != null) {
+				for (String asset : assets) {
+					if (asset.startsWith(path)) {
+						String relativePath = asset.substring(path.length());
+						int dirIndex = asset.lastIndexOf("/");
+						String dir = dirIndex != -1 ? relativePath.substring(0, dirIndex) : "";
+						if (dir.length() > 0) {
+							if (!listing.contains(dir)) {
+								listing.add(dir);
+							}
+						} else if (relativePath.length() > 0) {
+							listing.add(relativePath);
+						}
+					}
+				}
+			}
+
 		} catch (IOException e) {
 			Log.e(TAG, "Error while getting a directory listing: " + e.getMessage(), e);
 		}

--- a/android/titanium/src/java/org/appcelerator/titanium/io/TiResourceFile.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/io/TiResourceFile.java
@@ -243,10 +243,10 @@ public class TiResourceFile extends TiBaseFile
 				for (String asset : assets) {
 					if (asset.startsWith(path)) {
 						String relativePath = asset.substring(path.length());
-						int dirIndex = asset.lastIndexOf("/");
-						String dir = dirIndex != -1 ? relativePath.substring(0, dirIndex) : "";
-						if (dir.length() > 0) {
-							if (!listing.contains(dir)) {
+						int dirIndex = relativePath.lastIndexOf('/');
+						if (dirIndex != -1) {
+							String dir = relativePath.substring(0, dirIndex);
+							if (dir.length() > 0 && !listing.contains(dir)) {
 								listing.add(dir);
 							}
 						} else if (relativePath.length() > 0) {


### PR DESCRIPTION
- List encrypted assets when using `getDirectoryListing()`

###### TEST CASE BY @jquick-axway
```JS
function logFileTree (file) {
    if (file) {
        Ti.API.info('- ' + file.nativePath + ' (directory: ' + file.isDirectory() + ')');
        let files = file.getDirectoryListing();
        if (files) {
            for (let f of files) {
                logFileTree(Ti.Filesystem.getFile(file.nativePath, f));
            }
        }
    }
}
logFileTree(Ti.Filesystem.getFile(Ti.Filesystem.getResourcesDirectory()));
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-25231)