### PR TITLE
chore: update docs from 7.4.0 -> 7.5.0

### DIFF
--- a/apidoc/Global/console/console.yml
+++ b/apidoc/Global/console/console.yml
@@ -117,4 +117,4 @@ methods:
         summary: Extra log data to be provided when logging
         type: Object
         optional: true
-    since: 7.4.0
+    since: 7.5.0

--- a/apidoc/Titanium/Android/Activity.yml
+++ b/apidoc/Titanium/Android/Activity.yml
@@ -362,7 +362,7 @@ events:
         See also:
         [onUserInteraction](https://developer.android.com/reference/android/app/Activity.html#onUserInteraction())
         in the Android Developer Reference.
-    since: "7.4.0"
+    since: "7.5.0"
 
 properties:
 

--- a/apidoc/Titanium/Geolocation/Geolocation.yml
+++ b/apidoc/Titanium/Geolocation/Geolocation.yml
@@ -187,7 +187,7 @@ description: |
         }
         Ti.Geolocation.addEventListener('heading', compassHandler);
 
-    Note that Android did not include a `success` property in the `heading` event prior to SDK 7.4.0.
+    Note that Android did not include a `success` property in the `heading` event prior to SDK 7.5.0.
     Heading events are only generated on Android when heading data is available. So if
     `success` is undefined on prior SDK versions, we assume that the event contains valid compass data.
 
@@ -335,7 +335,7 @@ events:
         platforms: [android, iphone, ipad]
 
       - name: success
-        summary: Indicate if the heading event was successfully received. Android returns this since SDK 7.4.0.
+        summary: Indicate if the heading event was successfully received. Android returns this since SDK 7.5.0.
         type: Boolean
         platforms: [android, iphone, ipad]
 

--- a/apidoc/Titanium/Media/AudioPlayer.yml
+++ b/apidoc/Titanium/Media/AudioPlayer.yml
@@ -5,12 +5,12 @@ summary: |
 description: |
     On Android, when you are done playing a given audio file, you must call the
     [release](Titanium.Media.AudioPlayer.release) method to stop buffering audio data and
-    release associated system resources. Since 7.4.0, this method is available on iOS as well
+    release associated system resources. Since 7.5.0, this method is available on iOS as well
     and will release all audio-player related resources. After this method has been called,
     the object should not be accessed anymore.
 
     On iOS, you can control how the audio stream interacts with other system sounds
