### PR TITLE
fix(ios): typo in JSValue type (7_5_X)

### DIFF
--- a/iphone/Classes/KrollContext.h
+++ b/iphone/Classes/KrollContext.h
@@ -205,7 +205,7 @@ KrollContext *GetKrollContext(TiContextRef context);
  */
 @property (strong, nonatomic, nullable) NSArray<JSValue *> *arguments;
 
-- (instancetype)initWithCallback:(nonnull JSValue *)callback arguments:(nullable NSArray<NSValue *> *)arguments;
+- (instancetype)initWithCallback:(nonnull JSValue *)callback arguments:(nullable NSArray<JSValue *> *)arguments;
 
 /**
  * The method that will be triggered when a timer fires.

--- a/iphone/Classes/KrollContext.m
+++ b/iphone/Classes/KrollContext.m
@@ -1568,7 +1568,7 @@ static TiValueRef StringFormatDecimalCallback(TiContextRef jsContext, TiObjectRe
 
 @implementation KrollTimerTarget
 
-- (instancetype)initWithCallback:(JSValue *)callback arguments:(NSArray<NSValue *> *)arguments
+- (instancetype)initWithCallback:(JSValue *)callback arguments:(NSArray<JSValue *> *)arguments
 {
   self = [super init];
   if (!self) {


### PR DESCRIPTION
This will just raise a compiler warning so not that important for the 7.5.0.GA release. Can be merged after the GA.