### PR TITLE
chore: remove node 6 from supported versions

### DIFF
--- a/android/package.json
+++ b/android/package.json
@@ -28,9 +28,7 @@
 		"android build tools": ">=25.x <=28.x",
 		"android platform tools": "28.x",
 		"android tools": "<=26.x",
-		"android ndk": ">=r11c <=r17b",
-		"node": ">=4.0 <=8.x",
-		"java": ">=1.8.x"
+		"android ndk": ">=r11c <=r17b"
 	},
 	"repository": {
 		"type": "git",

--- a/android/package.json
+++ b/android/package.json
@@ -28,7 +28,8 @@
 		"android build tools": ">=25.x <=28.x",
 		"android platform tools": "28.x",
 		"android tools": "<=26.x",
-		"android ndk": ">=r11c <=r17b"
+		"android ndk": ">=r11c <=r17b",	
+		"java": ">=1.8.x"
 	},
 	"repository": {
 		"type": "git",

--- a/iphone/package.json
+++ b/iphone/package.json
@@ -20,8 +20,7 @@
 	"minWatchosVersion": "2.0",
 	"vendorDependencies": {
 		"xcode": ">=8.0 <=10.x",
-		"ios sdk": ">=9.0 <=12.x",
-		"node": ">=4.0 <=8.x"
+		"ios sdk": ">=9.0 <=12.x"
 	},
 	"repository": {
 		"type": "git",

--- a/package.json
+++ b/package.json
@@ -124,10 +124,10 @@
     "visual studio": ">=10 <=12",
     "windows phone sdk": "8.x",
     "msbuild": ">=4.0",
-    "node": "6.x || 8.x || 10.x"
+    "node": "8.x || 10.x"
   },
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   },
   "license": "Apache-2.0"
 }


### PR DESCRIPTION
backport of #10600
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-26153

This aligns with the appc-cli requirements, I have also removed the platform specific vendorDependencies.node entries as a [GitHhub search](https://github.com/search?q=org%3Aappcelerator+vendorDependencies&type=Code) seems to show these are unused and they regularly fall out of sync
