### PR TITLE
fix: improve app build times

### DIFF
--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -2722,7 +2722,7 @@ AndroidBuilder.prototype.copyResources = function copyResources(next) {
 		// copy js files into assets directory and minify if needed
 		this.logger.info(__('Processing JavaScript files'));
 		const sdkCommonFolder = path.join(this.titaniumSdkPath, 'common', 'Resources');
-		appc.async.series(this, Object.keys(jsFiles).map(function (id) {
+		appc.async.parallel(this, Object.keys(jsFiles).map(function (id) {
 			return function (done) {
 				const from = jsFiles[id];
 				let to = path.join(this.buildBinAssetsResourcesDir, id);
@@ -2811,7 +2811,6 @@ AndroidBuilder.prototype.copyResources = function copyResources(next) {
 				}
 			};
 		}), function () {
-
 			// write the properties file
 			const buildAssetsPath = this.encryptJS ? this.buildAssetsDir : this.buildBinAssetsResourcesDir,
 				appPropsFile = path.join(buildAssetsPath, '_app_props_.json'),

--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -5818,7 +5818,7 @@ iOSBuilder.prototype.copyResources = function copyResources(next) {
 					this.logger.info(__('Processing JavaScript files'));
 					const sdkCommonFolder = path.join(this.titaniumSdkPath, 'common', 'Resources');
 
-					async.eachSeries(Object.keys(jsFiles), function (file, next) {
+					async.each(Object.keys(jsFiles), function (file, next) {
 						setImmediate(function () {
 							// A JS file ending with "*.bootstrap.js" is to be loaded before the "app.js".
 							// Add it as a require() compatible string to bootstrap array if it's a match.
@@ -5884,7 +5884,7 @@ iOSBuilder.prototype.copyResources = function copyResources(next) {
 											// dest doesn't exist, or new contents differs from existing dest file
 											if (!exists || newContents !== fs.readFileSync(to).toString()) {
 												this.logger.debug(__('Copying and minifying %s => %s', from.cyan, to.cyan));
-												exists && fs.unlinkSync(to);
+												// no need to delete if it exists, writeFile will overwrite anyways
 												fs.writeFileSync(to, newContents);
 												this.jsFilesChanged = true;
 											} else {


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-26917

**Description:**
Note that this fix does not yet touch the originally reported issue that we're checking all files for changes resulting in slower builds - instead this simply makes our processing of JS files run in parallel. Specifically the code around reading the files, parsing/transpiling/minifying and then writing the results.

Here's some quick and dirty timings of just that portion of the build for me:

ios
========
As-is:
- local ios-test: Took 13506ms to process 181 JS files
- mocha suite with npm packages: Took 724538ms to process 1799 JS files

in parallel:
- local ios-test: Took 6752ms to process 181 JS files
- mocha suite with npm packages: Took 24881ms to process 1799 JS files

android
========
As-is:
- local android-test: Took 6734ms to process 181 JS files
- mocha suite with npm packages: Took 17536ms to process 1801 JS files

parallel:
- local android-test: Took 4661ms to process 181 JS files
- mocha suite with npm packages: Took 15008ms to process 1801 JS files

So this does substantially improve performance for me. The difference is less noticeable on large Android projects as I suspect we'll hit a general chokepoint of the babel parse/transform (perhaps moving to async APIs in `node-titanium-sdk` could help there?) But for iOS projects, and especially large ones we see a huge performance increase (in this case **29x!**).

Interesting to note that even with this changes there's an obvious order-of-magnitude performance difference between iOS and Android, likely due to the exact issue @hansemannn reported.

On Android, we compare the original contents to the contents post-jsanalyze (both values we already have in vars/memory at the time). If they don't differ and we can do symlinks we simply symlink the original. If they do differ we delete the destination (in case it *was* a symlink) and then write the new contents.

On iOS, we compare the contents post-jsanalyze to the destination file contents (here we check if the file exists and then if it does we read it in). If they match we do nothing. If the destination does not exist or is different, we write the new contents.

The issue here is how each plays with "differential" builds (and indeed if having to read the destination files in each time negates any benefit of a differential build). Android is comparing original src js to post-babel contents and ignoring if we've already got a post-babel version in the app destination. iOS is comparing post-babel to app destination file and attempting to avoid modifying the file in the app destination if nothing changed.