### PR TITLE
(7_3_X) [TIMOB-26325] Android: Ti.UI.WebView not firing events in 7.x

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
@@ -78,11 +78,6 @@ public class TiUIWebView extends TiUIView
 	public static final int PLUGIN_STATE_ON = 1;
 	public static final int PLUGIN_STATE_ON_DEMAND = 2;
 
-	// TIMOB-25462: minor 'hack' to prevent 'beforeload' and 'load' being
-	// called when the user-agent has been changed, this is a chromium bug
-	// https://bugs.chromium.org/p/chromium/issues/detail?id=315891
-	public boolean hasSetUserAgent = false;
-
 	private static enum reloadTypes { DEFAULT, DATA, HTML, URL }
 
 	private reloadTypes reloadMethod = reloadTypes.DEFAULT;
@@ -443,6 +438,11 @@ public class TiUIWebView extends TiUIView
 			}
 		}
 
+		// set user-agent befoe loading url to avoid immediate reload
+		if (d.containsKey(TiC.PROPERTY_USER_AGENT)) {
+			((WebViewProxy) getProxy()).setUserAgent(d.getString(TiC.PROPERTY_USER_AGENT));
+		}
+
 		if (d.containsKey(TiC.PROPERTY_URL)
 			&& !TiC.URL_ANDROID_ASSET_RESOURCES.equals(TiConvert.toString(d, TiC.PROPERTY_URL))) {
 			setUrl(TiConvert.toString(d, TiC.PROPERTY_URL));
@@ -481,10 +481,6 @@ public class TiUIWebView extends TiUIView
 
 		if (d.containsKey(TiC.PROPERTY_DISABLE_CONTEXT_MENU)) {
 			disableContextMenu = TiConvert.toBoolean(d, TiC.PROPERTY_DISABLE_CONTEXT_MENU);
-		}
-
-		if (d.containsKey(TiC.PROPERTY_USER_AGENT)) {
-			((WebViewProxy) getProxy()).setUserAgent(d.getString(TiC.PROPERTY_USER_AGENT));
 		}
 
 		if (d.containsKey(TiC.PROPERTY_ZOOM_LEVEL)) {
@@ -720,11 +716,11 @@ public class TiUIWebView extends TiUIView
 	}
 
 	/**
-	 * Loads HTML content into the web view.  Note that the "historyUrl" property 
-	 * must be set to non null in order for the web view history to work correctly 
-	 * when working with local files (IE:  goBack() and goForward() will not work if 
+	 * Loads HTML content into the web view.  Note that the "historyUrl" property
+	 * must be set to non null in order for the web view history to work correctly
+	 * when working with local files (IE:  goBack() and goForward() will not work if
 	 * null is used)
-	 * 
+	 *
 	 * @param html					HTML data to load into the web view
 	 * @param baseUrl				url to associate with the data being loaded
 	 * @param mimeType			mime type of the data being loaded
@@ -897,7 +893,6 @@ public class TiUIWebView extends TiUIView
 	{
 		WebView currWebView = getWebView();
 		if (currWebView != null) {
-			hasSetUserAgent = true;
 			currWebView.getSettings().setUserAgentString(userAgentString);
 		}
 	}

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiWebViewClient.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiWebViewClient.java
@@ -58,8 +58,7 @@ public class TiWebViewClient extends WebViewClientClassicExt
 	{
 		super.onPageFinished(view, url);
 		WebViewProxy proxy = (WebViewProxy) webView.getProxy();
-		if (proxy == null || webView.hasSetUserAgent) {
-			webView.hasSetUserAgent = false;
+		if (proxy == null) {
 			return;
 		}
 		webView.changeProxyUrl(url);
@@ -94,7 +93,7 @@ public class TiWebViewClient extends WebViewClientClassicExt
 	{
 		super.onPageStarted(view, url, favicon);
 		WebViewProxy proxy = (WebViewProxy) webView.getProxy();
-		if (proxy == null || webView.hasSetUserAgent) {
+		if (proxy == null) {
 			return;
 		}
 		KrollDict data = new KrollDict();
@@ -312,8 +311,8 @@ public class TiWebViewClient extends WebViewClientClassicExt
 	public void onReceivedSslError(WebView view, SslErrorHandler handler, SslError error)
 	{
 		/*
-		 * in theory this should be checked to make sure it's not null but if there is some failure 
-		 * in the association then usage of proxy should trigger a NPE to make sure the issue 
+		 * in theory this should be checked to make sure it's not null but if there is some failure
+		 * in the association then usage of proxy should trigger a NPE to make sure the issue
 		 * is not ignored
 		 */
 		WebViewProxy proxy = (WebViewProxy) webView.getProxy();

--- a/apidoc/Titanium/UI/WebView.yml
+++ b/apidoc/Titanium/UI/WebView.yml
@@ -635,6 +635,10 @@ properties:
     description: |
         On the iOS platform, this is not per-webview. Once you have set this property for a webview
         it will not change for same. But while creating new webview it can be changed to new user agent.
+
+        On Android, changing the user agent after the webview has begun loading content may cause
+        the webview to reload and fire multiple `load` or `beforeLoad` events. Developers should provide the
+        user agent value in the creation properties to avoid the reload and multiple events firing.
     type: String
     default: System default user-agent value.
     platforms: [android, iphone, ipad]


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-26325

**Description:**
This reverts the boolean flag hack to prevent multiple `load`/`beforeLoad` events getting fired when changing the `userAgent` after construction.

When running through `processProperties` we set the user agent string before loading the html/url/data content to avoid immediate reload.

I think so long as you provide the user agent in the construction properties this should only ever fire the `load`/`beforeLoad` events once. If you construct a WebView with an Url and then change the user agent after (mid-load), it's entirely possible you'll get multiple `load`/`beforeLoad` events fired based on the timing of the code.

I included a quick blurb in the Ti.UI.WebView.userAgent apidocs about this behavior.