### PR TITLE
fix(android): File.read().text wrongly returns null for JSON files on Android Q

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiMimeTypeHelper.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiMimeTypeHelper.java
@@ -24,6 +24,7 @@ import org.appcelerator.titanium.TiApplication;
 public class TiMimeTypeHelper
 {
 	private static final String DEFAULT_MIME_TYPE = "application/octet-stream";
+	public static final String MIME_TYPE_OCTET_STREAM = DEFAULT_MIME_TYPE;
 	public static final String MIME_TYPE_JAVASCRIPT = "text/javascript";
 	public static final String MIME_TYPE_HTML = "text/html";
 	public static final HashMap<String, String> EXTRA_MIMETYPES = new HashMap<String, String>();
@@ -248,19 +249,27 @@ public class TiMimeTypeHelper
 
 	public static boolean isBinaryMimeType(String mimeType)
 	{
-		if (mimeType != null) {
+		boolean isBinary = false;
+		if ((mimeType != null) && !mimeType.isEmpty()) {
 			String parts[] = mimeType.split(";");
 			mimeType = parts[0];
 
-			if (mimeType.startsWith("application/") && !mimeType.endsWith("xml")) {
-				return true;
-			} else if (mimeType.startsWith("image/") && !mimeType.endsWith("xml")) {
-				return true;
-			} else if (mimeType.startsWith("audio/") || mimeType.startsWith("video/")) {
-				return true;
-			} else
-				return false;
+			if (mimeType.startsWith("application/")) {
+				if (!mimeType.endsWith("xml") && !mimeType.endsWith("json")) {
+					isBinary = true;
+				}
+			} else if (mimeType.startsWith("image/")) {
+				if (!mimeType.endsWith("xml")) {
+					isBinary = true;
+				}
+			} else if (mimeType.startsWith("audio/")) {
+				isBinary = true;
+			} else if (mimeType.startsWith("font/")) {
+				isBinary = true;
+			} else if (mimeType.startsWith("video/")) {
+				isBinary = true;
+			}
 		}
-		return false;
+		return isBinary;
 	}
 }


### PR DESCRIPTION
**JIRA:**
https://jira.appcelerator.org/browse/TIMOB-26954

**Summary:**
- Caused by Android Q returning mime-type "application/json" which Titanium's `TiMimeTypeHelper` Java class incorrectly interpreted as a binary type.
- Modified `Ti.Blob` object's "text" property to always return text, even if it's a binary type.
  * Now matches iOS' behavior.
- Modified `Ti.Blob` object's `toString()` method to only return blob's text if mime-type is a known text type, like how "text" property used to work.

**Test:**
1. Build and run the below code on Android Q (aka: Android 10).
2. Verify that an alert appears on screen reading: `Success!`

```javascript
// Create the JSON data to test with.
var jsonOriginalData = {
	myBoolean: true,
	myNumber: 123.456,
	myString: "Hello World",
	myArray: [false, true, -1, 0, 1, 123.456, "", "My String"],
	myDictionary: {
		nestedBoolean: false,
		nestedNumber: -43.21,
		nestedString: "This is a test.",
		nestedArray: [true, 123, "Hello Again"],
	},
};
var jsonOriginalString = JSON.stringify(jsonOriginalData);

// Write above JSON data to file.
var jsonFile = Ti.Filesystem.getFile(Ti.Filesystem.applicationDataDirectory, "test.json");
jsonFile.write(jsonOriginalString);
Ti.API.info("@@@ JSON string written:\n" + jsonOriginalString);

// Read the JSON file that was just written above.
var jsonReadString = jsonFile.read().text;
Ti.API.info("@@@ JSON string read:\n" + jsonReadString);

// Check if JSON was written/read to/from file successfully.
if (jsonReadString === jsonOriginalString) {
	alert("Success!");
} else {
	alert("Failed!");
}
```
