### PR TITLE
fix(android)(7_5_X): use NDK r16b

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -225,7 +225,7 @@ timestamps {
 					// TODO parallelize the iOS/Android/Mobileweb/Windows portions?
 					dir('build') {
 						timeout(15) {
-							sh "node scons.js build --android-ndk ${env.ANDROID_NDK_R12B} --android-sdk ${env.ANDROID_SDK}"
+							sh "node scons.js build --android-ndk ${env.ANDROID_NDK_R16B} --android-sdk ${env.ANDROID_SDK}"
 						} // timeout
 						ansiColor('xterm') {
 							timeout(15) {


### PR DESCRIPTION
- NDK `r12b` contains a known issue where `__cxa_bad_typeid` is not defined
  - https://github.com/android-ndk/ndk/issues/408
- Use NDK `r16b`

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-26763)