### PR TITLE
fix(android)(8_1_X): TableView click/longpress events won't fire after LiveView restarts runtime

### DIFF
--- a/android/modules/app/src/java/ti/modules/titanium/app/AppModule.java
+++ b/android/modules/app/src/java/ti/modules/titanium/app/AppModule.java
@@ -218,7 +218,15 @@ public class AppModule extends KrollModule implements SensorEventListener
 	@Kroll.method(name = "_restart")
 	public void restart()
 	{
-		TiApplication.getInstance().softRestart();
+		// Restart the JavaScript runtime on the next message pump.
+		// We don't want to terminate the JS runtime while it's still on the stack.
+		getMainHandler().post(new Runnable() {
+			@Override
+			public void run()
+			{
+				TiApplication.getInstance().softRestart();
+			}
+		});
 	}
 
 	@Kroll.method


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-26326

**Cherry-pick of:** #10948
