### PR TITLE
[TIDOC-3189] Fixed Android "Intent" get*Extra() method docs for bool/int/long/double

### DIFF
--- a/apidoc/Titanium/Android/Intent.yml
+++ b/apidoc/Titanium/Android/Intent.yml
@@ -145,6 +145,9 @@ methods:
       - name: name
         summary: Property to get.
         type: String
+      - name: default
+        summary: Default value to return if property does not exist or is of a different type.
+        type: Boolean
 
   - name: getData
     summary: Get the Data URI from this `Intent`.
@@ -159,6 +162,9 @@ methods:
       - name: name
         summary: Property to get.
         type: String
+      - name: default
+        summary: Default value to return if property does not exist or is of a different type.
+        type: Number
 
   - name: getIntExtra
     summary: Get an integer property from this `Intent`.
@@ -168,6 +174,9 @@ methods:
       - name: name
         summary: Property to get.
         type: String
+      - name: default
+        summary: Default value to return if property does not exist or is of a different type.
+        type: Number
 
   - name: getLongExtra
     summary: Get a long property from this `Intent`.
@@ -177,6 +186,9 @@ methods:
       - name: name
         summary: Property to get.
         type: String
+      - name: default
+        summary: Default value to return if property does not exist or is of a different type.
+        type: Number
 
   - name: getStringExtra
     summary: Get a string property from this `Intent`.


### PR DESCRIPTION
**JIRA:**
https://jira.appcelerator.org/browse/TIDOC-3189

**Summary:**
- These methods require 2 arguments, not 1 argument, or else an exception will be thrown.
- The 2nd argument is the default value to return in case extra was not found or of a different type.
- The `getStringExtra()` and `getBlobExtra()` methods are documented correctly. They only require 1 argument.
