### PR TITLE
fix: unify properties of GeocodedAddress and deprecate old properties

### DIFF
--- a/android/modules/geolocation/src/java/ti/modules/titanium/geolocation/TiLocation.java
+++ b/android/modules/geolocation/src/java/ti/modules/titanium/geolocation/TiLocation.java
@@ -321,20 +321,25 @@ public class TiLocation implements Handler.Callback
 
 	private KrollDict buildAddress(JSONObject place)
 	{
+		Log.w(
+			TAG,
+			"GeocodedAddress properties country_code, displayAddress, and zipcode are deprecated in SDK 8.0.0 and will be removed in 9.0.0");
+		Log.w(TAG, "Please replace usage with the respective properties: countryCode, address, and postalCode");
 		KrollDict address = new KrollDict();
 		address.put(TiC.PROPERTY_STREET1, place.optString(TiC.PROPERTY_STREET, ""));
 		address.put(TiC.PROPERTY_STREET, place.optString(TiC.PROPERTY_STREET, ""));
 		address.put(TiC.PROPERTY_CITY, place.optString(TiC.PROPERTY_CITY, ""));
-		address.put(TiC.PROPERTY_REGION1, ""); // AdminArea
-		address.put(TiC.PROPERTY_REGION2, ""); // SubAdminArea
+		address.put(TiC.PROPERTY_REGION1, "");                  // AdminArea
+		address.put(TiC.PROPERTY_REGION2, "");                  // SubAdminArea
+		address.put("zipcode", place.optString("zipcode", "")); // TODO: To be removed in SDK 9.0.0!
 		address.put(TiC.PROPERTY_POSTAL_CODE, place.optString("zipcode", ""));
 		address.put(TiC.PROPERTY_COUNTRY, place.optString(TiC.PROPERTY_COUNTRY, ""));
 		address.put(TiC.PROPERTY_STATE, place.optString(TiC.PROPERTY_STATE, ""));
-		address.put("countryCode", place.optString(TiC.PROPERTY_COUNTRY_CODE,
-												   "")); // TIMOB-4478, remove this later, was old android name
+		// Replace TiC.PROPERTY_COUNTRY_CODE value with "countryCode" in SDK 9.0.0
+		address.put("countryCode", place.optString(TiC.PROPERTY_COUNTRY_CODE, ""));
 		address.put(TiC.PROPERTY_COUNTRY_CODE, place.optString(TiC.PROPERTY_COUNTRY_CODE, ""));
-		address.put(TiC.PROPERTY_LONGITUDE, place.optString(TiC.PROPERTY_LONGITUDE, ""));
-		address.put(TiC.PROPERTY_LATITUDE, place.optString(TiC.PROPERTY_LATITUDE, ""));
+		address.put(TiC.PROPERTY_LONGITUDE, place.optDouble(TiC.PROPERTY_LONGITUDE, 0.0d));
+		address.put(TiC.PROPERTY_LATITUDE, place.optDouble(TiC.PROPERTY_LATITUDE, 0.0d));
 		address.put(TiC.PROPERTY_DISPLAY_ADDRESS, place.optString(TiC.PROPERTY_ADDRESS));
 		address.put(TiC.PROPERTY_ADDRESS, place.optString(TiC.PROPERTY_ADDRESS));
 

--- a/android/titanium/src/java/org/appcelerator/titanium/TiC.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiC.java
@@ -1432,6 +1432,7 @@ public class TiC
 
 	/**
 	 * @module.api
+	 * @deprecated Value will be changed to "countryCode" in SDK 9.0.0
 	 */
 	public static final String PROPERTY_COUNTRY_CODE = "country_code";
 

--- a/apidoc/Titanium/Geolocation/Geolocation.yml
+++ b/apidoc/Titanium/Geolocation/Geolocation.yml
@@ -1279,14 +1279,16 @@ properties:
     platforms: [android]
 
   - name: postalCode
-    summary: Postal code. On iOS, use `zipcode`.
+    summary: Postal code
     type: String
-    platforms: [android]
+    platforms: [android, iphone, ipad]
 
   - name: zipcode
-    summary: Postal code. On Android, use `postalCode`.
+    summary: Postal code. To be replaced by `postalCode`
     type: String
     platforms: [iphone, ipad]
+    deprecated:
+        since: {iphone: "8.0.0", ipad: "8.0.0"}
 
   - name: country
     summary: Country name.
@@ -1294,29 +1296,33 @@ properties:
     platforms: [android, iphone, ipad]
 
   - name: countryCode
-    summary: Country code. On iOS, use `country_code`.
-    type: String
-    platforms: [android]
-
-  - name: country_code
-    summary: Country code. Same as `country_code`.
+    summary: Country code.
     type: String
     platforms: [android, iphone, ipad]
 
+  - name: country_code
+    summary: Country code. To be replaced by `countryCode`.
+    type: String
+    platforms: [android, iphone, ipad]
+    deprecated:
+        since: {android: "8.0.0", iphone: "8.0.0", ipad: "8.0.0"}
+
   - name: longitude
     summary: Longitude of the geocoded point.
-    type: String
+    type: Number
     platforms: [android, iphone, ipad]
 
   - name: latitude
     summary: Latitude of the geocoded point.
-    type: String
+    type: Number
     platforms: [android, iphone, ipad]
 
   - name: displayAddress
     summary: Display address. Identical to `address`.
     type: String
     platforms: [android]
+    deprecated:
+        since: {android: "8.0.0"}
 
   - name: address
     summary: Full address.

--- a/iphone/Classes/GeolocationModule.m
+++ b/iphone/Classes/GeolocationModule.m
@@ -144,6 +144,14 @@ extern NSString *const TI_APPLICATION_GUID;
     BOOL success = [TiUtils boolValue:@"success" properties:event def:YES];
     NSMutableDictionary *revisedEvent = [TiUtils dictionaryWithCode:success ? 0 : -1 message:success ? nil : @"error reverse geocoding"];
     [revisedEvent setValuesForKeysWithDictionary:event];
+    // TODO: Remove the zipcode and country_code values after on SDK 9.0.0!
+    NSArray<NSMutableDictionary *> *places = (NSArray<NSMutableDictionary *> *)revisedEvent[@"places"];
+    for (NSMutableDictionary *dict in places) {
+      dict[@"postalCode"] = dict[@"zipcode"];
+      dict[@"countryCode"] = dict[@"country_code"];
+    }
+    NSLog(@"[WARN] GeocodedAddress properties country_code and zipcode are deprecated in SDK 8.0.0 and will be removed in 9.0.0");
+    NSLog(@"[WARN] Please replace usage with the respective properties: countryCode and postalCode");
     [context fireEvent:callback withObject:revisedEvent remove:NO thisObject:nil];
   }
 }

