### PR TITLE
[TIMOB-26155] Android: Fix generatedDiffProperties()

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/ViewItem.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/ViewItem.java
@@ -43,7 +43,7 @@ public class ViewItem
 
 		for (String appliedProp : this.properties.keySet()) {
 			if (!properties.containsKey(appliedProp)) {
-				applyProperty(appliedProp, null);
+				applyProperty(appliedProp, this.properties.get(appliedProp));
 			}
 		}
 


### PR DESCRIPTION
- Prevent properties from being reset to `null`

##### TEST CASE
- See JIRA

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-26155)