### PR TITLE
remove getters from drawerlayout documentation

### DIFF
--- a/apidoc/Titanium/UI/Android/DrawerLayout.yml
+++ b/apidoc/Titanium/UI/Android/DrawerLayout.yml
@@ -209,8 +209,8 @@ examples:
             centerView.add(btn);
 
             win.addEventListener('open', function(){
-                var activity = win.getActivity(),
-                    actionBar = activity.getActionBar();
+                var activity = win.activity,
+                    actionBar = activity.actionBar;
 
                 if (actionBar) {
                     actionBar.displayHomeAsUp = true;


### PR DESCRIPTION
Getters are deprecated, documentation still listed two of them.