### PR TITLE
[TIMOB-26115] TiAPI: Add support for console.timeLog

### DIFF
--- a/android/runtime/common/src/js/console.js
+++ b/android/runtime/common/src/js/console.js
@@ -26,6 +26,22 @@ function join(args) {
 	}).join(' ');
 }
 
+function logTime(label, ...logData) {
+	label = `${label}`;
+	const startTime = times.get(label);
+	if (!startTime) {
+		exports.warn(`Label "${label}" does not exist`);
+		return true;
+	}
+	const duration = Date.now() - startTime;
+	if (logData) {
+		exports.log(`${label}: ${duration}ms`, logData);
+	} else {
+		exports.log(`${label}: ${duration}ms`);
+	}
+	return false;
+}
+
 exports.log = function () {
 	Titanium.API.info(join(arguments));
 };
@@ -56,13 +72,12 @@ exports.time = function (label = 'default') {
 };
 
 exports.timeEnd = function (label = 'default') {
-	label = `${label}`;
-	const startTime = times.get(label);
-	if (!startTime) {
-		exports.warn(`Label "${label}" does not exist`);
-		return;
+	const warned = logTime(label);
+	if (!warned) {
+		times.delete(label);
 	}
-	const duration = Date.now() - startTime;
-	exports.log(`${label}: ${duration}ms`);
-	times.delete(label);
+};
+
+exports.timeLog = function (label = 'default', ...logData) {
+	logTime(label, logData);
 };

--- a/android/runtime/common/src/js/console.js
+++ b/android/runtime/common/src/js/console.js
@@ -26,7 +26,7 @@ function join(args) {
 	}).join(' ');
 }
 
