### PR TITLE
chore(ios): Add scons command to copy the unit test suite into the Xcode project for testing inside xcode

### DIFF
--- a/build/scons-xcode-test.js
+++ b/build/scons-xcode-test.js
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs-extra');
+const path = require('path');
+
+// TODO Copy files from titanium-mobile-mocha-suite/Resources?
+const TEST_SUITE_DIR = path.join(__dirname, '..', 'titanium-mobile-mocha-suite');
+const JS_DIR = path.join(TEST_SUITE_DIR, 'Resources');
+const DEST = path.join(__dirname, '..', 'iphone', 'Resources');
+const DEST_APP_JS = path.join(DEST, 'app.js');
+const APP_PROPS_JSON = path.join(TEST_SUITE_DIR, 'scripts', 'mocha', 'build', 'iphone', 'build', 'Products', 'Debug-iphonesimulator', 'mocha.app', '_app_props_.json');
+
+// Test files to skip
+const TO_SKIP = [ 'es6.class.test', 'es6.import.test', 'ti.map.test' ];
+
+fs.copy(JS_DIR, DEST)
+	.then(() => fs.readFile(DEST_APP_JS))
+	.then(data => {
+		const content = data.toString().split(/\r?\n/).filter(line => {
+			return !TO_SKIP.some(blah => line.includes(blah));
+		});
+		return fs.writeFile(DEST_APP_JS, content.join('\n'));
+	})
+	.then(() => fs.pathExists(APP_PROPS_JSON))
+	.then(exists => {
+		if (exists) {
+			fs.copySync(APP_PROPS_JSON, path.join(DEST, '_app_props_.json'));
+		}
+	})
+	.catch(err => {
+		console.error(err);
+	});

--- a/build/scons.js
+++ b/build/scons.js
@@ -15,4 +15,5 @@ commander
 	.command('update-node-deps', 'deletes and reinstalls node dependencies')
 	.command('ssri [urls]', 'generates ssri integrity hashes for URLs')
 	.command('modules-integrity', 'Regenerates ssri integrity hashes for all the modules in our pre-packaged listing under support/module/packged/modules.json given the current url values')
+	.command('xcode-test', 'Hacks the XCode project for iOS to copy in the unit test suite so it can be run under XCode\'s debugger')
 	.parse(process.argv);


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/[TICKET]

**Description:**
This is an internal development command added to our build scripts (`scons`). Running `scons xcode-test` will copy the unit test suite into the `iphone/Resources` directory and skip a couple es6 module tests that need transpilation to actually work.

This is handy for running (most of) the unit test suite under Xcode (and an obj-c debugger) to help drill into issues that are surfaced by our tests.