### PR TITLE
[TIMOB-26250] Android: Allow activity "android:launchMode" to be set in "tiapp.xml"

### DIFF
--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -3775,14 +3775,14 @@ AndroidBuilder.prototype.generateAndroidManifest = function generateAndroidManif
 		}, this);
 	}, this);
 
-	// TIMOB-15253: Titanium Android cannot be used with 'android:launchMode' as it can dispose the KrollRuntime instance
-	// prevent 'android:launchMode' from being defined in the AndroidManifest.xml
+	// scan "AndroidManifest.xml" activities
 	if (tiappAndroidManifest && tiappAndroidManifest.application) {
+		// Log a warning if Activity "launchMode" is set. May make app behave in a manner Titanium does not expect.
+		// Note: Allow it since some developers want "singleTask" support and know how to deal with its repercussions.
 		for (const activity in tiappAndroidManifest.application.activity) {
 			const parameters = tiappAndroidManifest.application.activity[activity];
 			if (parameters['launchMode']) {
-				delete parameters['launchMode'];
-				this.logger.warn(__('%s should not be used. Ignoring definition from %s', 'android:launchMode'.red, activity.cyan));
+				this.logger.warn(__('Setting activity "%s" is not recommended.', 'android:launchMode'.red, activity.cyan));
 			}
 		}
 

--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -3782,7 +3782,7 @@ AndroidBuilder.prototype.generateAndroidManifest = function generateAndroidManif
 		for (const activity in tiappAndroidManifest.application.activity) {
 			const parameters = tiappAndroidManifest.application.activity[activity];
 			if (parameters['launchMode']) {
-				this.logger.warn(__('Setting activity "%s" is not recommended.', 'android:launchMode'.red, activity.cyan));
+				this.logger.warn(__('Setting "%s" is not recommended for activity "%s"', 'android:launchMode'.red, activity.cyan));
 			}
 		}
 


### PR DESCRIPTION
**JIRA:**
https://jira.appcelerator.org/browse/TIMOB-26250

**Summary:**
- Reverses change made in Titanium 6.1.0 where "launchMode" setting was ignored.
- Now allows it to be set, but keeps build warning.
  * Note that some developers already know how to deal with the repercussions of the "singleTask" setting where all child activity windows are closed upon app resume.
  * For everyone else, the plan is to provide a different solution in Titanium 8.0.0 with [TIMOB-26075](https://jira.appcelerator.org/browse/TIMOB-26075).

**Test:**
1. Add the below XML to your project's "tiapp.xml" file.
2. In the XML, change the `<activity>` element's "name" attribute's `<ProjectName>` part to the name of your Titanium project where only the 1st letter is capitalized. _(Ex: "MyProject" would become "Myproject".)_
3. Build and run to an Android device.
4. In the log, verify the following warning exists: `[WARN]: Setting "android:launchMode" is not recommended for activity...`
5. Verify that the app's titlebar text reads "Launch Window".
6. Tap on the home button.
7. Drag down the top status bar to reveal its notifications.
8. Tap on the "Titanium Notification" item.
9. Verify that a new window with titlebar "Received Intent" is displayed.
10. Tap on the "Back" button.
11. Verify that app exits out and does not display the original "Launch Window". (The Android "singleTask" feature should have already closed it.)

---
tiapp.xml
```xml
<?xml version="1.0" encoding="UTF-8"?>
<ti:app xmlns:ti="http://ti.appcelerator.org">
	<android xmlns:android="http://schemas.android.com/apk/res/android">
		<manifest>
			<application>
				<activity android:name=".<ProjectName>Activity" android:launchMode="singleTask">
					<intent-filter>
						<action android:name="android.intent.action.MAIN"/>
						<category android:name="android.intent.category.LAUNCHER"/>
					</intent-filter>
				</activity>
			</application>
		</manifest>
	</android>
</ti:app>
```

---
app.js
```javascript
function showWindow(name, intent) {
	var window = Ti.UI.createWindow({
		title: name ? name : "New Window"
	});
	if (intent) {
		window.add(Ti.UI.createLabel({
			text: "Intent:\n" + JSON.stringify(intent),
			width: Ti.UI.FILL,
			height: Ti.UI.SIZE,
		}));
	}
	window.open();
}

function getAppResumeIntent() {
	var intent = Ti.App.Android.launchIntent;
	if (!intent) {
		intent = Ti.Android.createIntent({});
	}
	return intent;
}

// We must listen for "newIntent" event, not "newintent".
// There is a significant behavior difference.
Ti.Android.currentActivity.addEventListener("newIntent", function(e) {
	Ti.API.info("@@@ newIntent:\n" + JSON.stringify(e));
	showWindow("Received Intent", e.intent);
});

Ti.Android.NotificationManager.notify(123, Ti.Android.createNotification({
	contentTitle: "Titanium Notification",
	contentText: "Content Text",
	contentIntent: Ti.Android.createPendingIntent({
		intent: getAppResumeIntent(),
	}),
	flags: Ti.Android.FLAG_ONLY_ALERT_ONCE,
}));

showWindow("Launch Window", Ti.App.Android.launchIntent);
```
