### PR TITLE
[TIMOB-26390] Android: Connect getters with background drawables for Unit test purposes.

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/TiC.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiC.java
@@ -1032,6 +1032,9 @@ public class TiC
 	 */
 	public static final String PROPERTY_BACKGROUND_PREFIX = "background";
 
+	/**
+	 * @module.api
+	 */
 	public static final String PROPERTY_BACKGROUND_REPEAT = "backgroundRepeat";
 
 	/**
@@ -2721,6 +2724,9 @@ public class TiC
 	 */
 	public static final String PROPERTY_RETURN_KEY_TYPE = "returnKeyType";
 
+	/**
+	 * @module.api
+	 */
 	public static final String PROPERTY_REVERSE = "reverse";
 
 	/**

--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/TiViewProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/TiViewProxy.java
@@ -8,8 +8,6 @@ package org.appcelerator.titanium.proxy;
 
 import java.lang.ref.WeakReference;
 import java.lang.reflect.Array;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.ConcurrentModificationException;
 import java.util.HashMap;
@@ -42,9 +40,6 @@ import android.app.Activity;
 import android.graphics.Bitmap;
 import android.graphics.Bitmap.Config;
 import android.graphics.drawable.ColorDrawable;
-import android.graphics.drawable.Drawable;
-import android.graphics.drawable.LayerDrawable;
-import android.graphics.drawable.StateListDrawable;
 import android.os.Build;
 import android.os.Handler;
 import android.os.Message;
@@ -57,44 +52,50 @@ import android.view.ViewAnimationUtils;
 // clang-format off
 @Kroll.proxy(propertyAccessors = {
 	// background properties
-	"backgroundImage",
-	"backgroundRepeat",
-	"backgroundSelectedImage",
-	"backgroundFocusedImage",
-	"backgroundDisabledImage",
-	"backgroundColor",
-	"backgroundSelectedColor",
-	"backgroundFocusedColor",
-	"backgroundDisabledColor",
-	"backgroundPadding",
-	"backgroundGradient",
+	TiC.PROPERTY_BACKGROUND_IMAGE,
+	TiC.PROPERTY_BACKGROUND_REPEAT,
+	TiC.PROPERTY_BACKGROUND_SELECTED_IMAGE,
+	TiC.PROPERTY_BACKGROUND_FOCUSED_IMAGE,
+	TiC.PROPERTY_BACKGROUND_DISABLED_IMAGE,
+	TiC.PROPERTY_BACKGROUND_COLOR,
+	TiC.PROPERTY_BACKGROUND_SELECTED_COLOR,
+	TiC.PROPERTY_BACKGROUND_FOCUSED_COLOR,
+	TiC.PROPERTY_BACKGROUND_DISABLED_COLOR,
+	TiC.PROPERTY_BACKGROUND_PADDING,
+	TiC.PROPERTY_BACKGROUND_GRADIENT,
 	// border properties
-	"borderColor", "borderRadius", "borderWidth",
+	TiC.PROPERTY_BORDER_COLOR,
+	TiC.PROPERTY_BORDER_RADIUS,
+	TiC.PROPERTY_BORDER_WIDTH,
 	// layout / dimension (size/width/height have custom accessors)
-	"left", "top", "right", "bottom", "layout", "zIndex",
+	TiC.PROPERTY_LEFT,
+	TiC.PROPERTY_TOP,
+	TiC.PROPERTY_RIGHT,
+	TiC.PROPERTY_BOTTOM,
+	TiC.PROPERTY_LAYOUT,
+	TiC.PROPERTY_ZINDEX,
 	// accessibility
 	TiC.PROPERTY_ACCESSIBILITY_HINT,
 	TiC.PROPERTY_ACCESSIBILITY_LABEL,
 	TiC.PROPERTY_ACCESSIBILITY_VALUE,
 	TiC.PROPERTY_ACCESSIBILITY_HIDDEN,
 	// others
-	"focusable",
-	"touchEnabled",
-	"visible",
-	"enabled",
-	"opacity",
-	"softKeyboardOnFocus",
-	"transform",
-	"elevation",
-	"touchTestId",
-	"translationX",
-	"translationY",
-	"translationZ",
-	"rotation",
-	"rotationX",
-	"rotationY",
-	"scaleX",
-	"scaleY",
+	TiC.PROPERTY_FOCUSABLE,
+	TiC.PROPERTY_TOUCH_ENABLED,
+	TiC.PROPERTY_VISIBLE,
+	TiC.PROPERTY_ENABLED,
+	TiC.PROPERTY_OPACITY,
+	TiC.PROPERTY_SOFT_KEYBOARD_ON_FOCUS,
+	TiC.PROPERTY_TRANSFORM,
+	TiC.PROPERTY_ELEVATION,
+	TiC.PROPERTY_TRANSLATION_X,
+	TiC.PROPERTY_TRANSLATION_Y,
+	TiC.PROPERTY_TRANSLATION_Z,
+	TiC.PROPERTY_ROTATION,
+	TiC.PROPERTY_ROTATION_X,
+	TiC.PROPERTY_ROTATION_Y,
+	TiC.PROPERTY_SCALE_X,
+	TiC.PROPERTY_SCALE_Y,
 	TiC.PROPERTY_TOUCH_FEEDBACK,
 	TiC.PROPERTY_TOUCH_FEEDBACK_COLOR,
 	TiC.PROPERTY_TRANSITION_NAME,
@@ -1026,8 +1027,32 @@ public abstract class TiViewProxy extends KrollProxy
 	// clang-format off
 	@Kroll.method
 	@Kroll.getProperty
-	public String getBackgroundDisabledColor()
-	// clang-format on
+	public String getBackgroundColor()
+	// clang - format on
+	{
+		// Try to get the background drawable if one is available.
+		TiBackgroundDrawable backgroundDrawable = getOrCreateView().getBackground();
+		// If only backgroundColor is defined then no ColorStateList is created,
+		// we resort to only the color defined.
+		if (backgroundDrawable == null) {
+			// Guard for not having the nativeView set.
+			if (getOrCreateView().getNativeView() != null) {
+				if (getOrCreateView().getNativeView().getBackground() instanceof ColorDrawable) {
+					return TiUIHelper.transcriptColorIntToString(((ColorDrawable) getOrCreateView().getNativeView().getBackground()).getColor());
+				}
+			}
+			return null;
+		} else {
+			// It shouldn't matter if we request the color for DEFAULT_STATE_1 or DEFAULT_STATE_2. They are the same.
+			return TiUIHelper.getColorOfBackgroundForState(backgroundDrawable, TiUIHelper.BACKGROUND_DEFAULT_STATE_1);
+		}
+	}
+
+	// clang-format off
+	@Kroll.method
+	@Kroll.getProperty
+	public String getBackgroundSelectedColor()
+	// clang - format on
 	{
 		TiUIView view = getOrCreateView();
 		if (view == null) {
@@ -1039,45 +1064,39 @@ public abstract class TiViewProxy extends KrollProxy
 		if (backgroundDrawable == null) {
 			return null;
 		} else {
-			try {
-				// Get the backgroundDrawable background as a StateListDrawable.
-				StateListDrawable stateListDrawable = ((StateListDrawable) backgroundDrawable.getBackground());
-				// Get the reflection methods.
-				Method getStateDrawableIndexMethod =
-					StateListDrawable.class.getMethod("getStateDrawableIndex", int[].class);
-				Method getStateDrawableMethod = StateListDrawable.class.getMethod("getStateDrawable", int.class);
-				// Get the disabled state's (as defined in TiUIHelper) index.
-				int index =
-					(int) getStateDrawableIndexMethod.invoke(stateListDrawable, TiUIHelper.BACKGROUND_DISABLED_STATE);
-				// Get the drawable at the index.
-				Drawable drawable = (Drawable) getStateDrawableMethod.invoke(stateListDrawable, index);
-				// Try to get the 0 index of the result.
-				if (drawable instanceof LayerDrawable) {
-					Drawable drawableFromLayer = ((LayerDrawable) drawable).getDrawable(0);
-					// Cast it as a ColorDrawable.
-					if (drawableFromLayer instanceof ColorDrawable) {
-						// Transcript the color int to HexString.
-						String strColor =
-							String.format("#%08X", 0xFFFFFFFF & ((ColorDrawable) drawableFromLayer).getColor());
-						return strColor;
-					} else {
-						Log.w(TAG, "Background drawable of unexpected type. Expected - ColorDrawable. Found - "
-									   + drawableFromLayer.getClass().toString());
-						return null;
-					}
-				} else {
-					Log.w(TAG, "Background drawable of unexpected type. Expected - LayerDrawable. Found - "
-								   + drawable.getClass().toString());
-					return null;
-				}
-			} catch (NoSuchMethodException e) {
-				Log.w(TAG, "Unable to get a method for reflection.");
-			} catch (IllegalAccessException e) {
-				Log.w(TAG, "Unable to access a method for reflection.");
-			} catch (InvocationTargetException e) {
-				Log.w(TAG, "Unable to invoke a method for reflection.");
-			}
+			return TiUIHelper.getColorOfBackgroundForState(backgroundDrawable, TiUIHelper.BACKGROUND_SELECTED_STATE);
+		}
+	}
+
+	// clang-format off
+	@Kroll.method
+	@Kroll.getProperty
+	public String getBackgroundFocusedColor()
+	// clang - format on
+	{
+		// Try to get the background drawable if one is available.
+		TiBackgroundDrawable backgroundDrawable = getOrCreateView().getBackground();
+		// Guard for views without color state backgrounds.
+		if (backgroundDrawable == null) {
 			return null;
+		} else {
+			return TiUIHelper.getColorOfBackgroundForState(backgroundDrawable, TiUIHelper.BACKGROUND_FOCUSED_STATE);
+		}
+	}
+
+	// clang-format off
+	@Kroll.method
+	@Kroll.getProperty
+	public String getBackgroundDisabledColor()
+	// clang - format on
+	{
+		// Try to get the background drawable if one is available.
+		TiBackgroundDrawable backgroundDrawable = getOrCreateView().getBackground();
+		// Guard for views without color state backgrounds.
+		if (backgroundDrawable == null) {
+			return null;
+		} else {
+			return TiUIHelper.getColorOfBackgroundForState(backgroundDrawable, TiUIHelper.BACKGROUND_DISABLED_STATE);
 		}
 	}
 

--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/TiViewProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/TiViewProxy.java
@@ -1029,6 +1029,10 @@ public abstract class TiViewProxy extends KrollProxy
 	public String getBackgroundColor()
 	// clang - format on
 	{
+		// Return property if available.
+		if (getProperties().containsKeyAndNotNull(TiC.PROPERTY_BACKGROUND_COLOR)) {
+			return getProperties().getString(TiC.PROPERTY_BACKGROUND_COLOR);
+		}
 		// Try to get the background drawable if one is available.
 		TiBackgroundDrawable backgroundDrawable = getOrCreateView().getBackground();
 		// If only backgroundColor is defined then no ColorStateList is created, we resort to only the color defined.
@@ -1051,6 +1055,10 @@ public abstract class TiViewProxy extends KrollProxy
 	public String getBackgroundSelectedColor()
 	// clang - format on
 	{
+		// Return property if available.
+		if (getProperties().containsKeyAndNotNull(TiC.PROPERTY_BACKGROUND_SELECTED_COLOR)) {
+			return getProperties().getString(TiC.PROPERTY_BACKGROUND_SELECTED_COLOR);
+		}
 		TiUIView view = getOrCreateView();
 		if (view == null) {
 			return null;
@@ -1069,6 +1077,10 @@ public abstract class TiViewProxy extends KrollProxy
 	public String getBackgroundFocusedColor()
 	// clang - format on
 	{
+		// Return property if available.
+		if (getProperties().containsKeyAndNotNull(TiC.PROPERTY_BACKGROUND_FOCUSED_COLOR)) {
+			return getProperties().getString(TiC.PROPERTY_BACKGROUND_FOCUSED_COLOR);
+		}
 		// Try to get the background drawable if one is available.
 		TiBackgroundDrawable backgroundDrawable = getOrCreateView().getBackground();
 		if (backgroundDrawable == null) {
@@ -1083,6 +1095,10 @@ public abstract class TiViewProxy extends KrollProxy
 	public String getBackgroundDisabledColor()
 	// clang - format on
 	{
+		// Return property if available.
+		if (getProperties().containsKeyAndNotNull(TiC.PROPERTY_BACKGROUND_DISABLED_COLOR)) {
+			return getProperties().getString(TiC.PROPERTY_BACKGROUND_DISABLED_COLOR);
+		}
 		// Try to get the background drawable if one is available.
 		TiBackgroundDrawable backgroundDrawable = getOrCreateView().getBackground();
 		if (backgroundDrawable == null) {

--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/TiViewProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/TiViewProxy.java
@@ -1035,16 +1035,16 @@ public abstract class TiViewProxy extends KrollProxy
 		// If only backgroundColor is defined then no ColorStateList is created,
 		// we resort to only the color defined.
 		if (backgroundDrawable == null) {
-			// Guard for not having the nativeView set.
-			if (getOrCreateView().getNativeView() != null) {
-				if (getOrCreateView().getNativeView().getBackground() instanceof ColorDrawable) {
-					return TiUIHelper.transcriptColorIntToString(((ColorDrawable) getOrCreateView().getNativeView().getBackground()).getColor());
+			View view = getOrCreateView().getNativeView();
+			if (view != null) {
+				if (view.getBackground() instanceof ColorDrawable) {
+					return TiUIHelper.hexStringFrom(((ColorDrawable) view.getBackground()).getColor());
 				}
 			}
 			return null;
 		} else {
 			// It shouldn't matter if we request the color for DEFAULT_STATE_1 or DEFAULT_STATE_2. They are the same.
-			return TiUIHelper.getColorOfBackgroundForState(backgroundDrawable, TiUIHelper.BACKGROUND_DEFAULT_STATE_1);
+			return TiUIHelper.getBackgroundColorForState(backgroundDrawable, TiUIHelper.BACKGROUND_DEFAULT_STATE_1);
 		}
 	}
 
@@ -1064,7 +1064,7 @@ public abstract class TiViewProxy extends KrollProxy
 		if (backgroundDrawable == null) {
 			return null;
 		} else {
-			return TiUIHelper.getColorOfBackgroundForState(backgroundDrawable, TiUIHelper.BACKGROUND_SELECTED_STATE);
+			return TiUIHelper.getBackgroundColorForState(backgroundDrawable, TiUIHelper.BACKGROUND_SELECTED_STATE);
 		}
 	}
 
@@ -1080,7 +1080,7 @@ public abstract class TiViewProxy extends KrollProxy
 		if (backgroundDrawable == null) {
 			return null;
 		} else {
-			return TiUIHelper.getColorOfBackgroundForState(backgroundDrawable, TiUIHelper.BACKGROUND_FOCUSED_STATE);
+			return TiUIHelper.getBackgroundColorForState(backgroundDrawable, TiUIHelper.BACKGROUND_FOCUSED_STATE);
 		}
 	}
 
@@ -1096,7 +1096,7 @@ public abstract class TiViewProxy extends KrollProxy
 		if (backgroundDrawable == null) {
 			return null;
 		} else {
-			return TiUIHelper.getColorOfBackgroundForState(backgroundDrawable, TiUIHelper.BACKGROUND_DISABLED_STATE);
+			return TiUIHelper.getBackgroundColorForState(backgroundDrawable, TiUIHelper.BACKGROUND_DISABLED_STATE);
 		}
 	}
 

--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/TiViewProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/TiViewProxy.java
@@ -1020,7 +1020,6 @@ public abstract class TiViewProxy extends KrollProxy
 		if (this.parent == null) {
 			return null;
 		}
-
 		return this.parent.get();
 	}
 
@@ -1032,8 +1031,7 @@ public abstract class TiViewProxy extends KrollProxy
 	{
 		// Try to get the background drawable if one is available.
 		TiBackgroundDrawable backgroundDrawable = getOrCreateView().getBackground();
-		// If only backgroundColor is defined then no ColorStateList is created,
-		// we resort to only the color defined.
+		// If only backgroundColor is defined then no ColorStateList is created, we resort to only the color defined.
 		if (backgroundDrawable == null) {
 			View view = getOrCreateView().getNativeView();
 			if (view != null) {
@@ -1042,10 +1040,9 @@ public abstract class TiViewProxy extends KrollProxy
 				}
 			}
 			return null;
-		} else {
-			// It shouldn't matter if we request the color for DEFAULT_STATE_1 or DEFAULT_STATE_2. They are the same.
-			return TiUIHelper.getBackgroundColorForState(backgroundDrawable, TiUIHelper.BACKGROUND_DEFAULT_STATE_1);
 		}
+		// It shouldn't matter if we request the color for DEFAULT_STATE_1 or DEFAULT_STATE_2. They are the same.
+		return TiUIHelper.getBackgroundColorForState(backgroundDrawable, TiUIHelper.BACKGROUND_DEFAULT_STATE_1);
 	}
 
 	// clang-format off
@@ -1060,12 +1057,10 @@ public abstract class TiViewProxy extends KrollProxy
 		}
 		// Try to get the background drawable if one is available.
 		TiBackgroundDrawable backgroundDrawable = view.getBackground();
-		// Guard for views without color state backgrounds.
 		if (backgroundDrawable == null) {
 			return null;
-		} else {
-			return TiUIHelper.getBackgroundColorForState(backgroundDrawable, TiUIHelper.BACKGROUND_SELECTED_STATE);
 		}
+		return TiUIHelper.getBackgroundColorForState(backgroundDrawable, TiUIHelper.BACKGROUND_SELECTED_STATE);
 	}
 
 	// clang-format off
@@ -1076,12 +1071,10 @@ public abstract class TiViewProxy extends KrollProxy
 	{
 		// Try to get the background drawable if one is available.
 		TiBackgroundDrawable backgroundDrawable = getOrCreateView().getBackground();
-		// Guard for views without color state backgrounds.
 		if (backgroundDrawable == null) {
 			return null;
-		} else {
-			return TiUIHelper.getBackgroundColorForState(backgroundDrawable, TiUIHelper.BACKGROUND_FOCUSED_STATE);
 		}
+		return TiUIHelper.getBackgroundColorForState(backgroundDrawable, TiUIHelper.BACKGROUND_FOCUSED_STATE);
 	}
 
 	// clang-format off
@@ -1092,12 +1085,10 @@ public abstract class TiViewProxy extends KrollProxy
 	{
 		// Try to get the background drawable if one is available.
 		TiBackgroundDrawable backgroundDrawable = getOrCreateView().getBackground();
-		// Guard for views without color state backgrounds.
 		if (backgroundDrawable == null) {
 			return null;
-		} else {
-			return TiUIHelper.getBackgroundColorForState(backgroundDrawable, TiUIHelper.BACKGROUND_DISABLED_STATE);
 		}
+		return TiUIHelper.getBackgroundColorForState(backgroundDrawable, TiUIHelper.BACKGROUND_DISABLED_STATE);
 	}
 
 	public void setParent(TiViewProxy parent)
@@ -1137,8 +1128,9 @@ public abstract class TiViewProxy extends KrollProxy
 	public TiViewProxy[] getChildren()
 	// clang-format on
 	{
-		if (children == null)
+		if (children == null) {
 			return new TiViewProxy[0];
+		}
 		return children.toArray(new TiViewProxy[children.size()]);
 	}
 

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiUIHelper.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiUIHelper.java
@@ -42,6 +42,7 @@ import org.appcelerator.titanium.view.TiDrawableReference;
 import org.appcelerator.titanium.view.TiUIView;
 
 import android.app.Activity;
+import android.graphics.drawable.PaintDrawable;
 import android.support.v7.app.AlertDialog;
 import android.content.Context;
 import android.content.DialogInterface;
@@ -642,15 +643,15 @@ public class TiUIHelper
 		return new LayerDrawable(layers.toArray(new Drawable[layers.size()]));
 	}
 
-	private static final int[] BACKGROUND_DEFAULT_STATE_1 = { android.R.attr.state_window_focused,
-															  android.R.attr.state_enabled };
-	private static final int[] BACKGROUND_DEFAULT_STATE_2 = { android.R.attr.state_enabled };
-	private static final int[] BACKGROUND_SELECTED_STATE = { android.R.attr.state_window_focused,
-															 android.R.attr.state_enabled,
-															 android.R.attr.state_pressed };
-	private static final int[] BACKGROUND_FOCUSED_STATE = { android.R.attr.state_focused,
-															android.R.attr.state_window_focused,
-															android.R.attr.state_enabled };
+	public static final int[] BACKGROUND_DEFAULT_STATE_1 = { android.R.attr.state_window_focused,
+															 android.R.attr.state_enabled };
+	public static final int[] BACKGROUND_DEFAULT_STATE_2 = { android.R.attr.state_enabled };
+	public static final int[] BACKGROUND_SELECTED_STATE = { android.R.attr.state_window_focused,
+															android.R.attr.state_enabled,
+															android.R.attr.state_pressed };
+	public static final int[] BACKGROUND_FOCUSED_STATE = { android.R.attr.state_focused,
+														   android.R.attr.state_window_focused,
+														   android.R.attr.state_enabled };
 	public static final int[] BACKGROUND_DISABLED_STATE = { -android.R.attr.state_enabled };
 
 	public static StateListDrawable buildBackgroundDrawable(String image, boolean tileImage, String color,
@@ -1220,5 +1221,65 @@ public class TiUIHelper
 			}
 		}
 		return mUri;
+	}
+
+	/**
+	 * Helper method for getting the actual color values for Views with defined custom backgrounds
+	 * that take advantage of color state lists.
+	 */
+	public static String getColorOfBackgroundForState(TiBackgroundDrawable backgroundDrawable, int[] state)
+	{
+		try {
+			// TiBackgroundDrawable's background can be either PaintDrawable or StateListDrawable.
+			// Handle the cases separately.
+			Drawable simpleDrawable = backgroundDrawable.getBackground();
+			if (simpleDrawable instanceof PaintDrawable) {
+				// For backwards compatibility return null if the required state is not the default one.
+				if (state != TiUIHelper.BACKGROUND_DEFAULT_STATE_1) {
+					return null;
+				}
+				return transcriptColorIntToString(((PaintDrawable) simpleDrawable).getPaint().getColor());
+			}
+			// Get the backgroundDrawable background as a StateListDrawable.
+			StateListDrawable stateListDrawable = ((StateListDrawable) simpleDrawable);
+			// Get the reflection methods.
+			Method getStateDrawableIndexMethod =
+				StateListDrawable.class.getMethod("getStateDrawableIndex", int[].class);
+			Method getStateDrawableMethod = StateListDrawable.class.getMethod("getStateDrawable", int.class);
+			// Get the disabled state's (as defined in TiUIHelper) index.
+			int index = (int) getStateDrawableIndexMethod.invoke(stateListDrawable, state);
+			// Get the drawable at the index.
+			Drawable drawable = (Drawable) getStateDrawableMethod.invoke(stateListDrawable, index);
+			// Try to get the 0 index of the result.
+			if (drawable instanceof LayerDrawable) {
+				Drawable drawableFromLayer = ((LayerDrawable) drawable).getDrawable(0);
+				// Cast it as a ColorDrawable.
+				if (drawableFromLayer instanceof ColorDrawable) {
+					// Transcript the color int to HexString.
+					String strColor = transcriptColorIntToString(((ColorDrawable) drawableFromLayer).getColor());
+					return strColor;
+				} else {
+					Log.w(TAG, "Background drawable of unexpected type. Expected - ColorDrawable. Found - "
+								   + drawableFromLayer.getClass().toString());
+					return null;
+				}
+			} else {
+				Log.w(TAG, "Background drawable of unexpected type. Expected - LayerDrawable. Found - "
+							   + drawable.getClass().toString());
+				return null;
+			}
+		} catch (NoSuchMethodException e) {
+			Log.w(TAG, "Unable to get a method for reflection.");
+		} catch (IllegalAccessException e) {
+			Log.w(TAG, "Unable to access a method for reflection.");
+		} catch (InvocationTargetException e) {
+			Log.w(TAG, "Unable to invoke a method for reflection.");
+		}
+		return null;
+	}
+
+	public static String transcriptColorIntToString(int colorInt)
+	{
+		return String.format("#%08X", 0xFFFFFFFF & colorInt);
 	}
 }

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiUIHelper.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiUIHelper.java
@@ -1227,7 +1227,7 @@ public class TiUIHelper
 	 * Helper method for getting the actual color values for Views with defined custom backgrounds
 	 * that take advantage of color state lists.
 	 */
