### PR TITLE
fix(android): validate clearCookies url

### DIFF
--- a/android/modules/network/src/java/ti/modules/titanium/network/TiHTTPClient.java
+++ b/android/modules/network/src/java/ti/modules/titanium/network/TiHTTPClient.java
@@ -732,6 +732,10 @@ public class TiHTTPClient
 
 	public void clearCookies(String url)
 	{
+		if (url == null) {
+			return;
+		}
+
 		List<HttpCookie> cookies = new ArrayList<HttpCookie>(cookieManager.getCookieStore().getCookies());
 		cookieManager.getCookieStore().removeAll();
 		String lower_url = url.toLowerCase();


### PR DESCRIPTION
- Validate `url` is not `null` for `TiHTTPClient.clearCookies()`

##### TEST CASE
```JS
const client = Ti.Network.createHTTPClient({
    onload : (e) => {
        // attempt to clear cookies of invalid host
        client.clearCookies(null);
    }
});
client.open('GET', 'https://google.com/');
client.send();
```
- Should not throw an exception

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-27200)