### PR TITLE
fix(android): Fixed activity callback regressions

### DIFF
--- a/tests/Resources/ti.android.addontest.js
+++ b/tests/Resources/ti.android.addontest.js
@@ -1,0 +1,87 @@
+/*
+ * Axway Appcelerator Titanium Mobile
+ * Copyright (c) 2011-Present by Axway, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+/* eslint-env mocha */
+/* global Ti */
+/* eslint no-unused-expressions: "off" */
+'use strict';
+var should = require('./utilities/assertions');
+
+describe.android('Titanium.Android', function () {
+	it('activity callbacks', function (finish) {
+		let wasOnCreateCalled = false;
+		let wasOnRestartCalled = false;
+		let wasOnStartCalled = false;
+		let wasOnResumeCalled = false;
+		let wasOnPauseCalled = false;
+		let wasOnStopCalled = false;
+		let wasOnDestroyCalled = false;
+
+		this.timeout(5000);
+
+		const win = Ti.UI.createWindow();
+		win.activity.onCreate = function () {
+			wasOnCreateCalled = true;
+			win.activity.onCreate = null;
+		};
+		win.activity.onRestart = function () {
+			wasOnRestartCalled = true;
+			win.activity.onRestart = null;
+			setTimeout(function () {
+				// Now that app was resumed from background, test destroy behavior.
+				win.close();
+			}, 50);
+		};
+		win.activity.onStart = function () {
+			wasOnStartCalled = true;
+			win.activity.onStart = null;
+		};
+		win.activity.onResume = function () {
+			wasOnResumeCalled = true;
+			win.activity.onResume = null;
+		};
+		win.activity.onPause = function () {
+			wasOnPauseCalled = true;
+			win.activity.onPause = null;
+		};
+		win.activity.onStop = function () {
+			wasOnStopCalled = true;
+			win.activity.onStop = null;
+			setTimeout(function () {
+				// App was put into the background. Next, resume it to trigger onRestart() callback.
+				Ti.Android.currentActivity.startActivity(Ti.App.Android.launchIntent);
+			}, 50);
+		};
+		win.activity.onDestroy = function () {
+			wasOnDestroyCalled = true;
+			win.activity.onDestroy = null;
+		};
+		win.addEventListener('open', function () {
+			// Navigate to the device's home screen. Equivalent to pressing the "home" button.
+			const homeIntent = Ti.Android.createIntent({
+				action: Ti.Android.ACTION_MAIN,
+			});
+			homeIntent.addCategory(Ti.Android.CATEGORY_HOME);
+			homeIntent.flags = Ti.Android.FLAG_ACTIVITY_NEW_TASK;
+			Ti.Android.currentActivity.startActivity(homeIntent);
+		});
+		win.addEventListener('close', function () {
+			try {
+				should(wasOnCreateCalled).be.true;
+				should(wasOnRestartCalled).be.true;
+				should(wasOnStartCalled).be.true;
+				should(wasOnResumeCalled).be.true;
+				should(wasOnPauseCalled).be.true;
+				should(wasOnStopCalled).be.true;
+				should(wasOnDestroyCalled).be.true;
+				finish();
+			} catch (err) {
+				finish(err);
+			}
+		});
+		win.open();
+	});
+});


### PR DESCRIPTION
**JIRA:**
- https://jira.appcelerator.org/browse/TIMOB-26850
- https://jira.appcelerator.org/browse/TIMOB-26865

**Summary:**
- [TIMOB-26850](https://jira.appcelerator.org/browse/TIMOB-26850) Fixed regression introduced in 7.5.0 where `onStop` and `onDestroy` callbacks are not invoked by root activity.
  * Only happens when "tiapp.xml" property "run-on-main-thread" is set to `true`, which can longer be set to `false` as of 8.0.0.
  * All activity callbacks are now invoked synchronously.
- [TIMOB-26865](https://jira.appcelerator.org/browse/TIMOB-26865) Re-added `onRestart` callback support that was accidentally removed in 8.0.0.RC.
  * This is called when resuming app from the background.

**Test:**
1. Build and run the below code on Android.
2. Wait for the app to launch.
3. In the log verify the following was printed.
```
[INFO]  @@@ RootActivity.onCreate() called.
[INFO]  @@@ RootActivity.onStart() called.
[INFO]  @@@ RootActivity.onResume() called.
[INFO]  @@@ RootActivity.onPause() called.
[INFO]  @@@ TopActivity.onCreate() called.
[INFO]  @@@ TopActivity.onStart() called.
[INFO]  @@@ TopActivity.onResume() called.
[INFO]  @@@ RootActivity.onStop() called.
```
4. Press the Android "Home" button.
5. In the log verify the following was printed.
```
[INFO]  @@@ TopActivity.onPause() called.
[INFO]  @@@ TopActivity.onStop() called.
```
6. Resume the app.
7. In the log verify the following was printed. _(Especially the `onRestart` message.)_
```
[INFO]  @@@ TopActivity.onRestart() called.
[INFO]  @@@ TopActivity.onStart() called.
[INFO]  @@@ TopActivity.onResume() called.
```
8. Exit out of the app via the "Back" button.
9. In the log verify the following was printed. _(It's okay if the "TopActivity" and "RootActivity" messages happen in a different order. We can't fully control this.)_
```
[INFO]  @@@ TopActivity.onPause() called.
[INFO]  @@@ RootActivity.onDestroy() called.
[INFO]  @@@ TopActivity.onStop() called.
[INFO]  @@@ TopActivity.onDestroy() called.
```

---
**app.js**
```javascript
function addActivityListenersTo(activity, name) {
	if (!activity) {
		return;
	}
	if (!name) {
		name = "Activity";
	}
	activity.onCreate = function() {
		Ti.API.info("@@@ " + name + ".onCreate() called.");
	};
	activity.onRestart = function() {
		Ti.API.info("@@@ " + name + ".onRestart() called.");
	};
	activity.onStart = function() {
		Ti.API.info("@@@ " + name + ".onStart() called.");
	};
	activity.onResume = function() {
		Ti.API.info("@@@ " + name + ".onResume() called.");
	};
	activity.onPause = function() {
		Ti.API.info("@@@ " + name + ".onPause() called.");
	};
	activity.onStop = function() {
		Ti.API.info("@@@ " + name + ".onStop() called.");
	};
	activity.onDestroy = function() {
		Ti.API.info("@@@ " + name + ".onDestroy() called.");
	};
}

addActivityListenersTo(Ti.Android.currentActivity, "RootActivity");

var window = Ti.UI.createWindow();
window.add(Ti.UI.createLabel({ text: "Activity Callback Test" }));
addActivityListenersTo(window.activity, "TopActivity");
window.open();
```
