### PR TITLE
[TIMOB-26261] Android: Compile with API Level 28 (Android P)

### DIFF
--- a/android/.idea/misc.xml
+++ b/android/.idea/misc.xml
@@ -24,7 +24,7 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" default="false" project-jdk-name="Android API 27 Platform" project-jdk-type="Android SDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" default="false" project-jdk-name="Android API 28 Platform" project-jdk-type="Android SDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/android/.idea/workspace.xml
+++ b/android/.idea/workspace.xml
@@ -675,7 +675,7 @@
         </state>
       </provider>
     </entry>
-    <entry file="file://$USER_HOME$/Library/Android/sdk/sources/android-27/android/app/Activity.java">
+    <entry file="file://$USER_HOME$/Library/Android/sdk/sources/android-28/android/app/Activity.java">
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="207">
           <caret line="885" column="29" lean-forward="false" selection-start-line="885" selection-start-column="29" selection-end-line="885" selection-end-column="29" />
@@ -1047,7 +1047,7 @@
       </state>
       <state key="JdkListConfigurable.UI">
         <settings>
-          <last-edited>Android API 27 Platform</last-edited>
+          <last-edited>Android API 28 Platform</last-edited>
           <splitter-proportions>
             <option name="proportions">
               <list>

--- a/android/dev/TitaniumTest/project.properties
+++ b/android/dev/TitaniumTest/project.properties
@@ -11,7 +11,7 @@
 #proguard.config=${sdk.dir}/tools/proguard/proguard-android.txt:proguard-project.txt
 
 # Project target.
-target=android-23
+target=android-28
 android.library.reference.1=../../titanium
 android.library.reference.2=../../modules/accelerometer
 android.library.reference.3=../../modules/analytics

--- a/android/modules/accelerometer/project.properties
+++ b/android/modules/accelerometer/project.properties
@@ -9,7 +9,7 @@
 
 android.library=true
 # Project target.
-target=android-27
+target=android-28
 android.library.reference.1=../../runtime/common
 android.library.reference.2=../../titanium
 android.library.reference.3=../../kroll-apt

--- a/android/modules/analytics/project.properties
+++ b/android/modules/analytics/project.properties
@@ -9,7 +9,7 @@
 
 android.library=true
 # Project target.
-target=android-27
+target=android-28
 android.library.reference.1=../../runtime/common
 android.library.reference.2=../../titanium
 android.library.reference.3=../../kroll-apt

--- a/android/modules/android/AndroidManifest.xml
+++ b/android/modules/android/AndroidManifest.xml
@@ -4,7 +4,7 @@
 	android:versionCode="1"
 	android:versionName="1.0">
 
-	<uses-sdk android:minSdkVersion="16" android:targetSdkVersion="27" />
+	<uses-sdk android:minSdkVersion="16" android:targetSdkVersion="28" />
 
 	<application android:label="@string/app_name">
 	</application>

--- a/android/modules/android/project.properties
+++ b/android/modules/android/project.properties
@@ -9,7 +9,7 @@
 
 android.library=true
 # Project target.
-target=android-27
+target=android-28
 android.library.reference.1=../../runtime/common
 android.library.reference.2=../../titanium
 android.library.reference.3=../filesystem

--- a/android/modules/app/project.properties
+++ b/android/modules/app/project.properties
@@ -9,7 +9,7 @@
 
 android.library=true
 # Project target.
-target=android-27
+target=android-28
 android.library.reference.1=../../runtime/common
 android.library.reference.2=../../titanium
 android.library.reference.3=../../kroll-apt

--- a/android/modules/appcompat/project.properties
+++ b/android/modules/appcompat/project.properties
@@ -11,5 +11,5 @@
 #proguard.config=${sdk.dir}/tools/proguard/proguard-android.txt:proguard-project.txt
 
 # Project target.
-target=android-27
+target=android-28
 android.library=true

--- a/android/modules/calendar/project.properties
+++ b/android/modules/calendar/project.properties
@@ -9,7 +9,7 @@
 
 android.library=true
 # Project target.
-target=android-27
+target=android-28
 android.library.reference.1=../../runtime/common
 android.library.reference.2=../../titanium
 android.library.reference.3=../../kroll-apt