-    by setting <Titanium.Media.audioSessionCategory>. Since Titanium 7.4.0, this API
+    by setting <Titanium.Media.audioSessionCategory>. Since Titanium 7.5.0, this API
     uses the [AVPlayer API](https://developer.apple.com/documentation/avfoundation/avplayer) for a more modern
     and performant audio playback.
 
@@ -130,7 +130,7 @@ methods:
   - name: play
     summary: Starts or resumes audio playback.
     deprecated:
-        since: "7.4.0"
+        since: "7.5.0"
         notes: Use the cross-platform API [start](Titanium.Media.AudioPlayer.start) instead.
     description: |
         This method is identical to .
@@ -147,7 +147,7 @@ methods:
         summary: Pass `true` to pause the current playback temporarily, `false` to unpause it.
         type: Boolean
     deprecated:
-        since: "7.4.0"
+        since: "7.5.0"
         notes: Use the cross-platform API [pause](Titanium.Media.AudioPlayer.pause) instead.
     platforms: [iphone, ipad]
 
@@ -163,7 +163,7 @@ methods:
         Use this method to seek to a specified time for the current player item and 
         to be notified by the `seek` event when the seek operation is complete.  
     platforms: [iphone, ipad]
-    since: "7.4.0"
+    since: "7.5.0"
 
   - name: release
     summary: Stops buffering audio data and releases audio resources.
@@ -175,7 +175,7 @@ methods:
         instance and it's observers. Note: If you are listening to the `progress` event,
         you should remove and re-add the event listener.
     platforms: [android, iphone, ipad]
-    since: { "android": "0.9", "iphone": "7.4.0", "ipad": "7.4.0" }
+    since: { "android": "0.9", "iphone": "7.5.0", "ipad": "7.5.0" }
 
   - name: getAudioSessionId
     summary: Returns the audio session id.
@@ -189,7 +189,7 @@ methods:
   
   - name: restart
     summary: Restarts (stops and stars) audio playback.
-    since: "7.4.0"
+    since: "7.5.0"
 
   - name: stateDescription
     summary: |
@@ -239,7 +239,7 @@ events:
             Otherwise, this value will be -1.
         type: Number
     platforms: [android, iphone, ipad]
-    since: {"android": "0.9", "iphone": "7.4.0", "ipad": "7.4.0"}
+    since: {"android": "0.9", "iphone": "7.5.0", "ipad": "7.5.0"}
 
   - name: metadata
     summary: Fired when the timed metadata was encountered most recently within the media as it plays.
@@ -251,7 +251,7 @@ events:
         summary: An array of metadata items containing relevant information about the current media item.
         type: Array<TiMetadataItemType>  
     platforms: [iphone, ipad]
-    since: "7.4.0"
+    since: "7.5.0"
     
   - name: error
     summary: Fired when there's an error.
@@ -288,7 +288,7 @@ properties:
     type: Number
     permission: read-only
     deprecated:
-        since: "7.4.0"
+        since: "7.5.0"
         notes: Use <Titanium.Media.AUDIO_STATE_BUFFERING> instead.
 
   - name: STATE_INITIALIZED
@@ -296,7 +296,7 @@ properties:
     type: Number
     permission: read-only
     deprecated:
-        since: "7.4.0"
+        since: "7.5.0"
         notes: Use <Titanium.Media.AUDIO_STATE_INITIALIZED> instead.
 
   - name: STATE_PAUSED
@@ -304,7 +304,7 @@ properties:
     type: Number
     permission: read-only
     deprecated:
-        since: "7.4.0"
+        since: "7.5.0"
         notes: Use <Titanium.Media.AUDIO_STATE_PAUSED> instead.
 
   - name: STATE_PLAYING
@@ -312,7 +312,7 @@ properties:
     type: Number
     permission: read-only
     deprecated:
-        since: "7.4.0"
+        since: "7.5.0"
         notes: Use <Titanium.Media.AUDIO_STATE_PLAYING> instead.
 
   - name: STATE_STARTING
@@ -320,7 +320,7 @@ properties:
     type: Number
     permission: read-only
     deprecated:
-        since: "7.4.0"
+        since: "7.5.0"
         notes: Use <Titanium.Media.AUDIO_STATE_STARTING> instead.
 
   - name: STATE_STOPPED
@@ -328,7 +328,7 @@ properties:
     type: Number
     permission: read-only
     deprecated:
-        since: "7.4.0"
+        since: "7.5.0"
         notes: Use <Titanium.Media.AUDIO_STATE_STOPPED> instead.
 
   - name: STATE_STOPPING
@@ -336,7 +336,7 @@ properties:
     type: Number
     permission: read-only
     deprecated:
-        since: "7.4.0"
+        since: "7.5.0"
         notes: Use <Titanium.Media.AUDIO_STATE_STOPPING> instead.
 
   - name: STATE_WAITING_FOR_DATA
@@ -344,7 +344,7 @@ properties:
     type: Number
     permission: read-only
     deprecated:
-        since: "7.4.0"
+        since: "7.5.0"
         notes: Use <Titanium.Media.AUDIO_STATE_WAITING_FOR_DATA> instead.
 
   - name: STATE_WAITING_FOR_QUEUE
@@ -352,7 +352,7 @@ properties:
     type: Number
     permission: read-only
     deprecated:
-        since: "7.4.0"
+        since: "7.5.0"
         notes: Use <Titanium.Media.AUDIO_STATE_WAITING_FOR_QUEUE> instead.
 
   - name: AUDIO_TYPE_ALARM
@@ -455,20 +455,20 @@ properties:
     description: Only affects audio muting for the player instance and not for the device.
     platforms: [iphone, ipad, android]
     type: Boolean
-    since: "7.4.0"
+    since: "7.5.0"
     
   - name: externalPlaybackActive
     summary: Indicates whether the player is currently playing video in "external playback" mode.
     platforms: [iphone, ipad]
     type: Boolean
-    since: "7.4.0"    
+    since: "7.5.0"    
     permission: read-only
  
   - name: allowsExternalPlayback
     summary: Indicates whether the player allows switching to "external playback" mode.
     default: true
     type: Boolean
-    since: "7.4.0"    
+    since: "7.5.0"    
     platforms: [iphone, ipad]
     
   - name: rate
@@ -486,7 +486,7 @@ properties:
         default behavior of waiting in order to minimize stalling is permitted.
     default: 0.0
     type: Number
-    since: "7.4.0"    
+    since: "7.5.0"    
     platforms: [iphone, ipad]
 
   - name: paused
@@ -545,7 +545,7 @@ properties:
   - name: bufferSize
     summary: Size of the buffer used for streaming, in milliseconds.
     description: |
-        Prior to Titanium 7.4.0, this property was set in bytes. Since the internal iOS
+        Prior to Titanium 7.5.0, this property was set in bytes. Since the internal iOS
         API moved to the more modern AVPlayer, this property now works with milliseconds instead.
     type: Number
     platforms: [iphone, ipad]
@@ -565,7 +565,7 @@ description: |
     This type is key-value based and is returned inside an array of metadata items.
     Read more about timed metadata items in the [Apple docs](https://developer.apple.com/documentation/avfoundation/avmetadataitem?language=objc).
 platforms: [iphone, ipad]
-since: "7.4.0"
+since: "7.5.0"
 properties:
   - name: key
     summary: The key of the metadata item, e.g. "title".

--- a/apidoc/Titanium/Media/Media.yml
+++ b/apidoc/Titanium/Media/Media.yml
@@ -896,55 +896,55 @@ properties:
     summary: Audio data is being buffered from the network.
     type: Number
     permission: read-only
-    since: "7.4.0"
+    since: "7.5.0"
 
   - name: AUDIO_STATE_INITIALIZED
     summary: Audio playback is being initialized.
     type: Number
     permission: read-only
-    since: "7.4.0"
+    since: "7.5.0"
 
   - name: AUDIO_STATE_PAUSED
     summary: Playback is paused.
     type: Number
     permission: read-only
-    since: "7.4.0"
+    since: "7.5.0"
 
   - name: AUDIO_STATE_PLAYING
     summary: Audio playback is active.
     type: Number
     permission: read-only
-    since: "7.4.0"
+    since: "7.5.0"
 
   - name: AUDIO_STATE_STARTING
     summary: Audio playback is starting.
     type: Number
     permission: read-only
-    since: "7.4.0"
+    since: "7.5.0"
 
   - name: AUDIO_STATE_STOPPED
     summary: Audio playback is stopped.
     type: Number
     permission: read-only
-    since: "7.4.0"
+    since: "7.5.0"
 
   - name: AUDIO_STATE_STOPPING
     summary: Audio playback is stopping.
     type: Number
     permission: read-only
-    since: "7.4.0"
+    since: "7.5.0"
 
   - name: AUDIO_STATE_WAITING_FOR_DATA
     summary: Player is waiting for audio data from the network.
     type: Number
     permission: read-only
-    since: "7.4.0"
+    since: "7.5.0"
 
   - name: AUDIO_STATE_WAITING_FOR_QUEUE
     summary: Player is waiting for audio data to fill the queue.
     type: Number
     permission: read-only
-    since: "7.4.0"
+    since: "7.5.0"
 
   - name: CAMERA_FLASH_AUTO
     summary: Constant specifying to have the device determine to use the flash or not.
@@ -1195,7 +1195,7 @@ properties:
     type: Number
     permission: read-only
     platforms: [iphone, ipad, android]
-    since: { iphone: "0.9.0", ipad: "0.9.0", android: "7.4.0" }
+    since: { iphone: "0.9.0", ipad: "0.9.0", android: "7.5.0" }
   - name: QUALITY_LOW
     summary: Media type constant for low-quality video recording.
     description: |
@@ -1203,7 +1203,7 @@ properties:
     type: Number
     permission: read-only
     platforms: [iphone, ipad, android]
-    since: { iphone: "0.9.0", ipad: "0.9.0", android: "7.4.0" }
+    since: { iphone: "0.9.0", ipad: "0.9.0", android: "7.5.0" }
   - name: QUALITY_MEDIUM
     summary: Media type constant for medium-quality video recording.
     description: |
@@ -1220,14 +1220,14 @@ properties:
     type: Number
     permission: read-only
     platforms: [iphone, ipad, android]
-    since: { iphone: "0.9.0", ipad: "0.9.0", android: "7.4.0" }
+    since: { iphone: "0.9.0", ipad: "0.9.0", android: "7.5.0" }
   - name: QUALITY_IFRAME_1280x720
     summary: Media type constant for medium-quality video recording.
     description: If recording, specifies that you want to use 1280x720 iFrame format.
     type: Number
     permission: read-only
     platforms: [iphone, ipad, android]
-    since: { android: "7.4.0", iphone: "6.0.0", ipad: "6.0.0" }
+    since: { android: "7.5.0", iphone: "6.0.0", ipad: "6.0.0" }
   - name: QUALITY_IFRAME_960x540
     summary: Media type constant for medium-quality video recording.
     description: If recording, specifies that you want to use 960x540 iFrame format.

--- a/apidoc/Titanium/UI/AlertDialog.yml
+++ b/apidoc/Titanium/UI/AlertDialog.yml
@@ -208,7 +208,7 @@ properties:
         if the dialog does not have any buttons, then the dialog can only be closed programmatically via the hide() method.
     type: Boolean
     default: false on Android
-    since: "7.4.0"
+    since: "7.5.0"
     platforms: [android]
 
   - name: canceledOnTouchOutside

--- a/apidoc/Titanium/UI/Button.yml
+++ b/apidoc/Titanium/UI/Button.yml
@@ -111,9 +111,9 @@ properties:
     type: Titanium.UI.AttributedString
     platforms: [android, iphone, ipad]
     since:
-        android: 7.4.0
-        iphone: 7.4.0
-        ipad: 7.4.0
+        android: 7.5.0
+        iphone: 7.5.0
+        ipad: 7.5.0
 
   - name: backgroundImage
     summary: |

--- a/apidoc/Titanium/UI/ScrollView.yml
+++ b/apidoc/Titanium/UI/ScrollView.yml
@@ -319,7 +319,7 @@ properties:
     summary: View positioned above the first row that is only revealed when the user drags the scroll view contents down.
     description: |
         An alternate to the pullView property. See <Titanium.UI.RefreshControl> for usage and examples. Since Titanium
-        SDK 7.4.0, the RefreshControl API is also available on iOS < 10.
+        SDK 7.5.0, the RefreshControl API is also available on iOS < 10.
     type: Titanium.UI.RefreshControl
     platforms: [android, iphone, ipad]
     since: { android: "6.3.0", iphone: "6.0.0", ipad: "6.0.0" }

--- a/apidoc/Titanium/UI/ScrollableView.yml
+++ b/apidoc/Titanium/UI/ScrollableView.yml
@@ -360,7 +360,7 @@ properties:
     type: Boolean
     availability: creation
     default: true
-    since: { iphone: 0.9, ipad: 0.9, android: 7.4.0 }
+    since: { iphone: 0.9, ipad: 0.9, android: 7.5.0 }
     platforms: [iphone, ipad, android]
 
   - name: hitRect
@@ -380,7 +380,7 @@ properties:
     summary: The padding applied to the scrollable view.
     platforms: [android]
     type: ViewPadding
-    since: "7.4.0"
+    since: "7.5.0"
 
 examples:
   - title: Simple Scrollable View with 3 Views

--- a/apidoc/Titanium/UI/SearchBar.yml
+++ b/apidoc/Titanium/UI/SearchBar.yml
@@ -186,7 +186,7 @@ properties:
       If this property is not specified, the default white background is used.
     type: String
     platforms: [iphone, ipad]
-    since: "7.4.0"
+    since: "7.5.0"
 
   - name: fieldBackgroundDisabledImage
     summary: Background image of the text field in disabled state, specified as a local file path or URL.
@@ -194,7 +194,7 @@ properties:
       If this property is not specified, the default white background is used.
     type: String
     platforms: [iphone, ipad]
-    since: "7.4.0"
+    since: "7.5.0"
 
   - name: hintText
     summary: Text to show when the search bar field is not focused.

--- a/apidoc/Titanium/UI/TextArea.yml
+++ b/apidoc/Titanium/UI/TextArea.yml
@@ -359,7 +359,7 @@ properties:
     description: Sets the height of the text area by line height. Set to -1 to respect the view's height property instead.
     default: 1
     type: Number
-    since: { android: "7.4.0" }
+    since: { android: "7.5.0" }
     platforms: [android]
 
   - name: maxLength
@@ -377,7 +377,7 @@ properties:
     description: Sets the maximum of lines that the field will be extended to when pressing `Return`.
     default: -1
     type: Number
-    since: { android: "7.4.0" }
+    since: { android: "7.5.0" }
     platforms: [android]
 
   - name: padding

--- a/apidoc/Titanium/UI/TextField.yml
+++ b/apidoc/Titanium/UI/TextField.yml
@@ -473,7 +473,7 @@ properties:
       compatible with your service. You can learn more about the purpose of and syntax for these rules
       on the [Password Rules documentation guide](https://developer.apple.com/documentation/security/password_autofill/customizing_password_autofill_rules).
     type: String
-    since: "7.4.0"
+    since: "7.5.0"
     osver: { ios: { min: "12.0" } }
     platforms: [iphone, ipad]
 

--- a/apidoc/Titanium/UI/View.yml
+++ b/apidoc/Titanium/UI/View.yml
@@ -332,7 +332,7 @@ events:
       - name: time
         summary: The event time of the current event being processed.
         type: Number
-        since: "7.4.0"
+        since: "7.5.0"
         platforms: [android]
         
       - name: timeDelta
@@ -340,7 +340,7 @@ events:
             The time difference in milliseconds between the previous accepted scaling event and the 
             current scaling event.
         type: Number
-        since: "7.4.0"
+        since: "7.5.0"
         platforms: [android]
         
       - name: currentSpan
@@ -348,7 +348,7 @@ events:
             The average distance between each of the pointers forming the gesture in progress through
             the focal point.
         type: Number
-        since: "7.4.0"
+        since: "7.5.0"
         platforms: [android]
         
       - name: currentSpanX
@@ -356,7 +356,7 @@ events:
             The average X distance between each of the pointers forming the gesture in progress through 
             the focal point.
         type: Number
-        since: "7.4.0"
+        since: "7.5.0"
         platforms: [android]
 
       - name: currentSpanY
@@ -364,7 +364,7 @@ events:
             The average Y distance between each of the pointers forming the gesture in progress through 
             the focal point.
         type: Number
-        since: "7.4.0"
+        since: "7.5.0"
         platforms: [android]
         
       - name: previousSpan
@@ -372,7 +372,7 @@ events:
             The previous average distance between each of the pointers forming the gesture in progress through 
             the focal point.
         type: Number
-        since: "7.4.0"
+        since: "7.5.0"
         platforms: [android]
         
       - name: previousSpanX
@@ -380,7 +380,7 @@ events:
             The previous average X distance between each of the pointers forming the gesture in progress through 
             the focal point.
         type: Number
-        since: "7.4.0"
+        since: "7.5.0"
         platforms: [android]
         
       - name: previousSpanY
@@ -388,27 +388,27 @@ events:
             The previous average Y distance between each of the pointers forming the gesture in progress through 
             the focal point.
         type: Number
-        since: "7.4.0"
+        since: "7.5.0"
         platforms: [android]
         
       - name: focusX
         summary: |
             The X coordinate of the current gesture's focal point.
         type: Number
-        since: "7.4.0"
+        since: "7.5.0"
         platforms: [android]
         
       - name: focusY
         summary: |
             The Y coordinate of the current gesture's focal point.
         type: Number
-        since: "7.4.0"
+        since: "7.5.0"
         platforms: [android]
         
       - name: inProgress
         summary: Returns `true` if a scale gesture is in progress, `false` otherwise.
         type: Number
-        since: "7.4.0"
+        since: "7.5.0"
         platforms: [android]
 
   - name: postlayout

--- a/apidoc/Titanium/UI/WebView.yml
+++ b/apidoc/Titanium/UI/WebView.yml
@@ -616,7 +616,7 @@ properties:
         The plist key is enabled by default, allowing arbitrary loads to be processed.
     type: Boolean
     platforms: [android]
-    since: "7.4.0"
+    since: "7.5.0"
     default: false
     availability: creation
 

--- a/apidoc/Titanium/UI/Window.yml
+++ b/apidoc/Titanium/UI/Window.yml
@@ -544,7 +544,7 @@ properties:
     platforms: [iphone, ipad]
     type: Boolean
     default: false
-    since: 7.4.0
+    since: 7.5.0
 
   - name: largeTitleEnabled
     summary: A Boolean value indicating whether the title should be displayed in a large format.


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-0000

> No backport required, because 7_4_X is currently based off 7.3.0 and it's cherry-picked iOS commits will be the only 7.4.0 references.