### PR TITLE
[TIMOB-23527] iOS: Fix method access for two methods, fix 7.2.0 -> 7.3.0, fix docs

### DIFF
--- a/apidoc/Titanium/App/iOS/UserNotificationCenter.yml
+++ b/apidoc/Titanium/App/iOS/UserNotificationCenter.yml
@@ -1,5 +1,5 @@
 ---
-name: Titanium.App.iOS.NotificationCenter
+name: Titanium.App.iOS.UserNotificationCenter
 summary: |
     The top-level App iOS Notification Center module, available only to iOS devices running iOS 8 or later. It is
     used to control scheduled notifications and receive details about the system-wide notification settings.
@@ -58,8 +58,8 @@ methods:
 name: UserNotificationCallbackResponse
 summary: |
     Response when receiving pending or local notifications
-    in <Titanium.App.iOS.NotificationCenter.getPendingNotifications> and
-    <Titanium.App.iOS.NotificationCenter.getDeliveredNotifications>.
+    in <Titanium.App.iOS.UserNotificationCenter.getPendingNotifications> and
+    <Titanium.App.iOS.UserNotificationCenter.getDeliveredNotifications>.
 since: "7.3.0"
 properties:
   - name: notifications
@@ -71,8 +71,8 @@ name: UserNotificationDictionary
 summary: |
     Dictionary of notification data used in the array of `notifications`
     when receiving pending or local notifications in
-    <Titanium.App.iOS.NotificationCenter.getPendingNotifications> and
-    <Titanium.App.iOS.NotificationCenter.getDeliveredNotifications>.
+    <Titanium.App.iOS.UserNotificationCenter.getPendingNotifications> and
+    <Titanium.App.iOS.UserNotificationCenter.getDeliveredNotifications>.
 since: "7.3.0"
 properties:
   - name: alertTitle

--- a/apidoc/Titanium/App/iOS/iOS.yml
+++ b/apidoc/Titanium/App/iOS/iOS.yml
@@ -315,7 +315,7 @@ properties:
         user notifications.
     description: |
         Used to check the `authorizationStatus` attribute received in
-        <Titanium.App.iOS.NotificationCenter.requestUserNotificationSettings>.
+        <Titanium.App.iOS.UserNotificationCenter.requestUserNotificationSettings>.
     type: Number
     permission: read-only
     osver: {ios: {min: "10.0"}}
@@ -325,7 +325,7 @@ properties:
     summary: The application is authorized to post user notifications.
     description: |
         Used to check the `authorizationStatus` attribute received in
-        <Titanium.App.iOS.NotificationCenter.requestUserNotificationSettings>.
+        <Titanium.App.iOS.UserNotificationCenter.requestUserNotificationSettings>.
     type: Number
     permission: read-only
     osver: {ios: {min: "10.0"}}
@@ -335,7 +335,7 @@ properties:
     summary: The application is not authorized to post user notifications.
     description: |
         Used to check the `authorizationStatus` attribute received in
-        <Titanium.App.iOS.NotificationCenter.requestUserNotificationSettings>.
+        <Titanium.App.iOS.UserNotificationCenter.requestUserNotificationSettings>.
     type: Number
     permission: read-only
     osver: {ios: {min: "10.0"}}
@@ -345,7 +345,7 @@ properties:
     summary: The application does not support this notification type.
     description: |
         Used to check application-wide enabled notification settings received in
-        <Titanium.App.iOS.NotificationCenter.requestUserNotificationSettings>.
+        <Titanium.App.iOS.UserNotificationCenter.requestUserNotificationSettings>.
     type: Number
     permission: read-only
     osver: {ios: {min: "10.0"}}
@@ -355,7 +355,7 @@ properties:
     summary: The notification setting is turned on.
     description: |
         Used to check application-wide enabled notification settings received in
-        <Titanium.App.iOS.NotificationCenter.requestUserNotificationSettings>.
+        <Titanium.App.iOS.UserNotificationCenter.requestUserNotificationSettings>.
     type: Number
     permission: read-only
     osver: {ios: {min: "10.0"}}
@@ -365,7 +365,7 @@ properties:
     summary: The notification setting is turned off.
     description: |
         Used to check application-wide enabled notification settings received in
-        <Titanium.App.iOS.NotificationCenter.requestUserNotificationSettings>.
+        <Titanium.App.iOS.UserNotificationCenter.requestUserNotificationSettings>.
     type: Number
     permission: read-only
     osver: {ios: {min: "10.0"}}
