### PR TITLE
[TIMOB-26425] Always use thread-safe access to timers array

### DIFF
--- a/iphone/Classes/KrollContext.h
+++ b/iphone/Classes/KrollContext.h
@@ -40,10 +40,10 @@
 #endif
   TiGlobalContextRef context;
   NSMutableDictionary *timers;
+  NSRecursiveLock *timerLock;
   void *debugger;
 
 #ifdef TI_USE_KROLL_THREAD
-  NSRecursiveLock *timerLock;
   NSString *krollContextId;
   NSRecursiveLock *lock;
   NSCondition *condition;

--- a/iphone/Classes/KrollContext.m
+++ b/iphone/Classes/KrollContext.m
@@ -761,10 +761,10 @@ static TiValueRef StringFormatDecimalCallback(TiContextRef jsContext, TiObjectRe
     queue = [[NSMutableArray alloc] init];
     lock = [[NSRecursiveLock alloc] init];
     [lock setName:[NSString stringWithFormat:@"%@ Lock", [self threadName]]];
+#endif
     timerLock = [[NSRecursiveLock alloc] init];
     NSString *timerName = [NSString stringWithFormat:@"%@ Timer Lock", [self threadName]];
     [timerLock setName:timerName];
-#endif
     stopped = YES;
     KrollContextCount++;
     debugger = NULL;

--- a/iphone/Classes/KrollContext.m
+++ b/iphone/Classes/KrollContext.m
@@ -850,24 +850,18 @@ static TiValueRef StringFormatDecimalCallback(TiContextRef jsContext, TiObjectRe
 #endif
 - (void)registerTimer:(id)timer timerId:(double)timerId
 {
-#ifdef TI_USE_KROLL_THREAD
   [timerLock lock];
-#endif
   if (timers == nil) {
     timers = [[NSMutableDictionary alloc] init];
   }
   NSString *key = [[NSNumber numberWithDouble:timerId] stringValue];
   [timers setObject:timer forKey:key];
-#ifdef TI_USE_KROLL_THREAD
   [timerLock unlock];
-#endif
 }
 
 - (void)unregisterTimer:(double)timerId
 {
-#ifdef TI_USE_KROLL_THREAD
   [timerLock lock];
-#endif
   if (timers != nil) {
     NSString *timer = [[NSNumber numberWithDouble:timerId] stringValue];
     KrollTimer *t = [timers objectForKey:timer];
@@ -881,9 +875,7 @@ static TiValueRef StringFormatDecimalCallback(TiContextRef jsContext, TiObjectRe
       RELEASE_TO_NIL(timers);
     }
   }
-#ifdef TI_USE_KROLL_THREAD
   [timerLock unlock];
-#endif
 }
 
 - (void)start
@@ -1411,9 +1403,8 @@ static TiValueRef StringFormatDecimalCallback(TiContextRef jsContext, TiObjectRe
   if (delegate != nil && [delegate respondsToSelector:@selector(willStopNewContext:)]) {
     [delegate performSelector:@selector(willStopNewContext:) withObject:self];
   }
-#ifdef TI_USE_KROLL_THREAD
+
   [timerLock lock];
-#endif
   // stop any running timers
   if (timers != nil && [timers count] > 0) {
     for (id timerId in [NSDictionary dictionaryWithDictionary:timers]) {
@@ -1422,9 +1413,8 @@ static TiValueRef StringFormatDecimalCallback(TiContextRef jsContext, TiObjectRe
     }
     [timers removeAllObjects];
   }
-#ifdef TI_USE_KROLL_THREAD
   [timerLock unlock];
-#endif
+
   [KrollCallback shutdownContext:self];
 
   // now we can notify listeners we're done

--- a/iphone/Classes/KrollContext.m
+++ b/iphone/Classes/KrollContext.m
@@ -743,12 +743,15 @@ static TiValueRef StringFormatDecimalCallback(TiContextRef jsContext, TiObjectRe
   }
 }
 
-#ifdef TI_USE_KROLL_THREAD
 - (NSString *)threadName
 {
+#ifdef TI_USE_KROLL_THREAD
   return [NSString stringWithFormat:@"KrollContext<%@>", krollContextId];
-}
+#else
+  return @"KrollContext<MainThread>";
 #endif
+}
+
 - (id)init
 {
   if (self = [super init]) {


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-26425

**Optional Description:**
Timers are always started in their own thread. Locking should also be done when running on main thread to make the access to the timers array thread-safe.