### PR TITLE
feat(api): create node-compatible os core module

### DIFF
--- a/apidoc/Titanium/Platform/Platform.yml
+++ b/apidoc/Titanium/Platform/Platform.yml
@@ -34,6 +34,16 @@ methods:
         summary: The url to check.
         type: String
 
+  - name: cpus
+    summary: |
+        Returns an array of basic cpu information for all logical processors
+    description: |
+        This is intended to provide an implementation similar to Node's `os.cpus()`.
+    returns:
+        type: Array<CPU>
+    platforms: [android]
+    since: "8.0.0"
+
   - name: createUUID
     summary: Creates a globally-unique identifier.
     platforms: [android, iphone, ipad]
@@ -44,12 +54,12 @@ methods:
     summary: |
         Opens this URL using the system's default application for its protocol.
     description: |
-        **iOS Note**: For iOS 10 and later, this method is performed asynchronously 
+        **iOS Note**: For iOS 10 and later, this method is performed asynchronously
         and will call the function passed as an (optional) third parameter instead
         of returning a boolean synchronously.
-        
+
         Example:
-          
+
             Ti.Platform.openURL('myapp://', {
               'UIApplicationOpenURLOptionUniversalLinksOnly': true
             }, function(e) {
@@ -117,7 +127,7 @@ properties:
     platforms: [android, iphone, ipad]
 
   - name: availableMemory
-    summary: System's unused memory, measured in megabytes on iOS and bytes on Android.
+    summary: System's unused memory, measured in bytes.
     type: Number
     permission: read-only
     platforms: [android, iphone, ipad]
@@ -155,16 +165,16 @@ properties:
     description: |
         On Android, this may be the UDID (unique device ID). For iOS, this
         is a unique identifier for this install of the application.
-        
+
         Previously on iOS this may have been a UDID, but access to
         this has been restricted by Apple. For more information, see
         [UUID Article on NSHipster](http://nshipster.com/uuid-udid-unique-identifier/)
         documentation.
 
         To use a UUID across different applications of the same vendor,
-        use <Titanium.Platform.identifierForVendor> instead. 
+        use <Titanium.Platform.identifierForVendor> instead.
 
-        To use a UUID for tracking / advertising purposes, 
+        To use a UUID for tracking / advertising purposes,
         use <Titanium.Platform.identifierForAdvertising> instead.
     platforms: [android, iphone, ipad]
     type: String
@@ -173,9 +183,9 @@ properties:
   - name: identifierForVendor
     summary: An alphanumeric string that uniquely identifies a device to the app's vendor.
     description: |
-        The value of this property is the same for apps that come from the same 
-        vendor running on the same device. A different value is returned for apps 
-        on the same device that come from different vendors, and for apps on 
+        The value of this property is the same for apps that come from the same
+        vendor running on the same device. A different value is returned for apps
+        on the same device that come from different vendors, and for apps on
         different devices regardless of vendor. See the [Apple docs](https://developer.apple.com/reference/uikit/uidevice/1620059-identifierforvendor) for more infos.
     platforms: [iphone, ipad]
     type: String
@@ -185,32 +195,32 @@ properties:
   - name: identifierForAdvertising
     summary: An alphanumeric string unique to each device, used only for serving advertisements.
     description: |
-        Unlike the <Titanium.Platform.identifierForVendor> property, the same 
-        value is returned to all vendors. This identifier may change, for example, 
+        Unlike the <Titanium.Platform.identifierForVendor> property, the same
+        value is returned to all vendors. This identifier may change, for example,
         if the user erases the device, so you should not cache it.
-        
-        In iOS 10.0 and later, the value of this property is all zeroes when the 
+
+        In iOS 10.0 and later, the value of this property is all zeroes when the
         user has limited ad tracking.
-        
+
         If the value is `null`, wait and get the value again later. This happens,
         for example, after the device has been restarted but before the user has
         unlocked the device.
     type: String
     platforms: [iphone, ipad]
     since: "7.0.0"
- 
+
   - name: isAdvertisingTrackingEnabled
     summary: A Boolean value that indicates whether the user has limited ad tracking.
     description: |
-        Check the value of this property before performing any advertising tracking. 
-        If the value is false, use the advertising identifier only for the following 
-        purposes: frequency capping, attribution, conversion events, estimating the 
+        Check the value of this property before performing any advertising tracking.
+        If the value is false, use the advertising identifier only for the following
+        purposes: frequency capping, attribution, conversion events, estimating the
         number of unique users, advertising fraud detection, and debugging.
     platforms: [iphone, ipad]
     type: Boolean
     permission: read-only
     since: "7.0.0"
-        
+
   - name: locale
     summary: System's default language.
     description: |
@@ -258,7 +268,7 @@ properties:
       - title: Testing for a Virtual Device
         example: |
             Determine whether the application is running on a virtual device.
-                if (Ti.Platform.model === 'Simulator' || Ti.Platform.model.indexOf('sdk') !== -1 ){
+                if (Ti.Platform.model.indexOf('Simulator') !== -1 || Ti.Platform.model.indexOf('sdk') !== -1 ){
                   alert('Accelerometer does not work on a virtual device');
                 } else {
                   // Add Accelerometer event listener
@@ -294,7 +304,7 @@ properties:
     permission: read-only
 
   - name: processorCount
-    summary: Number of processing cores.
+    summary: Number of logical processing cores.
     type: Number
     permission: read-only
     platforms: [android, iphone, ipad]
@@ -305,6 +315,18 @@ properties:
       On iOS this is "javascriptcore", on Android either "v8" or "rhino".
     type: String
     permission: read-only
+
+  - name: totalMemory
+    summary: System's total memory, measured in bytes.
+    type: Number
+    permission: read-only
+    platforms: [android, iphone, ipad]
+
+  - name: uptime
+    summary: System uptime since last boot in seconds.
+    type: Number
+    permission: read-only
+    platforms: [android, iphone, ipad]
 
   - name: username
     summary: |
@@ -329,3 +351,44 @@ examples:
               Ti.API.info('The battery event source is ' + e.source);
               Ti.API.info('The battery event name ' + e.type);
             });
+---
+name: CPU
+summary: Simple object holding the data for a logical cpu.
+properties:
+
+  - name: model
+    summary: General description of the CPU
+    type: String
+
+  - name: speed
+    summary: Speed of the CPU in MHz
+    type: Number
+
+  - name: times
+    summary: A collection of timings for this logical CPU.
+    type: CPUTimes
+
+---
+name: CPUTimes
+summary: Simple object holding the data for a logical cpu execution times.
+properties:
+
+  - name: user
+    summary: The number of milliseconds the CPU has spent in user mode.
+    type: Number
+
+  - name: nice
+    summary: The number of milliseconds the CPU has spent in nice mode.
+    type: Number
+
+  - name: sys
+    summary: The number of milliseconds the CPU has spent in sys mode.
+    type: Number
+
+  - name: idle
+    summary: The number of milliseconds the CPU has spent in idle mode.
+    type: Number
+
+  - name: irq
+    summary: The number of milliseconds the CPU has spent in irq mode.
+    type: Number

--- a/common/Resources/ti.internal/extensions/os.js
+++ b/common/Resources/ti.internal/extensions/os.js
@@ -1,0 +1,529 @@
+'use strict';
+
+const isAndroid = Ti.Platform.osname === 'android';
+const isIOS = !isAndroid && (Ti.Platform.osname === 'iphone' || Ti.Platform.osname === 'ipad');
+const isWin32 = !isAndroid && !isIOS && Ti.Platform.name === 'windows';
+
+const PosixConstants = {
+	UV_UDP_REUSEADDR: 4,
+	dlopen: {},
+	errno: {
+		E2BIG: 7,
+		EACCES: 13,
+		EADDRINUSE: 48,
+		EADDRNOTAVAIL: 49,
+		EAFNOSUPPORT: 47,
+		EAGAIN: 35,
+		EALREADY: 37,
+		EBADF: 9,
+		EBADMSG: 94,
+		EBUSY: 16,
+		ECANCELED: 89,
+		ECHILD: 10,
+		ECONNABORTED: 53,
+		ECONNREFUSED: 61,
+		ECONNRESET: 54,
+		EDEADLK: 11,
+		EDESTADDRREQ: 39,
+		EDOM: 33,
+		EDQUOT: 69,
+		EEXIST: 17,
+		EFAULT: 14,
+		EFBIG: 27,
+		EHOSTUNREACH: 65,
+		EIDRM: 90,
+		EILSEQ: 92,
+		EINPROGRESS: 36,
+		EINTR: 4,
+		EINVAL: 22,
+		EIO: 5,
+		EISCONN: 56,
+		EISDIR: 21,
+		ELOOP: 62,
+		EMFILE: 24,
+		EMLINK: 31,
+		EMSGSIZE: 40,
+		EMULTIHOP: 95,
+		ENAMETOOLONG: 63,
+		ENETDOWN: 50,
+		ENETRESET: 52,
+		ENETUNREACH: 51,
+		ENFILE: 23,
+		ENOBUFS: 55,
+		ENODATA: 96,
+		ENODEV: 19,
+		ENOENT: 2,
+		ENOEXEC: 8,
+		ENOLCK: 77,
+		ENOLINK: 97,
+		ENOMEM: 12,
+		ENOMSG: 91,
+		ENOPROTOOPT: 42,
+		ENOSPC: 28,
+		ENOSR: 98,
+		ENOSTR: 99,
+		ENOSYS: 78,
+		ENOTCONN: 57,
+		ENOTDIR: 20,
+		ENOTEMPTY: 66,
+		ENOTSOCK: 38,
+		ENOTSUP: 45,
+		ENOTTY: 25,
+		ENXIO: 6,
+		EOPNOTSUPP: 102,
+		EOVERFLOW: 84,
+		EPERM: 1,
+		EPIPE: 32,
+		EPROTO: 100,
+		EPROTONOSUPPORT: 43,
+		EPROTOTYPE: 41,
+		ERANGE: 34,
+		EROFS: 30,
+		ESPIPE: 29,
+		ESRCH: 3,
+		ESTALE: 70,
+		ETIME: 101,
+		ETIMEDOUT: 60,
+		ETXTBSY: 26,
+		EWOULDBLOCK: 35,
+		EXDEV: 18
+	},
+	signals: {
+		SIGHUP: 1,
+		SIGINT: 2,
+		SIGQUIT: 3,
+		SIGILL: 4,
+		SIGTRAP: 5,
+		SIGABRT: 6,
+		SIGIOT: 6,
+		SIGBUS: 10,
+		SIGFPE: 8,
+		SIGKILL: 9,
+		SIGUSR1: 30,
+		SIGSEGV: 11,
+		SIGUSR2: 31,
+		SIGPIPE: 13,
+		SIGALRM: 14,
+		SIGTERM: 15,
+		SIGCHLD: 20,
+		SIGCONT: 19,
+		SIGSTOP: 17,
+		SIGTSTP: 18,
+		SIGTTIN: 21,
+		SIGTTOU: 22,
+		SIGURG: 16,
+		SIGXCPU: 24,
+		SIGXFSZ: 25,
+		SIGVTALRM: 26,
+		SIGPROF: 27,
+		SIGWINCH: 28,
+		SIGIO: 23,
+		SIGINFO: 29,
+		SIGSYS: 12
+	},
+	priority: {
+		PRIORITY_LOW: 19,
+		PRIORITY_BELOW_NORMAL: 10,
+		PRIORITY_NORMAL: 0,
+		PRIORITY_ABOVE_NORMAL: -7,
+		PRIORITY_HIGH: -14,
+		PRIORITY_HIGHEST: -20
+	}
+};
+
+// default implementations
+const OS = {
+	EOL: '\n',
+	arch: () => process.arch,
+	constants: PosixConstants,
+	cpus: () => {
+		const count = Ti.Platform.processorCount;
+		const array = [];
+		for (let i = 0; i < count; i++) {
+			array.push({
+				model: 'unknown',
+				speed: 0,
+				times: {
+					user: 0,
+					nice: 0,
+					sys: 0,
+					idle: 0,
+					irq: 0
+				}
+			});
+		}
+		return array;
+	},
+	endianness: () => {
+		// TODO: Cache the value!
+		const result = Ti.Codec.getNativeByteOrder();
+		if (result === Ti.Codec.LITTLE_ENDIAN) {
+			return 'LE';
+		}
+		return 'BE';
+	},
+	freemem: () => Ti.Platform.availableMemory,
+	getPriority: () => 0, // fake it
+	homedir: () => Ti.Filesystem.applicationDataDirectory, // fake it
+	hostname: () => Ti.Platform.address || '', // fake it
+	loadavg: () => [ 0, 0, 0 ], // fake it
+	networkInterfaces: () => {}, // FIXME: What do we do here? We might be able to piece some of this together using Ti.Platform.netmask, Ti.Platform.address
+	platform: () => process.platform,
+	release: () => Ti.Platform.version,
+	setPriority: () => {}, // no-op, fake it
+	/**
+	 * The `os.tmpdir()` method returns a string specifying the operating system's default directory for temporary files.
+	 * @return {string} [description]
+	 */
+	tmpdir: () => Ti.Filesystem.tempDirectory,
+	/**
+	 * The `os.totalmem()` method returns the total amount of system memory in bytes as an integer.
+	 * @return {integer} [description]
+	 */
+	totalmem: () => Ti.Platform.totalMemory,
+	type: () => 'Unknown', // overridden per-platform at bottom
+	/**
+	 * The `os.uptime()` method returns the system uptime in number of seconds.
+	 * @return {integer} [description]
+	 */
+	uptime: () => Ti.Platform.uptime,
+	userInfo: () => { // fake it!
+		return {
+			uid: -1,
+			guid: -1,
+			username: Ti.Platform.username,
+			homedir: Ti.Filesystem.applicationDataDirectory,
+			shell: null
+		};
+	}
+};
+
+// On specific platforms, override implementations because we don't have them
+// yet and need to fake it, or to hack them
+// I'm also doing this in blocks to assign implementations that don't need to consult platform
+// type at runtime (hopefully speeding up execution at runtime)
+if (isIOS) {
+	OS.type = () => 'Darwin';
+
+	// Now a giant hack for looking up CPU info for OS.cpus() on iOS
+	// https://www.theiphonewiki.com/wiki/List_of_iPhones
+	const AppleMap = {
+		// iPhone XR
+		'iPhone11,8': [ 'Apple A12 Bionic @ 2.49 GHz', 2490 ],
+		// iPhone XS Max
+		'iPhone11,6': [ 'Apple A12 Bionic @ 2.49 GHz', 2490 ],
+		'iPhone11,4': [ 'Apple A12 Bionic @ 2.49 GHz', 2490 ],
+		// iPhone XS
+		'iPhone11,2': [ 'Apple A12 Bionic @ 2.49 GHz', 2490 ],
+		// iPhone X
+		'iPhone10,6': [ 'Apple A11 Bionic @ 2.39 GHz', 2390 ],
+		'iPhone10,3': [ 'Apple A11 Bionic @ 2.39 GHz', 2390 ],
+		// iPhone 8 Plus
+		'iPhone10,5': [ 'Apple A11 Bionic @ 2.39 GHz', 2390 ],
+		'iPhone10,2': [ 'Apple A11 Bionic @ 2.39 GHz', 2390 ],
+		// iPhone 8
+		'iPhone10,4': [ 'Apple A11 Bionic @ 2.39 GHz', 2390 ],
+		'iPhone10,1': [ 'Apple A11 Bionic @ 2.39 GHz', 2390 ],
+		// iPhone 7 Plus
+		'iPhone9,4': [ 'Apple A10 Fusion @ 2.34 GHz', 2340 ],
+		'iPhone9,2': [ 'Apple A10 Fusion @ 2.34 GHz', 2340 ],
+		// iPhone 7
+		'iPhone9,3': [ 'Apple A10 Fusion @ 2.34 GHz', 2340 ],
+		'iPhone9,1': [ 'Apple A10 Fusion @ 2.34 GHz', 2340 ],
+		// iPhone SE
+		'iPhone8,4': [ 'Apple A9 Twister @ 1.85 GHz', 1850 ],
+		// iPhone 6s Plus
+		'iPhone8,2': [ 'Apple A9 Twister @ 1.85 GHz', 1850 ],
+		// iPhone 6s
+		'iPhone8,1': [ 'Apple A9 Twister @ 1.85 GHz', 1850 ],
+		// iPhone 6 Plus
+		'iPhone7,1': [ 'Apple A8 Typhoon @ 1.38 GHz', 1380 ],
+		// iPhone 6
+		'iPhone7,2': [ 'Apple A8 Typhoon @ 1.38 GHz', 1380 ],
+		// iPhone 5s
+		'iPhone6,2': [ 'Apple A7 Cyclone @ 1.3 GHz', 1300 ],
+		'iPhone6,1': [ 'Apple A7 Cyclone @ 1.3 GHz', 1300 ],
+		// iPhone 5c
+		'iPhone5,4': [ 'Apple A6 Swift @ 1.2 GHz', 1200 ],
+		'iPhone5,3': [ 'Apple A6 Swift @ 1.2 GHz', 1200 ],
+		// iPhone 5
+		'iPhone5,1': [ 'Apple A6 Swift @ 1.2 GHz', 1200 ],
+		'iPhone5,2': [ 'Apple A6 Swift @ 1.2 GHz', 1200 ],
+		// iPhone 4s
+		'iPhone4,1': [ 'Apple A5 @ 800 MHz', 800 ],
+		// iPhone 4
+		'iPhone3,3': [ 'Apple A4 @ 800 MHz', 800 ],
+		'iPhone3,2': [ 'Apple A4 @ 800 MHz', 800 ],
+		'iPhone3,1': [ 'Apple A4 @ 800 MHz', 800 ],
+		// iPhone 3GS
+		'iPhone2,1': [ 'Samsung S5L8920 @ 620 MHz', 620 ],
+		// iPhone 3G
+		'iPhone1,2': [ 'Samsung S5L8900 @ 412 MHz', 412 ],
+		// iPhone
+		'iPhone1,1': [ 'Samsung S5L8900 @ 412 MHz', 412 ],
+
+		// ////// iPads
+		// https://www.theiphonewiki.com/wiki/List_of_iPads
+		// https://en.wikipedia.org/wiki/IPad
+		// iPad Pro (12.9" 3rd gen)
+		'iPad8,8': [ 'Apple A12X @ 2.49 GHz', 2490 ],
+		'iPad8,7': [ 'Apple A12X @ 2.49 GHz', 2490 ],
+		'iPad8,6': [ 'Apple A12X @ 2.49 GHz', 2490 ],
+		'iPad8,5': [ 'Apple A12X @ 2.49 GHz', 2490 ],
+		// iPad Pro (11")
+		'iPad8,4': [ 'Apple A12X @ 2.49 GHz', 2490 ],
+		'iPad8,3': [ 'Apple A12X @ 2.49 GHz', 2490 ],
+		'iPad8,2': [ 'Apple A12X @ 2.49 GHz', 2490 ],
+		'iPad8,1': [ 'Apple A12X @ 2.49 GHz', 2490 ],
+		// iPad (6th gen)
+		'iPad7,6': [ 'Apple A10 @ 2.31 GHz', 2310 ], // FIXME: Wikipedia says 2.34 GHz
+		'iPad7,5': [ 'Apple A10 @ 2.31 GHz', 2310 ],
+		// iPad Pro (10.5")
+		'iPad7,4': [ 'Apple A10X @ 2.38 GHz', 2380 ],
+		'iPad7,3': [ 'Apple A10X @ 2.38 GHz', 2380 ],
+		// iPad Pro (12.9" 2nd gen)
+		'iPad7,2': [ 'Apple A10X @ 2.38 GHz', 2380 ],
+		'iPad7,1': [ 'Apple A10X @ 2.38 GHz', 2380 ],
+		// iPad (5th gen)
+		'iPad6,12': [ 'Apple A9 @ 1.85 GHz', 1850 ],
+		'iPad6,11': [ 'Apple A9 @ 1.85 GHz', 1850 ],
+		// iPad Pro (12.9" 1st gen)
+		'iPad6,8': [ 'Apple A9X @ 2.24 GHz', 2240 ],
+		'iPad6,7': [ 'Apple A9X @ 2.24 GHz', 2240 ],
+		// iPad Pro (9.7")
+		'iPad6,4': [ 'Apple A9X @ 2.16 GHz', 2160 ],
+		'iPad6,3': [ 'Apple A9X @ 2.16 GHz', 2160 ],
+		// iPad Air 2
+		'iPad5,4': [ 'Apple A8X @ 1.5 GHz', 1500 ],
+		'iPad5,3': [ 'Apple A8X @ 1.5 GHz', 1500 ],
+		// iPad Mini 4
+		'iPad5,2': [ 'Apple A8 @ 1.49 GHz', 1490 ],
+		'iPad5,1': [ 'Apple A8 @ 1.49 GHz', 1490 ],
+		// iPad Mini 3
+		'iPad4,9': [ 'Apple A7 @ 1.3 GHz', 1300 ],
+		'iPad4,8': [ 'Apple A7 @ 1.3 GHz', 1300 ],
+		'iPad4,7': [ 'Apple A7 @ 1.3 GHz', 1300 ],
+		// iPad Mini 2
+		'iPad4,6': [ 'Apple A7 @ 1.3 GHz', 1300 ],
+		'iPad4,5': [ 'Apple A7 @ 1.3 GHz', 1300 ],
+		'iPad4,4': [ 'Apple A7 @ 1.3 GHz', 1300 ],
+		// iPad Air 2
+		'iPad4,3': [ 'Apple A7 Rev A @ 1.4 GHz', 1400 ],
+		'iPad4,2': [ 'Apple A7 Rev A @ 1.4 GHz', 1400 ],
+		'iPad4,1': [ 'Apple A7 Rev A @ 1.4 GHz', 1400 ],
+		// iPad (4th gen)
+		'iPad3,6': [ 'Apple A6X @ 1.4 GHz', 1400 ],
+		'iPad3,5': [ 'Apple A6X @ 1.4 GHz', 1400 ],
+		'iPad3,4': [ 'Apple A6X @ 1.4 GHz', 1400 ],
+		// iPad (3rd gen)
+		'iPad3,3': [ 'Apple A5X @ 1 GHz', 1000 ],
+		'iPad3,2': [ 'Apple A5X @ 1 GHz', 1000 ],
+		'iPad3,1': [ 'Apple A5X @ 1 GHz', 1000 ],
+		// iPad Mini
+		'iPad2,7': [ 'Apple A5 Rev A @ 1 GHz', 1000 ],
+		'iPad2,6': [ 'Apple A5 Rev A @ 1 GHz', 1000 ],
+		'iPad2,5': [ 'Apple A5 Rev A @ 1 GHz', 1000 ],
+		// iPad 2
+		'iPad2,4': [ 'Apple A5 @ 1 GHz', 1000 ],
+		'iPad2,3': [ 'Apple A5 @ 1 GHz', 1000 ],
+		'iPad2,2': [ 'Apple A5 @ 1 GHz', 1000 ],
+		'iPad2,1': [ 'Apple A5 @ 1 GHz', 1000 ],
+		// iPad
+		'iPad1,1': [ 'Apple A4 @ 1 GHz', 1000 ],
+	};
+
+	/**
+	 * [cpuModel description]
+	 * @param  {string} model [description]
+	 * @return {array}       [description]
+	 */
+	const cpuModelAndSpeed = (model) => {
+		const trimmed = model.replace(' (Simulator)', '').trim();
+		return AppleMap[trimmed];
+	};
+	// override cpus impl
+	OS.cpus = () => {
+		// TODO: Cache the result!
+		const count = Ti.Platform.processorCount;
+		const modelAndSpeed = cpuModelAndSpeed(Ti.Platform.model);
+		const array = [];
+		for (let i = 0; i < count; i++) {
+			array.push({
+				model: modelAndSpeed[0],
+				speed: modelAndSpeed[1],
+				times: {}
+			});
+		}
+		return array;
+	};
+} else if (isWin32) {
+	OS.uptime = () => 0; // FIXME: Implement!
+	OS.totalmem = () =>  Number.MAX_VALUE; // FIXME: Implement!
+	OS.EOL = '\r\n';
+	OS.type = () => 'Windows_NT';
+	OS.constants = {
+		UV_UDP_REUSEADDR: 4,
+		dlopen: {},
+		errno: {
+			E2BIG: 7,
+			EACCES: 13,
+			EADDRINUSE: 100,
+			EADDRNOTAVAIL: 101,
+			EAFNOSUPPORT: 102,
+			EAGAIN: 11,
+			EALREADY: 103,
+			EBADF: 9,
+			EBADMSG: 104,
+			EBUSY: 16,
+			ECANCELED: 105,
+			ECHILD: 10,
+			ECONNABORTED: 106,
+			ECONNREFUSED: 107,
+			ECONNRESET: 108,
+			EDEADLK: 36,
+			EDESTADDRREQ: 109,
+			EDOM: 33,
+			EEXIST: 17,
+			EFAULT: 14,
+			EFBIG: 27,
+			EHOSTUNREACH: 110,
+			EIDRM: 111,
+			EILSEQ: 42,
+			EINPROGRESS: 112,
+			EINTR: 4,
+			EINVAL: 22,
+			EIO: 5,
+			EISCONN: 113,
+			EISDIR: 21,
+			ELOOP: 114,
+			EMFILE: 24,
+			EMLINK: 31,
+			EMSGSIZE: 115,
+			ENAMETOOLONG: 38,
+			ENETDOWN: 116,
+			ENETRESET: 117,
+			ENETUNREACH: 118,
+			ENFILE: 23,
+			ENOBUFS: 119,
+			ENODATA: 120,
+			ENODEV: 19,
+			ENOENT: 2,
+			ENOEXEC: 8,
+			ENOLCK: 39,
+			ENOLINK: 121,
+			ENOMEM: 12,
+			ENOMSG: 122,
+			ENOPROTOOPT: 123,
+			ENOSPC: 28,
+			ENOSR: 124,
+			ENOSTR: 125,
+			ENOSYS: 40,
+			ENOTCONN: 126,
+			ENOTDIR: 20,
+			ENOTEMPTY: 41,
+			ENOTSOCK: 128,
+			ENOTSUP: 129,
+			ENOTTY: 25,
+			ENXIO: 6,
+			EOPNOTSUPP: 130,
+			EOVERFLOW: 132,
+			EPERM: 1,
+			EPIPE: 32,
+			EPROTO: 134,
+			EPROTONOSUPPORT: 135,
+			EPROTOTYPE: 136,
+			ERANGE: 34,
+			EROFS: 30,
+			ESPIPE: 29,
+			ESRCH: 3,
+			ETIME: 137,
+			ETIMEDOUT: 138,
+			ETXTBSY: 139,
+			EWOULDBLOCK: 140,
+			EXDEV: 18,
+			WSAEINTR: 10004,
+			WSAEBADF: 10009,
+			WSAEACCES: 10013,
+			WSAEFAULT: 10014,
+			WSAEINVAL: 10022,
+			WSAEMFILE: 10024,
+			WSAEWOULDBLOCK: 10035,
+			WSAEINPROGRESS: 10036,
+			WSAEALREADY: 10037,
+			WSAENOTSOCK: 10038,
+			WSAEDESTADDRREQ: 10039,
+			WSAEMSGSIZE: 10040,
+			WSAEPROTOTYPE: 10041,
+			WSAENOPROTOOPT: 10042,
+			WSAEPROTONOSUPPORT: 10043,
+			WSAESOCKTNOSUPPORT: 10044,
+			WSAEOPNOTSUPP: 10045,
+			WSAEPFNOSUPPORT: 10046,
+			WSAEAFNOSUPPORT: 10047,
+			WSAEADDRINUSE: 10048,
+			WSAEADDRNOTAVAIL: 10049,
+			WSAENETDOWN: 10050,
+			WSAENETUNREACH: 10051,
+			WSAENETRESET: 10052,
+			WSAECONNABORTED: 10053,
+			WSAECONNRESET: 10054,
+			WSAENOBUFS: 10055,
+			WSAEISCONN: 10056,
+			WSAENOTCONN: 10057,
+			WSAESHUTDOWN: 10058,
+			WSAETOOMANYREFS: 10059,
+			WSAETIMEDOUT: 10060,
+			WSAECONNREFUSED: 10061,
+			WSAELOOP: 10062,
+			WSAENAMETOOLONG: 10063,
+			WSAEHOSTDOWN: 10064,
+			WSAEHOSTUNREACH: 10065,
+			WSAENOTEMPTY: 10066,
+			WSAEPROCLIM: 10067,
+			WSAEUSERS: 10068,
+			WSAEDQUOT: 10069,
+			WSAESTALE: 10070,
+			WSAEREMOTE: 10071,
+			WSASYSNOTREADY: 10091,
+			WSAVERNOTSUPPORTED: 10092,
+			WSANOTINITIALISED: 10093,
+			WSAEDISCON: 10101,
+			WSAENOMORE: 10102,
+			WSAECANCELLED: 10103,
+			WSAEINVALIDPROCTABLE: 10104,
+			WSAEINVALIDPROVIDER: 10105,
+			WSAEPROVIDERFAILEDINIT: 10106,
+			WSASYSCALLFAILURE: 10107,
+			WSASERVICE_NOT_FOUND: 10108,
+			WSATYPE_NOT_FOUND: 10109,
+			WSA_E_NO_MORE: 10110,
+			WSA_E_CANCELLED: 10111,
+			WSAEREFUSED: 10112
+		},
+		signals: {
+			SIGHUP: 1,
+			SIGINT: 2,
+			SIGILL: 4,
+			SIGABRT: 22,
+			SIGFPE: 8,
+			SIGKILL: 9,
+			SIGSEGV: 11,
+			SIGTERM: 15,
+			SIGBREAK: 21,
+			SIGWINCH: 28
+		},
+		priority: {
+			PRIORITY_LOW: 19,
+			PRIORITY_BELOW_NORMAL: 10,
+			PRIORITY_NORMAL: 0,
+			PRIORITY_ABOVE_NORMAL: -7,
+			PRIORITY_HIGH: -14,
+			PRIORITY_HIGHEST: -20
+		}
+	};
+} else if (isAndroid) {
+	OS.cpus = () => Ti.Platform.cpus();
+	OS.type = () => 'Linux';
+}
+
+module.exports = OS;

--- a/common/Resources/ti.internal/extensions/process.js
+++ b/common/Resources/ti.internal/extensions/process.js
@@ -1,7 +1,53 @@
 'use strict';
 
+/**
+ * This function 'standardizes' the reported architectures to the equivalents reported by Node.js
+ * node values: 'arm', 'arm64', 'ia32', 'mips', 'mipsel', 'ppc', 'ppc64', 's390', 's390x', 'x32', and 'x64'.
+ * iOS values: "arm64", "armv7", "x86_64", "i386", "Unknown"
+ * Android values: "armeabi", "armeabi-v7a", "arm64-v8a", "x86", "x86_64", "mips", "mips64", "unknown"
+ * Windows values: "x64", "ia64", "ARM", "x86", "unknown"
+ * @param {string} original original architecture reported by Ti.Platform
+ * @returns {string}
+ */
+function standardizeArch(original) {
+	switch (original) {
+		// coerce 'armv7', 'armeabi', 'armeabi-v7a', 'ARM' -> 'arm'
+		// 'armeabi' is a dead ABI for Android, removed in NDK r17
+		case 'armv7':
+		case 'armeabi':
+		case 'armeabi-v7a':
+		case 'ARM':
+			return 'arm';
+
+		// coerce 'arm64-v8a' -> 'arm64'
+		case 'arm64-v8a':
+			return 'arm64';
+
+		// coerce 'i386', 'x86' -> 'ia32'
+		case 'i386':
+		case 'x86':
+			return 'ia32';
+
+		// coerce 'x86_64', 'ia64', 'x64' -> 'x64'
+		case 'x86_64':
+		case 'ia64':
+			return 'x64';
+
+		// coerce 'mips64' -> 'mips' // 'mips' and 'mips64' are dead ABIs for Android, removed in NDK r17
+		case 'mips64':
+			return 'mips';
+
+		// coerce 'Unknown' -> 'unknown'
+		case 'Unknown':
+			return 'unknown';
+
+		default:
+			return original;
+	}
+}
+
 const process = {
-	arch: Ti.Platform.architecture,
+	arch: standardizeArch(Ti.Platform.architecture),
 	cwd: function () {
 		return __dirname;
 	},

--- a/common/Resources/ti.internal/extensions/process.js
+++ b/common/Resources/ti.internal/extensions/process.js
@@ -5,7 +5,9 @@ const process = {
 	cwd: function () {
 		return __dirname;
 	},
-	platform: Ti.Platform.name
+	// FIXME: Should we try and adopt 'windowsphone'/'windowsstore' to 'win32'?
+	// FIXME: Should we try and adopt 'ipad'/'iphone' to 'darwin'? or 'ios'?
+	platform: Ti.Platform.osname
 };
 global.process = process;
 module.exports = process;

--- a/common/Resources/ti.main.js
+++ b/common/Resources/ti.main.js
@@ -33,6 +33,7 @@ require('./ti.internal/extensions/process');
 const addBinding = require('./ti.internal/extensions/binding');
 // FIXME Use require.resolve to resolve the path, once we support it!
 addBinding('path', '/ti.internal/extensions/path');
+addBinding('os', '/ti.internal/extensions/os');
 
 // Load and execute all "*.bootstrap.js" files.
 // Note: This must be done after loading extensions since bootstraps might depend on them.

--- a/iphone/Classes/PlatformModule.h
+++ b/iphone/Classes/PlatformModule.h
@@ -19,6 +19,8 @@
   NSString *address;
   NSString *ostype;
   NSNumber *availableMemory;
+  NSNumber *totalMemory;
+  NSNumber *uptime;
   TiPlatformDisplayCaps *capabilities;
   BOOL batteryEnabled;
 }
@@ -35,6 +37,8 @@
 @property (readonly, nonatomic) NSString *address;
 @property (readonly, nonatomic) NSString *ostype;
 @property (readonly, nonatomic) NSNumber *availableMemory;
+@property (readonly, nonatomic) NSNumber *totalMemory;
+@property (readonly, nonatomic) NSNumber *uptime;
 @property (readonly, nonatomic) TiPlatformDisplayCaps *displayCaps;
 @property (readonly, nonatomic) NSNumber *batteryState;
 @property (readonly, nonatomic) NSNumber *batteryLevel;

--- a/tests/Resources/os.addontest.js
+++ b/tests/Resources/os.addontest.js
@@ -1,0 +1,236 @@
+/*
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2011-Present by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+/* eslint-env mocha */
+/* global Ti, process */
+/* eslint no-unused-expressions: "off" */
+'use strict';
+const should = require('./utilities/assertions'); // eslint-disable-line no-unused-vars
+let os;
+
+describe('os', function () {
+	it('should be required as core module', function () {
+		os = require('os');
+		os.should.be.an.Object;
+	});
+
+	it('.EOL', () => {
+		os.should.have.a.property('EOL').which.is.a.String;
+		// TODO: Validate \n or \r\n based on platform!
+	});
+
+	describe('#arch()', () => {
+		it('is a function', function () {
+			os.arch.should.be.a.Function;
+		});
+
+		it('returns a String', function () {
+			os.arch().should.be.a.String;
+		});
+
+		// node values: 'arm', 'arm64', 'ia32', 'mips', 'mipsel', 'ppc', 'ppc64', 's390', 's390x', 'x32', and 'x64'.
+		// iOS values: "arm64", "armv7", "x86_64", "i386", "Unknown"
+		// Android values: "armeabi", "armeabi-v7a", "arm64-v8a", "x86", "x86_64", "mips", "mips64", "unknown"
+		// Windows values: "x64", "ia64", "ARM", "x86", "unknown"
+	});
+
+	describe('.constants', () => {
+		it('is an Object', () => {
+			os.should.have.a.property('constants').which.is.an.Object;
+		});
+
+		it('has a signals property which is an Object', () => {
+			os.constants.should.have.a.property('signals').which.is.an.Object;
+		});
+
+		it('has a errno property which is an Object', () => {
+			os.constants.should.have.a.property('errno').which.is.an.Object;
+		});
+
+		it('has a priority property which is an Object', () => {
+			os.constants.should.have.a.property('priority').which.is.an.Object;
+		});
+	});
+
+	describe('#cpus()', () => {
+		it('is a function', () => {
+			os.cpus.should.be.a.Function;
+		});
+
+		it('returns array of objects whose length matches Ti.Platform.processorCount', () => {
+			const cpus = os.cpus();
+			cpus.should.be.an.Array;
+			cpus.should.have.length(Ti.Platform.processorCount);
+			// TODO: test that the elements are objects with properties: 'model', 'speed', 'times'
+		});
+	});
+
+	describe('#endianness()', () => {
+		it('is a function', () => {
+			os.endianness.should.be.a.Function;
+		});
+
+		it('returns "LE" or "BE", value is consistent with Ti.Codec#getNativeByteOrder()', () => {
+			const byteOrder = os.endianness();
+			if (Ti.Codec.getNativeByteOrder() === Ti.Codec.BIG_ENDIAN) {
+				byteOrder.should.eql('BE');
+			} else {
+				byteOrder.should.eql('LE');
+			}
+		});
+	});
+
+	describe('#freemem()', () => {
+		it('is a function', () => {
+			os.freemem.should.be.a.Function;
+		});
+
+		it('returns a positive Number', () => {
+			os.freemem().should.be.above(0);
+		});
+	});
+
+	describe('#getPriority()', () => {
+		it('is a function', () => {
+			os.getPriority.should.be.a.Function;
+		});
+
+		it('returns 0', () => {
+			os.getPriority().should.eql(0);
+		});
+	});
+
+	describe('#homedir()', () => {
+		it('is a function', () => {
+			os.homedir.should.be.a.Function;
+		});
+
+		it('returns Ti.Filesystem.applicationDataDirectory value', () => {
+			os.homedir().should.eql(Ti.Filesystem.applicationDataDirectory);
+		});
+	});
+
+	describe('#hostname()', () => {
+		it('is a function', () => {
+			os.hostname.should.be.a.Function;
+		});
+
+		it('returns Ti.Platform.address value', () => {
+			os.hostname().should.eql(Ti.Platform.address);
+		});
+	});
+
+	describe('#loadavg()', () => {
+		it('is a function', () => {
+			os.loadavg.should.be.a.Function;
+		});
+
+		it('returns [0, 0, 0]', () => {
+			os.loadavg().should.eql([ 0, 0, 0 ]);
+		});
+	});
+
+	describe('#networkInterfaces()', () => {
+		it('is a function', () => {
+			os.networkInterfaces.should.be.a.Function;
+		});
+
+		// TODO: Implement in some way?
+		// it('returns ...', () => {
+		// 	os.networkInterfaces().should.eql([ 0, 0, 0 ]);
+		// });
+	});
+
+	describe('#platform()', () => {
+		it('is a function', () => {
+			os.platform.should.be.a.Function;
+		});
+
+		it('returns process.platform value', () => {
+			os.platform().should.eql(process.platform);
+		});
+	});
+
+	describe('#release()', () => {
+		it('is a function', () => {
+			os.release.should.be.a.Function;
+		});
+
+		it('returns Ti.Platform.version value', () => {
+			os.release().should.eql(Ti.Platform.version);
+		});
+	});
+
+	describe('#setPriority()', () => {
+		it('is a function', () => {
+			os.setPriority.should.be.a.Function;
+		});
+
+		it('doesn\'t blow up when called (but is no-op)', () => {
+			(function () {
+				os.setPriority(0, 12);
+			}).should.not.throw();
+		});
+	});
+
+	describe('#tmpdir()', () => {
+		it('is a function', () => {
+			os.tmpdir.should.be.a.Function;
+		});
+
+		it('returns Ti.Filesystem.tempDirectory value', () => {
+			os.tmpdir().should.eql(Ti.Filesystem.tempDirectory);
+		});
+	});
+
+	describe('#totalmem()', () => {
+		it('is a function', () => {
+			os.totalmem.should.be.a.Function;
+		});
+
+		it('returns a positive Number', () => {
+			os.totalmem().should.be.above(0);
+			// TODO: verify it's above freemem?
+		});
+	});
+
+	describe('#type()', () => {
+		it('is a function', () => {
+			os.type.should.be.a.Function;
+		});
+
+		it('returns a String', () => {
+			os.type().should.be.a.String; // what values make sense here? We're coercing to node style values now, and I think that's probably wrong
+			// 'Linux', 'Windows_NT', or 'Darwin'!
+		});
+	});
+
+	describe('#uptime()', () => {
+		it('is a function', () => {
+			os.uptime.should.be.a.Function;
+		});
+
+		it('returns a positive Number', () => {
+			os.uptime().should.be.above(0);
+		});
+	});
+
+	describe('#userInfo()', () => {
+		it('is a function', () => {
+			os.userInfo.should.be.a.Function;
+		});
+
+		it('returns an Object', () => {
+			const userInfo = os.userInfo();
+			userInfo.should.be.an.Object;
+			userInfo.should.have.a.property('uid').which.eql(-1);
+			userInfo.should.have.a.property('guid').which.eql(-1);
+			userInfo.should.have.a.property('username').which.is.a.String; // "iPhone 7 Plus" on ios Simulator, "android-build" on android emulator
+			userInfo.should.have.a.property('homedir').which.eql(os.homedir());
+			userInfo.should.have.a.property('shell').which.eql(null);
+		});
+	});
+});


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-18584

**Description:**
- Adds new API to Ti.Platform to support this:
  - `totalMemory()` (analog to `availableMemory()`)
  - `uptime` property
  - `cpus()` (only on Android)

BREAKING CHANGES: This "fixes" iOS to report `Ti.Platform.availableMemory` in bytes, not megabytes - to achieve cross-platform parity.

Additionally, I modified some of the hacks built into `Ti.Platform.model`. On iOS, it would rename the original `"iPhone 2,1"` style strings to become `"iPhone 3GS"` - but only for a handful of very old models. Additionally, It would rename any simulator as simply `"Simulator"`. I now just pass through he original `"iPhone 2,1"` style strings, but if we know we're on a Simulator I append:
`" (Simulator)"`

This way we can still sniff for Simulator and the iPhone/iPad model it's emulating.

This is used to report iOS cpu information by using a lookup table from model to CPU.