### PR TITLE
build: use faster method for copying production npm packages into SDK

### DIFF
--- a/build/lib/module-copier.js
+++ b/build/lib/module-copier.js
@@ -1,0 +1,114 @@
+'use strict';
+
+const copier = {};
+module.exports = copier;
+
+const fs = require('fs-extra');
+const path = require('path');
+
+const NODE_MODULES = 'node_modules';
+
+/**
+ * @param {string} projectPath absolute filepath for project root directory
+ * @param {string} targetPath absolute filepath for target directory to copy node_modules into
+ * @param {object} [options] options object
+ * @param {boolean} [options.includeOptional=true] whether to include optional dependencies when gathering
+ * @returns {Promise<void>} A Promise that resolves on completion
+ */
+copier.execute = async (projectPath, targetPath, options = { includeOptional: true }) => {
+	if (projectPath === null || projectPath === undefined) {
+		throw new Error('projectPath must be defined.');
+	}
+	if (targetPath === null || targetPath === undefined) {
+		throw new Error('targetPath must be defined.');
+	}
+
+	// resolve path names for file copying
+	projectPath = path.resolve(projectPath);
+	targetPath = path.resolve(targetPath);
+
+	// recursively gather the full set of dependencies/directories we need to copy
+	const root = new Dependency(null, 'fake-id', projectPath);
+	const directoriesToBeCopied = await root.getDirectoriesToCopy(options.includeOptional);
+
+	const dirSet = new Set(directoriesToBeCopied); // de-duplicate
+	// back to Array so we can #map()
+	const deDuplicated = Array.from(dirSet);
+
+	// Then copy them over
+	return Promise.all(deDuplicated.map(async directory => {
+		const relativePath = directory.substring(projectPath.length);
+		const destPath = path.join(targetPath, relativePath);
+		return fs.copy(directory, destPath, { overwrite: true }); // TODO: Allow incremental copying! Maybe use gulp/vinyl?
+	}));
+};
+
+class Dependency {
+	constructor(parent, name, directory) {
+		this.name = name;
+		this.parent = parent;
+		this.directory = directory;
+	}
+
+	/**
+	 * @param {boolean} [includeOptional=true] include optional dependencies?
+	 * @returns {Promise<string[]>} full set of directories to copy
+	 */
+	async getDirectoriesToCopy(includeOptional = true) {
+		const childrenNames = await this.gatherChildren(includeOptional);
+		if (childrenNames.length === 0) {
+			return [ this.directory ]; // just need our own directory!
+		}
+
+		const children = await Promise.all(childrenNames.map(name => this.resolve(name)));
+		const allDirs = await Promise.all(children.map(c => c.getDirectoriesToCopy(includeOptional)));
+		// flatten allDirs doen to single Array
+		const flattened = allDirs.reduce((acc, val) => acc.concat(val), []); // TODO: replace with flat() call once Node 11+
+
+		// if this isn't the "root" module...
+		if (this.parent !== null) {
+			// ...prune any children directories that are underneath this one
+			const filtered = flattened.filter(dir => !dir.startsWith(this.directory + path.sep));
+			filtered.push(this.directory); // We need to include our own directory
+			return filtered;
+		}
+		return flattened;
+	}
+
+	/**
+	 * @param {boolean} [includeOptional] include optional dependencies?
+	 * @returns {Promise<string[]>} set of dependency names
+	 */
+	async gatherChildren(includeOptional = true) {
+		const packageJson = await fs.readJson(path.join(this.directory, 'package.json'));
+		const dependencies = Object.keys(packageJson.dependencies || {});
+		// include optional dependencies too?
+		if (includeOptional && packageJson.optionalDependencies) {
+			dependencies.push(...Object.keys(packageJson.optionalDependencies));
+		}
+		return dependencies;
+	}
+
+	/**
+	 * Attempts to resolve a given module by id to the correct
+	 * @param {string} subModule id of a module that is it's dependency
+	 * @returns {Promise<Dependency>} the resolved dependency
+	 */
+	async resolve(subModule) {
+		try {
+			// First try underneath the current module
+			const targetDir = path.join(this.directory, NODE_MODULES, subModule);
+			const packageJsonExists = await fs.pathExists(path.join(targetDir, 'package.json'));
+			if (packageJsonExists) {
+				return new Dependency(this, subModule, targetDir);
+			}
+		} catch (err) {
+			// this is the root and we still didn't find it, fail!
+			if (this.parent === null) {
+				throw err;
+			}
+		}
+
+		return this.parent.resolve(subModule); // Try the parent (recursively)
+	}
+}

--- a/build/lib/packager.js
+++ b/build/lib/packager.js
@@ -17,6 +17,7 @@ const utils = require('./utils');
 const copyFile = utils.copyFile;
 const copyFiles = utils.copyFiles;
 const copyPackageAndDependencies = utils.copyPackageAndDependencies;
+const moduleCopier = require('./module-copier');
 
 const ROOT_DIR = path.join(__dirname, '../..');
 const SUPPORT_DIR = path.join(ROOT_DIR, 'support');
@@ -176,12 +177,9 @@ class Packager {
 	 * @returns {Promise<void>}
 	 */
 	async packageNodeModules() {
+		console.log('Copying production npm dependencies');
 		// Copy node_modules/
-		await this.copy([ 'node_modules' ]);
-
-		// Now run 'npm prune --production' on the zipSDKDir, so we retain only production dependencies
-		console.log('Pruning to production npm dependencies');
-		await exec('npm prune --production', { cwd: this.zipSDKDir });
+		await moduleCopier.execute(this.srcDir, this.zipSDKDir);
 
 		// Remove any remaining binary scripts from node_modules
 		await fs.remove(path.join(this.zipSDKDir, 'node_modules/.bin'));


### PR DESCRIPTION
**Description:**
When we package up the SDK in our build process I used to handle the `node_modules` by doing:
- straight copy of the folder to the built SDK
- running `npm prune --production` to let npm remove all dev depndencies
- doing extra hacks we need around node-ios-device prebuilt binaries and node-titanium-sdk

This PR changes the first two steps to instead traverse the packages and copy over only the production dependencies. This came out of a PR I submitted to Brenton's package: brentonhouse/titanium-module-copier#2

He's using that package to run in some custom alloy build hook or something os needs it to run sync and do some other things that I don't think align with what I wanted to do here.

The goal here is to eventually also re-use this code in our CLI build process to allow copying production `node_modules` into the user's app so that they can have a top-level `package.json` and not have to stick it in `Resources/` or `app/lib` or something. I assume at that point we'll have to add extra knowledge about our re-packaged native modules and run things through the jsanalyze code.