### PR TITLE
An attempt to fix MapView in a TabGroup unit test.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -280,7 +280,7 @@ timestamps {
 		// Run unit tests in parallel for android/iOS
 		stage('Test') {
 			parallel(
-				'android unit tests': unitTests('android', nodeVersion, npmVersion, targetBranch),
+				'android unit tests': unitTests('android', nodeVersion, npmVersion, 'maps_sdk_tag'),
 				'iOS unit tests': unitTests('ios', nodeVersion, npmVersion, targetBranch),
 				failFast: true
 			)


### PR DESCRIPTION
Pointing to a branch of the test suite containing a potential fix for timing out of adding a MapView in a TabGroup.