### PR TITLE
fix: update template for latest webpack and angular versions

### DIFF
--- a/templates/app/angular-default/template/app/package.json
+++ b/templates/app/angular-default/template/app/package.json
@@ -8,26 +8,26 @@
     },
     "private": true,
     "dependencies": {
-        "@angular/common": "^6.1.10",
-        "@angular/compiler": "^6.1.10",
-        "@angular/compiler-cli": "^6.1.10",
-        "@angular/core": "^6.1.10",
-        "@angular/platform-browser": "^6.1.10",
-        "@angular/platform-browser-dynamic": "^6.1.10",
-        "@angular/router": "^6.1.10",
-        "reflect-metadata": "^0.1.10",
-        "rxjs": "^6.3.3",
+        "@angular/common": "^7.2.9",
+        "@angular/compiler": "^7.2.9",
+        "@angular/compiler-cli": "^7.2.9",
+        "@angular/core": "^7.2.9",
+        "@angular/platform-browser": "^7.2.9",
+        "@angular/platform-browser-dynamic": "^7.2.9",
+        "@angular/router": "^7.2.9",
+        "reflect-metadata": "^0.1.13",
+        "rxjs": "^6.4.0",
         "titanium-angular": "^0.1.0",
         "typescript": "^3.1.3",
-        "zone.js": "^0.8.18"
+        "zone.js": "^0.8.29"
     },
     "devDependencies": {
-        "@ngtools/webpack": "^6.2.5",
-        "@types/titanium": "^7.1.0",
-        "clean-webpack-plugin": "^0.1.18",
-        "copy-webpack-plugin": "^4.3.1",
-        "raw-loader": "^0.5.1",
-        "webpack": "^4.20.2",
+        "@ngtools/webpack": "^7.3.6",
+        "@types/titanium": "^7.3.1",
+        "clean-webpack-plugin": "^2.0.1",
+        "copy-webpack-plugin": "^5.0.1",
+        "raw-loader": "^2.0.0",
+        "webpack": "^4.29.6",
         "webpack-dev-titanium": "^0.1.0"
     }
 }

--- a/templates/app/angular-default/template/app/webpack.config.js
+++ b/templates/app/angular-default/template/app/webpack.config.js
@@ -40,7 +40,10 @@ module.exports = env => {
 			symlinks: false
 		},
 		node: {
-			fs: 'empty'
+			fs: 'empty',
+			global: false,
+			process: false,
+			setImmediate: false
 		},
 		module: {
 			rules: [
@@ -64,15 +67,14 @@ module.exports = env => {
 					allowExternal: true
 				}
 			),
-			new webpack.optimize.CommonsChunkPlugin({
-				name: 'vendor'
+			new webpack.DefinePlugin({
+				'process.env.TARGET_PLATFORM': JSON.stringify(env.platform)
 			}),
 			new CopyWebpackPlugin([
 				{ context: 'assets', from: '**/*' },
 				{ from: 'platform/**/*', to: '..' }
 			]),
 			new GenerateAppJsPlugin([
-				'vendor',
 				'bundle'
 			]),
 			new TitaniumAngularCompilerPlugin({


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-26798

Webpack dependency was already updated via Greenkeeper but the Webpack config template was never adjusted. This bumps all dependencies to the latest version and updates the Webpack template to be compatible with Webpack 4.x