### PR TITLE
[TIMOB-26333] Expose option to generate source maps when transpiling

### DIFF
--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -920,6 +920,7 @@ AndroidBuilder.prototype.validate = function validate(logger, config, cli) {
 
 	// Transpilation details
 	this.transpile = cli.tiapp['transpile'] === true; // Transpiling is an opt-in process for now
+	this.sourceMaps = cli.tiapp['source-maps'] === true; // opt-in to generate inline source maps
 	// We get a string here like 6.2.414.36, we need to convert it to 62 (integer)
 	const v8Version = this.packageJson.v8.version;
 	const found = v8Version.match(V8_STRING_VERSION_REGEXP);
@@ -2730,6 +2731,7 @@ AndroidBuilder.prototype.copyResources = function copyResources(next) {
 									filename: from,
 									minify: this.minifyJS,
 									transpile: this.transpile,
+									sourceMap: this.sourceMaps || this.deployType === 'development',
 									targets: {
 										chrome: this.chromeVersion
 									},

--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -1826,6 +1826,7 @@ iOSBuilder.prototype.validate = function validate(logger, config, cli) {
 
 		// Transpilation details
 		this.transpile = cli.tiapp['transpile'] === true; // Transpiling is an opt-in process for now
+		this.sourceMaps = cli.tiapp['source-maps'] === true; // opt-in to generate inline source maps
 		// this.minSupportedIosSdk holds the target ios version to transpile down to
 
 		// check for blacklisted files in the Resources directory
@@ -5842,6 +5843,7 @@ iOSBuilder.prototype.copyResources = function copyResources(next) {
 									filename: from,
 									minify: this.minifyJS,
 									transpile: this.transpile,
+									sourceMap: this.sourceMaps || this.deployType === 'development',
 									resourcesDir: this.xcodeAppDir
 								};
 								// generate our transpile target based on tijscore/jscore

--- a/package-lock.json
+++ b/package-lock.json
@@ -437,7 +437,7 @@
     },
     "babel-helper-is-nodes-equiv": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-is-nodes-equiv/-/babel-helper-is-nodes-equiv-0.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/babel-helper-is-nodes-equiv/-/babel-helper-is-nodes-equiv-0.0.1.tgz",
       "integrity": "sha1-NOmzALFHnd2Y7HfqC76TQt/jloQ="
     },
     "babel-helper-is-void-0": {
@@ -615,12 +615,12 @@
     },
     "babel-plugin-syntax-async-functions": {
       "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
       "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
     },
     "babel-plugin-syntax-exponentiation-operator": {
       "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
       "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
     },
     "babel-plugin-syntax-trailing-function-commas": {
@@ -1247,9 +1247,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30000878",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000878.tgz",
-      "integrity": "sha512-/dCGTdLCnjVJno1mFRn7Y6eit3AYaeFzSrMQHCoK0LEQaWl5snuLex1Ky4b8/Qu2ig5NgTX4cJx65hH9546puA=="
+      "version": "1.0.30000883",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000883.tgz",
+      "integrity": "sha512-ovvb0uya4cKJct8Rj9Olstz0LaWmyJhCp3NawRG5fVigka8pEhIIwipF7zyYd2Q58UZb5YfIt52pVF444uj2kQ=="
     },
     "caseless": {
       "version": "0.12.0",
@@ -1549,6 +1549,7 @@
         "require-from-string": "^2.0.1",
         "rfc6902": "^2.0.0",
         "supports-hyperlinks": "^1.0.1",
+        "vm2": "github:patriksimek/vm2#468bc1e54e75e766b842830ea775669992a979e0",
         "voca": "^1.2.0"
       },
       "dependencies": {
@@ -1589,10 +1590,6 @@
           "requires": {
             "has-flag": "^3.0.0"
           }
-        },
-        "vm2": {
-          "version": "github:patriksimek/vm2#468bc1e54e75e766b842830ea775669992a979e0",
-          "from": "github:patriksimek/vm2#468bc1e54e75e766b842830ea775669992a979e0"
         }
       }
     },
@@ -1740,9 +1737,9 @@
       "integrity": "sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ=="
     },
     "electron-to-chromium": {
-      "version": "1.3.59",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.59.tgz",
-      "integrity": "sha512-PbJGGpDSNn3fyUN1eQESAmnMT+a1QAO4NEZgikDuGOn7tbAuMHF87jNna+NoVsMBfEEYzfpn/ay88HgDCJUbQA=="
+      "version": "1.3.62",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.62.tgz",
+      "integrity": "sha512-x09ndL/Gjnuk3unlAyoGyUg3wbs4w/bXurgL7wL913vXHAOWmMhrLf1VNGRaMLngmadd5Q8gsV9BFuIr6rP+Xg=="
     },
     "encoding": {
       "version": "0.1.12",
@@ -2207,7 +2204,7 @@
     "file-state-monitor": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-state-monitor/-/file-state-monitor-1.0.0.tgz",
-      "integrity": "sha512-Tmn8VmqNW++Vyd0aMgNPR1F+56gp4GE9iY1rpM5X4YrN1yDxLVBfL2Q7qr6FCyoYyNiyOHCFidK1Mpl5t58BSA==",
+      "integrity": "sha1-sB6DdB3FijH828Bgk5Dinf49xDI=",
       "requires": {
         "fs-extra": "^4.0.0"
       },
@@ -3695,7 +3692,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -4328,9 +4325,9 @@
       }
     },
     "node-titanium-sdk": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/node-titanium-sdk/-/node-titanium-sdk-0.6.1.tgz",
-      "integrity": "sha512-PC8tUK7gj+HbENTBN5J2+rafSQskxFE9ehxueKp5EHYz0ddLEltnpPYTlRRnTkY+OlRMmUem+xNPgXfG57u1CQ==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/node-titanium-sdk/-/node-titanium-sdk-0.6.2.tgz",
+      "integrity": "sha512-PqJ2O/PNfxJUSqdctchyWDkk2ctZ4arYT+J1wnzbBzk5fA81p8/2DD2d57dFE/TJ/lDcnFoWNh82LL1GVxMlQA==",
       "requires": {
         "async": "^2.4.1",
         "babel-core": "^6.26.3",
@@ -4384,7 +4381,7 @@
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
       "dev": true,
       "requires": {
         "hosted-git-info": "^2.1.4",
@@ -5738,6 +5735,11 @@
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
       }
+    },
+    "vm2": {
+      "version": "github:patriksimek/vm2#468bc1e54e75e766b842830ea775669992a979e0",
+      "from": "github:patriksimek/vm2#custom_files",
+      "dev": true
     },
     "voca": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "markdown": "0.5.0",
     "moment": "^2.22.2",
     "node-appc": "^0.2.47",
-    "node-titanium-sdk": "^0.6.1",
+    "node-titanium-sdk": "^0.6.2",
     "node-uuid": "1.4.8",
     "pngjs": "^3.3.3",
     "request": "^2.87.0",


### PR DESCRIPTION
#### DEPENDED ON BY https://github.com/appcelerator/node-titanium-sdk/pull/44

- Allow Babel to generate source maps during development builds or when opted-in using `<source-maps>true</source-maps>`

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-26333)