### PR TITLE
fix(android): prevents TabGroup duplicate close event firing

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TabGroupProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TabGroupProxy.java
@@ -473,9 +473,6 @@ public class TabGroupProxy extends TiWindowProxy implements TiActivityWindow
 		//       This is needed in case the proxy's close() method was called before the activity was created.
 		TiActivityWindows.removeWindow(this);
 
-		// Fire a "close" event.
-		fireEvent(TiC.EVENT_CLOSE, null);
-
 		// Release views/resources.
 		modelListener = null;
 		releaseViews();


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-27118

**Description:**
Removes a redundant firing of a `close` event in the `handleClose` method of TabGroup.
Note: I am not really sure if it should modify the unit test to listen for only one `close` event. What do you think?

**Test case:**
There is a good sample code in the JIRA ticket.