### PR TITLE
 chore(package): update ioslib to version 1.7.9 (8_1_X)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6131,9 +6131,9 @@
       "dev": true
     },
     "ioslib": {
-      "version": "1.7.7",
-      "resolved": "https://registry.npmjs.org/ioslib/-/ioslib-1.7.7.tgz",
-      "integrity": "sha512-PkBKLGAex/2dWQ5aEAEyNVj4HNwIwC120N5lHZJN5QjITQwR3XM9vhUXhDpntvmP8KsDerkqHvi/REnsMbSgUQ==",
+      "version": "1.7.9",
+      "resolved": "https://registry.npmjs.org/ioslib/-/ioslib-1.7.9.tgz",
+      "integrity": "sha512-Kvr/7aqeyInvsIt9dduW2venRPfE+lKrVsxrkH2bYpInPqv032nlwRidqAUzEFOjUZxivIoTAwyfhnozF/AIRA==",
       "requires": {
         "always-tail": "0.2.0",
         "async": "^2.6.1",
@@ -6224,9 +6224,9 @@
           }
         },
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "node-appc": {
           "version": "0.2.49",
@@ -7895,9 +7895,9 @@
           }
         },
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
@@ -8257,9 +8257,9 @@
           }
         },
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "needle": {
           "version": "2.2.4",
@@ -8654,9 +8654,9 @@
       "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g=="
     },
     "npm-packlist": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.1.tgz",
-      "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.4.tgz",
+      "integrity": "sha512-zTLo8UcVYtDU3gdeaFu2Xu0n0EvelfHDGuqtNIn5RO7yQj4H1TqNdBc/yZjxnWA0PVB8D3Woyp0i5B43JwQ6Vw==",
       "requires": {
         "ignore-walk": "^3.0.1",
         "npm-bundled": "^1.0.1"
@@ -10516,17 +10516,17 @@
       }
     },
     "tar": {
-      "version": "4.4.8",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
-      "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
+      "version": "4.4.10",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.10.tgz",
+      "integrity": "sha512-g2SVs5QIxvo6OLp0GudTqEf05maawKUxXru104iaayWA09551tFCTI8f1Asb4lPfkBr91k07iL4c11XO3/b0tA==",
       "requires": {
         "chownr": "^1.1.1",
         "fs-minipass": "^1.2.5",
-        "minipass": "^2.3.4",
-        "minizlib": "^1.1.1",
+        "minipass": "^2.3.5",
+        "minizlib": "^1.2.1",
         "mkdirp": "^0.5.0",
         "safe-buffer": "^5.1.2",
-        "yallist": "^3.0.2"
+        "yallist": "^3.0.3"
       }
     },
     "tar-stream": {

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "ejs": "^2.6.1",
     "fields": "0.1.24",
     "fs-extra": "^8.0.1",
-    "ioslib": "^1.7.7",
+    "ioslib": "^1.7.9",
     "klaw-sync": "^6.0.0",
     "liveview": "^1.5.0",
     "lodash.defaultsdeep": "^4.6.0",


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-27124

**Optional Description:**
This backports ioslib 1.7.9 to SDK 8.1.0

While 8.2.0 is our Xcode 11/ iOS 13 target release, installing Xcode 11 betas can break SDK usage even if the user retains Xcode 10 and keeps it as the selected one. Porting this back helps fix that issue for users.

Relates to #11019