### PR TITLE
[TIMOB-26102] Update ti.cloudpush to 5.1.2

### DIFF
--- a/support/module/packaged/modules.json
+++ b/support/module/packaged/modules.json
@@ -39,8 +39,8 @@
 			"integrity": "sha512-1bbQt4X5rbUsSd0nVOL9hdqjgxzat3eef+aBct8jnGa2cIfj2ritxISzSoDii3Ou2fe9bXUV8sAR6DQzVMaD1w=="
 		},
 		"ti.cloudpush": {
-			"url": "https://s3.amazonaws.com/timobile.appcelerator.com/modules/ti.cloudpush-android-5.1.0.zip",
-			"integrity": "sha512-8ptNqnHY6kk4QjY7jrjvtOvPoxWpZeqLfbFNSMkY+aUfDPykpcw1UvC00pcfNMO3NbceZ3Csdulub96t1R492w=="
+			"url": "https://s3.amazonaws.com/timobile.appcelerator.com/modules/ti.cloudpush-android-5.1.2.zip",
+			"integrity": "sha512-ATXtunHN5sdPS6cELy7XyEw4NCDaiXWcDRMurxckpbFDtuFCDFGMkFkE2m8qJTE9OuBrC/8s3JaL+YdLARa84A=="
 		},
 		"ti.map": {
 			"url": "https://github.com/appcelerator-modules/ti.map/releases/download/android-4.2.0/ti.map-android-4.2.0.zip",


### PR DESCRIPTION
- Update `ti.cloudpush` to `5.1.2`

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-26102)