### PR TITLE
fix(buffer): constructor and from() compatibility

### DIFF
--- a/common/Resources/ti.internal/extensions/node/buffer.js
+++ b/common/Resources/ti.internal/extensions/node/buffer.js
@@ -1358,13 +1358,6 @@ class Buffer {
 			}
 			return newBuffer(Ti.createBuffer({ value: value, type: getTiCodecCharset(encoding) }));
 		} else if (valueType === 'object') {
-			if (Array.isArray(value)) {
-				const tiBuffer = Ti.createBuffer({ length: value.length });
-				for (let i = 0; i < value.length; i++) {
-					tiBuffer[i] = value[i] & 0xFF; // mask to one byte
-				}
-				return newBuffer(tiBuffer);
-			}
 			if (Buffer.isBuffer(value)) {
 				const length = value.length;
 				const buffer = Buffer.allocUnsafe(length);
@@ -1376,15 +1369,15 @@ class Buffer {
 				value.copy(buffer, 0, 0, length);
 				return buffer;
 			}
-			if (value instanceof Uint8Array) {
+			if (Array.isArray(value) || value instanceof Uint8Array) {
 				const length = value.length;
 				if (length === 0) {
-					return Buffer.alloc(0);
+					return Buffer.allocUnsafe(0);
 				}
 
 				const tiBuffer = Ti.createBuffer({ length });
 				for (let i = 0; i < length; i++) {
-					tiBuffer[i] = value[i];
+					tiBuffer[i] = value[i] & 0xFF; // mask to one byte
 				}
 
 				return newBuffer(tiBuffer);

--- a/common/Resources/ti.internal/extensions/node/internal/util.js
+++ b/common/Resources/ti.internal/extensions/node/internal/util.js
@@ -1,0 +1,44 @@
+const kNodeModulesRE = /^(.*)[\\/]node_modules[\\/]/;
+
+let getStructuredStack;
+class StackTraceError extends Error { }
+StackTraceError.prepareStackTrace = (err, trace) => trace;
+StackTraceError.stackTraceLimit = Infinity;
+
+export function isInsideNodeModules() {
+	if (getStructuredStack === undefined) {
+		getStructuredStack = () => new StackTraceError().stack;
+	}
+
+	let stack = getStructuredStack();
+
+	// stack is only an array on v8, try to convert manually if string
+	if (typeof stack === 'string') {
+		const stackFrames = [];
+		const lines = stack.split(/\n/);
+		for (const line of lines) {
+			const lineInfo = line.match(/(.*)@(.*):(\d+):(\d+)/);
+			if (lineInfo) {
+				const filename = lineInfo[2].replace('file://', '');
+				stackFrames.push({ getFileName: () => filename });
+			}
+		}
+		stack = stackFrames;
+	}
+
+	// Iterate over all stack frames and look for the first one not coming
+	// from inside Node.js itself:
+	if (Array.isArray(stack)) {
+		for (const frame of stack) {
+			const filename = frame.getFileName();
+			// If a filename does not start with / or contain \,
+			// it's likely from Node.js core.
+			if (!/^\/|\\/.test(filename)) {
+				continue;
+			}
+			return kNodeModulesRE.test(filename);
+		}
+	}
+
+	return false;
+}

--- a/tests/Resources/buffer.addontest.js
+++ b/tests/Resources/buffer.addontest.js
@@ -55,6 +55,14 @@ describe('Buffer', () => {
 	});
 
 	describe('constructor', () => {
+		before(() => {
+			process.noDeprecation = true;
+		});
+
+		after(() => {
+			process.noDeprecation = false;
+		});
+
 		it('should allocate a new Buffer using an array of octets', () => {
 			const arr = [ 0x54, 0x69, 0x74, 0x61, 0x6e, 0x69, 0x75, 0x6d ];
 			const buf = new Buffer(arr);

--- a/tests/Resources/buffer.addontest.js
+++ b/tests/Resources/buffer.addontest.js
@@ -54,9 +54,80 @@ describe('Buffer', () => {
 		should(global.Buffer).exist;
 	});
 
+	describe('constructor', () => {
+		it('should allocate a new Buffer using an array of octets', () => {
+			const arr = [ 0x54, 0x69, 0x74, 0x61, 0x6e, 0x69, 0x75, 0x6d ];
+			const buf = new Buffer(arr);
+			for (let i = 0; i < arr.length; i++) {
+				should(buf[i]).eql(arr[i]);
+			}
+		});
+
+		it('should copy the passed buffer onto a new buffer instance', () => {
+			const buf1 = new Buffer('buffer');
+			const buf2 = new Buffer(buf1);
+			buf1[0] = 0x61;
+			should(buf1.toString()).eql('auffer');
+			should(buf2.toString()).eql('buffer');
+
+			const buf3 = new Uint8Array(2);
+			buf3[0] = 0x54;
+			buf3[1] = 0x69;
+			const buf4 = new Buffer(buf3);
+			buf3[0] = 0x74;
+			should(buf3[0]).eql(0x74);
+			should(buf4[0]).eql(0x54);
+		});
+
+		it('should allocate a new buffer with given size', () => {
+			const buf = new Buffer(10);
+			should(buf.length).eql(10);
+		});
+
+		it('should create a new Buffer containing the passed string', () => {
+			const text = 'this is a tést';
+			const buf1 = new Buffer(text);
+			const buf2 = new Buffer('7468697320697320612074c3a97374', 'hex');
+			should(buf1.toString()).eql(text);
+			should(buf2.toString()).eql(text);
+		});
+	});
+
 	describe('.from()', () => {
 		it('is a function', () => {
 			should(Buffer.from).be.a.Function;
+		});
+
+		it('should allocate a new Buffer using an array of octets', () => {
+			const arr = [ 0x62, 0x75, 0x66, 0x66, 0x65, 0x72 ];
+			const buf = Buffer.from(arr);
+			for (let i = 0; i < arr.length; i++) {
+				should(buf[i]).eql(arr[i]);
+			}
+		});
+
+		it('should copy the passed buffer onto a new buffer instance', () => {
+			const buf1 = Buffer.from('buffer');
+			const buf2 = Buffer.from(buf1);
+			buf1[0] = 0x61;
+			should(buf1.toString()).eql('auffer');
+			should(buf2.toString()).eql('buffer');
+
+			const buf3 = new Uint8Array(2);
+			buf3[0] = 0x54;
+			buf3[1] = 0x69;
+			const buf4 = Buffer.from(buf3);
+			buf3[0] = 0x74;
+			should(buf3[0]).eql(0x74);
+			should(buf4[0]).eql(0x54);
+		});
+
+		it('should create a new Buffer containing the passed string', () => {
+			const text = 'this is a tést';
+			const buf1 = Buffer.from(text);
+			const buf2 = Buffer.from('7468697320697320612074c3a97374', 'hex');
+			should(buf1.toString()).eql(text);
+			should(buf2.toString()).eql(text);
 		});
 	});
 


### PR DESCRIPTION
Fixes a few issues i've found while working with our new `Buffer` implementation.

- Expose deprecated constructor signatures. Those are widely used in the ecosystem. Not having them implemented lead so undefined behavior and deadlocks in third-party modules.
- Add support for passing `Uint8Array` to `from()`