### PR TITLE
fix(android): amend attributedString diff condition

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/ListSectionProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/ListSectionProxy.java
@@ -689,9 +689,11 @@ public class ListSectionProxy extends ViewProxy
 		}
 
 		//process listItem properties
-		KrollDict listItemDiff = cellContent.getViewItem().generateDiffProperties(listItemProperties);
-		if (!listItemDiff.isEmpty()) {
-			listItem.processProperties(listItemDiff);
+		if (cellContent.getViewItem().getView() != null) {
+			KrollDict listItemDiff = cellContent.getViewItem().generateDiffProperties(listItemProperties);
+			if (!listItemDiff.isEmpty()) {
+				listItem.processProperties(listItemDiff);
+			}
 		}
 	}
 

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/ViewItem.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/ViewItem.java
@@ -69,9 +69,8 @@ public class ViewItem
 		}
 
 		//if text is null, we can't filter out attributedString, otherwise we get an empty label. [TIMOB-20266]
-		if (this.properties.containsKey(TiC.PROPERTY_ATTRIBUTED_STRING) && diffProperties.containsKey(TiC.PROPERTY_TEXT)
-			&& diffProperties.get(TiC.PROPERTY_TEXT) == null
-			&& !diffProperties.containsKey(TiC.PROPERTY_ATTRIBUTED_STRING)) {
+		if (this.properties.containsKeyAndNotNull(TiC.PROPERTY_ATTRIBUTED_STRING)
+			&& diffProperties.containsKeyAndNotNull(TiC.PROPERTY_TEXT)) {
 			diffProperties.put(TiC.PROPERTY_ATTRIBUTED_STRING, this.properties.get(TiC.PROPERTY_ATTRIBUTED_STRING));
 		}
 


### PR DESCRIPTION
- Fixed `attributedString` property condition in `generateDiffProperties()` method for optimizing ListView

##### TEST CASE
- Scroll up and down fast, ListView should render correctly
```JS
const win = Ti.UI.createWindow({ backgroundColor: 'gray' });
const listView = Ti.UI.createListView({
    templates: {
        template: {
            childTemplates: [
                {
                    type: 'Ti.UI.Label',
                    bindId: 'label'
                }
            ]
        }
    },
    defaultItemTemplate: 'template'
});
const section = Ti.UI.createListSection();

let items = [];
for (let i = 0; i < 100; i++) {
	let item = {
		template: 'template',
		label: {}
	};
	if (i % 2 === 1) {
		item.label.attributedString = Ti.UI.createAttributedString({
			text: 'italic row ' + i,
			attributes: [
				{
					type: Ti.UI.ATTRIBUTE_FONT,
					value: {
						fontWeight: 'normal',
						fontStyle: 'italic',
					},
					range: [0, 6]
				}
			]
		});
	} else {
		item.label.text = 'normal ' + i;
	}
	items.push(item);
}

section.setItems(items);
listView.setSections([ section ]);

win.add(listView);
win.open();
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-20266)