### PR TITLE
[TIMOB-26399] (7_4_X) iOS: Fix notification update to trigger correct callback for default notification action

### DIFF
--- a/iphone/Classes/TiApp.m
+++ b/iphone/Classes/TiApp.m
@@ -622,7 +622,12 @@ TI_INLINE void waitForMemoryPanicCleared(); //WARNING: This must never be run on
       responseInfo = [NSMutableDictionary dictionary];
       [responseInfo setValue:((UNTextInputNotificationResponse *)response).userText forKey:UIUserNotificationActionResponseTypedTextKey];
     }
-    [self application:[UIApplication sharedApplication] handleActionWithIdentifier:response.actionIdentifier forRemoteNotification:response.notification.request.content.userInfo withResponseInfo:responseInfo completionHandler:completionHandler];
+    if ([UNNotificationDefaultActionIdentifier isEqualToString:response.actionIdentifier]){
+        [self application:[UIApplication sharedApplication] didReceiveRemoteNotification:response.notification.request.content.userInfo];
+        completionHandler();
+    } else {
+        [self application:[UIApplication sharedApplication] handleActionWithIdentifier:response.actionIdentifier forRemoteNotification:response.notification.request.content.userInfo withResponseInfo:responseInfo completionHandler:completionHandler];
+    }
   } else {
     //NOTE Local notifications should be handled similar to BG above which ultimately calls handleRemoteNotificationWithIdentifier as this will allow BG Actions to execute.
     RELEASE_TO_NIL(localNotification);

--- a/iphone/Classes/TiApp.m
+++ b/iphone/Classes/TiApp.m
@@ -623,10 +623,10 @@ TI_INLINE void waitForMemoryPanicCleared(); //WARNING: This must never be run on
       [responseInfo setValue:((UNTextInputNotificationResponse *)response).userText forKey:UIUserNotificationActionResponseTypedTextKey];
     }
     if ([UNNotificationDefaultActionIdentifier isEqualToString:response.actionIdentifier]) {
-        [self application:[UIApplication sharedApplication] didReceiveRemoteNotification:response.notification.request.content.userInfo];
-        completionHandler();
+      [self application:[UIApplication sharedApplication] didReceiveRemoteNotification:response.notification.request.content.userInfo];
+      completionHandler();
     } else {
-        [self application:[UIApplication sharedApplication] handleActionWithIdentifier:response.actionIdentifier forRemoteNotification:response.notification.request.content.userInfo withResponseInfo:responseInfo completionHandler:completionHandler];
+      [self application:[UIApplication sharedApplication] handleActionWithIdentifier:response.actionIdentifier forRemoteNotification:response.notification.request.content.userInfo withResponseInfo:responseInfo completionHandler:completionHandler];
     }
   } else {
     //NOTE Local notifications should be handled similar to BG above which ultimately calls handleRemoteNotificationWithIdentifier as this will allow BG Actions to execute.

--- a/iphone/Classes/TiApp.m
+++ b/iphone/Classes/TiApp.m
@@ -622,7 +622,7 @@ TI_INLINE void waitForMemoryPanicCleared(); //WARNING: This must never be run on
       responseInfo = [NSMutableDictionary dictionary];
       [responseInfo setValue:((UNTextInputNotificationResponse *)response).userText forKey:UIUserNotificationActionResponseTypedTextKey];
     }
-    if ([UNNotificationDefaultActionIdentifier isEqualToString:response.actionIdentifier]){
+    if ([UNNotificationDefaultActionIdentifier isEqualToString:response.actionIdentifier]) {
         [self application:[UIApplication sharedApplication] didReceiveRemoteNotification:response.notification.request.content.userInfo];
         completionHandler();
     } else {


### PR DESCRIPTION
…remotenotification callback instead of remotenotificationaction callback. Ensures completion block is called in an orderly fashion

**JIRA:** https://jira.appcelerator.org/browse/TIMOB-26399

Provide a clear PR title prefixed with `[TICKET]`

**Optional Description:**
