### PR TITLE
build: resolve directory correctly on android snapshot generation, set corejs version in babel rollup args

### DIFF
--- a/build/lib/android/snapshot.js
+++ b/build/lib/android/snapshot.js
@@ -7,10 +7,11 @@ const fs = require('fs-extra');
 const path = require('path');
 const ejs = require('ejs');
 
-const ANDROID_DIR = path.resolve('..', 'android');
+const ROOT_DIR = path.join(__dirname, '..', '..', '..');
+const ANDROID_DIR = path.join(ROOT_DIR, 'android');
 const ANDROID_PROPS = require(path.join(ANDROID_DIR, 'package.json')); // eslint-disable-line security/detect-non-literal-require
 const V8_PROPS = ANDROID_PROPS.v8;
-const V8_LIB_DIR = path.join('..', 'dist', 'android', 'libv8', V8_PROPS.version, V8_PROPS.mode, 'libs');
+const V8_LIB_DIR = path.join(ROOT_DIR, 'dist', 'android', 'libv8', V8_PROPS.version, V8_PROPS.mode, 'libs');
 
 // Obtain target architectures
 const TARGETS = [];

--- a/build/lib/packager.js
+++ b/build/lib/packager.js
@@ -93,7 +93,8 @@ function determineBabelOptions() {
 		},
 		useBuiltIns: 'entry',
 		// DO NOT include web polyfills!
-		exclude: [ 'web.dom.iterable', 'web.immediate', 'web.timers' ]
+		exclude: [ 'web.dom.iterable', 'web.immediate', 'web.timers' ],
+		corejs: 2
 	};
 	// pull out windows target (if it exists)
 	if (fs.pathExistsSync(path.join(ROOT_DIR, 'windows/package.json'))) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3104,9 +3104,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "2.5.7",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
+      "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==",
       "dev": true
     },
     "core-js-compat": {

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "clang-format": "1.2.3",
     "commander": "^2.20.0",
     "commitizen": "^3.1.1",
+    "core-js": "^2.6.5",
     "cz-conventional-changelog": "^2.1.0",
     "danger": "^7.1.3",
     "eslint-config-axway": "^4.2.2",


### PR DESCRIPTION
208b937c3a0f0400c901718cd6fb12e42169c54f - Running `node build/scons cleanbuild android` currently bombs out due to the way the android directory is resolved. Resolve relative to the file, not the users cwd

b2e670bcf7945aae7bc5c53d2aa4df2df3c52965 - suppress warning from babel around no core-js version being set, and also add core-js@2 into our devDeps so we don't get burnt if core-js@3 starts getting hoisted. 