### PR TITLE
fix(ios): force alert() messages to be a string

### DIFF
--- a/iphone/TitaniumKit/TitaniumKit/Sources/Kroll/KrollContext.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/Kroll/KrollContext.m
@@ -186,7 +186,7 @@ static JSValueRef AlertCallback(JSContextRef jsContext, JSObjectRef jsFunction, 
   }
 
   KrollContext *ctx = GetKrollContext(jsContext);
-  NSString *message = [KrollObject toID:ctx value:args[0]];
+  NSString *message = [TiUtils stringValue:[KrollObject toID:ctx value:args[0]]];
 
   [[[TiApp app] controller] incrementActiveAlertControllerCount];
 


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-27090

No unit tests since it's a UI related change.