### PR TITLE
feat(android): Add "barColor" property of Ti.UI.Window to Android.

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/WindowProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/WindowProxy.java
@@ -23,6 +23,7 @@ import org.appcelerator.titanium.TiDimension;
 import org.appcelerator.titanium.TiTranslucentActivity;
 import org.appcelerator.titanium.proxy.ActivityProxy;
 import org.appcelerator.titanium.proxy.TiWindowProxy;
+import org.appcelerator.titanium.util.TiColorHelper;
 import org.appcelerator.titanium.util.TiConvert;
 import org.appcelerator.titanium.util.TiRHelper;
 import org.appcelerator.titanium.view.TiUIView;
@@ -39,6 +40,8 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.Message;
 import android.support.annotation.Nullable;
+import android.support.v7.app.ActionBar;
+import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
 import android.transition.ChangeBounds;
 import android.transition.ChangeClipBounds;
@@ -53,13 +56,13 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup.LayoutParams;
 import android.view.Window;
-import android.view.WindowManager;
 // clang-format off
 @Kroll.proxy(creatableInModule = UIModule.class,
 	propertyAccessors = {
 		TiC.PROPERTY_MODAL,
 		TiC.PROPERTY_WINDOW_PIXEL_FORMAT,
-		TiC.PROPERTY_FLAG_SECURE
+		TiC.PROPERTY_FLAG_SECURE,
+		TiC.PROPERTY_BAR_COLOR
 })
 // clang-format on
 public class WindowProxy extends TiWindowProxy implements TiActivityWindow
@@ -374,7 +377,18 @@ public class WindowProxy extends TiWindowProxy implements TiActivityWindow
 				}
 			}
 		}
-
+		if (name.equals(TiC.PROPERTY_BAR_COLOR)) {
+			// Get a reference to the ActionBar.
+			ActionBar actionBar = ((AppCompatActivity) activity.get()).getSupportActionBar();
+			// Check if it is available ( app is using a theme with one or a Toolbar is used as one ).
+			if (actionBar != null) {
+				// Change to background to the new color.
+				actionBar.setBackgroundDrawable(new ColorDrawable(TiColorHelper.parseColor(TiConvert.toString(value))));
+			} else {
+				// Log a warning if there is no ActionBar available.
+				Log.w(TAG, "There is no ActionBar available for this Window.");
+			}
+		}
 		super.onPropertyChanged(name, value);
 	}
 

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/WindowProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/WindowProxy.java
@@ -292,6 +292,11 @@ public class WindowProxy extends TiWindowProxy implements TiActivityWindow
 			activity.getSupportActionBar().setDisplayHomeAsUpEnabled(true);
 		}
 
+		// Handle barColor property.
+		if (hasProperty(TiC.PROPERTY_BAR_COLOR)) {
+			int colorInt = TiColorHelper.parseColor(TiConvert.toString(getProperty(TiC.PROPERTY_BAR_COLOR)));
+			activity.getSupportActionBar().setBackgroundDrawable(new ColorDrawable(colorInt));
+		}
 		activity.getActivityProxy().getDecorView().add(this);
 		activity.addWindowToStack(this);
 
@@ -378,15 +383,19 @@ public class WindowProxy extends TiWindowProxy implements TiActivityWindow
 			}
 		}
 		if (name.equals(TiC.PROPERTY_BAR_COLOR)) {
-			// Get a reference to the ActionBar.
-			ActionBar actionBar = ((AppCompatActivity) activity.get()).getSupportActionBar();
-			// Check if it is available ( app is using a theme with one or a Toolbar is used as one ).
-			if (actionBar != null) {
-				// Change to background to the new color.
-				actionBar.setBackgroundDrawable(new ColorDrawable(TiColorHelper.parseColor(TiConvert.toString(value))));
-			} else {
-				// Log a warning if there is no ActionBar available.
-				Log.w(TAG, "There is no ActionBar available for this Window.");
+			// Guard for activity being destroyed
+			if (windowActivity != null && windowActivity.get() != null) {
+				// Get a reference to the ActionBar.
+				ActionBar actionBar = ((AppCompatActivity) windowActivity.get()).getSupportActionBar();
+				// Check if it is available ( app is using a theme with one or a Toolbar is used as one ).
+				if (actionBar != null) {
+					// Change to background to the new color.
+					actionBar.setBackgroundDrawable(
+						new ColorDrawable(TiColorHelper.parseColor(TiConvert.toString(value))));
+				} else {
+					// Log a warning if there is no ActionBar available.
+					Log.w(TAG, "There is no ActionBar available for this Window.");
+				}
 			}
 		}
 		super.onPropertyChanged(name, value);

--- a/apidoc/Titanium/UI/Window.yml
+++ b/apidoc/Titanium/UI/Window.yml
@@ -350,7 +350,8 @@ properties:
         Background color for the nav bar, as a color name or hex triplet.
     description: |
         For information about color values, see the "Colors" section of <Titanium.UI>.
-    platforms: [iphone, ipad]
+    platforms: [android, iphone, ipad]
+    since: {android: "8.0.1", iphone: "0.9", ipad: "0.9"}
     type: String
 
   - name: barImage


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-26817

**Description:**
Adds parity for `barColor` property of Ti.UI.Window. Also removed an unused import.
Note: As for a unit test - the scenario is the same as in https://github.com/appcelerator/titanium_mobile/pull/10393, so for now I am skipping it.

**Test case:**

With a default ActionBar:
_app.js_
```js
var win = Ti.UI.createWindow(),
	button = Ti.UI.createButton();
win.add(button);
win.open();
button.addEventListener('click', function () {
	win.barColor = 'red';
});
```

With a Toolbar instance used as an ActionBar. You need to use a theme without an ActionBar for this sample to work.
_app.js_
```js
var win = Ti.UI.createWindow(),
	button = Ti.UI.createButton(),
	toolbar = Ti.UI.createToolbar({ top: 0, barColor: 'blue'});
win.activity.supportToolbar = toolbar;
win.add([toolbar, button]);
win.open();
button.addEventListener('click', function () {
	win.barColor = 'red';
});
```
