### PR TITLE
[TIMOB-26106] Windows: Update module apiversion

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "moduleApiVersion": {
     "iphone": "2",
     "android": "4",
-    "windows": "5"
+    "windows": "6"
   },
   "keywords": [
     "appcelerator",


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-26106

Update module apiversion for Windows because there's module binary incompatibility in upcoming 7.3.0.