### PR TITLE
[TIMOB-26080] Fix ERR_INVALID_CALLBACK error on Android build and misc Node 10 fixes

### DIFF
--- a/android/cli/commands/_buildModule.js
+++ b/android/cli/commands/_buildModule.js
@@ -1531,7 +1531,7 @@ AndroidModuleBuilder.prototype.jsToC = function (next) {
 
 	if (fs.existsSync(jsBootstrapFile)) {
 
-		const str = new Buffer(fs.readFileSync(jsBootstrapFile)); // eslint-disable-line security/detect-new-buffer
+		const str = Buffer.from(fs.readFileSync(jsBootstrapFile));
 
 		[].forEach.call(str, function (char) {
 			result.push(char);

--- a/android/cli/hooks/aar-transform.js
+++ b/android/cli/hooks/aar-transform.js
@@ -481,7 +481,7 @@ class SimpleFileCache {
 	 */
 	persist() {
 		var dataToWrite = JSON.stringify(this.data);
-		if (!fs.exists(path.dirname(this.cachePathAndFilename))) {
+		if (!fs.existsSync(path.dirname(this.cachePathAndFilename))) {
 			wrench.mkdirSyncRecursive(path.dirname(this.cachePathAndFilename));
 		}
 		fs.writeFileSync(this.cachePathAndFilename, dataToWrite);

--- a/android/package.json
+++ b/android/package.json
@@ -26,7 +26,7 @@
 		"android platform tools": "27.x",
 		"android tools": "<=26.x",
 		"android ndk": ">=r11c <=r16c",
-		"node": ">=4.0 <=7.x",
+		"node": ">=6.0 <=8.x",
 		"java": ">=1.8.x"
 	},
 	"repository": {

--- a/android/package.json
+++ b/android/package.json
@@ -26,7 +26,7 @@
 		"android platform tools": "27.x",
 		"android tools": "<=26.x",
 		"android ndk": ">=r11c <=r16c",
-		"node": ">=6.0 <=8.x",
+		"node": ">=4.0 <=8.x",
 		"java": ">=1.8.x"
 	},
 	"repository": {

--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -5480,7 +5480,7 @@ iOSBuilder.prototype.copyResources = function copyResources(next) {
 								const buf = [];
 								this.pack()
 									.on('data', function (bytes) {
-										buf.push(new Buffer(bytes)); // eslint-disable-line security/detect-new-buffer
+										buf.push(Buffer.from(bytes));
 									})
 									.on('end', function (err) {
 										if (err) {

--- a/iphone/package.json
+++ b/iphone/package.json
@@ -20,7 +20,7 @@
 	"vendorDependencies": {
 		"xcode": ">=6.0 <=9.x",
 		"ios sdk": ">=8.0 <=11.x",
-		"node": ">=6.0 <=8.x"
+		"node": ">=4.0 <=8.x"
 	},
 	"repository": {
 		"type": "git",

--- a/iphone/package.json
+++ b/iphone/package.json
@@ -20,7 +20,7 @@
 	"vendorDependencies": {
 		"xcode": ">=6.0 <=9.x",
 		"ios sdk": ">=8.0 <=11.x",
-		"node": ">=4.0 <=8.x"
+		"node": ">=6.0 <=8.x"
 	},
 	"repository": {
 		"type": "git",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2292,14 +2292,12 @@
     "fast-deep-equal": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
-      "dev": true
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-      "dev": true
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -3477,8 +3475,7 @@
     "json-schema-traverse": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
-      "dev": true
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
     },
     "json-stable-stringify": {
       "version": "1.0.1",
@@ -4027,43 +4024,209 @@
       "dev": true
     },
     "node-appc": {
-      "version": "0.2.45",
-      "resolved": "https://registry.npmjs.org/node-appc/-/node-appc-0.2.45.tgz",
-      "integrity": "sha512-F0rkZiXaHYvXPNtUUNLnJ8+v6yPElORjw1YrCofj9zyTsh0Kaaj2wEPL147QnpW/sym0DW5dmUwww399NOZcLQ==",
+      "version": "0.2.47",
+      "resolved": "https://registry.npmjs.org/node-appc/-/node-appc-0.2.47.tgz",
+      "integrity": "sha512-7ut/KUHyNv/MSwALvPi6+1AIP1hmlxxbWt9Z/aQhnitRAy2lzChp45CI9AgvcHPk+/CKcabVt3/6R83TwiaO2w==",
       "requires": {
-        "adm-zip": "0.4.7",
-        "async": "2.3.0",
-        "colors": "1.1.2",
-        "diff": "3.2.0",
-        "fs-extra": "2.0.0",
-        "optimist": "0.6.1",
-        "request": "2.81.0",
-        "semver": "5.3.0",
-        "sprintf": "0.1.5",
-        "temp": "0.8.3",
-        "uglify-js": "2.8.21",
-        "uuid": "3.0.1",
-        "xmldom": "0.1.22"
+        "adm-zip": "^0.4.11",
+        "async": "^2.6.1",
+        "colors": "^1.3.0",
+        "diff": "^3.5.0",
+        "fs-extra": "^2.1.2",
+        "optimist": "^0.6.1",
+        "request": "^2.87.0",
+        "semver": "^5.5.0",
+        "sprintf": "^0.1.5",
+        "temp": "^0.8.3",
+        "uglify-js": "^2.8.29",
+        "uuid": "^3.2.1",
+        "xmldom": "^0.1.27"
       },
       "dependencies": {
+        "adm-zip": {
+          "version": "0.4.11",
+          "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.11.tgz",
+          "integrity": "sha512-L8vcjDTCOIJk7wFvmlEUN7AsSb8T+2JrdP7KINBjzr24TJ5Mwj590sLu3BC7zNZowvJWa/JtPmD8eJCzdtDWjA=="
+        },
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "requires": {
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0"
+          }
+        },
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        },
+        "async": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+          "requires": {
+            "lodash": "^4.17.10"
+          }
+        },
+        "aws-sign2": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+          "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+        },
+        "colors": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.0.tgz",
+          "integrity": "sha512-EDpX3a7wHMWFA7PUHWPHNWqOxIIRSJetuwl0AS5Oi/5FMV8kWm69RTlgm00GKjBO1xFHMtBbL49yRtMMdticBw=="
+        },
+        "diff": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+        },
+        "form-data": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+          "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "1.0.6",
+            "mime-types": "^2.1.12"
+          },
+          "dependencies": {
+            "combined-stream": {
+              "version": "1.0.6",
+              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+              "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+              "requires": {
+                "delayed-stream": "~1.0.0"
+              }
+            }
+          }
+        },
         "fs-extra": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.0.0.tgz",
-          "integrity": "sha1-M3NSve1KC3FPPrhN6M6nZenTdgA=",
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
+          "integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=",
           "requires": {
             "graceful-fs": "^4.1.2",
             "jsonfile": "^2.1.0"
           }
         },
+        "har-schema": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+          "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+        },
+        "har-validator": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+          "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+          "requires": {
+            "ajv": "^5.1.0",
+            "har-schema": "^2.0.0"
+          }
+        },
+        "http-signature": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+          "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+          "requires": {
+            "assert-plus": "^1.0.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+        },
+        "mime-db": {
+          "version": "1.33.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+          "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
+        },
+        "mime-types": {
+          "version": "2.1.18",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+          "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+          "requires": {
+            "mime-db": "~1.33.0"
+          }
+        },
+        "performance-now": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+          "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+        },
+        "qs": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+        },
+        "request": {
+          "version": "2.87.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
+          "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
+          "requires": {
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.6.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.1",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.1",
+            "har-validator": "~5.0.3",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.17",
+            "oauth-sign": "~0.8.2",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.1",
+            "safe-buffer": "^5.1.1",
+            "tough-cookie": "~2.3.3",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.1.0"
+          }
+        },
         "semver": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+        },
