### PR TITLE
chore(build): restore placeholders after build

### DIFF
--- a/support/iphone/build_titaniumkit.sh
+++ b/support/iphone/build_titaniumkit.sh
@@ -37,6 +37,7 @@ then
 fi
 
 # Inject the values into the source
+cp TitaniumKit/Sources/API/TopTiModule.m TitaniumKit/Sources/API/TopTiModule.bak
 sed -i '' 's@__VERSION__@'"$SDK_VERSION"'@g' TitaniumKit/Sources/API/TopTiModule.m
 sed -i '' 's@__TIMESTAMP__@'"$TIMESTAMP"'@g' TitaniumKit/Sources/API/TopTiModule.m
 sed -i '' 's@__GITHASH__@'"$GIT_HASH"'@g' TitaniumKit/Sources/API/TopTiModule.m
@@ -62,6 +63,10 @@ xcodebuild -scheme TitaniumKit -sdk iphonesimulator -configuration Release clean
 
 xcodebuild -scheme TitaniumKit -sdk iphoneos -configuration Release clean build CONFIGURATION_BUILD_DIR=build/Release-iphoneos 2>&1
 [[ $? -ne 0 ]] && exit 1
+
+# restore TopTiModule.m
+rm TitaniumKit/Sources/API/TopTiModule.m
+mv TitaniumKit/Sources/API/TopTiModule.bak TitaniumKit/Sources/API/TopTiModule.m
 
 ######################
 # Create directory for universal


### PR DESCRIPTION
little addition to the TitaniumKit build script to automatically restore content of `TopTiModule.m` after placeholders have been changed during build.