### PR TITLE
fix(android): prevent multiple exception logs

### DIFF
--- a/android/runtime/common/src/java/org/appcelerator/kroll/KrollRuntime.java
+++ b/android/runtime/common/src/java/org/appcelerator/kroll/KrollRuntime.java
@@ -495,17 +495,16 @@ public abstract class KrollRuntime implements Handler.Callback
 	{
 		if (instance != null) {
 			HashMap<String, KrollExceptionHandler> handlers = instance.exceptionHandlers;
-			KrollExceptionHandler currentHandler;
 			ExceptionMessage exceptionMessage =
 				new ExceptionMessage(title, message, sourceName, line, lineSource, lineOffset, jsStack, javaStack);
 
 			if (!handlers.isEmpty()) {
-				for (String key : handlers.keySet()) {
-					currentHandler = handlers.get(key);
-					if (currentHandler != null) {
-						currentHandler.handleException(exceptionMessage);
+				for (KrollExceptionHandler handler : handlers.values()) {
+					if (handler != null) {
+						handler.handleException(exceptionMessage);
 					}
 				}
+				return;
 			}
 
 			// Handle exception with defaultExceptionHandler


### PR DESCRIPTION
- Prevent multiple unnecessary `TiExceptionHandler` logs when handlers are present

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-27153)