### PR TITLE
fix(ios): properly inject CODE_SIGN_IDENTITY flag for Xcode 11 compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6790,9 +6790,9 @@
       "dev": true
     },
     "ioslib": {
-      "version": "1.7.10",
-      "resolved": "https://registry.npmjs.org/ioslib/-/ioslib-1.7.10.tgz",
-      "integrity": "sha512-D86U7w0n86glviTTMt/n39swxEM4aU4gQYz7SHsD1FekhAGQ34VV49q/F17TbUc7PtQI9a7xQ8ono00P4BD34g==",
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/ioslib/-/ioslib-1.7.11.tgz",
+      "integrity": "sha512-QR9vOtetuvD+WxoHuLyTS7TTWmMu1IdqtutVFUOhUkn6CJ6+xVScLAc/nIf12cjT9Y07GB0tcaGJuMsfq7GU5w==",
       "requires": {
         "always-tail": "0.2.0",
         "async": "^2.6.1",
@@ -6804,9 +6804,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "6.10.1",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.1.tgz",
-          "integrity": "sha512-w1YQaVGNC6t2UCPjEawK/vo/dG8OOrVtUmhBT1uJJYxbl5kU2Tj3v6LGqBcsysN1yhuCStJCCA3GqdvKY8sqXQ==",
+          "version": "6.10.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+          "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
           "requires": {
             "fast-deep-equal": "^2.0.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -6826,11 +6826,6 @@
           "requires": {
             "ms": "^2.1.1"
           }
-        },
-        "extend": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-          "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
         },
         "fast-deep-equal": {
           "version": "2.0.1",
@@ -9269,9 +9264,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "ejs": "^2.6.1",
     "fields": "0.1.24",
     "fs-extra": "^8.0.1",
-    "ioslib": "^1.7.10",
+    "ioslib": "^1.7.11",
     "klaw-sync": "^6.0.0",
     "liveview": "^1.5.0",
     "lodash.defaultsdeep": "^4.6.1",


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-27330

Requires https://github.com/appcelerator/ioslib/pull/91 + package.json update to 1.7.11 once merged.