### PR TITLE
Updated Titanium.UI.TableViewRow

### DIFF
--- a/apidoc/Titanium/UI/TableViewRow.yml
+++ b/apidoc/Titanium/UI/TableViewRow.yml
@@ -343,12 +343,12 @@ properties:
     description: |
         For information about color values, see the "Colors" section of <Titanium.UI>.
     type: String
-
+    deprecated:
+        since: "8.0.0"
 
   - name: selectedBackgroundImage
     summary: Background image to render when the row is selected.
     type: String
-
 
   - name: selectedColor
     summary: Color of the row text when the row is selected, as a color name or hex triplet.


### PR DESCRIPTION
Set selectedBackgroundColor to deprecated (as of 8.0.0) according to https://github.com/appcelerator/titanium_mobile/pull/10210. This was request in https://jira.appcelerator.org/browse/AC-5803.