### PR TITLE
[TIMOB-26382] Android: Modified "appc run" to dismiss screen-lock before running built app

### DIFF
--- a/android/cli/hooks/run.js
+++ b/android/cli/hooks/run.js
@@ -352,33 +352,53 @@ exports.init = function (logger, config, cli) {
 
 						(function startApp() {
 							logger.debug(__('Trying to start the app...'));
-							adb.startApp(device.id, builder.appid, builder.classname + 'Activity', function (err) { // eslint-disable-line no-unused-vars
-								if (watchingPid) {
-									return;
+							async.series([
+								function (next) {
+									// Power on the screen if currently off.
+									adb.shell(device.id, 'input keyevent KEYCODE_MENU', next);
+								},
+								function (next) {
+									// Remove the screen-lock and show the home screen.
+									adb.shell(device.id, 'input keyevent KEYCODE_MENU', next);
+								},
+								function (next) {
+									// If the screen-lock was never shown to begin with, then the above might show
+									// the home screen's page selection interface. Clear out of it with the home key.
+									adb.shell(device.id, 'input keyevent KEYCODE_HOME', next);
+								},
+								function (next) {
+									// Launch the app's main activity.
+									// Note: The above ensures that the activiy is onscreen. This is especially needed
+									//       for automated testing since some UI events won't happen while backgrounded.
+									adb.startApp(device.id, builder.appid, builder.classname + 'Activity', function (err) { // eslint-disable-line no-unused-vars
+										if (watchingPid) {
+											return;
+										}
+										watchingPid = true;
+
+										let done = false;
+										async.whilst(
+											function () { return !done; },
+											function (cb2) {
+												adb.getPid(device.id, builder.appid, function (err, pid) {
+													if (err || !pid) {
+														setTimeout(cb2, 250);
+													} else {
+														clearTimeout(intervalTimer);
+														clearTimeout(abortTimer);
+
+														logger.info(__('Application pid: %s', String(pid).cyan));
+														device.appPidRegExp = new RegExp('\\(\\s*' + pid + '\\):'); // eslint-disable-line security/detect-non-literal-regexp
+														done = true;
+														setTimeout(cb2, 0);
+													}
+												});
+											},
+											next
+										);
+									});
 								}
-								watchingPid = true;
-
-								let done = false;
-								async.whilst(
-									function () { return !done; },
-									function (cb2) {
-										adb.getPid(device.id, builder.appid, function (err, pid) {
-											if (err || !pid) {
-												setTimeout(cb2, 250);
-											} else {
-												clearTimeout(intervalTimer);
-												clearTimeout(abortTimer);
-
-												logger.info(__('Application pid: %s', String(pid).cyan));
-												device.appPidRegExp = new RegExp('\\(\\s*' + pid + '\\):'); // eslint-disable-line security/detect-non-literal-regexp
-												done = true;
-												setTimeout(cb2, 0);
-											}
-										});
-									},
-									cb
-								);
-							});
+							], cb);
 
 							intervalTimer = setTimeout(function () {
 								logger.debug(__('App still not started, trying again'));


### PR DESCRIPTION
**JIRA:**
https://jira.appcelerator.org/browse/TIMOB-26382

**Note 1:**
We partly needs this for our mocha test suite. We will have timeout failures for "postlayout" based tests if the Android emulator's screen is locked. An Android emulator's screen locking timer cannot be disabled. We can only increase its idle timer to 30 minutes (from default of 1 minute).

**Note 2:**
This change cannot dismiss the screen-lock if it requires authorization such as a passkey, swipe gesture, touch id, etc.

**Test:**
1. Turn the Android device's screen off. (But don't power off the device.)
2. Build and run an app to the same device.
3. Verify that screen is automatically turned on and the app is displayed onscreen.