### PR TITLE
fix(ios): properly release timers

### DIFF
--- a/iphone/TitaniumKit/TitaniumKit/Sources/Kroll/KrollTimerManager.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/Kroll/KrollTimerManager.m
@@ -126,7 +126,7 @@
     callbackArgs = [args subarrayWithRange:NSMakeRange(2, argCount - 2)];
   }
   NSNumber *timerIdentifier = @(self.nextTimerIdentifier++);
-  KrollTimerTarget *timerTarget = [[KrollTimerTarget alloc] initWithCallback:callback arguments:callbackArgs];
+  KrollTimerTarget *timerTarget = [[[KrollTimerTarget alloc] initWithCallback:callback arguments:callbackArgs] autorelease];
   NSTimer *timer = [NSTimer timerWithTimeInterval:interval target:timerTarget selector:@selector(timerFired:) userInfo:timerTarget repeats:shouldRepeat];
   [[NSRunLoop mainRunLoop] addTimer:timer forMode:NSRunLoopCommonModes];
 


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-26688

The missing `autorelease` was keeping `KrollTimerTarget` from being released which in turn kept the callback function and arguments around with all proxies created in the timer callback.

