### PR TITLE
[TIMOB-26391](7_4_X) Improve proxy protection logic

### DIFF
--- a/iphone/Classes/KrollBridge.m
+++ b/iphone/Classes/KrollBridge.m
@@ -670,7 +670,9 @@ CFMutableSetRef krollBridgeRegistry = nil;
   ourKrollObject = [[KrollObject alloc] initWithTarget:proxy context:context];
 #endif
 #ifdef USE_JSCORE_FRAMEWORK
-  [ourKrollObject protectJsobject];
+  if (![proxy isKindOfClass:[TiModule class]]) {
+    [ourKrollObject applyGarbageCollectionSafeguard];
+  }
 #endif
 
   [self registerProxy:proxy

--- a/iphone/Classes/KrollObject.h
+++ b/iphone/Classes/KrollObject.h
@@ -83,4 +83,9 @@ bool KrollDeleteProperty(TiContextRef ctx, TiObjectRef object, TiStringRef prope
 - (void)removeListener:(KrollCallback *)eventCallback forEvent:(NSString *)eventName;
 - (void)triggerEvent:(NSString *)eventName withObject:(NSDictionary *)eventData thisObject:(KrollObject *)thisObject;
 
+#ifdef USE_JSCORE_FRAMEWORK
+- (void)applyGarbageCollectionSafeguard;
+- (void)removeGarbageCollectionSafeguard;
+#endif
+
 @end

--- a/iphone/Classes/KrollObject.m
+++ b/iphone/Classes/KrollObject.m
@@ -363,6 +363,16 @@ bool KrollHasInstance(TiContextRef ctx, TiObjectRef constructor, TiValueRef poss
   return false;
 }
 
+@interface KrollObject ()
+
+/**
+ Boolean flag indicating whether the underlying JSObjectRef was safeguarded against
+ being GC'ed during the proxy creation flow.
+ */
+@property (nonatomic, assign, getter=isGcSafeguarded) BOOL gcSafeguarded;
+
+@end
+
 @implementation KrollObject
 
 @synthesize propsObject, finalized, bridge;
@@ -414,6 +424,8 @@ bool KrollHasInstance(TiContextRef ctx, TiObjectRef constructor, TiValueRef poss
     bridge = (KrollBridge *)[context_ delegate];
     jsobject = TiObjectMake(jsContext, [[self class] jsClassRef], self);
     targetable = [target conformsToProtocol:@protocol(KrollTargetable)];
+    
+    self.gcSafeguarded = NO;
   }
   return self;
 }
@@ -1366,5 +1378,68 @@ TiThreadPerformOnMainThread(mainBlock, NO);
     }
   }
 }
+
+#ifdef USE_JSCORE_FRAMEWORK
+/**
+ Protects the underlying JSObjectRef from being accidentally GC'ed.
+ 
+ Upon proxy creation there is a small timeframe between creating the KrollObject
+ with its JSObject and the JSObject actually getting referenced in the JS object graph.
+ If JSC's garbage collection happens during this time the JSObject is lost and eventually
+ leads to a crash inside the JSC runtime.
+ */
+- (void)applyGarbageCollectionSafeguard
+{
+  if (self.isGcSafeguarded == YES) {
+    return;
+  }
+  
+  if (finalized == YES || jsContext == NULL || jsobject == NULL) {
+    return;
+  }
+  
+#ifdef TI_USE_KROLL_THREAD
+  if (![context isKJSThread]) {
+    NSOperation *safeProtect = [[NSInvocationOperation alloc] initWithTarget:self selector:@selector(applyGarbageCollectionSafeguard) object:nil];
+    [context enqueue:safeProtect];
+    [safeProtect release];
+    return;
+  }
+#endif
+  
+  TiValueProtect(jsContext, jsobject);
+  self.gcSafeguarded = YES;
+}
+
+/**
+ Removes the garbage collection safeguard by unprotecting the JSObjectRef again.
+ 
+ This must only be called immediately before the JSObjectRef gets inserted into the JS object
+ graph. Even better would be after the insertion but there is currently no viable place to do
+ that in our proxy creation flow.
+ */
+- (void)removeGarbageCollectionSafeguard
+{
+  if (self.isGcSafeguarded == NO) {
+    return;
+  }
+  
+  if (finalized == YES || jsContext == NULL || jsobject == NULL) {
+    return;
+  }
+  
+#ifdef TI_USE_KROLL_THREAD
+  if (![context isKJSThread]) {
+    NSOperation *safeUnprotect = [[NSInvocationOperation alloc] initWithTarget:self selector:@selector(removeGarbageCollectionSafeguard) object:nil];
+    [context enqueue:safeUnprotect];
+    [safeUnprotect release];
+    return;
+  }
+#endif
+  
+  TiValueUnprotect(jsContext, jsobject);
+  self.gcSafeguarded = NO;
+}
+#endif
 
 @end