@@ -375,7 +375,7 @@ properties:
     summary: No banner or alert dialog is presented when the notification is received.
     description: |
         Used to check the `alertStyle` attribute received in
-        <Titanium.App.iOS.NotificationCenter.requestUserNotificationSettings>.
+        <Titanium.App.iOS.UserNotificationCenter.requestUserNotificationSettings>.
     type: Number
     permission: read-only
     osver: {ios: {min: "10.0"}}
@@ -385,7 +385,7 @@ properties:
     summary: A alert dialog is presented when the notification is received.
     description: |
         Used to check the `alertStyle` attribute received in
-        <Titanium.App.iOS.NotificationCenter.requestUserNotificationSettings>.
+        <Titanium.App.iOS.UserNotificationCenter.requestUserNotificationSettings>.
     type: Number
     permission: read-only
     osver: {ios: {min: "10.0"}}
@@ -395,7 +395,7 @@ properties:
     summary: A banner is presented when the notification is received.
     description: |
         Used to check the `alertStyle` attribute received in
-        <Titanium.App.iOS.NotificationCenter.requestUserNotificationSettings>.
+        <Titanium.App.iOS.UserNotificationCenter.requestUserNotificationSettings>.
     type: Number
     permission: read-only
     osver: {ios: {min: "10.0"}}
@@ -715,7 +715,7 @@ properties:
     permission: read-only
     deprecated:
         since: "7.2.0"
-        notes: Use <Titanium.App.iOS.NotificationCenter.requestUserNotificationSettings> instead.
+        notes: Use <Titanium.App.iOS.UserNotificationCenter.requestUserNotificationSettings> instead.
     osver: {ios: {min: "8.0"}}
     since: "3.4.0"
 
@@ -1443,7 +1443,7 @@ summary: |
     the <Titanium.App.iOS.registerUserNotificationSettings> method.
 
     To retrieve the current notification settings, use the
-    <Titanium.App.iOS.NotificationCenter.requestUserNotificationSettings> method.
+    <Titanium.App.iOS.UserNotificationCenter.requestUserNotificationSettings> method.
 since: "3.4.0"
 platforms: [iphone, ipad]
 

--- a/iphone/Classes/TiApp.m
+++ b/iphone/Classes/TiApp.m
@@ -1499,8 +1499,6 @@ TI_INLINE void waitForMemoryPanicCleared(); //WARNING: This must never be run on
   [self checkBackgroundServices];
 }
 
-#define NOTNIL(v) ((v == nil) ? (id)[NSNull null] : v)
-
 + (NSDictionary *)dictionaryWithUserNotification:(UNNotification *)notification withIdentifier:(NSString *)identifier
 {
   if (notification == nil) {
@@ -1508,17 +1506,17 @@ TI_INLINE void waitForMemoryPanicCleared(); //WARNING: This must never be run on
   }
   NSMutableDictionary *event = [NSMutableDictionary dictionary];
 
-  [event setObject:NOTNIL([notification date]) forKey:@"date"];
+  [event setObject:NULL_IF_NIL([notification date]) forKey:@"date"];
   [event setObject:[[NSTimeZone defaultTimeZone] name] forKey:@"timezone"];
-  [event setObject:NOTNIL([[[notification request] content] body]) forKey:@"alertBody"];
-  [event setObject:NOTNIL([[[notification request] content] title]) forKey:@"alertTitle"];
-  [event setObject:NOTNIL([[[notification request] content] subtitle]) forKey:@"alertSubtitle"];
-  [event setObject:NOTNIL([[[notification request] content] launchImageName]) forKey:@"alertLaunchImage"];
-  [event setObject:NOTNIL([[[notification request] content] sound]) forKey:@"sound"];
-  [event setObject:NOTNIL([[[notification request] content] badge]) forKey:@"badge"];
-  [event setObject:NOTNIL([[[notification request] content] userInfo]) forKey:@"userInfo"];
-  [event setObject:NOTNIL([[[notification request] content] categoryIdentifier]) forKey:@"category"];
-  [event setObject:NOTNIL([[notification request] identifier]) forKey:@"identifier"];
+  [event setObject:NULL_IF_NIL([[[notification request] content] body]) forKey:@"alertBody"];
+  [event setObject:NULL_IF_NIL([[[notification request] content] title]) forKey:@"alertTitle"];
+  [event setObject:NULL_IF_NIL([[[notification request] content] subtitle]) forKey:@"alertSubtitle"];
+  [event setObject:NULL_IF_NIL([[[notification request] content] launchImageName]) forKey:@"alertLaunchImage"];
+  [event setObject:NULL_IF_NIL([[[notification request] content] sound]) forKey:@"sound"];
+  [event setObject:NULL_IF_NIL([[[notification request] content] badge]) forKey:@"badge"];
+  [event setObject:NULL_IF_NIL([[[notification request] content] userInfo]) forKey:@"userInfo"];
+  [event setObject:NULL_IF_NIL([[[notification request] content] categoryIdentifier]) forKey:@"category"];
+  [event setObject:NULL_IF_NIL([[notification request] identifier]) forKey:@"identifier"];
 
   return event;
 }
