### PR TITLE
fix(ios): fix leak in TiBlob imageAsCompressed method (7_5_X)

### DIFF
--- a/iphone/Classes/TiBlob.m
+++ b/iphone/Classes/TiBlob.m
@@ -382,7 +382,7 @@ static NSString *const MIMETYPE_JPEG = @"image/jpeg";
     ENSURE_ARG_COUNT(args, 1);
 
     float compressionQuality = [TiUtils floatValue:[args objectAtIndex:0] def:1.0];
-    return [[[TiBlob alloc] _initWithPageContext: [self pageContext] andData:UIImageJPEGRepresentation(image, compressionQuality) mimetype:@"image/jpeg"] autorelease];
+    return [[[TiBlob alloc] _initWithPageContext:[self pageContext] andData:UIImageJPEGRepresentation(image, compressionQuality) mimetype:@"image/jpeg"] autorelease];
   }
   return nil;
 }

--- a/iphone/Classes/TiBlob.m
+++ b/iphone/Classes/TiBlob.m
@@ -382,7 +382,7 @@ static NSString *const MIMETYPE_JPEG = @"image/jpeg";
     ENSURE_ARG_COUNT(args, 1);
 
     float compressionQuality = [TiUtils floatValue:[args objectAtIndex:0] def:1.0];
-    return [[[TiBlob alloc] initWithData:UIImageJPEGRepresentation(image, compressionQuality) mimetype:@"image/jpeg"] autorelease];
+    return [[[TiBlob alloc] _initWithPageContext: [self pageContext] andData:UIImageJPEGRepresentation(image, compressionQuality) mimetype:@"image/jpeg"] autorelease];
   }
   return nil;
 }


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-26800

The TiBlob.imageAsCompressed method leaks memory as it's not initialising the blob with the page context. For that reason, is not deallocated once it's JS proxy is garbage collected.
