### PR TITLE
fix(ios): remove startup log from titaniumkit

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -64,9 +64,13 @@ async function checkJIRA() {
 // Check that if we modify the Android or iOS SDK, we also update the tests
 // Also, assign labels based on changes to different dir paths
 async function checkChangedFileLocations() {
+	let modifiedTopTiModule = false;
 	const modified = danger.git.modified_files.concat(danger.git.created_files);
 	const modifiedAndroidFiles = modified.filter(p => p.startsWith('android/') && p.endsWith('.java'));
 	const modifiedIOSFiles = modified.filter(p => {
+		if (p.endsWith('TopTiModule.m')) {
+			modifiedTopTiModule = true;
+		}
 		return p.startsWith('iphone/') && (p.endsWith('.h') || p.endsWith('.m'));
 	});
 
@@ -100,6 +104,11 @@ async function checkChangedFileLocations() {
 		// If it has the "needs tests" label, remove it
 		labelsToRemove.add(Label.NEEDS_TESTS);
 	}
+
+	if (modifiedTopTiModule) {
+		warn('It looks like you have modified the TopTiModule.m file. Are you sure you meant to do that?');
+	}
+
 }
 
 // Does the PR have merge conflicts?

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiApp.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiApp.m
@@ -219,12 +219,6 @@ TI_INLINE void waitForMemoryPanicCleared(); //WARNING: This must never be run on
 
 - (void)boot
 {
-  DebugLog(@"[INFO] %@/%@ (%s.%@)",
-      [[TiSharedConfig defaultConfig] applicationName],
-      [[TiSharedConfig defaultConfig] applicationVersion],
-      TI_VERSION_STR,
-      [[TiSharedConfig defaultConfig] sdkVersion]);
-
   sessionId = [[TiUtils createUUID] retain];
   TITANIUM_VERSION = [[NSString stringWithCString:TI_VERSION_STR encoding:NSUTF8StringEncoding] retain];
 


### PR DESCRIPTION
This is now done via the ti.main script. Closes TIMOB-26833

**JIRA:** https://jira.appcelerator.org/browse/TIMOB-26833

⚠️ Note: the log that was being output had the SDK down as (0.0.0.(null)), and `TITANIUM_VERSION` is being set to `0.0.0` I can't find anywhere where we're referencing that? But if we are, whatever uses it is using invalid information?

### Test steps 

* Build an app to iOS device/sim, on startup only one log like `plainalloy 1.0 (Powered by Titanium 8.1.0.849c15e098)` should be output.

