### PR TITLE
Update SearchBar and SearchView apidoc

### DIFF
--- a/apidoc/Titanium/UI/ScrollView.yml
+++ b/apidoc/Titanium/UI/ScrollView.yml
@@ -27,7 +27,7 @@ description: |
 
     Pinching a `ScrollableView` to zoom in and out of content is not supported on Android. On iOS, this action
     is natively supported by the UIScrollView class, but on Android, the native ScrollView class does
-    not support this action. Parity between the two platforms cannot be achieved with this feature.
+    not support this action.
 extends: Titanium.UI.View
 since: "0.9"
 
@@ -224,7 +224,7 @@ properties:
     description: |
         While absolute dimensions are supported, relative values, such as those provided
         in percentages, are not. The minimum value for contentHeight is the height of the scroll view.
-        Measured in platform-specific units; pixels on Android and density-independent pixels (dip) on iOS.
+        Measured in platform-specific units; pixels on Android, effective pixels on Windows and density-independent pixels (dip) on iOS.
     type: [Number, String]
 
   - name: contentOffset
@@ -241,7 +241,7 @@ properties:
     description: |
         While absolute dimensions are supported, relative values, such as those provided
         in percentages, are not. The minimum value for contentWidth is the width of the scroll view.
-        Measured in platform-specific units; pixels on Android and density-independent pixels (dip) on iOS.
+        Measured in platform-specific units; pixels on Android, effective pixels on Windows and density-independent pixels (dip) on iOS.
     type: [Number, String]
 
   - name: decelerationRate
@@ -282,7 +282,7 @@ properties:
     type: Number
     constants: Titanium.UI.iOS.KEYBOARD_DISMISS_MODE_*
     platforms: [iphone, ipad]
-    default: Undefined (behaves like <Titanium.UI.iOS.KEYBOARD_DISMISS_MODE_NONE>)
+    default: Undefined (behaves like Titanium.UI.iOS.KEYBOARD_DISMISS_MODE_NONE)
     since: "6.0.0"
 
   - name: maxZoomScale
@@ -330,7 +330,7 @@ properties:
         The scroll-to-top gesture is a tap on the status bar; The default value of this property is true.
         This gesture works when you have a single visible scroll view.
         If there are multiple table views, web views, text areas, and/or scroll views visible,
-        you will need to disable (set to false) on the above views you DON'T want this
+        you will need to disable (set to false) on the above views that you don't want this
         behaviour on. The remaining view will then respond to scroll-to-top gesture.
     type: Boolean
     default: true
@@ -341,7 +341,7 @@ properties:
     summary: Style of the scrollbar.
     type: Number
     constants: Titanium.UI.iOS.ScrollIndicatorStyle.*
-    default: <Titanium.UI.iOS.ScrollIndicatorStyle.DEFAULT>
+    default: Titanium.UI.iOS.ScrollIndicatorStyle.DEFAULT
     platforms: [iphone, ipad]
 
   - name: scrollType

--- a/apidoc/Titanium/UI/SearchBar.yml
+++ b/apidoc/Titanium/UI/SearchBar.yml
@@ -6,8 +6,9 @@ description: |
       <tr>
         <td><img src="images/searchbar/searchbar_android.png" height="25" /></td>
         <td><img src="images/searchbar/searchbar_ios.png" height="25" /></td>
+        <td><img src="images/searchbar/searchbar_windows.png" height="25" /></td>
       </tr>
-      <tr><th>Android</th><th>iOS</th></tr>
+      <tr><th>Android</th><th>iOS</th><th>Windows</th></tr>
     </table>
 
     The `SearchBar` object is closely modeled on an iOS native search bar.
@@ -15,10 +16,11 @@ description: |
     consider using a <Titanium.UI.Android.SearchView> object instead.
     
     Search bars are most commonly used for filtering the rows in a [TableView](Titanium.UI.TableView).
-    You can add a search bar to a table view by setting the table view's 
-    [search](Titanium.UI.TableView.search) property. 
-
+    You can add a search bar to a table view by setting the table view's [search](Titanium.UI.TableView.search) property.
     A search bar can also be used without a table view.
+
+    You can also use a `SearchView` object as the <Titanium.UI.ListView.searchView>
+    property of a [ListView](Titanium.UI.ListView) object.
 
     Use the <Titanium.UI.createSearchBar> method or Alloy **`<SearchBar>`** element to create a search bar.
 
