### PR TITLE
fix(ios): only delete build dir when force clean build (8_1_X)

### DIFF
--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -2877,11 +2877,12 @@ iOSBuilder.prototype.initBuildDir = function initBuildDir() {
 
 	if (this.forceCleanBuild && buildDirExists) {
 		this.logger.debug(__('Recreating %s', cyan(this.buildDir)));
+		fs.emptyDirSync(this.buildDir);
 	} else if (!buildDirExists) {
 		this.logger.debug(__('Creating %s', cyan(this.buildDir)));
+		fs.ensureDirSync(this.buildDir);
 		this.forceCleanBuild = true;
 	}
-	fs.emptyDirSync(this.buildDir);
 
 	fs.ensureDirSync(this.xcodeAppDir);
 };


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-27155

8_1_X backport of #10965 