### PR TITLE
[7_4_X] fix(ios): create timer using target and selector instead of block

### DIFF
--- a/iphone/Classes/KrollContext.h
+++ b/iphone/Classes/KrollContext.h
@@ -196,12 +196,12 @@ KrollContext *GetKrollContext(TiContextRef context);
 @interface KrollTimerManager : NSObject
 
 /**
- * Map of timer identifiers and the underlying native NSTimer.
+ * Map of timer identifiers and the underlying native NSTimer paired with its timer target.
  */
-@property (nonatomic, strong) NSMutableDictionary<NSNumber *, NSTimer *> *timers;
+@property (nonatomic, strong) NSMutableDictionary<NSNumber *, NSArray *> *timers;
 
 /**
- * Initailizes the timer manager in the given JS context. Exposes the global set/clear
+ * Initializes the timer manager in the given JS context. Exposes the global set/clear
  * functions for creating and clearing intervals/timeouts.
  *
  * @param context The JSContext where timer function should be made available to.


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-26391

the block solution is only available on iOS 10+. to remain compatible with iOS 8 and 9  move to a target object and selector that will be called when the timer fires.

@sgtcoolguy I opened this as a separate PR because i think we won't need the managed values now that we store the callback and arguments in the target object. `JSValue` objects will protect their `JSValueRef`, so as long as we hold a strong reference to them in the target object they won't get GC'ed.
