### PR TITLE
fix(android): fix for changing tabs properties after creation

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TabGroupProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TabGroupProxy.java
@@ -32,7 +32,6 @@ import ti.modules.titanium.ui.widget.tabgroup.TiUITabLayoutTabGroup;
 
 import android.app.Activity;
 import android.content.Intent;
-import android.os.Build;
 import android.os.Message;
 import android.os.Bundle;
 import android.support.v7.app.ActionBar;
@@ -121,25 +120,9 @@ public class TabGroupProxy extends TiWindowProxy implements TiActivityWindow
 		}
 	}
 
-	public TabProxy[] getTabs()
-	{
-		TabProxy[] tps = null;
-
-		if (tabs != null) {
-			tps = tabs.toArray(new TabProxy[tabs.size()]);
-		}
-
-		return tps;
-	}
-
 	public int getTabIndex(TabProxy tabProxy)
 	{
 		return tabs.indexOf(tabProxy);
-	}
-
-	public ArrayList<TabProxy> getTabList()
-	{
-		return tabs;
 	}
 
 	@Kroll.method

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TabProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TabProxy.java
@@ -21,10 +21,12 @@ import android.app.Activity;
 // clang-format off
 @Kroll.proxy(creatableInModule = UIModule.class,
 	propertyAccessors = {
+		TiC.PROPERTY_ACTIVE_TITLE_COLOR,
+		TiC.PROPERTY_ICON,
 		TiC.PROPERTY_TITLE,
-		TiC.PROPERTY_TITLEID,
-		TiC.PROPERTY_ICON
-})
+		TiC.PROPERTY_TITLE_COLOR,
+		TiC.PROPERTY_TITLEID
+	})
 // clang-format on
 public class TabProxy extends TiViewProxy
 {
@@ -143,6 +145,16 @@ public class TabProxy extends TiViewProxy
 		}
 	}
 
