### PR TITLE
build(jenkins): add timeout for adb commands

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -108,9 +108,11 @@ def unitTests(os, nodeVersion, npmVersion, testSuiteBranch) {
 							} finally {
 								// Kill the emulators!
 								if ('android'.equals(os)) {
-									sh returnStatus: true, script: 'adb -e shell am force-stop com.appcelerator.testApp.testing'
-									sh returnStatus: true, script: 'adb -e uninstall com.appcelerator.testApp.testing'
-									killAndroidEmulators()
+									timeout(5) {
+										sh returnStatus: true, script: 'adb -e shell am force-stop com.appcelerator.testApp.testing'
+										sh returnStatus: true, script: 'adb -e uninstall com.appcelerator.testApp.testing'
+										killAndroidEmulators()
+									}
 								} // if
 							} // finally
 							// save the junit reports as artifacts explicitly so danger.js can use them later

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -111,8 +111,8 @@ def unitTests(os, nodeVersion, npmVersion, testSuiteBranch) {
 									timeout(5) {
 										sh returnStatus: true, script: 'adb -e shell am force-stop com.appcelerator.testApp.testing'
 										sh returnStatus: true, script: 'adb -e uninstall com.appcelerator.testApp.testing'
-										killAndroidEmulators()
 									}
+									killAndroidEmulators()
 								} // if
 							} // finally
 							// save the junit reports as artifacts explicitly so danger.js can use them later


### PR DESCRIPTION
The adb commands will wait for a device when none was found which blocks the build forever.

See [this](https://jenkins.appcelerator.org/blue/organizations/jenkins/titanium-sdk%2Ftitanium_mobile/detail/PR-10668/7/pipeline) build for an example.

@sgtcoolguy i guess this shouldn't happen in the first place. Are there some nodes that don't have an emulator installed?