### PR TITLE
Improve resilience of git checkout

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -127,6 +127,7 @@ timestamps {
 				dir('..') {
 					if (fileExists('titanium_mobile.git')) {
 						dir('titanium_mobile.git') {
+							sh 'git gc'
 							sh 'git remote update -p' // update the clone
 							sh 'git prune' // prune to avoid "warning: There are too many unreachable loose objects"
 						}
@@ -142,7 +143,7 @@ timestamps {
 					branches: scm.branches,
 					extensions: scm.extensions + [
 						[$class: 'WipeWorkspace'],
-						[$class: 'CloneOption', honorRefspec: true, noTags: true, reference: "${pwd()}/../titanium_mobile.git", shallow: true, depth: 30, timeout: 30]],
+						[$class: 'CloneOption', honorRefspec: true, noTags: true, reference: "${pwd()}/../titanium_mobile.git", shallow: true, depth: 30, timeout: 300]],
 					userRemoteConfigs: scm.userRemoteConfigs
 				])
 				// FIXME: Workaround for missing env.GIT_COMMIT: http://stackoverflow.com/questions/36304208/jenkins-workflow-checkout-accessing-branch-name-and-git-commit


### PR DESCRIPTION
This PR improves the reliability of the Jenkins checkout. The timeout has been extended to 5 minutes (due to repository size), and there's a `gc` run before each update. 

@garymathews verified that the `gc` calls appear to help (if nothing else, it's not any worse).