### PR TITLE
perf(android): implement ability to pre-cache common js assets

### DIFF
--- a/android/dev/TitaniumTest/assets/cache.json
+++ b/android/dev/TitaniumTest/assets/cache.json
@@ -1,0 +1,1 @@
+["Resources/app.js"]

--- a/android/dev/TitaniumTest/src/com/titanium/test/TitaniumTestApplication.java
+++ b/android/dev/TitaniumTest/src/com/titanium/test/TitaniumTestApplication.java
@@ -8,24 +8,31 @@ package com.titanium.test;
 
 import org.appcelerator.kroll.KrollRuntime;
 import org.appcelerator.kroll.runtime.v8.V8Runtime;
+import org.appcelerator.kroll.util.KrollAssetCache;
 import org.appcelerator.titanium.TiApplication;
 import org.appcelerator.titanium.TiRootActivity;
 
-public final class TitaniumTestApplication extends TiApplication {
-    private static final String TAG = "TitaniumTestApplication";
+public final class TitaniumTestApplication extends TiApplication
+{
+	private static final String TAG = "TitaniumTestApplication";
 
-    @Override
-    public void onCreate() {
-        super.onCreate();
+	@Override
+	public void onCreate()
+	{
+		super.onCreate();
 
-        appInfo = new TitaniumTestAppInfo(this);
+		// Load cache as soon as possible.
+		KrollAssetCache.init(this);
 
-        V8Runtime runtime = new V8Runtime();
-        KrollRuntime.init(this, runtime);
-        postOnCreate();
-    }
+		appInfo = new TitaniumTestAppInfo(this);
 
-    @Override
-    public void verifyCustomModules(TiRootActivity rootActivity) {
-    }
+		V8Runtime runtime = new V8Runtime();
+		KrollRuntime.init(this, runtime);
+		postOnCreate();
+	}
+
+	@Override
+	public void verifyCustomModules(TiRootActivity rootActivity)
+	{
+	}
 }

--- a/android/runtime/common/src/java/org/appcelerator/kroll/util/KrollAssetCache.java
+++ b/android/runtime/common/src/java/org/appcelerator/kroll/util/KrollAssetCache.java
@@ -1,0 +1,98 @@
+/**
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2019 by Axway, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+package org.appcelerator.kroll.util;
+
+import java.util.HashMap;
+
+import android.content.Context;
+import android.os.AsyncTask;
+import android.util.Log;
+
+import org.json.JSONArray;
+
+public class KrollAssetCache
+{
+	private static final String TAG = "TiAssetCache";
+
+	private static HashMap<String, byte[]> cache = new HashMap<>();
+
+	/**
+     * Asynchronous task to load specified assets into cache.
+     */
+	private static class CacheTask extends AsyncTask<String[], Void, Void>
+	{
+		protected Void doInBackground(String[]... args)
+		{
+			final String[] paths = args[0];
+			for (String path : paths) {
+				byte[] bytes = KrollAssetHelper.readAssetBytes(path);
+				if (bytes != null) {
+					cache.put(path, bytes);
+				}
+			}
+			return null;
+		}
+	}
+	private static final CacheTask task = new CacheTask();
+
+	/**
+     * Initialize KrollAssetCache class by parsing 'cache.json'
+     * then loading the asset cache from a background thread.
+     * @param context Application context.
+     */
+	public static void init(Context context)
+	{
+		// Make sure KrollAssetHelper is initialized.
+		KrollAssetHelper.init(context);
+
+		String[] assets = null;
+		try {
+
+			// Attempt to read and parse 'cache.json'.
+			String cacheJsonString = KrollAssetHelper.readAsset("cache.json");
+			if (cacheJsonString != null) {
+				JSONArray cacheJsonArray = new JSONArray(cacheJsonString);
+				assets = new String[cacheJsonArray.length()];
+
+				// Add entries to assets array.
+				for (int i = 0; i < assets.length; i++) {
+					assets[i] = cacheJsonArray.getString(i);
+				}
+
+				// Execute cache task on background thread.
+				if (assets != null) {
+					task.execute(assets);
+				}
+			}
+		} catch (Exception e) {
+			Log.e(TAG, "Failed to parse 'cache.json'.");
+		}
+	}
+
+	/**
+     * Determine if cache contains specified asset.
+     * @param path Asset to check.
+     * @return boolean of result.
+     */
+	public static boolean has(String path)
+	{
+		return cache.containsKey(path);
+	}
+
+	/**
+     * Obtain cached byte array for specified asset.
+     * Cache is relieved after first call.
+     * @param path Asset to obtain.
+     * @return byte array of asset.
+     */
+	public static byte[] get(String path)
+	{
+		byte[] bytes = cache.get(path);
+		cache.remove(path);
+		return bytes;
+	}
+}

