### PR TITLE
fix(android): call WebView.stopLoading() from main thread

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
@@ -17,6 +17,7 @@ import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
 
+import android.os.Handler;
 import android.support.annotation.StringRes;
 import android.view.ActionMode;
 import android.view.Menu;
@@ -51,6 +52,8 @@ import android.view.MotionEvent;
 import android.view.View;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
+
+import static android.os.Looper.getMainLooper;
 
 @SuppressWarnings("deprecation")
 public class TiUIWebView extends TiUIView
@@ -1066,7 +1069,13 @@ public class TiUIWebView extends TiUIView
 
 	public void stopLoading()
 	{
-		getWebView().stopLoading();
+		new Handler(getMainLooper()).post(new Runnable() {
+			@Override
+			public void run()
+			{
+				getWebView().stopLoading();
+			}
+		});
 	}
 
 	public boolean shouldInjectBindingCode()

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
@@ -17,7 +17,6 @@ import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
 
-import android.os.Handler;
 import android.support.annotation.StringRes;
 import android.view.ActionMode;
 import android.view.Menu;
@@ -52,8 +51,6 @@ import android.view.MotionEvent;
 import android.view.View;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
-
-import static android.os.Looper.getMainLooper;
 
 @SuppressWarnings("deprecation")
 public class TiUIWebView extends TiUIView

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
@@ -1069,7 +1069,7 @@ public class TiUIWebView extends TiUIView
 
 	public void stopLoading()
 	{
-		new Handler(getMainLooper()).post(new Runnable() {
+		getWebView().getHandler().post(new Runnable() {
 			@Override
 			public void run()
 			{


### PR DESCRIPTION
- Allow `Titanium.UI.WebView.stopLoading()` to function when called from events

##### TEST CASE
```JS
const win = Ti.UI.createWindow();
const webView = Ti.UI.createWebView({ url: 'https://google.com/' });

webView.addEventListener('beforeload', e => {
    webView.stopLoading();
});

win.add(webView);
win.open();
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-27348)