### PR TITLE
Speculative db device fix

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,7 @@ def includeWindows = isMainlineBranch // Include Windows SDK if on a mainline br
 // Note that the `includeWindows` flag also currently toggles whether we build for all OSes/platforms, or just iOS/Android for macOS
 def runDanger = isPR // run Danger.JS if it's a PR by default. (should we also run on origin branches that aren't mainline?)
 def publishToS3 = isMainlineBranch // publish zips to S3 if on mainline branch, by default
-def testOnDevices = isMainlineBranch // run tests on devices
+def testOnDevices = true // run tests on devices
 
 // Variables we can change
 def nodeVersion = '8.9.1' // NOTE that changing this requires we set up the desired version on jenkins master first!

--- a/android/modules/database/src/java/ti/modules/titanium/database/TiDatabaseProxy.java
+++ b/android/modules/database/src/java/ti/modules/titanium/database/TiDatabaseProxy.java
@@ -32,6 +32,8 @@ import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 @Kroll.proxy(parentModule = DatabaseModule.class)
 public class TiDatabaseProxy extends KrollProxy
@@ -39,6 +41,7 @@ public class TiDatabaseProxy extends KrollProxy
 	private static final String TAG = "TiDB";
 
 	private Thread thread;
+	private Lock dbLock = new ReentrantLock(true); // use a "fair" lock
 	private BlockingQueue<Runnable> queue = new LinkedBlockingQueue<>();
 	private AtomicBoolean executingQueue = new AtomicBoolean(false);
 	private boolean isClosed = false;
@@ -131,23 +134,25 @@ public class TiDatabaseProxy extends KrollProxy
 	@Kroll.method
 	public void close()
 	{
-		synchronized (this)
-		{
+		dbLock.lock();
+		try {
 			// Close database.
 			if (db != null && db.isOpen()) {
 				db.close();
 			}
 			db = null;
 			isClosed = true;
-
-			// Abort query queue execution.
-			if (thread != null) {
-				thread.interrupt();
-				thread = null;
-			}
-			executingQueue.set(false);
-			queue.clear();
+		} finally {
+			dbLock.unlock();
 		}
+
+		// Abort query queue execution.
+		if (thread != null) {
+			thread.interrupt();
+			thread = null;
+		}
+		executingQueue.set(false);
+		queue.clear();
 	}
 
 	private boolean expectResult(String query)
@@ -182,9 +187,9 @@ public class TiDatabaseProxy extends KrollProxy
 		// to maintain correct execution order and prevent write-locks.
 		waitForQueue();
 
-		// Execute query using rawQuery() in order to receive results.
-		synchronized (this)
-		{ // lock on db proxy instance
+		// lock on db proxy instance
+		dbLock.lockInterruptibly();
+		try {
 			if (isClosed) {
 				throw new IllegalStateException("database is closed");
 			}
@@ -202,6 +207,7 @@ public class TiDatabaseProxy extends KrollProxy
 				}
 			}
 
+			// Execute query using rawQuery() in order to receive results.
 			Cursor cursor = db.rawQuery(query, parameters);
 			if (cursor != null) {
 				// Validate and set query result.
@@ -222,6 +228,8 @@ public class TiDatabaseProxy extends KrollProxy
 			}
 
 			return null;
+		} finally {
+			dbLock.unlock();
 		}
 	}
 
@@ -379,12 +387,15 @@ public class TiDatabaseProxy extends KrollProxy
 	public int getLastInsertRowId()
 	// clang-format on
 	{
-		synchronized (this)
-		{ // lock on db proxy instance
+		// lock on db proxy instance
+		dbLock.lock();
+		try {
 			if (isClosed) {
 				throw new IllegalStateException("database is closed");
 			}
 			return (int) DatabaseUtils.longForQuery(db, "select last_insert_rowid()", null);
+		} finally {
+			dbLock.unlock();
 		}
 	}
 
@@ -398,12 +409,15 @@ public class TiDatabaseProxy extends KrollProxy
 	public int getRowsAffected()
 	// clang-format on
 	{
-		synchronized (this)
-		{ // lock on db proxy instance
+		// lock on db proxy instance
+		dbLock.lock();
+		try {
 			if (isClosed) {
 				throw new IllegalStateException("database is closed");
 			}
 			return (int) DatabaseUtils.longForQuery(db, "select changes()", null);
+		} finally {
+			dbLock.unlock();
 		}
 	}
 

--- a/android/modules/database/src/java/ti/modules/titanium/database/TiDatabaseProxy.java
+++ b/android/modules/database/src/java/ti/modules/titanium/database/TiDatabaseProxy.java
@@ -167,7 +167,7 @@ public class TiDatabaseProxy extends KrollProxy
 	 * @param query SQL query to execute on database.
 	 * @param parameterObjects Parameters for `query`
 	 */
-	private TiResultSetProxy executeSQL(String query, Object[] parameterObjects)
+	private TiResultSetProxy executeSQL(String query, Object[] parameterObjects) throws InterruptedException
 	{
 		// Validate and parse `parameterObjects`.
 		if (parameterObjects != null) {
@@ -239,7 +239,7 @@ public class TiDatabaseProxy extends KrollProxy
 	 * @param parameterObjects Parameters for `query`
 	 */
 	@Kroll.method
-	public TiResultSetProxy execute(String query, Object... parameterObjects)
+	public TiResultSetProxy execute(String query, Object... parameterObjects) throws InterruptedException
 	{
 		// Validate `query` parameter.
 		if (query == null) {


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/[TICKET]

Provide a clear PR title prefixed with `[TICKET]`

**Optional Description:**
This is a speculative fix to see if this helps the XT1032 Android device pass the DB test suite. Right now it does not seem to "interrupt" a series of async queries if we call `close()` on a timer.

I changed from using a `synchronized(this)` block to using an explicit `Lock` instance that we lock/unlock - with the query method that may be running off main thread acquiring via `lockInterruptibly()`. Additionally, the lock implementation is set to be "fair" so that it gives preferences to the longest waiting thread. This should ensure threads acquire the lock in-order