### PR TITLE
[TIMOB-26300] iOS: Fix crash when using (deprecated) kroll-thread

### DIFF
--- a/iphone/Classes/TiUITextArea.m
+++ b/iphone/Classes/TiUITextArea.m
@@ -90,21 +90,17 @@
 {
   if (textWidgetView == nil) {
     TiUITextViewImpl *textViewImpl = [[TiUITextViewImpl alloc] initWithFrame:CGRectZero];
-    textViewImpl.delaysContentTouches = NO;
     [textViewImpl setTouchHandler:self];
+    textViewImpl.delaysContentTouches = NO;
     textViewImpl.delegate = self;
+    textViewImpl.text = @"";
+
     [self addSubview:textViewImpl];
     [textViewImpl setContentInset:UIEdgeInsetsZero];
     self.clipsToBounds = YES;
 
     lastSelectedRange.location = 0;
     lastSelectedRange.length = 0;
-    //Temporarily setting text to a blank space, to set the editable property [TIMOB-10295]
-    //This is a workaround for a Apple Bug.
-    textViewImpl.text = @" ";
-    textViewImpl.editable = YES;
-
-    textViewImpl.text = @""; //Setting TextArea text to empty string
 
     textWidgetView = textViewImpl;
   }

--- a/tests/Resources/ti.ui.textarea.addontest.js
+++ b/tests/Resources/ti.ui.textarea.addontest.js
@@ -58,7 +58,10 @@ describe('Titanium.UI.TextArea', function () {
 			keyboardMessageView.add(keyboardMessage);
 			typingView.add(keyboardMessageView);
 			subwin.add(typingView);
-			tabA.open(subwin);
+
+			setTimeout(function () {
+				tabA.open(subwin);
+			}, 1000);
 		});
 
 		tabGroup.open();

--- a/tests/Resources/ti.ui.textarea.addontest.js
+++ b/tests/Resources/ti.ui.textarea.addontest.js
@@ -1,0 +1,66 @@
+/*
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2011-Present by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+/* eslint-env mocha */
+/* global Ti, Titanium */
+/* eslint no-unused-expressions: "off" */
+'use strict';
+
+describe('Titanium.UI.TextArea', function () {
+	var win;
+
+	afterEach(function () {
+		if (win) {
+			win.close();
+		}
+		win = null;
+	});
+
+	// Tests adding and removing a TextArea's focus.
+	it('textArea in tabGroup', function (finish) {
+		var windowA, windowB, tabA, tabB, tabGroup;
+
+		this.timeout(7500);
+
+		windowA = Ti.UI.createWindow();
+		windowB = Ti.UI.createWindow();
+
+		tabA = Ti.UI.createTab({
+			window: windowA,
+			title: 'Tab A'
+		});
+
+		tabB = Ti.UI.createTab({
+			window:windowB,
+			title: 'Tab B'
+		});
+
+		tabGroup = Titanium.UI.createTabGroup({
+			tabs: [ tabA, tabB ]
+		});
+
+		windowA.addEventListener('open', function () {
+			var subwin, typingView, keyboardMessageView, keyboardMessage;
+
+			subwin = Ti.UI.createWindow({ backgroundColor: 'blur' });
+
+			subwin.addEventListener('open', function () {
+				finish();
+			});
+
+			typingView = Ti.UI.createView();
+			keyboardMessageView = Ti.UI.createView();
+			keyboardMessage = Ti.UI.createTextArea();
+
+			keyboardMessageView.add(keyboardMessage);
+			typingView.add(keyboardMessageView);
+			subwin.add(typingView);
+			tabA.open(subwin);
+		});
+
+		tabGroup.open();
+	});
+});

--- a/tests/Resources/ti.ui.textarea.addontest.js
+++ b/tests/Resources/ti.ui.textarea.addontest.js
@@ -34,7 +34,7 @@ describe('Titanium.UI.TextArea', function () {
 		});
 
 		tabB = Ti.UI.createTab({
-			window:windowB,
+			window: windowB,
 			title: 'Tab B'
 		});
 


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-26300

> Removed some dirty old hacks that caused the internal iOS API to go mad when not using main-thread. I confirmed that the ticket linked to the initial code (from SDK 3.0.0) still works.