### PR TITLE
fix: discard V8Snapshots.h changes after packaging

### DIFF
--- a/build/lib/android/index.js
+++ b/build/lib/android/index.js
@@ -4,6 +4,7 @@ const path = require('path');
 const fs = require('fs-extra');
 const AndroidSDK = require('./androidsdk');
 const ant = require('./ant');
+const git = require('../git');
 const utils = require('../utils');
 const copyFile = utils.copyFile;
 const copyFiles = utils.copyFiles;
@@ -107,6 +108,9 @@ class Android {
 
 		// Copy android/modules/*/lib/*.jar
 		await this.copyModuleLibraries(path.join(ANDROID_ROOT, 'modules'), ANDROID_DEST);
+
+		// Discard local changes on the generated V8Snapshots.h
+		await git.discardLocalChange(ANDROID_ROOT, 'runtime/v8/src/native/V8Snapshots.h');
 
 		// Copy over module resources
 		const filterRegExp = new RegExp('\\' + path.sep  + 'android(\\' + path.sep + 'titanium-(.+)?.(jar|res.zip|respackage))?$'); // eslint-disable-line security/detect-non-literal-regexp

--- a/build/lib/git.js
+++ b/build/lib/git.js
@@ -9,8 +9,18 @@ const exec = promisify(require('child_process').exec); // eslint-disable-line se
  * @returns {Promise<string>} sha of current git commit for HEAD
  */
 async function getHash(cwd) {
-	const { stdout } = await exec('git rev-parse --short --no-color HEAD', { cwd: cwd });
+	const { stdout } = await exec('git rev-parse --short --no-color HEAD', { cwd });
 	return stdout.trim(); // drop leading 'commit ', just take 7-character sha
 }
 
-module.exports = { getHash };
+/**
+ * Discards a local Git change.
+ * @param {string} cwd current working directory path
+ * @param {string} file the file to discard
+ * @returns {Promise<string>} sha of current git commit for HEAD
+ */
+function discardLocalChange(cwd, file) {
+	return exec(`git checkout -- ${file}`, { cwd });
+}
+
+module.exports = { getHash, discardLocalChange };


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-0000

Fixing an issue that bugged us for a while, where the generated V8Snapshots.h remains changed after the build completes. This little cleanup resolved it for us, so we thought to share it.