### PR TITLE
Variety of doc fixes

### DIFF
--- a/apidoc/Titanium/Android/Notification.yml
+++ b/apidoc/Titanium/Android/Notification.yml
@@ -447,13 +447,13 @@ properties:
         The application needs to also set the `android.permission.WAKE_LOCK` permission
         in the Android manifest section of the `tiapp.xml` file.
         
-        <ti:app>
-            <android>
-                <manifest>
-                    <uses-permission android:name="android.permission.WAKE_LOCK" />
-                </manifest>
-            </android>
-        </ti:app>
+            <ti:app>
+                <android>
+                    <manifest>
+                        <uses-permission android:name="android.permission.WAKE_LOCK" />
+                    </manifest>
+                </android>
+            </ti:app>
     type: wakeLockOptions
     default: 0
     since: "6.2.0"

--- a/apidoc/Titanium/Database/DB.yml
+++ b/apidoc/Titanium/Database/DB.yml
@@ -87,7 +87,7 @@ methods:
       On failure, this will throw an [Error](BatchQueryError) that reports the failed index and partial results
     returns:
         type: Array<Titanium.Database.ResultSet>
-    platforms: [android]
+    platforms: [android, iphone, ipad]
     parameters:
       - name: queries
         summary: Array of SQL queries to execute.
@@ -97,8 +97,8 @@ methods:
   - name: executeAllAsync
     summary: |
       Asynchronously executes an array of SQL statements against the database and fires a callback with a possible Error, and an array of `ResultSet`.
-      On failure, this will call the callback with an [Error](PossibleBatchQueryError) that reports the failed index, and a second arguemnt with the partial results
-    platforms: [android]
+      On failure, this will call the callback with an [Error](PossibleBatchQueryError) that reports the failed index, and a second argument with the partial results
+    platforms: [android, iphone, ipad]
     parameters:
       - name: queries
         summary: Array of SQL queries to execute.

--- a/apidoc/Titanium/UI/Matrix3D.yml
+++ b/apidoc/Titanium/UI/Matrix3D.yml
@@ -183,3 +183,16 @@ examples:
               label.animate(a1);
             });
             win.open();
+
+---
+name: Matrix3DCreationDict
+summary: Simple object passed to <Titanium.UI.createMatrix3D> to initialize a matrix.
+description: |
+    The matrix is initialized with the specified transforms.
+properties:
+  - name: scale
+    summary: |
+        Scale the matrix by the specified scaling factor.
+    type: Number
+    optional: true
+    default: 1

--- a/apidoc/Titanium/UI/OptionDialog.yml
+++ b/apidoc/Titanium/UI/OptionDialog.yml
@@ -321,7 +321,8 @@ examples:
 
   - title: Alloy XML Markup
     example: |
-        Previous example as an Alloy view.
+        Previous example as an Alloy view. You can set [cancel](Titanium.UI.OptionDialog.cancel)
+        and [destructive](Titanium.UI.OptionDialog.destructive) on a `<Option/>` tag.
 
         optiondialog.xml:
 
@@ -337,9 +338,9 @@ examples:
 
                         <!-- The Options tag sets the options property. -->
                         <Options>
-                            <Option>Confirm</Option>
+                            <Option destructive="true">Confirm</Option>
                             <Option platform="ios">Help</Option>
-                            <Option>Cancel</Option>
+                            <Option cancel="true">Cancel</Option>
                         </Options>
 
                         <!-- The ButtonNames tag sets the Android-only buttonNames property. -->

--- a/apidoc/Titanium/UI/UI.yml
+++ b/apidoc/Titanium/UI/UI.yml
@@ -160,6 +160,29 @@ methods:
         type: Matrix2DCreationDict
         optional: true
 
