### PR TITLE
fix(ios): trigger event when receiving local notification in foreground

### DIFF
--- a/apidoc/Titanium/App/iOS/iOS.yml
+++ b/apidoc/Titanium/App/iOS/iOS.yml
@@ -848,12 +848,12 @@ events:
           The unique identifier for the thread or conversation related to this notification request.
           It will be used to visually group notifications together. Available in Titanium SDK 7.5.0+ and iOS 10+.
         type: String
-        since: { ios: "7.5.0" }
+        since: { iphone: "7.5.0", ipad: "7.5.0" }
 
       - name: category
         summary: The identifier of the app-defined [category object](Titanium.App.iOS.UserNotificationCategory). Available in Titanium SDK 7.5.0+ and iOS 10+.
         type: String
-        since: { ios: "7.5.0" }
+        since: { iphone: "7.5.0", ipad: "7.5.0" }
 
   - name: localnotificationaction
     summary: Fired when a user selects an action for an interactive local notification.
@@ -916,12 +916,12 @@ events:
           The unique identifier for the thread or conversation related to this notification request.
           It will be used to visually group notifications together. Available in Titanium SDK 7.5.0+ and iOS 10+.
         type: String
-        since: { ios: "7.5.0" }
+        since: { iphone: "7.5.0", ipad: "7.5.0" }
 
       - name: category
         summary: The identifier of the app-defined [category object](Titanium.App.iOS.UserNotificationCategory). Available in Titanium SDK 7.5.0+ and iOS 10+.
         type: String
-        since: { ios: "7.5.0" }
+        since: { iphone: "7.5.0", ipad: "7.5.0" }
 
   - name: remotenotificationaction
     summary: Fired when a user selects an action for an interactive remote notification.

--- a/apidoc/Titanium/App/iOS/iOS.yml
+++ b/apidoc/Titanium/App/iOS/iOS.yml
@@ -838,13 +838,19 @@ events:
         type: Dictionary
 
       - name: inBackground
-        summary: Boolean indicating if notification was received while app was in background. Available in Titanium SDK 6.2.0+.
+        summary: |
+          Boolean indicating if notification was received while app was in background. Available in Titanium SDK 6.2.0.
+          On iOS 10+ this is no longer available since this event will only fire if the app is in foreground.
         type: Boolean
 
       - name: threadIdentifier
         summary: |
-            The unique identifier for the thread or conversation related to this notification request.
-            It will be used to visually group notifications together. Available in Titanium SDK 7.4.0+ and iOS 12+.
+          The unique identifier for the thread or conversation related to this notification request.
+          It will be used to visually group notifications together. Available in Titanium SDK 7.4.0+ and iOS 10+.
+        type: String
+
+      - name: category
+        summary: The identifier of the app-defined [category object](Titanium.App.iOS.UserNotificationCategory). Available in Titanium SDK 7.4.0+ and iOS 10+.
         type: String
 
   - name: localnotificationaction
@@ -896,8 +902,22 @@ events:
         type: Dictionary
 
       - name: inBackground
-        summary: Boolean indicating if notification was received while app was in background (since Titanium SDK 6.2.0).
+        summary: |
+          Boolean indicating if notification was received while app was in background (since Titanium SDK 6.2.0).
+          On iOS 10+ this is no longer available since the event will only fire when opening the app after interacting
+          with a notification from the iOS notification center (which means the app was in background when the
+          notification was received).
         type: Boolean
+
+      - name: threadIdentifier
+        summary: |
+          The unique identifier for the thread or conversation related to this notification request.
+          It will be used to visually group notifications together. Available in Titanium SDK 7.4.0+ and iOS 10+.
+        type: String
+
+      - name: category
+        summary: The identifier of the app-defined [category object](Titanium.App.iOS.UserNotificationCategory). Available in Titanium SDK 7.4.0+ and iOS 10+.
+        type: String
 
   - name: remotenotificationaction
     summary: Fired when a user selects an action for an interactive remote notification.
@@ -1348,9 +1368,9 @@ properties:
   - name: identifier
     summary: The notification identifier.
     description: |
-        This property is required in iOS 10+ and will fallback to a generated 
-        UUID-string if not set. It is recommended to manage the identifier 
-        yourself, but you can also get the generated UUID by accessing via 
+        This property is required in iOS 10+ and will fallback to a generated
+        UUID-string if not set. It is recommended to manage the identifier
+        yourself, but you can also get the generated UUID by accessing via
         the "userInfo.id" field for parity with older iOS versions.
     optional: false
     since: "7.3.0"

