### PR TITLE
[TIMOB-26055] Android: Fixed build failure if AAR AndroidManifest.xml contains multiple ${applicationId}

### DIFF
--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -3888,9 +3888,9 @@ AndroidBuilder.prototype.generateAndroidManifest = function generateAndroidManif
 		if (fs.existsSync(libraryManifestPath)) {
 			let libraryManifestContent = fs.readFileSync(libraryManifestPath).toString();
 
-			// handle injected build variables
+			// handle injected build variables such as ${applicationId}
 			// https://developer.android.com/studio/build/manifest-build-variables
-			libraryManifestContent = libraryManifestContent.replace('${applicationId}', this.appid); // eslint-disable-line no-template-curly-in-string
+			libraryManifestContent = libraryManifestContent.replace(/\$\{applicationId\}/g, this.appid); // eslint-disable-line no-template-curly-in-string
 
 			const libraryManifest = new AndroidManifest();
 			libraryManifest.parse(libraryManifestContent);


### PR DESCRIPTION
**JIRA:**
https://jira.appcelerator.org/browse/TIMOB-26055

**Summary:**
- Continuation of PR #10065 
- Previous fix was only replacing 1st instance of `${applicationId}` in an AAR library's "AndroidManifest.xml" instead of all instances.
- Note that JS `String.replace(string, string)` only replaces one instance, but `String.replace(regex, string)` replaces all instances.

**Test:**
1. Create a project targeting Titanium 7.3.0 or higher.
2. Add module: [titanium-firebase-core](https://github.com/hansemannn/titanium-firebase-core) v2.2.0
3. Build for Android.
