### PR TITLE
[TIMOB-26242] Android: Attempt to fix memory behaviour

### DIFF
--- a/android/runtime/v8/src/java/org/appcelerator/kroll/runtime/v8/GCWatcher.java
+++ b/android/runtime/v8/src/java/org/appcelerator/kroll/runtime/v8/GCWatcher.java
@@ -1,0 +1,40 @@
+/**
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2018 by Axway, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+package org.appcelerator.kroll.runtime.v8;
+
+import org.appcelerator.kroll.KrollRuntime;
+
+import java.lang.ref.WeakReference;
+
+/**
+ * Detect JVM garbage collections to initiate V8 garbage collections.
+ *
+ * We do this because the V8 objects do not represent the memory footprint
+ * of the Java objects, this means V8 does not garbage collect as often as is
+ * necessary and prevents JVM from collecting objects as they are still referenced.
+ * This GCWatcher will coincide JVM collections with V8 collections.
+ */
+public final class GCWatcher
+{
+
+	private static WeakReference watcher = new WeakReference(new GCWatcher());
+
+	@Override
+	protected void finalize() throws Throwable
+	{
+
+		// suggest V8 GC
+		KrollRuntime.suggestGC();
+
+		// re-new weak reference
+		if (watcher != null && watcher.get() == null) {
+			watcher = new WeakReference(new GCWatcher());
+		}
+
+		super.finalize();
+	}
+}

--- a/android/runtime/v8/src/java/org/appcelerator/kroll/runtime/v8/ReferenceTable.java
+++ b/android/runtime/v8/src/java/org/appcelerator/kroll/runtime/v8/ReferenceTable.java
@@ -44,12 +44,6 @@ public final class ReferenceTable
 		long key = lastKey++;
 		Log.d(TAG, "Creating strong reference for key: " + key, Log.DEBUG_MODE);
 		references.put(key, object);
-
-		// store reference key in proxy
-		if (object instanceof KrollProxy) {
-			((KrollProxy) object).setReferenceKey(key);
-		}
-
 		return key;
 	}
 
@@ -71,9 +65,6 @@ public final class ReferenceTable
 				V8Object v8 = (V8Object) ko;
 				v8.setPointer(0);
 			}
-		}
-		if (obj instanceof KrollProxy) {
-			((KrollProxy) obj).setReferenceKey(0);
 		}
 		references.remove(key);
 	}

--- a/android/runtime/v8/src/java/org/appcelerator/kroll/runtime/v8/V8Function.java
+++ b/android/runtime/v8/src/java/org/appcelerator/kroll/runtime/v8/V8Function.java
@@ -95,7 +95,6 @@ public class V8Function extends V8Object implements KrollFunction, Handler.Callb
 		}
 
 		nativeRelease(functionPointer);
-		KrollRuntime.suggestGC();
 	}
 
 	@Override

--- a/android/runtime/v8/src/java/org/appcelerator/kroll/runtime/v8/V8Object.java
+++ b/android/runtime/v8/src/java/org/appcelerator/kroll/runtime/v8/V8Object.java
@@ -84,7 +84,6 @@ public class V8Object extends KrollObject
 
 		if (!KrollRuntime.isDisposed() && nativeRelease(ptr)) {
 			ptr = 0;
-			KrollRuntime.suggestGC();
 		}
 	}
 

--- a/android/runtime/v8/src/java/org/appcelerator/kroll/runtime/v8/V8Runtime.java
+++ b/android/runtime/v8/src/java/org/appcelerator/kroll/runtime/v8/V8Runtime.java
@@ -63,7 +63,6 @@ public final class V8Runtime extends KrollRuntime implements Handler.Callback
 	@Override
 	public void initRuntime()
 	{
-		boolean useGlobalRefs = false;
 		KrollApplication application = getKrollApplication();
 		TiDeployData deployData = application.getDeployData();
 
@@ -97,7 +96,7 @@ public final class V8Runtime extends KrollRuntime implements Handler.Callback
 			jsDebugger = new JSDebugger(deployData.getDebuggerPort(), application.getSDKVersion());
 		}
 
-		nativeInit(useGlobalRefs, jsDebugger, DBG, deployData.isProfilerEnabled());
+		nativeInit(jsDebugger, DBG, deployData.isProfilerEnabled());
 
 		if (jsDebugger != null) {
 			jsDebugger.start();
@@ -222,7 +221,7 @@ public final class V8Runtime extends KrollRuntime implements Handler.Callback
 	}
 
 	// JNI method prototypes