+        "tough-cookie": {
+          "version": "2.3.4",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+          "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+          "requires": {
+            "punycode": "^1.4.1"
+          }
+        },
+        "uglify-js": {
+          "version": "2.8.29",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+          "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+          "requires": {
+            "source-map": "~0.5.1",
+            "uglify-to-browserify": "~1.0.0",
+            "yargs": "~3.10.0"
+          }
         },
         "uuid": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
-          "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE="
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+          "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
+        },
+        "xmldom": {
+          "version": "0.1.27",
+          "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
+          "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "lodash.defaultsdeep": "4.6.0",
     "markdown": "0.5.0",
     "moment": "2.18.1",
-    "node-appc": "^0.2.45",
+    "node-appc": "^0.2.47",
     "node-titanium-sdk": "^0.4.11",
     "node-uuid": "1.4.8",
     "pngjs": "3.0.1",
@@ -77,10 +77,10 @@
     "visual studio": ">=10 <=12",
     "windows phone sdk": "8.x",
     "msbuild": ">=4.0",
-    "node": "6.x || 8.x"
+    "node": "4.x || 6.x || 8.x"
   },
   "engines": {
-    "node": ">=6"
+    "node": ">=4"
   },
   "license": "Apache-2.0"
 }

--- a/package.json
+++ b/package.json
@@ -77,10 +77,10 @@
     "visual studio": ">=10 <=12",
     "windows phone sdk": "8.x",
     "msbuild": ">=4.0",
-    "node": "4.x || 6.x || 8.x"
+    "node": "6.x || 8.x"
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=6"
   },
   "license": "Apache-2.0"
 }


### PR DESCRIPTION
This PR contains two tickets as they are closely related, however the second commit has some consequences on our supported Node version, as `Buffer.from` is only available in Node 6+. We can easily ponyfill this using [buffer-from](https://github.com/LinusU/buffer-from) but I chose to drop Node 4 for the following reasons

- It is end of life, as per our [third party software support](https://docs.appcelerator.com/platform/latest/#!/guide/Axway_Appcelerator_Deprecation_Policy) it is not required to support Node 4 now that it is EOL, and I would not consider this removal a semver major for that reason.
- [Node 4 support is currently broken](https://jira.appcelerator.org/browse/TIMOB-25944), I haven't seen any one (but me) complain about this.

That said, if anyone has differing opinions, I'm happy to rework fd207d044face2ccf0a70c56a7c813fdeeeeb835 to use the ponyfill

**Tickets:**

1. **JIRA:** https://jira.appcelerator.org/browse/TIMOB-26080
- Fix the `ERR_INVALID_CALLBACK` error when building a project with .aar files.
	- Steps to reproduce:
	1. Download the [facebook module](https://github.com/appcelerator-modules/ti.facebook)
	2. Build using this SDK and Node 10, no error should be thrown

2. **JIRA:** https://jira.appcelerator.org/browse/TIMOB-26081
- Remove deprecation warnings from `new Buffer` usage
- It's kinda easy to miss these logs in a debug/trace log level, it's easy to spot in info. They look like `(node:19383) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.`
	- Steps to reproduce:
	1. Build an app for iOS where the `DefaultIcon.png` has an alpha channel, [here's one](https://www.dropbox.com/s/5hgafhldtoxo1y4/DefaultIcon.png?dl=0)
	2. Build any Android module


