### PR TITLE
fix(android): Titanium.Network.addSystemCookie not adding cookie to webview

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/WebViewProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/WebViewProxy.java
@@ -40,7 +40,8 @@ import ti.modules.titanium.ui.widget.webview.TiUIWebView;
 		TiC.PROPERTY_OVER_SCROLL_MODE,
 		TiC.PROPERTY_CACHE_MODE,
 		TiC.PROPERTY_LIGHT_TOUCH_ENABLED,
-		TiC.PROPERTY_ON_LINK
+		TiC.PROPERTY_ON_LINK,
+		TiC.PROPERTY_ACCEPT_THIRD_PARTY_COOKIES
 })
 public class WebViewProxy extends ViewProxy implements Handler.Callback, OnLifecycleEvent, interceptOnBackPressedEvent
 {

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
@@ -228,6 +228,7 @@ public class TiUIWebView extends TiUIView
 
 			boolean superHandled = super.onTouchEvent(ev);
 
+
 			return (superHandled || handled || swipeHandled);
 		}
 

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
@@ -228,7 +228,6 @@ public class TiUIWebView extends TiUIView
 
 			boolean superHandled = super.onTouchEvent(ev);
 
-
 			return (superHandled || handled || swipeHandled);
 		}
 

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
@@ -228,6 +228,7 @@ public class TiUIWebView extends TiUIView
 
 			boolean superHandled = super.onTouchEvent(ev);
 
+
 			return (superHandled || handled || swipeHandled);
 		}
 
@@ -308,6 +309,13 @@ public class TiUIWebView extends TiUIView
 			// silence unnecessary internal logs...
 		}
 		webView.setVerticalScrollbarOverlay(true);
+
+		boolean acceptThirdPartyCookies =
+				TiConvert.toBoolean(proxy.getProperty(TiC.PROPERTY_ACCEPT_THIRD_PARTY_COOKIES), false);
+
+		if(acceptThirdPartyCookies) {
+		    changeAcceptThirdPartyCookies(webView, acceptThirdPartyCookies);
+		}
 
 		WebSettings settings = webView.getSettings();
 		settings.setUseWideViewPort(true);
@@ -534,6 +542,8 @@ public class TiUIWebView extends TiUIView
 			zoomBy(getWebView(), TiConvert.toFloat(newValue, 1.0f));
 		} else if (TiC.PROPERTY_USER_AGENT.equals(key)) {
 			((WebViewProxy) getProxy()).setUserAgent(TiConvert.toString(newValue));
+		} else if (TiC.PROPERTY_ACCEPT_THIRD_PARTY_COOKIES.equals(key)) {
+		    changeAcceptThirdPartyCookies(getWebView(), TiConvert.toBoolean(newValue));
 		} else {
 			super.propertyChanged(key, oldValue, newValue, proxy);
 		}
@@ -547,6 +557,16 @@ public class TiUIWebView extends TiUIView
 			nativeView.setBackgroundColor(Color.TRANSPARENT);
 		}
 	}
+
+    private void changeAcceptThirdPartyCookies(WebView webView, boolean acceptThirdPartyCookie)
+    {
+        if (android.os.Build.VERSION.SDK_INT >= 21) {
+            android.webkit.CookieManager.getInstance().setAcceptThirdPartyCookies(webView, acceptThirdPartyCookie);
+        } else {
+            android.webkit.CookieManager.getInstance().setAcceptCookie(acceptThirdPartyCookie);
+        }
+    }
+
 
 	private void zoomBy(WebView webView, float scale)
 	{

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
@@ -228,7 +228,6 @@ public class TiUIWebView extends TiUIView
 
 			boolean superHandled = super.onTouchEvent(ev);
 
-
 			return (superHandled || handled || swipeHandled);
 		}
 
@@ -311,10 +310,9 @@ public class TiUIWebView extends TiUIView
 		webView.setVerticalScrollbarOverlay(true);
 
 		boolean acceptThirdPartyCookies =
-				TiConvert.toBoolean(proxy.getProperty(TiC.PROPERTY_ACCEPT_THIRD_PARTY_COOKIES), false);
-
-		if(acceptThirdPartyCookies) {
-		    changeAcceptThirdPartyCookies(webView, acceptThirdPartyCookies);
+			TiConvert.toBoolean(proxy.getProperty(TiC.PROPERTY_ACCEPT_THIRD_PARTY_COOKIES), false);
+		if (acceptThirdPartyCookies) {
+			changeAcceptThirdPartyCookies(webView, acceptThirdPartyCookies);
 		}
 
 		WebSettings settings = webView.getSettings();
@@ -543,7 +541,7 @@ public class TiUIWebView extends TiUIView
 		} else if (TiC.PROPERTY_USER_AGENT.equals(key)) {
 			((WebViewProxy) getProxy()).setUserAgent(TiConvert.toString(newValue));
 		} else if (TiC.PROPERTY_ACCEPT_THIRD_PARTY_COOKIES.equals(key)) {
-		    changeAcceptThirdPartyCookies(getWebView(), TiConvert.toBoolean(newValue));
+			changeAcceptThirdPartyCookies(getWebView(), TiConvert.toBoolean(newValue));
 		} else {
 			super.propertyChanged(key, oldValue, newValue, proxy);
 		}
