### PR TITLE
Fix for missing parameters of setContentOffset

### DIFF
--- a/apidoc/Titanium/UI/ScrollView.yml
+++ b/apidoc/Titanium/UI/ScrollView.yml
@@ -28,7 +28,7 @@ description: |
     is natively supported by the UIScrollView class, but on Android, the native ScrollView class does
     not support this action.
 extends: Titanium.UI.View
-since: '0.9'
+since: "0.9"
 
 methods:
   - name: scrollTo

--- a/apidoc/Titanium/UI/ScrollView.yml
+++ b/apidoc/Titanium/UI/ScrollView.yml
@@ -1,7 +1,6 @@
 ---
 name: Titanium.UI.ScrollView
-summary: |
-    A view that contains a horizontally and/or vertically-scrollable region of content.
+summary: A view that contains a horizontally and/or vertically-scrollable region of content.
 description: |
     Use the <Titanium.UI.createScrollView> method or **`<ScrollView>`** Alloy element to create a scroll view.
 
@@ -29,7 +28,7 @@ description: |
     is natively supported by the UIScrollView class, but on Android, the native ScrollView class does
     not support this action.
 extends: Titanium.UI.View
-since: "0.9"
+since: '0.9'
 
 methods:
   - name: scrollTo
@@ -56,13 +55,10 @@ methods:
         summary: |
             X and Y coordinates to which to reposition the top-left point of the scrollable region.
         type: Dictionary
-
       - name: animated
         summary: Determines whether the scrollable region reposition should be animated
         type: contentOffsetOption
         optional: true
-
-
   - name: setZoomScale
     summary: Sets the value of the [zoomScale](Titanium.UI.ScrollView.zoomScale) property.
     platforms: [iphone, ipad]
@@ -75,7 +71,6 @@ methods:
         summary: Determines whether the scrollable region reposition should be animated
         type: zoomScaleOption
         optional: true
-
 
   - name: scrollToBottom
     summary: Moves the end of the scrollable region into the viewable area.
@@ -227,14 +222,12 @@ properties:
         Measured in platform-specific units; pixels on Android, effective pixels on Windows and density-independent pixels (dip) on iOS.
     type: [Number, String]
 
-  - name: contentOffset
-    summary: |
-        X and Y coordinates to which to reposition the top-left point of the scrollable region.
-    type: Dictionary
+  - name: contentOffsetXY
+    summary: X and Y coordinates to which to reposition the top-left point of the scrollable region.
     description: |
         On iOS, a new value causes the scroll view to perform an animated scroll to the new offset.
         The <Titanium.UI.ScrollView.setContentOffset> method can be used to prevent this animation.
-
+    type: Dictionary
 
   - name: contentWidth
     summary: Width of the scrollable region.


### PR DESCRIPTION
This PR fixes the missing parameters of setContentOffset. The parameter contentOffset shared a property with the same name. This was causing the rendered HTML to fail to display all the setContentOffset parameters.

https://jira.appcelerator.org/browse/TIDOC-3232