### PR TITLE
fix(android)(8_1_X): TabGroup crashes if tab "title" property not set as of 8.0.2

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIBottomNavigationTabGroup.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIBottomNavigationTabGroup.java
@@ -20,6 +20,7 @@ import org.appcelerator.titanium.TiBaseActivity;
 import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.TiDimension;
 import org.appcelerator.titanium.proxy.TiViewProxy;
+import org.appcelerator.titanium.util.TiConvert;
 import org.appcelerator.titanium.util.TiUIHelper;
 import org.appcelerator.titanium.view.TiCompositeLayout;
 
@@ -220,9 +221,10 @@ public class TiUIBottomNavigationTabGroup extends TiUIAbstractTabGroup implement
 	public void selectTabItemInController(int position)
 	{
 		// Fire the UNSELECTED event from the currently selected tab.
-		if (currentlySelectedIndex != -1) {
-			if (getProxy() != null) {
-				tabs.get(currentlySelectedIndex).getProxy().fireEvent(TiC.EVENT_UNSELECTED, null, false);
+		if ((currentlySelectedIndex >= 0) && (currentlySelectedIndex < this.tabs.size()) && (getProxy() != null)) {
+			TiViewProxy tabProxy = this.tabs.get(currentlySelectedIndex).getProxy();
+			if (tabProxy != null) {
+				tabProxy.fireEvent(TiC.EVENT_UNSELECTED, null, false);
 			}
 		}
 		currentlySelectedIndex = position;
@@ -258,8 +260,17 @@ public class TiUIBottomNavigationTabGroup extends TiUIAbstractTabGroup implement
 	@Override
 	public void updateTabTitle(int index)
 	{
-		this.mBottomNavigationView.getMenu().getItem(index).setTitle(
-			tabs.get(index).getProxy().getProperty(TiC.PROPERTY_TITLE).toString());
+		if ((index < 0) || (index >= this.tabs.size())) {
+			return;
+		}
+
+		TiViewProxy tabProxy = this.tabs.get(index).getProxy();
+		if (tabProxy == null) {
+			return;
+		}
+
+		String title = TiConvert.toString(tabProxy.getProperty(TiC.PROPERTY_TITLE));
+		this.mBottomNavigationView.getMenu().getItem(index).setTitle(title);
 	}
 
 	@Override
@@ -281,7 +292,16 @@ public class TiUIBottomNavigationTabGroup extends TiUIAbstractTabGroup implement
 	@Override
 	public void updateTabIcon(int index)
 	{
-		Drawable drawable = TiUIHelper.getResourceDrawable(tabs.get(index).getProxy().getProperty(TiC.PROPERTY_ICON));
+		if ((index < 0) || (index >= this.tabs.size())) {
+			return;
+		}
+
+		TiViewProxy tabProxy = this.tabs.get(index).getProxy();
+		if (tabProxy == null) {
+			return;
+		}
+
+		Drawable drawable = TiUIHelper.getResourceDrawable(tabProxy.getProperty(TiC.PROPERTY_ICON));
 		this.mBottomNavigationView.getMenu().getItem(index).setIcon(drawable);
 	}
 
@@ -306,11 +326,14 @@ public class TiUIBottomNavigationTabGroup extends TiUIAbstractTabGroup implement
 	{
 		// The controller has changed its selected item.
 		int index = this.mMenuItemsArray.indexOf(item);
-		if (index != currentlySelectedIndex) {
-			if (getProxy() != null) {
-				tabs.get(currentlySelectedIndex).getProxy().fireEvent(TiC.EVENT_UNSELECTED, null, false);
-				currentlySelectedIndex = index;
+		if ((index != currentlySelectedIndex) && (getProxy() != null)) {
+			if ((currentlySelectedIndex >= 0) && (currentlySelectedIndex < this.tabs.size())) {
+				TiViewProxy tabProxy = this.tabs.get(currentlySelectedIndex).getProxy();
+				if (tabProxy != null) {
+					tabProxy.fireEvent(TiC.EVENT_UNSELECTED, null, false);
+				}
 			}
+			currentlySelectedIndex = index;
 		}
 		// Make the ViewPager to select the proper page too.
 		selectTab(index);

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUITabLayoutTabGroup.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUITabLayoutTabGroup.java
@@ -19,6 +19,7 @@ import org.appcelerator.titanium.TiBaseActivity;
 import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.TiDimension;
 import org.appcelerator.titanium.proxy.TiViewProxy;
+import org.appcelerator.titanium.util.TiConvert;
 import org.appcelerator.titanium.util.TiUIHelper;
 import org.appcelerator.titanium.view.TiCompositeLayout;
 
@@ -219,7 +220,17 @@ public class TiUITabLayoutTabGroup extends TiUIAbstractTabGroup implements TabLa
 	@Override
 	public void updateTabTitle(int index)
 	{
-		this.mTabLayout.getTabAt(index).setText(tabs.get(index).getProxy().getProperty(TiC.PROPERTY_TITLE).toString());
+		if ((index < 0) || (index >= this.tabs.size())) {
+			return;
+		}
+
+		TiViewProxy tabProxy = this.tabs.get(index).getProxy();
+		if (tabProxy == null) {
+			return;
+		}
+
+		String title = TiConvert.toString(tabProxy.getProperty(TiC.PROPERTY_TITLE));
+		this.mTabLayout.getTabAt(index).setText(title);
 	}
 
 	@Override
@@ -298,16 +309,15 @@ public class TiUITabLayoutTabGroup extends TiUIAbstractTabGroup implements TabLa
 	@Override
 	public void onTabUnselected(TabLayout.Tab tab)
 	{
-		int position = tab.getPosition();
-		// skip invalid position tabs
-		if (position < 0) {
-			return;
+		if (tab != null) {
+			int index = tab.getPosition();
+			if ((index >= 0) && (index < this.tabs.size())) {
+				TiViewProxy tabProxy = this.tabs.get(index).getProxy();
+				if (tabProxy != null) {
+					tabProxy.fireEvent(TiC.EVENT_UNSELECTED, null, false);
+				}
+			}
 		}
-
-		if (position >= tabs.size()) { // skip if past end of list
-			return;
-		}
-		tabs.get(position).getProxy().fireEvent(TiC.EVENT_UNSELECTED, null, false);
 	}
 
 	@Override

--- a/tests/Resources/ti.ui.tabgroup.addontest.js
+++ b/tests/Resources/ti.ui.tabgroup.addontest.js
@@ -1,0 +1,65 @@
+/*
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2011-Present by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+/* eslint-env mocha */
+/* global Ti */
+/* eslint no-unused-expressions: "off" */
+'use strict';
+
+describe('Titanium.UI.TabGroup', function () {
+	let tabGroup = null;
+
+	this.slow(2000);
+	this.timeout(5000);
+
+	afterEach(() => {
+		if (tabGroup) {
+			tabGroup.close();
+			tabGroup = null;
+		}
+	});
+
+	it('icon-only tabs - default style', (finish) => {
+		this.timeout(5000);
+		tabGroup = Ti.UI.createTabGroup({
+			tabs: [
+				Ti.UI.createTab({
+					icon: '/SmallLogo.png',
+					window: Ti.UI.createWindow({ title: 'Tab 1' })
+				}),
+				Ti.UI.createTab({
+					icon: '/SmallLogo.png',
+					window: Ti.UI.createWindow({ title: 'Tab 2' })
+				}),
+			]
+		});
+		tabGroup.addEventListener('open', () => {
+			finish();
+		});
+		tabGroup.open();
+	});
+
+	it.android('icon-only tabs - android bottom style', (finish) => {
+		this.timeout(5000);
+		tabGroup = Ti.UI.createTabGroup({
+			style: Ti.UI.Android.TABS_STYLE_BOTTOM_NAVIGATION,
+			tabs: [
+				Ti.UI.createTab({
+					icon: '/SmallLogo.png',
+					window: Ti.UI.createWindow({ title: 'Tab 1' })
+				}),
+				Ti.UI.createTab({
+					icon: '/SmallLogo.png',
+					window: Ti.UI.createWindow({ title: 'Tab 2' })
+				}),
+			]
+		});
+		tabGroup.addEventListener('open', () => {
+			finish();
+		});
+		tabGroup.open();
+	});
+});


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-27188

**Cherry-pick of:** #11001
