### PR TITLE
[TIMOB-26252] Android: Fixed bug where "Ti.Android.currentActivity" always returns null as of 7.3.0

### DIFF
--- a/android/modules/android/src/java/ti/modules/titanium/android/AndroidModule.java
+++ b/android/modules/android/src/java/ti/modules/titanium/android/AndroidModule.java
@@ -582,7 +582,7 @@ public class AndroidModule extends KrollModule
 	{
 		Activity activity = TiApplication.getAppCurrentActivity();
 		if (activity instanceof TiBaseActivity) {
-			((TiBaseActivity) activity).getActivityProxy();
+			return ((TiBaseActivity) activity).getActivityProxy();
 		}
 		return null;
 	}

--- a/tests/Resources/ti.android.addontest.js
+++ b/tests/Resources/ti.android.addontest.js
@@ -1,0 +1,18 @@
+/*
+ * Axway Appcelerator Titanium Mobile
+ * Copyright (c) 2011-2018 by Axway Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+/* eslint-env mocha */
+/* global Ti */
+/* eslint no-unused-expressions: "off" */
+'use strict';
+var should = require('./utilities/assertions');
+
+describe.android('Titanium.Android', function () {
+	it('currentActivity', function () {
+		should(Ti.Android.currentActivity).not.be.undefined;
+		should(Ti.Android.currentActivity).be.a.Object;
+	});
+});


### PR DESCRIPTION
**JIRA:**
https://jira.appcelerator.org/browse/TIMOB-26252

**Note:**
This issue was introduced after 7.3.0.RC, but before GA. It has not been introduced into a customer release.

**Test:**
1. Build and run the below on Android.
2. Verify that it does not crash on app startup.

```javascript
Ti.Android.currentActivity.addEventListener("newIntent", function(e) {
	Ti.API.info("@@@ newIntent:\n" + JSON.stringify(e));
});
alert("It's fixed! Woo-hoo!");
```
