### PR TITLE
fix(android)(7_5_X): Restored pre-7.5.0 behavior where "app.js" should be re-executed when launched via data intent while backgrounded

### DIFF
--- a/common/Resources/ti.main.js
+++ b/common/Resources/ti.main.js
@@ -24,5 +24,15 @@ require('./ti.internal/extensions/Error');
 require('./ti.internal/bootstrap.loader').loadAsync(function () {
 	// We've finished loading/executing all bootstrap scripts.
 	// We can now proceed to run the main "app.js" script.
+	if (Ti.Android) {
+		// On Android, Titanium 7.5.x can launch another UI stack for the same JS runtime via an intent.
+		// The require() function has already cached "app.js" in this case. We must re-execute it explicitly.
+		// Note: Below is not needed as of 8.0.0 since intents in that version will resume existing UI instead.
+		if (global.Module.cache['/app.js']) {
+			var scriptText = Ti.Filesystem.getFile('app.js').read().text;
+			global.kroll.binding('evals').Script.runInThisContext(scriptText, '/app.js', true);
+			return;
+		}
+	}
 	require('./app');
 });


### PR DESCRIPTION
**JIRA:**
https://jira.appcelerator.org/browse/TIMOB-26774

**Summary:**
- This resolves a regression introduced in 7.5.0.
  * New issue is that 2nd UI stack will be stuck at the splash screen because "app.js" was already loaded.
  * This PR restores old behavior by re-executing "app.js" explicitly if it's already cached.
  * Note that the old behavior was never intended, but some app developers currently depend on it.
- This code change is **not** needed in 8.0.0.
  * Intent handling was refactored so that intents will resume an existing UI stack (like iOS) instead of creating a new UI stack.

**Test:**
1. Create a classic Titanium app.
2. Set project name to "IntentTest". (This is `<name/>` in "tiapp.xml".)
3. Set project's "Application Id" to "com.appc.intent.test". (This is `<id/>` in "tiapp.xml.)
4. Set up the "app.js" with the below code.
5. Build and run on Android.
6. Wait for the app to launch.
7. Open the Mac "Terminal" app.
8. CD (change directory) to: `~/Library/Android/sdk/platform-tools`
9. In the terminal, enter the following:
```./adb shell am start -n com.appc.intent.test/.IntenttestActivity -a android.intent.action.VIEW -d https://www.google.com -f 0x04000000```
10. Verify that the app relaunches successfully.
11. Verify that "https://www.google.com" is displayed within the text.
12. Press the device's "Back" button.
13. Verify that the app exited out successfully. (Should not navigate back to splash screen.)
14. Build and run the app on iOS.
15. Verify that the app launches successfully on iOS.

```javascript
var window = Ti.UI.createWindow();
var text = "Hello World!";
if (Ti.Android) {
	text += "\n\nLaunch Intent:\n" + JSON.stringify(Ti.Android.currentActivity.intent);
}
window.add(Ti.UI.createLabel({
	text: text,
	width: Ti.UI.FILL,
	height: Ti.UI.SIZE,
}));
window.open();
```