--- a/apidoc/Titanium/App/iOS/iOS.yml
+++ b/apidoc/Titanium/App/iOS/iOS.yml
@@ -846,12 +846,14 @@ events:
       - name: threadIdentifier
         summary: |
           The unique identifier for the thread or conversation related to this notification request.
-          It will be used to visually group notifications together. Available in Titanium SDK 7.4.0+ and iOS 10+.
+          It will be used to visually group notifications together. Available in Titanium SDK 7.5.0+ and iOS 10+.
         type: String
+        since: { ios: "7.5.0" }
 
       - name: category
-        summary: The identifier of the app-defined [category object](Titanium.App.iOS.UserNotificationCategory). Available in Titanium SDK 7.4.0+ and iOS 10+.
+        summary: The identifier of the app-defined [category object](Titanium.App.iOS.UserNotificationCategory). Available in Titanium SDK 7.5.0+ and iOS 10+.
         type: String
+        since: { ios: "7.5.0" }
 
   - name: localnotificationaction
     summary: Fired when a user selects an action for an interactive local notification.
@@ -912,12 +914,14 @@ events:
       - name: threadIdentifier
         summary: |
           The unique identifier for the thread or conversation related to this notification request.
-          It will be used to visually group notifications together. Available in Titanium SDK 7.4.0+ and iOS 10+.
+          It will be used to visually group notifications together. Available in Titanium SDK 7.5.0+ and iOS 10+.
         type: String
+        since: { ios: "7.5.0" }
 
       - name: category
-        summary: The identifier of the app-defined [category object](Titanium.App.iOS.UserNotificationCategory). Available in Titanium SDK 7.4.0+ and iOS 10+.
+        summary: The identifier of the app-defined [category object](Titanium.App.iOS.UserNotificationCategory). Available in Titanium SDK 7.5.0+ and iOS 10+.
         type: String
+        since: { ios: "7.5.0" }
 
   - name: remotenotificationaction
     summary: Fired when a user selects an action for an interactive remote notification.

--- a/iphone/Classes/TiAppiOSProxy.m
+++ b/iphone/Classes/TiAppiOSProxy.m
@@ -825,16 +825,17 @@
       if (summaryArgument != nil) {
         [content setSummaryArgument:summaryArgument];
       }
-      // Set a number that indicates how many items in the summary are represented in the summary.
+      // Set a number that indicates how many items are represented in the summary.
       if (summaryArgumentCount != nil) {
         [content setSummaryArgumentCount:[TiUtils intValue:summaryArgumentCount]];
       }
-      // Set the thread identifier to enable grouped notifications
-      if (threadIdentifier != nil) {
-        [content setThreadIdentifier:threadIdentifier];
-      }
     }
 #endif
