### PR TITLE
fix(android)(8_0_X): backwards compatibility with 7.X.X Titanium SDK

### DIFF
--- a/android/kroll-apt/src/java/org/appcelerator/kroll/annotations/generator/ProxyBinding.fm
+++ b/android/kroll-apt/src/java/org/appcelerator/kroll/annotations/generator/ProxyBinding.fm
@@ -748,7 +748,7 @@ beprovided to handle the result.
 <#macro getHolder>
 	Local<Object> holder = args.Holder();
 	if (!JavaObject::isJavaObject(holder)) {
-		holder = holder->FindInstanceInPrototypeChain(getProxyTemplate(context));
+		holder = holder->FindInstanceInPrototypeChain(getProxyTemplate(isolate));
 	}
 	if (holder.IsEmpty() || holder->IsNull()) {
 		LOGE(TAG, "Couldn't obtain argument holder");

--- a/android/kroll-apt/src/java/org/appcelerator/kroll/annotations/generator/ProxyBindingV8.cpp.fm
+++ b/android/kroll-apt/src/java/org/appcelerator/kroll/annotations/generator/ProxyBindingV8.cpp.fm
@@ -50,7 +50,7 @@ void ${className}::bindProxy(Local<Object> exports, Local<Context> context)
 {
 	Isolate* isolate = context->GetIsolate();
 
-	Local<FunctionTemplate> pt = getProxyTemplate(context);
+	Local<FunctionTemplate> pt = getProxyTemplate(isolate);
 
 	v8::TryCatch tryCatch(isolate);
 	Local<Function> constructor;
@@ -105,7 +105,7 @@ Local<FunctionTemplate> ${className}::getProxyTemplate(v8::Isolate* isolate)
 	Local<FunctionTemplate> t = titanium::Proxy::inheritProxyTemplate(
 		isolate,
 	<#if superProxyClassName??>
-		<@Proxy.superNamespace/>${superProxyClassName}::getProxyTemplate(context),
+		<@Proxy.superNamespace/>${superProxyClassName}::getProxyTemplate(isolate),
 	<#else>
 		titanium::Proxy::baseProxyTemplate.Get(isolate),
 	</#if>


### PR DESCRIPTION
- Use old `getProxyTemplate` interface for `7.X.X` compatibility

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-26727)