### PR TITLE
fix(android): set text cursor color from text color

### DIFF
--- a/android/modules/ui/res/layout/titanium_ui_edittext.xml
+++ b/android/modules/ui/res/layout/titanium_ui_edittext.xml
@@ -3,4 +3,5 @@
     android:id="@+id/titanium_ui_edittext"
     android:layout_height="wrap_content"
     android:layout_width="wrap_content"
+    android:textCursorDrawable="@null"
 />


### PR DESCRIPTION
- Prevent text cursor from depending on theme color, instead depend on text color

##### TEST CASE
```JS
const win = Ti.UI.createWindow({ backgroundColor: 'white' });
const textArea = Ti.UI.createTextArea({
    color: 'black',
    borderColor: 'black',
    lines: 2,
    left: 10,
    right: 10
});
win.add(textArea);
win.open();
```
- Text cursor should be visible and match the text color

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-26792)