--- a/android/runtime/common/src/java/org/appcelerator/kroll/util/KrollAssetHelper.java
+++ b/android/runtime/common/src/java/org/appcelerator/kroll/util/KrollAssetHelper.java
@@ -165,6 +165,9 @@ public class KrollAssetHelper
 
 	public static byte[] readAssetBytes(String path)
 	{
+		if (KrollAssetCache.has(path)) {
+			return KrollAssetCache.get(path);
+		}
 		try {
 			if (assetCrypt != null) {
 				InputStream in = assetCrypt.openAsset(path);

--- a/android/templates/build/App.java
+++ b/android/templates/build/App.java
@@ -12,6 +12,7 @@ import org.appcelerator.kroll.common.KrollSourceCodeProvider;
 import org.appcelerator.kroll.KrollModule;
 import org.appcelerator.kroll.KrollModuleInfo;
 import org.appcelerator.kroll.KrollRuntime;
+import org.appcelerator.kroll.util.KrollAssetCache;
 import org.appcelerator.kroll.util.KrollAssetHelper;
 import org.appcelerator.titanium.TiApplication;
 import org.appcelerator.titanium.TiRootActivity;
@@ -31,14 +32,17 @@ public final class <%= classname %>Application extends TiApplication
 	@Override
 	public void onCreate()
 	{
+<% if (encryptJS) { %>
+		KrollAssetHelper.setAssetCrypt(new AssetCryptImpl());
+<% } %>
+
+		// Load cache as soon as possible.
+		KrollAssetCache.init(this);
+
 		super.onCreate();
 
 		appInfo = new <%= classname %>AppInfo(this);
 		postAppInfo();
-
-<% if (encryptJS) { %>
-		KrollAssetHelper.setAssetCrypt(new AssetCryptImpl());
-<% } %>
 
 		V8Runtime runtime = new V8Runtime();
 

--- a/android/templates/build/AssetCryptImpl.java
+++ b/android/templates/build/AssetCryptImpl.java
@@ -23,10 +23,10 @@ public class AssetCryptImpl implements KrollAssetHelper.AssetCrypt
 	private static final String TAG = "AssetCryptImpl";
 
 	private static byte[] salt = {
-<% for (let i = 0; i < salt.length - 1; i++){ -%>
-		<%-'(byte)' + salt.readUInt8(i) + ', ' -%>
+		<% for (let i = 0; i < salt.length - 1; i++){ -%>
+<%- '(byte)' + salt.readUInt8(i) + ', ' -%>
 <% } -%>
-<%-'(byte)' + salt.readUInt8(salt.length - 1) %>
+<%- '(byte)' + salt.readUInt8(salt.length - 1) %>
 	};
 
 	private static final Collection<String> assets =
@@ -75,8 +75,7 @@ public class AssetCryptImpl implements KrollAssetHelper.AssetCrypt
 		}
 		try {
 			Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
-			cipher.init(Cipher.DECRYPT_MODE, new SecretKeySpec(ti.cloak.Binding.getKey(salt), "AES"),
-						new IvParameterSpec(salt));
+			cipher.init(Cipher.DECRYPT_MODE, new SecretKeySpec(ti.cloak.Binding.getKey(salt), "AES"), new IvParameterSpec(salt));
 			return new CipherInputStream(KrollAssetHelper.getAssetManager().open(path), cipher);
 		} catch (Exception e) {
 			Log.e(TAG, "Could not decrypt '" + path + "'");

--- a/android/titanium/src/java/org/appcelerator/titanium/TiApplication.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiApplication.java
@@ -365,6 +365,8 @@ public abstract class TiApplication extends Application implements KrollApplicat
 			}
 		});
 
+		loadBuildProperties();
+
 		appProperties = new TiProperties(getApplicationContext(), APPLICATION_PREFERENCES_NAME, false);
 
 		File fullPath = new File(TiC.URL_ANDROID_ASSET_RESOURCES, "app.js");

--- a/android/titanium/src/java/org/appcelerator/titanium/TiApplication.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiApplication.java
@@ -365,8 +365,6 @@ public abstract class TiApplication extends Application implements KrollApplicat
 			}
 		});
 
-		loadBuildProperties();
-
 		appProperties = new TiProperties(getApplicationContext(), APPLICATION_PREFERENCES_NAME, false);
 
 		File fullPath = new File(TiC.URL_ANDROID_ASSET_RESOURCES, "app.js");


### PR DESCRIPTION
**NOTE: Requires #11045 to be merged**

- Cache commonly used assets at startup (_app.js and Alloy_), improving launch time and `require()` performance
- Since CommonJS modules are cached on the JS side after the initial `require()` we can clear the asset from the Java cache after the first `get()`

##### Review [b4b3b0ab - perf(android): implement ability to pre-cache common js assets](https://github.com/appcelerator/titanium_mobile/pull/11150/commits/d64e75940e5a623c464633a879e6fa8783abb7d5?w=1)

**TEST CASE**
1. Build and run [kitchensink-v2](https://github.com/appcelerator/kitchensink-v2)
    - Build with and without `-D test` flag
2. Application should run without issues

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-27336)