### PR TITLE
fix(android): Fixed 8.0.0 regression where resuming an OS forced-quit app shows empty window

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/TiActivity.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiActivity.java
@@ -8,16 +8,44 @@ package org.appcelerator.titanium;
 
 import android.content.Intent;
 import android.os.Bundle;
+import org.appcelerator.kroll.common.Log;
+import org.appcelerator.kroll.KrollRuntime;
 
 /** The activity that is shown when opening a Titanium "Ti.UI.Window" in JavaScript. */
 public class TiActivity extends TiBaseActivity
 {
+	/** The default Android log tag name to be used by this class. */
+	private static final String TAG = "TiActivity";
+
 	/** Listener that detects when the root activity's onNewIntent() method has been called. */
 	private TiRootActivity.OnNewIntentListener rootNewIntentListener;
+
+	/** Set true if this activity was flagged to be destroyed by onCreate(). */
+	private boolean isInvalidLaunch;
 
 	@Override
 	protected void onCreate(Bundle savedInstanceState)
 	{
+		// Destroy this activity if it's the first one launched.
+		// The "TiRootActivity" must be launched 1st to start up the JS runtime. This activity can't work by itself.
+		// ---------------------------------------------------------------------------------------------------------
+		// Can happen when:
+		// 1) Started by another app via "startActivity(TiActivity)".
+		// 2) If app was force-quit by the OS due to low memory, then on app relaunch the OS will restore last shown
+		//    activities backwards, starting with last displayed top-most child activity instead of root activity.
+		//    Last known parent activity won't be restored/recreated until after finishing the child activity.
+		//    So, in this case, we want to keep finishing child activities until we're back to the root activity.
+		// ---------------------------------------------------------------------------------------------------------
+		if (KrollRuntime.getActivityRefCount() <= 0) {
+			Log.i(TAG, "Launching with '" + getClass().getName() + "' is not allowed. Closing activity.");
+			this.isInvalidLaunch = true;
+			activityOnCreate(savedInstanceState);
+			finish();
+			overridePendingTransition(android.R.anim.fade_in, 0);
+			return;
+		}
+
+		// Create this activity normally.
 		super.onCreate(savedInstanceState);
 
 		// Fetch the root activity.
@@ -44,6 +72,13 @@ public class TiActivity extends TiBaseActivity
 	@Override
 	protected void onDestroy()
 	{
+		// If activity is invalid, then it's not tied to a Titanium "Ti.UI.Window". Quickly destroy it and bail out.
+		// Note: Below method calls Activity.onDestroy() directly, bypassing TiBaseActivity.onDestroy() method.
+		if (this.isInvalidLaunch) {
+			activityOnDestroy();
+			return;
+		}
+
 		// Remove the onNewIntent() listener from the root activity.
 		TiRootActivity rootActivity = getTiApp().getRootActivity();
 		if (rootActivity != null) {


### PR DESCRIPTION
**JIRA:**
https://jira.appcelerator.org/browse/TIMOB-26914

**Summary:**
When the OS force-quits an app, the next time you relaunch the app, the OS will attempt to restore its previous state starting with the top-most child activity window that was displayed instead of starting with the root activity. When you back out of the top-most child activity, the OS will then restore/recreate its parent activity and so forth. This means that it's restoring the activities in reverse order.

When the end-user force quits the app, the above behavior does not happen. Relaunch the app will startup as normal, starting with the main launcher activity. This is the desired behavior.

**Test:**
1. On Android, go to its "Developer Options" screen.
2. Tap on the "Background process limit" row. (It's near the bottom of the list.)
3. Tap on "No background processes". _(This tells the OS to force quit the last displayed app when launching another app.)_
4. Build and run the below code on the same Android device.
5. In the app, tap on the "Show Child Window" button.
6. Press the Android "Home" button.
7. Tap on another app such as "Gmail".
8. Press the Android "Home" button.
9. Resume the Titanium app.
10. Verify that the app restarts, starting with the splash screen. _(It will launch with a blank window, but quickly restart. Unfortunately, we are stuck with this behavior.)_

```javascript
var window = Ti.UI.createWindow();
var openButton = Ti.UI.createButton({ title: "Show Child Window" });
openButton.addEventListener("click", function(e) {
	var childWindow = Ti.UI.createWindow({ backgroundColor: "orange" });
	var closeButton = Ti.UI.createButton({ title: "Close Me" });
	closeButton.addEventListener("click", function(e) {
		childWindow.close();
	});
	childWindow.add(closeButton);
	childWindow.open();
});
window.add(openButton);
window.open();
```