--- a/tests/Resources/ti.geolocation.test.js
+++ b/tests/Resources/ti.geolocation.test.js
@@ -1,0 +1,313 @@
+/*
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2011-Present by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+/* eslint-env mocha */
+/* global Ti */
+/* eslint no-unused-expressions: "off" */
+'use strict';
+var should = require('./utilities/assertions');
+
+// FIXME This pops a prompt on Windows 10 and will hang tests. We can log on and allow manually...
+// Skip on Windows 10 Mobile device family due to prompt,
+// however we might be able to run some tests?
+describe.windowsBroken('Titanium.Geolocation', function () {
+	it('.apiName', function () {
+		should(Ti.Geolocation).have.readOnlyProperty('apiName').which.is.a.String;
+		should(Ti.Geolocation.apiName).be.eql('Ti.Geolocation');
+	});
+
+	it('.ACCURACY_BEST', function () {
+		should(Ti.Geolocation).have.constant('ACCURACY_BEST').which.is.a.Number;
+	});
+
+	// Intentionally skip for Android, doesn't exist
+	it.androidMissing('.ACCURACY_BEST_FOR_NAVIGATION', function () {
+		should(Ti.Geolocation).have.constant('ACCURACY_BEST_FOR_NAVIGATION').which.is.a.Number;
+	});
+
+	it('.ACCURACY_HIGH', function () {
+		should(Ti.Geolocation).have.constant('ACCURACY_HIGH').which.is.a.Number;
+	});
+
+	it('.ACCURACY_HUNDRED_METERS', function () {
+		should(Ti.Geolocation).have.constant('ACCURACY_HUNDRED_METERS').which.is.a.Number;
+	});
+
+	it('.ACCURACY_KILOMETER', function () {
+		should(Ti.Geolocation).have.constant('ACCURACY_KILOMETER').which.is.a.Number;
+	});
+
+	it('.ACCURACY_LOW', function () {
+		should(Ti.Geolocation).have.constant('ACCURACY_LOW').which.is.a.Number;
+	});
+
+	it('.ACCURACY_NEAREST_TEN_METERS', function () {
+		should(Ti.Geolocation).have.constant('ACCURACY_NEAREST_TEN_METERS').which.is.a.Number;
+	});
+
+	it('.ACCURACY_THREE_KILOMETERS', function () {
+		should(Ti.Geolocation).have.constant('ACCURACY_THREE_KILOMETERS').which.is.a.Number;
+	});
+
+	it.androidMissing('.ACTIVITYTYPE_*', function () {
+		should(Ti.Geolocation).have.enumeration('Number', [ 'ACTIVITYTYPE_AUTOMOTIVE_NAVIGATION', 'ACTIVITYTYPE_FITNESS', 'ACTIVITYTYPE_OTHER', 'ACTIVITYTYPE_OTHER_NAVIGATION' ]);
+	});
+
+	it.androidMissing('.AUTHORIZATION_*', function () {
+		should(Ti.Geolocation).have.enumeration('Number', [ 'AUTHORIZATION_ALWAYS', 'AUTHORIZATION_DENIED', 'AUTHORIZATION_RESTRICTED', 'AUTHORIZATION_UNKNOWN', 'AUTHORIZATION_WHEN_IN_USE' ]);
+	});
+
+	it.androidMissing('.ERROR_*', function () {
+		should(Ti.Geolocation).have.enumeration('Number', [ 'ERROR_DENIED', 'ERROR_HEADING_FAILURE', 'ERROR_LOCATION_UNKNOWN', 'ERROR_NETWORK', 'ERROR_REGION_MONITORING_DELAYED', 'ERROR_REGION_MONITORING_DENIED', 'ERROR_REGION_MONITORING_FAILURE' ]);
+	});
+
+	it.iosMissing('.PROVIDER_*', function () {
+		should(Ti.Geolocation).have.enumeration('String', [ 'PROVIDER_GPS', 'PROVIDER_NETWORK', 'PROVIDER_PASSIVE' ]);
+	});
+
+	// FIXME Get working on Android
+	it.androidBroken('.accuracy', function () {
+		should(Ti.Geolocation).have.a.property('accuracy').which.is.a.Number;
+	});
+
+	it.androidBroken('#getAccuracy()', function () {
+		should(Ti.Geolocation).have.a.property('getAccuracy').which.is.a.Function;
+		should(Ti.Geolocation.getAccuracy()).be.a.Number;
+	});
+
+	it.androidBroken('#setAccuracy()', function () {
+		should(Ti.Geolocation).have.a.property('setAccuracy').which.is.a.Function;
+		Ti.Geolocation.setAccuracy(Ti.Geolocation.ACCURACY_BEST);
+		should(Ti.Geolocation.accuracy).be.eql(Ti.Geolocation.ACCURACY_BEST);
+	});
+
+	it.ios('.activityType', function () {
+		should(Ti.Geolocation).have.a.property('activityType').which.is.a.Number;
+	});
+
+	it.ios('#getActivityType()', function () {
+		should(Ti.Geolocation).have.a.property('getActivityType').which.is.a.Function;
+		should(Ti.Geolocation.getActivityType()).be.a.Number;
+	});
+
+	it.ios('#setActivityType()', function () {
+		should(Ti.Geolocation).have.a.property('setActivityType').which.is.a.Function;
+		Ti.Geolocation.setActivityType(Ti.Geolocation.ACTIVITYTYPE_FITNESS);
+		should(Ti.Geolocation.activityType).be.eql(Ti.Geolocation.ACTIVITYTYPE_FITNESS);
+	});
+
+	it.ios('.allowsBackgroundLocationUpdates', function () {
+		should(Ti.Geolocation).have.a.property('allowsBackgroundLocationUpdates').which.is.a.Boolean;
+		should(Ti.Geolocation.allowsBackgroundLocationUpdates).be.eql(false); // defaults to false (unless a special tiapp property is set, see docs)
+	});
+
+	it.ios('#getAllowsBackgroundLocationUpdates()', function () {
+		should(Ti.Geolocation).have.a.property('getAllowsBackgroundLocationUpdates').which.is.a.Function;
+		should(Ti.Geolocation.getAllowsBackgroundLocationUpdates()).be.a.Boolean;
+	});
+
+	it.ios('#setAllowsBackgroundLocationUpdates()', function () {
+		should(Ti.Geolocation).have.a.property('setAllowsBackgroundLocationUpdates').which.is.a.Function;
+		Ti.Geolocation.setAllowsBackgroundLocationUpdates(true); // defaults to false, set to true
+		should(Ti.Geolocation.allowsBackgroundLocationUpdates).be.eql(true);
+	});
+
+	// Intentionally skip for Android, doesn't exist
+	it.androidMissing('.distanceFilter', function () {
+		should(Ti.Geolocation).have.a.property('distanceFilter').which.is.a.Number;
+	});
+
+	it.androidMissing('#getDistanceFilter()', function () {
+		should(Ti.Geolocation).have.a.property('getDistanceFilter').which.is.a.Function;
+		should(Ti.Geolocation.getDistanceFilter()).be.a.Number;
+	});
+
+	it.androidMissing('#setDistanceFilter()', function () {
+		should(Ti.Geolocation).have.a.property('setDistanceFilter').which.is.a.Function;
+		Ti.Geolocation.setDistanceFilter(1000);
+		should(Ti.Geolocation.distanceFilter).eql(1000);
+	});
+
+	it.ios('.hasCompass', function () {
+		should(Ti.Geolocation).have.a.property('hasCompass').which.is.a.Boolean;
+	});
+
+	it.ios('#getHasCompass()', function () {
+		should(Ti.Geolocation).have.a.property('getHasCompass').which.is.a.Function;
+		should(Ti.Geolocation.getHasCompass()).be.a.Boolean;
+	});
+
+	// Intentionally skip for Android, doesn't exist
+	it.androidMissing('.headingFilter', function () {
+		should(Ti.Geolocation).have.a.property('headingFilter').which.is.a.Number;
+	});
+
+	it.androidMissing('#getHeadingFilter()', function () {
+		should(Ti.Geolocation).have.a.property('getHeadingFilter').which.is.a.Function;
+		should(Ti.Geolocation.getHeadingFilter()).be.a.Number;
+	});
+
+	it.androidMissing('#setHeadingFilter', function () {
+		should(Ti.Geolocation).have.a.property('setHeadingFilter').which.is.a.Function;
+		Ti.Geolocation.setHeadingFilter(90);
+		should(Ti.Geolocation.headingFilter).eql(90);
+	});
+
+	// https://jira.appcelerator.org/browse/TIMOB-26452
+	it.iosBroken('.lastGeolocation', function () {
+		should(Ti.Geolocation).have.a.property('lastGeolocation'); // TODO: which is a String/null/undefined?
+	});
+
+	it('#getLastGeolocation()', function () {
+		should(Ti.Geolocation).have.a.property('getLastGeolocation').which.is.a.Function;
+		Ti.Geolocation.getLastGeolocation();
+		// const returnValue = Ti.Geolocation.getLastGeolocation();
+		// should(returnValue).be.a.Object; // FIXME How do we test return type? Docs say String. May be null or undefined, as well!
+	});
+
+	it.androidMissing('.locationServicesAuthorization', function () {
+		should(Ti.Geolocation).have.a.property('locationServicesAuthorization').which.is.a.Number;
+	});
+
+	it.androidMissing('#getLocationServicesAuthorization()', function () {
+		should(Ti.Geolocation).have.a.property('getLocationServicesAuthorization').which.is.a.Function;
+		should(Ti.Geolocation.getLocationServicesAuthorization()).be.a.Number;
+	});
+
+	it('.locationServicesEnabled', function () {
+		should(Ti.Geolocation).have.a.property('locationServicesEnabled').which.is.a.Boolean;
+	});
+
+	it('#getLocationServicesEnabled()', function () {
+		should(Ti.Geolocation).have.a.property('getLocationServicesEnabled').which.is.a.Function;
+		should(Ti.Geolocation.getLocationServicesEnabled()).be.a.Boolean;
+	});
+
+	it.ios('.pauseLocationUpdateAutomatically', function () {
+		should(Ti.Geolocation).have.a.property('pauseLocationUpdateAutomatically').which.is.a.Boolean;
+		should(Ti.Geolocation.pauseLocationUpdateAutomatically).eql(false); // defaults to false
+	});
+
+	it.ios('#getPauseLocationUpdateAutomatically()', function () {
+		should(Ti.Geolocation).have.a.property('getPauseLocationUpdateAutomatically').which.is.a.Function;
+		should(Ti.Geolocation.getPauseLocationUpdateAutomatically()).be.a.Boolean;
+	});
+
+	it.ios('#setPauseLocationUpdateAutomatically()', function () {
+		should(Ti.Geolocation).have.a.property('setPauseLocationUpdateAutomatically').which.is.a.Function;
+		Ti.Geolocation.setPauseLocationUpdateAutomatically(true); // defaults to false
+		should(Ti.Geolocation.pauseLocationUpdateAutomatically).eql(true);
+	});
+
+	it.ios('.showBackgroundLocationIndicator', function () {
+		should(Ti.Geolocation).have.a.property('showBackgroundLocationIndicator').which.is.a.Boolean;
+		should(Ti.Geolocation.showBackgroundLocationIndicator).eql(false); // defaults to false
+	});
+
+	it.ios('#getShowBackgroundLocationIndicator()', function () {
+		should(Ti.Geolocation).have.a.property('getShowBackgroundLocationIndicator').which.is.a.Function;
+		should(Ti.Geolocation.getShowBackgroundLocationIndicator()).be.a.Boolean;
+	});
+
+	it.ios('#setShowBackgroundLocationIndicator()', function () {
+		should(Ti.Geolocation).have.a.property('setShowBackgroundLocationIndicator').which.is.a.Function;
+		Ti.Geolocation.setShowBackgroundLocationIndicator(true); // defaults to false
+		should(Ti.Geolocation.showBackgroundLocationIndicator).eql(true);
+	});
+
+	it.ios('.showCalibration', function () {
+		should(Ti.Geolocation).have.a.property('showCalibration').which.is.a.Boolean;
+		should(Ti.Geolocation.showCalibration).eql(true); // defaults to true
+	});
+
+	it.ios('#getShowCalibration()', function () {
+		should(Ti.Geolocation).have.a.property('getShowCalibration').which.is.a.Function;
+		should(Ti.Geolocation.getShowCalibration()).be.a.Boolean;
+	});
+
+	it.ios('#setShowCalibration()', function () {
+		should(Ti.Geolocation).have.a.property('setShowCalibration').which.is.a.Function;
+		Ti.Geolocation.setShowCalibration(false); // defaults to true
+		should(Ti.Geolocation.showCalibration).eql(false);
+	});
+
+	it.ios('.trackSignificantLocationChange', function () {
+		should(Ti.Geolocation).have.a.property('trackSignificantLocationChange').which.is.a.Boolean;
+		should(Ti.Geolocation.trackSignificantLocationChange).eql(false); // defaults to false
+	});
+
+	it.ios('#getTrackSignificantLocationChange()', function () {
+		should(Ti.Geolocation).have.a.property('getTrackSignificantLocationChange').which.is.a.Function;
+		should(Ti.Geolocation.getTrackSignificantLocationChange()).be.a.Boolean;
+	});
+
+	it.ios('#setTrackSignificantLocationChange()', function () {
+		should(Ti.Geolocation).have.a.property('setTrackSignificantLocationChange').which.is.a.Function;
+		Ti.Geolocation.setTrackSignificantLocationChange(true); // defaults to false
+		should(Ti.Geolocation.trackSignificantLocationChange).eql(true);
+	});
+
+	// Methods
+
+	it('#forwardGeocoder()', function (finish) {
+		this.timeout(6e4); // 60 sec
+
+		should(Ti.Geolocation.forwardGeocoder).be.a.Function;
+		Ti.Geolocation.forwardGeocoder('440 N Bernardo Ave, Mountain View', function (data) {
+			try {
+				should(data).have.property('success').which.is.a.Boolean;
+				should(data.success).be.eql(true);
+				should(data).have.property('code').which.is.a.Number;
+				should(data.code).be.eql(0);
+				should(data.latitude).be.approximately(37.387, 0.002); // iOS gives: 37.38605, Windows does 37.3883645
+				should(data.longitude).be.approximately(-122.065, 0.02); // WIndows gives: -122.0512682, iOS gives -122.08385
+				finish();
+			} catch (err) {
+				finish(err);
+			}
+		});
+	});
+
+	// FIXME The address object is different from platform to platform! https://jira.appcelerator.org/browse/TIMOB-23496
+	it('#reverseGeocoder()', function (finish) {
+		this.timeout(6e4); // 60 sec
+
+		should(Ti.Geolocation.reverseGeocoder).be.a.Function;
+		Ti.Geolocation.reverseGeocoder(37.3883645, -122.0512682, function (data) {
+			try {
+				should(data).have.property('success').which.is.a.Boolean;
+				should(data.success).be.eql(true);
+				should(data).have.property('code').which.is.a.Number;
+				should(data.code).be.eql(0);
+				// FIXME error property is missing altogether on success for iOS...
+				// should(data).have.property('error'); // undefined on success, holds error message as String otherwise.
+				should(data).have.property('places').which.is.an.Array;
+
+				should(data.places[0].postalCode).be.eql('94043');
+				should(data.places[0].zipcode).be.eql('94043');
+				should(data.places[0]).have.property('latitude').which.is.a.Number; // docs say String!
+				should(data.places[0]).have.property('longitude').which.is.a.Number; // docs say String!
+				should(data.places[0].country).be.eql('USA');
+				should(data.places[0].state).be.eql('California');
+				should(data.places[0].country_code).be.eql('US');
+				should(data.places[0]).have.property('city').which.is.a.String;
+				should(data.places[0]).have.property('address').which.is.a.String;
+
+				finish();
+			} catch (err) {
+				finish(err);
+			}
+		});
+	});
+
+	it('#getCurrentPosition()', function () {
+		should(Ti.Geolocation).have.a.property('getCurrentPosition').which.is.a.Function;
+	});
+
+	it('#getCurrentHeading()', function () {
+		should(Ti.Geolocation).have.a.property('getCurrentHeading').which.is.a.Function;
+	});
+});

