### PR TITLE
fix(ios): properly retain geolocation callback

### DIFF
--- a/iphone/Classes/GeolocationModule.m
+++ b/iphone/Classes/GeolocationModule.m
@@ -780,7 +780,7 @@ MAKE_SYSTEM_PROP(ACTIVITYTYPE_OTHER_NAVIGATION, CLActivityTypeOtherNavigation);
       [authorizationCallback release];
       authorizationCallback = nil;
     }
-    authorizationCallback = [JSManagedValue managedValueWithValue:callback andOwner:self];
+    authorizationCallback = [[JSManagedValue managedValueWithValue:callback andOwner:self] retain];
     [callback.context.virtualMachine addManagedReference:authorizationCallback withOwner:self];
   }
 


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-27089

Fixes a regression from #10381.

Currently not unit-testable, since the geolocation permissions dialog required user interaction. I used the static code analyzer to make sure there is no retain leak.