### PR TITLE
[TIMOB-26411] API: Support async variants of Ti.IOStream methods

### DIFF
--- a/android/modules/network/src/java/ti/modules/titanium/network/socket/TCPProxy.java
+++ b/android/modules/network/src/java/ti/modules/titanium/network/socket/TCPProxy.java
@@ -18,7 +18,6 @@ import org.appcelerator.kroll.KrollProxy;
 import org.appcelerator.kroll.annotations.Kroll;
 import org.appcelerator.kroll.common.Log;
 import org.appcelerator.titanium.io.TiStream;
-import org.appcelerator.titanium.TiApplication;
 import org.appcelerator.titanium.util.TiConvert;
 import org.appcelerator.titanium.util.TiStreamHelper;
 
@@ -374,86 +373,26 @@ public class TCPProxy extends KrollProxy implements TiStream
 
 	// TiStream interface methods
 	@Kroll.method
-	public int read(Object args[]) throws IOException
+	//public void read(BufferProxy buffer)
+	//public void read(BufferProxy buffer, KrollFunction resultsCallback)
+	//public void read(BufferProxy buffer, int offset, int length)
+	//public void read(BufferProxy buffer, int offset, int length, KrollFunction resultsCallback)
+	public int read(Object args[]) throws Exception
 	{
 		if (!isConnected()) {
 			throw new IOException("Unable to read from socket, not connected");
 		}
 
-		BufferProxy bufferProxy = null;
-		int offset = 0;
-		int length = 0;
+		return TiStreamHelper.readTiStream(TAG, getKrollObject(), this, args);
+	}
 
-		if (args.length == 1 || args.length == 3) {
-			if (args.length > 0) {
-				if (args[0] instanceof BufferProxy) {
-					bufferProxy = (BufferProxy) args[0];
-					length = bufferProxy.getLength();
-
-				} else {
-					throw new IllegalArgumentException("Invalid buffer argument");
-				}
-			}
-
-			if (args.length == 3) {
-				if (args[1] instanceof Integer) {
-					offset = ((Integer) args[1]).intValue();
-
-				} else if (args[1] instanceof Double) {
-					offset = ((Double) args[1]).intValue();
-
-				} else {
-					throw new IllegalArgumentException("Invalid offset argument");
-				}
-
-				if (args[2] instanceof Integer) {
-					length = ((Integer) args[2]).intValue();
-
-				} else if (args[2] instanceof Double) {
-					length = ((Double) args[2]).intValue();
-
-				} else {
-					throw new IllegalArgumentException("Invalid length argument");
-				}
-			}
-
-		} else {
-			throw new IllegalArgumentException("Invalid number of arguments");
-		}
-
-		// Attempt to read from the socket.
-		final BufferProxy finalBufferProxy = bufferProxy;
-		final int finalOffset = offset;
-		final int finalLength = length;
-		final RunnableResult finalRunnableResult = new RunnableResult();
-		Runnable runnable = new Runnable() {
-			@Override
-			public void run()
-			{
-				try {
-					finalRunnableResult.streamedByteCount =
-						TiStreamHelper.read(clientSocket.getInputStream(), finalBufferProxy, finalOffset, finalLength);
-				} catch (Exception ex) {
-					finalRunnableResult.exception = ex;
-				}
-			}
-		};
-		if (TiApplication.isUIThread()) {
-			try {
-				Thread thread = new Thread(runnable);
-				thread.start();
-				thread.join();
-			} catch (Exception ex) {
-				finalRunnableResult.exception = ex;
-			}
-		} else {
-			runnable.run();
-		}
-
-		// If the above read failed, then update the socket state and throw an exception.
-		if (finalRunnableResult.exception != null) {
-			finalRunnableResult.exception.printStackTrace();
-			String message = finalRunnableResult.exception.getMessage();
+	public int readSync(Object bufferProxy, int offset, int length) throws IOException
+	{
+		try {
+			return TiStreamHelper.read(clientSocket.getInputStream(), (BufferProxy) bufferProxy, offset, length);
+		} catch (IOException e) {
+			e.printStackTrace();
+			String message = e.getMessage();
 			if (message == null) {
 				message = "Unknown Error";
 			}
@@ -463,92 +402,29 @@ public class TCPProxy extends KrollProxy implements TiStream
 			}
 			throw ex;
 		}
-
-		// The read was successful. Return the number of bytes read.
-		return finalRunnableResult.streamedByteCount;
 	}
 
 	@Kroll.method
-	public int write(Object args[]) throws IOException
+	//public void write(BufferProxy buffer)
+	//public void write(BufferProxy buffer, KrollFunction resultsCallback)
+	//public void write(BufferProxy buffer, int offset, int length)
+	//public void write(BufferProxy buffer, int offset, int length, KrollFunction resultsCallback)
+	public int write(Object args[]) throws Exception
 	{
 		if (!isConnected()) {
 			throw new IOException("Unable to write to socket, not connected");
 		}
 
-		BufferProxy bufferProxy = null;
-		int offset = 0;
-		int length = 0;
+		return TiStreamHelper.writeTiStream(TAG, getKrollObject(), this, args);
+	}
 
-		if (args.length == 1 || args.length == 3) {
-			if (args.length > 0) {
-				if (args[0] instanceof BufferProxy) {
-					bufferProxy = (BufferProxy) args[0];
-					length = bufferProxy.getLength();
-
-				} else {
-					throw new IllegalArgumentException("Invalid buffer argument");
-				}
-			}
-
-			if (args.length == 3) {
-				if (args[1] instanceof Integer) {
-					offset = ((Integer) args[1]).intValue();
-
-				} else if (args[1] instanceof Double) {
-					offset = ((Double) args[1]).intValue();
-
-				} else {
-					throw new IllegalArgumentException("Invalid offset argument");
-				}
-
-				if (args[2] instanceof Integer) {
-					length = ((Integer) args[2]).intValue();
-
-				} else if (args[2] instanceof Double) {
-					length = ((Double) args[2]).intValue();
-
-				} else {
-					throw new IllegalArgumentException("Invalid length argument");
-				}
-			}
-
-		} else {
-			throw new IllegalArgumentException("Invalid number of arguments");
-		}
-
-		// Write to the socket.
-		final BufferProxy finalBufferProxy = bufferProxy;
-		final int finalOffset = offset;
-		final int finalLength = length;
-		final RunnableResult finalRunnableResult = new RunnableResult();
-		Runnable runnable = new Runnable() {
-			@Override
-			public void run()
-			{
-				try {
-					finalRunnableResult.streamedByteCount = TiStreamHelper.write(
-						clientSocket.getOutputStream(), finalBufferProxy, finalOffset, finalLength);
-				} catch (Exception ex) {
-					finalRunnableResult.exception = ex;
-				}
-			}
-		};
-		if (TiApplication.isUIThread()) {
-			try {
-				Thread thread = new Thread(runnable);
-				thread.start();
-				thread.join();
-			} catch (Exception ex) {
-				finalRunnableResult.exception = ex;
-			}
-		} else {
-			runnable.run();
-		}
-
-		// If the above write failed, then update the socket state and throw an exception.
-		if (finalRunnableResult.exception != null) {
-			finalRunnableResult.exception.printStackTrace();
-			String message = finalRunnableResult.exception.getMessage();
+	public int writeSync(Object buffer, int offset, int length) throws IOException
+	{
+		try {
+			return TiStreamHelper.write(clientSocket.getOutputStream(), (BufferProxy) buffer, offset, length);
+		} catch (IOException e) {
+			e.printStackTrace();
+			String message = e.getMessage();
 			if (message == null) {
 				message = "Unknown Error";
 			}
@@ -556,9 +432,6 @@ public class TCPProxy extends KrollProxy implements TiStream
 			updateState(SocketModule.ERROR, "error", buildErrorCallbackArgs(ex.getMessage(), 0));
 			throw ex;
 		}
-
-		// The write was successful. Return the number of bytes written.
-		return finalRunnableResult.streamedByteCount;
 	}
 
 	@Kroll.method
@@ -600,15 +473,5 @@ public class TCPProxy extends KrollProxy implements TiStream
 	public String getApiName()
 	{
 		return "Ti.Network.Socket.TCP";
-	}
-
-	/** Private class used to capture async results of the "TCPProxy" read() and write() methods. */
-	private static class RunnableResult
-	{
-		/** The number of bytes read/written to/from the socket if successful. */
-		int streamedByteCount;
-
-		/** Provides the exception error that occurred if failed. Set to null if read/write was successful. */
-		Exception exception;
 	}
 }

