### PR TITLE
fix(android): fix onlink callback being cretion only

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/WebViewProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/WebViewProxy.java
@@ -47,7 +47,8 @@ import ti.modules.titanium.ui.widget.webview.TiUIWebView;
 		TiC.PROPERTY_WEBVIEW_IGNORE_SSL_ERROR,
 		TiC.PROPERTY_OVER_SCROLL_MODE,
 		TiC.PROPERTY_CACHE_MODE,
-		TiC.PROPERTY_LIGHT_TOUCH_ENABLED
+		TiC.PROPERTY_LIGHT_TOUCH_ENABLED,
+		TiC.PROPERTY_ON_LINK
 })
 // clang-format on
 public class WebViewProxy extends ViewProxy implements Handler.Callback, OnLifecycleEvent, interceptOnBackPressedEvent


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-27238

**Description:**
Fix `onlink` callback property being creation-only.

**Test case:**

```js
var htmlText =
'<!DOCTYPE html>\n' +
'<html>\n' +
'	<head>\n' +
'		<meta name="viewport" content="width=device-width, initial-scale=1.0">\n' +
'	</head>\n' +
'	<body>\n' +
'		<p>WebView "onlink" Test</p>\n' +
'		<br/>\n' +
'		<br/>\n' +
'		<a href="mylink://show/alert">Show Alert</a>\n' +
'	</body>\n' +
'</html>\n';
 
function onLinkHandler(e) {
if (e.url === "mylink://show/alert") {
alert("'onlink' callback invoked.");
return false;
}
return true;
}
 
var window = Ti.UI.createWindow();
var webView = Ti.UI.createWebView({
html: htmlText,
//	onlink: onLinkHandler,  // <- Must be set upon creation to work.
});
webView.onlink = onLinkHandler;
window.add(webView);
window.open();
```

