### PR TITLE
feat(common): expose global.binding register and redirect methods

### DIFF
--- a/common/Resources/ti.internal/extensions/node/index.js
+++ b/common/Resources/ti.internal/extensions/node/index.js
@@ -8,10 +8,10 @@ import assert from './assert';
 import events from './events';
 
 // hook our implementations to get loaded by require
-import { bindObjectToCoreModuleId } from '../binding';
-bindObjectToCoreModuleId('path', path);
-bindObjectToCoreModuleId('os', os);
-bindObjectToCoreModuleId('tty', tty);
-bindObjectToCoreModuleId('util', util);
-bindObjectToCoreModuleId('assert', assert);
-bindObjectToCoreModuleId('events', events);
+import { register } from '../binding';
+register('path', path);
+register('os', os);
+register('tty', tty);
+register('util', util);
+register('assert', assert);
+register('events', events);


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-27150

**Optional Description:**
Re-works and exposes a new API to JS for registering values or redirects as the modules for "core" module ids.

Internally this is how the Node shims are hooked so that they get returned if a user does something like `require('fs');`

Note that this API was not originally intended for external use, but @brentonhouse saw it, used it and wanted to maintain exposing it. This PR aims to make the API a little more more formal in its use.