### PR TITLE
[TIMOB-26556] TiAPI: Modified SDK's core JS files to not use deprecated property get/set methods

### DIFF
--- a/common/Resources/ti.internal/bootstrap.loader.js
+++ b/common/Resources/ti.internal/bootstrap.loader.js
@@ -33,7 +33,7 @@ function fetchScriptsFromJson() {
 
 	try {
 		jsonFile = Ti.Filesystem.getFile(
-			Ti.Filesystem.getResourcesDirectory(), 'ti.internal/' + JSON_FILE_NAME);
+			Ti.Filesystem.resourcesDirectory, 'ti.internal/' + JSON_FILE_NAME);
 		if (jsonFile.exists()) {
 			settings = JSON.parse(jsonFile.read().text);
 			if (Array.isArray(settings.scripts)) {
@@ -55,7 +55,7 @@ function fetchScriptsFromJson() {
  * Returns an empty array if no bootstrap files were found.
  */
 function fetchScriptsFromResourcesDirectory() {
-	var resourceDirectory = Ti.Filesystem.getFile(Ti.Filesystem.getResourcesDirectory()),
+	var resourceDirectory = Ti.Filesystem.getFile(Ti.Filesystem.resourcesDirectory),
 		resourceDirectoryPath = resourceDirectory.nativePath,
 		bootstrapScripts = [];
 


### PR DESCRIPTION
**JIRA:**
https://jira.appcelerator.org/browse/TIMOB-26556

**Test:**
1. Create a Classic Titanium app via "Default Project" template.
2. Build and run on Android or iOS.
3. Verify that neither of the following warning messages get logged.
```
Automatic getter methods for properties are deprecated in SDK 8.0.0 and will be removed in SDK 9.0.0. Please access the property in standard JS style...
Automatic setter methods for properties are deprecated in SDK 8.0.0 and will be removed in SDK 9.0.0. Please access the property in standard JS style...
```
