### PR TITLE
fix(android): Fixed incremental build issues introduced by [TIMOB-27043] in 8.1.0

### DIFF
--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -2075,6 +2075,22 @@ AndroidBuilder.prototype.checkIfShouldForceRebuild = function checkIfShouldForce
 		return true;
 	}
 
+	// if sourceMaps changed, then we need to re-process all of the JS files
+	if (this.sourceMaps !== manifest.sourceMaps) {
+		this.logger.info(__('Forcing rebuild: JavaScript sourceMaps flag changed'));
+		this.logger.info('  ' + __('Was: %s', manifest.sourceMaps));
+		this.logger.info('  ' + __('Now: %s', this.sourceMaps));
+		return true;
+	}
+
+	// if transpile changed, then we need to re-process all of the JS files
+	if (this.transpile !== manifest.transpile) {
+		this.logger.info(__('Forcing rebuild: JavaScript transpile flag changed'));
+		this.logger.info('  ' + __('Was: %s', manifest.transpile));
+		this.logger.info('  ' + __('Now: %s', this.transpile));
+		return true;
+	}
+
 	// check if the titanium sdk paths are different
 	if (this.platformPath !== manifest.platformPath) {
 		this.logger.info(__('Forcing rebuild: Titanium SDK path changed since last build'));
@@ -4606,6 +4622,8 @@ AndroidBuilder.prototype.writeBuildManifest = function writeBuildManifest(callba
 		skipJSMinification: !!this.cli.argv['skip-js-minify'],
 		mergeCustomAndroidManifest: this.config.get('android.mergeCustomAndroidManifest', true),
 		encryptJS: this.encryptJS,
+		sourceMaps: this.sourceMaps,
+		transpile: this.transpile,
 		minSDK: this.minSDK,
 		targetSDK: this.targetSDK,
 		propertiesHash: this.propertiesHash,

--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -2669,7 +2669,7 @@ AndroidBuilder.prototype.copyResources = function copyResources(next) {
 			const from = jsFiles[relPath];
 			if (htmlJsFiles[relPath]) {
 				// this js file is referenced from an html file, so don't minify or encrypt
-				copyUnmodified.push(from);
+				copyUnmodified.push(relPath);
 			} else {
 				inputFiles.push(from);
 			}
@@ -2814,8 +2814,10 @@ AndroidBuilder.prototype.copyResources = function copyResources(next) {
 				}
 
 				// write the encrypted JS bytes to the generated Java file
+				const assetCryptDest = path.join(this.buildGenAppIdDir, 'AssetCryptImpl.java');
+				this.unmarkBuildDirFile(assetCryptDest);
 				fs.writeFileSync(
-					path.join(this.buildGenAppIdDir, 'AssetCryptImpl.java'),
+					assetCryptDest,
 					ejs.render(fs.readFileSync(path.join(this.templatesDir, 'AssetCryptImpl.java')).toString(), {
 						appid: this.appid,
 						encryptedAssets: out

--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -1908,6 +1908,7 @@ AndroidBuilder.prototype.initialize = function initialize(next) {
 	this.buildBinClassesDir         = path.join(this.buildBinDir, 'classes');
 	this.buildBinClassesDex         = path.join(this.buildBinDir, 'dexfiles');
 	this.buildGenDir                = path.join(this.buildDir, 'gen');
+	this.buildIncrementalDir        = path.join(this.buildDir, 'incremental');
 	this.buildIntermediatesDir      = path.join(this.buildDir, 'intermediates');
 	this.buildGenAppIdDir           = path.join(this.buildGenDir, this.appid.split('.').join(path.sep));
 	this.buildResDir                = path.join(this.buildDir, 'res');
@@ -2276,8 +2277,9 @@ AndroidBuilder.prototype.createBuildDirs = function createBuildDirs(next) {
 	// make directories if they don't already exist
 	let dir = this.buildAssetsDir;
 	if (this.forceRebuild) {
+		fs.emptyDirSync(this.buildIncrementalDir);
 		fs.emptyDirSync(dir);
-		this.unmarkBuildDirFiles(this.buildAssetsDir);
+		this.unmarkBuildDirFiles(dir);
 	} else {
 		fs.ensureDirSync(dir);
 	}
@@ -2677,7 +2679,7 @@ AndroidBuilder.prototype.copyResources = function copyResources(next) {
 
 		const task = new ProcessJsTask({
 			inputFiles,
-			incrementalDirectory: path.join(this.buildDir, 'incremental', 'process-js'),
+			incrementalDirectory: path.join(this.buildIncrementalDir, 'process-js'),
 			logger: this.logger,
 			builder: this,
 			jsFiles: Object.keys(jsFiles).reduce((jsFilesInfo, relPath) => {

--- a/tests/Resources/ti.ui.webview.addontest.js
+++ b/tests/Resources/ti.ui.webview.addontest.js
@@ -1,0 +1,37 @@
+/*
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2011-Present by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+/* eslint-env mocha */
+/* global Ti */
+/* eslint no-unused-expressions: "off" */
+'use strict';
+
+describe('Titanium.UI.WebView', function () {
+	var win;
+
+	afterEach(function () {
+		if (win) {
+			win.close();
+		}
+		win = null;
+	});
+
+	// Verifies local HTML file can access local JS file and invoke an HTML "onload" callback.
+	it.windowsMissing('html-script-tag', function (finish) {
+		this.slow(3000);
+		this.timeout(5000);
+
+		Ti.App.addEventListener('ti.ui.webview.script.tag:onPageLoaded', function () {
+			finish();
+		});
+
+		win = Ti.UI.createWindow();
+		win.add(Ti.UI.createWebView({
+			url: 'ti.ui.webview.script.tag.html'
+		}));
+		win.open();
+	});
+});

--- a/tests/Resources/ti.ui.webview.script.tag.html
+++ b/tests/Resources/ti.ui.webview.script.tag.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<script src="ti.ui.webview.script.tag.js"></script>
+	</head>
+	<body onload="onPageLoaded();">
+		This verifies that a local HTML file can access a local JS file.
+	</body>
+</html>

--- a/tests/Resources/ti.ui.webview.script.tag.js
+++ b/tests/Resources/ti.ui.webview.script.tag.js
@@ -1,0 +1,15 @@
+/*
+ * Axway Appcelerator Titanium Mobile
+ * Copyright (c) 2011-2019 by Axway Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+/* eslint-env mocha */
+/* global Ti */
+/* eslint no-unused-expressions: "off" */
+'use strict';
+
+// eslint-disable-next-line no-unused-vars
+function onPageLoaded() {
+	Ti.App.fireEvent('ti.ui.webview.script.tag:onPageLoaded', {});
+}


### PR DESCRIPTION
**JIRA:**
https://jira.appcelerator.org/browse/TIMOB-27135

**Summary:**
- This bug was caught before release.
- Fixed build failure when a local HTML file references a local JS file.
  * Added unit test to exercise this feature on Android and iOS. (Not supported on Windows.)
- Fixed incremental build failure when building for "device" or "production".
  * This is really an encrypted assets issue.

**Test:**
1. Create a Classic app project from default template.
2. Build and run to an Android device. (Not the emulator. Must be a device.)
3. Build and run to the same Android device again.
4. Verify that the build succeeds and runs successfully on device. (This used to fail.)
