### PR TITLE
[TIMOB-26168] Android: Fix initializing of scrollbars

### DIFF
--- a/android/modules/ui/res/xml/titanium_ui_horizontal_nested_scrollview.xml
+++ b/android/modules/ui/res/xml/titanium_ui_horizontal_nested_scrollview.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.v4.widget.NestedScrollView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:scrollbars="horizontal"/>

--- a/android/modules/ui/res/xml/titanium_ui_vertical_nested_scrollview.xml
+++ b/android/modules/ui/res/xml/titanium_ui_vertical_nested_scrollview.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.v4.widget.NestedScrollView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:scrollbars="vertical"/>

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIScrollView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIScrollView.java
@@ -15,10 +15,12 @@ import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.TiDimension;
 import org.appcelerator.titanium.proxy.TiViewProxy;
 import org.appcelerator.titanium.util.TiConvert;
+import org.appcelerator.titanium.util.TiRHelper;
 import org.appcelerator.titanium.TiBaseActivity;
 import org.appcelerator.titanium.view.TiCompositeLayout;
 import org.appcelerator.titanium.view.TiCompositeLayout.LayoutArrangement;
 import org.appcelerator.titanium.view.TiUIView;
+import org.xmlpull.v1.XmlPullParser;
 
 import ti.modules.titanium.ui.RefreshControlProxy;
 
@@ -28,6 +30,8 @@ import android.os.Build;
 import android.support.v4.view.NestedScrollingChild;
 import android.support.v4.view.NestedScrollingChildHelper;
 import android.support.v4.widget.NestedScrollView;
+import android.util.AttributeSet;
+import android.util.Xml;
 import android.view.GestureDetector;
 import android.view.MotionEvent;
 import android.view.View;
@@ -50,6 +54,9 @@ public class TiUIScrollView extends TiUIView
 	private boolean mScrollingEnabled = true;
 	private boolean isScrolling = false;
 	private boolean isTouching = false;
+
+	private static int verticalAttrId = -1;
+	private static int horizontalAttrId = -1;
 
 	public class TiScrollViewLayout extends TiCompositeLayout
 	{
@@ -315,6 +322,26 @@ public class TiUIScrollView extends TiUIView
 		}
 	}
 
+	// TIMOB-26168: if 'android:scrollbars' is not defined then our scrollbars will never be initialized
+	// so we do this our selves
+	private AttributeSet getAttributeSet(Context context, int resourceId)
+	{
+		AttributeSet attr = null;
+		try {
+			XmlPullParser parser = context.getResources().getXml(resourceId);
+			try {
+				parser.next();
+				parser.nextTag();
+			} catch (Exception e) {
+				// ignore...
+			}
+			attr = Xml.asAttributeSet(parser);
+		} catch (Exception e) {
+			// ignore...
+		}
+		return attr;
+	}
+
 	// same code, different super-classes
 	private class TiVerticalScrollView extends NestedScrollView
 	{
@@ -322,7 +349,7 @@ public class TiUIScrollView extends TiUIView
 
 		public TiVerticalScrollView(Context context, LayoutArrangement arrangement)
 		{
-			super(context);
+			super(context, getAttributeSet(context, verticalAttrId));
 
 			// TIMOB-25359: allow window to re-size when keyboard is shown
 			if (context instanceof TiBaseActivity) {
@@ -475,7 +502,7 @@ public class TiUIScrollView extends TiUIView
 
 		public TiHorizontalScrollView(Context context, LayoutArrangement arrangement)
 		{
-			super(context);
+			super(context, getAttributeSet(context, horizontalAttrId));
 			setScrollBarStyle(SCROLLBARS_INSIDE_OVERLAY);
 			setScrollContainer(true);
 
@@ -690,6 +717,17 @@ public class TiUIScrollView extends TiUIView
 		super(proxy);
 		getLayoutParams().autoFillsHeight = true;
 		getLayoutParams().autoFillsWidth = true;
+
+		try {
+			if (verticalAttrId == -1) {
+				verticalAttrId = TiRHelper.getResource("xml.titanium_ui_vertical_nested_scrollview");
+			}
+			if (horizontalAttrId == -1) {
+				horizontalAttrId = TiRHelper.getResource("xml.titanium_ui_horizontal_nested_scrollview");
+			}
+		} catch (Exception e) {
+			Log.w(TAG, "could not load NestedScrollView attributes");
+		}
 	}
 
 	@Override


### PR DESCRIPTION
- Scrollbars do not show in `Titanium.UI.ScrollView`
- Works around a Google bug where scrollbars are not initialized

##### TEST CASE
```JS
const win = Ti.UI.createWindow({ backgroundColor: 'gray' }),
      scrollView = Ti.UI.createScrollView({
          showVerticalScrollIndicator: true,
          width: Ti.UI.FILL,
          height: Ti.UI.FILL
      }),
      view = Ti.UI.createLabel({
          backgroundColor: 'blue',
          width: Ti.UI.FILL,
          height: 1000,
          text: Array(16).join('SCROLL ')
      });

scrollView.add(view);

win.add(scrollView);
win.open();
```
- Scrollbar should be visible when scrolling

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-26168)