### PR TITLE
[TIMOB-26237] (7_3_X) iOS: Fix local notifications triggered when the app is closed

### DIFF
--- a/apidoc/Titanium/App/iOS/LocalNotification.yml
+++ b/apidoc/Titanium/App/iOS/LocalNotification.yml
@@ -18,3 +18,6 @@ createable: false
 methods:
   - name: cancel
     summary: Cancels the pending notification.
+    deprecated:
+        since: "7.3.0"
+        notes: Use <Titanium.App.iOS.NotificationCenter.removePendingNotificationsWithIdentifiers> instead.

--- a/apidoc/Titanium/App/iOS/iOS.yml
+++ b/apidoc/Titanium/App/iOS/iOS.yml
@@ -91,6 +91,9 @@ methods:
     since: "4.0.0"
   - name: cancelAllLocalNotifications
     summary: Cancels all scheduled local notifications.
+    deprecated:
+        since: "7.3.0"
+        notes: Use <Titanium.App.iOS.UserNotificationCenter.removeAllPendingNotifications> instead.
 
   - name: cancelLocalNotification
     summary: Cancels a local notification.
@@ -101,6 +104,9 @@ methods:
             To create an ID for the notification, set the `id` property in the `userInfo` dictionary
             passed to the <Titanium.App.iOS.scheduleLocalNotification> method.
         type: [Number,String]
+    deprecated:
+        since: "7.3.0"
+        notes: Use <Titanium.App.iOS.UserNotificationCenter.removePendingNotificationsWithIdentifiers> instead.
 
   - name: registerBackgroundService
     summary: Registers a service to run when the application is placed in the background.

--- a/iphone/Classes/TiApp.m
+++ b/iphone/Classes/TiApp.m
@@ -424,42 +424,70 @@ TI_INLINE void waitForMemoryPanicCleared(); //WARNING: This must never be run on
   [TiLogServer startServer];
 #endif
 
-  // nibless window
+  // Initialize the root-window
   window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
 
-  [self initController];
-
-  // get the current remote device UUID if we have one
-  NSString *curKey = [[NSUserDefaults standardUserDefaults] stringForKey:@"APNSRemoteDeviceUUID"];
-  if (curKey != nil) {
-    remoteDeviceUUID = [curKey copy];
-  }
-
+  // Initialize the launch options to be used by the client
   launchOptions = [[NSMutableDictionary alloc] initWithDictionary:launchOptions_];
 
+  // Initialize the root-controller
+  [self initController];
+
+  // If we have a APNS-UUID, assign it
+  NSString *apnsUUID = [[NSUserDefaults standardUserDefaults] stringForKey:@"APNSRemoteDeviceUUID"];
+  if (apnsUUID != nil) {
+    remoteDeviceUUID = [apnsUUID copy];
+  }
+
+  // iOS 10+: Register our notification delegate
+  if ([TiUtils isIOS10OrGreater]) {
+    [[UNUserNotificationCenter currentNotificationCenter] setDelegate:self];
+  }
+
+  // Get some launch options to validate before finish launching. Some of them
+  // need to be mapepd from native to JS-types to be used by the client
   NSURL *urlOptions = [launchOptions objectForKey:UIApplicationLaunchOptionsURLKey];
   NSString *sourceBundleId = [launchOptions objectForKey:UIApplicationLaunchOptionsSourceApplicationKey];
-  NSDictionary *notification = [launchOptions objectForKey:UIApplicationLaunchOptionsRemoteNotificationKey];
+  NSDictionary *_remoteNotification = [launchOptions objectForKey:UIApplicationLaunchOptionsRemoteNotificationKey];
+  UILocalNotification *_localNotification = [launchOptions objectForKey:UIApplicationLaunchOptionsLocalNotificationKey];
+  NSNumber *launchedLocation = [launchOptions objectForKey:UIApplicationLaunchOptionsLocationKey];
 
-  [launchOptions setObject:NUMBOOL([[launchOptions objectForKey:UIApplicationLaunchOptionsLocationKey] boolValue]) forKey:@"launchOptionsLocationKey"];
-  [launchOptions removeObjectForKey:UIApplicationLaunchOptionsLocationKey];
+  // Map background location key
+  if (launchedLocation != nil) {
+    [launchOptions setObject:launchedLocation forKey:@"launchOptionsLocationKey"];
+    [launchOptions removeObjectForKey:UIApplicationLaunchOptionsLocationKey];
+  }
 
