### PR TITLE
fix(ios): module builds broken

### DIFF
--- a/build/lib/ios.js
+++ b/build/lib/ios.js
@@ -6,8 +6,6 @@ const utils = require('./utils');
 const spawn = require('child_process').spawn;  // eslint-disable-line security/detect-child-process
 const copyFiles = utils.copyFiles;
 const copyAndModifyFile = utils.copyAndModifyFile;
-const globCopy = utils.globCopy;
-const globCopyFlat = utils.globCopyFlat;
 
 const ROOT_DIR = path.join(__dirname, '../..');
 const IOS_ROOT = path.join(ROOT_DIR, 'iphone');

--- a/build/lib/ios.js
+++ b/build/lib/ios.js
@@ -3,6 +3,8 @@
 const path = require('path');
 const fs = require('fs-extra');
 const utils = require('./utils');
+const promisify = require('util').promisify;
+const glob = promisify(require('glob'));
 const spawn = require('child_process').spawn;  // eslint-disable-line security/detect-child-process
 const copyFiles = utils.copyFiles;
 const copyAndModifyFile = utils.copyAndModifyFile;
@@ -51,46 +53,77 @@ class IOS {
 		});
 	}
 
+	/**
+	 * This generates "redirecting" headers in built SDK's iphone/include directory that points to the "real" headers
+	 * whether they are in TitaniumKit's framework, or the iphone/Classes directory
+	 * This should retain backwards compatibility for module builds and allow iphone/include to be a sort of single header path that can be used
+	 *
+	 * @param {string} DEST_IOS destination directory to copy files to
+	 */
+	async copyLegacyHeaders(DEST_IOS) {
+		// Gather all the *.h files in TitaniumKit, create "redirecting" headers in iphone/include that point to the TitaniumKit ones
+		await fs.ensureDir(path.join(DEST_IOS, 'include'));
+		const subdirs = await fs.readdir(path.join(IOS_ROOT, 'TitaniumKit/build/Release-iphoneuniversal/TitaniumKit.framework/Headers'));
+		// create them all in parallel
+		await Promise.all(subdirs.map(file => {
+			// TODO: Inject a deprecation warning if used and remove in SDK 9.0.0?
+			return fs.writeFile(path.join(DEST_IOS, 'include', file), `#import <TitaniumKit/${file}>\n`);
+		}));
+
+		// re-arrange redirecting headers for iphone/TitaniumKit/TitankumKit/Libraries/*/*.h files
+		const libDirs = await fs.readdir(path.join(IOS_ROOT, 'TitaniumKit/TitaniumKit/Libraries'));
+		for (const libDir of libDirs) {
+			await fs.ensureDir(path.join(DEST_IOS, 'include', libDir));
+			const libFiles = await fs.readdir(path.join(IOS_ROOT, 'TitaniumKit/TitaniumKit/Libraries', libDir));
+			for (const libFile of libFiles) {
+				if (libFile.endsWith('.h') && libFile !== 'APSUtility.h') { // for whatever reason APSUtility.h seems not to get copied as part of framework?
+					await fs.move(path.join(DEST_IOS, 'include', libFile), path.join(DEST_IOS, 'include', libDir, libFile));
+				}
+			}
+		}
+
+		// Create redirecting headers in iphone/include/ pointing to iphone/Classes/ headers
+		// TODO: Use map and Promise.all to run these in parallel
+		const classesHeaders = await glob('**/*.h', { cwd: path.join(IOS_ROOT, 'Classes') });
+		for (const classHeader of classesHeaders) {
+			let depth = 1;
+			if (classHeader.includes(path.sep)) { // there's a sub-directory
+				await fs.ensureDir(path.join(DEST_IOS, 'include', path.dirname(classHeader))); // make sure we create destination
+				depth = classHeader.split(path.sep).length;
+			}
+			// TODO: Inject a deprecation warning if used and remove in SDK 9.0.0?
+			await fs.writeFile(path.join(DEST_IOS, 'include', classHeader), `#import "${'../'.repeat(depth)}Classes/${classHeader}"\n`);
+		}
+	}
+
 	async package(packager) {
 		// FIXME: This is a hot mess. Why can't we place artifacts in their proper location already like Windows?
 		console.log('Packaging iOS platform...');
 		const DEST_IOS = path.join(packager.zipSDKDir, 'iphone');
 
-		// Gather all the *.h files in TitaniumKit, create "redirecting" headers in iphone/include that point to the TitaniumKit ones
-		await fs.ensureDir(path.join(DEST_IOS, 'include'));
-		const subdirs = await fs.readdir(path.join(IOS_ROOT, 'TitaniumKit/build/Release-iphoneuniversal/TitaniumKit.framework/Headers'));
-		for (const file of subdirs) {
-			// TODO: Inject a deprecation warning if used and remove in SDK 9.0.0
-			await fs.writeFile(path.join(DEST_IOS, 'include', file), `#include <TitaniumKit/${file}>\n`);
-		}
-		// Copy legacy copies of APSAnalytics.h and APSHTTPClient.h into 'include/' subdirs 'APSAnalytics' and 'APSHTTPClient' to retain backwards compatibility in SDK 8.0.0
-		await fs.ensureDir(path.join(DEST_IOS, 'include/APSAnalytics'));
-		await fs.move(path.join(DEST_IOS, 'include/APSAnalytics.h'), path.join(DEST_IOS, 'include/APSAnalytics/APSAnalytics.h'));
-		await fs.ensureDir(path.join(DEST_IOS, 'include/APSHTTPClient'));
-		await fs.move(path.join(DEST_IOS, 'include/APSHTTPClient.h'), path.join(DEST_IOS, 'include/APSHTTPClient/APSHTTPClient.h'));
-		// TODO: Wipe the other APSUtility.h and APSHTTP*.h headers?
+		return Promise.all([
+			this.copyLegacyHeaders(DEST_IOS),
 
-		// Copy meta files and directories
-		await copyFiles(IOS_ROOT, DEST_IOS, [ 'AppledocSettings.plist', 'Classes', 'cli', 'iphone', 'templates' ]);
+			// Copy meta files and directories
+			// Copy module templates (Swift & Obj-C)
+			copyFiles(IOS_ROOT, DEST_IOS, [ 'AppledocSettings.plist', 'Classes', 'cli', 'iphone', 'templates' ]),
 
-		// Copy TitaniumKit
-		await copyFiles(path.join(IOS_ROOT, 'TitaniumKit/build/Release-iphoneuniversal'), path.join(DEST_IOS, 'Frameworks'), [ 'TitaniumKit.framework' ]);
+			// Copy TitaniumKit
+			copyFiles(path.join(IOS_ROOT, 'TitaniumKit/build/Release-iphoneuniversal'), path.join(DEST_IOS, 'Frameworks'), [ 'TitaniumKit.framework' ]),
 
-		// Copy module templates (Swift & Obj-C)
-		await copyFiles(IOS_ROOT, DEST_IOS, [ 'AppledocSettings.plist', 'Classes', 'cli', 'iphone', 'templates' ]);
+			// Copy and inject values for special source files
+			this.injectSDKConstants(path.join(DEST_IOS, 'main.m')),
 
-		// Copy and inject values for special source files
-		await this.injectSDKConstants(path.join(DEST_IOS, 'main.m'));
+			// Copy Ti.Verify
+			copyFiles(IOS_LIB, DEST_IOS, [ 'libtiverify.a' ]),
 
-		// Copy Ti.Verify
-		await copyFiles(IOS_LIB, DEST_IOS, [ 'libtiverify.a' ]);
+			// Copy iphone/package.json, but replace __VERSION__ with our version!
+			copyAndModifyFile(IOS_ROOT, DEST_IOS, 'package.json', { __VERSION__: this.sdkVersion }),
 
-		// Copy iphone/package.json, but replace __VERSION__ with our version!
-		await copyAndModifyFile(IOS_ROOT, DEST_IOS, 'package.json', { __VERSION__: this.sdkVersion });
-
-		// Copy iphone/Resources/modules/<name>/* to this.zipSDKDir/iphone/modules/<name>/images
-		// TODO: Pretty sure these can be removed nowadays
-		return fs.copy(path.join(IOS_ROOT, 'Resources/modules'), path.join(DEST_IOS, 'modules'));
+			// Copy iphone/Resources/modules/<name>/* to this.zipSDKDir/iphone/modules/<name>/images
+			// TODO: Pretty sure these can be removed nowadays
+			fs.copy(path.join(IOS_ROOT, 'Resources/modules'), path.join(DEST_IOS, 'modules'))
+		]);
 	}
 
 	async injectSDKConstants(dest) {

--- a/build/lib/utils.js
+++ b/build/lib/utils.js
@@ -45,15 +45,6 @@ Utils.globCopy = async function (pattern, srcFolder, destFolder) {
 	return Utils.copyFiles(srcFolder, destFolder, files);
 };
 
-Utils.globCopyFlat = async function (pattern, srcFolder, destFolder) {
-	const files = await glob(pattern, { cwd: srcFolder });
-
-	return Promise.all(files.map(f => {
-		const filenameWithoutDirectory = f.split('/')[1]; // TODO: Refactor to simply copy without it's source directory
-		return fs.copy(path.join(srcFolder, f), path.join(destFolder, filenameWithoutDirectory));
-	}));
-};
-
 /**
  * @param {string} srcFolder source directory to copy from
  * @param {string} destFolder destination directory to copy to

--- a/iphone/cli/commands/_buildModule.js
+++ b/iphone/cli/commands/_buildModule.js
@@ -210,7 +210,15 @@ iOSModuleBuilder.prototype.processTiXcconfig = function processTiXcconfig(next) 
 		bindingReg = /\$\(([^$]+)\)/g;
 
 	if (fs.existsSync(this.tiXcconfigFile)) {
-		fs.readFileSync(this.tiXcconfigFile).toString().split('\n').forEach(function (line) {
+		const contents = fs.readFileSync(this.tiXcconfigFile).toString();
+		// with move to 8.0.0, we needed to add FRAMEWORK_SEARCH_PATHS to titanium.xcconfig
+		if (!contents.includes('FRAMEWORK_SEARCH_PATHS = $(inherited) "$(TITANIUM_SDK)/iphone/Frameworks"')) {
+			this.logger.warn(`Build may fail due to missing FRAMEWORK_SEARCH_PATHS value in ${this.tiXcconfigFile.cyan}
+Please append the following line to that file:
+
+FRAMEWORK_SEARCH_PATHS = $(inherited) "$(TITANIUM_SDK)/iphone/Frameworks"`);
+		}
+		contents.split('\n').forEach(function (line) {
 			const match = line.match(re);
 			if (match) {
 				const keyList = [];

--- a/iphone/templates/module/objc/template/ios/titanium.xcconfig.ejs
+++ b/iphone/templates/module/objc/template/ios/titanium.xcconfig.ejs
@@ -11,3 +11,4 @@ TITANIUM_SDK_VERSION = <%- tisdkVersion %>
 //
 TITANIUM_SDK = <%- tisdkPath %>
 HEADER_SEARCH_PATHS = $(inherited) "$(TITANIUM_SDK)/iphone/include"
+FRAMEWORK_SEARCH_PATHS = $(inherited) "$(TITANIUM_SDK)/iphone/Frameworks"

--- a/iphone/templates/module/swift/template/ios/titanium.xcconfig.ejs
+++ b/iphone/templates/module/swift/template/ios/titanium.xcconfig.ejs
@@ -10,5 +10,5 @@ TITANIUM_SDK_VERSION = <%- tisdkVersion %>
 // THESE SHOULD BE OK GENERALLY AS-IS
 //
 TITANIUM_SDK = <%- tisdkPath %>
-HEADER_SEARCH_PATHS = $(inherited) "$(TITANIUM_SDK)"
+HEADER_SEARCH_PATHS = $(inherited) "$(TITANIUM_SDK)/iphone/include"
 FRAMEWORK_SEARCH_PATHS = $(inherited) "$(TITANIUM_SDK)/iphone/Frameworks"


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-26981

**Optional Description:**
- Add redirecting headers to `iphone/include` that point at the real copies in `iphone/Classes`
- Add redirecting headers to `iphone/include` that point to real headers in TitaniumKit framework
- fixed module templates to point `FRAMEWORK_SEARCH_PATHS` at `iphone/Frameworks`
- added warning log to module build if `titanium.xcconfig` doesn't have value for `FRAMEWORK_SEARCH_PATHS` so dev is at least warned they made need to append the value if their build is failing
