### PR TITLE
fix(android): skip inclusion of soasta module

### DIFF
--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -1518,9 +1518,18 @@ AndroidBuilder.prototype.validate = function validate(logger, config, cli) {
 			const manifestHashes = [],
 				nativeHashes = [],
 				bindingsHashes = [],
-				jarHashes = {};
+				jarHashes = {},
+				blacklist = [ 'com.soasta.touchtest' ];
 
 			modules.found.forEach(function (module) {
+
+				// skip modules from blacklist
+				// TODO: remove SOASTA files from project in 8.1.0
+				if (blacklist.includes(module.id)) {
+					this.logger.warn(__('Skipping unsupported module "%s"', module.id.cyan));
+					return;
+				}
+
 				manifestHashes.push(this.hash(JSON.stringify(module.manifest)));
 
 				if (module.platform.indexOf('commonjs') !== -1) {


### PR DESCRIPTION
- Skip inclusion of `com.soasta.touchtest` module for Android builds

##### TEST CASE
- Build an existing project that has SOASTA included
- SOASTA module should be skipped during build and not present in built application

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-26785)