### PR TITLE
fix(android): Fix displaying of multiple exception dialogs

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/TiExceptionHandler.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiExceptionHandler.java
@@ -211,13 +211,12 @@ public class TiExceptionHandler implements Handler.Callback, KrollExceptionHandl
 		final OnClickListener clickListener = new OnClickListener() {
 			public void onClick(DialogInterface dialog, int which)
 			{
+				dialogShowing = false;
 				if (which == DialogInterface.BUTTON_POSITIVE) {
 					Process.killProcess(Process.myPid());
 				}
 				if (!errorMessages.isEmpty()) {
 					handleOpenErrorDialog(errorMessages.removeFirst());
-				} else {
-					dialogShowing = false;
 				}
 			}
 		};

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/KrollBridge.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/KrollBridge.m
@@ -69,7 +69,7 @@ void TiBindingRunLoopAnnounceStart(TiBindingRunLoop runLoop);
       if (buildType != nil || buildType.length > 0) {
         [sharedAnalytics performSelector:@selector(setBuildType:) withObject:buildType];
       }
-      [sharedAnalytics performSelector:@selector(setSDKVersion:) withObject:[NSString stringWithFormat:@"ti.%@", [module performSelector:@selector(version)]]];
+      [sharedAnalytics performSelector:@selector(setSDKVersion:) withObject:[module performSelector:@selector(version)]];
       [sharedAnalytics enableWithAppKey:guid andDeployType:deployType];
     }
   }


### PR DESCRIPTION
- Fix bug where subsequent exception dialogs are not displayed on Android
- Minor fix to `sdk_version` on iOS (remove unnecessary `ti.`)