### PR TITLE
fix(android): don't copy Ti.Buffer properties not set during #clone()

### DIFF
--- a/android/titanium/src/java/ti/modules/titanium/BufferProxy.java
+++ b/android/titanium/src/java/ti/modules/titanium/BufferProxy.java
@@ -306,10 +306,12 @@ public class BufferProxy extends KrollProxy
 		BufferProxy clone = new BufferProxy(copyOfRange(buffer, offset, offset + length));
 		// Copy over byteOrder and type properties
 		clone.setProperty(TiC.PROPERTY_BYTE_ORDER, this.getProperty(TiC.PROPERTY_BYTE_ORDER));
-		clone.setProperty(TiC.PROPERTY_TYPE, this.getProperty(TiC.PROPERTY_TYPE));
+		if (this.hasProperty(TiC.PROPERTY_TYPE)) {
+			clone.setProperty(TiC.PROPERTY_TYPE, this.getProperty(TiC.PROPERTY_TYPE));
+		}
 		// Copy value if cloning with no args
 		// TODO How would we handle this with a partial clone?
-		if (args.length == 0) {
+		if (args.length == 0 && this.hasProperty(TiC.PROPERTY_VALUE)) {
 			clone.setProperty(TiC.PROPERTY_VALUE, this.getProperty(TiC.PROPERTY_VALUE));
 		}
 		return clone;


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-26789

**Optional Description:**
Exposed by a stricter equality check in a newer `should.js` - when cloning a Ti.Buffer, the clone would get `null` values for `type` and `value` if the original had no values for those properties so the equality check would fail (`null !== undefined`, whereas before `null == undefined`)

Note that this fix is already merged to `master`