### PR TITLE
[TIMOB-26051] Android: Fire refreshstart event

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/RefreshControlProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/RefreshControlProxy.java
@@ -176,6 +176,9 @@ public class RefreshControlProxy extends KrollProxy
 
 				// Show the refresh progress indicator.
 				swipeRefreshLayout.setRefreshing(true);
+
+				// Notify the owner that the refresh state has started.
+				fireEvent(TiC.EVENT_REFRESH_START, null);
 			}
 		});
 	}


### PR DESCRIPTION
- Fire `refreshstart` event on `beginRefreshing()`

###### TEST CASE
```JS
var window = Ti.UI.createWindow(),
    control = Ti.UI.createRefreshControl(),
    listView = Ti.UI.createListView({ refreshControl: control });

window.addEventListener('open', function () {
    Ti.API.info('begining...');
    control.beginRefreshing();
});

control.addEventListener('refreshstart', function () {
    Ti.API.info('refreshstart');
    setTimeout(function () {
        Ti.API.info('ending...');
        control.endRefreshing();
    }, 2000);
});

control.addEventListener('refreshend', function () {
    Ti.API.info('refreshend');
    alert('DONE!');
});

window.add(listView);
window.open();
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-26051)