### PR TITLE
fix(android)(8_0_X): TabGroup bar background color is wrongly transparent on Android 4.4 as of 8.0.0

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIAbstractTabGroup.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIAbstractTabGroup.java
@@ -28,6 +28,7 @@ import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 
+import org.appcelerator.kroll.common.Log;
 import org.appcelerator.kroll.KrollDict;
 import org.appcelerator.kroll.KrollProxy;
 import org.appcelerator.titanium.TiBaseActivity;
@@ -35,6 +36,7 @@ import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.proxy.ActivityProxy;
 import org.appcelerator.titanium.util.TiColorHelper;
 import org.appcelerator.titanium.util.TiConvert;
+import org.appcelerator.titanium.util.TiRHelper;
 import org.appcelerator.titanium.view.TiInsetsProvider;
 import org.appcelerator.titanium.view.TiUIView;
 
@@ -118,16 +120,21 @@ public abstract class TiUIAbstractTabGroup extends TiUIView
 	{
 		super(proxy);
 
-		// Getting the value for colorPrimary from the currently used theme.
-		TypedValue colorPrimaryTypedValue = new TypedValue();
-		TypedArray colorPrimary =
-			activity.obtainStyledAttributes(colorPrimaryTypedValue.data, new int[] { android.R.attr.colorPrimary });
-		this.colorPrimaryInt = colorPrimary.getColor(0, 0);
-		// Getting the value for textColorPrimary for the currently used theme.
-		TypedValue typedValue = new TypedValue();
-		TypedArray textColor =
-			activity.obtainStyledAttributes(typedValue.data, new int[] { android.R.attr.textColorPrimary });
-		this.textColorInt = textColor.getColor(0, 0);
+		// Fetch primary background and text colors from ActionBar style assigned to activity theme.
+		// Note: We use ActionBar style for backward compatibility with Titanium versions older than 8.0.0.
+		this.colorPrimaryInt = 0xFF212121; // Default to dark gray.
+		this.textColorInt = 0xFFFFFFFF;    // Default to white.
+		try {
+			int styleAttributeId = TiRHelper.getResource("attr.actionBarStyle");
+			int[] idArray = new int[] { TiRHelper.getResource("attr.colorPrimary"),
+										TiRHelper.getResource("attr.textColorPrimary") };
+			TypedArray typedArray = activity.obtainStyledAttributes(null, idArray, styleAttributeId, 0);
+			this.colorPrimaryInt = typedArray.getColor(0, this.colorPrimaryInt);
+			this.textColorInt = typedArray.getColor(1, this.textColorInt);
+			typedArray.recycle();
+		} catch (Exception ex) {
+			Log.e(TAG, "Failed to fetch color from theme.", ex);
+		}
 
 		this.tabGroupPagerAdapter = new TabGroupFragmentPagerAdapter(activity.getSupportFragmentManager());
 


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-27117

**Cherry-pick of PR:** #10928