-	public static String getColorOfBackgroundForState(TiBackgroundDrawable backgroundDrawable, int[] state)
+	public static String getBackgroundColorForState(TiBackgroundDrawable backgroundDrawable, int[] state)
 	{
 		try {
 			// TiBackgroundDrawable's background can be either PaintDrawable or StateListDrawable.
@@ -1238,47 +1238,44 @@ public class TiUIHelper
 				if (state != TiUIHelper.BACKGROUND_DEFAULT_STATE_1) {
 					return null;
 				}
-				return transcriptColorIntToString(((PaintDrawable) simpleDrawable).getPaint().getColor());
-			}
-			// Get the backgroundDrawable background as a StateListDrawable.
-			StateListDrawable stateListDrawable = ((StateListDrawable) simpleDrawable);
-			// Get the reflection methods.
-			Method getStateDrawableIndexMethod =
-				StateListDrawable.class.getMethod("getStateDrawableIndex", int[].class);
-			Method getStateDrawableMethod = StateListDrawable.class.getMethod("getStateDrawable", int.class);
-			// Get the disabled state's (as defined in TiUIHelper) index.
-			int index = (int) getStateDrawableIndexMethod.invoke(stateListDrawable, state);
-			// Get the drawable at the index.
-			Drawable drawable = (Drawable) getStateDrawableMethod.invoke(stateListDrawable, index);
-			// Try to get the 0 index of the result.
-			if (drawable instanceof LayerDrawable) {
-				Drawable drawableFromLayer = ((LayerDrawable) drawable).getDrawable(0);
-				// Cast it as a ColorDrawable.
-				if (drawableFromLayer instanceof ColorDrawable) {
-					// Transcript the color int to HexString.
-					String strColor = transcriptColorIntToString(((ColorDrawable) drawableFromLayer).getColor());
-					return strColor;
+				return hexStringFrom(((PaintDrawable) simpleDrawable).getPaint().getColor());
+			} else if (simpleDrawable instanceof StateListDrawable) {
+				// Get the backgroundDrawable background as a StateListDrawable.
+				StateListDrawable stateListDrawable = (StateListDrawable) simpleDrawable;
+				// Get the reflection methods.
+				Method getStateDrawableIndexMethod =
+					StateListDrawable.class.getMethod("getStateDrawableIndex", int[].class);
+				Method getStateDrawableMethod = StateListDrawable.class.getMethod("getStateDrawable", int.class);
+				// Get the disabled state's (as defined in TiUIHelper) index.
+				int index = (int) getStateDrawableIndexMethod.invoke(stateListDrawable, state);
+				// Get the drawable at the index.
+				Drawable drawable = (Drawable) getStateDrawableMethod.invoke(stateListDrawable, index);
+				// Try to get the 0 index of the result.
+				if (drawable instanceof LayerDrawable) {
+					Drawable drawableFromLayer = ((LayerDrawable) drawable).getDrawable(0);
+					// Cast it as a ColorDrawable.
+					if (drawableFromLayer instanceof ColorDrawable) {
+						// Transcript the color int to HexString.
+						String strColor = hexStringFrom(((ColorDrawable) drawableFromLayer).getColor());
+						return strColor;
+					} else {
+						Log.w(TAG, "Background drawable of unexpected type. Expected - ColorDrawable. Found - "
+									   + drawableFromLayer.getClass().toString());
+						return null;
+					}
 				} else {
-					Log.w(TAG, "Background drawable of unexpected type. Expected - ColorDrawable. Found - "
-								   + drawableFromLayer.getClass().toString());
+					Log.w(TAG, "Background drawable of unexpected type. Expected - LayerDrawable. Found - "
+								   + drawable.getClass().toString());
 					return null;
 				}
-			} else {
-				Log.w(TAG, "Background drawable of unexpected type. Expected - LayerDrawable. Found - "
-							   + drawable.getClass().toString());
-				return null;
 			}
-		} catch (NoSuchMethodException e) {
-			Log.w(TAG, "Unable to get a method for reflection.");
-		} catch (IllegalAccessException e) {
-			Log.w(TAG, "Unable to access a method for reflection.");
-		} catch (InvocationTargetException e) {
-			Log.w(TAG, "Unable to invoke a method for reflection.");
+		} catch (Exception e) {
+			Log.w(TAG, e.toString());
 		}
 		return null;
 	}
 
