### PR TITLE
[FRAME-11] Remove uses-sdk setting

### DIFF
--- a/templates/app/angular-default/template/tiapp.xml
+++ b/templates/app/angular-default/template/tiapp.xml
@@ -45,7 +45,6 @@
 	<android xmlns:android="http://schemas.android.com/apk/res/android">
 		<manifest>
 			<application android:theme="@style/TitaniumAngular"/>
-			<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="25"/>
 		</manifest>
 	</android>
 	<modules>


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/FRAME-11

**Optional Description:**
Removes the now unnecessary `uses-sdk` setting. This was a leftover from when the template used the Material theme as a base instead of the AppCompat one.
