### PR TITLE
fix(ios): validate setNeedsUpdateOfHomeIndicatorAutoHidden selector

### DIFF
--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiRootViewController.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiRootViewController.m
@@ -1364,7 +1364,7 @@
     [self updateStatusBar];
   }
 
-  if ([TiUtils isIOSVersionOrGreater:@"11.0"]) {
+  if ([TiUtils isIOSVersionOrGreater:@"11.0"] && [self respondsToSelector:@selector(setNeedsUpdateOfHomeIndicatorAutoHidden)]) {
     [self setNeedsUpdateOfHomeIndicatorAutoHidden];
   }
 }


### PR DESCRIPTION
- iOS 11.0.0 issue where a crash can occur if the selector does not exist
  - Validate the selector exists

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-26628)