### PR TITLE
fix(android): fix dialog without selectedIndex reusage

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIDialog.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIDialog.java
@@ -47,7 +47,7 @@ public class TiUIDialog extends TiUIView
 		}
 		public void onClick(DialogInterface dialog, int which)
 		{
-			handleEvent(result);
+			handleEvent(result, true);
 			hide(null);
 		}
 	}
@@ -134,7 +134,7 @@ public class TiUIDialog extends TiUIView
 				@Override
 				public void onClick(DialogInterface dialog, int which)
 				{
-					handleEvent(which);
+					handleEvent(which, true);
 					hide(null);
 				}
 			});
@@ -143,7 +143,7 @@ public class TiUIDialog extends TiUIView
 				@Override
 				public void onClick(DialogInterface dialog, int which)
 				{
-					handleEvent(which);
+					handleEvent(which, false);
 					hide(null);
 				}
 			});
@@ -322,7 +322,8 @@ public class TiUIDialog extends TiUIView
 										  ? TiConvert.toInt(proxy.getProperty(TiC.PROPERTY_CANCEL))
 										  : -1;
 					Log.d(TAG, "onCancelListener called. Sending index: " + cancelIndex, Log.DEBUG_MODE);
-					handleEvent(cancelIndex);
+					// In case wew cancel the Dialog we should not overwrite the selectedIndex
+					handleEvent(cancelIndex, false);
 					hide(null);
 				}
 			});
@@ -438,7 +439,7 @@ public class TiUIDialog extends TiUIView
 		}
 	}
 
-	public void handleEvent(int id)
+	public void handleEvent(int id, boolean saveSelectedIndex)
 	{
 		int cancelIndex =
 			(proxy.hasProperty(TiC.PROPERTY_CANCEL)) ? TiConvert.toInt(proxy.getProperty(TiC.PROPERTY_CANCEL)) : -1;
@@ -452,8 +453,8 @@ public class TiUIDialog extends TiUIView
 				id &= ~BUTTON_MASK;
 			} else {
 				data.put(TiC.PROPERTY_BUTTON, false);
-				// If an option was selected and the user accepted it, update the proxy.
-				if (proxy.hasProperty(TiC.PROPERTY_OPTIONS)) {
+				// If an option was selected, the user accepted and we are showing radio buttons, update the proxy.
+				if (proxy.hasProperty(TiC.PROPERTY_OPTIONS) && saveSelectedIndex) {
 					proxy.setProperty(TiC.PROPERTY_SELECTED_INDEX, id);
 				}
 			}


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-27249

**Description:**
Prevents a dialog to be shown with the wrong type of buttons if reused, by adding a new parameter. It determines whether the selected index should be passed to the proxy.
Note: No unit test, since this is a visual fix.

**Test case:**
There is a very good sample in the JIRA ticket.