### PR TITLE
refactor(common): move to es6 import/export syntax for common sdk js when possible

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -44,7 +44,15 @@
       }
     },
     {
-      "files": [ "common/Resources/ti.main.js" ],
+      "files": [
+        "common/Resources/ti.main.js",
+        "common/Resources/ti.internal/extensions/binding.js",
+        "common/Resources/ti.internal/extensions/os.js",
+        "common/Resources/ti.internal/extensions/path.js",
+        "common/Resources/ti.internal/extensions/tty.js",
+        "common/Resources/ti.internal/extensions/util.js",
+        "common/Resources/ti.internal/bootstrap.loader.js"
+      ],
       "parserOptions": {
         "ecmaVersion": 2017,
         "sourceType": "module"

--- a/.eslintrc
+++ b/.eslintrc
@@ -46,6 +46,7 @@
     {
       "files": [
         "common/Resources/ti.main.js",
+        "common/Resources/ti.internal/extensions/assert.js",
         "common/Resources/ti.internal/extensions/binding.js",
         "common/Resources/ti.internal/extensions/os.js",
         "common/Resources/ti.internal/extensions/path.js",
@@ -56,13 +57,6 @@
       "parserOptions": {
         "ecmaVersion": 2017,
         "sourceType": "module"
-      }
-    },
-    {
-      "files": [ "common/Resources/ti.internal/extensions/assert.js" ],
-      "parserOptions": {
-        "ecmaVersion": 2017,
-        "sourceType": "script"
       }
     }
   ]

--- a/common/Resources/ti.internal/bootstrap.loader.js
+++ b/common/Resources/ti.internal/bootstrap.loader.js
@@ -15,35 +15,30 @@
  * - Ensure "Google Play Services" is installed/updated on app startup on Android.
  */
 
-'use strict';
-
 /**
  * Attempts to load all bootstraps from a "bootstrap.json" file created by the app build system.
  * This is an optional feature and is the fastest method of acquiring boostraps configured for the app.
  * This JSON file, if provided, must be in the same directory as this script.
- * @returns {Array.<string>}
+ * @returns {string[]}
  * Returns an array of require() compatible strings if bootstraps were successfully loaded from JSON.
  * Returns an empty array if JSON file was found, but no bootstraps were configured for the app.
  * Returns null if JSON file was not found.
  */
 function fetchScriptsFromJson() {
-	var JSON_FILE_NAME = 'bootstrap.json',
-		jsonFile,
-		settings;
+	const JSON_FILE_NAME = 'bootstrap.json';
 
 	try {
-		jsonFile = Ti.Filesystem.getFile(
-			Ti.Filesystem.resourcesDirectory, 'ti.internal/' + JSON_FILE_NAME);
+		const jsonFile = Ti.Filesystem.getFile(
+			Ti.Filesystem.resourcesDirectory, `ti.internal/${JSON_FILE_NAME}`);
 		if (jsonFile.exists()) {
-			settings = JSON.parse(jsonFile.read().text);
+			const settings = JSON.parse(jsonFile.read().text);
 			if (Array.isArray(settings.scripts)) {
 				return settings.scripts;
-			} else {
-				return [];
 			}
+			return [];
 		}
 	} catch (error) {
-		Ti.API.error('Failed to read "' + JSON_FILE_NAME + '". Reason: ' + error.message);
+		Ti.API.error(`Failed to read "${JSON_FILE_NAME}". Reason: ${error.message}`);
 	}
 	return null;
 }
@@ -55,31 +50,27 @@ function fetchScriptsFromJson() {
  * Returns an empty array if no bootstrap files were found.
  */
 function fetchScriptsFromResourcesDirectory() {
-	var resourceDirectory = Ti.Filesystem.getFile(Ti.Filesystem.resourcesDirectory),
-		resourceDirectoryPath = resourceDirectory.nativePath,
-		bootstrapScripts = [];
+	const resourceDirectory = Ti.Filesystem.getFile(Ti.Filesystem.resourcesDirectory);
+	const resourceDirectoryPathLength = resourceDirectory.nativePath.length;
+	const bootstrapScripts = [];
 
 	function loadFrom(file) {
-		var index,
-			fileNameArray,
-			bootstrapPath;
-
 		if (file) {
 			if (file.isDirectory()) {
 				// This is a directory. Recursively look for bootstrap files under it.
-				fileNameArray = file.getDirectoryListing();
+				const fileNameArray = file.getDirectoryListing();
 				if (fileNameArray) {
-					for (index = 0; index < fileNameArray.length; index++) {
+					for (let index = 0; index < fileNameArray.length; index++) {
 						loadFrom(Ti.Filesystem.getFile(file.nativePath, fileNameArray[index]));
 					}
 				}
 			} else if (file.name.search(/.bootstrap.js$/) >= 0) {
 				// This is a bootstrap file.
 				// Convert its path to something loadable via require() and add it to the array.
-				bootstrapPath = file.nativePath;
+				let bootstrapPath = file.nativePath;
 				bootstrapPath = bootstrapPath.substr(
-					resourceDirectoryPath.length,
-					(bootstrapPath.length - resourceDirectoryPath.length) - '.js'.length);
+					resourceDirectoryPathLength,
+					(bootstrapPath.length - resourceDirectoryPathLength) - '.js'.length);
 				bootstrapScripts.push(bootstrapPath);
 			}
 		}
@@ -92,11 +83,11 @@ function fetchScriptsFromResourcesDirectory() {
  * Non-blocking function which loads and executes all bootstrap scripts configured for the app.
  * @param {function} finished Callback to be invoked once all bootstraps have finished executing. Cannot be null.
  */
-exports.loadAsync = function (finished) {
+function loadAsync(finished) {
 	// Acquire an array of all bootstrap scripts included with the app.
-	// - For best performance, attempt to fetch scripts via an optional JSON file create by the build system.
+	// - For best performance, attempt to fetch scripts via an optional JSON file created by the build system.
 	// - If JSON file not found (will return null), then search "Resources" directory for bootstrap files.
-	var bootstrapScripts = fetchScriptsFromJson();
+	let bootstrapScripts = fetchScriptsFromJson();
 	if (!bootstrapScripts) {
 		bootstrapScripts = fetchScriptsFromResourcesDirectory();
 	}
@@ -112,14 +103,13 @@ exports.loadAsync = function (finished) {
 
 	// Loads all bootstrap scripts found.
 	function loadBootstrapScripts(finished) {
-		var bootstrapIndex = 0;
+		let bootstrapIndex = 0;
 		function doLoad() {
 			// Attempt to load all bootstrap scripts.
-			var fileName, bootstrap;
 			while (bootstrapIndex < bootstrapScripts.length) {
 				// Load the next bootstrap.
-				fileName = bootstrapScripts[bootstrapIndex];
-				bootstrap = require(fileName);
+				const fileName = bootstrapScripts[bootstrapIndex];
+				const bootstrap = require(fileName);
 
 				// Invoke the bootstrap's execute() method if it has one. (This is optional.)
 				// We must wait for the given callback to be invoked before loading the next script.
@@ -140,15 +130,14 @@ exports.loadAsync = function (finished) {
 			// Last bootstrap has finished execution. Time to load the next one.
 			// Note: Add a tiny delay so whatever UI the last bootstrap loaded has time to close.
 			bootstrapIndex++;
-			setTimeout(function () {
-				doLoad();
-			}, 1);
+			setTimeout(() => doLoad(), 1);
 		}
 		doLoad();
 	}
-	loadBootstrapScripts(function () {
-		// We've finished loading/executing all bootstrap scripts.
-		// Inform caller by invoking the callback given to loadAsync().
-		finished();
-	});
-};
+
+	// We've finished loading/executing all bootstrap scripts.
+	// Inform caller by invoking the callback given to loadAsync().
+	loadBootstrapScripts(finished);
+}
+
+export default loadAsync;

--- a/common/Resources/ti.internal/extensions/assert.js
+++ b/common/Resources/ti.internal/extensions/assert.js
@@ -1,6 +1,4 @@
-'use strict';
-
-const util = require('util');
+import util from './util';
 
 const DEFAULT_MESSAGES = {
 	deepStrictEqual: 'Expected values to be strictly deep-equal:',
@@ -706,4 +704,4 @@ assert.strict.notEqual = assert.notStrictEqual;
 // hang strict off itself
 assert.strict.strict = assert.strict;
 
-module.exports = assert;
+export default assert;

--- a/common/Resources/ti.internal/extensions/binding.js
+++ b/common/Resources/ti.internal/extensions/binding.js
@@ -6,17 +6,39 @@
  * implementation. We then intercept require calls to handle requests for these modules
  * and lazily load the file.
  */
-'use strict';
 
+/**
+ * Used by @function bindObjectToCoreModuleId
+ * @type {map<string, object>}
+ */
 const bindings = new Map();
 
-// FIXME: Use a cache to avoid the redirection? Maybe just make the map hold either the filepath *or* the cached require result?
+/**
+ * Used by @function redirectCoreModuleIdToPath
+ * @type {map<string, string>}
+ */
+const redirects = new Map();
+
+/**
+ * Does the request look like a typical core module? (no '.' or '/' characters)
+ * @param {string} path original require path/id
+ * @returns {boolean}
+ */
+function isCoreModuleId(path) {
+	return !path.includes('.') && !path.includes('/');
+}
+
 // Hack require to point to this as a core module "binding"
 const originalRequire = global.require;
 // This works for iOS as-is, and also intercepts the call on Android for ti.main.js (the first file executed)
 global.require = function (moduleId) {
-	if (bindings.has(moduleId)) {
-		moduleId = bindings.get(moduleId);
+	if (isCoreModuleId(moduleId)) {
+		if (bindings.has(moduleId)) {
+			return bindings.get(moduleId);
+		}
+		if (redirects.has(moduleId)) {
+			moduleId = redirects.get(moduleId);
+		}
 	}
 	return originalRequire(moduleId);
 };
@@ -25,8 +47,13 @@ if (Ti.Platform.name === 'android') {
 	// ... but we still need to hack it when requiring from other files for Android
 	const originalModuleRequire = global.Module.prototype.require;
 	global.Module.prototype.require = function (path, context) {
-		if (bindings.has(path)) {
-			path = bindings.get(path);
+		if (isCoreModuleId(path)) {
+			if (bindings.has(path)) {
+				return bindings.get(path);
+			}
+			if (redirects.has(path)) {
+				path = redirects.get(path);
+			}
 		}
 		return originalModuleRequire.call(this, path, context);
 	};
@@ -36,13 +63,23 @@ if (Ti.Platform.name === 'android') {
  * Registers a binding from a short module id to the full under the hood filepath.
  * This allows for lazy instantiation of the module on-demand.
  *
- * @param {string} bindingId    the short module id
+ * @param {string} coreModuleId the module id to "hijack"
  * @param {string} internalPath the full filepath to require under the hood.
  *                              This should be an already resolved absolute path,
  *                              as otherwise the context of the call could change what gets loaded!
  */
-function addBinding(bindingId, internalPath) {
-	bindings.set(bindingId, internalPath);
+export function redirectCoreModuleIdToPath(coreModuleId, internalPath) {
+	redirects.set(coreModuleId, internalPath);
 }
 
-module.exports = addBinding;
+// TODO: Allow two types of bindings: a "redirect" from a "core" module id to the actual underlying file (as we have here)
+// OR binding an object already loaded to a "core" module id
+
+/**
+ * Registers a binding from a short module id to already loaded/constructed object to export for that core module id.
+ * @param {string} coreModuleId the core module id to register under
+ * @param {object} object the object to hook to respond to require requests for the module id
+ */
+export function bindObjectToCoreModuleId(coreModuleId, object) {
+	bindings.set(coreModuleId, object);
+}

--- a/common/Resources/ti.internal/extensions/os.js
+++ b/common/Resources/ti.internal/extensions/os.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const isAndroid = Ti.Platform.osname === 'android';
 const isIOS = !isAndroid && (Ti.Platform.osname === 'iphone' || Ti.Platform.osname === 'ipad');
 const isWin32 = !isAndroid && !isIOS && Ti.Platform.name === 'windows';
@@ -526,4 +524,4 @@ if (isIOS) {
 	OS.type = () => 'Linux';
 }
 
-module.exports = OS;
+export default OS;

--- a/common/Resources/ti.internal/extensions/path.js
+++ b/common/Resources/ti.internal/extensions/path.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const isWin32 = (Ti.Platform.osname === 'windowsphone') || (Ti.Platform.osname === 'windowsstore');
 
 const FORWARD_SLASH = 47; // '/'
@@ -577,4 +575,4 @@ const path = isWin32 ? Win32Path : PosixPath;
 path.win32 = Win32Path;
 path.posix = PosixPath;
 
-module.exports = path;
+export default path;

--- a/common/Resources/ti.internal/extensions/tty.js
+++ b/common/Resources/ti.internal/extensions/tty.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const tty = {
 	isatty: () => false,
 	ReadStream: () => {
@@ -10,4 +8,4 @@ const tty = {
 	}
 };
 
-module.exports = tty;
+export default tty;

--- a/common/Resources/ti.internal/extensions/util.js
+++ b/common/Resources/ti.internal/extensions/util.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const MONTHS = [
 	'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'
 ];
@@ -555,4 +553,4 @@ util.debuglog = () => {
 	return noop;
 };
 
-module.exports = util;
+export default util;

--- a/common/Resources/ti.main.js
+++ b/common/Resources/ti.main.js
@@ -12,7 +12,7 @@
  */
 
 // Log the app name, app version, and Titanium version on startup.
-Ti.API.info(Ti.App.name + ' ' + Ti.App.version + ' (Powered by Titanium ' + Ti.version + '.' + Ti.buildHash + ')');
+Ti.API.info(`${Ti.App.name} ${Ti.App.version} (Powered by Titanium ${Ti.version}.${Ti.buildHash})`);
 
 // Attempt to load crash analytics module.
 // NOTE: This should be the first module that loads on startup.
@@ -29,19 +29,24 @@ import '@babel/polyfill';
 import './ti.internal/extensions/Error';
 import './ti.internal/extensions/process';
 
-// When registering a binding, need to resolve the path *now* versus whenever the call actually gets made
-// i.e. we want absolute paths
-const addBinding = require('./ti.internal/extensions/binding');
-// FIXME Use require.resolve to resolve the path, once we support it!
-addBinding('path', '/ti.internal/extensions/path');
-addBinding('os', '/ti.internal/extensions/os');
-addBinding('tty', '/ti.internal/extensions/tty');
-addBinding('util', '/ti.internal/extensions/util');
-addBinding('assert', '/ti.internal/extensions/assert');
+// Load all the node compatible core modules
+import path from './ti.internal/extensions/path';
+import os from './ti.internal/extensions/os';
+import tty from './ti.internal/extensions/tty';
+import util from './ti.internal/extensions/util';
+import assert from './ti.internal/extensions/assert';
+// hook our implementations to get loaded by require
+import { bindObjectToCoreModuleId } from './ti.internal/extensions/binding';
+bindObjectToCoreModuleId('path', path);
+bindObjectToCoreModuleId('os', os);
+bindObjectToCoreModuleId('tty', tty);
+bindObjectToCoreModuleId('util', util);
+bindObjectToCoreModuleId('assert', assert);
 
 // Load and execute all "*.bootstrap.js" files.
 // Note: This must be done after loading extensions since bootstraps might depend on them.
-require('./ti.internal/bootstrap.loader').loadAsync(function () {
+import loadAsync from './ti.internal/bootstrap.loader';
+loadAsync(function () {
 	// We've finished loading/executing all bootstrap scripts.
 	// We can now proceed to run the main "app.js" script.
 	require('./app');


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/[TICKET]

**Description:**
Since we are already both polyfilling and transpiling the common SDK JS code, we should make use of more modern syntax. The gain here is that using import/export means more of the extensions are bundled up using rollup into the ti.main.js file to help reduce startup performance impact. I had to change my "binding" hack to support two variants: redirecting requires from a core id to the underlying file path to actually load (no longer used right now); and to add a pre-loaded binding, attaching an object to return when requiring the module id (now used to bind util/assert/tty/path/os impls to the module ids to "expose" them as via require).


Additionally, I'd say that moving to es6 syntax helps clean up some of the code (for me, the move from `var` to `const`/`let` make for much more natural code around variables).