### PR TITLE
docs: remove docs for properties that have been removed, fix most warnings from docgen

### DIFF
--- a/apidoc/Titanium/Android/Activity.yml
+++ b/apidoc/Titanium/Android/Activity.yml
@@ -265,7 +265,7 @@ events:
     description: |
         This event will only be fired by [Ti.Android.rootActivity](Titanium.Android.rootActivity), which is
         the splash screen activity. This event will never be fired by any of the child activities. The root
-        activity' [intent](Titanium.Android.intent) property will be updated when to the new intent when fired.
+        activity' [intent](Titanium.Android.Intent) property will be updated when to the new intent when fired.
 
         See also:
         [onNewIntent](https://developer.android.com/reference/android/app/Activity.html#onNewIntent(android.content.Intent))

--- a/apidoc/Titanium/Android/Notification.yml
+++ b/apidoc/Titanium/Android/Notification.yml
@@ -358,7 +358,7 @@ properties:
         ([Filesystem.externalStorageDirectory](Titanium.Filesystem.externalStorageDirectory)).
 
         Note that this sound property is ignored on Android 8.0 and above. On these OS versions,
-        you must use the [NotificationChannel.sound]Titanium.Android.NotificationChannel.sound)
+        you must use the [NotificationChannel.sound](Titanium.Android.NotificationChannel.sound)
         property and that sound will play for any notification posted under that channel. Also, you will
         still need to set this notification's sound property for OS versions older than Android 8.0 too,
         meaning that the sound URL needs to be set in both places.

--- a/apidoc/Titanium/Android/Notification.yml
+++ b/apidoc/Titanium/Android/Notification.yml
@@ -358,7 +358,7 @@ properties:
         ([Filesystem.externalStorageDirectory](Titanium.Filesystem.externalStorageDirectory)).
 
         Note that this sound property is ignored on Android 8.0 and above. On these OS versions,
-        you must use the [NotificationChannel.sound](Titanium.Android.Titanium.Android.NotificationChannel.sound)
+        you must use the [NotificationChannel.sound]Titanium.Android.NotificationChannel.sound)
         property and that sound will play for any notification posted under that channel. Also, you will
         still need to set this notification's sound property for OS versions older than Android 8.0 too,
         meaning that the sound URL needs to be set in both places.

--- a/apidoc/Titanium/Geolocation/Android/Android.yml
+++ b/apidoc/Titanium/Geolocation/Android/Android.yml
@@ -47,18 +47,6 @@ description: |
     To enable manual configuration mode, set the [manualMode](Titanium.Geolocation.Android.manualMode) 
     property to `true`. In manual configuration mode, the location providers and location
     rules set through this module control the generation of location updates.
-    
-    When `manualMode` is `true`, the following configuration settings in the
-    <Titanium.Geolocation> module are ignored:
-
-    *   [Geolocation.accuracy](Titanium.Geolocation.accuracy)
-    *   [Geolocation.frequency](Titanium.Geolocation.frequency)
-    *   [Geolocation.preferredProvider](Titanium.Geolocation.preferredProvider)
-
-    When `manualMode` is `false`, the `accuracy`, `frequency` and `preferredProvider` 
-    settings from <Titanium.Geolocation> are used to configure location updates.
-    Any location providers and location rules set in <Titanium.Geolocation.Android> 
-    are retained, but they have no effect.
 
     #### Location Providers
         
@@ -165,7 +153,7 @@ properties:
         
         If `false`, location updates are configured using the  [accuracy](Titanium.Geolocation.accuracy),
         [frequency](Titanium.Geolocation.frequency) and [preferredProvider](Titanium.Geolocation.preferredProvider)
-        properties in the <Titanium.Geolocation> module.
+        properties in the <Titanium.Geolocation> module. // check me!
     type: Boolean
     default: false
     

--- a/apidoc/Titanium/Geolocation/Android/Android.yml
+++ b/apidoc/Titanium/Geolocation/Android/Android.yml
@@ -48,8 +48,20 @@ description: |
     property to `true`. In manual configuration mode, the location providers and location
     rules set through this module control the generation of location updates.
 
+    When `manualMode` is `true`, the following configuration settings in the
+    <Titanium.Geolocation> module are ignored:
+
+    *   [Geolocation.accuracy](Titanium.Geolocation.accuracy)
+    *   [Geolocation.frequency](Titanium.Geolocation.frequency)
+    *   [Geolocation.preferredProvider](Titanium.Geolocation.preferredProvider)
+
+    When `manualMode` is `false`, the `accuracy`, `frequency` and `preferredProvider`
+    settings from <Titanium.Geolocation> are used to configure location updates.
+    Any location providers and location rules set in <Titanium.Geolocation.Android> 
+    are retained, but they have no effect.
+
     #### Location Providers
-        
+
     Android supports three kinds of location providers: GPS, network, and the 
     "passive" location provider, which provides only cached information. 
 
@@ -153,10 +165,48 @@ properties:
         
         If `false`, location updates are configured using the  [accuracy](Titanium.Geolocation.accuracy),
         [frequency](Titanium.Geolocation.frequency) and [preferredProvider](Titanium.Geolocation.preferredProvider)
-        properties in the <Titanium.Geolocation> module. // check me!
+        properties in the <Titanium.Geolocation> module.
     type: Boolean
     default: false
