### PR TITLE
fix: remove unmarking of @babel/polyfill during android build

### DIFF
--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -2808,37 +2808,6 @@ AndroidBuilder.prototype.copyResources = function copyResources(next) {
 				}
 			};
 		}), function () {
-			// jsanalyze will copy polyfils into buildBinAssetsResourcesDir and we need
-			// to unmark them here so they won't get removed on subsequent builds
-			if (this.transpile) {
-				/**
-				 * Recursively unmarks a module and it's dependencies from the last
-				 * build files list.
-				 *
-				 * @param {String} moduleId The module to remove from the list of files
-				 * @param {String} nodeModulesPath Path to the node_modules folder
-				 */
-				const unmarkPackageAndDependencies = (moduleId, nodeModulesPath) => {
-					let packageJsonPath;
-					if (require.resolve.paths) {
-						packageJsonPath = require.resolve(path.join(moduleId, 'package.json'), { paths: [ nodeModulesPath ] });
-					} else {
-						packageJsonPath = require.resolve(path.join(moduleId, 'package.json'));
-						packageJsonPath = path.join(nodeModulesPath, packageJsonPath.substring(packageJsonPath.indexOf('node_modules') + 12));
-					}
-					const modulePath = path.dirname(packageJsonPath);
-					Object.keys(this.lastBuildFiles).forEach(p => {
-						if (p.startsWith(modulePath)) {
-							delete this.lastBuildFiles[p];
-						}
-					});
-					const packageJson = fs.readJSONSync(packageJsonPath);
-					for (const dependency in packageJson.dependencies) {
-						unmarkPackageAndDependencies(dependency, nodeModulesPath);
-					}
-				};
-				unmarkPackageAndDependencies('@babel/polyfill', path.join(this.buildBinAssetsResourcesDir, 'node_modules'));
-			}
 
 			// write the properties file
 			const buildAssetsPath = this.encryptJS ? this.buildAssetsDir : this.buildBinAssetsResourcesDir,


### PR DESCRIPTION
@babel/polyfill is now bundled and distributed via the core ti.internal scripts rather than being placed into the app at build time

**JIRA:** https://jira.appcelerator.org/browse/TIMOB-26869