-	private native void nativeInit(boolean useGlobalRefs, JSDebugger jsDebugger, boolean DBG, boolean profilerEnabled);
+	private native void nativeInit(JSDebugger jsDebugger, boolean DBG, boolean profilerEnabled);
 
 	private native void nativeRunModule(String source, String filename, KrollProxySupport activityProxy);
 

--- a/android/runtime/v8/src/native/JavaObject.h
+++ b/android/runtime/v8/src/native/JavaObject.h
@@ -76,11 +76,6 @@ public:
 	 */
 	void unreferenceJavaObject(jobject ref);
 
-	// True when we use global refs for the wrapped jobject.
-	// This is false for the emulator since it has a low limit
-	// of how many global refs you can hold. Instead we use an internal
-	// hash map for holding onto references to avoid this limit.
-	static bool useGlobalRefs;
 private:
 	/**
 	 * If we're using global references, this will hold the wrapped object. Otherwise it's NULL

--- a/android/runtime/v8/src/native/TypeConverter.cpp
+++ b/android/runtime/v8/src/native/TypeConverter.cpp
@@ -640,7 +640,7 @@ jobject TypeConverter::jsValueToJavaObject(v8::Isolate* isolate, JNIEnv *env, v8
 		v8::Local<v8::Object> jsObject = jsValue.As<Object>();
 
 		if (JavaObject::isJavaObject(jsObject)) {
-			*isNew = JavaObject::useGlobalRefs ? false : true;
+			*isNew = true;
 			JavaObject *javaObject = JavaObject::Unwrap<JavaObject>(jsObject);
 			return javaObject->getJavaObject();
 		} else {
@@ -650,7 +650,7 @@ jobject TypeConverter::jsValueToJavaObject(v8::Isolate* isolate, JNIEnv *env, v8
 				v8::Local<v8::Value> nativeObject = jsObject->GetRealNamedProperty(nativeString);
 				jsObject = nativeObject->ToObject(isolate);
 				if (JavaObject::isJavaObject(jsObject)) {
-					*isNew = JavaObject::useGlobalRefs ? false : true;
+					*isNew = true;
 					JavaObject *javaObject = JavaObject::Unwrap<JavaObject>(jsObject);
 					return javaObject->getJavaObject();
 				}

--- a/android/runtime/v8/src/native/V8Runtime.cpp
+++ b/android/runtime/v8/src/native/V8Runtime.cpp
@@ -348,9 +348,13 @@ JNIEXPORT jboolean JNICALL Java_org_appcelerator_kroll_runtime_v8_V8Runtime_nati
 	// while (v8::platform::PumpMessageLoop(V8Runtime::platform, V8Runtime:v8_isolate)) continue;
 	// v8::platform::RunIdleTasks(g_platform, isolate, 50.0 / base::Time::kMillisecondsPerSecond);
 
-	// FIXME What is a good value to use here? We're basically giving it 100 ms to run right now
-	double deadline_in_s = V8Runtime::platform->MonotonicallyIncreasingTime() + 0.1;
-	return V8Runtime::v8_isolate->IdleNotificationDeadline(deadline_in_s);
+	// notify V8 of low memory to suggest a full GC
+	V8Runtime::v8_isolate->LowMemoryNotification();
+	return true;
+
+	// give GC time to perform cleanup (1 second)
+	// double deadline_in_s = V8Runtime::platform->MonotonicallyIncreasingTime() + 1;
+	// return V8Runtime::v8_isolate->IdleNotificationDeadline(deadline_in_s);
 }
 
 /*

--- a/android/runtime/v8/src/native/V8Runtime.cpp
+++ b/android/runtime/v8/src/native/V8Runtime.cpp
@@ -199,7 +199,7 @@ using namespace titanium;
  * Method:    nativeInit
  * Signature: (Lorg/appcelerator/kroll/runtime/v8/V8Runtime;)J
  */
