### PR TITLE
fix(ios): set CODE_SIGN_IDENTITY to the cert name

### DIFF
--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -3123,7 +3123,7 @@ iOSBuilder.prototype.createXcodeProject = function createXcodeProject(next) {
 
 	// add the post-compile build phase for dist-appstore builds
 	if (this.target === 'dist-appstore' || this.target === 'dist-adhoc') {
-		buildSettings.CODE_SIGN_IDENTITY = '"iPhone Distribution"';
+		buildSettings.CODE_SIGN_IDENTITY = `"${this.certDistributionName}"`;
 		buildSettings.CODE_SIGN_STYLE = 'Manual';
 
 		xobjs.PBXShellScriptBuildPhase || (xobjs.PBXShellScriptBuildPhase = {});
@@ -3149,10 +3149,7 @@ iOSBuilder.prototype.createXcodeProject = function createXcodeProject(next) {
 		};
 		xobjs.PBXShellScriptBuildPhase[buildPhaseUuid + '_comment'] = '"' + name + '"';
 	} else if (this.target === 'device') {
-		// sign the application using a signing identity that contains the phrase "iPhone Developer"
-		// as long as there's a valid development signing identity (identity certificate and private key)
-		// build and deployment should succeed.
-		buildSettings.CODE_SIGN_IDENTITY = '"iPhone Developer"';
+		buildSettings.CODE_SIGN_IDENTITY = `"${this.certDeveloperName}"`;
 		buildSettings.CODE_SIGN_STYLE = 'Manual';
 	}
 

--- a/iphone/cli/hooks/package.js
+++ b/iphone/cli/hooks/package.js
@@ -214,7 +214,7 @@ exports.init = function (logger, config, cli) {
 		const keychains = builder.iosInfo.certs.keychains;
 		Object.keys(keychains).some(function (keychain) {
 			return (keychains[keychain].distribution || []).some(function (d) {
-				if (!d.invalid && d.name === builder.certDistributionName) {
+				if (!d.invalid && d.fullname === builder.certDistributionName) {
 					exportsOptions.signingCertificate = d.fullname;
 					return true;
 				}


### PR DESCRIPTION
It seems to be that if you have an Apple cert and an iPhone cert with the same Team ID, xcode will prefer to use the Apple cert due to the ambigious certificate name we passed in, this would then error out as the provisioning profile we passed in would not match the cert xcode selected (incorrectly) for us

Fixes TIMOB-27358

**JIRA:** https://jira.appcelerator.org/browse/TIMOB-27358

I have tested this with a watch extension to dist-adhoc/dist-appstore builds and the codesigning is successful, the adhoc build can be installed to device, and xcode verifies the appstore build just fine. I would like to test some other extensions also.

Update:

Tested with signing a StickerPack and a Today extension and it signs correctly also