-	public static String transcriptColorIntToString(int colorInt)
+	public static String hexStringFrom(int colorInt)
 	{
 		return String.format("#%08X", 0xFFFFFFFF & colorInt);
 	}

--- a/tests/Resources/ti.ui.view.addontest.js
+++ b/tests/Resources/ti.ui.view.addontest.js
@@ -1,0 +1,124 @@
+/*
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2015-Present by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+/* eslint-env mocha */
+/* global Ti */
+/* eslint no-unused-expressions: "off" */
+'use strict';
+var should = require('./utilities/assertions');
+
+describe('Titanium.UI.View', function () {
+
+	var rootWindow,
+		win;
+
+	this.slow(2000);
+	this.timeout(10000);
+
+	before(function (finish) {
+		rootWindow = Ti.UI.createWindow();
+		rootWindow.addEventListener('open', function () {
+			finish();
+		});
+		rootWindow.open();
+	});
+
+	after(function (finish) {
+		rootWindow.addEventListener('close', function () {
+			finish();
+		});
+		rootWindow.close();
+	});
+
+	afterEach(function () {
+		if (win) {
+			win.close();
+		}
+		win = null;
+	});
+
+	it.android('backgroundColor without color state', function (finish) {
+		var view;
+		win = Ti.UI.createWindow({ backgroundColor: 'blue' });
+		view = Ti.UI.createView({ backgroundColor: '#88FFFFFF', width: Ti.UI.FILL, height: Ti.UI.FILL });
+		win.add(view);
+		win.addEventListener('focus', function () {
+			try {
+				should(view.backgroundColor).be.eql('#88FFFFFF');
+				finish();
+			} catch (err) {
+				finish(err);
+			}
+		});
+		win.open();
+	});
+
+	it.android('backgroundColor with border', function (finish) {
+		var view;
+		win = Ti.UI.createWindow({ backgroundColor: 'blue' });
+		view = Ti.UI.createView({ backgroundColor: '#88FFFFFF', borderWidth: 10, borderColor: 'green', width: Ti.UI.FILL, height: Ti.UI.FILL });
+		win.add(view);
+		win.addEventListener('focus', function () {
+			try {
+				should(view.backgroundColor).be.eql('#88FFFFFF');
+				finish();
+			} catch (err) {
+				finish(err);
+			}
+		});
+		win.open();
+	});
+
+	it.android('backgroundColor default with color state', function (finish) {
+		var view;
+		win = Ti.UI.createWindow({ backgroundColor: 'blue' });
+		view = Ti.UI.createView({ backgroundColor: '#88FFFFFF', backgroundSelectedColor: 'cyan', width: Ti.UI.FILL, height: Ti.UI.FILL });
+		win.add(view);
+		win.addEventListener('focus', function () {
+			try {
+				should(view.backgroundColor).be.eql('#88FFFFFF');
+				finish();
+			} catch (err) {
+				finish(err);
+			}
+		});
+		win.open();
+	});
+
+	it.android('backgroundSelectedColor', function (finish) {
+		var view;
+		win = Ti.UI.createWindow({ backgroundColor: 'blue' });
+		view = Ti.UI.createView({ width: Ti.UI.FILL, height: Ti.UI.FILL });
+		win.add(view);
+		win.addEventListener('focus', function () {
+			try {
+				view.backgroundSelectedColor = '#88FFFFFF';
+				should(view.backgroundSelectedColor).be.eql('#88FFFFFF');
+				finish();
+			} catch (err) {
+				finish(err);
+			}
+		});
+		win.open();
+	});
+
+	it.android('backgroundFocusedColor', function (finish) {
+		var view;
+		win = Ti.UI.createWindow({ backgroundColor: 'blue' });
+		view = Ti.UI.createView({ width: Ti.UI.FILL, height: Ti.UI.FILL });
+		win.add(view);
+		win.addEventListener('focus', function () {
+			try {
+				view.backgroundFocusedColor = '#88FFFFFF';
+				should(view.backgroundFocusedColor).be.eql('#88FFFFFF');
+				finish();
+			} catch (err) {
+				finish(err);
+			}
+		});
+		win.open();
+	});
+});


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-26390

