### PR TITLE
fix(android)(8_0_X): APK signing will fail when using MD5 keystore and JDK 8+

### DIFF
--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -798,8 +798,11 @@ AndroidBuilder.prototype.config = function config(logger, config, cli) {
 											_t.keystoreAliases.pop();
 										}
 
+										// Parse the keystore's alias name and signature algorithm.
+										// Note: Algorithm can return "MD5withRSA (weak)" on JDK 8 and higher.
+										//       Only extract 1st token since we need a valid algorithm name.
 										const aliasRegExp = /Alias name: (.+)/,
-											sigalgRegExp = /Signature algorithm name: (.+)/;
+											sigalgRegExp = /Signature algorithm name: (.[^\s]+)/;
 										out.split('\n\n').forEach(function (chunk) {
 											chunk = chunk.trim();
 											const m = chunk.match(aliasRegExp);
@@ -807,7 +810,7 @@ AndroidBuilder.prototype.config = function config(logger, config, cli) {
 												const sigalg = chunk.match(sigalgRegExp);
 												_t.keystoreAliases.push({
 													name: m[1],
-													sigalg: sigalg && sigalg[1]
+													sigalg: sigalg && sigalg[1] && sigalg[1].trim()
 												});
 											}
 										});


### PR DESCRIPTION
**JIRA:**  https://jira.appcelerator.org/browse/TIMOB-26895

**Cherry-pick of PR:** #10888