--- a/tests/Resources/ti.geolocation.test.js
+++ b/tests/Resources/ti.geolocation.test.js
@@ -19,12 +19,11 @@ describe.windowsBroken('Titanium.Geolocation', function () {
 		should(Ti.Geolocation.apiName).be.eql('Ti.Geolocation');
 	});
 
-	it('.ACCURACY_BEST', function () {
+	it.ios('.ACCURACY_BEST', function () {
 		should(Ti.Geolocation).have.constant('ACCURACY_BEST').which.is.a.Number;
 	});
 
-	// Intentionally skip for Android, doesn't exist
-	it.androidMissing('.ACCURACY_BEST_FOR_NAVIGATION', function () {
+	it.ios('.ACCURACY_BEST_FOR_NAVIGATION', function () {
 		should(Ti.Geolocation).have.constant('ACCURACY_BEST_FOR_NAVIGATION').which.is.a.Number;
 	});
 
@@ -32,11 +31,11 @@ describe.windowsBroken('Titanium.Geolocation', function () {
 		should(Ti.Geolocation).have.constant('ACCURACY_HIGH').which.is.a.Number;
 	});
 
-	it('.ACCURACY_HUNDRED_METERS', function () {
+	it.ios('.ACCURACY_HUNDRED_METERS', function () {
 		should(Ti.Geolocation).have.constant('ACCURACY_HUNDRED_METERS').which.is.a.Number;
 	});
 
-	it('.ACCURACY_KILOMETER', function () {
+	it.ios('.ACCURACY_KILOMETER', function () {
 		should(Ti.Geolocation).have.constant('ACCURACY_KILOMETER').which.is.a.Number;
 	});
 
@@ -44,11 +43,11 @@ describe.windowsBroken('Titanium.Geolocation', function () {
 		should(Ti.Geolocation).have.constant('ACCURACY_LOW').which.is.a.Number;
 	});
 
-	it('.ACCURACY_NEAREST_TEN_METERS', function () {
+	it.ios('.ACCURACY_NEAREST_TEN_METERS', function () {
 		should(Ti.Geolocation).have.constant('ACCURACY_NEAREST_TEN_METERS').which.is.a.Number;
 	});
 
-	it('.ACCURACY_THREE_KILOMETERS', function () {
+	it.ios('.ACCURACY_THREE_KILOMETERS', function () {
 		should(Ti.Geolocation).have.constant('ACCURACY_THREE_KILOMETERS').which.is.a.Number;
 	});
 
@@ -62,10 +61,6 @@ describe.windowsBroken('Titanium.Geolocation', function () {
 
 	it.androidMissing('.ERROR_*', function () {
 		should(Ti.Geolocation).have.enumeration('Number', [ 'ERROR_DENIED', 'ERROR_HEADING_FAILURE', 'ERROR_LOCATION_UNKNOWN', 'ERROR_NETWORK', 'ERROR_REGION_MONITORING_DELAYED', 'ERROR_REGION_MONITORING_DENIED', 'ERROR_REGION_MONITORING_FAILURE' ]);
-	});
-
-	it.iosMissing('.PROVIDER_*', function () {
-		should(Ti.Geolocation).have.enumeration('String', [ 'PROVIDER_GPS', 'PROVIDER_NETWORK', 'PROVIDER_PASSIVE' ]);
 	});
 
 	// FIXME Get working on Android


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-23496

**Description:**
- Spit out deprecation notices when Ti.Geolocation.reverseGeocode result is returned (with suggested replacements)
- Deprecate `country_code`, `displayAddress` and `zipcode` properties in favor of `countryCode`, `address` and `postalCode` (respectively)

BREAKING CHANGE: Return `latitude` and `longitude` as Numbers, not Strings on Android (to match iOS/Windows behavior and forwardGeocode results)