### PR TITLE
[7_3_X][TIMOB-26151] Ti.Platform.id not working on Android in 7.2.0.GA (works on 7.1.1.GA)

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/TiApplication.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiApplication.java
@@ -428,9 +428,9 @@ public abstract class TiApplication extends Application implements KrollApplicat
 
 	public void postAppInfo()
 	{
+		TiPlatformHelper.getInstance().initialize();
 		if (isAnalyticsEnabled()) {
 
-			TiPlatformHelper.getInstance().initialize();
 			TiPlatformHelper.getInstance().initAnalytics();
 			TiPlatformHelper.getInstance().setSdkVersion("ti." + getTiBuildVersion());
 			TiPlatformHelper.getInstance().setAppName(getAppInfo().getName());


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-26151

**Description:**
PlatformHelper does not depend on analytics to be initialized.
Change in the order of an application start to provide the ability to opt out from Analytics left the Platform module depending on Analytics to be enabled.

This is sort of a backport of: https://github.com/appcelerator/titanium_mobile/pull/10008
where the issue is not present.

**Note:**  We have unit tests for the module.

**Test case:**

If you disable analytics in `tiapp.xml`, clicking the button will cause the application to crash.

_app.js_
```
var win = Ti.UI.createWindow(),
	button = Ti.UI.createButton({title: 'Get Info'});
button.addEventListener('click', function () {
	alert('Address: ' + Ti.Platform.address + '\n' +
		'Architecture: ' + Ti.Platform.architecutre + '\n' +
		'Available Memory: ' + Ti.Platform.availableMemory + '\n' +
		'Battery Level: ' + Ti.Platform.batteryLevel + '\n' +
		'Battery Monitoring: ' + Ti.Platform.batteryMonitoring + '\n' +
		'Battery State: ' + Ti.Platform.batteryState + '\n' +
		'Id: ' + Ti.Platform.id + '\n' +
		'Id for Advertising: ' + Ti.Platform.identifierForAdvertising + '\n' +
		'Id for Vendor: ' + Ti.Platform.identifierForVendor + '\n' +
		'Is AdTracking enabled: ' + Ti.Platform.isAdvertisingTrackingEnabled + '\n' +
		'Locale: ' + Ti.Platform.locale + '\n' +
		'Mac address: ' + Ti.Platform.macaddress + '\n' +
		'Manufacturer: ' + Ti.Platform.manufacturer + '\n' +
		'Model: ' + Ti.Platform.model + '\n' +
		'Name: ' + Ti.Platform.name + '\n' +
		'Netmask: ' + Ti.Platform.netmask + '\n' +
		'OS name: ' + Ti.Platform.osname + '\n' +
		'OS type: ' + Ti.Platform.ostype + '\n' +
		'Processor count: ' + Ti.Platform.processorCount + '\n' +
		'Runtime: ' + Ti.Platform.runtime + '\n' +
		'Username: ' + Ti.Platform.username + '\n' +
		'Version: ' + Ti.Platform.version);
});
win.add(button);
win.open();
```