### PR TITLE
chore(deps): update to node-appc@0.3.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8099,9 +8099,9 @@
       "dev": true
     },
     "node-appc": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/node-appc/-/node-appc-0.3.2.tgz",
-      "integrity": "sha512-B5ZQksJJNX9o9pt/xb6usFCn8eBch7duCm+lO3f3gQMiqrB58Imb9ktT1YxBfXPNreoVp5Zr3MiAqtPPZyjmIg==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/node-appc/-/node-appc-0.3.3.tgz",
+      "integrity": "sha512-UNAuJ/muZvW4V6gd3aSUqSp5VlLQFRpEdirGu1AEAZFPZiUsw02lkADxyUmT6QpNrwhzrOx/6CAS2itS1IEanA==",
       "requires": {
         "adm-zip": "^0.4.11",
         "async": "~2.6.1",

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
   },
   "lint-staged": {
     "iphone/**/*.{m,h}": [
-        "npx clang-format -style=file -i",
-        "git add"
+      "npx clang-format -style=file -i",
+      "git add"
     ],
     "iphone/TitaniumKit/TitaniumKit/Sources/API/TopTiModule.m": [
       "npm run ios-sanity-check --"
@@ -75,7 +75,7 @@
     "lodash.defaultsdeep": "^4.6.0",
     "markdown": "0.5.0",
     "moment": "^2.22.2",
-    "node-appc": "^0.3.2",
+    "node-appc": "^0.3.3",
     "node-titanium-sdk": "^3.2.0",
     "node-uuid": "1.4.8",
     "p-limit": "^2.2.0",


### PR DESCRIPTION
[TIMOB-27203](https://jira.appcelerator.org/browse/TIMOB-27203) - iOS: no apiversion validation performed on application build

[TIMOB-27204](https://jira.appcelerator.org/browse/TIMOB-27204) - CLI: apiversion validation always fails for native modules installed via npm
