### PR TITLE
Android: add to catch for IllegalStateException to TiVideoView8.java

### DIFF
--- a/android/modules/media/src/java/android/widget/TiVideoView8.java
+++ b/android/modules/media/src/java/android/widget/TiVideoView8.java
@@ -421,7 +421,14 @@ public class TiVideoView8 extends SurfaceView implements MediaPlayerControl
 			mTargetState = STATE_ERROR;
 			mErrorListener.onError(mMediaPlayer, MediaPlayer.MEDIA_ERROR_UNKNOWN, 0);
 			return;
+		} catch (IllegalStateException ex) {
+			Log.e(TAG, "Unable to open content: " + mUri, ex);
+			mCurrentState = STATE_ERROR;
+			mTargetState = STATE_ERROR;
+			mErrorListener.onError(mMediaPlayer, MediaPlayer.MEDIA_ERROR_UNKNOWN, 0);
+			return;
 		}
+		
 	}
 
 	public void setMediaController(MediaController controller)


### PR DESCRIPTION
add catch for IllegalStateException
- If there's no file, occurs an error from setDisplay or prepareAsync.

**JIRA:** https://jira.appcelerator.org/browse/[TICKET]

Provide a clear PR title prefixed with `[TICKET]`

**Optional Description:**