+  - name: create3DMatrix
+    summary: Creates and returns an instance of <Titanium.UI.3DMatrix>.
+    returns:
+        type: Titanium.UI.3DMatrix
+    parameters:
+      - name: parameters
+        summary: Initial transformation of the matrix.
+        type: Matrix3DCreationDict
+        optional: true
+    deprecated:
+        since: "8.0.0"
+        notes: Use [Titanium.UI.createMatrix3D](Titanium.UI.createMatrix3D) instead.
+
+  - name: createMatrix3D
+    summary: Creates and returns an instance of <Titanium.UI.Matrix3D>.
+    returns:
+        type: Titanium.UI.Matrix3D
+    parameters:
+      - name: parameters
+        summary: Initial transformation of the matrix.
+        type: Matrix3DCreationDict
+        optional: true
+
   - name: convertUnits
     summary: Converts one type of unit to another using the metrics of the main display.
     description: As this method does not support percentages, `0` is returned if they are specified.

--- a/apidoc/Titanium/UI/UI.yml
+++ b/apidoc/Titanium/UI/UI.yml
@@ -148,7 +148,7 @@ methods:
         optional: true
     deprecated:
         since: "8.0.0"
-        notes: Use [Titanium.UI.Matrix2D](Titanium.UI.Matrix2D) for improved ES6+ compatibility instead.
+        notes: Use [Titanium.UI.createMatrix2D](Titanium.UI.createMatrix2D) instead.
 
   - name: createMatrix2D
     summary: Creates and returns an instance of <Titanium.UI.Matrix2D>.

--- a/apidoc/Titanium/UI/iOS/Attribute.yml
+++ b/apidoc/Titanium/UI/iOS/Attribute.yml
@@ -2,7 +2,7 @@
 name: Titanium.UI.iOS.Attribute
 deprecated:
     since: "3.6.0"
-    notes: Use [Titanium.UI.Attribute](Titanium.UI.Attribute) instead.
+    notes: Use [Attribute](Attribute) instead.
     removed: "6.0.0"
 summary: An abstract datatype for specifying an attributed string attribute.
 description: |

--- a/apidoc/Titanium/UI/iPad/DocumentViewer.yml
+++ b/apidoc/Titanium/UI/iPad/DocumentViewer.yml
@@ -3,7 +3,7 @@ name: Titanium.UI.iPad.DocumentViewer
 deprecated:
     since: "3.0.0"
     removed: "6.0.0"
-    notes: Use [itanium.UI.iOS.DocumentViewer](itanium.UI.iOS.DocumentViewer) instead.
+    notes: Use [Titanium.UI.iOS.DocumentViewer](Titanium.UI.iOS.DocumentViewer) instead.
 summary: |
     A DocumentViewer provides in-app support for managing user interactions with files on the 
     local system.

--- a/apidoc/lib/html_generator.js
+++ b/apidoc/lib/html_generator.js
@@ -419,7 +419,15 @@ function exportType(api) {
 				// Parse out the multiple types of args!
 				const subTypes = t.substring(t.indexOf('<') + 1, t.lastIndexOf('>'));
 				// split by ', ' then convert to link for each and join by ', '
-				const linkified = subTypes.split(',').map(t => convertAPIToLink(t.trim())).join(', ');
+				const linkified = subTypes.split(',').map(t =>  {
+					t = t.trim();
+					if (t.startsWith('Array<')) {
+						const apiName = /Array<(.+)>/.exec(t);
+						return convertAPIToLink(apiName[1]);
+					} else {
+						return convertAPIToLink(t);
+					}
+				}).join(', ');
 				t = `Callback&lt;${linkified}&gt;`;
 			} else if (t.indexOf('Dictionary<') === 0) {
 				t = 'Dictionary&lt;' + convertAPIToLink(t.substring(t.indexOf('<') + 1, t.lastIndexOf('>'))) + '&gt;';


### PR DESCRIPTION
This fixes all the warnings generated by the docgen script. Some by fixing typos, and one by introducing support for `Array<type>` syntax in the html generator.

It also proposes a change to the `create2DMatrix` deprecation notice, by proposing `createMatrix2D` instead (which is a more correct replacement). I'd like to do this for `create3DMatrix` too, but I would need to create an entry in `UI.yml` for it with a correct parameter type, and I can't fully figure out what the actual structure for a `Matrix3DCreationDict` would be, if anyone knows, please ping me!

I'd like to propose we backport this into 8.1.0 otherwise we'll be shipping some invalid docs in places