### PR TITLE
[TIMOB-26184] iOS: Allow modification of global timer functions

### DIFF
--- a/iphone/Classes/KrollContext.m
+++ b/iphone/Classes/KrollContext.m
@@ -1098,7 +1098,7 @@ static TiValueRef StringFormatDecimalCallback(TiContextRef jsContext, TiObjectRe
     TiObjectRef global = TiContextGetGlobalObject(context);
     TiObjectSetProperty(context, global,
         invokerFnName, invoker,
-        kTiPropertyAttributeReadOnly | kTiPropertyAttributeDontDelete,
+        kTiPropertyAttributeNone,
         NULL);
   }
   TiStringRelease(invokerFnName);

--- a/tests/Resources/timers.addontest.js
+++ b/tests/Resources/timers.addontest.js
@@ -1,0 +1,39 @@
+/*
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2018-Present by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+/* eslint-env mocha */
+/* global Ti */
+/* eslint no-unused-expressions: "off" */
+'use strict';
+var should = require('./utilities/assertions');
+
+describe('Timers', function () {
+	it('setTimeout', function () {
+		should(setTimeout).be.a.Function;
+	});
+
+	it('setInterval', function () {
+		should(setInterval).be.a.Function;
+	});
+
+	it('clearTimeout', function () {
+		should(clearTimeout).be.a.Function;
+	});
+
+	it('clearInterval', function () {
+		should(clearInterval).be.a.Function;
+	});
+
+	it('should be able to override', function () {
+		const methodNames = [ 'setTimeout', 'clearTimeout', 'setInterval', 'clearInterval' ];
+		for (const methodName of methodNames) {
+			const descriptor = Object.getOwnPropertyDescriptor(global, methodName);
+			should(descriptor.configurable).be.true;
+			should(descriptor.enumerable).be.true;
+			should(descriptor.writable).be.true;
+		}
+	});
+});


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-26184

**Optional Description:**
Allow modifying some of our global function like `setTimeout` or `setInterval`. This is possible in other JS environments too and required for using Jasmin for example.

Note that this is already possible on Android.