@@ -143,7 +145,7 @@ properties:
     type: Number
     constants: Titanium.UI.TEXT_AUTOCAPITALIZATION_*
     platforms: [iphone, ipad]
-    default: No autocapitalization.
+    default: Titanium.UI.TEXT_AUTOCAPITALIZATION_NONE
 
   - name: autocorrect
     summary: Determines whether the text in the search bar is autocorrected during typing.
@@ -157,6 +159,7 @@ properties:
         For information about color values, see the "Colors" section of <Titanium.UI>. 
         
         On iOS and Android, `barColor` specifies the color of the "frame" around the search text field.
+        On Windows, `barColor` specifies the color of the whole surrounding area of the search text field.
     type: String
     platforms: [android, iphone, ipad]
     default: System default bar color.
@@ -165,7 +168,7 @@ properties:
     summary: The title of the cancel button when the search bar field is focused.
     description: Use this property if you want to display a custom cancel title.
     type: String
-    default: System-localized "Cancel"
+    default: System-localized 'Cancel'
     since: "5.4.0"
     platforms: [iphone,ipad]
 
@@ -196,7 +199,7 @@ properties:
   - name: hintText
     summary: Text to show when the search bar field is not focused.
     type: String
-    default: On iOS, "Search"; on Android, no hint text.
+    default: On iOS, System-localized 'Search'. On Android and Windows, no hint text.
 
   - name: hintTextColor
     summary: Hint text color to display when the field is empty.
@@ -219,7 +222,7 @@ properties:
     type: Number
     platforms: [iphone, ipad]
     constants: Titanium.UI.KEYBOARD_TYPE_*
-    default: <Titanium.UI.KEYBOARD_TYPE_DEFAULT>
+    default: Titanium.UI.KEYBOARD_TYPE_DEFAULT
 
   - name: keyboardAppearance
     summary: Determines the appearance of the keyboard to be displayed the field is focused.
@@ -227,7 +230,7 @@ properties:
     since: 5.2.0
     platforms: [iphone, ipad]
     constants: Titanium.UI.KEYBOARD_APPEARANCE_*
-    default: <Titanium.UI.KEYBOARD_APPEARANCE_DEFAULT>
+    default: Titanium.UI.KEYBOARD_APPEARANCE_DEFAULT
 
   - name: prompt
     summary: Single line of text displayed at the top of the search bar.
@@ -263,7 +266,7 @@ properties:
     since: 5.4.0
     platforms: [iphone, ipad]
     constants: Titanium.UI.iOS.SEARCH_BAR_STYLE_*
-    default: <Titanium.UI.iOS.SEARCH_BAR_STYLE_PROMINENT>
+    default: Titanium.UI.iOS.SEARCH_BAR_STYLE_PROMINENT
 
   - name: value
     summary: Value of the search bar.
@@ -290,3 +293,23 @@ examples:
             <Alloy>
                 <SearchBar id="search" barColor="#000" showCancel="true" height="43" top="0" />
             </Alloy>
+
+  - title: Search Bar with TableView
+    example: |
+            var search = Ti.UI.createSearchBar({
+                showCancel: true
+            });
+            var tableview = Ti.UI.createTableView({
+                search: search
+            });
+
+  - title: Alloy XML Markup
+    example: |
+        Previous example as an Alloy view.
+
+            <Alloy>
+                <TableView id="tableview">
+                    <SearchBar id="search" showCancel="true" />
+                </TableView>
+            </Alloy>
+


### PR DESCRIPTION
Update apidoc for `SearchBar` and `SearchView` for the Day of Docs July 2018.

- Changed some defaults, it turns out `<>` and `"` don't work at `default` section.
- Added more descriptions for Windows
- Added more examples

@jawa9000 Could you upload screenshot image of `SearchBar` [searchbar_windows.png](https://user-images.githubusercontent.com/1661068/42489732-b0d96276-8447-11e8-9525-e6043955cece.PNG) onto `images/searchbar/searchbar_windows.png`? It is used in `SearchBar.yml`.

```html
<td><img src="images/searchbar/searchbar_windows.png" height="25" /></td> 
```

![searchbarwindows](https://user-images.githubusercontent.com/1661068/42489732-b0d96276-8447-11e8-9525-e6043955cece.PNG)

Additional note: I'm wondering if we could get rid of `table` HTML element from `SearchBar.yml`. I thought the table HTML tag such as `<table>`, `<td>` and `<th>` are obsolete 😮 

