### PR TITLE
fix(cli): add deprecation notice for node < 10.13

### DIFF
--- a/cli/commands/build.js
+++ b/cli/commands/build.js
@@ -247,7 +247,7 @@ exports.config = function config(logger, config, cli) {
 exports.validate = function validate(logger, config, cli) {
 
 	if (!semver.satisfies(process.versions.node, '>= 10.13')) {
-		logger.warn('DEPRECATION NOTICE: Titanium SDK 9 will no longer support Node 8 or lower. We intend to support Node 10/12 LTS, which will be Node 10.13 or higher.\n');
+		logger.warn('DEPRECATION NOTICE: Titanium SDK 9 will no longer support Node.js 8 or lower. We intend to support Node.js 10/12 LTS, which will be 10.13 or higher.\n');
 	}
 
 	// Determine if the project is an app or a module, run appropriate build command

--- a/cli/commands/build.js
+++ b/cli/commands/build.js
@@ -15,6 +15,7 @@ const appc = require('node-appc'),
 	sprintf = require('sprintf'),
 	ti = require('node-titanium-sdk'),
 	tiappxml = require('node-titanium-sdk/lib/tiappxml'),
+	semver = require('semver'),
 	__ = appc.i18n(__dirname).__;
 
 fields.setup({
@@ -244,6 +245,11 @@ exports.config = function config(logger, config, cli) {
 };
 
 exports.validate = function validate(logger, config, cli) {
+
+	if (!semver.satisfies(process.versions.node, '>= 10.13')) {
+		logger.warn('DEPRECATION NOTICE: Titanium SDK 9 will no longer support Node 8 or lower. We intend to support Node 10/12 LTS, which will be Node 10.13 or higher.\n');
+	}
+
 	// Determine if the project is an app or a module, run appropriate build command
 	if (cli.argv.type === 'module') {
 


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-27250

**Optional Description:**
If the user is running a build with Node < 10.13, we will spit out a deprecation notice.

It looks like so:

```
Titanium Command-Line Interface, CLI version 5.2.1, Titanium SDK version 8.1.0
Copyright (c) 2012-2017, Appcelerator, Inc.  All Rights Reserved.

Please report bugs to http://jira.appcelerator.org/

[WARN] DEPRECATION NOTICE: Titanium SDK 9 will no longer support Node 8 or lower. We intend to support Node 10/12 LTS, which will be Node 10.13 or higher.

2019-7-19 12:38:47

Operating System
  Name                        = Mac OS X
  Version                     = 10.14.5
  Architecture                = 64bit
  # CPUs                      = 12
  Memory                      = 17179869184

Node.js
  Node.js Version             = 8.15.0
  npm Version                 = 6.9.0
```

I'd love any feedback on the exact text to display if we have more clear warnings we could give. There's a bit of a mis-match in that we test against 10.13 (the first LTS of 10.x) while the message talks about dropping 8, and intention to support 10/12 (and specifically 10.13_+).