### PR TITLE
chore(android): bump Android minSdkVersion to 19

### DIFF
--- a/android/dependency.json
+++ b/android/dependency.json
@@ -1,5 +1,5 @@
 {
-	"min_api_level": "16",
+	"min_api_level": "19",
 	"dependencies":
 	{
 		"appcompat":["compat","design"],

--- a/android/dev/TitaniumTest/AndroidManifest.xml
+++ b/android/dev/TitaniumTest/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.titanium.test" android:versionCode="1" android:versionName="1.0">
-	<uses-sdk android:minSdkVersion="16" android:targetSdkVersion="27"/>
+	<uses-sdk android:minSdkVersion="19" android:targetSdkVersion="28"/>
 	<application android:icon="@drawable/appicon" android:label="TitaniumTest" android:name=".TitaniumTestApplication" android:theme="@style/Theme.AppCompat">
 		<activity android:name=".TitaniumTestActivity" android:label="@string/app_name" android:theme="@style/Theme.Titanium" android:configChanges="keyboardHidden|orientation|screenSize">
 			<intent-filter>

--- a/android/modules/accelerometer/AndroidManifest.xml
+++ b/android/modules/accelerometer/AndroidManifest.xml
@@ -3,7 +3,7 @@
 	package="ti.modules.titanium.accelerometer"
 	android:versionCode="1"
 	android:versionName="1.0">
-	<uses-sdk android:minSdkVersion="16" />
+	<uses-sdk android:minSdkVersion="19" />
 
 	<application android:label="@string/app_name">
 	</application>

--- a/android/modules/analytics/AndroidManifest.xml
+++ b/android/modules/analytics/AndroidManifest.xml
@@ -4,7 +4,7 @@
 	android:versionCode="1"
 	android:versionName="1.0">
 
-	<uses-sdk android:minSdkVersion="16" />
+	<uses-sdk android:minSdkVersion="19" />
 
 	<application android:label="@string/app_name">
 	</application>

--- a/android/modules/android/AndroidManifest.xml
+++ b/android/modules/android/AndroidManifest.xml
@@ -4,7 +4,7 @@
 	android:versionCode="1"
 	android:versionName="1.0">
 
-	<uses-sdk android:minSdkVersion="16" android:targetSdkVersion="28" />
+	<uses-sdk android:minSdkVersion="19" android:targetSdkVersion="28" />
 
 	<application android:label="@string/app_name">
 	</application>

--- a/android/modules/app/AndroidManifest.xml
+++ b/android/modules/app/AndroidManifest.xml
@@ -4,7 +4,7 @@
 	android:versionCode="1"
 	android:versionName="1.0">
 
-	<uses-sdk android:minSdkVersion="16" />
+	<uses-sdk android:minSdkVersion="19" />
 
 	<application android:label="@string/app_name">
 	</application>

--- a/android/modules/calendar/AndroidManifest.xml
+++ b/android/modules/calendar/AndroidManifest.xml
@@ -4,7 +4,7 @@
 	android:versionCode="1"
 	android:versionName="1.0">
 
-	<uses-sdk android:minSdkVersion="16" />
+	<uses-sdk android:minSdkVersion="19" />
 
 	<application android:label="@string/app_name">
 	</application>

--- a/android/modules/contacts/AndroidManifest.xml
+++ b/android/modules/contacts/AndroidManifest.xml
@@ -4,7 +4,7 @@
 	android:versionCode="1"
 	android:versionName="1.0">
 
-	<uses-sdk android:minSdkVersion="16" />
+	<uses-sdk android:minSdkVersion="19" />
 
 	<application android:label="@string/app_name">
 	</application>

--- a/android/modules/database/AndroidManifest.xml
+++ b/android/modules/database/AndroidManifest.xml
@@ -4,7 +4,7 @@
 	android:versionCode="1"
 	android:versionName="1.0">
 
-	<uses-sdk android:minSdkVersion="16" />
+	<uses-sdk android:minSdkVersion="19" />
 
 	<application android:label="@string/app_name">
 	</application>

--- a/android/modules/filesystem/AndroidManifest.xml
+++ b/android/modules/filesystem/AndroidManifest.xml
@@ -4,7 +4,7 @@
 	android:versionCode="1"
 	android:versionName="1.0">
 
-	<uses-sdk android:minSdkVersion="16" />
+	<uses-sdk android:minSdkVersion="19" />
 
 	<application android:label="@string/app_name">
 	</application>

--- a/android/modules/geolocation/AndroidManifest.xml
+++ b/android/modules/geolocation/AndroidManifest.xml
@@ -4,7 +4,7 @@
 	android:versionCode="1"
 	android:versionName="1.0">
 
-	<uses-sdk android:minSdkVersion="16" />
+	<uses-sdk android:minSdkVersion="19" />
 
 	<application android:label="@string/app_name">
 	</application>

--- a/android/modules/gesture/AndroidManifest.xml
+++ b/android/modules/gesture/AndroidManifest.xml
@@ -4,7 +4,7 @@
 	android:versionCode="1"
 	android:versionName="1.0">
 
-	<uses-sdk android:minSdkVersion="16" />
+	<uses-sdk android:minSdkVersion="19" />
 
 	<application android:label="@string/app_name">
 	</application>

--- a/android/modules/locale/AndroidManifest.xml
+++ b/android/modules/locale/AndroidManifest.xml
@@ -4,7 +4,7 @@
 	android:versionCode="1"
 	android:versionName="1.0">
 
-	<uses-sdk android:minSdkVersion="16" />
+	<uses-sdk android:minSdkVersion="19" />
 
 	<application android:label="@string/app_name">
 	</application>

--- a/android/modules/media/AndroidManifest.xml
+++ b/android/modules/media/AndroidManifest.xml
@@ -4,7 +4,7 @@
     android:versionCode="1"
     android:versionName="1.0" >
 
-    <uses-sdk android:minSdkVersion="16" />
+    <uses-sdk android:minSdkVersion="19" />
 
     <application android:label="@string/app_name" >
     </application>

--- a/android/modules/network/AndroidManifest.xml
+++ b/android/modules/network/AndroidManifest.xml
@@ -3,7 +3,7 @@
 	package="ti.modules.titanium.network"
 	android:versionCode="1"
 	android:versionName="1.0">
-	<uses-sdk android:minSdkVersion="16" />
+	<uses-sdk android:minSdkVersion="19" />
 
 	<application android:label="@string/app_name">
 	</application>

--- a/android/modules/platform/AndroidManifest.xml
+++ b/android/modules/platform/AndroidManifest.xml
@@ -4,7 +4,7 @@
 	android:versionCode="1"
 	android:versionName="1.0">
 
-	<uses-sdk android:minSdkVersion="16" />
+	<uses-sdk android:minSdkVersion="19" />
 
 	<application android:label="@string/app_name">
 	</application>

--- a/android/modules/ui/AndroidManifest.xml
+++ b/android/modules/ui/AndroidManifest.xml
@@ -4,7 +4,7 @@
 	android:versionCode="1"
 	android:versionName="1.0">
 
-	<uses-sdk android:minSdkVersion="16" android:targetSdkVersion="28" />
+	<uses-sdk android:minSdkVersion="19" android:targetSdkVersion="28" />
 
 	<application android:label="@string/app_name">
 	</application>

--- a/android/modules/utils/AndroidManifest.xml
+++ b/android/modules/utils/AndroidManifest.xml
@@ -4,7 +4,7 @@
 	android:versionCode="1"
 	android:versionName="1.0">
 
-	<uses-sdk android:minSdkVersion="16" />
+	<uses-sdk android:minSdkVersion="19" />
 
 	<application android:label="@string/app_name">
 	</application>

--- a/android/modules/xml/AndroidManifest.xml
+++ b/android/modules/xml/AndroidManifest.xml
@@ -4,7 +4,7 @@
 	android:versionCode="1"
 	android:versionName="1.0">
 
-	<uses-sdk android:minSdkVersion="16" />
+	<uses-sdk android:minSdkVersion="19" />
 
 	<application android:label="@string/app_name">
 	</application>

--- a/android/package.json
+++ b/android/package.json
@@ -21,7 +21,7 @@
 		"version": "7.0.276.32",
 		"mode": "release"
 	},
-	"minSDKVersion": "16",
+	"minSDKVersion": "19",
 	"compileSDKVersion": "28",
 	"vendorDependencies": {
 		"android sdk": ">=23.x <=28.x",

--- a/android/runtime/common/AndroidManifest.xml
+++ b/android/runtime/common/AndroidManifest.xml
@@ -4,7 +4,7 @@
 	android:versionCode="1"
 	android:versionName="1.0">
 
-	<uses-sdk android:minSdkVersion="16" />
+	<uses-sdk android:minSdkVersion="19" />
 
 	<application android:label="@string/app_name">
 	</application>

--- a/android/runtime/v8/AndroidManifest.xml
+++ b/android/runtime/v8/AndroidManifest.xml
@@ -4,7 +4,7 @@
     android:versionCode="1"
     android:versionName="1.0" >
 
-    <uses-sdk android:minSdkVersion="16" />
+    <uses-sdk android:minSdkVersion="19" />
 
     <application
         android:debuggable="true"

--- a/android/runtime/v8/Application.mk
+++ b/android/runtime/v8/Application.mk
@@ -7,7 +7,7 @@
 # Entry point Makefile for ndk-build
 
 APP_BUILD_SCRIPT = src/native/Android.mk
-APP_PLATFORM := android-16
+APP_PLATFORM := android-19
 APP_CPPFLAGS += -std=c++11
 APP_STL := c++_shared
 ifeq ($(BUILD_X86), 1)

--- a/android/runtime/v8/ndk-build.sh
+++ b/android/runtime/v8/ndk-build.sh
@@ -23,11 +23,11 @@ if [ "$ANDROID_PLATFORM" = "" ]; then
 		fi
 
 		if [ "$ANDROID_SDK" = "" ]; then
-			echo "Error: The path to the Android SDK platform must be set in the ANDROID_PLATFORM environment variable (e.g. /opt/android-sdk-macosx/platforms/android-16)"
+			echo "Error: The path to the Android SDK platform must be set in the ANDROID_PLATFORM environment variable (e.g. /opt/android-sdk-macosx/platforms/android-19)"
 			exit 1
 		fi
 	fi
-	export ANDROID_PLATFORM="$(cd "$ANDROID_SDK"; pwd)/platforms/android-16"
+	export ANDROID_PLATFORM="$(cd "$ANDROID_SDK"; pwd)/platforms/android-19"
 fi
 
 THIS_DIR=$(cd "$(dirname "$0")"; pwd)

--- a/android/runtime/v8/project.properties
+++ b/android/runtime/v8/project.properties
@@ -10,4 +10,4 @@
 android.library=true
 android.library.reference.1=../common
 # Project target.
-target=android-16
+target=android-19

--- a/android/titanium/AndroidManifest.xml
+++ b/android/titanium/AndroidManifest.xml
@@ -4,7 +4,7 @@
 	android:versionCode="1"
 	android:versionName="1.0">
 
-	<uses-sdk android:minSdkVersion="16" android:targetSdkVersion="28" />
+	<uses-sdk android:minSdkVersion="19" android:targetSdkVersion="28" />
 
 	<application android:label="@string/app_name">
 	</application>


### PR DESCRIPTION
- Bump `minSdkVersion` from 16 (Android 4.1) to API 19 (Android 4.4)

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-26633)

**Test:**
1. Create a new "Classic" Titanium app from template.
2. Build for Android.
3. Go to project folder: `./build/android`
4. Open the "AndroidManifest.xml" file.
5. Verify `<uses-sdk/>` XML attribute "minSdkVersion" is set to `19`.