+	/*@Kroll.getProperty
+	public String getTitle()
+	{
+		// Validate tabGroup proxy.
+		if (tabGroupProxy == null ) {
+			return null;
+		}
+		return ((TiUIAbstractTabGroup) tabGroupProxy.getOrCreateView()).getTabTitle(tabGroupProxy.getTabIndex(this));
+	}*/
+
 	public void setWindowId(int id)
 	{
 		windowId = id;
@@ -229,10 +241,23 @@ public class TabProxy extends TiViewProxy
 	public void onPropertyChanged(String name, Object value)
 	{
 		super.onPropertyChanged(name, value);
+		// Check if the Tab Group proxy has been released.
+		if (tabGroupProxy == null) {
+			return;
+		}
 		if (name.equals(TiC.PROPERTY_BACKGROUND_COLOR) || name.equals(TiC.PROPERTY_BACKGROUND_FOCUSED_COLOR)) {
-			if (tabGroupProxy != null) {
-				((TiUIAbstractTabGroup) tabGroupProxy.getOrCreateView()).setDrawables();
-			}
+			((TiUIAbstractTabGroup) tabGroupProxy.getOrCreateView())
+				.updateTabBackgroundDrawable(tabGroupProxy.getTabIndex(this));
+		}
+		if (name.equals(TiC.PROPERTY_TITLE)) {
+			((TiUIAbstractTabGroup) tabGroupProxy.getOrCreateView()).updateTabTitle(tabGroupProxy.getTabIndex(this));
+		}
+		if (name.equals(TiC.PROPERTY_TITLE_COLOR) || name.equals(TiC.PROPERTY_ACTIVE_TITLE_COLOR)) {
+			((TiUIAbstractTabGroup) tabGroupProxy.getOrCreateView())
+				.updateTabTitleColor(tabGroupProxy.getTabIndex(this));
+		}
+		if (name.equals(TiC.PROPERTY_ICON)) {
+			((TiUIAbstractTabGroup) tabGroupProxy.getOrCreateView()).updateTabIcon(tabGroupProxy.getTabIndex(this));
 		}
 	}
 

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIAbstractTabGroup.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIAbstractTabGroup.java
@@ -14,7 +14,6 @@ import android.graphics.drawable.RippleDrawable;
 import android.graphics.drawable.StateListDrawable;
 import android.os.Build;
 import android.os.Bundle;
-import android.os.Parcelable;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentPagerAdapter;
@@ -33,6 +32,7 @@ import org.appcelerator.kroll.KrollProxy;
 import org.appcelerator.titanium.TiBaseActivity;
 import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.proxy.ActivityProxy;
+import org.appcelerator.titanium.proxy.TiViewProxy;
 import org.appcelerator.titanium.util.TiColorHelper;
 import org.appcelerator.titanium.util.TiConvert;
 import org.appcelerator.titanium.view.TiInsetsProvider;
@@ -64,7 +64,7 @@ public abstract class TiUIAbstractTabGroup extends TiUIView
 	 *
 	 * @param tabProxy proxy to be parsed for tab item.
 	 */
-	public abstract void addTabItemInController(TabProxy tabProxy);
+	public abstract void addTabItemInController(TiViewProxy tabProxy);
 
 	/**
 	 * Removes an item from the TabGroup controller for a specific position.
@@ -88,9 +88,40 @@ public abstract class TiUIAbstractTabGroup extends TiUIView
 	public abstract void setBackgroundColor(int colorInt);
 
 	/**
-	 * Changes the tabs background drawables to the proper color states.
+	 * Updates the tab's background drawables to the proper color states.
+	 *
+	 * @param index of the Tab to update.
 	 */
-	public abstract void setDrawables();
+	public abstract void updateTabBackgroundDrawable(int index);
+
+	/**
+	 * Update the tab's title to the proper text.
+	 *
+	 * @param index of the Tab to update.
+	 */
+	public abstract void updateTabTitle(int index);
+
+	/**
+	 * Updates the tab's title to the proper color states.
+	 *
+	 * @param index of the Tab to update.
+	 */
+	public abstract void updateTabTitleColor(int index);
+
+	/**
+	 * Updates the tabs' icon to the proper image.
+	 *
+	 * @param index of the Tab to update.
+	 */
+	public abstract void updateTabIcon(int index);
+
+	/**
+	 * Returns the value of the Tab's title.
+	 *
+	 * @param index the index of the Tab.
+	 * @return
+	 */
+	public abstract String getTabTitle(int index);
 
 	// region protected fields
 	protected static final String TAG = "TiUITabLayoutTabGroup";
@@ -111,7 +142,7 @@ public abstract class TiUIAbstractTabGroup extends TiUIView
 	private int textColorInt;
 	private AtomicLong fragmentIdGenerator = new AtomicLong();
 	private ArrayList<Long> tabFragmentIDs = new ArrayList<Long>();
-	private ArrayList<TiUITab> tabs = new ArrayList<TiUITab>();
+	protected ArrayList<TiUITab> tabs = new ArrayList<TiUITab>();
 	// endregion
 
 	public TiUIAbstractTabGroup(final TabGroupProxy proxy, TiBaseActivity activity)
@@ -165,7 +196,7 @@ public abstract class TiUIAbstractTabGroup extends TiUIView
 	public void disableTabNavigation(boolean value)
 	{
 		this.tabsDisabled = value;
-		this.numTabsWhenDisabled = ((TabGroupProxy) getProxy()).getTabList().size();
+		this.numTabsWhenDisabled = tabs.size();
 	}
 
 	/**
@@ -175,7 +206,7 @@ public abstract class TiUIAbstractTabGroup extends TiUIView
 	 */
 	public void selectTab(TabProxy tabProxy)
 	{
-		int index = ((TabGroupProxy) getProxy()).getTabList().indexOf(tabProxy);
+		int index = ((TabGroupProxy) getProxy()).getTabIndex(tabProxy);
 		// Guard for trying to set a tab, that is not part of the group, as active.
 		if (index != -1 && !tabsDisabled) {
 			selectTabItemInController(index);
@@ -195,7 +226,6 @@ public abstract class TiUIAbstractTabGroup extends TiUIView
 		TiUITab abstractTab = new TiUITab(tabProxy);
 		tabs.add(abstractTab);
 		tabFragmentIDs.add(fragmentIdGenerator.getAndIncrement());
-		tabProxy.setView(abstractTab);
 
 		this.tabGroupPagerAdapter.notifyDataSetChanged();
 
@@ -213,7 +243,7 @@ public abstract class TiUIAbstractTabGroup extends TiUIView
 	 * @param stateToUse appropriate state for the Controller type.
 	 * @return ColorStateList for the provided state.
 	 */
-	protected ColorStateList textColorStateList(TabProxy tabProxy, int stateToUse)
+	protected ColorStateList textColorStateList(TiViewProxy tabProxy, int stateToUse)
 	{
 		int[][] textColorStates = new int[][] { new int[] { -stateToUse }, new int[] { stateToUse } };
 		int[] textColors = { tabProxy.hasPropertyAndNotNull(TiC.PROPERTY_TITLE_COLOR)
@@ -238,7 +268,7 @@ public abstract class TiUIAbstractTabGroup extends TiUIView
 	 * @param stateToUse appropriate state for the Controller type.
 	 * @return RippleDrawable for the provided state.
 	 */
-	protected Drawable createBackgroundDrawableForState(TabProxy tabProxy, int stateToUse)
+	protected Drawable createBackgroundDrawableForState(TiViewProxy tabProxy, int stateToUse)
 	{
 		Drawable resultDrawable;
 		StateListDrawable stateListDrawable = new StateListDrawable();
@@ -365,22 +395,17 @@ public abstract class TiUIAbstractTabGroup extends TiUIView
 		} else if (key.equals(TiC.PROPERTY_SMOOTH_SCROLL_ON_TAB_CLICK)) {
 			this.smoothScrollOnTabClick = TiConvert.toBoolean(newValue);
 		} else if (key.equals(TiC.PROPERTY_TABS_BACKGROUND_COLOR)) {
-			setDrawables();
+			for (TiUITab tabView : tabs) {
+				updateTabBackgroundDrawable(tabs.indexOf(tabView));
+			}
 			setBackgroundColor(TiColorHelper.parseColor(newValue.toString()));
 		} else if (key.equals(TiC.PROPERTY_TABS_BACKGROUND_SELECTED_COLOR)) {
-			setDrawables();
+			for (TiUITab tabView : tabs) {
+				updateTabBackgroundDrawable(tabs.indexOf(tabView));
+			}
 		} else {
 			super.propertyChanged(key, oldValue, newValue, proxy);
 		}
-	}
-
-	/**
-	 * Returns the currently selected TabProxy
-	 * @return the TabProxy instance.
-	 */
-	public TabProxy getSelectedTab()
-	{
-		return ((TabGroupProxy) getProxy()).getTabList().get(this.tabGroupViewPager.getCurrentItem());
 	}
 
 	public void updateTitle(String title)
@@ -394,7 +419,7 @@ public abstract class TiUIAbstractTabGroup extends TiUIView
 	}
 
 	/**
-	 * Implemenation of the FragmentPagerAdapter
+	 * Implementation of the FragmentPagerAdapter
 	 */
 	private class TabGroupFragmentPagerAdapter extends FragmentPagerAdapter
 	{

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIBottomNavigationTabGroup.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIBottomNavigationTabGroup.java
@@ -6,7 +6,6 @@
  */
 package ti.modules.titanium.ui.widget.tabgroup;
 
-import android.content.res.ColorStateList;
 import android.graphics.Rect;
 import android.graphics.drawable.Drawable;
 import android.support.design.internal.BottomNavigationItemView;
@@ -20,7 +19,7 @@ import org.appcelerator.kroll.common.Log;
 import org.appcelerator.titanium.TiBaseActivity;
 import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.TiDimension;
-import org.appcelerator.titanium.util.TiColorHelper;
+import org.appcelerator.titanium.proxy.TiViewProxy;
 import org.appcelerator.titanium.util.TiUIHelper;
 import org.appcelerator.titanium.view.TiCompositeLayout;
 
@@ -28,7 +27,6 @@ import java.lang.reflect.Field;
 import java.util.ArrayList;
 
 import ti.modules.titanium.ui.TabGroupProxy;
-import ti.modules.titanium.ui.TabProxy;
 
 /**
  * TabGroup implementation using BottomNavigationView as a controller.
@@ -134,7 +132,7 @@ public class TiUIBottomNavigationTabGroup extends TiUIAbstractTabGroup implement
 	}
 
 	@Override
-	public void addTabItemInController(TabProxy tabProxy)
+	public void addTabItemInController(TiViewProxy tabProxy)
 	{
 		// Guard for the limit of tabs in the BottomNavigationView.
 		if (this.mMenuItemsArray.size() == 5) {
@@ -145,49 +143,23 @@ public class TiUIBottomNavigationTabGroup extends TiUIAbstractTabGroup implement
 		MenuItem menuItem = this.mBottomNavigationView.getMenu().add(null);
 		// Set the click listener.
 		menuItem.setOnMenuItemClickListener(this);
-		// Set the title.
-		if (tabProxy.hasPropertyAndNotNull(TiC.PROPERTY_TITLE)) {
-			menuItem.setTitle(tabProxy.getProperty(TiC.PROPERTY_TITLE).toString());
-		}
-		// Set the icon.
-		if (tabProxy.hasPropertyAndNotNull(TiC.PROPERTY_ICON)) {
-			Drawable drawable = TiUIHelper.getResourceDrawable(tabProxy.getProperty(TiC.PROPERTY_ICON));
-			menuItem.setIcon(drawable);
-		}
 		// Add the MenuItem to the menu of BottomNavigationView.
 		this.mMenuItemsArray.add(menuItem);
-		// Set the drawables.
-		setDrawables();
+		// Get the MenuItem index
+		int index = this.mMenuItemsArray.size() - 1;
+		// Set the title.
+		updateTabTitle(index);
+		// Set the title text color.
+		updateTabTitleColor(index);
+		// Set the background drawable.
+		updateTabBackgroundDrawable(index);
+		// Set the icon.
+		updateTabIcon(index);
 		// Handle shift mode.
 		if (this.proxy.hasPropertyAndNotNull(TiC.PROPERTY_SHIFT_MODE)) {
 			if (!((Boolean) proxy.getProperty(TiC.PROPERTY_SHIFT_MODE))) {
 				disableShiftMode();
 			}
-		}
-	}
-
-	/**
-	 * This method resets the custom drawables for every item in BottomNavigationView because
-	 * it rebuilds its menu on every addition of a new item in it.
-	 *
-	 */
-	public void setDrawables()
-	{
-		try {
-			ArrayList<TabProxy> tabs = ((TabGroupProxy) proxy).getTabList();
-			BottomNavigationMenuView bottomMenuView =
-				((BottomNavigationMenuView) this.mBottomNavigationView.getChildAt(0));
-			// BottomNavigationMenuView rebuilds itself after adding a new item, so we need to reset the colors each time.
-			for (int i = 0; i < this.mMenuItemsArray.size(); i++) {
-				TabProxy tabProxy = tabs.get(i);
-				Drawable backgroundDrawable = createBackgroundDrawableForState(tabProxy, android.R.attr.state_checked);
-				bottomMenuView.getChildAt(i).setBackground(backgroundDrawable);
-				// Set the TextView textColor.
-				((BottomNavigationItemView) bottomMenuView.getChildAt(i))
-					.setTextColor(textColorStateList(tabProxy, android.R.attr.state_checked));
-			}
-		} catch (Exception e) {
-			Log.w(TAG, WARNING_LAYOUT_MESSAGE);
 		}
 	}
 
@@ -227,8 +199,8 @@ public class TiUIBottomNavigationTabGroup extends TiUIAbstractTabGroup implement
 	{
 		this.mBottomNavigationView.getMenu().clear();
 		this.mMenuItemsArray.clear();
-		for (TabProxy tabProxy : ((TabGroupProxy) proxy).getTabList()) {
-			addTabItemInController(tabProxy);
+		for (TiUITab tabView : tabs) {
+			addTabItemInController(tabView.getProxy());
 		}
 	}
 
@@ -243,10 +215,7 @@ public class TiUIBottomNavigationTabGroup extends TiUIAbstractTabGroup implement
 		// Fire the UNSELECTED event from the currently selected tab.
 		if (currentlySelectedIndex != -1) {
 			if (getProxy() != null) {
-				((TabGroupProxy) getProxy())
-					.getTabList()
-					.get(currentlySelectedIndex)
-					.fireEvent(TiC.EVENT_UNSELECTED, null, false);
+				tabs.get(currentlySelectedIndex).getProxy().fireEvent(TiC.EVENT_UNSELECTED, null, false);
 			}
 		}
 		currentlySelectedIndex = position;
@@ -264,6 +233,65 @@ public class TiUIBottomNavigationTabGroup extends TiUIAbstractTabGroup implement
 		this.mBottomNavigationView.setBackgroundColor(colorInt);
 	}
 
+	@Override
+	public void updateTabBackgroundDrawable(int index)
+	{
+		try {
+			BottomNavigationMenuView bottomMenuView =
+				((BottomNavigationMenuView) this.mBottomNavigationView.getChildAt(0));
+			// BottomNavigationMenuView rebuilds itself after adding a new item, so we need to reset the colors each time.
+			for (int i = 0; i < this.mMenuItemsArray.size(); i++) {
+				TiViewProxy tabProxy = tabs.get(i).getProxy();
+				Drawable backgroundDrawable = createBackgroundDrawableForState(tabProxy, android.R.attr.state_checked);
+				bottomMenuView.getChildAt(i).setBackground(backgroundDrawable);
+			}
+		} catch (Exception e) {
+			Log.w(TAG, WARNING_LAYOUT_MESSAGE);
+		}
+	}
+
+	@Override
+	public void updateTabTitle(int index)
+	{
+		this.mBottomNavigationView.getMenu().getItem(index).setTitle(
+			tabs.get(index).getProxy().getProperty(TiC.PROPERTY_TITLE).toString());
+	}
+
+	@Override
+	public void updateTabTitleColor(int index)
+	{
+		try {
+			BottomNavigationMenuView bottomMenuView =
+				((BottomNavigationMenuView) this.mBottomNavigationView.getChildAt(0));
+			// BottomNavigationMenuView rebuilds itself after adding a new item, so we need to reset the colors each time.
+			for (int i = 0; i < this.mMenuItemsArray.size(); i++) {
+				TiViewProxy tabProxy = tabs.get(i).getProxy();
+				// Set the TextView textColor.
+				((BottomNavigationItemView) bottomMenuView.getChildAt(i))
+					.setTextColor(textColorStateList(tabProxy, android.R.attr.state_checked));
+			}
+		} catch (Exception e) {
+			Log.w(TAG, WARNING_LAYOUT_MESSAGE);
+		}
+	}
+
+	@Override
+	public void updateTabIcon(int index)
+	{
+		Drawable drawable = TiUIHelper.getResourceDrawable(tabs.get(index).getProxy().getProperty(TiC.PROPERTY_ICON));
+		this.mBottomNavigationView.getMenu().getItem(index).setIcon(drawable);
+	}
+
+	@Override
+	public String getTabTitle(int index)
+	{
+		// Validate index.
+		if (index < 0 || index > tabs.size() - 1) {
+			return null;
+		}
+		return this.mBottomNavigationView.getMenu().getItem(index).getTitle().toString();
+	}
+
 	/**
 	 * After a menu item is clicked this method sends the proper index to the ViewPager to a select
 	 * a page. Also takes care of sending SELECTED/UNSELECTED events from the proper tabs.
@@ -277,10 +305,7 @@ public class TiUIBottomNavigationTabGroup extends TiUIAbstractTabGroup implement
 		int index = this.mMenuItemsArray.indexOf(item);
 		if (index != currentlySelectedIndex) {
 			if (getProxy() != null) {
-				((TabGroupProxy) getProxy())
-					.getTabList()
-					.get(currentlySelectedIndex)
-					.fireEvent(TiC.EVENT_UNSELECTED, null, false);
+				tabs.get(currentlySelectedIndex).getProxy().fireEvent(TiC.EVENT_UNSELECTED, null, false);
 				currentlySelectedIndex = index;
 			}
 		}

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIBottomNavigationTabGroup.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIBottomNavigationTabGroup.java
@@ -147,19 +147,26 @@ public class TiUIBottomNavigationTabGroup extends TiUIAbstractTabGroup implement
 		this.mMenuItemsArray.add(menuItem);
 		// Get the MenuItem index
 		int index = this.mMenuItemsArray.size() - 1;
-		// Set the title.
-		updateTabTitle(index);
-		// Set the title text color.
-		updateTabTitleColor(index);
-		// Set the background drawable.
-		updateTabBackgroundDrawable(index);
-		// Set the icon.
-		updateTabIcon(index);
+		updateDrawablesAfterNewItem(index);
 		// Handle shift mode.
 		if (this.proxy.hasPropertyAndNotNull(TiC.PROPERTY_SHIFT_MODE)) {
 			if (!((Boolean) proxy.getProperty(TiC.PROPERTY_SHIFT_MODE))) {
 				disableShiftMode();
 			}
+		}
+	}
+
+	private void updateDrawablesAfterNewItem(int index)
+	{
+		// Set the title.
+		updateTabTitle(index);
+		// Set the icon.
+		updateTabIcon(index);
+		for (int i = 0; i < this.mBottomNavigationView.getMenu().size(); i++) {
+			// Set the title text color.
+			updateTabTitleColor(i);
+			// Set the background drawable.
+			updateTabBackgroundDrawable(i);
 		}
 	}
 
@@ -240,11 +247,9 @@ public class TiUIBottomNavigationTabGroup extends TiUIAbstractTabGroup implement
 			BottomNavigationMenuView bottomMenuView =
 				((BottomNavigationMenuView) this.mBottomNavigationView.getChildAt(0));
 			// BottomNavigationMenuView rebuilds itself after adding a new item, so we need to reset the colors each time.
-			for (int i = 0; i < this.mMenuItemsArray.size(); i++) {
-				TiViewProxy tabProxy = tabs.get(i).getProxy();
-				Drawable backgroundDrawable = createBackgroundDrawableForState(tabProxy, android.R.attr.state_checked);
-				bottomMenuView.getChildAt(i).setBackground(backgroundDrawable);
-			}
+			TiViewProxy tabProxy = tabs.get(index).getProxy();
+			Drawable backgroundDrawable = createBackgroundDrawableForState(tabProxy, android.R.attr.state_checked);
+			bottomMenuView.getChildAt(index).setBackground(backgroundDrawable);
 		} catch (Exception e) {
 			Log.w(TAG, WARNING_LAYOUT_MESSAGE);
 		}
@@ -264,12 +269,10 @@ public class TiUIBottomNavigationTabGroup extends TiUIAbstractTabGroup implement
 			BottomNavigationMenuView bottomMenuView =
 				((BottomNavigationMenuView) this.mBottomNavigationView.getChildAt(0));
 			// BottomNavigationMenuView rebuilds itself after adding a new item, so we need to reset the colors each time.
-			for (int i = 0; i < this.mMenuItemsArray.size(); i++) {
-				TiViewProxy tabProxy = tabs.get(i).getProxy();
-				// Set the TextView textColor.
-				((BottomNavigationItemView) bottomMenuView.getChildAt(i))
-					.setTextColor(textColorStateList(tabProxy, android.R.attr.state_checked));
-			}
+			TiViewProxy tabProxy = tabs.get(index).getProxy();
+			// Set the TextView textColor.
+			((BottomNavigationItemView) bottomMenuView.getChildAt(index))
+				.setTextColor(textColorStateList(tabProxy, android.R.attr.state_checked));
 		} catch (Exception e) {
 			Log.w(TAG, WARNING_LAYOUT_MESSAGE);
 		}

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUITab.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUITab.java
@@ -22,6 +22,7 @@ public class TiUITab extends TiUIView
 	public TiUITab(TabProxy proxy)
 	{
 		super(proxy);
+		proxy.setModelListener(this);
 		proxy.setView(this);
 	}
 

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUITab.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUITab.java
@@ -22,7 +22,6 @@ public class TiUITab extends TiUIView
 	public TiUITab(TabProxy proxy)
 	{
 		super(proxy);
-		proxy.setModelListener(this);
 		proxy.setView(this);
 	}
 


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-27075

**Description:**
Fix for changing TabGroup's tabs' properties after they are created. Now every implementation of
AbstractTabGroup must take care of the exposed properties. Improvement of properties handling - they
are now separated for title, tilteColor, background drawable and icon. Imports clean up.

**Note:** I haven't updated the unit-tests for the following reason - currently our unit tests expect Tab instances to be tested without being added in a TabGroup. In this case I can't connect properties of the TabProxy with their counterparts in the native implementation - TabLayout.Tabs or MenuItems, because they are not created yet. That got me thinking "Do we want to have the native components be created without them being used in an actual drawn TabGroup?". If we do - this will need some rework of the code there. I checked what was the case in 7.5.0.GA (before the refactoring) and it does not create the native tabs if they are not added in a TabGroup (and they can't be added to another type of container directly) What do you think?

**Test case:**
There is a good sample code in the JIRA ticket.