### PR TITLE
chore(deps): update to liveview@1.4.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6728,9 +6728,9 @@
       }
     },
     "liveview": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/liveview/-/liveview-1.4.4.tgz",
-      "integrity": "sha512-wNWotUhQZyYbuZSh0PKBLJjgB83ED8MyN/vCW8TQiMiuRF688YrT5UsklqVS70F8df78x2xW5yNHcjxXi33TqA==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/liveview/-/liveview-1.4.5.tgz",
+      "integrity": "sha512-4gEZ4mV07LUz3HEwZ8TWV7n193yYRO8pzcWhwCZkPpw7bsgIbNKzJmcWj0LH8jIq0SmjAwaZxX5ZnnidfB8j8Q==",
       "requires": {
         "chokidar": "~0.6.3",
         "coloring": "~0.1.0",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "glob": "^7.1.2",
     "humanize": "0.0.9",
     "ioslib": "^1.7.5",
-    "liveview": "^1.4.4",
+    "liveview": "^1.4.5",
     "lodash.defaultsdeep": "^4.6.0",
     "markdown": "0.5.0",
     "moment": "^2.22.2",


### PR DESCRIPTION
8_0_X backport for #10694

Fixes TIMOB-26781

**JIRA:** https://jira.appcelerator.org/browse/TIMOB-26781

Updates to liveview@1.4.5 to fix an alloy spawning problem on Windows