### PR TITLE
[TIMOB-26202] Android: Fix references when releasing views

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TableViewProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TableViewProxy.java
@@ -134,10 +134,24 @@ public class TableViewProxy extends TiViewProxy
 	public void releaseViews()
 	{
 		super.releaseViews();
+
 		if (localSections != null) {
 			for (TableViewSectionProxy section : localSections) {
 				section.releaseViews();
 			}
+		}
+	}
+
+	@Override
+	public void release()
+	{
+		super.release();
+
+		releaseViews();
+
+		if (localSections != null) {
+			localSections.clear();
+			localSections = null;
 		}
 	}
 

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TableViewRowProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TableViewRowProxy.java
@@ -274,14 +274,27 @@ public class TableViewRowProxy extends TiViewProxy
 	{
 		super.releaseViews();
 
+		if (controls != null) {
+			for (TiViewProxy control : controls) {
+				control.releaseKroll();
+			}
+		}
+	}
+
+	@Override
+	public void release()
+	{
+		super.release();
+
+		releaseViews();
+
 		if (tableViewItem != null) {
 			tableViewItem.release();
 			tableViewItem = null;
 		}
 		if (controls != null) {
-			for (TiViewProxy control : controls) {
-				control.releaseKroll();
-			}
+			controls.clear();
+			controls = null;
 		}
 	}
 

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TableViewSectionProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TableViewSectionProxy.java
@@ -163,6 +163,19 @@ public class TableViewSectionProxy extends TiViewProxy
 	}
 
 	@Override
+	public void release()
+	{
+		super.release();
+
+		releaseViews();
+
+		if (rows != null) {
+			rows.clear();
+			rows = null;
+		}
+	}
+
+	@Override
 	public String getApiName()
 	{
 		return "Ti.UI.TableViewSection";

--- a/android/runtime/v8/src/java/org/appcelerator/kroll/runtime/v8/ReferenceTable.java
+++ b/android/runtime/v8/src/java/org/appcelerator/kroll/runtime/v8/ReferenceTable.java
@@ -134,4 +134,16 @@ public final class ReferenceTable
 		}
 		return ref;
 	}
+
+	/**
+	 * Determines if the reference is strong
+	 *
+	 * @param key the key for the reference.
+	 * @return returns true if the reference is strong
+	 */
+	public static boolean isStrongReference(long key)
+	{
+		Object ref = getReference(key);
+		return !(ref instanceof WeakReference || ref instanceof SoftReference);
+	}
 }

--- a/android/runtime/v8/src/native/JNIUtil.cpp
+++ b/android/runtime/v8/src/native/JNIUtil.cpp
@@ -96,6 +96,7 @@ jmethodID JNIUtil::referenceTableMakeWeakReferenceMethod = NULL;
 jmethodID JNIUtil::referenceTableMakeSoftReferenceMethod = NULL;
 jmethodID JNIUtil::referenceTableClearReferenceMethod = NULL;
 jmethodID JNIUtil::referenceTableGetReferenceMethod = NULL;
+jmethodID JNIUtil::referenceTableIsStrongReferenceMethod = NULL;
 
 jint JNIUtil::krollRuntimeDontIntercept = -1;
 jmethodID JNIUtil::krollInvocationInitMethod = NULL;
@@ -378,6 +379,7 @@ void JNIUtil::initCache()
 	referenceTableMakeSoftReferenceMethod = getMethodID(referenceTableClass, "makeSoftReference", "(J)V", true);
 	referenceTableClearReferenceMethod = getMethodID(referenceTableClass, "clearReference", "(J)Ljava/lang/Object;", true);
 	referenceTableGetReferenceMethod = getMethodID(referenceTableClass, "getReference", "(J)Ljava/lang/Object;", true);
+	referenceTableIsStrongReferenceMethod = getMethodID(referenceTableClass, "isStrongReference", "(J)Z", true);
 
 	jfieldID dontInterceptField = env->GetStaticFieldID(krollRuntimeClass, "DONT_INTERCEPT", "I");
 	krollRuntimeDontIntercept = env->GetStaticIntField(krollRuntimeClass, dontInterceptField);

