### PR TITLE
build: check destination exists before trying to get stats info

### DIFF
--- a/build/utils.js
+++ b/build/utils.js
@@ -260,7 +260,7 @@ Utils.installSDK = async function (versionTag, symlinkIfPossible = false) {
 	}
 
 	const destDir = path.join(dest, 'mobilesdk', osName, versionTag);
-	if (await fs.pathExists(destDir)) {
+	try {
 		const destStats = fs.lstatSync(destDir);
 		if (destStats.isDirectory()) {
 			console.log('Destination exists, deleting %s...', destDir);
@@ -269,6 +269,8 @@ Utils.installSDK = async function (versionTag, symlinkIfPossible = false) {
 			console.log('Destination exists as symlink, unlinking %s...', destDir);
 			fs.unlinkSync(destDir);
 		}
+	} catch (error) {
+		// Do nothing
 	}
 
 	const zipDir = path.join(__dirname, '..', 'dist', `mobilesdk-${versionTag}-${osName}`);

--- a/build/utils.js
+++ b/build/utils.js
@@ -260,13 +260,15 @@ Utils.installSDK = async function (versionTag, symlinkIfPossible = false) {
 	}
 
 	const destDir = path.join(dest, 'mobilesdk', osName, versionTag);
-	const destStats = fs.lstatSync(destDir);
-	if (destStats.isDirectory()) {
-		console.log('Destination exists, deleting %s...', destDir);
-		await fs.remove(destDir);
-	} else if (destStats.isSymbolicLink()) {
-		console.log('Destination exists as symlink, unlinking %s...', destDir);
-		fs.unlinkSync(destDir);
+	if (await fs.pathExists(destDir)) {
+		const destStats = fs.lstatSync(destDir);
+		if (destStats.isDirectory()) {
+			console.log('Destination exists, deleting %s...', destDir);
+			await fs.remove(destDir);
+		} else if (destStats.isSymbolicLink()) {
+			console.log('Destination exists as symlink, unlinking %s...', destDir);
+			fs.unlinkSync(destDir);
+		}
 	}
 
 	const zipDir = path.join(__dirname, '..', 'dist', `mobilesdk-${versionTag}-${osName}`);


### PR DESCRIPTION
If the destination dir (`/Users/eharris/Library/Application\Support/Titanium/mobilesdk/osx/8.1.0` or similar), doesn't exist then this will currently throw checking for the stats. Just check if it exists before that

#### Verification steps

1. Nuke your dir that matches `/Users/eharris/Library/Application\Support/Titanium/mobilesdk/osx/8.1.0`
2. Run `node build/scons cleanbuild`

No errors should occur and you should have an SDK copied over