### PR TITLE
Revert "[7_3_X][TIMOB-26130] Android: Remove flag that breaks NDK compatibility"

### DIFF
--- a/android/runtime/v8/src/native/common.mk
+++ b/android/runtime/v8/src/native/common.mk
@@ -35,7 +35,7 @@ endif
 LDLIBS := -L$(SYSROOT)/usr/lib -ldl -llog -L$(TARGET_OUT)
 
 # optimize output size
-CFLAGS += -Os -ffunction-sections -fdata-sections
+CFLAGS += -Os -flto -ffunction-sections -fdata-sections
 LDLIBS += -Wl,--gc-sections,--strip-all
 
 # exclude v8 libraries


### PR DESCRIPTION
Reverts appcelerator/titanium_mobile#10240