--- a/iphone/Classes/KrollObject.m
+++ b/iphone/Classes/KrollObject.m
@@ -424,7 +424,7 @@ bool KrollHasInstance(TiContextRef ctx, TiObjectRef constructor, TiValueRef poss
     bridge = (KrollBridge *)[context_ delegate];
     jsobject = TiObjectMake(jsContext, [[self class] jsClassRef], self);
     targetable = [target conformsToProtocol:@protocol(KrollTargetable)];
-    
+
     self.gcSafeguarded = NO;
   }
   return self;
@@ -949,14 +949,14 @@ bool KrollHasInstance(TiContextRef ctx, TiObjectRef constructor, TiValueRef poss
 TI_INLINE TiStringRef TiStringCreateWithPointerValue(int value)
 {
   /*
-	 *	When we note proxies, we need to come up with a property name
-	 *	that is unique. We previously did an nsstring with format
-	 *	of __PX%X, but this method is so often called, and allocating a string
-	 *	can be a waste, so it's better to jump straight to something hardwired
-	 *
-	 *	No sense in doing hex when so many more characters are valid property
-	 *	characters. So we do it in chunks of 6 bits, from '<' (60) to '{' (123)
-	 */
+   *	When we note proxies, we need to come up with a property name
+   *	that is unique. We previously did an nsstring with format
+   *	of __PX%X, but this method is so often called, and allocating a string
+   *	can be a waste, so it's better to jump straight to something hardwired
+   *
+   *	No sense in doing hex when so many more characters are valid property
+   *	characters. So we do it in chunks of 6 bits, from '<' (60) to '{' (123)
+   */
   char result[10];
   result[0] = '_';
   result[1] = '_';
@@ -1382,7 +1382,7 @@ TiThreadPerformOnMainThread(mainBlock, NO);
 #ifdef USE_JSCORE_FRAMEWORK
 /**
  Protects the underlying JSObjectRef from being accidentally GC'ed.
- 
+
  Upon proxy creation there is a small timeframe between creating the KrollObject
  with its JSObject and the JSObject actually getting referenced in the JS object graph.
  If JSC's garbage collection happens during this time the JSObject is lost and eventually
@@ -1393,11 +1393,11 @@ TiThreadPerformOnMainThread(mainBlock, NO);
   if (self.isGcSafeguarded == YES) {
     return;
   }
-  
+
   if (finalized == YES || jsContext == NULL || jsobject == NULL) {
     return;
   }
-  
+
 #ifdef TI_USE_KROLL_THREAD
   if (![context isKJSThread]) {
     NSOperation *safeProtect = [[NSInvocationOperation alloc] initWithTarget:self selector:@selector(applyGarbageCollectionSafeguard) object:nil];
@@ -1406,14 +1406,14 @@ TiThreadPerformOnMainThread(mainBlock, NO);
     return;
   }
 #endif
-  
+
   TiValueProtect(jsContext, jsobject);
   self.gcSafeguarded = YES;
 }
 
 /**
  Removes the garbage collection safeguard by unprotecting the JSObjectRef again.
- 
+
  This must only be called immediately before the JSObjectRef gets inserted into the JS object
  graph. Even better would be after the insertion but there is currently no viable place to do
  that in our proxy creation flow.
@@ -1423,11 +1423,11 @@ TiThreadPerformOnMainThread(mainBlock, NO);
   if (self.isGcSafeguarded == NO) {
     return;
   }
-  
+
   if (finalized == YES || jsContext == NULL || jsobject == NULL) {
     return;
   }
-  
+
 #ifdef TI_USE_KROLL_THREAD
   if (![context isKJSThread]) {
     NSOperation *safeUnprotect = [[NSInvocationOperation alloc] initWithTarget:self selector:@selector(removeGarbageCollectionSafeguard) object:nil];
@@ -1436,7 +1436,7 @@ TiThreadPerformOnMainThread(mainBlock, NO);
     return;
   }
 #endif
-  
+
   TiValueUnprotect(jsContext, jsobject);
   self.gcSafeguarded = NO;
 }

--- a/iphone/Classes/TiBindingTiValue.m
+++ b/iphone/Classes/TiBindingTiValue.m
@@ -227,7 +227,7 @@ TiValueRef TiBindingTiValueFromProxy(TiContextRef jsContext, TiProxy *obj)
     }
     KrollObject *objKrollObject = [ourBridge krollObjectForProxy:obj];
 #ifdef USE_JSCORE_FRAMEWORK
-    [objKrollObject unprotectJsobject];
+    [objKrollObject removeGarbageCollectionSafeguard];
 #endif
     return [objKrollObject jsobject];
   }


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-26391

**Optional Description:**
Using the existing protect/unprotect methods caused unwanted side effects. This introduces two similar methods for the sole purpose of safeguarding the JS object during our proxy creation flow.