### PR TITLE
[TIMOB-26338](7_3_X): iOS Label not shown when opened in window from tab-group (kroll-thread only)

### DIFF
--- a/iphone/Classes/TiUITabProxy.m
+++ b/iphone/Classes/TiUITabProxy.m
@@ -256,10 +256,6 @@
   [window setTab:self];
   [window setParentOrientationController:self];
 
-  TiUIView *view = [window view];
-  TiViewController *controller = (TiViewController *)[window hostingController];
-  [view setFrame:controller.view.bounds];
-
   //Send to open. Will come back after _handleOpen returns true.
   if (![window opening]) {
     args = ([args count] > 1) ? [args objectAtIndex:1] : nil;
@@ -267,6 +263,10 @@
       args = [NSArray arrayWithObject:args];
     }
     [window open:args];
+
+    TiUIView *view = [window view];
+    TiViewController *controller = (TiViewController *)[window hostingController];
+    [view setFrame:controller.view.bounds];
     return;
   }
 


### PR DESCRIPTION
 https://jira.appcelerator.org/browse/TIMOB-26338
