### PR TITLE
[TIMOB-26506] Validate TiUIAbstractTab getWindowProxy()

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIAbstractTab.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIAbstractTab.java
@@ -63,11 +63,12 @@ public abstract class TiUIAbstractTab extends TiUIView
 
 	private TiWindowProxy getWindowProxy()
 	{
-		Object windowProxy = proxy.getProperty(TiC.PROPERTY_WINDOW);
-		if (windowProxy instanceof TiWindowProxy) {
-			return (TiWindowProxy) windowProxy;
+		if (proxy != null) {
+			Object windowProxy = proxy.getProperty(TiC.PROPERTY_WINDOW);
+			if (windowProxy instanceof TiWindowProxy) {
+				return (TiWindowProxy) windowProxy;
+			}
 		}
-
 		return null;
 	}
 }


### PR DESCRIPTION
- Titanium.UI.AbstractTab getWindowProxy does not validate if the proxy exists
- Causes test failure https://jenkins.appcelerator.org/job/titanium-sdk/job/titanium_mobile/job/PR-10405/24/console

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-26506)