### PR TITLE
[DOC] Mark Titanium.Android.Calendar as removed.

### DIFF
--- a/apidoc/Titanium/Android/Calendar/Alert.yml
+++ b/apidoc/Titanium/Android/Calendar/Alert.yml
@@ -5,7 +5,10 @@ extends: Titanium.Proxy
 since: "1.5"
 platforms: [android]
 createable: false
-deprecated: {since: "3.2.0"}
+deprecated:
+    since: "3.2.0"
+    removed: "6.0.0"
+    notes: Use <Titanium.Calendar> instead.
 
 properties:
   - name: alarmTime

--- a/apidoc/Titanium/Android/Calendar/Calendar.yml
+++ b/apidoc/Titanium/Android/Calendar/Calendar.yml
@@ -17,6 +17,7 @@ since: "1.5"
 createable: false
 deprecated: 
     since: "3.2.0"
+    removed: "6.0.0"
     notes: Use <Titanium.Calendar> instead.
 
 methods:

--- a/apidoc/Titanium/Android/Calendar/CalendarProxy.yml
+++ b/apidoc/Titanium/Android/Calendar/CalendarProxy.yml
@@ -5,7 +5,10 @@ extends: Titanium.Proxy
 platforms: [android]
 since: "1.5"
 createable: false
-deprecated: {since: "3.2.0"}
+deprecated:
+    since: "3.2.0"
+    removed: "6.0.0"
+    notes: Use <Titanium.Calendar> instead.
 
 methods:
   - name: createEvent

--- a/apidoc/Titanium/Android/Calendar/Event.yml
+++ b/apidoc/Titanium/Android/Calendar/Event.yml
@@ -11,7 +11,10 @@ extends: Titanium.Proxy
 platforms: [android]
 since: "1.5"
 createable: false
-deprecated: {since: "3.2.0"}
+deprecated:
+    since: "3.2.0"
+    removed: "6.0.0"
+    notes: Use <Titanium.Calendar> instead.
 
 methods:
   - name: createAlert

--- a/apidoc/Titanium/Android/Calendar/Reminder.yml
+++ b/apidoc/Titanium/Android/Calendar/Reminder.yml
@@ -12,7 +12,10 @@ extends: Titanium.Proxy
 platforms: [android]
 since: "1.5"
 createable: false
-deprecated: {since: "3.2.0"}
+deprecated:
+    since: "3.2.0"
+    removed: "6.0.0"
+    notes: Use <Titanium.Calendar> instead.
 
 properties:
   - name: id


### PR DESCRIPTION
**Description:**
I traced the removal of the deprecated Titanium.Android.Calendar namespace to here:
https://github.com/appcelerator/titanium_mobile/pull/8101
I allowed myself to mark all the files as removed since 6.0.0