### PR TITLE
feat: inject polyfills to common JS code bundled in SDK

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -42,6 +42,13 @@
         "ecmaVersion": 6,
         "sourceType": "script"
       }
+    },
+    {
+      "files": [ "common/Resources/ti.main.js" ],
+      "parserOptions": {
+        "ecmaVersion": 2017,
+        "sourceType": "module"
+      }
     }
   ]
 }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -31,6 +31,7 @@ module.exports = function (grunt) {
 				'apidoc/**/*.js',
 				'build/**/*.js',
 				'cli/!(locales)/**/*.js',
+				'common/**/*.js',
 				'android/cli/!(locales)/**/*.js',
 				'android/modules/**/src/js/**/*.js',
 				'android/runtime/common/src/js/**/*.js',

--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -2761,10 +2761,11 @@ AndroidBuilder.prototype.copyResources = function copyResources(next) {
 							try {
 								// DO NOT TRANSPILE CODE inside SDK's common folder. It's already transpiled!
 								const transpile = from.startsWith(sdkCommonFolder) ? false : this.transpile;
+								const minify = from.startsWith(sdkCommonFolder) ? false : this.minifyJS;
 								const modified = jsanalyze.analyzeJs(source, {
 									filename: from,
-									minify: this.minifyJS,
-									transpile: transpile,
+									minify,
+									transpile,
 									sourceMap: this.sourceMaps || this.deployType === 'development',
 									targets: {
 										chrome: this.chromeVersion

--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -2719,6 +2719,7 @@ AndroidBuilder.prototype.copyResources = function copyResources(next) {
 
 		// copy js files into assets directory and minify if needed
 		this.logger.info(__('Processing JavaScript files'));
+		const sdkCommonFolder = path.join(this.titaniumSdkPath, 'common', 'Resources');
 		appc.async.series(this, Object.keys(jsFiles).map(function (id) {
 			return function (done) {
 				const from = jsFiles[id];
@@ -2758,10 +2759,12 @@ AndroidBuilder.prototype.copyResources = function copyResources(next) {
 							const source = r.contents;
 							// Analyze Ti API usage, possibly also minify/transpile
 							try {
+								// DO NOT TRANSPILE CODE inside SDK's common folder. It's already transpiled!
+								const transpile = from.startsWith(sdkCommonFolder) ? false : this.transpile;
 								const modified = jsanalyze.analyzeJs(source, {
 									filename: from,
 									minify: this.minifyJS,
-									transpile: this.transpile,
+									transpile: transpile,
 									sourceMap: this.sourceMaps || this.deployType === 'development',
 									targets: {
 										chrome: this.chromeVersion

--- a/build/packager.js
+++ b/build/packager.js
@@ -356,7 +356,9 @@ Packager.prototype.package = function (next) {
 					chrome: chromeVersion,
 					ios: minSupportedIosSdk
 				},
-				useBuiltIns: 'entry'
+				useBuiltIns: 'entry',
+				// DO NOT include web polyfills!
+				exclude: [ 'web.dom.iterable', 'web.immediate', 'web.timers' ]
 			};
 			// pull out windows target (if it exists)
 			if (fs.pathExistsSync('../windows/package.json')) {
@@ -373,9 +375,9 @@ Packager.prototype.package = function (next) {
 					fs.ensureDirSync(modulesDir);
 
 					copyPackageAndDependencies('@babel/polyfill', modulesDir);
-					cb();
+					return cb(); // eslint-disable-line promise/no-callback-in-promise
 				})
-				.catch(err => cb(err));  // eslint-disable-line promise/no-callback-in-promise
+				.catch(err => cb(err)); // eslint-disable-line promise/no-callback-in-promise
 		}.bind(this),
 		// Now run 'npm prune --production' on the zipSDKDir, so we retain only production dependencies
 		function (cb) {

--- a/build/packager.js
+++ b/build/packager.js
@@ -6,7 +6,10 @@ const exec = require('child_process').exec; // eslint-disable-line security/dete
 const spawn = require('child_process').spawn; // eslint-disable-line security/detect-child-process
 const async = require('async');
 const fs = require('fs-extra');
-const babel = require('@babel/core');
+const rollup = require('rollup').rollup;
+const babel = require('rollup-plugin-babel');
+const resolve = require('rollup-plugin-node-resolve');
+const commonjs = require('rollup-plugin-commonjs');
 const appc = require('node-appc');
 const version = appc.version;
 const utils = require('./utils');
@@ -251,25 +254,76 @@ Packager.prototype.zip = function (next) {
 	}.bind(this));
 };
 
-Packager.prototype.transpile = async function (srcDir, destDir, options) {
-	const files = await fs.readdir(srcDir);
-	await Promise.all(files.map(file => {
-		const srcPath = path.join(srcDir, file);
-		const destPath = path.join(destDir, file);
-		const stats = fs.statSync(srcPath);
-		if (stats.isDirectory()) {
-			// recurse!
-			return fs.ensureDir(destPath).then(() => this.transpile(srcPath, destPath, options));
-		}
+function determineBabelOptions() {
+	// Pull out android's V8 target (and transform into equivalent chrome version)
+	const v8Version = require('../android/package.json').v8.version;
+	const found = v8Version.match(V8_STRING_VERSION_REGEXP);
+	const chromeVersion = parseInt(found[1] + found[2]); // concat the first two numbers as string, then turn to int
+	// Now pull out min IOS target
+	const minSupportedIosSdk = version.parseMin(require('../iphone/package.json').vendorDependencies['ios sdk']);
+	// TODO: filter to only targets relevant for platforms we're building?
+	const options = {
+		targets: {
+			chrome: chromeVersion,
+			ios: minSupportedIosSdk
+		},
+		useBuiltIns: 'entry',
+		// DO NOT include web polyfills!
+		exclude: [ 'web.dom.iterable', 'web.immediate', 'web.timers' ]
+	};
+	// pull out windows target (if it exists)
+	if (fs.pathExistsSync('../windows/package.json')) {
+		const windowsSafariVersion = require('../windows/package.json').safari;
+		options.targets.safari = windowsSafariVersion;
+	}
+	return {
+		presets: [ [ '@babel/env', options ] ],
+		exclude: 'node_modules/**'
+	};
+}
 
-		// read file in (if JS), transpile, write it out
-		if (file.endsWith('.js')) {
-			return babel.transformFileAsync(srcPath, options)
-				.then(result => fs.writeFile(destPath, result.code));
-		}
-		// just copy it
-		return fs.copy(srcPath, destPath);
-	}));
+Packager.prototype.transpile = async function () {
+	// Copy over common dir, @babel/polyfill, etc into some temp dir
+	// Then run rollup/babel on it, then just copy the resulting bundle to our real destination!
+	// The temporary location we'll assembled the transpiled bundle
+	const tmpBundleDir = path.join(this.zipSDKDir, 'common_temp');
+
+	console.log('Copying common SDK JS over');
+	fs.copySync(path.join(this.srcDir, 'common'), tmpBundleDir);
+
+	// copy over polyfill and its dependencies
+	console.log('Copying JS polyfills over');
+	const modulesDir = path.join(tmpBundleDir, 'Resources/node_modules');
+	// make sure our 'node_modules' directory exists
+	fs.ensureDirSync(modulesDir);
+	copyPackageAndDependencies('@babel/polyfill', modulesDir);
+
+	console.log('Transpiling and bundling common SDK JS');
+	// the ultimate destinatio for our common SDK JS
+	const destDir = path.join(this.zipSDKDir, 'common');
+	// create a bundle
+	console.log('running rollup');
+	const babelOptions = determineBabelOptions();
+	const bundle = await rollup({
+		input: `${tmpBundleDir}/Resources/ti.main.js`,
+		plugins: [
+			resolve(),
+			commonjs(),
+			babel(babelOptions)
+		],
+		external: [ './app', 'com.appcelerator.aca' ]
+	});
+
+	// write the bundle to disk
+	console.log('Writing common SDK JS bundle to disk');
+	await bundle.write({ format: 'cjs', file: `${destDir}/Resources/ti.main.js` });
+
+	// Copy over the files we can't bundle/inline: common/Resources/ti.internal
+	await fs.copy(path.join(this.srcDir, 'common/Resources/ti.internal'), path.join(destDir, 'Resources/ti.internal'));
+
+	// Remove the temp dir we assembled the parts inside!
+	console.log('Removing temporary common SDK JS bundle directory');
+	await fs.remove(tmpBundleDir);
 };
 
 /**
@@ -342,41 +396,8 @@ Packager.prototype.package = function (next) {
 			this.copy([ 'CREDITS', 'README.md', 'package.json', 'cli', 'node_modules', 'templates' ], cb);
 		}.bind(this),
 		function (cb) {
-			console.log('Transpiling common SDK JS');
-			const destDir = path.join(this.zipSDKDir, 'common');
-			// Pull out android's V8 target (and transform into equivalent chrome version)
-			const v8Version = require('../android/package.json').v8.version;
-			const found = v8Version.match(V8_STRING_VERSION_REGEXP);
-			const chromeVersion = parseInt(found[1] + found[2]); // concat the first two numbers as string, then turn to int
-			// Now pull out min IOS target
-			const minSupportedIosSdk = version.parseMin(require('../iphone/package.json').vendorDependencies['ios sdk']);
-			// TODO: filter to only targets relevant for platforms we're building?
-			const options = {
-				targets: {
-					chrome: chromeVersion,
-					ios: minSupportedIosSdk
-				},
-				useBuiltIns: 'entry',
-				// DO NOT include web polyfills!
-				exclude: [ 'web.dom.iterable', 'web.immediate', 'web.timers' ]
-			};
-			// pull out windows target (if it exists)
-			if (fs.pathExistsSync('../windows/package.json')) {
-				const windowsSafariVersion = require('../windows/package.json').safari;
-				options.targets.safari = windowsSafariVersion;
-			}
-			this.transpile(path.join(this.srcDir, 'common'), destDir, {
-				presets: [ [ '@babel/env', options ] ]
-			})
-				// copy over polyfill and its dependencies
-				.then(() => {  // eslint-disable-line promise/no-callback-in-promise
-					const modulesDir = path.join(destDir, 'Resources/node_modules');
-					// make sure our 'node_modules' directory exists
-					fs.ensureDirSync(modulesDir);
-
-					copyPackageAndDependencies('@babel/polyfill', modulesDir);
-					return cb(); // eslint-disable-line promise/no-callback-in-promise
-				})
+			this.transpile()
+				.then(() => cb()) // eslint-disable-line promise/no-callback-in-promise
 				.catch(err => cb(err)); // eslint-disable-line promise/no-callback-in-promise
 		}.bind(this),
 		// Now run 'npm prune --production' on the zipSDKDir, so we retain only production dependencies

--- a/common/Resources/ti.main.js
+++ b/common/Resources/ti.main.js
@@ -24,6 +24,9 @@ try {
 	// Could not load module, silently ignore exception.
 }
 
+// Load JS language polyfills
+require('@babel/polyfill');
+
 // Load all JavaScript extensions.
 require('./ti.internal/extensions/Error');
 require('./ti.internal/extensions/process');

--- a/common/Resources/ti.main.js
+++ b/common/Resources/ti.main.js
@@ -11,8 +11,6 @@
  * - Load the app developer's main "app.js" script after doing all of the above.
  */
 
-'use strict';
-
 // Log the app name, app version, and Titanium version on startup.
 Ti.API.info(Ti.App.name + ' ' + Ti.App.version + ' (Powered by Titanium ' + Ti.version + '.' + Ti.buildHash + ')');
 

--- a/common/Resources/ti.main.js
+++ b/common/Resources/ti.main.js
@@ -25,11 +25,11 @@ try {
 }
 
 // Load JS language polyfills
-require('@babel/polyfill');
+import '@babel/polyfill';
 
 // Load all JavaScript extensions.
-require('./ti.internal/extensions/Error');
-require('./ti.internal/extensions/process');
+import './ti.internal/extensions/Error';
+import './ti.internal/extensions/process';
 
 // When registering a binding, need to resolve the path *now* versus whenever the call actually gets made
 // i.e. we want absolute paths

--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -5815,6 +5815,7 @@ iOSBuilder.prototype.copyResources = function copyResources(next) {
 			series(this, [
 				function processJSFiles(next) {
 					this.logger.info(__('Processing JavaScript files'));
+					const sdkCommonFolder = path.join(this.titaniumSdkPath, 'common', 'Resources');
 
 					async.eachSeries(Object.keys(jsFiles), function (file, next) {
 						setImmediate(function () {
@@ -5853,10 +5854,12 @@ iOSBuilder.prototype.copyResources = function copyResources(next) {
 										// Read the possibly modified file contents
 										const source = r.contents;
 										// Analyze Ti API usage, possibly also minify/transpile
+										// DO NOT TRANSPILE CODE inside SDK's common folder. It's already transpiled!
+										const transpile = from.startsWith(sdkCommonFolder) ? false : this.transpile;
 										const analyzeOptions = {
 											filename: from,
 											minify: this.minifyJS,
-											transpile: this.transpile,
+											transpile: transpile,
 											sourceMap: this.sourceMaps || this.deployType === 'development',
 											resourcesDir: this.xcodeAppDir,
 											logger: this.logger,

--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -5856,10 +5856,11 @@ iOSBuilder.prototype.copyResources = function copyResources(next) {
 										// Analyze Ti API usage, possibly also minify/transpile
 										// DO NOT TRANSPILE CODE inside SDK's common folder. It's already transpiled!
 										const transpile = from.startsWith(sdkCommonFolder) ? false : this.transpile;
+										const minify = from.startsWith(sdkCommonFolder) ? false : this.minifyJS;
 										const analyzeOptions = {
 											filename: from,
-											minify: this.minifyJS,
-											transpile: transpile,
+											minify,
+											transpile,
 											sourceMap: this.sourceMaps || this.deployType === 'development',
 											resourcesDir: this.xcodeAppDir,
 											logger: this.logger,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1381,6 +1381,18 @@
         }
       }
     },
+    "@types/estree": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "11.9.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.9.5.tgz",
+      "integrity": "sha512-vVjM0SVzgaOUpflq4GYBvCpozes8OgIIS5gVXVka+OfK3hvnkC1i93U8WiY2OtNE4XUWyyy/86Kf6e0IHTQw1Q==",
+      "dev": true
+    },
     "JSONStream": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
@@ -1763,7 +1775,7 @@
     },
     "babel-helper-is-nodes-equiv": {
       "version": "0.0.1",
-      "resolved": "http://registry.npmjs.org/babel-helper-is-nodes-equiv/-/babel-helper-is-nodes-equiv-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-helper-is-nodes-equiv/-/babel-helper-is-nodes-equiv-0.0.1.tgz",
       "integrity": "sha1-NOmzALFHnd2Y7HfqC76TQt/jloQ="
     },
     "babel-helper-is-void-0": {
@@ -3795,6 +3807,12 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
       "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+      "dev": true
+    },
+    "estree-walker": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.0.tgz",
+      "integrity": "sha512-peq1RfVAVzr3PU/jL31RaOjUKLoZJpObQWJJ+LgfcxDUifyLZ1RjPQZTl0pzj2uJ45b7A7XpyppXvxdEqzo4rw==",
       "dev": true
     },
     "esutils": {
@@ -5905,6 +5923,12 @@
         "is-extglob": "^2.1.0"
       }
     },
+    "is-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+      "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
+      "dev": true
+    },
     "is-number": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
@@ -7124,6 +7148,15 @@
       "integrity": "sha512-iCM3ZGeqIzlrH7KxYK+fphlJpCCczyHXc+HhRVbEu9uNTCrzYJjvvtefzeKTCVHd5AP/aD/fzC80JZ4ZP+dQ/A==",
       "dev": true
     },
+    "magic-string": {
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.2.tgz",
+      "integrity": "sha512-iLs9mPjh9IuTtRsqqhNGYcZXGei0Nh/A4xirrsqW7c+QhKVFL2vm7U09ru6cHRD22azaP/wMDgI+HCqbETMTtg==",
+      "dev": true,
+      "requires": {
+        "sourcemap-codec": "^1.4.4"
+      }
+    },
     "make-iterator": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.1.tgz",
@@ -8175,7 +8208,7 @@
         },
         "rimraf": {
           "version": "2.2.8",
-          "resolved": "http://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
           "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI="
         },
         "source-map": {
@@ -9199,7 +9232,7 @@
       "dependencies": {
         "jsesc": {
           "version": "0.5.0",
-          "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
           "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
         }
       }
@@ -9391,6 +9424,114 @@
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "requires": {
         "glob": "^7.0.5"
+      }
+    },
+    "rollup": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.3.0.tgz",
+      "integrity": "sha512-QiT0wFmu0IzkGgT5LvzRK5hezHcJW8T9MQdvdC+FylrNpsprpz0gTOpcyY9iM6Sda1fD1SatwNutCxcQd3Y/Lg==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "0.0.39",
+        "@types/node": "^11.9.5",
+        "acorn": "^6.1.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.0.tgz",
+          "integrity": "sha512-MW/FjM+IvU9CgBzjO3UIPCE2pyEwUsoFl+VGdczOPEdxfGFjuKny/gN54mOuX7Qxmb9Rg9MCn2oKiSUeW+pjrw==",
+          "dev": true
+        }
+      }
+    },
+    "rollup-plugin-babel": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-babel/-/rollup-plugin-babel-4.3.2.tgz",
+      "integrity": "sha512-KfnizE258L/4enADKX61ozfwGHoqYauvoofghFJBhFnpH9Sb9dNPpWg8QHOaAfVASUYV8w0mCx430i9z0LJoJg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "rollup-pluginutils": "^2.3.0"
+      }
+    },
+    "rollup-plugin-commonjs": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-commonjs/-/rollup-plugin-commonjs-9.2.1.tgz",
+      "integrity": "sha512-X0A/Cp/t+zbONFinBhiTZrfuUaVwRIp4xsbKq/2ohA2CDULa/7ONSJTelqxon+Vds2R2t2qJTqJQucKUC8GKkw==",
+      "dev": true,
+      "requires": {
+        "estree-walker": "^0.5.2",
+        "magic-string": "^0.25.1",
+        "resolve": "^1.10.0",
+        "rollup-pluginutils": "^2.3.3"
+      },
+      "dependencies": {
+        "estree-walker": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.5.2.tgz",
+          "integrity": "sha512-XpCnW/AE10ws/kDAs37cngSkvgIR8aN3G0MS85m7dUpuK2EREo9VJ00uvw6Dg/hXEpfsE1I1TvJOJr+Z+TL+ig==",
+          "dev": true
+        },
+        "path-parse": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+          "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+          "dev": true
+        },
+        "resolve": {
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
+          "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        }
+      }
+    },
+    "rollup-plugin-node-resolve": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-4.0.1.tgz",
+      "integrity": "sha512-fSS7YDuCe0gYqKsr5OvxMloeZYUSgN43Ypi1WeRZzQcWtHgFayV5tUSPYpxuaioIIWaBXl6NrVk0T2/sKwueLg==",
+      "dev": true,
+      "requires": {
+        "builtin-modules": "^3.0.0",
+        "is-module": "^1.0.0",
+        "resolve": "^1.10.0"
+      },
+      "dependencies": {
+        "builtin-modules": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.0.0.tgz",
+          "integrity": "sha512-hMIeU4K2ilbXV6Uv93ZZ0Avg/M91RaKXucQ+4me2Do1txxBDyDZWCBa5bJSLqoNTRpXTLwEzIk1KmloenDDjhg==",
+          "dev": true
+        },
+        "path-parse": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+          "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+          "dev": true
+        },
+        "resolve": {
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
+          "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        }
+      }
+    },
+    "rollup-pluginutils": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.4.1.tgz",
+      "integrity": "sha512-wesMQ9/172IJDIW/lYWm0vW0LiKe5Ekjws481R7z9WTRtmO59cqyM/2uUlxvf6yzm/fElFmHUobeQOYz46dZJw==",
+      "dev": true,
+      "requires": {
+        "estree-walker": "^0.6.0",
+        "micromatch": "^3.1.10"
       }
     },
     "run-async": {
@@ -9688,6 +9829,12 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
+    },
+    "sourcemap-codec": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.4.tgz",
+      "integrity": "sha512-CYAPYdBu34781kLHkaW3m6b/uUSyMOC2R61gcYMWooeuaGtjof86ZA/8T+qVPPt7np1085CR9hmMGrySwEc8Xg==",
+      "dev": true
     },
     "spdx-correct": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -118,6 +118,10 @@
     "lint-staged": "^8.1.0",
     "mocha": "^5.2.0",
     "pagedown": "~1.1.0",
+    "rollup": "^1.3.0",
+    "rollup-plugin-babel": "^4.3.2",
+    "rollup-plugin-commonjs": "^9.2.1",
+    "rollup-plugin-node-resolve": "^4.0.1",
     "ssri": "^6.0.1"
   },
   "repository": {


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-26729

**Optional Description:**
This injects the core-js/regenerator polyfills into the bundle `common` JS SDK code we ship when we build.
This way we can inject the polyfills once at startup and have the polyfills packaged as part of the SDK.

Pros:
- We can remove polyfilling from node-titanium-sdk based on usage. The full set of possible polyfills are loaded once at the beginning of startup.
- We can use pretty much every JS feature we want in our common/bootstrap code in the SDK
- Should be faster overall to just require/import the polyfills once at the beginning rather than sporadically throughout the code (given enough usage of them. If the user doesn't use them, then it's overkill)

Cons:
- We're technically shipping `@babel/polyfill` (and `core-js`/`regenerator-runtime`) twice in the SDK (once under `node_modules`, once under `common/Resources/node_modules`)
- Requires change to node-titanium-sdk to avoid doing the polyfilling (which would also remove the duplicated packages above)
- With little or no usage of these polyfills in our code or user code, there's no real gain. (and right now we're not using them, so it's based on the user)


Relates to #10555