-  localNotification = [[[self class] dictionaryWithLocalNotification:[launchOptions objectForKey:UIApplicationLaunchOptionsLocalNotificationKey]] retain];
-  [launchOptions removeObjectForKey:UIApplicationLaunchOptionsLocalNotificationKey];
+  // Map local notification
+  if (_localNotification != nil) {
+    localNotification = [[[self class] dictionaryWithLocalNotification:_localNotification] retain];
+    [launchOptions removeObjectForKey:UIApplicationLaunchOptionsLocalNotificationKey];
 
-  // reset these to be a little more common if we have them
+    // Queue the "localnotificationaction" event for iOS 9 and lower.
+    // For iOS 10+, the "userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler" delegate handles it
+    if ([TiUtils isIOSVersionLower:@"9.0"]) {
+      [self tryToPostNotification:localNotification withNotificationName:kTiLocalNotificationAction completionHandler:nil];
+    }
+  }
+
+  // Map launched URL
   if (urlOptions != nil) {
     [launchOptions setObject:[urlOptions absoluteString] forKey:@"url"];
     [launchOptions removeObjectForKey:UIApplicationLaunchOptionsURLKey];
   }
+
+  // Map launched App-ID
   if (sourceBundleId != nil) {
     [launchOptions setObject:sourceBundleId forKey:@"source"];
     [launchOptions removeObjectForKey:UIApplicationLaunchOptionsSourceApplicationKey];
   }
-  if (notification != nil) {
-    [self generateNotification:notification];
+
+  // Generate remote notification of available
+  if (_remoteNotification != nil) {
+    [self generateNotification:_remoteNotification];
   }
 
+  // iOS 9+: Map application shortcuts
   if ([TiUtils isIOS9OrGreater] == YES) {
     UIApplicationShortcutItem *shortcut = [launchOptions objectForKey:UIApplicationLaunchOptionsShortcutItemKey];
 
@@ -468,12 +496,19 @@ TI_INLINE void waitForMemoryPanicCleared(); //WARNING: This must never be run on
     }
   }
 
+  // Queue selector for usage in modules / Hyperloop
   [self tryToInvokeSelector:@selector(application:didFinishLaunchingWithOptions:)
               withArguments:[NSOrderedSet orderedSetWithObjects:application, launchOptions_, nil]];
 
+  // If a "application-launch-url" is set, launch it directly
   [self launchToUrl];
+
+  // Boot our kroll-core
   [self boot];
+
+  // Create application support directory if not exists
   [self createDefaultDirectories];
+
   return YES;
 }
 

--- a/iphone/Classes/TiUtils.h
+++ b/iphone/Classes/TiUtils.h
@@ -625,6 +625,13 @@ typedef enum {
 + (BOOL)isIOSVersionOrGreater:(NSString *)version;
 
 /**
+ Whether or not the current OS version is lower than the specified version.
+ @param version The version to compare.
+ @return _YES_ if the current OS version is lower than the specified version, _NO_ otherwise.
+ */
++ (BOOL)isIOSVersionLower:(NSString *)version;
+
+/**
  Whether or not the current device is an iPhone 4.
  @return _YES_ if the current device is an iPhone 4, _NO_ otherwise.
  */

--- a/iphone/Classes/TiUtils.m
+++ b/iphone/Classes/TiUtils.m
@@ -199,6 +199,11 @@ static NSString *kAppUUIDString = @"com.appcelerator.uuid"; // don't obfuscate
   return [[[UIDevice currentDevice] systemVersion] compare:version options:NSNumericSearch] != NSOrderedAscending;
 }
 
++ (BOOL)isIOSVersionLower:(NSString *)version
+{
+  return [[[UIDevice currentDevice] systemVersion] compare:version options:NSNumericSearch] == NSOrderedAscending;
+}
+
 + (BOOL)isIPad
 {
   return [[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad;


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-26237

> `no_tests`, since it's a UI-related change that requires the app to be killed and relaunched.

Also adding missing deprecation notes that have been left over from 7.3.0.