### PR TITLE
fix: pass along eventual destination for js file in jsanalyze

### DIFF
--- a/cli/lib/tasks/process-js-task.js
+++ b/cli/lib/tasks/process-js-task.js
@@ -224,6 +224,7 @@ class ProcessJsTask extends IncrementalFileTask {
 		const minify = isFileFromCommonFolder ? false : this.defaultAnalyzeOptions.minify;
 		const analyzeOptions = Object.assign({}, this.defaultAnalyzeOptions, {
 			filename: from,
+			dest: to,
 			minify,
 			transpile,
 		});


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-27098

Relates to appcelerator/node-titanium-sdk#106

**Optional Description:**
Passes in to the jsanalyze options a `dest` property pointing at the eventual file path of the generated JS file we write after transpilation.