--- a/android/modules/cardview/project.properties
+++ b/android/modules/cardview/project.properties
@@ -11,5 +11,5 @@
 #proguard.config=${sdk.dir}/tools/proguard/proguard-android.txt:proguard-project.txt
 
 # Project target.
-target=android-27
+target=android-28
 android.library=true

--- a/android/modules/compat/project.properties
+++ b/android/modules/compat/project.properties
@@ -11,5 +11,5 @@
 #proguard.config=${sdk.dir}/tools/proguard/proguard-android.txt:proguard-project.txt
 
 # Project target.
-target=android-27
+target=android-28
 android.library=true

--- a/android/modules/contacts/project.properties
+++ b/android/modules/contacts/project.properties
@@ -9,7 +9,7 @@
 
 android.library=true
 # Project target.
-target=android-27
+target=android-28
 android.library.reference.1=../../runtime/common
 android.library.reference.2=../../titanium
 android.library.reference.3=../../kroll-apt

--- a/android/modules/database/project.properties
+++ b/android/modules/database/project.properties
@@ -9,7 +9,7 @@
 
 android.library=true
 # Project target.
-target=android-27
+target=android-28
 android.library.reference.1=../../runtime/common
 android.library.reference.2=../../titanium
 android.library.reference.3=../../kroll-apt

--- a/android/modules/design/project.properties
+++ b/android/modules/design/project.properties
@@ -11,5 +11,5 @@
 #proguard.config=${sdk.dir}/tools/proguard/proguard-android.txt:proguard-project.txt
 
 # Project target.
-target=android-27
+target=android-28
 android.library=true

--- a/android/modules/filesystem/project.properties
+++ b/android/modules/filesystem/project.properties
@@ -9,7 +9,7 @@
 
 android.library=true
 # Project target.
-target=android-27
+target=android-28
 android.library.reference.1=../../runtime/common
 android.library.reference.2=../../titanium
 android.library.reference.3=../../kroll-apt

--- a/android/modules/geolocation/project.properties
+++ b/android/modules/geolocation/project.properties
@@ -9,7 +9,7 @@
 
 android.library=true
 # Project target.
-target=android-27
+target=android-28
 android.library.reference.1=../../runtime/common
 android.library.reference.2=../../titanium
 android.library.reference.3=../../kroll-apt

--- a/android/modules/gesture/project.properties
+++ b/android/modules/gesture/project.properties
@@ -9,7 +9,7 @@
 
 android.library=true
 # Project target.
-target=android-27
+target=android-28
 android.library.reference.1=../../runtime/common
 android.library.reference.2=../../titanium
 android.library.reference.3=../../kroll-apt

--- a/android/modules/locale/project.properties
+++ b/android/modules/locale/project.properties
@@ -9,7 +9,7 @@
 
 android.library=true
 # Project target.
-target=android-27
+target=android-28
 android.library.reference.1=../../runtime/common
 android.library.reference.2=../../titanium
 android.library.reference.3=../../kroll-apt

--- a/android/modules/media/project.properties
+++ b/android/modules/media/project.properties
@@ -9,7 +9,7 @@
 
 android.library=true
 # Project target.
-target=android-27
+target=android-28
 android.library.reference.1=../../runtime/common
 android.library.reference.3=../filesystem
 android.library.reference.2=../../titanium

--- a/android/modules/network/project.properties
+++ b/android/modules/network/project.properties
@@ -9,7 +9,7 @@
 
 android.library=true
 # Project target.
-target=android-27
+target=android-28
 android.library.reference.1=../../runtime/common
 android.library.reference.3=../xml
 android.library.reference.2=../../titanium

--- a/android/modules/platform/project.properties
+++ b/android/modules/platform/project.properties
@@ -9,7 +9,7 @@
 
 android.library=true
 # Project target.
-target=android-27
+target=android-28
 android.library.reference.1=../../runtime/common
 android.library.reference.2=../../titanium
 android.library.reference.3=../../kroll-apt

--- a/android/modules/ui/AndroidManifest.xml
+++ b/android/modules/ui/AndroidManifest.xml
@@ -4,7 +4,7 @@
 	android:versionCode="1"
 	android:versionName="1.0">
 
-	<uses-sdk android:minSdkVersion="16" android:targetSdkVersion="27" />
+	<uses-sdk android:minSdkVersion="16" android:targetSdkVersion="28" />
 
 	<application android:label="@string/app_name">
 	</application>

