### PR TITLE
fix(ios)(8_0_X): init TiLogServer only when required

### DIFF
--- a/iphone/iphone/main.m
+++ b/iphone/iphone/main.m
@@ -51,7 +51,9 @@ int main(int argc, char *argv[])
   [[TiSharedConfig defaultConfig] setShowErrorController:TI_APPLICATION_SHOW_ERROR_CONTROLLER];
   [[TiSharedConfig defaultConfig] setApplicationBuildType:TI_APPLICATION_BUILD_TYPE];
   [[TiSharedConfig defaultConfig] setApplicationResourcesDirectory:TI_APPLICATION_RESOURCE_DIR];
+#ifndef DISABLE_TI_LOG_SERVER
   [[TiLogServer defaultLogServer] setPort:TI_LOG_SERVER_PORT];
+#endif
 
   UIColor *defaultBgColor = UIColor.blackColor;
 #if defined(DEFAULT_BGCOLOR_RED) && defined(DEFAULT_BGCOLOR_GREEN) && defined(DEFAULT_BGCOLOR_BLUE)

--- a/support/iphone/main.m
+++ b/support/iphone/main.m
@@ -45,7 +45,9 @@ int main(int argc, char *argv[])
   [[TiSharedConfig defaultConfig] setShowErrorController:TI_APPLICATION_SHOW_ERROR_CONTROLLER];
   [[TiSharedConfig defaultConfig] setApplicationBuildType:TI_APPLICATION_BUILD_TYPE];
   [[TiSharedConfig defaultConfig] setApplicationResourcesDirectory:TI_APPLICATION_RESOURCE_DIR];
+#ifndef DISABLE_TI_LOG_SERVER
   [[TiLogServer defaultLogServer] setPort:TI_LOG_SERVER_PORT];
+#endif
 
   UIColor *defaultBgColor = UIColor.blackColor;
 #if defined(DEFAULT_BGCOLOR_RED) && defined(DEFAULT_BGCOLOR_GREEN) && defined(DEFAULT_BGCOLOR_BLUE)


### PR DESCRIPTION
- Cherry-pick of https://github.com/appcelerator/titanium_mobile/pull/10607

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-26718)