### PR TITLE
[TIMOB-25955] Load ACA module on startup

### DIFF
--- a/common/Resources/ti.main.js
+++ b/common/Resources/ti.main.js
@@ -16,6 +16,14 @@
 // Log the app name, app version, and Titanium version on startup.
 Ti.API.info(Ti.App.name + ' ' + Ti.App.version + ' (Powered by Titanium ' + Ti.version + '.' + Ti.buildHash + ')');
 
+// Attempt to load crash analytics module.
+// NOTE: This should be the first module that loads on startup.
+try {
+	require('com.appcelerator.aca');
+} catch (e) {
+	// Could not load module, silently ignore exception.
+}
+
 // Load all JavaScript extensions.
 require('./ti.internal/extensions/Error');
 


### PR DESCRIPTION
- Attempt to load `com.appcelerator.aca` module on startup for all platforms

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-25955)