### PR TITLE
docs(typescript): update sdk version in typescript definition header

### DIFF
--- a/apidoc/Titanium/UI/ShortcutItem.yml
+++ b/apidoc/Titanium/UI/ShortcutItem.yml
@@ -21,7 +21,7 @@ methods:
     platforms: [android]
 
   - name: pin
-    description: Pin shortcut to launcher.
+    summary: Pin shortcut to launcher.
     platforms: [android]
     osver: {android: {min: "8.0"}}
 
@@ -34,13 +34,13 @@ properties:
     availability: creation
 
   - name: title
-    description: Title of the shortcut.
+    summary: Title of the shortcut.
     type: String
     platforms: [android]
     availability: creation
 
   - name: description
-    description: Description of the shortcut.
+    summary: Description of the shortcut.
     type: String
     platforms: [android]
     availability: creation

--- a/apidoc/Titanium/UI/WebView.yml
+++ b/apidoc/Titanium/UI/WebView.yml
@@ -297,7 +297,7 @@ methods:
     parameters:
       - name: propertyList
         summary: List of properties for listen.
-        type: Array
+        type: Array<String>
 
   - name: stopListeningToProperties
     summary: Remove native properties from observing.
@@ -306,7 +306,7 @@ methods:
     parameters:
       - name: propertyList
         summary: List of properties to remove.
-        type: Array
+        type: Array<String>
 
   - name: takeSnapshot
     summary: Takes a snapshot of the view's visible viewport.

--- a/apidoc/lib/typescript_generator.js
+++ b/apidoc/lib/typescript_generator.js
@@ -306,10 +306,10 @@ class GlobalTemplateWriter {
 	/**
 	 * Writes the type definition header required by DefinitelyTyped.
 	 *
-	 * @todo Automatically update the Titanium version string.
 	 */
 	writeHeader() {
-		this.output += '// Type definitions for Titanium 7.1\n';
+		const { version } = require('../../package.json');
+		this.output += `// Type definitions for Titanium ${version}\n`;
 		this.output += '// Project: https://github.com/appcelerator/titanium_mobile\n';
 		this.output += '// Definitions by: Axway Appcelerator <https://github.com/appcelerator>\n';
 		this.output += '//                 Jan Vennemann <https://github.com/janvennemann>\n';

--- a/apidoc/lib/typescript_generator.js
+++ b/apidoc/lib/typescript_generator.js
@@ -309,13 +309,14 @@ class GlobalTemplateWriter {
 	 */
 	writeHeader() {
 		const { version } = require('../../package.json');
-		this.output += `// Type definitions for Titanium ${version}\n`;
+		const versionSplit = version.split('.');
+		const majorMinor = `${versionSplit[0]}.${versionSplit[1]}`;
+		this.output += `// Type definitions for Titanium ${majorMinor}\n`;
 		this.output += '// Project: https://github.com/appcelerator/titanium_mobile\n';
 		this.output += '// Definitions by: Axway Appcelerator <https://github.com/appcelerator>\n';
 		this.output += '//                 Jan Vennemann <https://github.com/janvennemann>\n';
 		this.output += '// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped\n';
 		this.output += '// TypeScript Version: 2.6\n';
-		this.output += '\n';
 	}
 
 	/**
@@ -380,7 +381,7 @@ class GlobalTemplateWriter {
 		if (interfaceNode.methods.length > 0) {
 			interfaceNode.methods.forEach(methodNode => this.writeMethodNode(methodNode, nestingLevel + 1));
 		}
-		this.output += `${this.indent(nestingLevel)}}\n\n`;
+		this.output += `${this.indent(nestingLevel)}}\n`;
 	}
 
 	/**

--- a/apidoc/lib/typescript_generator.js
+++ b/apidoc/lib/typescript_generator.js
@@ -311,7 +311,7 @@ class GlobalTemplateWriter {
 		const { version } = require('../../package.json');
 		const versionSplit = version.split('.');
 		const majorMinor = `${versionSplit[0]}.${versionSplit[1]}`;
-		this.output += `// Type definitions for Titanium ${majorMinor}\n`;
+		this.output += `// Type definitions for non-npm package Titanium ${majorMinor}\n`;
 		this.output += '// Project: https://github.com/appcelerator/titanium_mobile\n';
 		this.output += '// Definitions by: Axway Appcelerator <https://github.com/appcelerator>\n';
 		this.output += '//                 Jan Vennemann <https://github.com/janvennemann>\n';


### PR DESCRIPTION
Not sure whether this is what you had in mind but it looks like the docgen script only reads in the version for generating changes, figured it made sense to just require in the package.json in the write header func.