### PR TITLE
[TIMOB-26240] Android: Removed harmless activity errors/warnings logged on startup

### DIFF
--- a/android/modules/android/src/java/ti/modules/titanium/android/AndroidModule.java
+++ b/android/modules/android/src/java/ti/modules/titanium/android/AndroidModule.java
@@ -580,26 +580,18 @@ public class AndroidModule extends KrollModule
 	public ActivityProxy getCurrentActivity()
 	// clang-format on
 	{
-		TiBaseActivity resultBaseActivity = (TiBaseActivity) TiApplication.getAppCurrentActivity();
-		if (resultBaseActivity != null) {
-			return resultBaseActivity.getActivityProxy();
-		} else {
-			Log.w(TAG, "Application instance no longer available. Unable to get current activity.");
-			return null;
+		Activity activity = TiApplication.getAppCurrentActivity();
+		if (activity instanceof TiBaseActivity) {
+			((TiBaseActivity) activity).getActivityProxy();
 		}
+		return null;
 	}
 
 	@Kroll.method
 	public void startService(IntentProxy intentProxy)
 	{
-		TiApplication app = TiApplication.getInstance();
-		if (app == null) {
-			Log.w(TAG, "Application instance no longer available. Unable to startService.");
-			return;
-		}
-
 		try {
-			app.startService(intentProxy.getIntent());
+			TiApplication.getInstance().startService(intentProxy.getIntent());
 		} catch (Exception ex) {
 			String message = ex.getMessage();
 			if (message == null) {
@@ -612,12 +604,7 @@ public class AndroidModule extends KrollModule
 	@Kroll.method
 	public void stopService(IntentProxy intentProxy)
 	{
-		TiApplication app = TiApplication.getInstance();
-		if (app != null) {
-			app.stopService(intentProxy.getIntent());
-		} else {
-			Log.w(TAG, "Application instance no longer available. Unable to stopService.");
-		}
+		TiApplication.getInstance().stopService(intentProxy.getIntent());
 	}
 
 	@Kroll.method
@@ -691,13 +678,6 @@ public class AndroidModule extends KrollModule
 		}
 
 		TiApplication app = TiApplication.getInstance();
-		if (app == null) {
-			Log.w(
-				TAG,
-				"Application instance is no longer available. Unable to check isServiceRunning. Returning false though value is meaningless.");
-			return false;
-		}
-
 		ActivityManager am = (ActivityManager) app.getApplicationContext().getSystemService(Context.ACTIVITY_SERVICE);
 		if (am != null) {
 			List<RunningServiceInfo> services = am.getRunningServices(Integer.MAX_VALUE);

--- a/android/titanium/src/java/org/appcelerator/titanium/TiApplication.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiApplication.java
@@ -71,7 +71,7 @@ public abstract class TiApplication extends Application implements KrollApplicat
 	private static final String PROPERTY_USE_LEGACY_WINDOW = "ti.android.useLegacyWindow";
 	private static long mainThreadId = 0;
 
-	protected static WeakReference<TiApplication> tiApp = null;
+	protected static TiApplication tiApp = null;
 
 	public static final String DEPLOY_TYPE_DEVELOPMENT = "development";
 	public static final String DEPLOY_TYPE_TEST = "test";
@@ -140,10 +140,12 @@ public abstract class TiApplication extends Application implements KrollApplicat
 	{
 		Log.checkpoint(TAG, "checkpoint, app created.");
 
+		// Keep a reference to this application object. Accessible via static getInstance() method.
+		tiApp = this;
+
 		loadBuildProperties();
 
 		mainThreadId = Looper.getMainLooper().getThread().getId();
-		tiApp = new WeakReference<TiApplication>(this);
 
 		modules = new HashMap<String, WeakReference<KrollModule>>();
 		TiMessenger.getMessenger(); // initialize message queue for main thread
@@ -158,15 +160,7 @@ public abstract class TiApplication extends Application implements KrollApplicat
 	 */
 	public static TiApplication getInstance()
 	{
-		if (tiApp != null) {
-			TiApplication tiAppRef = tiApp.get();
-			if (tiAppRef != null) {
-				return tiAppRef;
-			}
-		}
-
-		Log.e(TAG, "Unable to get the TiApplication instance");
-		return null;
+		return tiApp;
 	}
 
 	public static void addToActivityStack(Activity activity)
@@ -241,11 +235,6 @@ public abstract class TiApplication extends Application implements KrollApplicat
 	 */
 	public static Activity getAppCurrentActivity()
 	{
-		TiApplication tiApp = getInstance();
-		if (tiApp == null) {
-			return null;
-		}
-
 		return tiApp.getCurrentActivity();
 	}
 
@@ -257,11 +246,6 @@ public abstract class TiApplication extends Application implements KrollApplicat
 	 */
 	public static Activity getAppRootOrCurrentActivity()
 	{
-		TiApplication tiApp = getInstance();
-		if (tiApp == null) {
-			return null;
-		}
-
 		return tiApp.getRootOrCurrentActivity();
 	}
 


### PR DESCRIPTION
**JIRA:**
https://jira.appcelerator.org/browse/TIMOB-26240

**Summary:**
- Removed `null` activity error/warning log messages.
  * It's up to the caller to decide if they should be logged, not the method.
  * It's okay for these methods to return `null` if there are no activities, such as when the app was launched in the background via a `BroadcastReceiver`.
- Changed TiApplication.getInstance() handling:
  * Changed "tiApp" from weak reference to strong. Guaranteed to exist for lifetime of app, so, it was unnecessary.
  * Removed TiApplication.getInstance() null checks. Not necessary.

**Test:**
1. Create a new Titanium app project.
2. Build and run on an Android device.
3. Wait for the app to startup.
4. View the Android log and verify the following have **not** been logged.

```
[ERROR] :  TiApplication: (main) [3,913] No valid root or current activity found for application instance
[WARN] :   TiAndroid: (main) [2,915] Application instance no longer available. Unable to get current activity.
```