--- a/android/titanium/src/java/org/appcelerator/titanium/io/TiStream.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/io/TiStream.java
@@ -1,6 +1,6 @@
 /**
  * Appcelerator Titanium Mobile
- * Copyright (c) 2010 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2010-2018 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
@@ -18,18 +18,38 @@ public interface TiStream {
 	 * Refer to <a href="https://wiki.appcelerator.org/display/guides/Stream+Spec">Stream Spec</a> for more details.
 	 * @param args  arguments passed in. Must match the arguments listed in the <a href="https://wiki.appcelerator.org/display/guides/Stream+Spec">Stream Spec</a>.
 	 * @return number of bytes read, -1 if no data is available.
-	 * @throws IOException on error.
+	 * @throws Exception on error.
 	 */
-	int read(Object args[]) throws IOException;
+	int read(Object args[]) throws Exception;
+
+	/**
+	 * [readSync description]
+	 * @param  bufferProxy Expected to be a BufferProxy, but due to dependency cycle declared as Object
+	 * @param  offset      [description]
+	 * @param  length      [description]
+	 * @return             [description]
+	 * @throws IOException [description]
+	 */
+	int readSync(Object bufferProxy, int offset, int length) throws IOException;
 
 	/**
 	 * Implementing classes should use this method to write data from a buffer to this stream.
 	 * Refer to <a href="https://wiki.appcelerator.org/display/guides/Stream+Spec">Stream Spec</a> for more details.
 	 * @param args arguments passed in. Must match the arguments listed in the <a href="https://wiki.appcelerator.org/display/guides/Stream+Spec">Stream Spec</a>.
 	 * @return number of bytes written, -1 if no data is available.
-	 * @throws IOException on error.
+	 * @throws Exception on error.
 	 */
-	int write(Object args[]) throws IOException;
+	int write(Object args[]) throws Exception;
+
+	/**
+	 * [writeSync description]
+	 * @param  bufferProxy Expected to be a BufferProxy, but due to dependency cycle declared as Object
+	 * @param  offset      [description]
+	 * @param  length      [description]
+	 * @return             [description]
+	 * @throws IOException [description]
+	 */
+	int writeSync(Object bufferProxy, int offset, int length) throws IOException;
 
 	/**
 	 * @return true if the stream is writable, false otherwise.

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiStreamHelper.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiStreamHelper.java
@@ -1,6 +1,6 @@
 /**
  * Appcelerator Titanium Mobile
- * Copyright (c) 2009-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2009-2018 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
@@ -11,10 +11,214 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
+import org.appcelerator.kroll.KrollDict;
+import org.appcelerator.kroll.KrollFunction;
+import org.appcelerator.kroll.KrollObject;
+import org.appcelerator.kroll.common.Log;
+import org.appcelerator.titanium.TiApplication;
+import org.appcelerator.titanium.io.TiStream;
+
 import ti.modules.titanium.BufferProxy;
 
 public class TiStreamHelper
 {
+
+	/**
+	 * Common code for handling JS calls for #read() on a Ti.IOStream.
+	 * @param  TAG         logging tag
+	 * @param  krollObject kroll object for the stream proxy
+	 * @param  tiStream    the instance of the stream
+	 * @param  args        the arguments passed from JS
+	 * @return             bytes read (if sync call), otherwise 0
+	 */
+	public static int readTiStream(final String TAG, final KrollObject krollObject, final TiStream tiStream,
+								   Object[] args) throws Exception
+	{
+		// first throw out any obviously bad calls
+		if (args.length == 0 || args.length > 4) {
+			throw new IllegalArgumentException("Invalid number of arguments");
+		}
+
+		// Allow a final callback argument. If not present, spit out deprecation notice and state that usage with main thread will block/crash
+		Object lastArg = args[args.length - 1];
+		KrollFunction callback = null;
+		if (!(lastArg instanceof KrollFunction)) {
+			// must have buffer arg OR buffer, offset and length
+			if (args.length != 1 && args.length != 3) {
+				throw new IllegalArgumentException("Invalid number of arguments");
+			}
+		} else {
+			callback = (KrollFunction) lastArg;
+			// must have buffer and callback OR buffer, offset, length and callback
+			if (args.length != 2 && args.length != 4) {
+				throw new IllegalArgumentException("Invalid number of arguments");
+			}
+		}
+
+		// buffer is always first arg
+		if (!(args[0] instanceof BufferProxy)) {
+			throw new IllegalArgumentException("Invalid buffer argument");
+		}
+		BufferProxy bufferProxy = (BufferProxy) args[0];
+		int length = bufferProxy.getLength();
+		int offset = 0;
+
+		// if we have at least 3 args (remember we check invalid arg counts taking callback into account above)
+		if (args.length >= 3) {
+			if (!(args[1] instanceof Number)) {
+				throw new IllegalArgumentException("Invalid offset argument");
+			}
+			offset = ((Number) args[1]).intValue();
+
+			if (!(args[2] instanceof Number)) {
+				throw new IllegalArgumentException("Invalid length argument");
+			}
+			length = ((Number) args[2]).intValue();
+		}
+
+		// If we have a callback, fire the read to happen async and return 0
+		if (callback != null) {
+			TiStreamHelper.readAsync(krollObject, tiStream, bufferProxy, offset, length, callback);
+			return 0;
+		}
+
+		Log.w(
+			TAG,
+			"Synchronous invocation of read will cause performance issues under the main thread. This will no longer be supported in SDK 9.0.0. Please invoke with a final callback function to receive the result.");
+		final BufferProxy finalBufferProxy = bufferProxy;
+		final int finalOffset = offset;
+		final int finalLength = length;
+		final RunnableResult finalRunnableResult = new RunnableResult();
+		Runnable runnable = new Runnable() {
+			@Override
+			public void run()
+			{
+				try {
+					finalRunnableResult.streamedByteCount =
+						tiStream.readSync(finalBufferProxy, finalOffset, finalLength);
+				} catch (Exception ex) {
+					finalRunnableResult.exception = ex;
+				}
+			}
+		};
+		if (TiApplication.isUIThread()) {
+			try {
+				Thread thread = new Thread(runnable);
+				thread.start();
+				thread.join();
+			} catch (Exception ex) {
+				finalRunnableResult.exception = ex;
+			}
+		} else {
+			runnable.run();
+		}
+		// If the above read failed, then throw an exception.
+		if (finalRunnableResult.exception != null) {
+			throw finalRunnableResult.exception;
+		}
+
+		// The read was successful. Return the number of bytes read.
+		return finalRunnableResult.streamedByteCount;
+	}
+
+	/**
+	 * Common code for handling JS calls for #write() on a Ti.IOStream.
+	 * @param  TAG         logging tag
+	 * @param  krollObject kroll object for the stream proxy
+	 * @param  tiStream    the instance of the stream
+	 * @param  args        the arguments passed from JS
+	 * @return             bytes read (if sync call), otherwise 0
+	 */
+	public static int writeTiStream(final String TAG, final KrollObject krollObject, final TiStream tiStream,
+									Object[] args) throws Exception
+	{
+		// first throw out any obviously bad calls
+		if (args.length == 0 || args.length > 4) {
+			throw new IllegalArgumentException("Invalid number of arguments");
+		}
+
+		// Allow a final callback argument. If not present, spit out deprecation notice and state that usage with main thread will block/crash?
+		Object lastArg = args[args.length - 1];
+		KrollFunction callback = null;
+		if (!(lastArg instanceof KrollFunction)) {
+			// must have buffer arg OR buffer, offset and length args
+			if (args.length != 1 && args.length != 3) {
+				throw new IllegalArgumentException("Invalid number of arguments");
+			}
+		} else {
+			callback = (KrollFunction) lastArg;
+			// must have buffer and callback args OR buffer, offset, length and callback args
+			if (args.length != 2 && args.length != 4) {
+				throw new IllegalArgumentException("Invalid number of arguments");
+			}
+		}
+
+		// buffer is always first arg
+		if (!(args[0] instanceof BufferProxy)) {
+			throw new IllegalArgumentException("Invalid buffer argument");
+		}
+		BufferProxy bufferProxy = (BufferProxy) args[0];
+
+		int offset = 0;
+		int length = bufferProxy.getLength();
+
+		// if we have at least 3 args (remember we check invalid arg counts taking callback into account above)
+		if (args.length >= 3) {
+			if (!(args[1] instanceof Number)) {
+				throw new IllegalArgumentException("Invalid offset argument");
+			}
+			offset = ((Number) args[1]).intValue();
+
+			if (!(args[2] instanceof Number)) {
+				throw new IllegalArgumentException("Invalid length argument");
+			}
+			length = ((Number) args[2]).intValue();
+		}
+
+		// If we have a callback, fire the write to happen async and return 0
+		if (callback != null) {
+			TiStreamHelper.writeAsync(krollObject, tiStream, bufferProxy, offset, length, callback);
+			return 0;
+		}
+
+		Log.w(
+			TAG,
+			"Synchronous invocation of write will cause performance issues under the main thread. This will no longer be supported in SDK 9.0.0. Please invoke with a final callback function to receive the result.");
+		final BufferProxy finalBufferProxy = bufferProxy;
+		final int finalOffset = offset;
+		final int finalLength = length;
+		final RunnableResult finalRunnableResult = new RunnableResult();
+		Runnable runnable = new Runnable() {
+			@Override
+			public void run()
+			{
+				try {
+					finalRunnableResult.streamedByteCount =
+						tiStream.writeSync(finalBufferProxy, finalOffset, finalLength);
+				} catch (Exception ex) {
+					finalRunnableResult.exception = ex;
+				}
+			}
+		};
+		if (TiApplication.isUIThread()) {
+			try {
+				Thread thread = new Thread(runnable);
+				thread.start();
+				thread.join();
+			} catch (Exception ex) {
+				finalRunnableResult.exception = ex;
+			}
+		} else {
+			runnable.run();
+		}
+		// If the above read failed, then throw an exception.
+		if (finalRunnableResult.exception != null) {
+			throw finalRunnableResult.exception;
+		}
+
+		// The read was successful. Return the number of bytes written.
+		return finalRunnableResult.streamedByteCount;
+	}
 
 	public static int read(InputStream inputStream, BufferProxy bufferProxy, int offset, int length) throws IOException
 	{
@@ -25,6 +229,32 @@ public class TiStreamHelper
 		}
 
 		return inputStream.read(buffer, offset, length);