-JNIEXPORT void JNICALL Java_org_appcelerator_kroll_runtime_v8_V8Runtime_nativeInit(JNIEnv *env, jobject self, jboolean useGlobalRefs, jobject debugger, jboolean DBG, jboolean profilerEnabled)
+JNIEXPORT void JNICALL Java_org_appcelerator_kroll_runtime_v8_V8Runtime_nativeInit(JNIEnv *env, jobject self, jobject debugger, jboolean DBG, jboolean profilerEnabled)
 {
 	if (!V8Runtime::initialized) {
 		// Initialize V8.
@@ -215,7 +215,6 @@ JNIEXPORT void JNICALL Java_org_appcelerator_kroll_runtime_v8_V8Runtime_nativeIn
 
 	titanium::JNIScope jniScope(env);
 
-	JavaObject::useGlobalRefs = useGlobalRefs;
 	V8Runtime::DBG = DBG;
 
 	V8Runtime::javaInstance = env->NewGlobalRef(self);

--- a/android/titanium/src/java/org/appcelerator/kroll/KrollProxy.java
+++ b/android/titanium/src/java/org/appcelerator/kroll/KrollProxy.java
@@ -1414,32 +1414,8 @@ public class KrollProxy implements Handler.Callback, KrollProxySupport, OnLifecy
 	 */
 	public void releaseKroll()
 	{
-		// TIMOB-25910: attempt to make any strong references into weak references
-		// NOTE: there is an issue where proxies created in another context (such as an event listener callback)
-		// may not be destroyed when the context has ended. This workaround allows the GC to free these objects
-		// if memory is constraint.
-		if (referenceKey != -1) {
-			try {
-				final Class referenceTableClass = Class.forName("org.appcelerator.kroll.runtime.v8.ReferenceTable");
-				final Method getReferenceMethod = referenceTableClass.getDeclaredMethod("getReference", long.class);
-
-				final Object reference = getReferenceMethod.invoke(null, this.referenceKey);
-				if (!(reference instanceof WeakReference || reference instanceof SoftReference)) {
-					final Method weakReferenceMethod =
-						referenceTableClass.getDeclaredMethod("makeWeakReference", long.class);
-					weakReferenceMethod.invoke(null, this.referenceKey);
-				} else {
-					if (krollObject != null) {
-						krollObject.release();
-					}
-				}
-			} catch (Exception e) {
-				// do nothing...
-			}
-		} else {
-			if (krollObject != null) {
-				krollObject.release();
-			}
+		if (krollObject != null) {
+			krollObject.release();
 		}
 	}
 

--- a/android/titanium/src/java/org/appcelerator/kroll/KrollProxy.java
+++ b/android/titanium/src/java/org/appcelerator/kroll/KrollProxy.java
@@ -85,7 +85,6 @@ public class KrollProxy implements Handler.Callback, KrollProxySupport, OnLifecy
 	protected KrollDict defaultValues = new KrollDict();
 	protected Handler mainHandler = null;
 	protected Handler runtimeHandler = null;
-	protected long referenceKey = -1;
 
 	private KrollDict langConversionTable = null;
 	private boolean bubbleParent = true;
@@ -145,11 +144,6 @@ public class KrollProxy implements Handler.Callback, KrollProxySupport, OnLifecy
 		}
 
 		return null;
-	}
-
-	public void setReferenceKey(long key)
-	{
-		this.referenceKey = key;
 	}
 
 	protected void initActivity(Activity activity)

--- a/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
@@ -1448,7 +1448,6 @@ public abstract class TiBaseActivity extends AppCompatActivity implements TiActi
 				}
 			}
 		}
-		KrollRuntime.suggestGC();
 	}
 
 	@Override
@@ -1601,7 +1600,6 @@ public abstract class TiBaseActivity extends AppCompatActivity implements TiActi
 		// Don't dispose the runtime if the activity is forced to destroy by Android,
 		// so we can recover the activity later.
 		KrollRuntime.decrementActivityRefCount(isFinishing);
-		KrollRuntime.suggestGC();
 	}
 
 	@Override

--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/TiViewProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/TiViewProxy.java
@@ -633,9 +633,6 @@ public abstract class TiViewProxy extends KrollProxy implements Handler.Callback
 			mainHandler = null;
 		}
 		setModelListener(null);
-
-		releaseKroll();
-		KrollRuntime.suggestGC();
 	}
 
 	@Override


### PR DESCRIPTION
- Attempt to fix regressions from recent memory management refactor
- The changes for [TIMOB-25910](https://jira.appcelerator.org/browse/TIMOB-25910) in `releaseKroll()` are not necessary since the recent memory management refactor
- V8 does not account for the size of objects in JVM, so it does not GC as often as it should. This PR aims to increase the rate of V8 GC by coinciding with JVMs GC, allowing JVM to free objects.

#### OBJECT LIFECYCLE
<img src="https://jira.appcelerator.org/secure/attachment/65408/lifecycle.svg" width=500>

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-26242)