### PR TITLE
[TIMOB-26371] Ensure buildAssetsDir exists before writing app props file

### DIFF
--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -5816,6 +5816,8 @@ iOSBuilder.prototype.copyResources = function copyResources(next) {
 			const contents = JSON.stringify(props);
 			if (!fs.existsSync(appPropsFile) || contents !== fs.readFileSync(appPropsFile).toString()) {
 				this.logger.debug(__('Writing %s', appPropsFile.cyan));
+
+				fs.existsSync(this.buildAssetsDir) || wrench.mkdirSyncRecursive(this.buildAssetsDir);
 				fs.writeFileSync(appPropsFile, contents);
 			} else {
 				this.logger.trace(__('No change, skipping %s', appPropsFile.cyan));

--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -5817,7 +5817,9 @@ iOSBuilder.prototype.copyResources = function copyResources(next) {
 			if (!fs.existsSync(appPropsFile) || contents !== fs.readFileSync(appPropsFile).toString()) {
 				this.logger.debug(__('Writing %s', appPropsFile.cyan));
 
-				fs.existsSync(this.buildAssetsDir) || wrench.mkdirSyncRecursive(this.buildAssetsDir);
+				if (this.encryptJS && !fs.existsSync(this.buildAssetsDir)) {
+					wrench.mkdirSyncRecursive(this.buildAssetsDir);
+				}
 				fs.writeFileSync(appPropsFile, contents);
 			} else {
 				this.logger.trace(__('No change, skipping %s', appPropsFile.cyan));


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-26371

Due to the parallelisation of this processes the assets dir doesn't already exist. Just make sure it exists before we write it.