### PR TITLE
[TIMOB-26435] Update gradle for JDK 11 support

### DIFF
--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -4376,7 +4376,7 @@ AndroidBuilder.prototype.runDexer = function runDexer(next) {
 				'-Pconfiguration=' + quotePath(baserules) + pathArraySeparator + quotePath(mainDexProGuardFilePath)
 			], { shell: true, windowsHide: true }, function (code, out, err) {
 				if (code) {
-					this.logger.error(__('Failed to run dexer:'));
+					this.logger.error(__('Failed to run gradle:'));
 					this.logger.error();
 					err.trim().split('\n').forEach(this.logger.error);
 					this.logger.log();

--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -4395,7 +4395,7 @@ AndroidBuilder.prototype.runDexer = function runDexer(next) {
 			appc.subprocess.run(this.jdkInfo.executables.java, [ '-cp', this.androidInfo.sdk.dx, 'com.android.multidex.MainDexListBuilder', outjar, injarsCore.join(pathArraySeparator) ], {}, function (code, out, err) {
 				var mainDexClassesList = path.join(this.buildDir, 'main-dex-classes.txt');
 				if (code) {
-					this.logger.error(__('Failed to run dexer:'));
+					this.logger.error(__('Failed to generate main class for dexer:'));
 					this.logger.error();
 					err.trim().split('\n').forEach(this.logger.error);
 					this.logger.log();

--- a/android/templates/gradle/gradle/wrapper/gradle-wrapper.properties
+++ b/android/templates/gradle/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-4.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-26435

- Update to gradle 4.10.2
- Use https to download gradle
- Change "Failed to run dexer" warning to "Failed to run gradle"
	- We have (had) 3 potential error cases where we log "Failed to run dexer" so tracking down _what_ went wrong is kind of a PITA
	- I'd like to reduce this to 1 "Failed to run dexer" error case, so if anyone has suggestions for [this](https://github.com/ewanharris/titanium_mobile/blob/77fd3f2acd5976dd63eb489a4f42d60d9426c2f8/android/cli/commands/_build.js#L4398) error log, send them in on a postcard 🙂 I think it's still the dexer step but can we make it a little more clear what the task is?

**JDK 11 Test:**
1. Install JDK 11. _(Note that this will currently break Appc Studio.)_
2. Build and run a Titanium app for Android.
3. Verify that it builds and runs successfully.

**Multidexing Test:**
Run the test shown in [TIMOB-25597](https://jira.appcelerator.org/browse/TIMOB-25597), but use this PR's Titanium version. Verify that the app can launch successfully on an Android 4.x without crashing.