@@ -1529,18 +1527,18 @@ TI_INLINE void waitForMemoryPanicCleared(); //WARNING: This must never be run on
     return nil;
   }
   NSMutableDictionary *event = [NSMutableDictionary dictionary];
-  [event setObject:NOTNIL([notification fireDate]) forKey:@"date"];
-  [event setObject:NOTNIL([[notification timeZone] name]) forKey:@"timezone"];
-  [event setObject:NOTNIL([notification alertTitle]) forKey:@"alertTitle"];
-  [event setObject:NOTNIL([notification alertBody]) forKey:@"alertBody"];
-  [event setObject:NOTNIL([notification alertAction]) forKey:@"alertAction"];
-  [event setObject:NOTNIL([notification alertLaunchImage]) forKey:@"alertLaunchImage"];
-  [event setObject:NOTNIL([notification soundName]) forKey:@"sound"];
-  [event setObject:NUMINTEGER([notification applicationIconBadgeNumber]) forKey:@"badge"];
-  [event setObject:NOTNIL([notification userInfo]) forKey:@"userInfo"];
-  [event setObject:NOTNIL([notification category]) forKey:@"category"];
-  [event setObject:NOTNIL(identifier) forKey:@"identifier"];
-  [event setObject:NUMBOOL([[UIApplication sharedApplication] applicationState] != UIApplicationStateActive) forKey:@"inBackground"];
+  [event setObject:NULL_IF_NIL([notification fireDate]) forKey:@"date"];
+  [event setObject:NULL_IF_NIL([[notification timeZone] name]) forKey:@"timezone"];
+  [event setObject:NULL_IF_NIL([notification alertTitle]) forKey:@"alertTitle"];
+  [event setObject:NULL_IF_NIL([notification alertBody]) forKey:@"alertBody"];
+  [event setObject:NULL_IF_NIL([notification alertAction]) forKey:@"alertAction"];
+  [event setObject:NULL_IF_NIL([notification alertLaunchImage]) forKey:@"alertLaunchImage"];
+  [event setObject:NULL_IF_NIL([notification soundName]) forKey:@"sound"];
+  [event setObject:@([notification applicationIconBadgeNumber]) forKey:@"badge"];
+  [event setObject:NULL_IF_NIL([notification userInfo]) forKey:@"userInfo"];
+  [event setObject:NULL_IF_NIL([notification category]) forKey:@"category"];
+  [event setObject:NULL_IF_NIL(identifier) forKey:@"identifier"];
+  [event setObject:@([[UIApplication sharedApplication] applicationState] != UIApplicationStateActive) forKey:@"inBackground"];
 
   return event;
 }