-    
+
+  - name: PROVIDER_GPS
+    summary: |
+        Specifies the GPS location provider.
+    description: |
+        Used with [LocationProvider.name](Titanium.Geolocation.Android.LocationProvider),
+        [LocationRule.provider](Titanium.Geolocation.Android.LocationRule).
+         In general, the GPS provider has the highest power consumption and the
+        highest accuracy, but this may vary. In some circumstances, the network
+        provider may be more reliable.
+    type: String
+    permission: read-only
+    platforms: [android]
+
+  - name: PROVIDER_NETWORK
+    summary: |
+        Specifies the network location provider.
+    description: |
+        Used with [LocationProvider.name](Titanium.Geolocation.Android.LocationProvider),
+        [LocationRule.provider](Titanium.Geolocation.Android.LocationRule).
+         Generally requires less power than the GPS provider and provides less accurate
+        results, but may produce very accurate results in densely-populated areas
+        with many cell towers and WiFi networks.
+    type: String
+    permission: read-only
+    platforms: [android]
+
+  - name: PROVIDER_PASSIVE
+    summary: |
+        Specifies the passive location provider.
+    description: |
+        Used with [LocationProvider.name](Titanium.Geolocation.Android.LocationProvider),
+        [LocationRule.provider](Titanium.Geolocation.Android.LocationRule).
+         This provider only uses cached location information, so it does not use
+        any power, but makes no guarantee that the location results are recent.
+    type: String
+    permission: read-only
+    platforms: [android]
+
 methods:
 
   - name: addLocationProvider

--- a/apidoc/Titanium/Geolocation/Android/LocationProvider.yml
+++ b/apidoc/Titanium/Geolocation/Android/LocationProvider.yml
@@ -12,7 +12,7 @@ properties:
     summary: |
         Type of location provider: [PROVIDER_GPS](Titanium.Geolocation.PROVIDER_GPS), 
         [PROVIDER_NETWORK](Titanium.Geolocation.PROVIDER_NETWORK), or 
-        [PROVIDER_PASSIVE](Titanium.Geolocation.PROVIDER_PASSIVE).
+        [PROVIDER_PASSIVE](Titanium.Geolocation.PROVIDER_PASSIVE). // check me!
     type: String
     optional: false
         

--- a/apidoc/Titanium/Geolocation/Android/LocationProvider.yml
+++ b/apidoc/Titanium/Geolocation/Android/LocationProvider.yml
@@ -10,9 +10,9 @@ platforms: ["android"]
 properties:
   - name: name
     summary: |
-        Type of location provider: [PROVIDER_GPS](Titanium.Geolocation.PROVIDER_GPS), 
-        [PROVIDER_NETWORK](Titanium.Geolocation.PROVIDER_NETWORK), or 
-        [PROVIDER_PASSIVE](Titanium.Geolocation.PROVIDER_PASSIVE). // check me!
+        Type of location provider: [PROVIDER_GPS](Titanium.Geolocation.Android.PROVIDER_GPS), 
+        [PROVIDER_NETWORK](Titanium.Geolocation.Android.PROVIDER_NETWORK), or 
+        [PROVIDER_PASSIVE](Titanium.Geolocation.Android.PROVIDER_PASSIVE).
     type: String
     optional: false
         

--- a/apidoc/Titanium/Geolocation/Android/LocationRule.yml
+++ b/apidoc/Titanium/Geolocation/Android/LocationRule.yml
@@ -17,7 +17,7 @@ properties:
     description: |
         Can be [PROVIDER_GPS](Titanium.Geolocation.PROVIDER_GPS), 
         [PROVIDER_NETWORK](Titanium.Geolocation.PROVIDER_NETWORK), or 
-        [PROVIDER_PASSIVE](Titanium.Geolocation.PROVIDER_PASSIVE).
+        [PROVIDER_PASSIVE](Titanium.Geolocation.PROVIDER_PASSIVE). // checkme!
     type: String
     default: null
     

--- a/apidoc/Titanium/Geolocation/Android/LocationRule.yml
+++ b/apidoc/Titanium/Geolocation/Android/LocationRule.yml
@@ -15,9 +15,9 @@ properties:
         If specified, this rule only applies to updates generated
         by the specified provider. If `null`, this rule applies to all updates.
     description: |
-        Can be [PROVIDER_GPS](Titanium.Geolocation.PROVIDER_GPS), 
-        [PROVIDER_NETWORK](Titanium.Geolocation.PROVIDER_NETWORK), or 
-        [PROVIDER_PASSIVE](Titanium.Geolocation.PROVIDER_PASSIVE). // checkme!
+        Can be [PROVIDER_GPS](Titanium.Geolocation.Android.PROVIDER_GPS), 
+        [PROVIDER_NETWORK](Titanium.Geolocation.Android.PROVIDER_NETWORK), or 
+        [PROVIDER_PASSIVE](Titanium.Geolocation.Android.PROVIDER_PASSIVE).
     type: String
     default: null
     

--- a/apidoc/Titanium/Geolocation/Geolocation.yml
+++ b/apidoc/Titanium/Geolocation/Geolocation.yml
@@ -110,7 +110,7 @@ description: |
         to `true`. In manual mode, the `accuracy` property is not used, and all
         configuration is done through the <Titanium.Geolocation.Android> module.
 
