### PR TITLE
fix(android): also use GPS for low accuracy

### DIFF
--- a/android/modules/geolocation/src/java/ti/modules/titanium/geolocation/GeolocationModule.java
+++ b/android/modules/geolocation/src/java/ti/modules/titanium/geolocation/GeolocationModule.java
@@ -508,15 +508,19 @@ public class GeolocationModule extends KrollModule implements Handler.Callback, 
 	public void requestLocationPermissions(@Kroll.argument(optional = true) Object type,
 										   @Kroll.argument(optional = true) KrollFunction permissionCallback)
 	{
-		if (hasLocationPermissions()) {
-			return;
-		}
-
 		KrollFunction permissionCB;
 		if (type instanceof KrollFunction && permissionCallback == null) {
 			permissionCB = (KrollFunction) type;
 		} else {
 			permissionCB = permissionCallback;
+		}
+
+		// already have permissions, fall through
+		if (hasLocationPermissions()) {
+			KrollDict response = new KrollDict();
+			response.putCodeAndMessage(0, null);
+			permissionCB.callAsync(getKrollObject(), response);
+			return;
 		}
 
 		TiBaseActivity.registerPermissionRequestCallback(TiC.PERMISSION_CODE_LOCATION, permissionCB, getKrollObject());

--- a/android/modules/geolocation/src/java/ti/modules/titanium/geolocation/GeolocationModule.java
+++ b/android/modules/geolocation/src/java/ti/modules/titanium/geolocation/GeolocationModule.java
@@ -111,9 +111,6 @@ public class GeolocationModule extends KrollModule implements Handler.Callback, 
 	public int numLocationListeners = 0;
 	public HashMap<String, LocationProviderProxy> simpleLocationProviders =
 		new HashMap<String, LocationProviderProxy>();
-	@Deprecated
-	public HashMap<String, LocationProviderProxy> legacyLocationProviders =
-		new HashMap<String, LocationProviderProxy>();
 
 	protected static final int MSG_ENABLE_LOCATION_PROVIDERS = KrollModule.MSG_LAST_ID + 100;
 	protected static final int MSG_LAST_ID = MSG_ENABLE_LOCATION_PROVIDERS;
@@ -135,17 +132,10 @@ public class GeolocationModule extends KrollModule implements Handler.Callback, 
 	private ArrayList<LocationRuleProxy> simpleLocationRules = new ArrayList<LocationRuleProxy>();
 	private LocationRuleProxy simpleLocationGpsRule;
 	private LocationRuleProxy simpleLocationNetworkRule;
-	private int simpleLocationAccuracyProperty = ACCURACY_LOW;
 	private Location currentLocation;
 	//currentLocation is conditionally updated. lastLocation is unconditionally updated
 	//since currentLocation determines when to send out updates, and lastLocation is passive
 	private Location lastLocation;
-	@Deprecated
-	private HashMap<Integer, Double> legacyLocationAccuracyMap = new HashMap<Integer, Double>();
-	@Deprecated
-	private double legacyLocationFrequency = 5000;
-	@Deprecated
-	private String legacyLocationPreferredProvider = AndroidModule.PROVIDER_NETWORK;
 
 	private FusedLocationProvider fusedLocationProvider;
 
@@ -178,6 +168,8 @@ public class GeolocationModule extends KrollModule implements Handler.Callback, 
 		simpleLocationNetworkRule =
 			new LocationRuleProxy(AndroidModule.PROVIDER_NETWORK, SIMPLE_LOCATION_NETWORK_DISTANCE_RULE,
 								  SIMPLE_LOCATION_NETWORK_MIN_AGE_RULE, null);
+		simpleLocationRules.add(simpleLocationNetworkRule);
+		simpleLocationRules.add(simpleLocationGpsRule);
 	}
 
 	/**
@@ -321,40 +313,21 @@ public class GeolocationModule extends KrollModule implements Handler.Callback, 
 	@SuppressLint("MissingPermission")
 	private void propertyChangedAccuracy(Object newValue)
 	{
-		// is simple mode enabled (registered with OS, not just selected via the accuracy property)
-		boolean simpleModeEnabled = false;
-		if (!(getManualMode()) && (numLocationListeners > 0)) {
-			simpleModeEnabled = true;
-		}
-
 		int accuracyProperty = TiConvert.toInt(newValue);
-
 		if ((accuracyProperty == ACCURACY_HIGH) || (accuracyProperty == ACCURACY_LOW)) {
-			// has the value changed from the last known good value?
-			if (accuracyProperty != simpleLocationAccuracyProperty) {
-				simpleLocationAccuracyProperty = accuracyProperty;
-				LocationProviderProxy gpsProvider = simpleLocationProviders.get(AndroidModule.PROVIDER_GPS);
 
-				if ((accuracyProperty == ACCURACY_HIGH) && (gpsProvider == null)) {
-					gpsProvider = new LocationProviderProxy(AndroidModule.PROVIDER_GPS, SIMPLE_LOCATION_GPS_DISTANCE,
-															SIMPLE_LOCATION_GPS_TIME, this);
-					simpleLocationProviders.put(AndroidModule.PROVIDER_GPS, gpsProvider);
-					simpleLocationRules.add(simpleLocationNetworkRule);
-					simpleLocationRules.add(simpleLocationGpsRule);
+			double accuracyDistance = SIMPLE_LOCATION_GPS_DISTANCE;
+			if (accuracyProperty == ACCURACY_LOW) {
+				accuracyDistance = 3000.0;
+			}
+			LocationProviderProxy gpsProvider =
+				new LocationProviderProxy(AndroidModule.PROVIDER_GPS, accuracyDistance, SIMPLE_LOCATION_GPS_TIME, this);
 
-					if (simpleModeEnabled) {
-						registerLocationProvider(gpsProvider);
-					}
+			unregisterLocationProvider(simpleLocationProviders.get(AndroidModule.PROVIDER_GPS));
+			simpleLocationProviders.put(AndroidModule.PROVIDER_GPS, gpsProvider);
 
-				} else if ((accuracyProperty == ACCURACY_LOW) && (gpsProvider != null)) {
-					simpleLocationProviders.remove(AndroidModule.PROVIDER_GPS);
-					simpleLocationRules.remove(simpleLocationNetworkRule);
-					simpleLocationRules.remove(simpleLocationGpsRule);
-
-					if (simpleModeEnabled) {
-						unregisterLocationProvider(gpsProvider);
-					}
-				}
+			if (!getManualMode()) {
+				registerLocationProvider(gpsProvider);
 			}
 		}
 	}
@@ -367,15 +340,6 @@ public class GeolocationModule extends KrollModule implements Handler.Callback, 
 	private void propertyChangedFrequency(Object newValue)
 	{
 		double frequencyProperty = TiConvert.toDouble(newValue) * 1000;
-		if (frequencyProperty != legacyLocationFrequency) {
-			legacyLocationFrequency = frequencyProperty;
-
-			Iterator<String> iterator = legacyLocationProviders.keySet().iterator();
-			while (iterator.hasNext()) {
-				LocationProviderProxy locationProvider = legacyLocationProviders.get(iterator.next());
-				locationProvider.setProperty(TiC.PROPERTY_MIN_UPDATE_TIME, legacyLocationFrequency);
-			}
-		}
 	}
 
 	/**
@@ -390,24 +354,6 @@ public class GeolocationModule extends KrollModule implements Handler.Callback, 
 		if (!(preferredProviderProperty.equals(AndroidModule.PROVIDER_NETWORK))
 			&& (!(preferredProviderProperty.equals(AndroidModule.PROVIDER_GPS)))) {
 			return;
-		}
-
-		if (!(preferredProviderProperty.equals(legacyLocationPreferredProvider))) {
-			LocationProviderProxy oldProvider = legacyLocationProviders.get(legacyLocationPreferredProvider);
-			LocationProviderProxy newProvider = legacyLocationProviders.get(preferredProviderProperty);
-
-			if (oldProvider != null) {
-				legacyLocationProviders.remove(legacyLocationPreferredProvider);
-			}
-
-			if (newProvider == null) {
-				newProvider = new LocationProviderProxy(preferredProviderProperty,
-														legacyLocationAccuracyMap.get(simpleLocationAccuracyProperty),
-														legacyLocationFrequency, this);
-				legacyLocationProviders.put(preferredProviderProperty, newProvider);
-			}
-
-			legacyLocationPreferredProvider = preferredProviderProperty;
 		}
 	}
 
@@ -591,6 +537,9 @@ public class GeolocationModule extends KrollModule implements Handler.Callback, 
 		if (!hasLocationPermissions()) {
 			Log.e(TAG, "Location permissions missing", Log.DEBUG_MODE);
 			return;
+		} else if (locationProvider == null) {
+			Log.e(TAG, "Invalid location provider", Log.DEBUG_MODE);
+			return;
 		}
 
 		if (FusedLocationProvider.hasPlayServices(context)) {
@@ -615,6 +564,9 @@ public class GeolocationModule extends KrollModule implements Handler.Callback, 
 	@SuppressLint("MissingPermission")
 	public void unregisterLocationProvider(LocationProviderProxy locationProvider)
 	{
+		if (locationProvider == null) {
+			return;
+		}
 		if (FusedLocationProvider.hasPlayServices(context)) {
 			fusedLocationProvider.unregisterLocationProvider(locationProvider);
 		} else {
@@ -673,10 +625,6 @@ public class GeolocationModule extends KrollModule implements Handler.Callback, 
 	@SuppressLint("MissingPermission")
 	private void disableLocationProviders()
 	{
-		for (LocationProviderProxy locationProvider : legacyLocationProviders.values()) {
-			unregisterLocationProvider(locationProvider);
-		}
-
 		for (LocationProviderProxy locationProvider : simpleLocationProviders.values()) {
 			unregisterLocationProvider(locationProvider);
 		}

--- a/android/modules/geolocation/src/java/ti/modules/titanium/geolocation/android/LocationProviderProxy.java
+++ b/android/modules/geolocation/src/java/ti/modules/titanium/geolocation/android/LocationProviderProxy.java
@@ -37,8 +37,8 @@ import android.os.Bundle;
 @Kroll.proxy
 public class LocationProviderProxy extends KrollProxy implements LocationListener
 {
-	public static final int STATE_DISABLED = 0;
-	public static final int STATE_ENABLED = 1;
+	public static final int STATE_ENABLED = 0;
+	public static final int STATE_DISABLED = 1;
 	public static final int STATE_OUT_OF_SERVICE = 2;
 	public static final int STATE_UNAVAILABLE = 3;
 	public static final int STATE_AVAILABLE = 4;


### PR DESCRIPTION
- Also use GPS provider for low accuracy
- Remove more legacy code
- Fix `STATE_DISABLED` to output as an error
- Allow `requestLocationPermissions` to fall through when permissions are already granted

###### TEST CASE
```JS
const win = Ti.UI.createWindow({ backgroundColor: 'gray' });
const listView = Ti.UI.createListView();
let count = 1;

Ti.Geolocation.accuracy = Ti.Geolocation.ACCURACY_LOW;

function push (e) {
    let section = Ti.UI.createListSection({ headerTitle: '#' + count++ });
    if (e.success) {
        if (e.coords) {
            e = e.coords;
        }
        section.setItems([
            { properties: { title: 'LOCATION:\n' + e.latitude + ', ' + e.longitude, color: 'orange' } },
            { properties: { title: 'ALTITUDE:\n' + e.altitude, color: 'orange' } },
            { properties: { title: 'ACCURACY:\n' + e.accuracy, color: 'orange' } }
        ]);
    } else {
        section.setItems([
            { properties: { title: 'ERROR:\n' + e.error, color: 'red' } }
        ]);
    }
    listView.appendSection(section);
}

function getLocation () {
    Ti.Geolocation.addEventListener('location', push);
}

win.addEventListener('open', () => {
    Ti.Geolocation.requestLocationPermissions(Ti.Geolocation.AUTHORIZATION_ALWAYS, (e) => {
        if (e.success) {
            getLocation();
        } else {
            alert('could not obtain location permissions');
        }
    });
});

win.add(listView);
win.open();
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-26851)