### PR TITLE
TIMOB-27164 iOS: Implement async Ti.Database.DB methods

### DIFF
--- a/android/modules/database/src/java/ti/modules/titanium/database/TiDatabaseProxy.java
+++ b/android/modules/database/src/java/ti/modules/titanium/database/TiDatabaseProxy.java
@@ -6,6 +6,7 @@
  */
 package ti.modules.titanium.database;
 
+import org.appcelerator.kroll.KrollDict;
 import org.appcelerator.kroll.KrollFunction;
 import org.appcelerator.kroll.KrollProxy;
 import org.appcelerator.kroll.annotations.Kroll;
@@ -251,13 +252,27 @@ public class TiDatabaseProxy extends KrollProxy
 				@Override
 				public void run()
 				{
-					final TiResultSetProxy result = execute(query, parameters);
-					callback.callAsync(getKrollObject(), new Object[] { result });
+					Object[] args = null;
+					try {
+						final TiResultSetProxy result = execute(query, parameters);
+						args = new Object[] { null, result };
+					} catch (Throwable t) {
+						args = new Object[] { buildErrorObject(t) };
+					}
+					callback.callAsync(getKrollObject(), args);
 				}
 			});
 		} catch (InterruptedException e) {
 			// Ignore...
 		}
+	}
+
+	private Object buildErrorObject(Throwable t)
+	{
+		// TODO: Produce a better error object!
+		KrollDict callbackArgs = new KrollDict();
+		callbackArgs.putCodeAndMessage(0, t.getMessage());
+		return callbackArgs;
 	}
 
 	/**
@@ -299,8 +314,14 @@ public class TiDatabaseProxy extends KrollProxy
 				@Override
 				public void run()
 				{
-					final Object[] results = executeAll(queries);
-					callback.callAsync(getKrollObject(), new Object[] { results });
+					Object[] args = null;
+					try {
+						final Object[] results = executeAll(queries);
+						args = new Object[] { null, results };
+					} catch (Throwable t) {
+						args = new Object[] { buildErrorObject(t) };
+					}
+					callback.callAsync(getKrollObject(), args);
 				}
 			});
 		} catch (InterruptedException e) {

--- a/android/runtime/common/src/java/org/appcelerator/kroll/JSError.java
+++ b/android/runtime/common/src/java/org/appcelerator/kroll/JSError.java
@@ -1,0 +1,13 @@
+/**
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2019-Present by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+package org.appcelerator.kroll;
+
+import java.util.HashMap;
+
+public interface JSError {
+	HashMap getJSProperties();
+}

--- a/android/runtime/v8/src/native/JNIUtil.cpp
+++ b/android/runtime/v8/src/native/JNIUtil.cpp
@@ -56,6 +56,7 @@ jclass JNIUtil::krollAssetHelperClass = NULL;
 jclass JNIUtil::krollLoggingClass = NULL;
 jclass JNIUtil::krollDictClass = NULL;
 jclass JNIUtil::referenceTableClass = NULL;
+jclass JNIUtil::jsErrorClass = NULL;
 
 jmethodID JNIUtil::classGetNameMethod = NULL;
 jmethodID JNIUtil::arrayListInitMethod = NULL;
@@ -115,6 +116,8 @@ jmethodID JNIUtil::krollAssetHelperReadAssetMethod = NULL;
 jmethodID JNIUtil::krollLoggingLogWithDefaultLoggerMethod = NULL;
 
 jmethodID JNIUtil::krollRuntimeDispatchExceptionMethod = NULL;
+
+jmethodID JNIUtil::getJSPropertiesMethod = NULL;
 
 JNIEnv* JNIScope::current = NULL;
 
@@ -337,7 +340,9 @@ void JNIUtil::initCache()
 	krollExceptionClass = findClass("org/appcelerator/kroll/KrollException");
 	krollDictClass = findClass("org/appcelerator/kroll/KrollDict");
 	referenceTableClass = findClass("org/appcelerator/kroll/runtime/v8/ReferenceTable");
+	jsErrorClass = findClass("org/appcelerator/kroll/JSError");
 
+	getJSPropertiesMethod = getMethodID(jsErrorClass, "getJSProperties", "()Ljava/util/HashMap;", false);
 	classGetNameMethod = getMethodID(classClass, "getName", "()Ljava/lang/String;", false);
 	arrayListInitMethod = getMethodID(arrayListClass, "<init>", "()V", false);
 	arrayListAddMethod = getMethodID(arrayListClass, "add", "(Ljava/lang/Object;)Z", false);

--- a/android/runtime/v8/src/native/JNIUtil.h
+++ b/android/runtime/v8/src/native/JNIUtil.h
@@ -107,6 +107,7 @@ public:
 	static jclass krollDictClass;
 	static jclass tiJsErrorDialogClass;
 	static jclass referenceTableClass;
+	static jclass jsErrorClass;
 
 	// Java methods
 	static jmethodID classGetNameMethod;
@@ -137,9 +138,11 @@ public:
 	static jmethodID v8ObjectInitMethod;
 	static jmethodID v8FunctionInitMethod;
 
+	// KrollDict
 	static jmethodID krollDictInitMethod;
 	static jmethodID krollDictPutMethod;
 
+	// ReferenceTable
 	static jmethodID referenceTableCreateReferenceMethod;
 	static jmethodID referenceTableDestroyReferenceMethod;
 	static jmethodID referenceTableMakeWeakReferenceMethod;
@@ -148,12 +151,19 @@ public:
 	static jmethodID referenceTableGetReferenceMethod;
 	static jmethodID referenceTableIsStrongReferenceMethod;
 
+	// KrollRuntime
 	static jint krollRuntimeDontIntercept;
+	static jmethodID krollRuntimeDispatchExceptionMethod;
+
 	static jmethodID krollInvocationInitMethod;
 	static jmethodID krollExceptionInitMethod;
+
+	// KrollObject
 	static jfieldID krollObjectProxySupportField;
 	static jmethodID krollObjectSetHasListenersForEventTypeMethod;
 	static jmethodID krollObjectOnEventFiredMethod;
+
+	// KrollProxy
 	static jmethodID krollProxyCreateProxyMethod;
 	static jfieldID krollProxyKrollObjectField;
 	static jfieldID krollProxyModelListenerField;
@@ -161,10 +171,15 @@ public:
 	static jmethodID krollProxyGetIndexedPropertyMethod;
 	static jmethodID krollProxyOnPropertyChangedMethod;
 	static jmethodID krollProxyOnPropertiesChangedMethod;
-	static jmethodID krollLoggingLogWithDefaultLoggerMethod;
-	static jmethodID krollRuntimeDispatchExceptionMethod;
 
+	// KrollLogging
+	static jmethodID krollLoggingLogWithDefaultLoggerMethod;
+
+	// KrollAssetHelper
 	static jmethodID krollAssetHelperReadAssetMethod;
+
+	// CustomError
+	static jmethodID getJSPropertiesMethod;
 
 };
 

--- a/android/runtime/v8/src/native/JSException.cpp
+++ b/android/runtime/v8/src/native/JSException.cpp
@@ -1,19 +1,13 @@
 /**
  * Appcelerator Titanium Mobile
- * Copyright (c) 2011-2018 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2011-Present by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
-#include <cstring>
-#include <sstream>
-
 #include <jni.h>
 #include <v8.h>
 
-#include "JNIUtil.h"
 #include "TypeConverter.h"
-#include "V8Util.h"
-
 #include "JSException.h"
 
 using namespace v8;
@@ -34,45 +28,10 @@ Local<Value> JSException::fromJavaException(v8::Isolate* isolate, jthrowable jav
 	}
 	env->ExceptionClear();
 
-	jstring javaMessage = (jstring) env->CallObjectMethod(javaException, JNIUtil::throwableGetMessageMethod);
-	if (!javaMessage) {
-		return THROW(isolate, "Java Exception occurred");
-	}
-
-	Local<Context> context = isolate->GetCurrentContext();
-
-	// Grab the top-level error message
-	Local<Value> message = TypeConverter::javaStringToJsString(isolate, env, javaMessage);
-	env->DeleteLocalRef(javaMessage);
-	// Create a JS Error holding this message
-	// We use .As<String> here because we know that the return value of TypeConverter::javaStringToJsString
-	// must be a String. Only other variant is Null when the javaMessage is null, which we already checked for above.
-	// We use .As<Object> on Error because an Error is an Object.
-	Local<Object> error = Exception::Error(message.As<String>()).As<Object>();
-
-	// Now loop through the java stack and generate a JS String from the result and assign to Local<String> stack
-	std::stringstream stackStream;
-	jobjectArray frames = (jobjectArray) env->CallObjectMethod(javaException, JNIUtil::throwableGetStackTraceMethod);
-	jsize frames_length = env->GetArrayLength(frames);
-	for (int i = 0; i < (frames_length > MAX_STACK ? MAX_STACK : frames_length); i++) {
-		jobject frame = env->GetObjectArrayElement(frames, i);
-		jstring javaStack = (jstring) env->CallObjectMethod(frame, JNIUtil::stackTraceElementToStringMethod);
-
-		const char* stackPtr = env->GetStringUTFChars(javaStack, NULL);
-		stackStream << std::endl << "    " << stackPtr;
-
-		env->ReleaseStringUTFChars(javaStack, stackPtr);
-		env->DeleteLocalRef(javaStack);
-	}
+	Local<Object> error = TypeConverter::javaThrowableToJSError(isolate, env, javaException);
 	if (deleteRef) {
 		env->DeleteLocalRef(javaException);
 	}
-	stackStream << std::endl;
-
-	// Now explicitly assign our properly generated stacktrace
-	Local<String> javaStack = String::NewFromUtf8(isolate, stackStream.str().c_str());
-	error->Set(context, STRING_NEW(isolate, "nativeStack"), javaStack);
-
 	// throw it
 	return isolate->ThrowException(error);
 }

--- a/android/runtime/v8/src/native/JSException.h
+++ b/android/runtime/v8/src/native/JSException.h
@@ -1,6 +1,6 @@
 /**
  * Appcelerator Titanium Mobile
- * Copyright (c) 2011-2016 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2011-Present by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
@@ -11,7 +11,7 @@
 #include <jni.h>
 #include <v8.h>
 
-#define MAX_STACK 10
+#include "JNIUtil.h"
 
 #define THROW(isolate, msg) \
 	isolate->ThrowException(v8::String::NewFromUtf8(isolate, msg))

--- a/android/runtime/v8/src/native/TypeConverter.cpp
+++ b/android/runtime/v8/src/native/TypeConverter.cpp
@@ -4,7 +4,10 @@
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
+#include <cstring>
+#include <sstream>
 #include <limits>
+
 #include <jni.h>
 #include <stdio.h>
 #include <v8.h>
@@ -1022,6 +1025,9 @@ Local<Value> TypeConverter::javaObjectToJsValue(Isolate* isolate, JNIEnv *env, j
 	} else if (env->IsInstanceOf(javaObject, JNIUtil::booleanArrayClass)) {
 		return javaArrayToJsArray(isolate, (jbooleanArray) javaObject);
 
+	} else if (env->IsInstanceOf(javaObject, JNIUtil::throwableClass)) {
+		return javaThrowableToJSError(isolate, (jthrowable) javaObject);
+
 	} else if (env->IsSameObject(JNIUtil::undefinedObject, javaObject)) {
 		return Undefined(isolate);
 	}
@@ -1163,4 +1169,78 @@ Local<Array> TypeConverter::javaShortArrayToJsNumberArray(Isolate* isolate, JNIE
 	}
 	env->ReleaseShortArrayElements(javaShortArray, arrayElements, JNI_ABORT);
 	return jsArray;
+}
+
+Local<Object> TypeConverter::javaThrowableToJSError(Isolate* isolate, jthrowable javaException)
+{
+	JNIEnv *env = JNIScope::getEnv();
+	if (env == NULL) {
+		return Local<Object>();
+	}
+	return TypeConverter::javaThrowableToJSError(isolate, env, javaException);
+}
+
+Local<Object> TypeConverter::javaThrowableToJSError(v8::Isolate* isolate, JNIEnv *env, jthrowable javaException)
+{
+	// Grab the top-level error message
+	jstring javaMessage = (jstring) env->CallObjectMethod(javaException, JNIUtil::throwableGetMessageMethod);
+	Local<Value> message;
+	if (!javaMessage) {
+		message = STRING_NEW(isolate, "Unknown Java Exception occurred");
+	} else {
+		message = TypeConverter::javaStringToJsString(isolate, env, javaMessage);
+		env->DeleteLocalRef(javaMessage);
+	}
+
+	// Create a JS Error holding this message
+	// We use .As<String> here because we know that the return value of TypeConverter::javaStringToJsString
+	// must be a String. Only other variant is Null when the javaMessage is null, which we already checked for above.
+	// We use .As<Object> on Error because an Error is an Object.
+	Local<Object> error = Exception::Error(message.As<String>()).As<Object>();
+
+	// Now loop through the java stack and generate a JS String from the result and assign to Local<String> stack
+	std::stringstream stackStream;
+	jobjectArray frames = (jobjectArray) env->CallObjectMethod(javaException, JNIUtil::throwableGetStackTraceMethod);
+	jsize frames_length = env->GetArrayLength(frames);
+	for (int i = 0; i < (frames_length > MAX_STACK ? MAX_STACK : frames_length); i++) {
+		jobject frame = env->GetObjectArrayElement(frames, i);
+		jstring javaStack = (jstring) env->CallObjectMethod(frame, JNIUtil::stackTraceElementToStringMethod);
+
+		const char* stackPtr = env->GetStringUTFChars(javaStack, NULL);
+		stackStream << std::endl << "    " << stackPtr;
+
+		env->ReleaseStringUTFChars(javaStack, stackPtr);
+		env->DeleteLocalRef(javaStack);
+	}
+	stackStream << std::endl;
+
+	Local<Context> context = isolate->GetCurrentContext();
+
+	// Now explicitly assign our properly generated stacktrace
+	Local<String> javaStack = String::NewFromUtf8(isolate, stackStream.str().c_str());
+	error->Set(context, STRING_NEW(isolate, "nativeStack"), javaStack);
+
+	// If we're using our custom error interface we can ask for a map of additional properties ot set on the JS Error
+	if (env->IsInstanceOf(javaException, JNIUtil::jsErrorClass)) {
+		jobject customProps = (jobject) env->CallObjectMethod(javaException, JNIUtil::getJSPropertiesMethod);
+		if (customProps) {
+			// Grab the custom properties
+			Local<Object> props = TypeConverter::javaHashMapToJsValue(isolate, env, customProps);
+			env->DeleteLocalRef(customProps);
+
+			// Copy properties over to the JS Error!
+			Local<Array> objectKeys = props->GetOwnPropertyNames(context).ToLocalChecked();
+			int numKeys = objectKeys->Length();
+			for (int i = 0; i < numKeys; i++) {
+				// FIXME: Handle when empty!
+				Local<Value> jsObjectPropertyKey = objectKeys->Get(context, (uint32_t) i).ToLocalChecked();
+				Local<String> keyName = jsObjectPropertyKey.As<String>();
+
+				Local<Value> jsObjectPropertyValue = props->Get(context, jsObjectPropertyKey).ToLocalChecked();
+				error->Set(context, keyName, jsObjectPropertyValue);
+			}
+		}
+	}
+
+	return error;
 }

--- a/android/runtime/v8/src/native/TypeConverter.h
+++ b/android/runtime/v8/src/native/TypeConverter.h
@@ -12,6 +12,8 @@
 #include <jni.h>
 #include <v8.h>
 
+#define MAX_STACK 10
+
 namespace titanium {
 class TypeConverter
 {
@@ -161,6 +163,9 @@ public:
 	static jdoubleArray jsArrayToJavaDoubleArray(v8::Isolate* isolate, JNIEnv *env, v8::Local<v8::Array> jsArray);
 	static v8::Local<v8::Array> javaArrayToJsArray(v8::Isolate* isolate, JNIEnv *env, jdoubleArray javaDoubleArray);
 	static v8::Local<v8::Array> javaArrayToJsArray(v8::Isolate* isolate, JNIEnv *env, jobjectArray javaObjectArray);
+
+	static v8::Local<v8::Object> javaThrowableToJSError(v8::Isolate* isolate, jthrowable javaException);
+	static v8::Local<v8::Object> javaThrowableToJSError(v8::Isolate* isolate, JNIEnv *env, jthrowable javaException);
 
 	// object convert methods
 	static inline jobject jsValueToJavaObject(v8::Isolate* isolate, v8::Local<v8::Value> jsValue) {

--- a/android/runtime/v8/src/native/V8Util.cpp
+++ b/android/runtime/v8/src/native/V8Util.cpp
@@ -11,7 +11,6 @@
 
 #include "V8Util.h"
 #include "JNIUtil.h"
-#include "JSException.h"
 #include "AndroidUtil.h"
 #include "TypeConverter.h"
 

--- a/apidoc/Titanium/Database/DB.yml
+++ b/apidoc/Titanium/Database/DB.yml
@@ -78,8 +78,8 @@ methods:
 
       - name: callback
         summary: Callback when query execution has completed.
-        type: Callback<Titanium.Database.ResultSet>
-    since: { android: "8.1.0" }
+        type: Callback<Object, Titanium.Database.ResultSet>
+    since: { android: "8.1.0", iphone: "8.1.0", ipad: "8.1.0" }
 
   - name: executeAll
     summary: |
@@ -91,7 +91,7 @@ methods:
       - name: queries
         summary: Array of SQL queries to execute.
         type: Array<String>
-    since: { android: "8.1.0" }
+    since: { android: "8.1.0", iphone: "8.1.0", ipad: "8.1.0" }
 
   - name: executeAllAsync
     summary: |
@@ -104,8 +104,8 @@ methods:
 
       - name: callback
         summary: Callback when query execution has completed.
-        type: Callback<Array<Titanium.Database.ResultSet>>
-    since: { android: "8.1.0" }
+        type: Callback<Object, Array<Titanium.Database.ResultSet>>
+    since: { android: "8.1.0", iphone: "8.1.0", ipad: "8.1.0" }
 
   - name: remove
     summary: |

--- a/apidoc/Titanium/Database/DB.yml
+++ b/apidoc/Titanium/Database/DB.yml
@@ -62,7 +62,7 @@ methods:
 
   - name: executeAsync
     summary: |
-      Asynchronously executes an SQL statement against the database and fires a callback with a `ResultSet`.
+      Asynchronously executes an SQL statement against the database and fires a callback with a possible `Error` argument, and a second argument holding a possible `ResultSet`.
     platforms: [android]
     parameters:
       - name: query
@@ -83,7 +83,8 @@ methods:
 
   - name: executeAll
     summary: |
-      Synchronously executes an array of SQL statements against the database and fires a callback with an array of `ResultSet`.
+      Synchronously executes an array of SQL statements against the database and returns an array of `ResultSet`.
+      On failure, this will throw an [Error](BatchQueryError) that reports the failed index and partial results
     returns:
         type: Array<Titanium.Database.ResultSet>
     platforms: [android]
@@ -95,7 +96,8 @@ methods:
 
   - name: executeAllAsync
     summary: |
-      Asynchronously executes an array of SQL statements against the database and fires a callback with an array of `ResultSet`.
+      Asynchronously executes an array of SQL statements against the database and fires a callback with a possible Error, and an array of `ResultSet`.
+      On failure, this will call the callback with an [Error](PossibleBatchQueryError) that reports the failed index, and a second arguemnt with the partial results
     platforms: [android]
     parameters:
       - name: queries
@@ -104,7 +106,7 @@ methods:
 
       - name: callback
         summary: Callback when query execution has completed.
-        type: Callback<Object, Array<Titanium.Database.ResultSet>>
+        type: Callback<PossibleBatchQueryError, Array<Titanium.Database.ResultSet>>
     since: { android: "8.1.0", iphone: "8.1.0", ipad: "8.1.0" }
 
   - name: remove
@@ -139,3 +141,34 @@ properties:
     summary: The number of rows affected by the last query.
     type: Number
     permission: read-only
+
+---
+name: BatchQueryError
+summary: |
+    Simple `Error` instance thrown from the
+    [executeAll](Titanium.Database.DB.executeAll) method in case of failure
+since: { android: "8.1.0", iphone: "8.1.0", ipad: "8.1.0" }
+properties:
+
+  - name: index
+    summary: Index of the failed query
+    type: Number
+    since: { android: "8.1.0", iphone: "8.1.0", ipad: "8.1.0" }
+
+  - name: results
+    summary: partial `ResultSet`s of any successful queries before the failure 
+    type: Array<Titanium.Database.ResultSet>
+    since: { android: "8.1.0", iphone: "8.1.0", ipad: "8.1.0" }
+
+---
+name: PossibleBatchQueryError
+summary: |
+    Simple `Error` argument provided to the callback from the
+    [executeAllAsync](Titanium.Database.DB.executeAllAsync) method in case of failure
+since: { android: "8.1.0", iphone: "8.1.0", ipad: "8.1.0" }
+properties:
+
+  - name: index
+    summary: Index of the failed query
+    type: Number
+    since: { android: "8.1.0", iphone: "8.1.0", ipad: "8.1.0" }

--- a/apidoc/lib/html_generator.js
+++ b/apidoc/lib/html_generator.js
@@ -416,7 +416,11 @@ function exportType(api) {
 					t = 'Array&lt;' + convertAPIToLink(t) + '&gt;';
 				}
 			} else if (t.indexOf('Callback<') === 0) {
-				t = 'Callback&lt;' + convertAPIToLink(t.substring(t.indexOf('<') + 1, t.lastIndexOf('>'))) + '&gt;';
+				// Parse out the multiple types of args!
+				const subTypes = t.substring(t.indexOf('<') + 1, t.lastIndexOf('>'));
+				// split by ', ' then convert to link for each and join by ', '
+				const linkified = subTypes.split(',').map(t => convertAPIToLink(t.trim())).join(', ');
+				t = `Callback&lt;${linkified}&gt;`;
 			} else if (t.indexOf('Dictionary<') === 0) {
 				t = 'Dictionary&lt;' + convertAPIToLink(t.substring(t.indexOf('<') + 1, t.lastIndexOf('>'))) + '&gt;';
 			} else {

--- a/apidoc/lib/typescript_generator.js
+++ b/apidoc/lib/typescript_generator.js
@@ -475,12 +475,12 @@ class GlobalTemplateWriter {
 			const normalizedTypes = docType.map(typeName => this.normalizeType(typeName));
 			return normalizedTypes.indexOf('any') !== -1 ? 'any' : normalizedTypes.join(' | ');
 		}
-
-		if (docType.indexOf('<') !== -1) {
-			const typeRe = /(\w+)<([\w.,]+)>/;
-			const matches = docType.match(typeRe);
-			const baseType = matches[1];
-			const subTypes = matches[2].split(',').map(type => this.normalizeType(type));
+		const lessThanIndex = docType.indexOf('<');
+		if (lessThanIndex !== -1) {
+			const baseType = docType.slice(0, lessThanIndex);
+			const greaterThanIndex = docType.lastIndexOf('>');
+			const subType = docType.slice(lessThanIndex + 1, greaterThanIndex);
+			const subTypes = subType.split(',').map(type => this.normalizeType(type.trim()));
 			if (baseType === 'Array') {
 				return subTypes.map(typeName => {
 					if (usageHint === 'parameter') {

--- a/iphone/Classes/TiDatabaseProxy.h
+++ b/iphone/Classes/TiDatabaseProxy.h
@@ -24,6 +24,12 @@ READONLY_PROPERTY(NSUInteger, rowsAffected, RowsAffected);
 - (void)close;
 // This supports varargs, but we hack it in the impl to check currentArgs
 - (TiDatabaseResultSetProxy *)execute:(NSString *)sql;
+- (void)executeAsync:(NSString *)sql;
+- (NSArray<TiDatabaseResultSetProxy *> *)executeAll:(NSArray<NSString *> *)queries;
+JSExportAs(executeAllAsync,
+           -(void)executeAllAsync
+           : (NSArray<NSString *> *)queries withCallback
+           : (JSValue *)callback);
 - (void)remove;
 
 @end

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/ObjcProxy.h
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/ObjcProxy.h
@@ -148,6 +148,9 @@ JSExportAs(fireEvent,
 + (void)throwException:(NSString *)reason subreason:(NSString *)subreason location:(NSString *)location;
 - (void)throwException:(NSString *)reason subreason:(NSString *)subreason location:(NSString *)location;
 
++ (JSValue *)createError:(NSString *)reason subreason:(NSString *)subreason location:(NSString *)location inContext:(JSContext *)context;
+- (JSValue *)createError:(NSString *)reason subreason:(NSString *)subreason location:(NSString *)location inContext:(JSContext *)context;
+
 // FIXME: Should id be TiProxy* here?
 - (id)JSValueToNative:(JSValue *)jsValue;
 - (JSValue *)NativeToJSValue:(id)proxy;

--- a/tests/Resources/ti.database.test.js
+++ b/tests/Resources/ti.database.test.js
@@ -1,0 +1,645 @@
+/*
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2011-Present by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+/* eslint-env mocha */
+/* eslint no-unused-expressions: "off" */
+'use strict';
+const should = require('./utilities/assertions');
+
+describe('Titanium.Database', function () {
+	it('apiName', function () {
+		should(Ti.Database.apiName).be.eql('Ti.Database');
+		should(Ti.Database).have.readOnlyProperty('apiName').which.is.a.String;
+	});
+
+	it('FIELD_TYPE_DOUBLE', function () {
+		should(Ti.Database).have.constant('FIELD_TYPE_DOUBLE').which.is.a.Number;
+	});
+
+	it('FIELD_TYPE_FLOAT', function () {
+		should(Ti.Database).have.constant('FIELD_TYPE_FLOAT').which.is.a.Number;
+	});
+
+	it('FIELD_TYPE_INT', function () {
+		should(Ti.Database).have.constant('FIELD_TYPE_INT').which.is.a.Number;
+	});
+
+	it('FIELD_TYPE_STRING', function () {
+		should(Ti.Database).have.constant('FIELD_TYPE_STRING').which.is.a.Number;
+	});
+
+	describe('.install()', () => {
+		it('is a function', () => {
+			should(Ti.Database.install).not.be.undefined;
+			should(Ti.Database.install).be.a.Function;
+		});
+
+		// FIXME Get working for iOS - gets back John Smith\\u0000'
+		// FIXME Get working on Android, either lastInsertRowId or rowsAffected is starting as 1, not 0
+		it.androidAndIosBroken('copies db from app folder', function () {
+			// Database name
+			var dbName = 'testDbInstall';
+
+			// Copy database 'testDbResource.db' over from the application folder
+			// into the application data folder as 'testDbInstall'
+			var db = Ti.Database.install('testDbResource.db', dbName);
+
+			// Confirm 'db' is an object
+			should(db).be.a.Object;
+
+			// Confirm 'db.file' property is a valid object
+			should(db.file).be.a.Object;
+
+			// Validate the 'db.lastInsertRowId' property
+			should(db.lastInsertRowId).be.a.Number;
+			should(db.lastInsertRowId).be.eql(0);
+
+			// Confirm 'db.name' is a string
+			should(db.name).be.a.String;
+			should(db.name).be.eql(dbName);
+
+			// Validate the 'db.rowsAffected' property
+			should(db.rowsAffected).be.a.Number;
+			should(db.rowsAffected).be.eql(0);
+
+			// Define test data
+			var testName = 'John Smith';
+			var testNumber = 123456789;
+			var testArray = [ 'Smith John', 987654321 ];
+
+			// Execute a query to return the rows of the database
+			var rows = db.execute('SELECT rowid, text, number FROM testTable');
+
+			// Validate the returned 'rows' object
+			should(rows).be.a.Object;
+			should(rows.rowCount).be.eql(2);
+			should(rows.fieldCount).be.eql(3);
+			// Validate field names
+			should(rows.fieldName(0)).be.eql('rowid');
+			should(rows.fieldName(1)).be.eql('text');
+			should(rows.fieldName(2)).be.eql('number');
+
+			// Loop through each row
+			var index = 1;
+			while (rows.isValidRow()) {
+
+				// Validate the rowid field
+				var rowid = rows.fieldByName('rowid');
+				should(rowid).be.a.Number;
+				should(rowid).be.eql(index);
+
+				// Case insensitive search
+				rowid = rows.fieldByName('ROWID');
+				should(rowid).be.a.Number;
+				should(rowid).be.eql(index);
+
+				// Validate the text field
+				var text = rows.field(1);
+				should(text).be.a.String;
+
+				// Validate the number field
+				var number = rows.fieldByName('number');
+				should(number).be.a.Number;
+
+				// Case insensitive search
+				number = rows.fieldByName('NUMBER');
+				should(number).be.a.Number;
+
+				// Validate the test data
+				if (index === 1) {
+					should(text).be.eql(testName);
+					should(number).be.eql(testNumber);
+				} else if (index === 2) {
+					should(number).be.eql(testArray[1]);
+					should(text).be.eql(testArray[0]);
+				}
+
+				// Next row
+				rows.next();
+				index++;
+			}
+
+			// Close the 'rows' object
+			rows.close();
+
+			// test aliased field name
+			var aliased = db.execute('SELECT rowid, text AS something FROM testTable');
+
+			// Validate the returned 'rows' object
+			should(aliased).be.a.Object;
+			should(aliased.rowCount).be.eql(2);
+			should(aliased.fieldCount).be.eql(2);
+			// Validate field names
+			should(aliased.fieldName(0)).be.eql('rowid');
+			should(aliased.fieldName(1)).be.eql('something');
+
+			// Close the 'rows' object
+			aliased.close();
+
+			// Remove the 'testDbInstall' database file
+			db.remove();
+
+			// Close the database (unnecessary as remove() does this for us)
+			db.close();
+		});
+
+		// If the source db file was not found, then install() must throw an exception.
+		it('throws if missing source db', () => {
+			should.throws(() => {
+				Ti.Database.install('BadFilePath.db', 'IShouldNotExist.db');
+			}, Error);
+		});
+	});
+
+	describe('.open()', () => {
+		// Check if open exists and make sure it does not throw exception
+		// FIXME Get working on Android, either lastInsertRowId or rowsAffected is starting as 1, not 0
+		it.androidBroken('opens or creates database', function () {
+			should(Ti.Database.open).not.be.undefined;
+			should(Ti.Database.open).be.a.Function;
+
+			// Database name
+			var dbName = 'testDbOpen';
+
+			// Open database 'testDbOpen' if it exists in the
+			// application data folder, otherwise create a new one
+			var db = Ti.Database.open(dbName);
+
+			// Confirm 'db' is an object
+			should(db).be.a.Object;
+
+			// Confirm 'db.file' property is a valid object
+			should(db.file).be.a.Object;
+
+			// Validate the 'db.lastInsertRowId' property
+			should(db.lastInsertRowId).be.a.Number;
+			should(db.lastInsertRowId).be.eql(0);
+
+			// Confirm 'db.name' is a string
+			should(db.name).be.a.String;
+			should(db.name).be.eql(dbName);
+
+			// Validate the 'db.rowsAffected' property
+			should(db.rowsAffected).be.a.Number;
+			should(db.rowsAffected).be.eql(0);
+
+			// Execute a query to create a test table
+			db.execute('CREATE TABLE IF NOT EXISTS testTable (text TEXT, number INTEGER)');
+
+			// Delete any existing data if the table already existed
+			db.execute('DELETE FROM testTable');
+
+			// Define test data
+			var testName = 'John Smith';
+			var testNumber = 123456789;
+
+			// Insert test data into the table
+			db.execute('INSERT INTO testTable (text, number) VALUES (?, ?)', testName, testNumber);
+
+			// Validate that only one row has been affected
+			should(db.rowsAffected).be.eql(1);
+
+			// Define more test data
+			var testArray = [ 'Smith John', 987654321 ];
+
+			// Insert more test data into the table
+			db.execute('INSERT INTO testTable (text, number) VALUES (?, ?)', testArray);
+
+			// Validate that only one row has been affected
+			should(db.rowsAffected).be.eql(1);
+
+			// Execute a query to return the rows of the database
+			var rows = db.execute('SELECT rowid, text, number FROM testTable');
+
+			// Validate the returned 'rows' object
+			should(rows).be.a.Object;
+			should(rows.rowCount).be.eql(2);
+			should(rows.fieldCount).be.eql(3);
+			should(rows.validRow).be.true;
+			should(rows.isValidRow()).be.true;
+
+			// Loop through each row
+			var index = 1;
+			while (rows.isValidRow()) {
+
+				// Validate the rowid field
+				var rowid = rows.fieldByName('rowid');
+				should(rowid).be.a.Number;
+				should(rowid).be.eql(index);
+
+				// Validate the text field
+				var text = rows.field(1);
+				should(text).be.a.String;
+
+				// Validate the number field
+				var number = rows.fieldByName('number');
+				should(number).be.a.Number;
+
+				// Validate the test data
+				if (index === 1) {
+					should(text).be.eql(testName);
+					should(number).be.eql(testNumber);
+				} else if (index === 2) {
+					should(number).be.eql(testArray[1]);
+					should(text).be.eql(testArray[0]);
+				}
+
+				// Next row
+				rows.next();
+				index++;
+			}
+
+			// Close the 'rows' object
+			rows.close();
+
+			// Remove the 'testDbInstall' database file
+			db.remove();
+
+			// Close the database (unnecessary as remove() does this for us)
+			db.close();
+		});
+	});
+
+	// Check if it guards against 'closed' results
+	// FIXME Get working on Android, seems to retain rowCount after Result.close()
+	it.androidBroken('guards multiple calls to ResultSet#close()', function () {
+		// Database name
+		var dbName = 'testDbOpen';
+
+		// Open database 'testDbOpen' if it exists in the
+		// application data folder, otherwise create a new one
+		var db = Ti.Database.open(dbName);
+
+		// Execute a query to create a test table
+		db.execute('CREATE TABLE IF NOT EXISTS testTable (text TEXT, number INTEGER)');
+
+		// Delete any existing data if the table already existed
+		db.execute('DELETE FROM testTable');
+
+		// Define test data
+		var testName = 'John Smith';
+		var testNumber = 123456789;
+
+		// Insert test data into the table
+		db.execute('INSERT INTO testTable (text, number) VALUES (?, ?)', testName, testNumber);
+
+		// Validate that only one row has been affected
+		should(db.rowsAffected).be.eql(1);
+
+		// Define more test data
+		var testArray = [ 'Smith John', 987654321 ];
+
+		// Insert more test data into the table
+		db.execute('INSERT INTO testTable (text, number) VALUES (?, ?)', testArray);
+
+		// Validate that only one row has been affected
+		should(db.rowsAffected).be.eql(1);
+
+		// Execute a query to return the rows of the database
+		var rows = db.execute('SELECT rowid, text, number FROM testTable');
+
+		// Validate the returned 'rows' object
+		should(rows).be.a.Object;
+		should(rows.rowCount).be.eql(2);
+		should(rows.fieldCount).be.eql(3);
+		should(rows.validRow).be.true;
+
+		// Close the 'rows' object
+		rows.close();
+
+		// Make sure row is not 'valid'
+		should(rows.rowCount).be.eql(0); // Android still reports 2
+		should(rows.fieldCount).be.eql(0);
+		should(rows.validRow).be.false;
+
+		// Validate the rowid field
+		var rowid = rows.fieldByName('rowid');
+		should(rowid).not.exist; // null or undefined
+
+		// Validate the closed field
+		var field1 = rows.field(1);
+		should(field1).not.exist; // null or undefined
+
+		var field2 = rows.fieldByName('number');
+		should(field2).not.exist; // null or undefined
+
+		// Make sure next doesn't cause crash and return false
+		should(rows.next()).be.false;
+
+		// Make sure closing again doesn't cause crash
+		rows.close();
+
+		// Remove the 'testDbInstall' database file
+		db.remove();
+
+		// Close the database (unnecessary as remove() does this for us)
+		db.close();
+	});
+
+	describe('#execute()', () => {
+		it('is a function', () => {
+			const db = Ti.Database.open('execute.db');
+			try {
+				should(db.execute).be.a.Function;
+			} finally {
+				db.close();
+			}
+		});
+
+		// Test behavior expected by alloy code for createCollection. See TIMOB-20222
+		// skip this test, this behaviour is undocumented. Our current code will return null
+		// only if the result contains no fields/columns instead of the result containing no rows
+		it.skip('returns null instead of empty result set for pragma command', function () { // eslint-disable-line mocha/no-skipped-tests
+			// Call install on a database file that doesn't exist. We should just make a new db with name 'category'
+			const db = Ti.Database.install('made.up.sqlite', 'category');
+
+			try {
+				// Confirm 'db' is an object
+				should(db).be.a.Object;
+				const rows = db.execute('pragma table_info(\'category\');');
+				should(rows).be.null;
+			} finally {
+				// Remove the 'category' database file
+				db.remove();
+
+				// Close the database (unnecessary as remove() does this for us)
+				db.close();
+			}
+		});
+
+		it('throws Error for invalid SQL statement', () => { // eslint-disable-line mocha/no-identical-title
+			const db = Ti.Database.open('execute.db');
+			try {
+				should.throws(() => {
+					db.execute('THIS IS INVALID SQL');
+				}, Error);
+			} catch (e) {
+				db.close();
+				throw e;
+			}
+		});
+	});
+
+	// Integer boundary tests.
+	// Verify we can read/write largest/smallest 64-bit int values supported by JS number type.
+	it('db read/write integer boundaries', function () {
+		const MAX_SIGNED_INT32 = 2147483647;
+		const MIN_SIGNED_INT32 = -2147483648;
+		const MAX_SIGNED_INT16 = 32767;
+		const MIN_SIGNED_INT16 = -32768;
+		const rows = [
+			Number.MAX_SAFE_INTEGER,
+			MAX_SIGNED_INT32 + 1,
+			MAX_SIGNED_INT32,
+			MAX_SIGNED_INT16 + 1,
+			MAX_SIGNED_INT16,
+			1,
+			0,
+			-1,
+			MIN_SIGNED_INT16,
+			MIN_SIGNED_INT16 - 1,
+			MIN_SIGNED_INT32,
+			MIN_SIGNED_INT32 - 1,
+			Number.MIN_SAFE_INTEGER
+		];
+
+		const dbConnection = Ti.Database.open('int_test.db');
+		dbConnection.execute('CREATE TABLE IF NOT EXISTS intTable(id INTEGER PRIMARY KEY, intValue INTEGER);');
+		dbConnection.execute('DELETE FROM intTable;');
+		for (let index = 0; index < rows.length; index++) {
+			dbConnection.execute('INSERT INTO intTable (id, intValue) VALUES (?, ?);', index, rows[index]);
+		}
+		const resultSet = dbConnection.execute('SELECT id, intValue FROM intTable ORDER BY id');
+		should(resultSet.rowCount).eql(rows.length);
+		for (let index = 0; resultSet.isValidRow(); resultSet.next(), index++) {
+			should(resultSet.field(1)).eql(rows[index]);
+		}
+		dbConnection.close();
+	});
+
+	describe.windowsMissing('#executeAsync()', () => {
+		it('is a function', () => {
+			const db = Ti.Database.open('execute_async.db');
+			try {
+				should(db.executeAsync).be.a.Function;
+			} finally {
+				db.close();
+			}
+		});
+
+		it('executes asynchronously', function (finish) {
+			this.timeout(5000);
+			const db = Ti.Database.open('execute_async.db');
+			// Execute a query to create a test table
+			db.executeAsync('CREATE TABLE IF NOT EXISTS testTable (text TEXT, number INTEGER)', err => {
+				should(err).not.exist;
+				// Delete any existing data if the table already existed
+				db.executeAsync('DELETE FROM testTable', err => {
+					should(err).not.exist;
+
+					// Define test data
+					const testName = 'John Smith';
+					const testNumber = 123456789;
+
+					// Insert test data into the table
+					db.executeAsync('INSERT INTO testTable (text, number) VALUES (?, ?)', testName, testNumber, err => {
+						should(err).not.exist;
+
+						// Validate that only one row has been affected
+						should(db.rowsAffected).be.eql(1);
+
+						// Execute a query to return the rows of the database
+						db.executeAsync('SELECT rowid, text, number FROM testTable', (err, rows) => {
+							try {
+								should(err).not.exist;
+								// Validate the returned 'rows' object
+								should(rows).be.a.Object;
+								should(rows.rowCount).be.eql(1);
+								should(rows.fieldCount).be.eql(3);
+								should(rows.validRow).be.true;
+
+								finish();
+							} catch (e) {
+								finish(e);
+							} finally {
+								// Close the 'rows' object
+								rows.close();
+								db.close();
+							}
+						});
+					});
+				});
+			});
+		});
+
+		it('calls callback with Error for invalid SQL', function (finish) {
+			const db = Ti.Database.open('execute_async.db');
+			db.executeAsync('THIS IS SOME INVALID SQL', err => {
+				try {
+					should(err).exist;
+					finish();
+				} catch (e) {
+					finish(e);
+				} finally {
+					db.close();
+				}
+			});
+		});
+	});
+
+	describe.windowsMissing('#executeAll()', () => {
+		it('is a function', () => { // eslint-disable-line mocha/no-identical-title
+			const db = Ti.Database.open('execute_all.db');
+			try {
+				should(db.executeAll).be.a.Function;
+			} finally {
+				db.close();
+			}
+		});
+
+		it('executes synchronously', function (finish) {
+			this.timeout(5000);
+			const db = Ti.Database.open('execute_all.db');
+
+			// FIXME: There's no way to send in binding paramaters, you have to bake them into the query string with this API
+			const queries = [
+				// Execute a query to create a test table
+				'CREATE TABLE IF NOT EXISTS testTable (text TEXT, number INTEGER)',
+				// Delete any existing data if the table already existed
+				'DELETE FROM testTable',
+				// Insert test data into the table
+				'INSERT INTO testTable (text, number) VALUES (\'John Smith\', 123456789)',
+				// Execute a query to return the rows of the database
+				'SELECT rowid, text, number FROM testTable',
+			];
+
+			let rows;
+			try {
+				const results = db.executeAll(queries);
+				// the returned results array should be the same length as the input query array
+				should(results.length).eql(queries.length);
+
+				rows = results[3];
+				// TODO: If a consumer calls executeAll and some of them return a result set, is the caller expected to explicitly close
+				// all the non-null result sets returned?!
+
+				// Validate the returned 'rows' object
+				should(rows).be.a.Object;
+				should(rows.rowCount).be.eql(1);
+				should(rows.fieldCount).be.eql(3);
+				should(rows.validRow).be.true;
+
+				finish();
+			} catch (e) {
+				finish(e);
+			} finally {
+				// Close the 'rows' object
+				if (rows) {
+					rows.close();
+				}
+				db.close();
+			}
+		});
+
+		it('throws Error for invalid SQL statement', () => { // eslint-disable-line mocha/no-identical-title
+			const db = Ti.Database.open('execute_all.db');
+
+			const queries = [
+				'THIS IS INVALID SQL',
+			];
+
+			try {
+				should.throws(() => {
+					db.executeAll(queries);
+				}, Error);
+			} catch (e) {
+				db.close();
+				throw e;
+			}
+		});
+	});
+
+	describe.windowsMissing('#executeAllAsync()', () => {
+		it('is a function', () => { // eslint-disable-line mocha/no-identical-title
+			const db = Ti.Database.open('execute_all_async.db');
+			try {
+				should(db.executeAllAsync).be.a.Function;
+			} finally {
+				db.close();
+			}
+		});
+
+		it('executes asynchronously', function (finish) { // eslint-disable-line mocha/no-identical-title
+			this.timeout(5000);
+			const db = Ti.Database.open('execute_all.db');
+
+			const queries = [
+				// Execute a query to create a test table
+				'CREATE TABLE IF NOT EXISTS testTable (text TEXT, number INTEGER)',
+				// Delete any existing data if the table already existed
+				'DELETE FROM testTable',
+				// Insert test data into the table
+				'INSERT INTO testTable (text, number) VALUES (\'John Smith\', 123456789)',
+				// Execute a query to return the rows of the database
+				'SELECT rowid, text, number FROM testTable',
+			];
+
+			try {
+				db.executeAllAsync(queries, (err, results) => {
+					let rows;
+					try {
+						should(err).not.exist;
+						// the returned results array should be the same length as the input query array
+						should(results.length).eql(queries.length);
+
+						rows = results[3];
+						// Validate the returned 'rows' object
+						should(rows).be.a.Object;
+						should(rows.rowCount).be.eql(1);
+						should(rows.fieldCount).be.eql(3);
+						should(rows.validRow).be.true;
+
+						finish();
+					} catch (e) {
+						finish(e);
+					} finally {
+						// Close the 'rows' object
+						if (rows) {
+							rows.close();
+						}
+						db.close();
+					}
+				});
+			} catch (e) {
+				db.close();
+				finish(e);
+			}
+		});
+
+		it('calls callback with Error for invalid SQL statement', function (finish) { // eslint-disable-line mocha/no-identical-title
+			const db = Ti.Database.open('execute_all.db');
+
+			const queries = [
+				'THIS IS INVALID SQL',
+			];
+
+			try {
+				db.executeAllAsync(queries, (err, _results) => {
+					try {
+						should(err).exist;
+						finish();
+					} finally {
+						db.close();
+					}
+				});
+			} catch (e) {
+				// should call callback with error, not throw it!
+				db.close();
+				finish(e);
+			}
+		});
+	});
+});


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-27164

**Description:**
First, this modifies the test suite to run on iOS and Android. It also fixes expectations so that callbacks expect to receive a first argument of a possible Error object, second argument of results.

Second, this implements the new APIs on iOS. I'm not real sure of the best mechanism for lock/queueing the operations on iOS so that's probably the most important thing for @janvennemann or @vijaysingh-axway to look at - basically now that we have async APIs we need to synchronize access to the database so that only one base DB operation can run simultaneously under the hood. For that I used `@synchronize(self) {}` blocks to lock the `database.prepareStatement`, `statement.executeQuery` and the internal lazy add/removal of statements to an array used to retain/clean them up.