+	}
+
+	public static void readAsync(final KrollObject krollObject, final TiStream sourceStream, final BufferProxy buffer,
+								 final int offset, final int length, final KrollFunction resultsCallback)
+	{
+		new Thread(new Runnable() {
+			public void run()
+			{
+				int bytesRead = -1;
+				int errorState = 0;
+				String errorDescription = "";
+
+				try {
+					bytesRead = sourceStream.readSync(buffer, offset, length);
+
+				} catch (IOException e) {
+					e.printStackTrace();
+					errorState = 1;
+					errorDescription = e.getMessage();
+				}
+
+				resultsCallback.callAsync(krollObject,
+										  buildRWCallbackArgs(sourceStream, bytesRead, errorState, errorDescription));
+			}
+		})
+			.start();
 	}
 
 	public static int write(OutputStream outputStream, BufferProxy bufferProxy, int offset, int length)
@@ -40,5 +270,54 @@ public class TiStreamHelper
 		outputStream.flush();
 
 		return length;
+	}
+
+	public static void writeAsync(final KrollObject krollObject, final TiStream outputStream, final BufferProxy buffer,
+								  final int offset, final int length, final KrollFunction resultsCallback)
+	{
+		new Thread(new Runnable() {
+			public void run()
+			{
+				int bytesWritten = -1;
+				int errorState = 0;
+				String errorDescription = "";
+
+				try {
+					bytesWritten = outputStream.writeSync(buffer, offset, length);
+
+				} catch (IOException e) {
+					e.printStackTrace();
+					errorState = 1;
+					errorDescription = e.getMessage();
+				}
+
+				resultsCallback.callAsync(
+					krollObject, buildRWCallbackArgs(outputStream, bytesWritten, errorState, errorDescription));
+			}
+		})
+			.start();
+	}
+
+	public static KrollDict buildRWCallbackArgs(TiStream sourceStream, int bytesProcessed, int errorState,
+												String errorDescription)
+	{
+		KrollDict callbackArgs = new KrollDict();
+		callbackArgs.put("source", sourceStream);
+		callbackArgs.put("bytesProcessed", bytesProcessed);
+		callbackArgs.put("errorState", errorState);
+		callbackArgs.put("errorDescription", errorDescription);
+		callbackArgs.putCodeAndMessage(errorState, errorDescription);
+
+		return callbackArgs;
+	}
+
+	/** Private class used to capture async results of the "TCPProxy" read() and write() methods. */
+	private static class RunnableResult
+	{
+		/** The number of bytes read/written to/from the socket if successful. */
+		int streamedByteCount;
+
+		/** Provides the exception error that occurred if failed. Set to null if read/write was successful. */
+		Exception exception;
 	}
 }

--- a/android/titanium/src/java/ti/modules/titanium/stream/BufferStreamProxy.java
+++ b/android/titanium/src/java/ti/modules/titanium/stream/BufferStreamProxy.java
@@ -49,7 +49,7 @@ public class BufferStreamProxy extends KrollProxy implements TiStream
 
 	// TiStream interface methods
 	@Kroll.method
-	public int read(Object args[]) throws IOException
+	public int read(Object args[]) throws Exception
 	{
 		if (!isOpen) {
 			throw new IOException("Unable to read from buffer, not open");
@@ -59,56 +59,20 @@ public class BufferStreamProxy extends KrollProxy implements TiStream
 			throw new IOException("Unable to read on a stream, not opened in read mode");
 		}
 
-		BufferProxy bufferProxy = null;
-		int offset = 0;
-		int length = 0;
+		return TiStreamHelper.readTiStream(TAG, getKrollObject(), this, args);
+	}
 
