### PR TITLE
[TIMOB-26253] Android: Fixed NotificationManager.notify() crash if screen is off and missing WAKE_LOCK permission

### DIFF
--- a/android/modules/android/src/java/ti/modules/titanium/android/notificationmanager/NotificationManagerModule.java
+++ b/android/modules/android/src/java/ti/modules/titanium/android/notificationmanager/NotificationManagerModule.java
@@ -21,6 +21,8 @@ import android.app.Activity;
 import android.app.Notification;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
+import android.content.pm.PackageManager;
+import android.Manifest;
 import android.os.Build;
 import android.os.PowerManager;
 import android.os.PowerManager.WakeLock;
@@ -151,14 +153,16 @@ public class NotificationManagerModule extends KrollModule
 			int wakeFlags = TiConvert.toInt(
 				wakeParams.get("flags"),
 				(PowerManager.FULL_WAKE_LOCK | PowerManager.ACQUIRE_CAUSES_WAKEUP | PowerManager.ON_AFTER_RELEASE));
-			PowerManager pm = (PowerManager) TiApplication.getInstance().getSystemService(
-				TiApplication.getInstance().getApplicationContext().POWER_SERVICE);
-			if (pm != null && !pm.isScreenOn()) {
-				try {
-					WakeLock wl = pm.newWakeLock(wakeFlags, "TiWakeLock");
-					wl.acquire(wakeTime);
-				} catch (IllegalArgumentException e) {
-					Log.e(TAG, e.getMessage());
+			TiApplication app = TiApplication.getInstance();
+			if (app.checkCallingOrSelfPermission(Manifest.permission.WAKE_LOCK) == PackageManager.PERMISSION_GRANTED) {
+				PowerManager pm = (PowerManager) app.getSystemService(TiApplication.POWER_SERVICE);
+				if (pm != null && !pm.isScreenOn()) {
+					try {
+						WakeLock wl = pm.newWakeLock(wakeFlags, "TiWakeLock");
+						wl.acquire(wakeTime);
+					} catch (Exception e) {
+						Log.e(TAG, e.getMessage());
+					}
 				}
 			}
 		}


### PR DESCRIPTION
**JIRA:**
https://jira.appcelerator.org/browse/TIMOB-26253

**Summary:**
Now checks if manifest permission `android.permission.WAKE_LOCK` is defined before attempting to use a wake lock.

**Note:**
Currently, the notification wake lock feature cannot be disabled. You cannot `null` out the `wakeLock` dictionary. Nor will setting a time of zero disable it either. So, it always attempts to acquire a wake lock whether the app developer wants it or not. We may want to make a breaking change in Titanium 8.0.0 and change the default `wakeLock.time` setting from `3000` milliseconds to zero and modify the zero handling to disable the feature. This would be a breaking change, but allow app devs to opt-in to the feature instead. Alternatively, we can keep the feature as it is now and only attempt to use the wake lock feature if the permission is defined, otherwise it no-ops. 

**Test:**
1. Connect an Android device to your machine.
2. Turn the Android device's screen off.
3. Set up a Titanium project with the below "app.js" code. (Do not add the `WAKE_LOCK` permission yet.)
4. Build and run the app on the connected Android device.
5. After you hear the notification sound, turn on the Android screen.
6. Verify that the app did not crash on startup.
7. Add the `WAKE_LOCK` permission to your project's "tiapp.xml" file as shown below.
8. Turn off the Android device's screen.
9. Build and run the app on the connected Android device.
10. Verify that the Android device's screen automatically turns on when the notification sound goes off. (This proves that the wake lock feature works when given permission.)

---
app.js
```javascript
Ti.Android.NotificationManager.notify(123, Ti.Android.createNotification({
	contentTitle: "Titanium Notification",
	contentText: "Content Text",
	contentIntent: Ti.Android.createPendingIntent({
		intent: Ti.App.Android.launchIntent,
	}),
}));
```

---
tiapp.xml
```xml
<?xml version="1.0" encoding="UTF-8"?>
<ti:app xmlns:ti="http://ti.appcelerator.org">
	<android xmlns:android="http://schemas.android.com/apk/res/android">
		<manifest>
			<uses-permission android:name="android.permission.WAKE_LOCK"/>
		</manifest>
	</android>
</ti:app>
```
