### PR TITLE
[TIMOB-26233] (7_3_X) TiAPI: Use Hyperloop 3.1.0

### DIFF
--- a/support/module/packaged/modules.json
+++ b/support/module/packaged/modules.json
@@ -63,8 +63,8 @@
 	},
 	"hyperloop": {
 		"hyperloop": {
-			"url": "https://github.com/appcelerator-modules/hyperloop-builds/releases/download/v3.0.5/hyperloop-3.0.5.zip",
-			"integrity": "sha512-hXUzZIEs7IBnD5f7rBzEULhl1+0oJN1gJyi+2SpVds7jXjJ5MxblWkTQYjJAcEr1NdBpA70m0w5nLncDQU6avQ=="
+			"url": "https://github.com/appcelerator-modules/hyperloop-builds/releases/download/v3.1.0/hyperloop-3.1.0.zip",
+			"integrity": "sha512-3Ispi2aqkpXWCdma5fq4As7IdtEP3533adspl7PxnmHNUgD3yYrSwi7fNvq74fONyAXShG3zFCtJR5EyWFWp/A=="
 		}
 	}
 }


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-26233

The updated Hyperloop 3.1.0 release to incorporate the required Windows changes and other ES6-related bug-fixes and improvements.