### PR TITLE
build(android): verify the libv8 tar.bz2 file against a checksum

### DIFF
--- a/android/build/common.xml
+++ b/android/build/common.xml
@@ -773,6 +773,10 @@ Common ant tasks and macros for building Android-based Titanium modules and proj
 			<arg value="-p"/>
 			<arg value="require('../package.json').v8.mode"/>
 		</exec>
+		<exec executable="node" dir="${ti.build.dir}" outputproperty="libv8.checksum">
+			<arg value="-p"/>
+			<arg value="require('../package.json').v8.checksum"/>
+		</exec>
 		<property name="dist.libv8.dir" location="${dist.dir}/libv8/${libv8.version}/${libv8.mode}"/>
 		<property name="libv8.archive" value="libv8-${libv8.version}-${libv8.mode}.tar.bz2"/>
 		<mkdir dir="${dist.libv8.dir}"/>
@@ -780,7 +784,17 @@ Common ant tasks and macros for building Android-based Titanium modules and proj
 		<ti.jsonMap file="${dist.libv8.dir}/libv8.json" prefix="libv8.current"/>
 
 		<condition property="libv8.latest">
-			<equals arg1="${libv8.current.version}" arg2="${libv8.version}"/>
+			<and>
+				<!-- is it the version we want/need? -->
+				<equals arg1="${libv8.current.version}" arg2="${libv8.version}"/>
+				<and>
+					<!-- Does the tar.bz2 file exist and does it's checksum match expectations? -->
+					<resourceexists>
+						<file file="${dist.libv8.dir}/${libv8.archive}"/>
+					</resourceexists>
+					<checksum file="${dist.libv8.dir}/${libv8.archive}" algorithm="SHA-512" property="${libv8.checksum}"/>
+				</and>
+			</and>
 		</condition>
 		<antcall target="download.libv8"/>
 	</target>
@@ -788,6 +802,15 @@ Common ant tasks and macros for building Android-based Titanium modules and proj
 	<target name="download.libv8" unless="libv8.latest">
 		<get src="http://timobile.appcelerator.com.s3.amazonaws.com/libv8/${libv8.archive}"
 			dest="${dist.libv8.dir}" verbose="true" usetimestamp="true"/>
+		<checksum file="${dist.libv8.dir}/${libv8.archive}" algorithm="SHA-512" property="libv8.checksum.actual"/>
+		<!-- verify the checksum matches expectations -->
+		<fail message="Checksum for libv8 downloaded does not match expectations! Expected: ${libv8.checksum}, Received: ${libv8.checksum.actual}">
+			<condition>
+				<not>
+					<equals arg1="${libv8.checksum.actual}" arg2="${libv8.checksum}" />
+				</not>
+			</condition>
+		</fail>
 		<untar compression="bzip2" src="${dist.libv8.dir}/${libv8.archive}" dest="${dist.libv8.dir}"/>
 	</target>
 

--- a/android/package.json
+++ b/android/package.json
@@ -19,7 +19,8 @@
 	"architectures": ["arm64-v8a", "armeabi-v7a", "x86"],
 	"v8": {
 		"version": "7.3.492.26",
-		"mode": "release"
+		"mode": "release",
+		"checksum": "7798aae19b2efff53b1f18d53345291ab16a574e0524350eed3db6d45757bc476a158303b8df6c5f359439f9184818d61eba6bd820cec404e268ab0796cc7c5a"
 	},
 	"minSDKVersion": "19",
 	"compileSDKVersion": "28",


### PR DESCRIPTION
**Description:**
To avoid 'bad' builds of libv8 being used, verify not only the version/mode
from package.json, but also a SHA512 checksum hash of the tar.bz2 file.

This is an attempt to help avoid the bad builds/crashes we saw yesterday on Android. Now if the libv8 library content doesn't match expectations we'll bomb out immediately during build time and let the developer know the libv8 looks wrong and show the expected/actual hashes.

This does mean that when we update the v8 build we target/use we'll need to not just bump the version but also ensure the checksum is updated.