### PR TITLE
fix(ios): remove invalid arcitectures from TitaniumKit for distribution builds

### DIFF
--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -6352,7 +6352,24 @@ iOSBuilder.prototype.removeFiles = function removeFiles(next) {
 				// ignore
 			}
 		}, this);
-		done();
+
+		// remove invalid architectures from TitaniumKit.framework for App Store distributions
+		if (this.target === 'dist-appstore') {
+			this.logger.info(__('Removing invalid architectures from TitaniumKit.framework'));
+
+			const titaniumKitPath = path.join(this.buildDir, 'Frameworks', 'TitaniumKit.framework', 'TitaniumKit');
+			async.eachSeries([ 'x86_64', 'i386' ], function (architecture, next) {
+				const args = [ '-remove', architecture, titaniumKitPath, '-o', titaniumKitPath ];
+				this.logger.debug(__('Running: %s', (this.xcodeEnv.executables.lipo + ' ' + args.join(' ')).cyan));
+				appc.subprocess.run(this.xcodeEnv.executables.lipo, args, function (code, out, err) {
+					next();
+				});
+			}.bind(this), function () {
+				done();
+			});
+		} else {
+			done();
+		}
 	});
 
 	hook(function () {

--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -6361,7 +6361,7 @@ iOSBuilder.prototype.removeFiles = function removeFiles(next) {
 			async.eachSeries([ 'x86_64', 'i386' ], function (architecture, next) {
 				const args = [ '-remove', architecture, titaniumKitPath, '-o', titaniumKitPath ];
 				this.logger.debug(__('Running: %s', (this.xcodeEnv.executables.lipo + ' ' + args.join(' ')).cyan));
-				appc.subprocess.run(this.xcodeEnv.executables.lipo, args, function (code, out, err) {
+				appc.subprocess.run(this.xcodeEnv.executables.lipo, args, function (code, out) {
 					next();
 				});
 			}.bind(this), function () {


### PR DESCRIPTION
- Remove invalid arcitectures `x86_64` and `i386` from `TitaniumKit` during App Store distribution builds

##### TEST CASE
```
appc run -p ios -T dist-appstore
```
- Application should upload successfully

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-26723)