### PR TITLE
Remove Xcode 8 statement since we support it in general

### DIFF
--- a/iphone/Classes/TiErrorController.m
+++ b/iphone/Classes/TiErrorController.m
@@ -166,7 +166,6 @@
 
   [self.view layoutIfNeeded];
 
-#if IS_XCODE_8
   // use haptic feedback on supported devices
   if ([TiUtils isIOSVersionOrGreater:@"10.0"]) {
     UINotificationFeedbackGenerator *generator = [UINotificationFeedbackGenerator new];
@@ -174,7 +173,6 @@
     [generator notificationOccurred:UINotificationFeedbackTypeError];
     RELEASE_TO_NIL(generator);
   }
-#endif
 }
 
 - (BOOL)prefersHomeIndicatorAutoHidden


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-0000

Fixing a small typo that resulted of removing the IS_XCODE_8 macros and at the same time refactoring the iOS crash dialog.