### PR TITLE
[TIMOB-26391] Protect js objects for proxies

### DIFF
--- a/iphone/Classes/KrollBridge.m
+++ b/iphone/Classes/KrollBridge.m
@@ -668,6 +668,8 @@ CFMutableSetRef krollBridgeRegistry = nil;
   ourKrollObject = [[KrollCoverageObject alloc] initWithTarget:proxy context:context];
 #else
   ourKrollObject = [[KrollObject alloc] initWithTarget:proxy context:context];
+#endif
+#ifdef USE_JSCORE_FRAMEWORK
   [ourKrollObject protectJsobject];
 #endif
 

--- a/iphone/Classes/KrollBridge.m
+++ b/iphone/Classes/KrollBridge.m
@@ -668,6 +668,7 @@ CFMutableSetRef krollBridgeRegistry = nil;
   ourKrollObject = [[KrollCoverageObject alloc] initWithTarget:proxy context:context];
 #else
   ourKrollObject = [[KrollObject alloc] initWithTarget:proxy context:context];
+  [ourKrollObject protectJsobject];
 #endif
 
   [self registerProxy:proxy

--- a/iphone/Classes/TiBindingTiValue.m
+++ b/iphone/Classes/TiBindingTiValue.m
@@ -226,6 +226,7 @@ TiValueRef TiBindingTiValueFromProxy(TiContextRef jsContext, TiProxy *obj)
       return [[ourBridge registerProxy:obj] jsobject];
     }
     KrollObject *objKrollObject = [ourBridge krollObjectForProxy:obj];
+    [objKrollObject unprotectJsobject];
     return [objKrollObject jsobject];
   }
 

--- a/iphone/Classes/TiBindingTiValue.m
+++ b/iphone/Classes/TiBindingTiValue.m
@@ -226,7 +226,9 @@ TiValueRef TiBindingTiValueFromProxy(TiContextRef jsContext, TiProxy *obj)
       return [[ourBridge registerProxy:obj] jsobject];
     }
     KrollObject *objKrollObject = [ourBridge krollObjectForProxy:obj];
+#ifdef USE_JSCORE_FRAMEWORK
     [objKrollObject unprotectJsobject];
+#endif
     return [objKrollObject jsobject];
   }
 


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-26391

**Optional Description:**
This will protect JS objects temporarily until they are passed back into the js context so they don't get CG'd during the small timeframe of their creation and until they are actually referenced in the JS object graph.
