### PR TITLE
[TIMOB-26141] Android: Prevent lookup of invalid reference key

### DIFF
--- a/android/runtime/v8/src/native/JavaObject.cpp
+++ b/android/runtime/v8/src/native/JavaObject.cpp
@@ -76,8 +76,7 @@ jobject JavaObject::getJavaObject()
 	}
 	if (useGlobalRefs) {
 		return javaObject_;
-	} else {
-		ASSERT(refTableKey_ != 0);
+	} else if (refTableKey_ > 0) {
 		jobject ref = ReferenceTable::getReference(refTableKey_);
 		if (ref == NULL) {
 			// Sanity check. Did we get into a state where it was weak on Java, got GC'd but the C++ proxy didn't get deleted yet?
@@ -85,6 +84,7 @@ jobject JavaObject::getJavaObject()
 		}
 		return ref;
 	}
+	return NULL;
 }
 
 void JavaObject::unreferenceJavaObject(jobject ref) {

--- a/android/titanium/src/java/org/appcelerator/titanium/TiApplication.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiApplication.java
@@ -311,7 +311,6 @@ public abstract class TiApplication extends Application implements KrollApplicat
 			}
 		}
 
-		Log.e(TAG, "No valid root or current activity found for application instance");
 		return null;
 	}
 


### PR DESCRIPTION
- Prevent lookup of invalid reference key `0`
- Remove annoying error log `No valid root or current activity found for application instance`

###### TEST CASE
```JS
console.log(Ti.App.Android.R);
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-26141)