-    *   *Legacy mode* is the mode that existed prior to 2.0. Legacy mode is
+    *   *Legacy mode* is the mode that existed prior to 2.0. Legacy mode is // check me!
         used when the `manualMode` flag is `false` and the `accuracy` property is
         set to one of the iOS `ACCURACY` constants:
 
@@ -126,14 +126,6 @@ description: |
         In this mode, the specified `accuracy` value determines the
         *minimum distance between location updates*. If `accuracy` is set to
         `ACCURACY_BEST`, no distance filter is used on updates.
-
-        In legacy mode, only a single location provider (GPS, network, or passive) is
-        enabled at a time. You can specify a the location provider using the
-        [preferredProvider](Titanium.Geolocation.preferredProvider) property.
-
-        You can also specifying a desired update frequency using the
-        [frequency](Titanium.Geolocation.frequency) property. The `preferredProvider`
-        and `frequency` properties are not used in any other mode.
 
     As of Titanium SDK 7.1.0 and later, including the [`ti.playservices`](https://github.com/appcelerator-modules/ti.playservices) module will allow Google Play Services 
     to be used by default to obtain location information. This means the provider passed into [createLocationProvider](Titanium.Geolocation.Android.createLocationProvider)
@@ -420,9 +412,7 @@ properties:
         recommended.
     type: Number
     permission: read-only
-    platforms: [android, iphone, ipad]
-    deprecated:
-        since: {android: "2.0.0"}
+    platforms: [iphone, ipad]
 
   - name: ACCURACY_HUNDRED_METERS
     summary: |
@@ -433,9 +423,7 @@ properties:
         recommended.
     type: Number
     permission: read-only
-    platforms: [android, iphone, ipad]
-    deprecated:
-        since: {android: "2.0.0"}
+    platforms: [iphone, ipad]
 
   - name: ACCURACY_KILOMETER
     summary: |
@@ -446,9 +434,7 @@ properties:
         recommended.
     type: Number
     permission: read-only
-    platforms: [android, iphone, ipad]
-    deprecated:
-        since: {android: "2.0.0"}
+    platforms: [iphone, ipad]
 
   - name: ACCURACY_NEAREST_TEN_METERS
     summary: |
@@ -459,9 +445,7 @@ properties:
         recommended.
     type: Number
     permission: read-only
-    platforms: [android, iphone, ipad]
-    deprecated:
-        since: {android: "2.0.0"}
+    platforms: [iphone, ipad]
 
   - name: ACCURACY_THREE_KILOMETERS
     summary: |
@@ -472,9 +456,7 @@ properties:
         recommended.
     type: Number
     permission: read-only
-    platforms: [android, iphone, ipad]
-    deprecated:
-        since: {android: "2.0.0"}
+    platforms: [iphone, ipad]
 
   - name: ACCURACY_HIGH
     summary: |
@@ -612,50 +594,6 @@ properties:
     permission: read-only
     platforms: [iphone, ipad]
 
-  - name: PROVIDER_GPS
-    summary: |
-        Specifies the GPS location provider.
-    description: |
-        Used with [preferredProvider](Titanium.Geolocation.preferredProvider),
-        [LocationProvider.name](Titanium.Geolocation.Android.LocationProvider),
-        [LocationRule.provider](Titanium.Geolocation.Android.LocationRule).
-
-        In general, the GPS provider has the highest power consumption and the
-        highest accuracy, but this may vary. In some circumstances, the network
-        provider may be more reliable.
-    type: String
-    permission: read-only
-    platforms: [android]
-
-  - name: PROVIDER_NETWORK
-    summary: |
-        Specifies the network location provider.
-    description: |
-        Used with [preferredProvider](Titanium.Geolocation.preferredProvider),
-        [LocationProvider.name](Titanium.Geolocation.Android.LocationProvider),
-        [LocationRule.provider](Titanium.Geolocation.Android.LocationRule).
-
-        Generally requires less power than the GPS provider and provides less accurate
-        results, but may produce very accurate results in densely-populated areas
-        with many cell towers and WiFi networks.
-    type: String
-    permission: read-only
-    platforms: [android]
-
-  - name: PROVIDER_PASSIVE
-    summary: |
-        Specifies the passive location provider.
-    description: |
-        Used with [preferredProvider](Titanium.Geolocation.preferredProvider),
-        [LocationProvider.name](Titanium.Geolocation.Android.LocationProvider),
-        [LocationRule.provider](Titanium.Geolocation.Android.LocationRule).
-
-        This provider only uses cached location information, so it does not use
-        any power, but makes no guarantee that the location results are recent.
-    type: String
-    permission: read-only
-    platforms: [android]
-
   - name: ACTIVITYTYPE_OTHER
     summary: The location data is being used for an unknown activity.
     description: |
@@ -736,25 +674,6 @@ properties:
     default: 0
     platforms: [iphone, ipad]
 
-  - name: frequency
-    deprecated:
-        since: "2.0.0"
-        notes: |
-            Android legacy mode operation is deprecated. For new development, use
-            either simple mode or manual mode. See "Configurating Location Updates on Android"
-            in the main description of this class for more information.
-    summary: Requested frequency for location updates, in milliseconds.
-    description: |
-        Setting a frequency value enables legacy location mode on Android.
-        Note that only a single provider can be active at one time in legacy mode.
-
-        Note that the frequency value is used as a guideline: there are no guarantees
-        that the device will provide updates at the specified frequency.
-
-        A lower frequency value generally increases power consumption.
-        A value of 0 means that updates should be generated as quickly as possible.
-    type: Number
-
   - name: hasCompass
     summary: Indicates whether the current device supports a compass.
     type: Boolean
@@ -788,28 +707,6 @@ properties:
         Therefore, this method returns `true` on these devices if only there is GPS or network provider available.
     type: Boolean
     permission: read-only
-
-  - name: preferredProvider
-    deprecated:
-        since: "2.0.0"
-        notes: |
-            Android legacy mode operation is deprecated. For new development, use
-            either simple mode or manual mode. See "Configurating Location Updates on Android"
-            in the main description of this class for more information.
-    summary: |
-        Determines the preferred location provider.
-    description: |
-        Setting a preferred provider enables legacy location mode on Android.
-        Note that only a single provider can be active at one time in legacy mode.
-
-        The preferred provider affects power consumption. In general, `PROVIDER_GPS`
-        requires the most power, and `PROVIDER_PASSIVE` requires the least.
-
-        If `undefined`, the preferred provider is auto-detected.
-    type: String
-    constants: Titanium.Geolocation.PROVIDER_*
-    platforms: [android]
-    default: <Titanium.Geolocation.PROVIDER_NETWORK>
 
   - name: showCalibration
     summary: Determines whether the compass calibration UI is shown if needed.

--- a/apidoc/Titanium/Geolocation/Geolocation.yml
+++ b/apidoc/Titanium/Geolocation/Geolocation.yml
@@ -89,7 +89,7 @@ description: |
 
     #### Configurating Location Updates on Android
 
-    On Android, three different location service modes are supported: *simple*, *manual*, and *legacy*.
+    On Android, two different location service modes are supported: *simple*, and *manual*.
 
     *   *Simple mode* provides a compromise mode that provides adaquate support for
         undemanding location applications without requiring developers to
@@ -109,23 +109,6 @@ description: |
         Manual mode is used when the <Titanium.Geolocation.Android.manualMode> flag is set
         to `true`. In manual mode, the `accuracy` property is not used, and all
         configuration is done through the <Titanium.Geolocation.Android> module.
-
-    *   *Legacy mode* is the mode that existed prior to 2.0. Legacy mode is // check me!
-        used when the `manualMode` flag is `false` and the `accuracy` property is
-        set to one of the iOS `ACCURACY` constants:
-
-        *   [ACCURACY_BEST](Titanium.Geolocation.ACCURACY_BEST) (highest accuracy and power consumption)
-        *   [ACCURACY_NEAREST_TEN_METERS](Titanium.Geolocation.ACCURACY_NEAREST_TEN_METERS)
-        *   [ACCURACY_HUNDRED_METERS](Titanium.Geolocation.ACCURACY_HUNDRED_METERS)
-        *   [ACCURACY_KILOMETER](Titanium.Geolocation.ACCURACY_KILOMETER)
-        *   [ACCURACY_THREE_KILOMETERS](Titanium.Geolocation.ACCURACY_THREE_KILOMETERS) (lowest
-            accuracy and power consumption).
-
-        This mode is deprecated and should not be used for new development.
-
-        In this mode, the specified `accuracy` value determines the
-        *minimum distance between location updates*. If `accuracy` is set to
-        `ACCURACY_BEST`, no distance filter is used on updates.
 
     As of Titanium SDK 7.1.0 and later, including the [`ti.playservices`](https://github.com/appcelerator-modules/ti.playservices) module will allow Google Play Services 
     to be used by default to obtain location information. This means the provider passed into [createLocationProvider](Titanium.Geolocation.Android.createLocationProvider)
@@ -659,9 +642,6 @@ properties:
         is recommended to maximize accuracy and battery life.
         See <Titanium.Geolocation.Android> for details on using manual mode.
 
-        Note that for backwards compatibility, Android supports using the iOS accuracy constants.
-        This usage is deprecated. Applications using one of the iOS constants should
-        migrate to using `ACCURACY_HIGH`, `ACCURACY_LOW`, or Android manual mode.
     type: Number
     constants: Titanium.Geolocation.ACCURACY_*
 
@@ -673,6 +653,23 @@ properties:
     type: Number
     default: 0
     platforms: [iphone, ipad]
+
+  - name: frequency
+    deprecated:
+        since: "2.0.0"
+        notes: |
+            Android legacy mode operation is deprecated. For new development, use
+            either simple mode or manual mode. See "Configurating Location Updates on Android"
+            in the main description of this class for more information.
+    summary: Requested frequency for location updates, in milliseconds.
+    description: |
+        Setting a frequency value enables legacy location mode on Android.
+        Note that only a single provider can be active at one time in legacy mode.
+         Note that the frequency value is used as a guideline: there are no guarantees
+        that the device will provide updates at the specified frequency.
+         A lower frequency value generally increases power consumption.
+        A value of 0 means that updates should be generated as quickly as possible.
+    type: Number
 
   - name: hasCompass
     summary: Indicates whether the current device supports a compass.
@@ -707,6 +704,26 @@ properties:
         Therefore, this method returns `true` on these devices if only there is GPS or network provider available.
     type: Boolean
     permission: read-only
+
+  - name: preferredProvider
+    deprecated:
+        since: "2.0.0"
+        notes: |
+            Android legacy mode operation is deprecated. For new development, use
+            either simple mode or manual mode. See "Configurating Location Updates on Android"
+            in the main description of this class for more information.
+    summary: |
+        Determines the preferred location provider.
+    description: |
+        Setting a preferred provider enables legacy location mode on Android.
+        Note that only a single provider can be active at one time in legacy mode.
+         The preferred provider affects power consumption. In general, `PROVIDER_GPS`
+        requires the most power, and `PROVIDER_PASSIVE` requires the least.
+         If `undefined`, the preferred provider is auto-detected.
+    type: String
+    constants: Titanium.Geolocation.Android.PROVIDER_*
+    platforms: [android]
+    default: <Titanium.Geolocation.Android.PROVIDER_NETWORK>
 
   - name: showCalibration
     summary: Determines whether the compass calibration UI is shown if needed.

--- a/apidoc/Titanium/UI/Animation.yml
+++ b/apidoc/Titanium/UI/Animation.yml
@@ -62,7 +62,7 @@ properties:
         the view's top-left corner, `{0.5, 0.5}` at its center and `{1, 1}` at its bottom-right
         corner.
 
-        This property's value will overwrite the [anchorPoint](Ti.UI.Matrix2D.Matrix2DCreationDict.anchorPoint) used in the matrix's creation dictionary.
+        This property's value will overwrite the [anchorPoint](Matrix2DCreationDict.anchorPoint) used in the matrix's creation dictionary.
 
         See the "Using an anchorPoint" example for a demonstration.
     type: Point

--- a/apidoc/Titanium/UI/ScrollView.yml
+++ b/apidoc/Titanium/UI/ScrollView.yml
@@ -51,7 +51,7 @@ methods:
     summary: Sets the value of the [contentOffset](Titanium.UI.ScrollView.contentOffset) property.
     platforms: [iphone, ipad]
     parameters:
-      - name: contentOffset
+      - name: contentOffsetXY
         summary: |
             X and Y coordinates to which to reposition the top-left point of the scrollable region.
         type: Dictionary
@@ -222,7 +222,7 @@ properties:
         Measured in platform-specific units; pixels on Android, effective pixels on Windows and density-independent pixels (dip) on iOS.
     type: [Number, String]
 
-  - name: contentOffsetXY
+  - name: contentOffset
     summary: X and Y coordinates to which to reposition the top-left point of the scrollable region.
     description: |
         On iOS, a new value causes the scroll view to perform an animated scroll to the new offset.

--- a/apidoc/Titanium/UI/TabbedBar.yml
+++ b/apidoc/Titanium/UI/TabbedBar.yml
@@ -50,7 +50,7 @@ properties:
         color or gradient to show through.
         For Android:
         [Titanium.UI.TABS_STYLE_*]
-        In Android [style](Ti.UI.TabbedBar.style) is only supported in the creation dictionary 
+        In Android [style](Titanium.UI.TabbedBar.style) is only supported in the creation dictionary 
         of the proxy.
     type: Number
     default: Titanium.UI.iOS.SystemButtonStyle.PLAIN for iOS, Ti.UI.TABS_STYLE_DEFAULT for Android

--- a/apidoc/Titanium/UI/UI.yml
+++ b/apidoc/Titanium/UI/UI.yml
@@ -510,7 +510,7 @@ properties:
   - name: ATTRIBUTE_LINE_BREAK
     deprecated:
         since: "7.5.0"
-        notes: Use <Titanium.UI.ATTRIBUTE_PARAGRAPH_STYLE.lineBreakMode> instead.  
+        notes: Use <ParagraphAttribute.lineBreakMode> instead.  
     summary: |
         Use with <Attribute.type> to wrap and truncate the text.
     description: |

--- a/apidoc/Titanium/UI/WebView.yml
+++ b/apidoc/Titanium/UI/WebView.yml
@@ -256,7 +256,7 @@ methods:
 
   - name: setBasicAuthentication
     summary: |
-        Sets the basic authentication for this web view to use on subsequent URl requests.
+        Sets the basic authentication for this web view to use on subsequent URL requests.
     description: |
         The persistence property of this method is only supported on iOS and Titanium SDK 8.0.0+. 
         It is ignored on other platforms and versions.
@@ -296,7 +296,7 @@ methods:
         type: Array
 
   - name: stopListeningToProperties
-    summary: Remove native properties from observing.      
+    summary: Remove native properties from observing.
     platforms: [iphone, ipad]
     since: "8.0.0"
     parameters:
@@ -305,7 +305,7 @@ methods:
         type: Array
 
   - name: takeSnapshot
-    summary: Takes a snapshot of the view's visible viewport.      
+    summary: Takes a snapshot of the view's visible viewport.
     platforms: [iphone, ipad]
     since: "8.0.0"
     parameters:
@@ -314,7 +314,7 @@ methods:
         type: Callback<SnapshotResult>
 
   - name: addUserScript
-    summary: Adds a user script.      
+    summary: Adds a user script.
     platforms: [iphone, ipad]
     since: "8.0.0"
     parameters:
@@ -332,7 +332,7 @@ methods:
         type: Boolean
 
   - name: removeAllUserScripts
-    summary: Removes all associated user scripts.      
+    summary: Removes all associated user scripts.
     platforms: [iphone, ipad]
     since: "8.0.0"
 
@@ -352,7 +352,7 @@ methods:
         type: String
 
   - name: removeScriptMessageHandler
-    summary: Removes a script message handler.     
+    summary: Removes a script message handler.
     platforms: [iphone, ipad]
     since: "8.0.0"
     parameters:

--- a/apidoc/Titanium/UI/iOS/WebViewDecisionHandler.yml
+++ b/apidoc/Titanium/UI/iOS/WebViewDecisionHandler.yml
@@ -4,7 +4,7 @@ name: Titanium.UI.iOS.WebViewDecisionHandler
 summary: |
     It represents the decision handler to tell to webview, whether allow or cancel the navigation.
 description: |
-    Returned as the `handler` parameter of (handleurl)[Titanium.WebView.handleurl].
+    Returned as the `handler` parameter of <Titanium.UI.WebView.handleurl>.
     See the example section "Usage of allowedURLSchemes and handleurl in iOS" inside <Titanium.UI.WebView> for usage.
 
 extends: Titanium.Proxy

--- a/apidoc/Titanium/UI/iOS/WebViewDecisionHandler.yml
+++ b/apidoc/Titanium/UI/iOS/WebViewDecisionHandler.yml
@@ -4,9 +4,8 @@ name: Titanium.UI.iOS.WebViewDecisionHandler
 summary: |
     It represents the decision handler to tell to webview, whether allow or cancel the navigation.
 description: |
-    You need not to create it. It will be returned as parameter <Titanium.WebView.handleurl.handler> 
-    of event <Titanium.WebView.handleurl>. See the example section "Usage of allowedURLSchemes and handleurl in iOS"
-    inside <Titanium.UI.WebView> for usage.
+    Returned as the `handler` parameter of (handleurl)[Titanium.WebView.handleurl].
+    See the example section "Usage of allowedURLSchemes and handleurl in iOS" inside <Titanium.UI.WebView> for usage.
 
 extends: Titanium.Proxy
 since: "8.0.0"

--- a/apidoc/Titanium/UI/iOS/iOS.yml
+++ b/apidoc/Titanium/UI/iOS/iOS.yml
@@ -1955,7 +1955,7 @@ properties:
   - name: CREDENTIAL_PERSISTENCE_NONE
     summary: Credential should not be stored.
     description: |
-        Used with the `persistence` property of <Titanium.UI.WebView.setBasicAuthentication> to set the persistence level.
+        Used with the `persistence` argument of <Titanium.UI.WebView.setBasicAuthentication> to set the persistence level.
     type: Number
     since: "8.0.0"
     permission: read-only
@@ -1963,7 +1963,7 @@ properties:
   - name: CREDENTIAL_PERSISTENCE_FOR_SESSION
     summary: Credential should be stored only for this session.
     description: |
-        Used with the `persistence` property of <Titanium.UI.WebView.setBasicAuthentication> to set the persistence level.
+        Used with the `persistence` argument of <Titanium.UI.WebView.setBasicAuthentication> to set the persistence level.
     type: Number
     since: "8.0.0"
     permission: read-only
@@ -1971,7 +1971,7 @@ properties:
   - name: CREDENTIAL_PERSISTENCE_PERMANENT
     summary: Credential should be stored in the keychain.
     description: |
-       Used with the `persistence` property of <Titanium.UI.WebView.setBasicAuthentication> to set the persistence level.
+       Used with the `persistence` argument of <Titanium.UI.WebView.setBasicAuthentication> to set the persistence level.
     type: Number
     since: "8.0.0"
     permission: read-only
@@ -1981,7 +1981,7 @@ properties:
         Credential should be stored permanently in the keychain, and in addition should be 
         distributed to other devices based on the owning AppleID.
     description: |
-        Used with the `persistence` property of <Titanium.UI.WebView.setBasicAuthentication> to set the persistence level.
+        Used with the `persistence` argument of <Titanium.UI.WebView.setBasicAuthentication> to set the persistence level.
     type: Number
     since: "8.0.0"
     permission: read-only
@@ -2098,7 +2098,7 @@ properties:
     summary: |
         Inject the script after the document element is created, but before any other content is loaded.
     description: |
-        Used to set the `injectionTime` property of <Titanium.UI.WebView.addUserScript>.
+        Used to set the `injectionTime` argument of <Titanium.UI.WebView.addUserScript>.
     type: Number
     since: "8.0.0"
     permission: read-only
@@ -2107,7 +2107,7 @@ properties:
     summary: |
         Inject the script after the document finishes loading, but before other subresources finish loading.
     description: |
-        Used to set the `injectionTime` property of <Titanium.UI.WebView.addUserScript>.
+        Used to set the `injectionTime` argument of <Titanium.UI.WebView.addUserScript>.
     type: Number
     since: "8.0.0"
     permission: read-only

--- a/apidoc/Titanium/UI/iOS/iOS.yml
+++ b/apidoc/Titanium/UI/iOS/iOS.yml
@@ -1955,7 +1955,7 @@ properties:
   - name: CREDENTIAL_PERSISTENCE_NONE
     summary: Credential should not be stored.
     description: |
-        Use with <Titanium.UI.WebView.basicAuthentication.persistence>
+        Used with <Titanium.UI.WebView.setBasicAuthentication> to set the persistence level.
     type: Number
     since: "8.0.0"
     permission: read-only
@@ -1963,7 +1963,7 @@ properties:
   - name: CREDENTIAL_PERSISTENCE_FOR_SESSION
     summary: Credential should be stored only for this session.
     description: |
-        Use with <Titanium.UI.WebView.basicAuthentication.persistence>
+        Used with <Titanium.UI.WebView.setBasicAuthentication> to set the persistence level.
     type: Number
     since: "8.0.0"
     permission: read-only
@@ -1971,7 +1971,7 @@ properties:
   - name: CREDENTIAL_PERSISTENCE_PERMANENT
     summary: Credential should be stored in the keychain.
     description: |
-        Use with <Titanium.UI.WebView.basicAuthentication.persistence>
+       Used with <Titanium.UI.WebView.setBasicAuthentication> to set the persistence level.
     type: Number
     since: "8.0.0"
     permission: read-only
@@ -1981,7 +1981,7 @@ properties:
         Credential should be stored permanently in the keychain, and in addition should be 
         distributed to other devices based on the owning AppleID.
     description: |
-        Use with <Titanium.UI.WebView.basicAuthentication.persistence>
+        Used with <Titanium.UI.WebView.setBasicAuthentication> to set the persistence level.
     type: Number
     since: "8.0.0"
     permission: read-only
@@ -2025,7 +2025,7 @@ properties:
     description: |
         Use with <Titanium.UI.WebView.cachePolicy>. This is the default policy for URL load requests.
         If you are making HTTP or HTTPS byte-range requests, always use the 
-        <Titanium.UI.WebView.cachePolicy.CACHE_POLICY_RELOAD_IGNORING_LOCAL_CACHE_DATA> policy.
+        <Titanium.UI.iOS.CACHE_POLICY_RELOAD_IGNORING_LOCAL_CACHE_DATA> policy.
     type: Number
     since: "8.0.0"
     permission: read-only
@@ -2098,7 +2098,7 @@ properties:
     summary: |
         Inject the script after the document element is created, but before any other content is loaded.
     description: |
-        Use with <Titanium.UI.WebView.addUserScript.injectionTime>.
+        Used to set the `injectionTime` property for <Titanium.UI.WebView.addUserScript>.
     type: Number
     since: "8.0.0"
     permission: read-only
@@ -2107,7 +2107,7 @@ properties:
     summary: |
         Inject the script after the document finishes loading, but before other subresources finish loading.
     description: |
-        Use with <Titanium.UI.WebView.addUserScript.injectionTime>.
+        Used to set the `injectionTime` property for <Titanium.UI.WebView.addUserScript>.
     type: Number
     since: "8.0.0"
     permission: read-only

--- a/apidoc/Titanium/UI/iOS/iOS.yml
+++ b/apidoc/Titanium/UI/iOS/iOS.yml
@@ -1955,7 +1955,7 @@ properties:
   - name: CREDENTIAL_PERSISTENCE_NONE
     summary: Credential should not be stored.
     description: |
-        Used with <Titanium.UI.WebView.setBasicAuthentication> to set the persistence level.
+        Used with the `persistence` property of <Titanium.UI.WebView.setBasicAuthentication> to set the persistence level.
     type: Number
     since: "8.0.0"
     permission: read-only
@@ -1963,7 +1963,7 @@ properties:
   - name: CREDENTIAL_PERSISTENCE_FOR_SESSION
     summary: Credential should be stored only for this session.
     description: |
-        Used with <Titanium.UI.WebView.setBasicAuthentication> to set the persistence level.
+        Used with the `persistence` property of <Titanium.UI.WebView.setBasicAuthentication> to set the persistence level.
     type: Number
     since: "8.0.0"
     permission: read-only
@@ -1971,7 +1971,7 @@ properties:
   - name: CREDENTIAL_PERSISTENCE_PERMANENT
     summary: Credential should be stored in the keychain.
     description: |
-       Used with <Titanium.UI.WebView.setBasicAuthentication> to set the persistence level.
+       Used with the `persistence` property of <Titanium.UI.WebView.setBasicAuthentication> to set the persistence level.
     type: Number
     since: "8.0.0"
     permission: read-only
@@ -1981,7 +1981,7 @@ properties:
         Credential should be stored permanently in the keychain, and in addition should be 
         distributed to other devices based on the owning AppleID.
     description: |
-        Used with <Titanium.UI.WebView.setBasicAuthentication> to set the persistence level.
+        Used with the `persistence` property of <Titanium.UI.WebView.setBasicAuthentication> to set the persistence level.
     type: Number
     since: "8.0.0"
     permission: read-only
@@ -2098,7 +2098,7 @@ properties:
     summary: |
         Inject the script after the document element is created, but before any other content is loaded.
     description: |
-        Used to set the `injectionTime` property for <Titanium.UI.WebView.addUserScript>.
+        Used to set the `injectionTime` property of <Titanium.UI.WebView.addUserScript>.
     type: Number
     since: "8.0.0"
     permission: read-only
@@ -2107,7 +2107,7 @@ properties:
     summary: |
         Inject the script after the document finishes loading, but before other subresources finish loading.
     description: |
-        Used to set the `injectionTime` property for <Titanium.UI.WebView.addUserScript>.
+        Used to set the `injectionTime` property of <Titanium.UI.WebView.addUserScript>.
     type: Number
     since: "8.0.0"
     permission: read-only

--- a/apidoc/docgen.js
+++ b/apidoc/docgen.js
@@ -312,9 +312,10 @@ function hideAPIMembers(apis, type) {
  * Generates accessors from the given list of properties
  * @param {Array<Object>} apis Array of property objects
  * @param {String} className Name of the class
+ * @param {String} methods Array of defined methods on the API
  * @returns {Array<Object>} Array of methods
  */
-function generateAccessors(apis, className) {
+function generateAccessors(apis, className, methods) {
 	const rv = [];
 	apis.forEach(function (api) {
 
@@ -322,10 +323,12 @@ function generateAccessors(apis, className) {
 			return;
 		}
 
+		const getterName = 'get' + api.name.charAt(0).toUpperCase() + api.name.slice(1);
+		const setterName = 'set' + api.name.charAt(0).toUpperCase() + api.name.slice(1);
 		// Generate getter
-		if (!('permission' in api && api.permission === 'write-only') && !api.name.match(common.REGEXP_CONSTANTS)) {
+		if (!('permission' in api && api.permission === 'write-only') && !api.name.match(common.REGEXP_CONSTANTS) && !methods.includes(getterName)) {
 			rv.push({
-				name: 'get' + api.name.charAt(0).toUpperCase() + api.name.slice(1),
+				name: getterName,
 				summary: 'Gets the value of the <' + className + '.' + api.name + '> property.',
 				deprecated: api.deprecated || { since: '8.0.0', notes: 'Access <' + className + '.' + api.name + '> instead.' },
 				platforms: api.platforms,
@@ -339,9 +342,9 @@ function generateAccessors(apis, className) {
 		}
 
 		// Generate setter
-		if (!('permission' in api && api.permission === 'read-only')) {
+		if (!('permission' in api && api.permission === 'read-only') && !methods.includes(setterName)) {
 			rv.push({
-				name: 'set' + api.name.charAt(0).toUpperCase() + api.name.slice(1),
+				name: setterName,
 				summary: 'Sets the value of the <' + className + '.' + api.name + '> property.',
 				deprecated: api.deprecated || { since: '8.0.0', notes: 'Set the value using <' + className + '.' + api.name + '> instead.'  },
 				platforms: api.platforms,
@@ -477,7 +480,8 @@ function processAPIs (api) {
 		let accessors;
 		api = hideAPIMembers(api, 'properties');
 		api.properties = processAPIMembers(api.properties, 'properties', api.since, api.__addon);
-		if (api.__subtype !== 'pseudo' && (accessors = generateAccessors(api.properties, api.name))) {
+		const methods = api.methods.map(method => method.name);
+		if (api.__subtype !== 'pseudo' && (accessors = generateAccessors(api.properties, api.name, methods))) {
 			if (assert(api, 'methods')) {
 				matches = [];
 				accessors.forEach(function (accessor) {

--- a/apidoc/lib/html_generator.js
+++ b/apidoc/lib/html_generator.js
@@ -55,7 +55,8 @@ function convertAPIToLink(apiName) {
 			cls = apiName.substring(0, apiName.lastIndexOf('.'));
 
 		if (!(cls in doc) && !apiName.startsWith('Modules.')) {
-			common.log(common.LOG_WARN, 'Cannot find class: %s', cls);
+			common.log(common.LOG_WARN, 'Cannot find class: %s, referenced by %s', cls, apiName);
+			console.log(apiName);
 			return apiName;
 		} else {
 			if (common.findAPI(doc, cls, member, 'properties')) {


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIDOC-3289

This PR fixes up the docs to do the following, it would be great if the initial authors of PRs associated to the changes/doc authors can review to make sure I haven't screwed up 🙂 I've tried to split the commits up so that it's a single commit per reviewable change

@garymathews Could you please take a look at the following
637312e262b062d0f9deef0a82d1628d9d199ccd - Update Geolocation docs in accordance with #10547. Keep an eye out for `// check me!` as there are still references to the removed properties (and `legacy mode`) that I'm unsure as to what to do with


@vijaysingh-axway Could you please take a look over the following
d77316f50793216fa31662e033be35cc068402c5 - Fix reference to lineBreakMode
7281537c5b1c0e5fa37c0c01097bcaa1bbd18a93 / a2ec4ac63630d4d3df223237aa6f42d297ed3359 - Fix references in webview docs

@jawa9000  Could you please take a look over the following (and the others if you have time please)
2b97935687af4bd643406cde975f0dabfd9a4369 -  Correct name of contentOffset

Free for all commits 😆
7e25d1adce7d38fc16ab84bed702ba9a25314c8a - Fix typos
14ea75727d0a7bd3ad70fdd083d9ff05a997e1d9 - Adds API that referenced a class, makes doing this work much easier to know the full string to look for
feb7bbbb3bba9382acfe5234a9992801c52b8407 - Pass methods into the getter/setter generation to avoid creating invalid getters/setters