--- a/iphone/Classes/TiAppiOSLocalNotificationProxy.m
+++ b/iphone/Classes/TiAppiOSLocalNotificationProxy.m
@@ -26,7 +26,7 @@
 
 - (void)cancel:(id)unused
 {
-  DEPRECATED_REPLACED(@"App.iOS.LocalNotification.cancel", @"7.2.0", @"App.iOS.NotificationCenter.removePendingNotificationsWithIdentifiers");
+  DEPRECATED_REPLACED(@"App.iOS.LocalNotification.cancel", @"7.3.0", @"App.iOS.UserNotificationCenter.removePendingNotificationsWithIdentifiers");
 
   if ([TiUtils isIOS10OrGreater]) {
     NSString *identifier = @"notification";

--- a/iphone/Classes/TiAppiOSProxy.m
+++ b/iphone/Classes/TiAppiOSProxy.m
@@ -501,10 +501,10 @@
 
 - (NSDictionary *)currentUserNotificationSettings
 {
-  DEPRECATED_REPLACED(@"App.iOS.currentUserNotificationSettings", @"7.2.0", @"App.iOS.NotificationCenter.requestUserNotificationSettings");
+  DEPRECATED_REPLACED(@"App.iOS.currentUserNotificationSettings", @"7.3.0", @"App.iOS.UserNotificationCenter.requestUserNotificationSettings");
 
   if ([TiUtils isIOS10OrGreater]) {
-    DebugLog(@"[ERROR] Please use Ti.App.iOS.NotificationCenter.requestUserNotificationSettings in iOS 10 and later to request user notification settings asynchronously.");
+    DebugLog(@"[ERROR] Please use Ti.App.iOS.UserNotificationCenter.requestUserNotificationSettings in iOS 10 and later to request user notification settings asynchronously.");
   }
 
   __block NSDictionary *returnVal = nil;
@@ -843,7 +843,7 @@
 {
   ENSURE_UI_THREAD(cancelAllLocalNotifications, unused);
 
-  DEPRECATED_REPLACED(@"App.iOS.cancelAllLocalNotifications", @"7.2.0", @"App.iOS.NotificationCenter.removeAllPendingNotifications");
+  DEPRECATED_REPLACED(@"App.iOS.cancelAllLocalNotifications", @"7.3.0", @"App.iOS.UserNotificationCenter.removeAllPendingNotifications");
 
   if ([TiUtils isIOS10OrGreater]) {
     [[UNUserNotificationCenter currentNotificationCenter] removeAllPendingNotificationRequests];
@@ -857,7 +857,7 @@
   ENSURE_SINGLE_ARG(value, NSObject);
   ENSURE_UI_THREAD(cancelLocalNotification, value);
 
-  DEPRECATED_REPLACED(@"App.iOS.cancelLocalNotification", @"7.2.0", @"App.iOS.NotificationCenter.removePendingNotificationsWithIdentifiers");
+  DEPRECATED_REPLACED(@"App.iOS.cancelLocalNotification", @"7.3.0", @"App.iOS.UserNotificationCenter.removePendingNotificationsWithIdentifiers");
 
   if ([TiUtils isIOS10OrGreater]) {
     NSString *identifier = [TiUtils stringValue:value] ?: @"notification";

--- a/iphone/Classes/TiFilesystemFileProxy.m
+++ b/iphone/Classes/TiFilesystemFileProxy.m
@@ -60,13 +60,13 @@
 
 - (NSDate *)createTimestamp
 {
-  DEPRECATED_REPLACED(@"Filesystem.File.createTimestamp", @"7.2.0", @"Filesystem.File.createdAt()");
+  DEPRECATED_REPLACED(@"Filesystem.File.createTimestamp", @"7.3.0", @"Filesystem.File.createdAt()");
   return [self createdAt:nil];
 }
 
 - (NSDate *)createTimestamp:(id)unused
 {
-  DEPRECATED_REPLACED(@"Filesystem.File.createTimestamp()", @"7.2.0", @"Filesystem.File.createdAt()");
+  DEPRECATED_REPLACED(@"Filesystem.File.createTimestamp()", @"7.3.0", @"Filesystem.File.createdAt()");
   return [self createdAt:unused];
 }
 
@@ -87,13 +87,13 @@
 
 - (NSDate *)modificationTimestamp
 {
-  DEPRECATED_REPLACED(@"Filesystem.File.modificationTimestamp", @"7.2.0", @"Filesystem.File.modifiedAt()");
+  DEPRECATED_REPLACED(@"Filesystem.File.modificationTimestamp", @"7.3.0", @"Filesystem.File.modifiedAt()");
   return [self modifiedAt:nil];
 }
 
 - (NSDate *)modificationTimestamp:(id)unused
 {
-  DEPRECATED_REPLACED(@"Filesystem.File.modificationTimestamp()", @"7.2.0", @"Filesystem.File.modifiedAt()");
+  DEPRECATED_REPLACED(@"Filesystem.File.modificationTimestamp()", @"7.3.0", @"Filesystem.File.modifiedAt()");
   return [self modifiedAt:nil];
 }
 

--- a/iphone/Resources/app.js
+++ b/iphone/Resources/app.js
@@ -15,7 +15,7 @@ var btn = Ti.UI.createButton({
 });
 
 btn.addEventListener('click', function() {
-    Ti.API.info('Hello world!');
+    Ti.App.iOS.UserNotificationCenter.removePendingNotifications()
 });
 
 win.add(btn);


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-23527

There were two typos that caused a few methods to not work properly. Also, when we bumped the 7.3.0 features out of 7.2.0, we forgot to change a few in-code references. This PR fixes that all together.