### PR TITLE
[TIMOB-26055] Android: Handle injected build variables

### DIFF
--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -3885,8 +3885,15 @@ AndroidBuilder.prototype.generateAndroidManifest = function generateAndroidManif
 	this.androidLibraries.forEach(libraryInfo => {
 		const libraryManifestPath = path.join(libraryInfo.explodedPath, 'AndroidManifest.xml');
 		if (fs.existsSync(libraryManifestPath)) {
+			let libraryManifestContent = fs.readFileSync(libraryManifestPath).toString();
+
+			// handle injected build variables
+			// https://developer.android.com/studio/build/manifest-build-variables
+			libraryManifestContent = libraryManifestContent.replace('${applicationId}', this.appid); // eslint-disable-line no-template-curly-in-string
+
 			const libraryManifest = new AndroidManifest();
-			libraryManifest.load(libraryManifestPath);
+			libraryManifest.parse(libraryManifestContent);
+
 			// we don't want android libraries to override the <supports-screens> or <uses-sdk> tags
 			delete libraryManifest.__attr__;
 			delete libraryManifest['supports-screens'];


### PR DESCRIPTION
- Handle injected build variable `applicationId` in `AndroidManifest.xml`
- Related to https://github.com/appcelerator/titanium_mobile/pull/10002

##### TEST CASE
###### tiapp.xml
```XML
<module platform="android">facebook</module>
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-26055)