--- a/android/modules/ui/project.properties
+++ b/android/modules/ui/project.properties
@@ -9,7 +9,7 @@
 
 android.library=true
 # Project target.
-target=android-27
+target=android-28
 android.library.reference.1=../../runtime/common
 android.library.reference.2=../../titanium
 android.library.reference.3=../filesystem

--- a/android/modules/utils/project.properties
+++ b/android/modules/utils/project.properties
@@ -9,7 +9,7 @@
 
 android.library=true
 # Project target.
-target=android-27
+target=android-28
 android.library.reference.1=../../runtime/common
 android.library.reference.2=../../titanium
 android.library.reference.3=../../kroll-apt

--- a/android/modules/xml/project.properties
+++ b/android/modules/xml/project.properties
@@ -9,7 +9,7 @@
 
 android.library=true
 # Project target.
-target=android-27
+target=android-28
 android.library.reference.1=../../runtime/common
 android.library.reference.2=../../titanium
 android.library.reference.3=../../kroll-apt

--- a/android/modules/yahoo/project.properties
+++ b/android/modules/yahoo/project.properties
@@ -9,4 +9,4 @@
 
 android.library=true
 # Project target.
-target=android-27
+target=android-28

--- a/android/package.json
+++ b/android/package.json
@@ -19,14 +19,14 @@
 		"mode": "release"
 	},
 	"minSDKVersion": "16",
-	"compileSDKVersion": "27",
+	"compileSDKVersion": "28",
 	"vendorDependencies": {
 		"android sdk": ">=23.x <=27.x",
-		"android build tools": ">=25.x <=27.x",
-		"android platform tools": "27.x",
+		"android build tools": ">=25.x <=28.x",
+		"android platform tools": "28.x",
 		"android tools": "<=26.x",
-		"android ndk": ">=r11c <=r16c",
-		"node": ">=4.0 <=8.x",
+		"android ndk": ">=r11c <=r17b",
+		"node": ">=8.0 <=8.x",
 		"java": ">=1.8.x"
 	},
 	"repository": {

--- a/android/package.json
+++ b/android/package.json
@@ -26,7 +26,7 @@
 		"android platform tools": "28.x",
 		"android tools": "<=26.x",
 		"android ndk": ">=r11c <=r17b",
-		"node": ">=8.0 <=8.x",
+		"node": ">=4.0 <=8.x",
 		"java": ">=1.8.x"
 	},
 	"repository": {

--- a/android/titanium/AndroidManifest.xml
+++ b/android/titanium/AndroidManifest.xml
@@ -4,7 +4,7 @@
 	android:versionCode="1"
 	android:versionName="1.0">
 
-	<uses-sdk android:minSdkVersion="16" android:targetSdkVersion="27" />
+	<uses-sdk android:minSdkVersion="16" android:targetSdkVersion="28" />
 
 	<application android:label="@string/app_name">
 	</application>

--- a/android/titanium/project.properties
+++ b/android/titanium/project.properties
@@ -8,7 +8,7 @@
 # project structure.
 
 # Project target.
-target=android-27
+target=android-28
 android.library=true
 android.library.reference.1=../runtime/common
 android.library.reference.2=../modules/appcompat

--- a/build/androidsdk.js
+++ b/build/androidsdk.js
@@ -3,7 +3,7 @@
 var os = require('os'),
 	fs = require('fs-extra'),
 	path = require('path'),
-	DEFAULT_API_LEVEL = 27;
+	DEFAULT_API_LEVEL = 28;
 
 /**
  * Given a hinted at location of Android SDK, find one.


### PR DESCRIPTION
**JIRA:**
https://jira.appcelerator.org/browse/TIMOB-26261

**Summary:**
- Modified Titanium to compile against API Level 28 (Android P).
- Does not target API Level 28 by default yet.
  * To be done once all Android P breaking changes have been resolved.
  * App dev can opt-in to targeting API Level 28 via "tiapp.xml" `<uses-sdk/>` setting.
- Updated Android build-tools max version from `27.x` to `28.x`.
- Updated Android NDK max version from `r16c` to `r17b`.

**Test:**
Build and run KitchenSinkV2 on Android 9.0 and Android 4.1. Traverse app's UI features and verify that they work.