**Description:**
Connect the getters for different color states for Ti.UI.View with the Android object representing it.
Extract the method for getting colors for state in Ti.UIHelper.
Expose the states we assign for custom background drawables.
Guard for backwards compatibility.
Replace the String properties in Ti.UI.View with the proper TiC constants.

**NOTE:** This introduces behavior that may be classified as "breaking". Prior to this PR color state properties that have not been defined would return `undefined` and now that is replaced with `null`. Also colors set with predefined words ( like "green", "cyan", "yellow" ) will now return the hexadecimal value with alpha channel. For instance setting a `backgroundColor` to `blue` will afterwards return the value `#FF0000FF`. Please, let me know what do you think  about these changes and if they need reworking, mention in the docs or anything that this PR is missing.
The failed unit tests show pretty well what I had in mind with "breaking" change. Having a list with predefined color words for specific color values does solve the problem ( I personally don't like this approach because there may be a difference in naming specific color values across platforms** ). I see we have a defined color map, but it may need a bit of a rework to help in this case.
** A good example is Android - they are supporting both words "green" and "lime" according to their docs:
https://developer.android.com/reference/android/graphics/Color.html#parseColor(java.lang.String)
Which is great, but the result of the call of `Color.parseColor()` with both parameters is the same. Judging by the code it is more likely a bug, because there is no point in having two keys with the same value in their color map. 

**Test case:**
The added unit test should suffice, but here is a code sample 
_app.js_
```js
var win = Ti.UI.createWindow(),
	view = Ti.UI.createView({
		width: 100,
		height: 100,
		borderColor: 'green',
		borderWidth: 5,
		backgroundColor: 'red',
		backgroundSelectedColor: 'green',
		backgroundFocusedColor: 'blue',
		backgroundDisabledColor: 'gray'
	}),
	button = Ti.UI.createButton();

win.add(view);
win.add(button);

button.addEventListener('click', function () {
	Ti.API.info('backgroundColor is ' + view.getBackgroundColor());
	Ti.API.info('backgroundSelectedColor is ' + view.getBackgroundSelectedColor());
	Ti.API.info('backgroundFocusedColor is ' + view.backgroundFocusedColor);
	Ti.API.info('backgroundDisabledColor is ' + view.backgroundDisabledColor);
});
win.open();

```