### PR TITLE
[TIMOB-26403] Update node-titanium-sdk, pass logger to analyzeJs

### DIFF
--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -2755,7 +2755,8 @@ AndroidBuilder.prototype.copyResources = function copyResources(next) {
 									targets: {
 										chrome: this.chromeVersion
 									},
-									resourcesDir: this.buildBinAssetsResourcesDir
+									resourcesDir: this.buildBinAssetsResourcesDir,
+									logger: this.logger
 								});
 								const newContents = modified.contents;
 

--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -5893,7 +5893,8 @@ iOSBuilder.prototype.copyResources = function copyResources(next) {
 									minify: this.minifyJS,
 									transpile: this.transpile,
 									sourceMap: this.sourceMaps || this.deployType === 'development',
-									resourcesDir: this.xcodeAppDir
+									resourcesDir: this.xcodeAppDir,
+									logger: this.logger
 								};
 								// generate our transpile target based on tijscore/jscore
 								if (this.useJSCore) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1247,9 +1247,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30000884",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000884.tgz",
-      "integrity": "sha512-ibROerckpTH6U5zReSjbaitlH4gl5V4NWNCBzRNCa3GEDmzzkfStk+2k5mO4ZDM6pwtdjbZ3hjvsYhPGVLWgNw=="
+      "version": "1.0.30000889",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000889.tgz",
+      "integrity": "sha512-MFxcQ6x/LEEoaIhO7Zdb7Eg8YyNONN+WBnS5ERJ0li2yRw51+i4xXUNxnLaveTb/4ZoJqsWKEmlomhG2pYzlQA=="
     },
     "caseless": {
       "version": "0.12.0",
@@ -1740,9 +1740,9 @@
       "integrity": "sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ=="
     },
     "electron-to-chromium": {
-      "version": "1.3.62",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.62.tgz",
-      "integrity": "sha512-x09ndL/Gjnuk3unlAyoGyUg3wbs4w/bXurgL7wL913vXHAOWmMhrLf1VNGRaMLngmadd5Q8gsV9BFuIr6rP+Xg=="
+      "version": "1.3.73",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.73.tgz",
+      "integrity": "sha512-6PIg7v9zRoVGh6EheRF8h6Plti+3Yo/qtHobS4/Htyt53DNHmKKGFqSae1AIk0k1S4gCQvt7I2WgpbuZNcDY+g=="
     },
     "encoding": {
       "version": "0.1.12",
@@ -3410,7 +3410,7 @@
     },
     "json5": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
     },
     "jsonfile": {
@@ -4328,9 +4328,9 @@
       }
     },
     "node-titanium-sdk": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/node-titanium-sdk/-/node-titanium-sdk-0.6.3.tgz",
-      "integrity": "sha512-wTyEQuZ8vd5RS6GStDguSRru/70LdU1un+Sbzp7MBMt1bjwUxfnob0ax1zXeuKiMJaP/ubGjCSX5UKueRQCk+Q==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/node-titanium-sdk/-/node-titanium-sdk-0.6.4.tgz",
+      "integrity": "sha512-CfL+ORmLBRy+EjgIeim5K9g5OdBu2gSbCEXQixIc7eo/oR4w48muAzyp93j9TFJ9YvV2wKESsYBnqe0W98hqAQ==",
       "requires": {
         "async": "^2.4.1",
         "babel-core": "^6.26.3",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "markdown": "0.5.0",
     "moment": "^2.22.2",
     "node-appc": "^0.2.47",
-    "node-titanium-sdk": "^0.6.3",
+    "node-titanium-sdk": "^0.6.4",
     "node-uuid": "1.4.8",
     "pngjs": "^3.3.3",
     "request": "^2.87.0",


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-26403

- Update node-titanium-sdk@0.6.4 to include fix
- Pass logger into to analyzeJs so we can log deprecation warning

To test:

1. Build kitchensink-v2 to device or simulator
- You should see a warning log about "implicit global scope being deprecated
- It should launch successfully 