@@ -558,15 +556,14 @@ public class TiUIWebView extends TiUIView
 		}
 	}
 
-    private void changeAcceptThirdPartyCookies(WebView webView, boolean acceptThirdPartyCookie)
-    {
-        if (android.os.Build.VERSION.SDK_INT >= 21) {
-            android.webkit.CookieManager.getInstance().setAcceptThirdPartyCookies(webView, acceptThirdPartyCookie);
-        } else {
-            android.webkit.CookieManager.getInstance().setAcceptCookie(acceptThirdPartyCookie);
-        }
-    }
-
+	private void changeAcceptThirdPartyCookies(WebView webView, boolean acceptThirdPartyCookie)
+	{
+		if (android.os.Build.VERSION.SDK_INT >= 21) {
+			android.webkit.CookieManager.getInstance().setAcceptThirdPartyCookies(webView, acceptThirdPartyCookie);
+		} else {
+			android.webkit.CookieManager.getInstance().setAcceptCookie(acceptThirdPartyCookie);
+		}
+	}
 
 	private void zoomBy(WebView webView, float scale)
 	{

--- a/android/titanium/src/java/org/appcelerator/titanium/TiC.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiC.java
@@ -765,6 +765,11 @@ public class TiC
 	/**
 	 * @module.api
 	 */
+	public static final String PROPERTY_ACCEPT_THIRD_PARTY_COOKIES = "acceptThirdPartyCookies";
+
+	/**
+	 * @module.api
+	 */
 	public static final String PROPERTY_ACCESSIBILITY_HIDDEN = "accessibilityHidden";
 
 	/**

--- a/apidoc/Titanium/UI/WebView.yml
+++ b/apidoc/Titanium/UI/WebView.yml
@@ -631,7 +631,7 @@ properties:
         See also: [url](Titanium.UI.WebView.url)
     type: Boolean
     default: false
-    since: {android: "5.0.0"}
+    since: {android: "9.3.0"}
     platforms: [android]
     availability: creation
 

--- a/apidoc/Titanium/UI/WebView.yml
+++ b/apidoc/Titanium/UI/WebView.yml
@@ -621,6 +621,20 @@ events:
         type: String
 
 properties:
+  - name: acceptThirdPartyCookies
+    summary: |
+        A Boolean value that determines whether the webview should allow third party cookies to be set.
+    description: |
+        Set to true to allow third party cookies. This could be useful when you are loading a webview
+        from a html file and need to read some cookie that was set on the app using <Titanium.Network.addSystemCookie>
+
+        See also: [url](Titanium.UI.WebView.url)
+    type: Boolean
+    default: false
+    since: {android: "5.0.0"}
+    platforms: [android]
+    availability: creation
+
   - name: allowsLinkPreview
     summary: |
         A Boolean value that determines whether pressing on a link displays a preview of the

--- a/apidoc/Titanium/UI/WebView.yml
+++ b/apidoc/Titanium/UI/WebView.yml
@@ -635,6 +635,20 @@ properties:
     platforms: [android]
     availability: creation
 
+  - name: acceptThirdPartyCookies
+    summary: |
+        A Boolean value that determines whether the webview should allow third party cookies to be set.
+    description: |
+        Set to true to allow third party cookies. This could be useful when you are loading a webview
+        from a html file and need to read some cookie that was set on the app using <Titanium.Network.addSystemCookie>
+
+        See also: [url](Titanium.UI.WebView.url)
+    type: Boolean
+    default: false
+    since: {android: "5.0.0"}
+    platforms: [android]
+    availability: creation
+
   - name: allowsLinkPreview
     summary: |
         A Boolean value that determines whether pressing on a link displays a preview of the


### PR DESCRIPTION
Creating a new property on webview to allow set a third party cookie.
This is important when you load a webview from a local html file and need to read a cookie that was set on app.

**JIRA:** https://jira.appcelerator.org/browse/TIMOB-20075

Test Code -

```
var win = Ti.UI.createWindow({
    layout : 'vertical'
});
var url = 'http://www.appcelerator.com/'; //Or any html file
var reload = Ti.UI.createButton({
    title : 'reload',
    height : 50,
    width : 100,
    top : 5,
});

reload.addEventListener('click', function() {
    web.url = url;
});

win.add(reload);

var web = Ti.UI.createWebView({
    url : url,
    width : Ti.UI.FILL,
    top : 100,
    height : Ti.UI.FILL,
    acceptThirdPartyCookies: true
});

win.add(web);
var i = 1;

web.addEventListener('load', function(e) {

    var d = new Date();
    d.setTime(d.getTime() + (2 * 24 * 60 * 60 * 1000));

    // You can try this("addHTTPCookie",  "addSystemCookie") insted of "createCookie"

    var cookie = Ti.Network.createCookie({
        name : 'helloWorld',
        domain : url,
        value : "testCoockie",
        expiryDate : d,

    });

    Ti.API.info("createCookie -> " + JSON.stringify(cookie));

    var cookies = web.evalJS("document.cookie").split(";");
    Ti.API.info("# of cookies -> " + cookies.length);
    for ( i = 0; i <= cookies.length - 1; i++) {
        Ti.API.info("cookie -> " + cookies[i]);
    }

});

win.open();
```