### PR TITLE
fix(ios): expose --source-maps CLI flag, default to source maps for non-production builds

### DIFF
--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -923,7 +923,16 @@ AndroidBuilder.prototype.validate = function validate(logger, config, cli) {
 
 	// Transpilation details
 	this.transpile = cli.tiapp['transpile'] !== false; // Transpiling is an opt-out process now
-	this.sourceMaps = cli.tiapp['source-maps'] === true || cli.argv['source-maps'] || this.deployType !== 'production'; // opt-in to generate inline source maps
+	// If they're passing flag to do source-mapping, that overrides everything, so turn it on
+	if (cli.argv['source-maps']) {
+		this.sourceMaps = true;
+		// if they haven't, respect the tiapp.xml value if set one way or the other
+	} else if (cli.tiapp.hasOwnProperty['source-maps']) { // they've explicitly set a value in tiapp.xml
+		this.sourceMaps = cli.tiapp['source-maps'] === true; // respect the tiapp.xml value
+	} else { // otherwise turn on by default for non-production builds
+		this.sourceMaps = this.deployType !== 'production';
+	}
+
 	// We get a string here like 6.2.414.36, we need to convert it to 62 (integer)
 	const v8Version = this.packageJson.v8.version;
 	const found = v8Version.match(V8_STRING_VERSION_REGEXP);

--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -923,7 +923,7 @@ AndroidBuilder.prototype.validate = function validate(logger, config, cli) {
 
 	// Transpilation details
 	this.transpile = cli.tiapp['transpile'] !== false; // Transpiling is an opt-out process now
-	this.sourceMaps = cli.tiapp['source-maps'] === true; // opt-in to generate inline source maps
+	this.sourceMaps = cli.tiapp['source-maps'] === true || cli.argv['source-maps'] || this.deployType !== 'production'; // opt-in to generate inline source maps
 	// We get a string here like 6.2.414.36, we need to convert it to 62 (integer)
 	const v8Version = this.packageJson.v8.version;
 	const found = v8Version.match(V8_STRING_VERSION_REGEXP);
@@ -2692,7 +2692,7 @@ AndroidBuilder.prototype.copyResources = function copyResources(next) {
 			defaultAnalyzeOptions: {
 				minify: this.minifyJS,
 				transpile: this.transpile,
-				sourceMap: this.sourceMaps || this.deployType === 'development',
+				sourceMap: this.sourceMaps,
 				resourcesDir: this.buildBinAssetsResourcesDir,
 				logger: this.logger,
 				targets: {

--- a/cli/commands/build.js
+++ b/cli/commands/build.js
@@ -64,7 +64,10 @@ exports.config = function config(logger, config, cli) {
 						'skip-js-minify': {
 							default: false,
 							desc: __('bypasses JavaScript minification; %s builds are never minified; only supported for %s and %s', 'simulator'.cyan, 'Android'.cyan, 'iOS'.cyan)
-						}
+						},
+						'source-maps': {
+							desc: __('generate inline source maps for transpiled JS files')
+						},
 					},
 					options: appc.util.mix({
 						platform: {

--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -1805,7 +1805,7 @@ iOSBuilder.prototype.validate = function validate(logger, config, cli) {
 
 		// Transpilation details
 		this.transpile = cli.tiapp['transpile'] !== false; // Transpiling is an opt-out process now
-		this.sourceMaps = cli.tiapp['source-maps'] === true; // opt-in to generate inline source maps
+		this.sourceMaps = cli.tiapp['source-maps'] === true || cli.argv.hasOwnProperty('source-maps'); // opt-in to generate inline source maps
 		// this.minSupportedIosSdk holds the target ios version to transpile down to
 
 		// check for blacklisted files in the Resources directory

--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -440,6 +440,9 @@ iOSBuilder.prototype.config = function config(logger, config, cli) {
 						'force-copy': {
 							desc: __('forces files to be copied instead of symlinked for %s builds only', 'simulator'.cyan)
 						},
+						'hide-error-controller': {
+							hidden: true
+						},
 						'launch-watch-app': {
 							desc: __('for %s builds, after installing an app with a watch extention, launch the watch app and the main app', 'simulator'.cyan)
 						},
@@ -476,9 +479,6 @@ iOSBuilder.prototype.config = function config(logger, config, cli) {
 						'developer-name':             this.configOptionDeveloperName(170),
 						'distribution-name':          this.configOptionDistributionName(180),
 						'device-family':              this.configOptionDeviceFamily(120), // this MUST be processed before --device-id
-						'hide-error-controller': {
-							hidden: true
-						},
 						'ios-version':                this.configOptioniOSVersion(130),
 						keychain:                   this.configOptionKeychain(),
 						'launch-bundle-id':           this.configOptionLaunchBundleId(),
@@ -1793,7 +1793,7 @@ iOSBuilder.prototype.validate = function validate(logger, config, cli) {
 		if (cli.argv['skip-js-minify']) {
 			this.minifyJS = false;
 		}
-		if (cli.argv.hasOwnProperty('hide-error-controller')) {
+		if (cli.argv['hide-error-controller']) {
 			this.showErrorController = false;
 		}
 
@@ -1805,7 +1805,7 @@ iOSBuilder.prototype.validate = function validate(logger, config, cli) {
 
 		// Transpilation details
 		this.transpile = cli.tiapp['transpile'] !== false; // Transpiling is an opt-out process now
-		this.sourceMaps = cli.tiapp['source-maps'] === true || cli.argv.hasOwnProperty('source-maps'); // opt-in to generate inline source maps
+		this.sourceMaps = cli.tiapp['source-maps'] === true || this.cli.argv['source-maps']; // opt-in to generate inline source maps
 		// this.minSupportedIosSdk holds the target ios version to transpile down to
 
 		// check for blacklisted files in the Resources directory

--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -5860,7 +5860,7 @@ iOSBuilder.prototype.copyResources = function copyResources(next) {
 						defaultAnalyzeOptions: {
 							minify: this.minifyJS,
 							transpile: this.transpile,
-							sourceMap: this.sourceMaps || this.deployType === 'development',
+							sourceMap: this.sourceMaps,
 							resourcesDir: this.xcodeAppDir,
 							logger: this.logger,
 							targets: {

--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -1805,8 +1805,16 @@ iOSBuilder.prototype.validate = function validate(logger, config, cli) {
 
 		// Transpilation details
 		this.transpile = cli.tiapp['transpile'] !== false; // Transpiling is an opt-out process now
-		this.sourceMaps = cli.tiapp['source-maps'] === true || this.cli.argv['source-maps']; // opt-in to generate inline source maps
 		// this.minSupportedIosSdk holds the target ios version to transpile down to
+		// If they're passing flag to do source-mapping, that overrides everything, so turn it on
+		if (cli.argv['source-maps']) {
+			this.sourceMaps = true;
+			// if they haven't, respect the tiapp.xml value if set one way or the other
+		} else if (cli.tiapp.hasOwnProperty['source-maps']) { // they've explicitly set a value in tiapp.xml
+			this.sourceMaps = cli.tiapp['source-maps'] === true; // respect the tiapp.xml value
+		} else { // otherwise turn on by default for non-production builds
+			this.sourceMaps = this.deployType !== 'production';
+		}
 
 		// check for blacklisted files in the Resources directory
 		[	path.join(this.projectDir, 'Resources'),


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-27098

**Description:**
- Create a `--source-maps` CLI flag to force generation of source maps
- fix `--hide-error-controller` to be a flag, not an option (internal refactoring, it's a flag used by test suite so we can continue despite errors)
- Change source mapping behavior to behave like so:
  - if `--source-maps` flag is passed to CLI, turn them on
  - if tiapp.xml has a `source-maps` tag respect it's value
  - if neither, turn on source maps by default on non-`'production'` (deploy type) builds