### PR TITLE
[7_5_X] fix(android): Only remove x86 from valid abis if user does not specify abi tag

### DIFF
--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -1270,13 +1270,15 @@ AndroidBuilder.prototype.validate = function validate(logger, config, cli) {
 
 	// determine the abis to support
 	this.abis = this.validABIs;
-	if (this.deployType === 'production') {
-		// by default, remove 'x86' from production builds
-		// 'x86' devices are scarce; this is predominantly used for emulators
+	const customABIs = cli.tiapp.android && cli.tiapp.android.abi && cli.tiapp.android.abi.indexOf('all') === -1;
+	if (!customABIs && this.deployType === 'production') {
+		// If a users has not specified the abi tag in the tiapp,
+		// remove 'x86' from production builds 'x86' devices are scarce;
+		// this is predominantly used for emulators
 		// we can save 16MB+ by removing this from release builds
 		this.abis.splice(this.abis.indexOf('x86'), 1);
 	}
-	if (cli.tiapp.android && cli.tiapp.android.abi && cli.tiapp.android.abi.indexOf('all') === -1) {
+	if (customABIs) {
 		this.abis = cli.tiapp.android.abi;
 		this.abis.forEach(function (abi) {
 			if (this.validABIs.indexOf(abi) === -1) {


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-26548

We should let a user target x86 if they want to. Just want to call out that the change that caused this bug should have been done in a semver major release.

Test steps: See jira