### PR TITLE
[TIDOC-3190] Updated Ti.Network "online" property documentation

### DIFF
--- a/apidoc/Titanium/Network/Network.yml
+++ b/apidoc/Titanium/Network/Network.yml
@@ -433,7 +433,7 @@ events:
         summary: New network type as a string.
         type: String
       - name: online
-        summary: Boolean to indicate if the device is online.
+        summary: Boolean indicating if the device is connected to the network.
         type: Boolean
       - name: networkType
         summary: New network type
@@ -690,10 +690,14 @@ properties:
     permission: read-only
 
   - name: online
-    summary: Boolean value indicating if the device can reach the Internet.
+    summary: Boolean value indicating if the device is connected to the network.
     description: |
-        The `online` property is `true` if the device can currently reach the Internet
-        using either WiFi, mobile network or LAN.
+        The `online` property is `true` if the device has network access via WiFi,
+        LAN, or mobile/cellular network.
+
+        Note that if the device is connected to a private network without Internet access,
+        then this property will be `true` as well. This means you cannot assume the device
+        has Internet access if it's connected to the network.
     type: Boolean
     permission: read-only
 


### PR DESCRIPTION
**JIRA:**
https://jira.appcelerator.org/browse/TIDOC-3190

**Summary:**
- Fixed error in `online` boolean property description which stated that it indicates "Internet" access. This is wrong.
- This property will be `true` if connected to a private network without Internet access. I've confirmed this behavior on both Android and iOS. I also think this is the correct behavior. If you want to detect Internet access, then you must do an HTTP request to a public website.

**Note:**
@hansemannn I've also noticed that iOS returns a `Number` instead of a `Boolean`. I haven't updated the doc to reflect this (it would be kind of odd to document it as `Boolean/Number`).
