### PR TITLE
[TIMOB-26211] (7_3_X) iOS: Round layout percentage down instead of up (parity)

### DIFF
--- a/iphone/Classes/TiDimension.h
+++ b/iphone/Classes/TiDimension.h
@@ -106,7 +106,7 @@ TI_INLINE BOOL TiDimensionDidCalculateValue(TiDimension dimension, CGFloat bound
     *result = dimension.value;
     return YES;
   case TiDimensionTypePercent:
-    *result = roundf(dimension.value * boundingValue);
+    *result = floorf(dimension.value * boundingValue);
     return YES;
   default: {
     break;


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-26211

> `no_tests` since UI-related change.

⚠️Master PR #10194 merged already. This one can be merged once 7_3_X is 7.3.1