### PR TITLE
fix(android): Fixed crash caused by reading View's "backgroundDisabledColor" if background/border properties are set

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/TiViewProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/TiViewProxy.java
@@ -29,6 +29,7 @@ import org.appcelerator.titanium.TiBlob;
 import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.TiDimension;
 import org.appcelerator.titanium.util.TiAnimationBuilder;
+import org.appcelerator.titanium.util.TiCast;
 import org.appcelerator.titanium.util.TiConvert;
 import org.appcelerator.titanium.util.TiUrl;
 import org.appcelerator.titanium.util.TiUIHelper;
@@ -1030,50 +1031,49 @@ public abstract class TiViewProxy extends KrollProxy
 	{
 		// Try to get the background drawable if one is available.
 		TiBackgroundDrawable backgroundDrawable = getOrCreateView().getBackground();
-		// Guard for views without color state backgrounds.
 		if (backgroundDrawable == null) {
 			return null;
-		} else {
-			try {
-				// Get the backgroundDrawable background as a StateListDrawable.
-				StateListDrawable stateListDrawable = ((StateListDrawable) backgroundDrawable.getBackground());
-				// Get the reflection methods.
-				Method getStateDrawableIndexMethod =
-					StateListDrawable.class.getMethod("getStateDrawableIndex", int[].class);
-				Method getStateDrawableMethod = StateListDrawable.class.getMethod("getStateDrawable", int.class);
-				// Get the disabled state's (as defined in TiUIHelper) index.
-				int index =
-					(int) getStateDrawableIndexMethod.invoke(stateListDrawable, TiUIHelper.BACKGROUND_DISABLED_STATE);
-				// Get the drawable at the index.
-				Drawable drawable = (Drawable) getStateDrawableMethod.invoke(stateListDrawable, index);
-				// Try to get the 0 index of the result.
-				if (drawable instanceof LayerDrawable) {
-					Drawable drawableFromLayer = ((LayerDrawable) drawable).getDrawable(0);
-					// Cast it as a ColorDrawable.
-					if (drawableFromLayer instanceof ColorDrawable) {
-						// Transcript the color int to HexString.
-						String strColor =
-							String.format("#%08X", 0xFFFFFFFF & ((ColorDrawable) drawableFromLayer).getColor());
-						return strColor;
-					} else {
-						Log.w(TAG, "Background drawable of unexpected type. Expected - ColorDrawable. Found - "
-									   + drawableFromLayer.getClass().toString());
-						return null;
-					}
-				} else {
-					Log.w(TAG, "Background drawable of unexpected type. Expected - LayerDrawable. Found - "
-								   + drawable.getClass().toString());
-					return null;
-				}
-			} catch (NoSuchMethodException e) {
-				Log.w(TAG, "Unable to get a method for reflection.");
-			} catch (IllegalAccessException e) {
-				Log.w(TAG, "Unable to access a method for reflection.");
-			} catch (InvocationTargetException e) {
-				Log.w(TAG, "Unable to invoke a method for reflection.");
-			}
+		}
+
+		// Get the backgroundDrawable background as a StateListDrawable.
+		StateListDrawable stateListDrawable = TiCast.as(backgroundDrawable.getBackground(), StateListDrawable.class);
+		if (stateListDrawable == null) {
 			return null;
 		}
+
+		try {
+			// Get the reflection methods.
+			Method getStateDrawableIndexMethod =
+				StateListDrawable.class.getMethod("getStateDrawableIndex", int[].class);
+			Method getStateDrawableMethod = StateListDrawable.class.getMethod("getStateDrawable", int.class);
+			// Get the disabled state's (as defined in TiUIHelper) index.
+			int index =
+				(int) getStateDrawableIndexMethod.invoke(stateListDrawable, TiUIHelper.BACKGROUND_DISABLED_STATE);
+			// Get the drawable at the index.
+			Drawable drawable = (Drawable) getStateDrawableMethod.invoke(stateListDrawable, index);
+			// Try to get the 0 index of the result.
+			if (drawable instanceof LayerDrawable) {
+				Drawable drawableFromLayer = ((LayerDrawable) drawable).getDrawable(0);
+				// Cast it as a ColorDrawable.
+				if (drawableFromLayer instanceof ColorDrawable) {
+					// Transcript the color int to HexString.
+					String strColor =
+						String.format("#%08X", 0xFFFFFFFF & ((ColorDrawable) drawableFromLayer).getColor());
+					return strColor;
+				} else {
+					Log.w(TAG, "Background drawable of unexpected type. Expected - ColorDrawable. Found - "
+									+ drawableFromLayer.getClass().toString());
+					return null;
+				}
+			} else {
+				Log.w(TAG, "Background drawable of unexpected type. Expected - LayerDrawable. Found - "
+								+ drawable.getClass().toString());
+				return null;
+			}
+		} catch (Exception e) {
+			Log.w(TAG, "Unable access disabled background drawable via reflection.");
+		}
+		return null;
 	}
 
 	public void setParent(TiViewProxy parent)

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiCast.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiCast.java
@@ -1,0 +1,94 @@
+/**
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2019 by Axway, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+package org.appcelerator.titanium.util;
+
+/**
+ * Provides a safe means of casting an object via an as() method, similar to how the "as" keyword is
+ * used in C#, Swift, Rust, etc. This means if the object cannot be cast to the given type, then
+ * the as() method will return null.
+ * <p>
+ * Example Usage:
+ * <pre>
+ *	String result;
+ * 
+ *	result = TiCast.as("Test", String.class);
+ *	if (result != null) {
+ *		// Was safely cast to a String type.
+ *	}
+ *
+ *	result = TiCast.as(new Integer(1), String.class);
+ *	if (result == null) {
+ *		// Will be null since Integer cannot be cast to a String.
+ *	}
+ * </pre>
+ */
+public class TiCast
+{
+	/** Object value boxed by this class to be casted by the as() method. Can be null. */
+	private Object value;
+
+	/**
+	 * Private constructor used to box a given object value to be casted later.
+	 * @param value Object value to be casted by the as() method later. Can be null.
+	 */
+	private TiCast(Object value)
+	{
+		this.value = value;
+	}
+
+	/**
+	 * Gets the object value given to the TiCast.from() static method.
+	 * @return Returns the object value stored by this instance. Can be null.
+	 */
+	public Object getObject()
+	{
+		return this.value;
+	}
+
+	/**
+	 * Safely casts the stored object to the given type.
+	 * @param type The class type to cast the 1st argument type such as "String.class", "List.class", etc.
+	 * @return
+	 * Returns the object casted to the given type if successful.
+	 * <p>
+	 * Returns null if the given object cannot be cast to the given type or if given a null argument.
+	 */
+	public <T> T as(Class<T> type)
+	{
+		return TiCast.as(this.value, type);
+	}
+
+	/**
+	 * Safely casts the given object to the given type.
+	 * @param value The object to be cast. Can be null.
+	 * @param type The class type to cast the 1st argument type such as "String.class", "List.class", etc.
+	 * @return
+	 * Returns the object casted to the given type if successful.
+	 * <p>
+	 * Returns null if the given object cannot be cast to the given type or if given a null argument.
+	 */
+	public static <T> T as(Object value, Class<T> type)
+	{
+		if ((value != null) && (type != null)) {
+			if (type.isInstance(value)) {
+				return (T) value;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Boxes the given object value and returns a "TiCast" instance type.
+	 * Returned type can then be used to call the as() instance method.
+	 * @param value The object value to be casted later by the TiCast instance's as() method. Can be null.
+	 * @return Returns a new TiCast instance whose getObject() method will return the given "value" argument.
+	 */
+	public static TiCast from(Object value)
+	{
+		return new TiCast(value);
+	}
+}


### PR DESCRIPTION
**JIRA:**
https://jira.appcelerator.org/browse/TIMOB-26841

**Summary:**
Fixed bug where if both a background color property and a border property was set, then reading the "backgroundDisabledColor" property would cause a crash.

**Note:**
@garymathews , @ypbnv , I added a new `TiCast.java` class used to provide a C#/Swift `as` keyword like functionality where if it's unable to cast to the given type, then it'll return `null`. It allows us to do the following. What do you think?
```java
BitmapDrawable result = TiCast.as(getDrawable(), BitmapDrawable.class);
if (result != null) {
	// Got it!
}
```

Note that I'd prefer to use generics more heavily, but Java generics cannot provide type information at runtime, making the **below** impossible. The only viable solution that I know of is to pass in a `Class<T>` type like I'm doing in this PR's code.
```java
public static <T> T as(Object value)
{
	if (value instanceof T) { // <- This won't work.
		return (T) value;
	}
	return null;
}
```

**Test:**
1. Build and run the below code on Android.
2. Verify that the app does not crash on startup.
3. Uncomment the 2 lines of code below.
4. Rebuild and rerun the app on Android.
5. Verify that the displayed `TextField` now has a gray background.
6. In the log, verify that you see the following message. _("#FF888888" is the color "gray".)_
`[INFO] :   ### textField.backgroundDisabledColor: #FF888888`

```javascript
var window = Ti.UI.createWindow();
var textField = Ti.UI.createTextField({
	value: "Hello World",
	width: "80%",
	color: "white",
	backgroundColor: "black",
	borderColor: "white",
//	backgroundDisabledColor: "gray",
//	enabled: false,
});
window.add(textField);
window.open();
Ti.API.info("### textField.backgroundDisabledColor: " + textField.backgroundDisabledColor);
Ti.API.info("### JSON.stringify(textField): " + JSON.stringify(textField));
```