+
+    // Set the thread identifier to enable grouped notifications
+    if (threadIdentifier != nil) {
+      [content setThreadIdentifier:threadIdentifier];
+    }
 
     // Construct a new notiication request using our content and trigger (e.g. date or location)
     UNNotificationRequest *request = [UNNotificationRequest requestWithIdentifier:identifier

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiApp.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiApp.m
@@ -532,14 +532,25 @@ TI_INLINE void waitForMemoryPanicCleared(); //WARNING: This must never be run on
 // iOS 10+
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center willPresentNotification:(UNNotification *)notification withCompletionHandler:(void (^)(UNNotificationPresentationOptions options))completionHandler
 {
-  // For backwards compatibility with iOS < 10, we do not show notifications in-app, but make it configurable
+  // For backwards compatibility with iOS < 10, we do not show notifications while the app is in foreground, but make it configurable
+  // @fixme this is not documented and was silently introduced in TIMOB-26399
   BOOL showInForeground = [TiUtils boolValue:notification.request.content.userInfo[@"showInForeground"] def:NO];
-  if (showInForeground) {
-    completionHandler(UNNotificationPresentationOptionBadge | UNNotificationPresentationOptionAlert | UNNotificationPresentationOptionSound);
-  } else {
+  BOOL isRemote = [notification.request.trigger isKindOfClass:UNPushNotificationTrigger.class];
+
+  if (isRemote) {
     if ([self respondsToSelector:@selector(application:didReceiveRemoteNotification:)]) {
       [self application:[UIApplication sharedApplication] didReceiveRemoteNotification:notification.request.content.userInfo];
     }
+  } else {
+    RELEASE_TO_NIL(localNotification);
+    localNotification = [[TiApp dictionaryWithUserNotification:notification
+                                                withIdentifier:notification.request.identifier] retain];
+    [self tryToPostNotification:localNotification withNotificationName:kTiLocalNotification completionHandler:nil];
+  }
+
+  if (showInForeground) {
+    completionHandler(UNNotificationPresentationOptionBadge | UNNotificationPresentationOptionAlert | UNNotificationPresentationOptionSound);
+  } else {
     completionHandler(UNNotificationPresentationOptionNone);
   }
 }
@@ -548,7 +559,8 @@ TI_INLINE void waitForMemoryPanicCleared(); //WARNING: This must never be run on
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center didReceiveNotificationResponse:(UNNotificationResponse *)response
              withCompletionHandler:(void (^)(void))completionHandler
 {
-  if ([response.notification.request.content.userInfo valueForKey:@"aps"] != nil) {
+  BOOL isRemote = [response.notification.request.trigger isKindOfClass:UNPushNotificationTrigger.class];
+  if (isRemote) {
     NSMutableDictionary *responseInfo = nil;
     if ([response isKindOfClass:[UNTextInputNotificationResponse class]]) {
       responseInfo = [NSMutableDictionary dictionary];
@@ -1472,16 +1484,17 @@ TI_INLINE void waitForMemoryPanicCleared(); //WARNING: This must never be run on
   }
   NSMutableDictionary *event = [NSMutableDictionary dictionary];
 
-  [event setObject:NULL_IF_NIL([notification date]) forKey:@"date"];
-  [event setObject:[[NSTimeZone defaultTimeZone] name] forKey:@"timezone"];
-  [event setObject:NULL_IF_NIL([[[notification request] content] body]) forKey:@"alertBody"];
-  [event setObject:NULL_IF_NIL([[[notification request] content] title]) forKey:@"alertTitle"];
-  [event setObject:NULL_IF_NIL([[[notification request] content] subtitle]) forKey:@"alertSubtitle"];
-  [event setObject:NULL_IF_NIL([[[notification request] content] launchImageName]) forKey:@"alertLaunchImage"];
-  [event setObject:NULL_IF_NIL([[[notification request] content] badge]) forKey:@"badge"];
-  [event setObject:NULL_IF_NIL([[[notification request] content] userInfo]) forKey:@"userInfo"];
-  [event setObject:NULL_IF_NIL([[[notification request] content] categoryIdentifier]) forKey:@"category"];
-  [event setObject:NULL_IF_NIL([[notification request] identifier]) forKey:@"identifier"];
+  [event setObject:NULL_IF_NIL(notification.date) forKey:@"date"];
+  [event setObject:NSTimeZone.defaultTimeZone.name forKey:@"timezone"];
+  [event setObject:NULL_IF_NIL(notification.request.content.body) forKey:@"alertBody"];
+  [event setObject:NULL_IF_NIL(notification.request.content.title) forKey:@"alertTitle"];
+  [event setObject:NULL_IF_NIL(notification.request.content.subtitle) forKey:@"alertSubtitle"];
+  [event setObject:NULL_IF_NIL(notification.request.content.launchImageName) forKey:@"alertLaunchImage"];
+  [event setObject:NULL_IF_NIL(notification.request.content.badge) forKey:@"badge"];
+  [event setObject:NULL_IF_NIL(notification.request.content.userInfo) forKey:@"userInfo"];
+  [event setObject:NULL_IF_NIL(notification.request.content.categoryIdentifier) forKey:@"category"];
+  [event setObject:NULL_IF_NIL(notification.request.content.threadIdentifier) forKey:@"threadIdentifier"];
+  [event setObject:NULL_IF_NIL(notification.request.identifier) forKey:@"identifier"];
 
   // iOS 10+ does have "soundName" but "sound" which is a native object. But if we find
   // a sound in the APS dictionary, we can provide that one for parity


### PR DESCRIPTION
properly trigger event for local notification when on iOS 10. also updates the docs and the event object itself so both are in sync again.

resolves [TIMOB-26559](https://jira.appcelerator.org/browse/TIMOB-26559)
