### PR TITLE
fix(android): fix listItem processProperties null check

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/ListSectionProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/ListSectionProxy.java
@@ -689,7 +689,7 @@ public class ListSectionProxy extends ViewProxy
 		}
 
 		//process listItem properties
-		if (cellContent.getViewItem().getView() != null) {
+		if (cellContent.getViewItem() != null) {
 			KrollDict listItemDiff = cellContent.getViewItem().generateDiffProperties(listItemProperties);
 			if (!listItemDiff.isEmpty()) {
 				listItem.processProperties(listItemDiff);


### PR DESCRIPTION
- Fix null check that prevents `listItem` properties from being processed

##### TEST CASE
```JS
const win = Ti.UI.createWindow({ backgroundColor: 'gray' });
win.add(
    Ti.UI.createListView({
        sections: [
            Ti.UI.createListSection({
                items: () => {
                    let items = [];
                    for (let i = 1; i <= 100; i++) {
                        items.push({ properties: { title: 'Row' + i } });
                    }
                    return items;
                }
            })
        ]
    })
);
win.open();
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-26719)