### PR TITLE
fix(android): TIMOB-26541 setTimeout and setInterval do not support calls without interval specified

### DIFF
--- a/android/titanium/src/java/ti/modules/titanium/TitaniumModule.java
+++ b/android/titanium/src/java/ti/modules/titanium/TitaniumModule.java
@@ -1,6 +1,6 @@
 /**
  * Appcelerator Titanium Mobile
- * Copyright (c) 2009-2017 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2009-Present by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.text.DateFormat;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -182,13 +183,16 @@ public class TitaniumModule extends KrollModule
 		}
 	}
 
-	private int createTimer(KrollFunction callback, long timeout, Object[] args, boolean interval)
+	private int createTimer(KrollFunction callback, Number timeout, Object[] args, boolean interval)
 	{
 		// Generate an unique identifier for this timer.
 		// This will later be used by the developer to cancel a timer.
 		final int timerId = lastTimerId++;
 
-		Timer timer = new Timer(timerId, getRuntimeHandler(), callback, timeout, args, interval);
+		if (timeout == null || timeout.longValue() < 1L) {
+			timeout = 1L;
+		}
+		Timer timer = new Timer(timerId, getRuntimeHandler(), callback, timeout.longValue(), args, interval);
 		activeTimers.append(timerId, timer);
 
 		timer.schedule();
@@ -219,18 +223,28 @@ public class TitaniumModule extends KrollModule
 	// clang-format off
 	@Kroll.method
 	@Kroll.topLevel
-	public int setTimeout(KrollFunction krollFunction, long timeout, final Object[] args)
+	public int setTimeout(KrollFunction krollFunction, Object[] args)
 	// clang-format on
 	{
+		Number timeout = null;
+		if (args != null && args.length > 0) {
+			timeout = (Number) args[0];
+			args = Arrays.copyOfRange(args, 1, args.length);
+		}
 		return createTimer(krollFunction, timeout, args, false);
 	}
 
 	// clang-format off
 	@Kroll.method
 	@Kroll.topLevel
-	public int setInterval(KrollFunction krollFunction, long timeout, final Object[] args)
+	public int setInterval(KrollFunction krollFunction, Object[] args)
 	// clang-format on
 	{
+		Number timeout = null;
+		if (args != null && args.length > 0) {
+			timeout = (Number) args[0];
+			args = Arrays.copyOfRange(args, 1, args.length);
+		}
 		return createTimer(krollFunction, timeout, args, true);
 	}
 

--- a/tests/Resources/timers.test.js
+++ b/tests/Resources/timers.test.js
@@ -1,0 +1,179 @@
+/*
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2018-Present by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+/* eslint-env mocha */
+/* global Ti, global */
+/* eslint no-unused-expressions: "off" */
+'use strict';
+var should = require('./utilities/assertions');
+
+describe.only('Timers', function () {
+	describe('#setTimeout', function () {
+		it('is a function', function () {
+			should(setTimeout).be.a.Function;
+		});
+
+		it('accepts callback and interval', function (finish) {
+			setTimeout(function () {
+				finish();
+			}, 1);
+		});
+
+		it('accepts callback and no specified interval', function (finish) {
+			setTimeout(function () {
+				finish();
+			});
+		});
+
+		it('accepts callback and negative interval, still fires', function (finish) {
+			setTimeout(function () {
+				finish();
+			}, -1);
+		});
+
+		it('accepts callback, interval, and additional arguments', function (finish) {
+			setTimeout(function (argOne, argTwo, argThree) {
+				try {
+					argOne.should.eql(2);
+					argTwo.should.eql('3');
+					argThree.should.be.an.Object;
+					argThree.should.have.a.property('name').which.eql('four');
+					finish();
+				} catch (err) {
+					finish(err);
+				}
+			}, 1, 2, '3', { name: 'four' });
+		});
+	});
+
+	describe('#setInterval', function () {
+		it('is a function', function () {
+			should(setInterval).be.a.Function;
+		});
+
+		it('accepts callback and interval', function (finish) {
+			var timerId,
+				finished = false;
+			timerId = setInterval(function () {
+				if (finished) {
+					return;
+				}
+				finished = true;
+				clearInterval(timerId);
+				finish();
+			}, 10);
+		});
+
+		it('accepts callback and no specified interval', function (finish) {
+			var timerId,
+				finished = false;
+			timerId = setInterval(function () {
+				if (finished) {
+					return;
+				}
+				finished = true;
+				clearInterval(timerId);
+				finish();
+			});
+		});
+
+		it('accepts callback and negative interval, still fires', function (finish) {
+			var timerId,
+				finished = false;
+			timerId = setInterval(function () {
+				if (finished) {
+					return;
+				}
+				finished = true;
+				clearInterval(timerId);
+				finish();
+			}, -1);
+		});
+
+		it('accepts callback, interval, and additional arguments', function (finish) {
+			var timerId,
+				finished = false;
+			timerId = setInterval(function (argOne, argTwo, argThree) {
+				if (finished) {
+					return;
+				}
+				finished = true;
+				clearInterval(timerId);
+				try {
+					argOne.should.eql(2);
+					argTwo.should.eql('3');
+					argThree.should.be.an.Object;
+					argThree.should.have.a.property('name').which.eql('four');
+					finish();
+				} catch (err) {
+					finish(err);
+				}
+			}, 10, 2, '3', { name: 'four' });
+		});
+	});
+
+	describe('#clearTimeout', function () {
+		it('is a function', function () {
+			should(clearTimeout).be.a.Function;
+		});
+
+		it('clears timer created with #setTimeout()', function (finish) {
+			var timerId = setTimeout(function () {
+				finish(new Error('setTimeout should have never fired!'));
+			}, 10);
+			clearTimeout(timerId);
+			setTimeout(function () {
+				finish();
+			}, 20);
+		});
+
+		it('clears timer created with #setInterval()', function (finish) {
+			var timerId = setInterval(function () {
+				finish(new Error('setInterval should have never fired!'));
+			}, 10);
+			clearTimeout(timerId);
+			setTimeout(function () {
+				finish();
+			}, 20);
+		});
+	});
+
+	describe('#clearInterval', function () {
+		it('is a function', function () {
+			should(clearInterval).be.a.Function;
+		});
+
+		it('clears timer created with #setTimeout()', function (finish) {
+			var timerId = setTimeout(function () {
+				finish(new Error('setTimeout should have never fired!'));
+			}, 10);
+			clearInterval(timerId);
+			setTimeout(function () {
+				finish();
+			}, 20);
+		});
+
+		it('clears timer created with #setInterval()', function (finish) {
+			var timerId = setInterval(function () {
+				finish(new Error('setInterval should have never fired!'));
+			}, 10);
+			clearInterval(timerId);
+			setTimeout(function () {
+				finish();
+			}, 20);
+		});
+	});
+
+	it.windowsBroken('should be able to override', function () {
+		const methodNames = [ 'setTimeout', 'clearTimeout', 'setInterval', 'clearInterval' ];
+		for (const methodName of methodNames) {
+			const descriptor = Object.getOwnPropertyDescriptor(global, methodName);
+			should(descriptor.configurable).be.true;
+			should(descriptor.enumerable).be.true;
+			should(descriptor.writable).be.true;
+		}
+	});
+});


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-26541

**Description:**
* Update timers test suite
* fix Android implementation to support unspecified interval for timer

The update unit test suite really covers the use cases much better now, and specifically tests for this bug. Also note that the iOS implementation was fixed in #10426 (https://github.com/appcelerator/titanium_mobile/pull/10426/files#diff-4c4d01060a96380d965a014b8b0c3186R116)