### PR TITLE
fix(ios,android): require of dir with package.json main pointing at dir

### DIFF
--- a/android/runtime/common/src/js/module.js
+++ b/android/runtime/common/src/js/module.js
@@ -537,7 +537,7 @@ Module.prototype.loadAsDirectory = function (id, context) {
 			// b. let M = X + (json main field)
 			var m = path.resolve(id, object.exports.main);
 			// c. LOAD_AS_FILE(M)
-			return this.loadAsFile(m, context);
+			return this.loadAsFileOrDirectory(m, context);
 		}
 	}
 

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/KrollBridge.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/KrollBridge.m
@@ -1040,9 +1040,10 @@ CFMutableSetRef krollBridgeRegistry = nil;
     // b. let M = X + (json main field)
     m = [x stringByAppendingPathComponent:mainString];
     m = [self pathByStandarizingPath:m];
-    if ([self fileExists:m]) {
-      packageJSONMainCache[packageJsonPath] = m; // cache from package.json to main value
-      return m;
+    ResolvedModule *resolved = [self tryFileOrDirectory:m];
+    if (resolved) {
+      packageJSONMainCache[packageJsonPath] = resolved->path; // cache from package.json to main value
+      return resolved->path;
     }
   }
   return nil;

--- a/tests/Resources/package_with_main_dir/lib/index.js
+++ b/tests/Resources/package_with_main_dir/lib/index.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+	success: true
+};

--- a/tests/Resources/package_with_main_dir/package.json
+++ b/tests/Resources/package_with_main_dir/package.json
@@ -1,0 +1,5 @@
+{
+    "name": "package_with_main_dir",
+    "version": "1.0.0",
+    "main": "./lib"
+}

--- a/tests/Resources/require.addontest.js
+++ b/tests/Resources/require.addontest.js
@@ -1,0 +1,19 @@
+/*
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2019-Present by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+/* eslint-env mocha */
+/* global Ti */
+/* eslint no-unused-expressions: "off" */
+'use strict';
+const should = require('./utilities/assertions');
+
+describe('require', function () {
+	it('should handle directory with package.json main pointing at directory with index.js', function () {
+		const result = require('./package_with_main_dir');
+		should(result).have.property('success');
+		should(result.success).eql(true);
+	});
+});


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-26788

**Description:**
Found this one when trying to move to `mocha` npm package in our test suite (rather than `ti-mocha` using lots of shims).

Requiring a node_module or directory that had a `package.json` in it, it failed to properly handle when that file's `main` property pointed at another directory.

⚠️ 8_0_X/8.0.1 back port is #10672