--- a/android/runtime/v8/src/native/JNIUtil.h
+++ b/android/runtime/v8/src/native/JNIUtil.h
@@ -146,6 +146,7 @@ public:
 	static jmethodID referenceTableMakeSoftReferenceMethod;
 	static jmethodID referenceTableClearReferenceMethod;
 	static jmethodID referenceTableGetReferenceMethod;
+	static jmethodID referenceTableIsStrongReferenceMethod;
 
 	static jint krollRuntimeDontIntercept;
 	static jmethodID krollInvocationInitMethod;

--- a/android/runtime/v8/src/native/JavaObject.cpp
+++ b/android/runtime/v8/src/native/JavaObject.cpp
@@ -70,7 +70,7 @@ JavaObject::~JavaObject()
 
 jobject JavaObject::getJavaObject()
 {
-	if (isWeakRef_ || !ReferenceTable::isStrongReference(refTableKey_)) { // Did JS side try to collect our object already?
+	if (isWeak()) { // Did JS side try to collect our object already?
 		MakeJavaStrong(); // move back to strong reference on Java side
 		MakeJSWeak(); // ask V8 to let us know when it thinks it's dead again
 	}
@@ -148,7 +148,15 @@ void JavaObject::detach()
 
 bool JavaObject::isDetached()
 {
-	return (javaObject_ == NULL && refTableKey_ == 0) || isWeakRef_;
+	return (javaObject_ == NULL && refTableKey_ == 0) || isWeak();
+}
+
+bool JavaObject::isWeak()
+{
+    if (!isWeakRef_ && (!useGlobalRefs && refTableKey_ > 0 && !ReferenceTable::isStrongReference(refTableKey_))) {
+        isWeakRef_ = true;
+    }
+    return isWeakRef_;
 }
 
 void JavaObject::MakeJavaStrong()
@@ -158,7 +166,7 @@ void JavaObject::MakeJavaStrong()
 		JNIEnv *env = JNIUtil::getJNIEnv();
 		ASSERT(env != NULL);
 		jobject globalRef = env->NewGlobalRef(javaObject_);
-		if (isWeakRef_) { // if we're going from weak back to strong...
+		if (isWeak()) { // if we're going from weak back to strong...
 			env->DeleteWeakGlobalRef(javaObject_); // delete the weak ref we had
 		}
 		javaObject_ = globalRef;
@@ -167,7 +175,7 @@ void JavaObject::MakeJavaStrong()
 		ASSERT(refTableKey_ == 0);
 		ASSERT(javaObject_ != NULL);
 	} else {
-		if (refTableKey_ > 0 && (isWeakRef_ || !ReferenceTable::isStrongReference(refTableKey_))) { // if we are weak, upgrade back to strong
+		if (isWeak()) { // if we are weak, upgrade back to strong
 			JNIEnv *env = JNIUtil::getJNIEnv();
 			ASSERT(env != NULL);
 			jobject stored = ReferenceTable::clearReference(refTableKey_);
@@ -196,24 +204,24 @@ void JavaObject::MakeJavaStrong()
 void JavaObject::MakeJavaWeak()
 {
 	// Make sure we're not trying to make a weak reference weak again!
-	ASSERT(!isWeakRef_);
-	if (useGlobalRefs) {
-		JNIEnv *env = JNIUtil::getJNIEnv();
-		ASSERT(env != NULL);
-		ASSERT(javaObject_ != NULL);
-		// Convert our global ref to a weak global ref
-		jweak weakRef = env->NewWeakGlobalRef(javaObject_);
-		env->DeleteGlobalRef(javaObject_);
-		javaObject_ = weakRef;
-	} else {
-		ASSERT(refTableKey_ != 0);
+	if (!isWeak()) {
+        if (useGlobalRefs) {
+            JNIEnv *env = JNIUtil::getJNIEnv();
+            ASSERT(env != NULL);
+            ASSERT(javaObject_ != NULL);
+            // Convert our global ref to a weak global ref
+            jweak weakRef = env->NewWeakGlobalRef(javaObject_);
+            env->DeleteGlobalRef(javaObject_);
+            javaObject_ = weakRef;
+        } else {
+            ASSERT(refTableKey_ != 0);
 
-		// create a soft reference, which is more resiliant than a weak reference
-		ReferenceTable::makeSoftReference(refTableKey_);
+            // create a weak reference
+            ReferenceTable::makeWeakReference(refTableKey_);
+        }
+        UPDATE_STATS(0, 1); // add one to "detached" counter
+        isWeakRef_ = true; // remember that our ref on Java side is weak
 	}
-
-	UPDATE_STATS(0, 1); // add one to "detached" counter
-	isWeakRef_ = true; // remember that our ref on Java side is weak
 }
 
 void JavaObject::DeleteJavaRef()
@@ -225,7 +233,7 @@ void JavaObject::DeleteJavaRef()
 		ASSERT(javaObject_ != NULL);
 		// Wipe the V8Object ptr value back to 0, to denote that the native C++ proxy is gone
 		JNIUtil::removePointer(javaObject_);
-		if (isWeakRef_) {
+		if (isWeak()) {
 			env->DeleteWeakGlobalRef(javaObject_);
 		} else {
 			env->DeleteGlobalRef(javaObject_);

--- a/android/runtime/v8/src/native/JavaObject.h
+++ b/android/runtime/v8/src/native/JavaObject.h
@@ -59,6 +59,11 @@ public:
 	bool isDetached();
 
 	/**
+	 * Determines if our Java object maintains a weak reference
+	 */
+	bool isWeak();
+
+	/**
 	 * If possible call #unreferenceJavaObject() when done with the object so we can clean up the local JNI reference
 	 *
 	 * @return The wrapped jobject if it's still alive, NULL otherwise

--- a/android/runtime/v8/src/native/ReferenceTable.cpp
+++ b/android/runtime/v8/src/native/ReferenceTable.cpp
@@ -64,4 +64,13 @@ jobject ReferenceTable::getReference(jlong key)
 		key);
 }
 
+jboolean ReferenceTable::isStrongReference(jlong key)
+{
+	JNIEnv* env = JNIUtil::getJNIEnv();
+	return env->CallStaticBooleanMethod(
+		JNIUtil::referenceTableClass,
+		JNIUtil::referenceTableIsStrongReferenceMethod,
+		key);
+}
+
 } // namespace titanium

--- a/android/runtime/v8/src/native/ReferenceTable.h
+++ b/android/runtime/v8/src/native/ReferenceTable.h
@@ -30,6 +30,7 @@ public:
 	static void makeSoftReference(jlong key);
 	static jobject clearReference(jlong key);
 	static jobject getReference(jlong key);
+	static jboolean isStrongReference(jlong key);
 };
 
 } // namespace titanium

--- a/android/titanium/src/java/org/appcelerator/kroll/KrollProxy.java
+++ b/android/titanium/src/java/org/appcelerator/kroll/KrollProxy.java
@@ -1426,13 +1426,18 @@ public class KrollProxy implements Handler.Callback, KrollProxySupport, OnLifecy
 					final Method weakReferenceMethod =
 						referenceTableClass.getDeclaredMethod("makeWeakReference", long.class);
 					weakReferenceMethod.invoke(null, this.referenceKey);
+				} else {
+					if (krollObject != null) {
+						krollObject.release();
+					}
 				}
 			} catch (Exception e) {
 				// do nothing...
 			}
-		}
-		if (krollObject != null) {
-			krollObject.release();
+		} else {
+			if (krollObject != null) {
+				krollObject.release();
+			}
 		}
 	}
 

--- a/android/titanium/src/java/org/appcelerator/kroll/KrollProxy.java
+++ b/android/titanium/src/java/org/appcelerator/kroll/KrollProxy.java
@@ -1412,7 +1412,7 @@ public class KrollProxy implements Handler.Callback, KrollProxySupport, OnLifecy
 	 */
 	public void releaseKroll()
 	{
-		// TIMOB-25910: attempt to make any strong references into soft references
+		// TIMOB-25910: attempt to make any strong references into weak references
 		// NOTE: there is an issue where proxies created in another context (such as an event listener callback)
 		// may not be destroyed when the context has ended. This workaround allows the GC to free these objects
 		// if memory is constraint.
@@ -1423,9 +1423,9 @@ public class KrollProxy implements Handler.Callback, KrollProxySupport, OnLifecy
 
 				final Object reference = getReferenceMethod.invoke(null, this.referenceKey);
 				if (!(reference instanceof WeakReference || reference instanceof SoftReference)) {
-					final Method softReferenceMethod =
-						referenceTableClass.getDeclaredMethod("makeSoftReference", long.class);
-					softReferenceMethod.invoke(null, this.referenceKey);
+					final Method weakReferenceMethod =
+						referenceTableClass.getDeclaredMethod("makeWeakReference", long.class);
+					weakReferenceMethod.invoke(null, this.referenceKey);
 				}
 			} catch (Exception e) {
 				// do nothing...

--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/TiViewProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/TiViewProxy.java
@@ -626,6 +626,7 @@ public abstract class TiViewProxy extends KrollProxy implements Handler.Callback
 			view.release();
 			view = null;
 		}
+		releaseKroll();
 		if (runtimeHandler != null) {
 			runtimeHandler = null;
 		}

--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiUIView.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiUIView.java
@@ -1271,6 +1271,12 @@ public abstract class TiUIView implements KrollProxyListener, OnFocusChangeListe
 				}
 				d = null;
 			}
+			if (!(nativeView instanceof AdapterView)) {
+				nativeView.setOnClickListener(null);
+			}
+			nativeView.setOnLongClickListener(null);
+			nativeView.setOnTouchListener(null);
+			nativeView.setOnDragListener(null);
 			nativeView.setOnFocusChangeListener(null);
 			nativeView = null;
 			borderView = null;


### PR DESCRIPTION
- Amend references when releasing views

###### TEST CASE #1
```JS
let win = null;

new function create() {

    // create new window
    const newWin = Ti.UI.createWindow({ backgroundColor: 'gray', layout: 'vertical' }),
          btn = Ti.UI.createButton({ title: 'RELOAD' });

    btn.addEventListener('click', create);
    newWin.add(btn);

    // create multiple labels
    for (let i = 0; i < 16; i++) {
        const lbl = Ti.UI.createLabel({ text: '#' + i });
        newWin.add(lbl);
    }

    // display new window
    newWin.open();

    // close existing window
    if (win != null) {
        win.close();
    }
    win = newWin;
}
```
- Should not observe memory leak when reloading window multiple times
  - May need to force a GC to see results
###### TEST CASE #2
```JS
let win = Ti.UI.createWindow({ backgroundColor: 'gray', layout: 'vertical' }),
    lbl = Ti.UI.createLabel({ text: 'LABEL' }),
    btn = Ti.UI.createButton({ title: 'RE-USE' });

btn.addEventListener('click', () => {

    // create a new window
    const newWin = Ti.UI.createWindow({ backgroundColor: 'gray', layout: 'vertical' });
    newWin.open();

    // remove components so we can re-use them
    win.remove(btn);
    win.remove(lbl);

    // close existing window
    win.close();
    win = newWin;

    // re-use previous components
    win.add([btn, lbl]);
});

win.add([btn, lbl]);
win.open();
```
- Both the button and label should be able to be re-used by a new window

##### NOTE: QE should also run the tests from https://github.com/appcelerator/titanium_mobile/pull/10081 (including @ypbnv test case)

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-26202)