### PR TITLE
build: allow specifying a custom directory for caching downloads

### DIFF
--- a/build/utils.js
+++ b/build/utils.js
@@ -161,7 +161,7 @@ function downloadWithIntegrity(url, downloadPath, integrity, callback) {
 
 function cachedDownloadPath(url) {
 	// Use some consistent name so we can cache files!
-	const cacheDir = path.join(tempDir, 'timob-build');
+	const cacheDir = path.join(process.env.SDK_BUILD_CACHE_DIR || tempDir, 'timob-build');
 	fs.existsSync(cacheDir) || fs.mkdirsSync(cacheDir);
 
 	const filename = url.slice(url.lastIndexOf('/') + 1);


### PR DESCRIPTION
#### Reasoning

The internet speeds in the Dublin office can sometimes be less than fantastic so I resort to building locally as opposed to downloading SDKs. However, if I haven't built recently I then have to wait for the various modules to download as the temp dirs will have been deleted.

This change introduces allowing a developer to set an environment variable of `SDK_BUILD_CACHE_DIR` to specify a non-temp directory to cache downloads in.

I've been running this locally for a couple months myself and figured it might be useful for others