-		if (args.length == 1 || args.length == 3) {
-			if (args.length > 0) {
-				if (args[0] instanceof BufferProxy) {
-					bufferProxy = (BufferProxy) args[0];
-					length = bufferProxy.getLength();
-
-				} else {
-					throw new IllegalArgumentException("Invalid buffer argument");
-				}
-			}
-
-			if (args.length == 3) {
-				if (args[1] instanceof Integer) {
-					offset = ((Integer) args[1]).intValue();
-
-				} else if (args[1] instanceof Double) {
-					offset = ((Double) args[1]).intValue();
-
-				} else {
-					throw new IllegalArgumentException("Invalid offset argument");
-				}
-
-				if (args[2] instanceof Integer) {
-					length = ((Integer) args[2]).intValue();
-
-				} else if (args[2] instanceof Double) {
-					length = ((Double) args[2]).intValue();
-
-				} else {
-					throw new IllegalArgumentException("Invalid length argument");
-				}
-			}
-
-		} else {
-			throw new IllegalArgumentException("Invalid number of arguments");
-		}
-
+	public int readSync(Object bufferProxy, int offset, int length) throws IOException
+	{
 		ByteArrayInputStream bufferInputStream =
-			new ByteArrayInputStream(buffer.getBuffer(), position, (buffer.getLength() - position));
+			new ByteArrayInputStream(this.buffer.getBuffer(), this.position, (this.buffer.getLength() - this.position));
 		int bytesRead;
 
 		try {
-			bytesRead = TiStreamHelper.read(bufferInputStream, bufferProxy, offset, length);
+			bytesRead = TiStreamHelper.read(bufferInputStream, (BufferProxy) bufferProxy, offset, length);
 
 			if (bytesRead > -1) {
-				position += bytesRead;
+				this.position += bytesRead;
 			}
 
 			return bytesRead;
@@ -120,7 +84,11 @@ public class BufferStreamProxy extends KrollProxy implements TiStream
 	}
 
 	@Kroll.method
-	public int write(Object args[]) throws IOException
+	//public void write(BufferProxy buffer)
+	//public void write(BufferProxy buffer, KrollFunction resultsCallback)
+	//public void write(BufferProxy buffer, int offset, int length)
+	//public void write(BufferProxy buffer, int offset, int length, KrollFunction resultsCallback)
+	public int write(Object args[]) throws Exception
 	{
 		if (!isOpen) {
 			throw new IOException("Unable to write to buffer, not open");
@@ -130,48 +98,12 @@ public class BufferStreamProxy extends KrollProxy implements TiStream
 			throw new IOException("Unable to write on stream, not opened in read or append mode");
 		}
 
-		BufferProxy bufferProxy = null;
-		int offset = 0;
-		int length = 0;
+		return TiStreamHelper.writeTiStream(TAG, getKrollObject(), this, args);
+	}
 
-		if (args.length == 1 || args.length == 3) {
-			if (args.length > 0) {
-				if (args[0] instanceof BufferProxy) {
-					bufferProxy = (BufferProxy) args[0];
-					length = bufferProxy.getLength();
-
-				} else {
-					throw new IllegalArgumentException("Invalid buffer argument");
-				}
-			}
-
-			if (args.length == 3) {
-				if (args[1] instanceof Integer) {
-					offset = ((Integer) args[1]).intValue();
-
-				} else if (args[1] instanceof Double) {
-					offset = ((Double) args[1]).intValue();
-
-				} else {
-					throw new IllegalArgumentException("Invalid offset argument");
-				}
-
-				if (args[2] instanceof Integer) {
-					length = ((Integer) args[2]).intValue();
-
-				} else if (args[2] instanceof Double) {
-					length = ((Double) args[2]).intValue();
-
-				} else {
-					throw new IllegalArgumentException("Invalid length argument");
-				}
-			}
-
-		} else {
-			throw new IllegalArgumentException("Invalid number of arguments");
-		}
-
-		int bytesWritten = buffer.write(position, bufferProxy.getBuffer(), offset, length);
+	public int writeSync(Object bufferProxy, int offset, int length) throws IOException
+	{
+		int bytesWritten = buffer.write(position, ((BufferProxy) bufferProxy).getBuffer(), offset, length);
 		position += bytesWritten;
 
 		return bytesWritten;

--- a/android/titanium/src/java/ti/modules/titanium/stream/FileStreamProxy.java
+++ b/android/titanium/src/java/ti/modules/titanium/stream/FileStreamProxy.java
@@ -33,56 +33,20 @@ public class FileStreamProxy extends KrollProxy implements TiStream
 
 	// TiStream interface methods
 	@Kroll.method
-	public int read(Object args[]) throws IOException
+	public int read(Object args[]) throws Exception
 	{
 		if (!isOpen) {
 			throw new IOException("Unable to read from file, not open");
 		}
 
-		BufferProxy bufferProxy = null;
-		int offset = 0;
-		int length = 0;
+		return TiStreamHelper.readTiStream(TAG, getKrollObject(), this, args);
+	}
 
-		if (args.length == 1 || args.length == 3) {
-			if (args.length > 0) {
-				if (args[0] instanceof BufferProxy) {
-					bufferProxy = (BufferProxy) args[0];
-					length = bufferProxy.getLength();
-
-				} else {
-					throw new IllegalArgumentException("Invalid buffer argument");
-				}
-			}
-
-			if (args.length == 3) {
-				if (args[1] instanceof Integer) {
-					offset = ((Integer) args[1]).intValue();
-
-				} else if (args[1] instanceof Double) {
-					offset = ((Double) args[1]).intValue();
-
-				} else {
-					throw new IllegalArgumentException("Invalid offset argument");
-				}
-
-				if (args[2] instanceof Integer) {
-					length = ((Integer) args[2]).intValue();
-
-				} else if (args[2] instanceof Double) {
-					length = ((Double) args[2]).intValue();
-
-				} else {
-					throw new IllegalArgumentException("Invalid length argument");
-				}
-			}
-
-		} else {
-			throw new IllegalArgumentException("Invalid number of arguments");
-		}
-
+	public int readSync(Object bufferProxy, int offset, int length) throws IOException
+	{
 		try {
-			return TiStreamHelper.read(fileProxy.getBaseFile().getExistingInputStream(), bufferProxy, offset, length);
-
+			return TiStreamHelper.read(this.fileProxy.getBaseFile().getExistingInputStream(), (BufferProxy) bufferProxy,
+									   offset, length);
 		} catch (IOException e) {
 			Log.e(TAG, "Unable to read from file, IO error", e);
 			throw new IOException("Unable to read from file, IO error");
@@ -90,56 +54,20 @@ public class FileStreamProxy extends KrollProxy implements TiStream
 	}
 
 	@Kroll.method
-	public int write(Object args[]) throws IOException
+	public int write(Object args[]) throws Exception
 	{
 		if (!isOpen) {
 			throw new IOException("Unable to write to file, not open");
 		}
 
-		BufferProxy bufferProxy = null;
-		int offset = 0;
-		int length = 0;
+		return TiStreamHelper.writeTiStream(TAG, getKrollObject(), this, args);
+	}
 
-		if (args.length == 1 || args.length == 3) {
-			if (args.length > 0) {
-				if (args[0] instanceof BufferProxy) {
-					bufferProxy = (BufferProxy) args[0];
-					length = bufferProxy.getLength();
-
-				} else {
-					throw new IllegalArgumentException("Invalid buffer argument");
-				}
-			}
-
-			if (args.length == 3) {
-				if (args[1] instanceof Integer) {
-					offset = ((Integer) args[1]).intValue();
-
-				} else if (args[1] instanceof Double) {
-					offset = ((Double) args[1]).intValue();
-
-				} else {
-					throw new IllegalArgumentException("Invalid offset argument");
-				}
-
-				if (args[2] instanceof Integer) {
-					length = ((Integer) args[2]).intValue();
-
-				} else if (args[2] instanceof Double) {
-					length = ((Double) args[2]).intValue();
-
-				} else {
-					throw new IllegalArgumentException("Invalid length argument");
-				}
-			}
-
-		} else {
-			throw new IllegalArgumentException("Invalid number of arguments");
-		}
-
+	public int writeSync(Object bufferProxy, int offset, int length) throws IOException
+	{
 		try {
-			return TiStreamHelper.write(fileProxy.getBaseFile().getExistingOutputStream(), bufferProxy, offset, length);
-
+			return TiStreamHelper.write(this.fileProxy.getBaseFile().getExistingOutputStream(),
+										(BufferProxy) bufferProxy, offset, length);
 		} catch (IOException e) {
 			Log.e(TAG, "Unable to write to file, IO error", e);
 			throw new IOException("Unable to write to file, IO error");

--- a/android/titanium/src/java/ti/modules/titanium/stream/StreamModule.java
+++ b/android/titanium/src/java/ti/modules/titanium/stream/StreamModule.java
@@ -11,9 +11,11 @@ import java.io.IOException;
 import org.appcelerator.kroll.KrollDict;
 import org.appcelerator.kroll.KrollFunction;
 import org.appcelerator.kroll.KrollModule;
+import org.appcelerator.kroll.KrollObject;
 import org.appcelerator.kroll.annotations.Kroll;
 import org.appcelerator.titanium.TiBlob;
 import org.appcelerator.titanium.io.TiStream;
+import org.appcelerator.titanium.util.TiStreamHelper;
 
 import ti.modules.titanium.BufferProxy;
 import ti.modules.titanium.TitaniumModule;
@@ -21,6 +23,8 @@ import ti.modules.titanium.TitaniumModule;
 @Kroll.module(parentModule = TitaniumModule.class)
 public class StreamModule extends KrollModule
 {
+	private static final String TAG = "Stream";
+
 	@Kroll.constant
 	public static final int MODE_READ = 0;
 	@Kroll.constant
@@ -58,92 +62,21 @@ public class StreamModule extends KrollModule
 	@Kroll.method
 	//public void read(TiStream sourceStream, BufferProxy buffer, KrollFunction resultsCallback)
 	//public void read(TiStream sourceStream, BufferProxy buffer, int offset, int length, KrollFunction resultsCallback)
-	public void read(Object args[])
+	public void read(Object args[]) throws Exception
 	{
-		TiStream sourceStream = null;
-		BufferProxy buffer = null;
-		int offset = 0;
-		int length = 0;
-		KrollFunction resultsCallback = null;
-
-		if (args.length == 3 || args.length == 5) {
-			if (args[0] instanceof TiStream) {
-				sourceStream = (TiStream) args[0];
-
-			} else {
-				throw new IllegalArgumentException("Invalid stream argument");
-			}
-
-			if (args[1] instanceof BufferProxy) {
-				buffer = (BufferProxy) args[1];
-				length = buffer.getLength();
-
-			} else {
-				throw new IllegalArgumentException("Invalid buffer argument");
-			}
-
-			if (args.length == 3) {
-				if (args[2] instanceof KrollFunction) {
-					resultsCallback = (KrollFunction) args[2];
-
-				} else {
-					throw new IllegalArgumentException("Invalid callback argument");
-				}
-
-			} else if (args.length == 5) {
-				if (args[2] instanceof Number) {
-					offset = ((Number) args[2]).intValue();
-
-				} else {
-					throw new IllegalArgumentException("Invalid offset argument");
-				}
-
-				if (args[3] instanceof Number) {
-					length = ((Number) args[3]).intValue();
-
-				} else {
-					throw new IllegalArgumentException("Invalid length argument");
-				}
-
-				if (args[4] instanceof KrollFunction) {
-					resultsCallback = (KrollFunction) args[4];
-
-				} else {
-					throw new IllegalArgumentException("Invalid callback argument");
-				}
-			}
-
-		} else {
+		if (args.length == 0) {
 			throw new IllegalArgumentException("Invalid number of arguments");
 		}
 
-		final TiStream fsourceStream = sourceStream;
-		final BufferProxy fbuffer = buffer;
-		final int foffset = offset;
-		final int flength = length;
-		final KrollFunction fResultsCallback = resultsCallback;
+		if (!(args[0] instanceof TiStream)) {
+			throw new IllegalArgumentException("Invalid stream argument");
+		}
 
-		new Thread(new Runnable() {
-			public void run()
-			{
-				int bytesRead = -1;
-				int errorState = 0;
-				String errorDescription = "";
-
-				try {
-					bytesRead = fsourceStream.read(new Object[] { fbuffer, foffset, flength });
-
-				} catch (IOException e) {
-					e.printStackTrace();
-					errorState = 1;
-					errorDescription = e.getMessage();
-				}
-
-				fResultsCallback.callAsync(getKrollObject(),
-										   buildRWCallbackArgs(fsourceStream, bytesRead, errorState, errorDescription));
-			}
-		})
-			.start();
+		// delegate to TiStream now that it supports async calls
+		TiStream sourceStream = (TiStream) args[0];
+		Object[] newArgs = new Object[args.length - 1];
+		System.arraycopy(args, 1, newArgs, 0, args.length - 1);
+		sourceStream.read(newArgs);
 	}
 
 	@Kroll.method
@@ -151,86 +84,83 @@ public class StreamModule extends KrollModule
 	//public void readAll(final TiStream sourceStream, final BufferProxy buffer, final KrollFunction resultsCallback)
 	public Object readAll(Object args[]) throws IOException
 	{
-		TiStream sourceStream = null;
-		BufferProxy bufferArg = null;
-		KrollFunction resultsCallback = null;
-
-		if (args.length == 1 || args.length == 3) {
-			if (args[0] instanceof TiStream) {
-				sourceStream = (TiStream) args[0];
-
-			} else {
-				throw new IllegalArgumentException("Invalid stream argument");
-			}
-
-			if (args.length == 3) {
-				if (args[1] instanceof BufferProxy) {
-					bufferArg = (BufferProxy) args[1];
-
-				} else {
-					throw new IllegalArgumentException("Invalid buffer argument");
-				}
-
-				if (args[2] instanceof KrollFunction) {
-					resultsCallback = (KrollFunction) args[2];
-
-				} else {
-					throw new IllegalArgumentException("Invalid callback argument");
-				}
-			}
-
-		} else {
+		if (args.length != 1 && args.length != 3) {
 			throw new IllegalArgumentException("Invalid number of arguments");
 		}
 
-		if (args.length == 1) {
-			BufferProxy buffer = new BufferProxy(1024);
-			int offset = 0;
-
-			readAll(sourceStream, buffer, offset);
-
-			return buffer;
-
-		} else {
-			final TiStream fsourceStream = sourceStream;
-			final BufferProxy fbuffer = bufferArg;
-			final KrollFunction fResultsCallback = resultsCallback;
-
-			new Thread(new Runnable() {
-				public void run()
-				{
-					int offset = 0;
-					int errorState = 0;
-					String errorDescription = "";
-
-					if (fbuffer.getLength() < 1024) {
-						fbuffer.resize(1024);
-					}
-
-					try {
-						readAll(fsourceStream, fbuffer, offset);
-
-					} catch (IOException e) {
-						errorState = 1;
-						errorDescription = e.getMessage();
-					}
-
-					fResultsCallback.callAsync(getKrollObject(), buildRWCallbackArgs(fsourceStream, fbuffer.getLength(),
-																					 errorState, errorDescription));
-				}
-			})
-				.start();
-
-			return null; // TODO KrollProxy.UNDEFINED;
+		if (!(args[0] instanceof TiStream)) {
+			throw new IllegalArgumentException("Invalid stream argument");
 		}
+
+		TiStream sourceStream = (TiStream) args[0];
+
+		// when single arg, handle sync
+		if (args.length == 1) {
+			// Spit out deprecation notice about sync call!
+			// And throw exception when on main thread!
+			// final String syncIsANoNo = "Synchronous invocation of readAll will crash under the main thread. This will no longer be supported in SDK 8.0.0. Please invoke with a final callback function to receive the result.";
+			// if (TiApplication.isUIThread()) {
+			// 	throw new IOException(syncIsANoNo);
+			// } else {
+			// 	Log.w(TAG, syncIsANoNo);
+			// }
+			// FIXME: Don't we need to apply the same thread model here as we did in TIStreamHelper?
+			BufferProxy buffer = new BufferProxy(1024);
+			readAllSync(sourceStream, buffer, 0);
+			return buffer;
+		}
+
+		// When 3 args, handle async
+		// buffer arg
+		if (!(args[1] instanceof BufferProxy)) {
+			throw new IllegalArgumentException("Invalid buffer argument");
+		}
+		BufferProxy bufferArg = (BufferProxy) args[1];
+
+		// callback arg
+		if (!(args[2] instanceof KrollFunction)) {
+			throw new IllegalArgumentException("Invalid callback argument");
+		}
+		KrollFunction resultsCallback = (KrollFunction) args[2];
+
+		final TiStream fsourceStream = sourceStream;
+		final BufferProxy fbuffer = bufferArg;
+		final KrollFunction fResultsCallback = resultsCallback;
+		new Thread(new Runnable() {
+			public void run()
+			{
+				int offset = 0;
+				int errorState = 0;
+				String errorDescription = "";
+
+				if (fbuffer.getLength() < 1024) {
+					fbuffer.resize(1024);
+				}
+
+				try {
+					readAllSync(fsourceStream, fbuffer, offset);
+
+				} catch (IOException e) {
+					errorState = 1;
+					errorDescription = e.getMessage();
+				}
+
+				fResultsCallback.callAsync(getKrollObject(),
+										   TiStreamHelper.buildRWCallbackArgs(fsourceStream, fbuffer.getLength(),
+																			  errorState, errorDescription));
+			}
+		})
+			.start();
+
+		return null; // TODO KrollProxy.UNDEFINED;
 	}
 
-	private void readAll(TiStream sourceStream, BufferProxy buffer, int offset) throws IOException
+	private void readAllSync(TiStream sourceStream, BufferProxy buffer, int offset) throws IOException
 	{
 		int totalBytesRead = 0;
 
 		while (true) {
-			int bytesRead = sourceStream.read(new Object[] { buffer, offset, 1024 });
+			int bytesRead = sourceStream.readSync(buffer, offset, 1024);
 			if (bytesRead == -1) {
 				break;
 			}
@@ -246,92 +176,21 @@ public class StreamModule extends KrollModule
 	@Kroll.method
 	//public void write(TiStream outputStream, BufferProxy buffer, KrollFunction resultsCallback)
 	//public void write(TiStream outputStream, BufferProxy buffer, int offset, int length, KrollFunction resultsCallback)
-	public void write(Object args[])
+	public void write(Object args[]) throws Exception
 	{
-		TiStream outputStream = null;
-		BufferProxy buffer = null;
-		int offset = 0;
-		int length = 0;
-		KrollFunction resultsCallback = null;
-
-		if (args.length == 3 || args.length == 5) {
-			if (args[0] instanceof TiStream) {
-				outputStream = (TiStream) args[0];
-
-			} else {
-				throw new IllegalArgumentException("Invalid stream argument");
-			}
-
-			if (args[1] instanceof BufferProxy) {
-				buffer = (BufferProxy) args[1];
-				length = buffer.getLength();
-
-			} else {
-				throw new IllegalArgumentException("Invalid buffer argument");
-			}
-
-			if (args.length == 3) {
-				if (args[2] instanceof KrollFunction) {
-					resultsCallback = (KrollFunction) args[2];
-
-				} else {
-					throw new IllegalArgumentException("Invalid callback argument");
-				}
-
-			} else if (args.length == 5) {
-				if (args[2] instanceof Number) {
-					offset = ((Number) args[2]).intValue();
-
-				} else {
-					throw new IllegalArgumentException("Invalid offset argument");
-				}
-
-				if (args[3] instanceof Number) {
-					length = ((Number) args[3]).intValue();
-
-				} else {
-					throw new IllegalArgumentException("Invalid length argument");
-				}
-
-				if (args[4] instanceof KrollFunction) {
-					resultsCallback = (KrollFunction) args[4];
-
-				} else {
-					throw new IllegalArgumentException("Invalid callback argument");
-				}
-			}
-
-		} else {
+		if (args.length == 0) {
 			throw new IllegalArgumentException("Invalid number of arguments");
 		}
 
-		final TiStream foutputStream = outputStream;
-		final BufferProxy fbuffer = buffer;
-		final int foffset = offset;
-		final int flength = length;
-		final KrollFunction fResultsCallback = resultsCallback;
+		if (!(args[0] instanceof TiStream)) {
+			throw new IllegalArgumentException("Invalid stream argument");
+		}
 
-		new Thread(new Runnable() {
-			public void run()
-			{
-				int bytesWritten = -1;
-				int errorState = 0;
-				String errorDescription = "";
-
-				try {
-					bytesWritten = foutputStream.write(new Object[] { fbuffer, foffset, flength });
-
-				} catch (IOException e) {
-					e.printStackTrace();
-					errorState = 1;
-					errorDescription = e.getMessage();
-				}
-
-				fResultsCallback.callAsync(
-					getKrollObject(), buildRWCallbackArgs(foutputStream, bytesWritten, errorState, errorDescription));
-			}
-		})
-			.start();
+		// delegate to TiStream now that it supports async calls
+		TiStream outputStream = (TiStream) args[0];
+		Object[] newArgs = new Object[args.length - 1];
+		System.arraycopy(args, 1, newArgs, 0, args.length - 1);
+		outputStream.write(newArgs);
 	}
 
 	@Kroll.method
@@ -339,93 +198,86 @@ public class StreamModule extends KrollModule
 	//public void writeStream(TiStream inputStream, TiStream outputStream, int maxChunkSize, KrollFunction resultsCallback)
 	public int writeStream(Object args[]) throws IOException
 	{
-		TiStream inputStream = null;
-		TiStream outputStream = null;
-		int maxChunkSize = 0;
-		KrollFunction resultsCallback = null;
-
-		if (args.length == 3 || args.length == 4) {
-			if (args[0] instanceof TiStream) {
-				inputStream = (TiStream) args[0];
-
-			} else {
-				throw new IllegalArgumentException("Invalid input stream argument");
-			}
-
-			if (args[1] instanceof TiStream) {
-				outputStream = (TiStream) args[1];
-
-			} else {
-				throw new IllegalArgumentException("Invalid output stream argument");
-			}
-
-			if (args[2] instanceof Number) {
-				maxChunkSize = ((Number) args[2]).intValue();
-
-			} else {
-				throw new IllegalArgumentException("Invalid max chunk size argument");
-			}
-
-			if (args.length == 4) {
-				if (args[3] instanceof KrollFunction) {
-					resultsCallback = (KrollFunction) args[3];
-
-				} else {
-					throw new IllegalArgumentException("Invalid callback argument");
-				}
-			}
-
-		} else {
+		if (args.length < 3 || args.length > 4) {
 			throw new IllegalArgumentException("Invalid number of arguments");
 		}
 
-		if (args.length == 3) {
-			return writeStream(inputStream, outputStream, maxChunkSize);
-
-		} else {
-			final TiStream finputStream = inputStream;
-			final TiStream foutputStream = outputStream;
-			final int fmaxChunkSize = maxChunkSize;
-			final KrollFunction fResultsCallback = resultsCallback;
-
-			new Thread(new Runnable() {
-				public void run()
-				{
-					int totalBytesWritten = 0;
-					int errorState = 0;
-					String errorDescription = "";
-
-					try {
-						totalBytesWritten = writeStream(finputStream, foutputStream, fmaxChunkSize);
-
-					} catch (IOException e) {
-						errorState = 1;
-						errorDescription = e.getMessage();
-					}
-
-					fResultsCallback.callAsync(
-						getKrollObject(), buildWriteStreamCallbackArgs(finputStream, foutputStream, totalBytesWritten,
-																	   errorState, errorDescription));
-				}
-			})
-				.start();
-
-			return 0;
+		if (!(args[0] instanceof TiStream)) {
+			throw new IllegalArgumentException("Invalid input stream argument");
 		}
+		TiStream inputStream = (TiStream) args[0];
+
+		if (!(args[1] instanceof TiStream)) {
+			throw new IllegalArgumentException("Invalid output stream argument");
+		}
+		TiStream outputStream = (TiStream) args[1];
+
+		if (!(args[2] instanceof Number)) {
+			throw new IllegalArgumentException("Invalid max chunk size argument");
+		}
+		int maxChunkSize = ((Number) args[2]).intValue();
+
+		// sync variant?
+		if (args.length == 3) {
+			// Spit out deprecation notice about sync call!
+			// And throw exception when on main thread!
+			// final String syncIsANoNo = "Synchronous invocation of writeStream will crash under the main thread. This will no longer be supported in SDK 8.0.0. Please invoke with a final callback function to receive the result.";
+			// if (TiApplication.isUIThread()) {
+			// 	throw new IOException(syncIsANoNo);
+			// } else {
+			// 	Log.w(TAG, syncIsANoNo);
+			// }
+			// FIXME: Use same thread/Runnable model as in TiStreamHelper when running sync on main thread?
+			return writeStreamSync(inputStream, outputStream, maxChunkSize);
+		}
+
+		if (!(args[3] instanceof KrollFunction)) {
+			throw new IllegalArgumentException("Invalid callback argument");
+		}
+		KrollFunction resultsCallback = (KrollFunction) args[3];
+
+		final TiStream finputStream = inputStream;
+		final TiStream foutputStream = outputStream;
+		final int fmaxChunkSize = maxChunkSize;
+		final KrollFunction fResultsCallback = resultsCallback;
+
+		new Thread(new Runnable() {
+			public void run()
+			{
+				int totalBytesWritten = 0;
+				int errorState = 0;
+				String errorDescription = "";
+
+				try {
+					totalBytesWritten = writeStreamSync(finputStream, foutputStream, fmaxChunkSize);
+
+				} catch (IOException e) {
+					errorState = 1;
+					errorDescription = e.getMessage();
+				}
+
+				fResultsCallback.callAsync(getKrollObject(),
+										   buildWriteStreamCallbackArgs(finputStream, foutputStream, totalBytesWritten,
+																		errorState, errorDescription));
+			}
+		})
+			.start();
+
+		return 0;
 	}
 
-	private int writeStream(TiStream inputStream, TiStream outputStream, int maxChunkSize) throws IOException
+	private int writeStreamSync(TiStream inputStream, TiStream outputStream, int maxChunkSize) throws IOException
 	{
 		BufferProxy buffer = new BufferProxy(maxChunkSize);
 		int totalBytesWritten = 0;
 
 		while (true) {
-			int bytesRead = inputStream.read(new Object[] { buffer, 0, maxChunkSize });
+			int bytesRead = inputStream.readSync(buffer, 0, maxChunkSize);
 			if (bytesRead == -1) {
 				break;
 			}
 
-			int bytesWritten = outputStream.write(new Object[] { buffer, 0, bytesRead });
+			int bytesWritten = outputStream.writeSync(buffer, 0, bytesRead);
 			totalBytesWritten += bytesWritten;
 			buffer.clear();
 		}
@@ -438,47 +290,49 @@ public class StreamModule extends KrollModule
 	//public void pump(TiStream inputStream, KrollFunction handler, int maxChunkSize, boolean isAsync)
 	public void pump(Object args[])
 	{
-		TiStream inputStream = null;
-		KrollFunction handler = null;
-		int maxChunkSize = 0;
-		boolean isAsync = false;
-
-		if (args.length == 3 || args.length == 4) {
-			if (args[0] instanceof TiStream) {
-				inputStream = (TiStream) args[0];
-
-			} else {
-				throw new IllegalArgumentException("Invalid stream argument");
-			}
-
-			if (args[1] instanceof KrollFunction) {
-				handler = (KrollFunction) args[1];
-
-			} else {
-				throw new IllegalArgumentException("Invalid handler argument");
-			}
-
-			if (args[2] instanceof Number) {
-				maxChunkSize = ((Number) args[2]).intValue();
-
-			} else {
-				throw new IllegalArgumentException("Invalid max chunk size argument");
-			}
-
-			if (args.length == 4) {
-				if (args[3] instanceof Boolean) {
-					isAsync = ((Boolean) args[3]).booleanValue();
-
-				} else {
-					throw new IllegalArgumentException("Invalid async flag argument");
-				}
-			}
-
-		} else {
+		if (args.length != 3 && args.length != 4) {
 			throw new IllegalArgumentException("Invalid number of arguments");
 		}
 
-		if (isAsync) {
+		// stream
+		if (!(args[0] instanceof TiStream)) {
+			throw new IllegalArgumentException("Invalid stream argument");
+		}
+		TiStream inputStream = (TiStream) args[0];
+
+		// handler
+		if (!(args[1] instanceof KrollFunction)) {
+			throw new IllegalArgumentException("Invalid handler argument");
+		}
+		KrollFunction handler = (KrollFunction) args[1];
+
+		// max chunk size
+		if (!(args[2] instanceof Number)) {
+			throw new IllegalArgumentException("Invalid max chunk size argument");
+		}
+		int maxChunkSize = ((Number) args[2]).intValue();
+
+		// isAsync
+		boolean isAsync = false;
+		if (args.length == 4) {
+			if (!(args[3] instanceof Boolean)) {
+				throw new IllegalArgumentException("Invalid async flag argument");
+			}
+			isAsync = ((Boolean) args[3]).booleanValue();
+		}
+
+		if (!isAsync) {
+			// Spit out deprecation notice about sync call!
+			// And throw exception when on main thread!
+			// final String syncIsANoNo = "Synchronous invocation of pump will crash under the main thread. This will no longer be supported in SDK 8.0.0. final async boolean argument will be removed and calls will be assumed to be async.";
+			// if (TiApplication.isUIThread()) {
+			// 	throw new IllegalArgumentException(syncIsANoNo);
+			// } else {
+			// 	Log.w(TAG, syncIsANoNo);
+			// }
+			// FIXME: Use same thread/Runnable model as in TiStreamHelper when running sync on main thread?
+			pumpSync(inputStream, handler, maxChunkSize);
+		} else {
 			final TiStream finputStream = inputStream;
 			final KrollFunction fHandler = handler;
 			final int fmaxChunkSize = maxChunkSize;
@@ -486,26 +340,23 @@ public class StreamModule extends KrollModule
 			new Thread(new Runnable() {
 				public void run()
 				{
-					pump(finputStream, fHandler, fmaxChunkSize);
+					pumpSync(finputStream, fHandler, fmaxChunkSize);
 				}
 			}) {}
 				.start();
-
-		} else {
-			pump(inputStream, handler, maxChunkSize);
 		}
 	}
 
-	private void pump(TiStream inputStream, KrollFunction handler, int maxChunkSize)
+	private void pumpSync(TiStream inputStream, KrollFunction handler, int maxChunkSize)
 	{
 		int totalBytesRead = 0;
 		int errorState = 0;
 		String errorDescription = "";
-
+		final KrollObject krollObject = getKrollObject();
 		try {
 			while (true) {
 				BufferProxy buffer = new BufferProxy(maxChunkSize);
-				int bytesRead = inputStream.read(new Object[] { buffer, 0, maxChunkSize });
+				int bytesRead = inputStream.readSync(buffer, 0, maxChunkSize);
 				if (bytesRead != -1) {
 					totalBytesRead += bytesRead;
 				}
@@ -513,14 +364,13 @@ public class StreamModule extends KrollModule
 				if (bytesRead != buffer.getLength()) {
 					if (bytesRead == -1) {
 						buffer.resize(0);
-
 					} else {
 						buffer.resize(bytesRead);
 					}
 				}
 
-				handler.call(getKrollObject(), buildPumpCallbackArgs(inputStream, buffer, bytesRead, totalBytesRead,
-																	 errorState, errorDescription));
+				handler.call(krollObject, buildPumpCallbackArgs(inputStream, buffer, bytesRead, totalBytesRead,
+																errorState, errorDescription));
 				buffer = null;
 
 				if (bytesRead == -1) {
@@ -531,22 +381,9 @@ public class StreamModule extends KrollModule
 		} catch (IOException e) {
 			errorState = 1;
 			errorDescription = e.getMessage();
-			handler.call(getKrollObject(), buildPumpCallbackArgs(inputStream, new BufferProxy(), 0, totalBytesRead,
-																 errorState, errorDescription));
+			handler.call(krollObject, buildPumpCallbackArgs(inputStream, new BufferProxy(), 0, totalBytesRead,
+															errorState, errorDescription));
 		}
-	}
-
-	private KrollDict buildRWCallbackArgs(TiStream sourceStream, int bytesProcessed, int errorState,
-										  String errorDescription)
-	{
-		KrollDict callbackArgs = new KrollDict();
-		callbackArgs.put("source", sourceStream);
-		callbackArgs.put("bytesProcessed", bytesProcessed);
-		callbackArgs.put("errorState", errorState);
-		callbackArgs.put("errorDescription", errorDescription);
-		callbackArgs.putCodeAndMessage(errorState, errorDescription);
-
-		return callbackArgs;
 	}
 
 	private KrollDict buildWriteStreamCallbackArgs(TiStream fromStream, TiStream toStream, int bytesProcessed,

--- a/apidoc/Titanium/IOStream.yml
+++ b/apidoc/Titanium/IOStream.yml
@@ -14,6 +14,10 @@ methods:
   - name: read
     summary: Reads data from this stream into a buffer.
     description: |
+        Takes an optional `resultsCallback` function as the last argument. If specified,
+        the operation is done asynchronously. If no callback is passed in, the
+        operation is done synchronously.
+
         If `offset` and `length` are specified, data is written into the buffer starting at
         position `offset`. Data is read from this stream until one of the following occurs:
 
@@ -24,14 +28,13 @@ methods:
         If `offset` and `length` are omitted, data is written starting at the beginning
         of the buffer.
 
-        Returns the number of bytes read, or -1 if the end of stream was reached before
-        any data was read.
+        When called synchronously: returns the number of bytes read, or -1 if the end of
+        stream was reached before any data was read.
+
+        Returns 0 when called asynchronously.
 
         Throws an exception on error. For example, if the `offset` value is past
         the last byte of `buffer`.
-
-        This method is synchronous. To perform an asynchronous read on an `IOStream`, use
-        <Titanium.Stream.read>.
 
     returns:
         type: Number
@@ -57,9 +60,18 @@ methods:
         optional: true
         default: Length of the supplied buffer.
 
+      - name: resultsCallback
+        summary: Function to call with the results of the read operation.
+        type: Callback<ReadCallbackArgs>
+        optional: true
+
   - name: write
     summary: Writes data from a buffer to this stream.
     description: |
+        Takes an optional `resultsCallback` function as the last argument. If specified,
+        the operation is done asynchronously. If no callback is passed in, the
+        operation is done synchronously.
+
         If `offset` and `length` are specified, data is read from the buffer starting at
         `offset`. Bytes are read from the buffer and written to the stream until:
 
@@ -70,7 +82,9 @@ methods:
         If `offset` and `length` are omitted, all of the data in the buffer is written to
         this stream.
 
-        Returns the number of bytes actually written.
+        Returns the number of bytes actually written when called synchronously.
+
+        Returns 0 when called asynchronously.
 
         Throws an exception if an error is encountered.
     returns:
@@ -96,6 +110,11 @@ methods:
         type: Number
         optional: true
         default: Length of the supplied buffer.
+
+      - name: resultsCallback
+        summary: Function to call with the results of the write operation.
+        type: Callback<WriteCallbackArgs>
+        optional: true
 
   - name: isWritable
     summary: Indicates whether this stream is writable.

--- a/iphone/TitaniumKit/TitaniumKit/Sources/Modules/TiStreamProxy.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/Modules/TiStreamProxy.m
@@ -29,13 +29,36 @@
   TiBuffer *buffer = nil;
   id offset = nil;
   id length = nil;
+  KrollCallback *callback = nil;
 
   ENSURE_ARG_AT_INDEX(buffer, args, 0, TiBuffer);
-  ENSURE_ARG_OR_NIL_AT_INDEX(offset, args, 1, NSObject);
-  ENSURE_ARG_OR_NIL_AT_INDEX(length, args, 2, NSObject);
+  switch ([args count]) {
+  case 1:
+    // do nothing, just buffer
+    break;
+
+  case 2:
+    ENSURE_ARG_AT_INDEX(callback, args, 1, KrollCallback);
+    break;
+
+  case 3:
+    ENSURE_ARG_AT_INDEX(offset, args, 1, NSObject);
+    ENSURE_ARG_AT_INDEX(length, args, 2, NSObject);
+    break;
+
+  case 4:
+    ENSURE_ARG_AT_INDEX(offset, args, 1, NSObject);
+    ENSURE_ARG_AT_INDEX(length, args, 2, NSObject);
+    ENSURE_ARG_AT_INDEX(callback, args, 3, KrollCallback);
+    break;
+
+  default:
+    [self throwException:TiExceptionNotEnoughArguments subreason:[NSString stringWithFormat:@"expected %d-%d arguments, received: %lu", 1, 4, (unsigned long)[args count]] location:CODELOCATION];
+    break;
+  }
 
   if (offset == nil && length == nil) {
-    return NUMINTEGER([self readToBuffer:buffer offset:0 length:[[buffer data] length] callback:nil]);
+    return NUMINTEGER([self readToBuffer:buffer offset:0 length:[[buffer data] length] callback:callback]);
   } else {
     if (offset == nil || length == nil) {
       // TODO: Codify behavior
@@ -58,7 +81,7 @@
       return NUMINT(-1);
     }
 
-    return NUMINTEGER([self readToBuffer:buffer offset:offsetValue length:lengthValue callback:nil]);
+    return NUMINTEGER([self readToBuffer:buffer offset:offsetValue length:lengthValue callback:callback]);
   }
 
   return NUMINT(-1);
@@ -76,13 +99,36 @@
   TiBuffer *buffer = nil;
   id offset = nil; // May need to perform type coercion from string->int
   id length = nil;
+  KrollCallback *callback = nil;
 
   ENSURE_ARG_AT_INDEX(buffer, args, 0, TiBuffer);
-  ENSURE_ARG_OR_NIL_AT_INDEX(offset, args, 1, NSObject);
-  ENSURE_ARG_OR_NIL_AT_INDEX(length, args, 2, NSObject);
+  switch ([args count]) {
+  case 1:
+    // do nothing, just buffer
+    break;
+
+  case 2:
+    ENSURE_ARG_AT_INDEX(callback, args, 1, KrollCallback);
+    break;
+
+  case 3:
+    ENSURE_ARG_AT_INDEX(offset, args, 1, NSObject);
+    ENSURE_ARG_AT_INDEX(length, args, 2, NSObject);
+    break;
+
+  case 4:
+    ENSURE_ARG_AT_INDEX(offset, args, 1, NSObject);
+    ENSURE_ARG_AT_INDEX(length, args, 2, NSObject);
+    ENSURE_ARG_AT_INDEX(callback, args, 3, KrollCallback);
+    break;
+
+  default:
+    [self throwException:TiExceptionNotEnoughArguments subreason:[NSString stringWithFormat:@"expected %d-%d arguments, received: %lu", 1, 4, (unsigned long)[args count]] location:CODELOCATION];
+    break;
+  }
 
   if (offset == nil && length == nil) {
-    return NUMINTEGER([self writeFromBuffer:buffer offset:0 length:[[buffer data] length] callback:nil]);
+    return NUMINTEGER([self writeFromBuffer:buffer offset:0 length:[[buffer data] length] callback:callback]);
   } else {
     if (offset == nil || length == nil) {
       // TODO: Codify behavior
@@ -105,7 +151,7 @@
       return NUMINT(-1);
     }
 
-    return NUMINTEGER([self writeFromBuffer:buffer offset:offsetValue length:lengthValue callback:nil]);
+    return NUMINTEGER([self writeFromBuffer:buffer offset:offsetValue length:lengthValue callback:callback]);
   }
 
   return NUMINT(-1);

--- a/tests/Resources/ti.network.tcp.socket.addontest.js
+++ b/tests/Resources/ti.network.tcp.socket.addontest.js
@@ -1,0 +1,91 @@
+/*
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2018-Present by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+/* eslint-env mocha */
+/* global Ti */
+/* eslint no-unused-expressions: "off" */
+'use strict';
+var should = require('./utilities/assertions');
+
+describe('Ti.Network.TCP.Socket', function () {
+	var socket;
+	this.timeout(6e4);
+
+	afterEach(function () {
+		if (socket && socket.state == Ti.Network.Socket.CONNECTED) { // eslint-disable-line eqeqeq
+			socket.close();
+		}
+		socket = null;
+	});
+
+	it('#connect() and #write() async', function (finish) {
+		socket = Ti.Network.Socket.createTCP({
+			host: 'www.appcelerator.com',
+			port: 80,
+			connected: function () {
+				should(socket.write).not.be.null;
+				should(socket.write).be.a.Function;
+				socket.write(Ti.createBuffer({ value: 'GET / HTTP/1.1\r\nHost: www.appcelerator.com\r\nConnection: close\r\n\r\n' }), function (evt) {
+					try {
+						evt.success.should.eql(true);
+						evt.bytesProcessed.should.eql(65);
+						finish();
+					} catch (err) {
+						finish(err);
+					}
+				});
+			},
+			error: function (e) {
+				finish(e);
+			}
+		});
+		should(socket.connect).not.be.null;
+		should(socket.connect).be.a.Function;
+		socket.connect();
+	});
+
+	it.windowsBroken('#connect(), #write(), #pump() async', function (finish) {
+		var buffer = '';
+		socket = Ti.Network.Socket.createTCP({
+			host: 'pastebin.com',
+			port: 80,
+			timeout: 20000,
+			connected: function (e) {
+				// receive callback
+				should(socket.read).not.be.null;
+				should(socket.read).be.a.Function;
+
+				// send GET request
+				should(socket.write).not.be.null;
+				should(socket.write).be.a.Function;
+				socket.write(Ti.createBuffer({ value: 'GET /raw/eF5dK0xU HTTP/1.1\r\nHost: pastebin.com\r\nConnection: close\r\n\r\n' }), function (evt) {
+					evt.success.should.eql(true);
+
+					Ti.Stream.pump(e.socket, function (e) {
+						if (e.buffer) {
+							buffer += e.buffer.toString();
+						}
+						// end of stream
+						// note: iOS e.buffer will be `null` where Android wont
+						if (e.bytesProcessed === -1) {
+							if (buffer.indexOf('SUCCESS!') !== -1) {
+								finish();
+							} else {
+								finish(new Error('failed to receive success'));
+							}
+						}
+					}, 1024, true);
+				});
+			},
+			error: function (e) {
+				finish(e);
+			}
+		});
+		should(socket.connect).not.be.null;
+		should(socket.connect).be.a.Function;
+		socket.connect();
+	});
+});

--- a/tests/Resources/ti.ui.webview.addontest.js
+++ b/tests/Resources/ti.ui.webview.addontest.js
@@ -12,7 +12,14 @@ var should = require('./utilities/assertions'),
 	utilities = require('./utilities/utilities');
 
 describe('Ti.UI.WebView', function () {
-	var win;
+	var win,
+		didFocus = false;
+	this.slow(2000);
+	this.timeout(10000);
+
+	beforeEach(function () {
+		didFocus = false;
+	});
 
 	afterEach(function () {
 		if (win) {
@@ -49,5 +56,52 @@ describe('Ti.UI.WebView', function () {
 		win.open();
 
 		webView.url = URL;
+	});
+
+	it('#evalJS(string, function) - async variant', function (finish) {
+		var webview,
+			hadError = false;
+		win = Ti.UI.createWindow({
+			backgroundColor: 'blue'
+		});
+
+		webview = Ti.UI.createWebView();
+
+		webview.addEventListener('load', function () {
+			if (hadError) {
+				return;
+			}
+
+			// FIXME: Android is dumb and assumes no trailing semicolon!
+			webview.evalJS('Ti.API.info("Hello, World!");"WebView.evalJS.TEST"', function (result) {
+				try {
+					if (utilities.isAndroid()) {
+						should(result).be.eql('"WebView.evalJS.TEST"'); // FIXME: Why the double-quoting?
+					} else {
+						should(result).be.eql('WebView.evalJS.TEST');
+					}
+
+					finish();
+				} catch (err) {
+					finish(err);
+				}
+			});
+		});
+		win.addEventListener('focus', function () {
+			if (didFocus) {
+				return;
+			}
+			didFocus = true;
+
+			try {
+				webview.url = 'ti.ui.webview.test.html';
+			} catch (err) {
+				hadError = true;
+				finish(err);
+			}
+		});
+
+		win.add(webview);
+		win.open();
 	});
 });


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-26411

**Description:**
The goal is to ensure stream related APIs have async variants that can be used, and to mark the synchronous versions as deprecated.

**Android:**
Common code for handling read/write methods on Ti.IOStreams has been moved to TiStreamHelper in an effort to reduce duplicated code. The implementations of TiStream now need to delegate to TiStreamHelper for the JS facing `read`/`write` methods, but implement explicitly named sync variants with typed arguments. Then we delegate to the sync versions wrapping in Threads/Runnables when we perform async versions.

**iOS:**
The code was mainly already factored nicely. Was really just a matter of tweaking the read/write JS-facing methods to handle an optional callback argument last.