### PR TITLE
fix(android): Closing root window from child window causes app exit issues as of 8.0.1

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/TiWindowProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/TiWindowProxy.java
@@ -556,16 +556,15 @@ public abstract class TiWindowProxy extends TiViewProxy
 			intent.putExtra(TiC.PROPERTY_EXTEND_SAFE_AREA, value);
 		}
 
-		boolean exitOnClose = false;
 		if (hasProperty(TiC.PROPERTY_EXIT_ON_CLOSE)) {
-			exitOnClose = TiConvert.toBoolean(getProperty(TiC.PROPERTY_EXIT_ON_CLOSE), exitOnClose);
-		} else {
-			// If launching child activity from Titanium root activity, then have it exit out of the app.
+			// Use proxy's assigned "exitOnClose" property setting.
+			boolean exitOnClose = TiConvert.toBoolean(getProperty(TiC.PROPERTY_EXIT_ON_CLOSE), false);
+			intent.putExtra(TiC.INTENT_PROPERTY_FINISH_ROOT, exitOnClose);
+		} else if (activity.isTaskRoot() || (activity == TiApplication.getInstance().getRootActivity())) {
+			// We're opening child activity from Titanium root activity. Have it exit out of app by default.
 			// Note: If launched via startActivityForResult(), then root activity won't be the task's root.
-			exitOnClose = activity.isTaskRoot() || (activity == TiApplication.getInstance().getRootActivity());
-			setProperty(TiC.PROPERTY_EXIT_ON_CLOSE, exitOnClose);
+			intent.putExtra(TiC.INTENT_PROPERTY_FINISH_ROOT, true);
 		}
-		intent.putExtra(TiC.INTENT_PROPERTY_FINISH_ROOT, exitOnClose);
 
 		// Set the theme property
 		if (hasProperty(TiC.PROPERTY_THEME)) {


### PR DESCRIPTION
**JIRA:**
https://jira.appcelerator.org/browse/TIMOB-27177

**Summary:**
When child window closes the root window, the following regressions occur as of 8.0.1.
- Closing immediate child window causes app to home-out instead of exiting the app.
- Opening another child window and then closing it causes app to wrongly exit out.

---
**Close Root Window Test:**
1. Build and run the below code on Android.
2. Tap on the "Open" button in Window 1.
3. Note that this closes Window 1 after opening Window 2 in the background.
4. Tap on the Android "Back" button to exit.
5. Relaunch the app.
6. Verify that the splash screen is shown. (App used to resume instead of restarting.)
7. Tap on the "Open" button in Window 1.
8. Tap on the "Open" button in Window 2.
9. Tap on the Android "Back" button in Window 3.
10. Verify Window 3 closes and you are now back in Window 2. (Used to exit app.)

```javascript
var window1 = Ti.UI.createWindow({
	title: "Window 1",
	backgroundColor: "white",
});
var openButton = Ti.UI.createButton({
	title: "Open",
});
openButton.addEventListener("click", function() {
	var window2 = Ti.UI.createWindow({
		title: "Window 2",
		backgroundColor: "white",
	});
	var openButton = Ti.UI.createButton({
		title: "Open",
	});
	openButton.addEventListener("click", function() {
		var window3 = Ti.UI.createWindow({
			title: "Window 3",
			backgroundColor: "white",
		});
		var closeButton = Ti.UI.createButton({
			title: "Close",
		});
		closeButton.addEventListener("click", function() {
			window3.close();
		});
		window3.add(closeButton);
		window3.open();
	});
	window2.add(openButton);
	window2.open();
	window1.close();
});
window1.add(openButton);
window1.open();
```

---
**Window "exitOnClose" Test:**
1. Build and run the below code on Android.
2. Tap on the Android "Back" button.
3. Launch the app.
4. Verify that the splash screen was **NOT** shown. _(This is good. Window's "exitOnClose" was set to `false`.)_
5. Tap on the "Close Parent" button.
6. Verify that you were returned to the home screen.
7. Launch the app.
8. Verify that the splash screen was shown. _(This verifies that changing window's "exitOnClose" dynamically to `true` works.)_
9. Tap on the "Open Child" button.
10. Tap on the Android "Back" button.
11. Verify that the app exits. _(This is good. Child window's "exitOnClose" was set `true`.)_
12. Launch the app.
13. Verify that the splash screen was shown.
14. Tap on the "Open Child" button.
15. Tap on the "Close Child" button.
16. Verify that the app exits.

```javascript
var window = Ti.UI.createWindow({
	exitOnClose: false,
});
window.add(Ti.UI.createLabel({ text: "Parent Window" }));
var openButton = Ti.UI.createButton({
	title: "Open Child",
	bottom: "20%",
	left: "4%",
	width: "44%",
});
openButton.addEventListener("click", function() {
	var childWindow = Ti.UI.createWindow({
		exitOnClose: true,
	});
	childWindow.add(Ti.UI.createLabel({ text: "Child Window" }));
	var closeButton = Ti.UI.createButton({
		title: "Close Child",
		bottom: "20%",
	});
	closeButton.addEventListener("click", function() {
		childWindow.close();
	});
	childWindow.add(closeButton);
	childWindow.open();
});
window.add(openButton);
var closeButton = Ti.UI.createButton({
	title: "Close Parent",
	bottom: "20%",
	right: "4%",
	width: "44%",
});
closeButton.addEventListener("click", function() {
	window.exitOnClose = true;
	window.close();
});
window.add(closeButton);
window.open();
```
