### PR TITLE
[TIMOB-26477] Android: Fix Ti.Locale.setLanguage()

### DIFF
--- a/android/modules/locale/src/java/ti/modules/titanium/locale/LocaleModule.java
+++ b/android/modules/locale/src/java/ti/modules/titanium/locale/LocaleModule.java
@@ -17,6 +17,7 @@ import org.appcelerator.titanium.util.TiRHelper;
 
 import android.content.Context;
 import android.content.res.Configuration;
+import android.os.Build;
 import android.telephony.PhoneNumberUtils;
 
 @Kroll.module
@@ -108,9 +109,13 @@ public class LocaleModule extends KrollModule
 			Locale.setDefault(locale);
 
 			Configuration config = new Configuration();
-			config.locale = locale;
+			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+				config.setLocale(locale);
+			} else {
+				config.locale = locale;
+			}
 
-			Context ctx = TiApplication.getInstance().getBaseContext();
+			Context ctx = TiApplication.getAppRootOrCurrentActivity().getBaseContext();
 			ctx.getResources().updateConfiguration(config, ctx.getResources().getDisplayMetrics());
 		} catch (Exception e) {
 			Log.e(TAG, "Error trying to set language '" + language + "':", e);


### PR DESCRIPTION
- Fix `baseContext` used by locale configuration

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-26477)