-function logTime(label, ...logData) {
+function logTime(label, logData) {
 	label = `${label}`;
 	const startTime = times.get(label);
 	if (!startTime) {
@@ -35,7 +35,7 @@ function logTime(label, ...logData) {
 	}
 	const duration = Date.now() - startTime;
 	if (logData) {
-		exports.log(`${label}: ${duration}ms`, logData);
+		exports.log(`${label}: ${duration}ms`, ...logData);
 	} else {
 		exports.log(`${label}: ${duration}ms`);
 	}

--- a/apidoc/Global/console/console.yml
+++ b/apidoc/Global/console/console.yml
@@ -98,3 +98,23 @@ methods:
         optional: true
         default: "default"
     since: 7.3.0
+
+  - name: timeLog
+    summary: Log duration taken so far for an operation.
+    description: |
+          Output the time since a timer was started by calling
+          [console.time](Global.console.time) to the console, as well as any
+          other `data` arguments provided. To log extra data a label must
+          be provided. If not timer exists a warning will be logged to the
+          console.
+    parameters:
+      - name: label
+        summary: The label to track the timer by
+        type: String
+        optional: true
+        default: "default"
+      - name: ...data
+        summary: Extra log data to be provided when logging
+        type: Object
+        optional: true
+    since: 7.4.0

--- a/iphone/Classes/TiConsole.m
+++ b/iphone/Classes/TiConsole.m
@@ -50,6 +50,27 @@
   [_times removeObjectForKey:label];
 }
 
+- (void)timeLog:(id)args
+{
+  NSString *label = [args objectAtIndex:0];
+  NSArray *logData = [args count] > 1 ? [args subarrayWithRange:NSMakeRange(1, [args count] - 1)] : nil;
+  if (label == nil) {
+    label = @"default";
+  }
+  NSDate *startTime = _times[label];
+  if (startTime == nil) {
+    NSString *logMessage = [NSString stringWithFormat:@"Label \"%@\" does not exist", label];
+    [self logMessage:[logMessage componentsSeparatedByString:@" "] severity:@"warn"];
+    return;
+  }
+  double duration = [startTime timeIntervalSinceNow] * -1000;
+  NSString *logMessage = [NSString stringWithFormat:@"%@: %0.fms ", label, duration];
+  if ([logData count]) {
+    logMessage = [logMessage stringByAppendingString:[logData componentsJoinedByString:@" "]];
+  }
+  [self logMessage:[logMessage componentsSeparatedByString:@" "] severity:@"info"];
+}
+
 - (void)dealloc
 {
   RELEASE_TO_NIL(_times);

--- a/iphone/Classes/TiConsole.m
+++ b/iphone/Classes/TiConsole.m
@@ -44,7 +44,7 @@
     [self logMessage:[logMessage componentsSeparatedByString:@" "] severity:@"warn"];
     return;
   }
-  double duration = [startTime timeIntervalSinceNow] * -1000;
+  NSTimeInterval duration = [startTime timeIntervalSinceNow] * -1000;
   NSString *logMessage = [NSString stringWithFormat:@"%@: %0.fms", label, duration];
   [self logMessage:[logMessage componentsSeparatedByString:@" "] severity:@"info"];
   [_times removeObjectForKey:label];
@@ -52,20 +52,17 @@
 
 - (void)timeLog:(id)args
 {
-  NSString *label = [args objectAtIndex:0];
+  NSString *label = [args objectAtIndex:0] ?: @"default";
   NSArray *logData = [args count] > 1 ? [args subarrayWithRange:NSMakeRange(1, [args count] - 1)] : nil;
-  if (label == nil) {
-    label = @"default";
-  }
   NSDate *startTime = _times[label];
   if (startTime == nil) {
     NSString *logMessage = [NSString stringWithFormat:@"Label \"%@\" does not exist", label];
     [self logMessage:[logMessage componentsSeparatedByString:@" "] severity:@"warn"];
     return;
   }
-  double duration = [startTime timeIntervalSinceNow] * -1000;
+  NSTimeInterval duration = [startTime timeIntervalSinceNow] * -1000;
   NSString *logMessage = [NSString stringWithFormat:@"%@: %0.fms ", label, duration];
-  if ([logData count]) {
+  if ([logData count] > 0) {
     logMessage = [logMessage stringByAppendingString:[logData componentsJoinedByString:@" "]];
   }
   [self logMessage:[logMessage componentsSeparatedByString:@" "] severity:@"info"];

--- a/tests/Resources/console.addontest.js
+++ b/tests/Resources/console.addontest.js
@@ -1,0 +1,17 @@
+/*
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2018-Present by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+/* eslint-env mocha */
+/* global Ti */
+/* eslint no-unused-expressions: "off" */
+'use strict';
+var should = require('./utilities/assertions'); // eslint-disable-line no-unused-vars
+
+describe('console', function () {
+	it('#timeLog', function () {
+		should(console.timeLog).be.a.Function;
+	});
+});

--- a/tests/Resources/console.addontest.js
+++ b/tests/Resources/console.addontest.js
@@ -11,7 +11,55 @@
 var should = require('./utilities/assertions'); // eslint-disable-line no-unused-vars
 
 describe('console', function () {
-	it('#timeLog', function () {
-		should(console.timeLog).be.a.Function;
+	describe('#timeLog', function () {
+		it('is a function', function () {
+			should(console.timeLog).be.a.Function;
+		});
+
+		// FIXME Due to native impl on iOS that doesn't defer to the JS object, we cannot intercept the log calls
+		it.iosBroken('prefixes logs with label: and ends with millisecond timing', function () {
+			var orig = console.log,
+				logs = [];
+			try {
+				console.log = function (string) {
+					logs.push(string);
+				};
+				console.time('mytimer'); // Start timer
+				console.timeLog('mytimer'); // Log time taken so far
+				console.timeLog('mytimer', 'with', 'some', 'extra', 'info'); // Log time taken with extra logging
+				console.timeLog('mytimer', [ 'a', 'b', 'c' ], { objects: true }); // Should handle Arrays and Objects
+				console.timeEnd('mytimer');
+				logs.length.should.eql(4);
+				// We don't worry about the actual optional data sent along, just the format of the string
+				logs.forEach(function (log) {
+					log.should.match(/mytimer: \d+ms/);
+				});
+			} finally {
+				console.log = orig;
+			}
+		});
+
+		// FIXME Due to native impl on iOS that doesn't defer to the JS object, we cannot intercept the log calls
+		it.iosBroken('warns and does not log if label doesn\'t exist', function () {
+			var origLogFunction = console.log,
+				origWarnFunction = console.warn,
+				logs = [],
+				warnings = [];
+			try {
+				console.log = function (string) {
+					logs.push(string);
+				};
+				console.warn = function (string) {
+					warnings.push(string);
+				};
+				console.timeLog('mytimer'); // should spit out a warning that label doesn't exist, but not log the timer
+				warnings.length.should.eql(1);
+				warnings[0].should.eql('Label "mytimer" does not exist');
+				logs.length.should.eql(0);
+			} finally {
+				console.log = origLogFunction;
+				console.warn = origWarnFunction;
+			}
+		});
 	});
 });


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-26115

Implement console.timeLog for Android and iOS


Test:

```js
console.time('mytimer'); // Start timer
console.timeLog('mytimer'); // Log time taken so far
console.timeLog('mytimer', 'with', 'some', 'extra', 'info'); // Log time taken with extra logging
console.timeLog('mytimer', [ 'a', 'b', 'c' ], { objects: true }); // Should handle Arrays and Objects
console.timeEnd('mytimer');
```
Should log something like the below, there's some slight discrepancies between how Arrays/Objects are logged on platforms.
```
[INFO]  mytimer: 1ms
[INFO]  mytimer: 2ms with some extra info
[INFO]  mytimer: 3ms ["a","b","c"] {"objects":true}
[INFO]  mytimer: 3ms
```