### PR TITLE
fix(android): fix using barColor with a disabled ActionBar

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/WindowProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/WindowProxy.java
@@ -310,7 +310,13 @@ public class WindowProxy extends TiWindowProxy implements TiActivityWindow
 		// Handle barColor property.
 		if (hasProperty(TiC.PROPERTY_BAR_COLOR)) {
 			int colorInt = TiColorHelper.parseColor(TiConvert.toString(getProperty(TiC.PROPERTY_BAR_COLOR)));
-			activity.getSupportActionBar().setBackgroundDrawable(new ColorDrawable(colorInt));
+			ActionBar actionBar = activity.getSupportActionBar();
+			// Guard for using a theme with actionBar disabled.
+			if (actionBar != null) {
+				actionBar.setBackgroundDrawable(new ColorDrawable(colorInt));
+			} else {
+				Log.w(TAG, "Trying to set a barColor on a Window with ActionBar disabled. Property will be ignored.");
+			}
 		}
 		activity.getActivityProxy().getDecorView().add(this);
 

--- a/tests/Resources/ti.ui.window.addontest.js
+++ b/tests/Resources/ti.ui.window.addontest.js
@@ -1,0 +1,28 @@
+/*
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2011-Present by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+/* eslint-env mocha */
+/* eslint no-unused-expressions: "off" */
+'use strict';
+var should = require('./utilities/assertions');
+
+describe('Titanium.UI.Window', function () {
+	var win;
+
+	it('.barColor with disabled ActionBar', function (finish) {
+		win = Ti.UI.createWindow({
+			barColor: 'blue',
+			title: 'My Title',
+			theme: 'Theme.AppCompat.NoTitleBar',
+		});
+		win.add(Ti.UI.createLabel({ text: 'Window Title Test' }));
+		win.open();
+		win.addEventListener('open', function () {
+			finish();
+		});
+	});
+
+});

--- a/tests/Resources/ti.ui.window.addontest.js
+++ b/tests/Resources/ti.ui.window.addontest.js
@@ -12,7 +12,7 @@ var should = require('./utilities/assertions');
 describe('Titanium.UI.Window', function () {
 	var win;
 
-	it('.barColor with disabled ActionBar', function (finish) {
+	it.android('.barColor with disabled ActionBar', function (finish) {
 		win = Ti.UI.createWindow({
 			barColor: 'blue',
 			title: 'My Title',


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-27232

**Description:**
Adds a guard to check if the ActionBar is disabled for the Window before processing the `barColor` property. Ignores it if this is the case.

**Test case:**
1. Build and run the below code on Android.
2. Verify that a window was displayed with a "Window Title Test" label in the middle.

_app.js_
```js
var window = Ti.UI.createWindow({
	barColor: "blue",
	title: "My Title",
	theme: "Theme.AppCompat.NoTitleBar",
});
window.add(Ti.UI.createLabel({ text: "Window Title Test" }));
window.open();
```
