### PR TITLE
[TIDOC-3205] Rename Windows Phone to Windows

### DIFF
--- a/apidoc/lib/common.js
+++ b/apidoc/lib/common.js
@@ -38,7 +38,7 @@ exports.PRETTY_PLATFORM = {
 	iphone: 'iPhone',
 	ipad: 'iPad',
 	tizen: 'Tizen',
-	windowsphone: 'Windows Phone'
+	windowsphone: 'Windows'
 };
 
 // Matches FOO_CONSTANT


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIDOC-3205

This PR makes it so that what used to be generated as `Windows Phone` in the docs, is now `Windows`. In my opinion this aligns better with our supported targets and the general terminology.