### PR TITLE
feat(ios): support generic apple certificates

### DIFF
--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -856,7 +856,7 @@ iOSBuilder.prototype.configOptionDistributionName = function configOptionDistrib
 			if (value) {
 				// value can either be a fullname (Apple Distribution: Joe Bloggs (TEAMID)) or just name (Joe Bloggs (TEAMID)). We want to use fullname, so if we were provided
 				// a name try to map it back to the correct format.
-				const v = distributionCertLookup.filter(cert => cert.name.toLowerCase() === value.toLowerCase());
+				const v = distributionCertLookup.filter(cert => cert.name.toLowerCase() === value.toLowerCase() || cert.fullname.toLowerCase() === value.toLowerCase());
 
 				if (v.length === 1) {
 					return callback(null, v[0].fullname);

--- a/iphone/cli/lib/info.js
+++ b/iphone/cli/lib/info.js
@@ -167,10 +167,10 @@ exports.render = function (logger, config, rpad, styleHeading, styleValue, style
 			if (devs.length) {
 				logger.log(keychain.grey);
 				devs.sort(function (a, b) {
-					return a.name === b.name ? 0 : a.name < b.name ? -1 : 1;
+					return a.fullname === b.fullname ? 0 : a.fullname < b.fullname ? -1 : 1;
 				}).forEach(function (dev) {
 					counter++;
-					logger.log('  ' + dev.name.cyan + (dev.expired ? ' ' + styleBad(__('**EXPIRED**')) : dev.invalid ? ' ' + styleBad(__('**NOT VALID**')) : ''));
+					logger.log('  ' + dev.fullname.cyan + (dev.expired ? ' ' + styleBad(__('**EXPIRED**')) : dev.invalid ? ' ' + styleBad(__('**NOT VALID**')) : ''));
 					logger.log('  ' + rpad('  ' + __('Not valid before')) + ' = ' + styleValue(moment(dev.before).format('l LT')));
 					logger.log('  ' + rpad('  ' + __('Not valid after')) + ' = ' + styleValue(moment(dev.after).format('l LT')));
 				});
@@ -187,10 +187,10 @@ exports.render = function (logger, config, rpad, styleHeading, styleValue, style
 			if (dists.length) {
 				logger.log(keychain.grey);
 				dists.sort(function (a, b) {
-					return a.name === b.name ? 0 : a.name < b.name ? -1 : 1;
+					return a.fullname === b.fullname ? 0 : a.fullname < b.fullname ? -1 : 1;
 				}).forEach(function (dist) {
 					counter++;
-					logger.log('  ' + dist.name.cyan + (dist.expired ? ' ' + styleBad(__('**EXPIRED**')) : dist.invalid ? ' ' + styleBad(__('**NOT VALID**')) : ''));
+					logger.log('  ' + dist.fullname.cyan + (dist.expired ? ' ' + styleBad(__('**EXPIRED**')) : dist.invalid ? ' ' + styleBad(__('**NOT VALID**')) : ''));
 					logger.log('  ' + rpad('  ' + __('Not valid before')) + ' = ' + styleValue(moment(dist.before).format('l LT')));
 					logger.log('  ' + rpad('  ' + __('Not valid after')) + ' = ' + styleValue(moment(dist.after).format('l LT')));
 				});

--- a/package-lock.json
+++ b/package-lock.json
@@ -6476,9 +6476,9 @@
       "dev": true
     },
     "ioslib": {
-      "version": "1.7.10",
-      "resolved": "https://registry.npmjs.org/ioslib/-/ioslib-1.7.10.tgz",
-      "integrity": "sha512-D86U7w0n86glviTTMt/n39swxEM4aU4gQYz7SHsD1FekhAGQ34VV49q/F17TbUc7PtQI9a7xQ8ono00P4BD34g==",
+      "version": "1.7.12",
+      "resolved": "https://registry.npmjs.org/ioslib/-/ioslib-1.7.12.tgz",
+      "integrity": "sha512-wzeddjjQeHEUaWBhcgd1Ub0YgythxWpV4Kob2AB8ETM+yL8lfSu3OPpmvpFQ9fcK+z2ZmyJ+ZTvi91JUfYMiZA==",
       "requires": {
         "always-tail": "0.2.0",
         "async": "^2.6.1",
@@ -6490,9 +6490,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "6.10.1",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.1.tgz",
-          "integrity": "sha512-w1YQaVGNC6t2UCPjEawK/vo/dG8OOrVtUmhBT1uJJYxbl5kU2Tj3v6LGqBcsysN1yhuCStJCCA3GqdvKY8sqXQ==",
+          "version": "6.10.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+          "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
           "requires": {
             "fast-deep-equal": "^2.0.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -6512,11 +6512,6 @@
           "requires": {
             "ms": "^2.1.1"
           }
-        },
-        "extend": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-          "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
         },
         "fast-deep-equal": {
           "version": "2.0.1",
@@ -8107,9 +8102,9 @@
       }
     },
     "minipass": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
-      "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.5.0.tgz",
+      "integrity": "sha512-9FwMVYhn6ERvMR8XFdOavRz4QK/VJV8elU1x50vYexf9lslDcWe/f4HBRxCPd185ekRSjU6CfYyJCECa/CQy7Q==",
       "requires": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
@@ -8876,9 +8871,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "ejs": "^2.6.1",
     "fields": "0.1.24",
     "fs-extra": "^8.0.1",
-    "ioslib": "^1.7.10",
+    "ioslib": "^1.7.12",
     "klaw-sync": "^6.0.0",
     "liveview": "^1.5.0",
     "lodash.defaultsdeep": "^4.6.1",


### PR DESCRIPTION
If passed in the name/team ID variant, we make a best attempt to map it back to the fullname variant of cert type/name/team ID. It's possible that we cant figure out the correct name (in the case where the name matches both the iOS cert and Apple cert), in which case we will error and prompt for the correct value.

Closes TIMOB-27358

**JIRA:** https://jira.appcelerator.org/browse/TIMOB-27358

Requires appcelerator/ioslib/pull/93

I need to fully verify that this doesn't break any of the signing of extensions.