### PR TITLE
fix(android): TableView click/longpress events won't fire after LiveView restarts runtime

### DIFF
--- a/android/modules/app/src/java/ti/modules/titanium/app/AppModule.java
+++ b/android/modules/app/src/java/ti/modules/titanium/app/AppModule.java
@@ -218,7 +218,15 @@ public class AppModule extends KrollModule implements SensorEventListener
 	@Kroll.method(name = "_restart")
 	public void restart()
 	{
-		TiApplication.getInstance().softRestart();
+		// Restart the JavaScript runtime on the next message pump.
+		// We don't want to terminate the JS runtime while it's still on the stack.
+		getMainHandler().post(new Runnable() {
+			@Override
+			public void run()
+			{
+				TiApplication.getInstance().softRestart();
+			}
+		});
 	}
 
 	@Kroll.method


### PR DESCRIPTION
**JIRA:**
https://jira.appcelerator.org/browse/TIMOB-26326

**Note:**
Issue was happening because LiveView was calling our undocumented JavaScript `Ti.App._restart()` method, which was natively terminating the JS runtime **immediately**. The issue with this is that our Java `restart()` method was returning back to a destroyed a JS runtime on the stack... and I'm surprised this did not cause a crash, but it was definitely putting our JS runtime handling C++ code in a bad state. The solution is to not immediately restart the JS runtime and let the method call return out and unwind the stack naturally.

**Test:**
1. Build and run the below code on Android via LiveView.
`appc run -p android -T emulator --liveview`
2. Click/Tap on a row.
3. Notice that an alert is displayed indicating which row was clicked on.
4. Edit the below code and save to trigger LiveView to restart the app with new changes.
5. Click/Tap on a row.
6. Verify an alert is displayed indicating which row was clicked on. (This is the bug fix.)

```javascript
var window = Ti.UI.createWindow();
var tableData = [];
for (var index = 1; index <= 50; index++) {
	tableData.push(Ti.UI.createTableViewRow({ title: "Row " + index }));
}
var tableView = Ti.UI.createTableView({
	data: tableData,
	width: Ti.UI.FILL,
	height: Ti.UI.FILL,
});
tableView.addEventListener("click", function(e) {
	var message = "Clicked on row: " + (e.index + 1);
	Ti.API.info(message);
	alert(message);
});
tableView.addEventListener("longpress", function(e) {
	var message = "Long-press on row: " + (e.index + 1);
	Ti.API.info(message);
	alert(message);
});
window.add(tableView);
var restartButton = Ti.UI.createButton({
	title: "Restart",
	bottom: "5dp",
	right: "5dp",
});
restartButton.addEventListener("click", function() {
	Ti.App._restart();
});
window.add(restartButton);
window.open();
```
