### PR TITLE
fix(ios): include new iphone models into os extension

### DIFF
--- a/common/Resources/ti.internal/extensions/node/os.js
+++ b/common/Resources/ti.internal/extensions/node/os.js
@@ -206,6 +206,12 @@ if (isIOS) {
 	// Now a giant hack for looking up CPU info for OS.cpus() on iOS
 	// https://www.theiphonewiki.com/wiki/List_of_iPhones
 	const AppleMap = {
+		// iPhone 11 Pro Max
+		'iPhone12,5': [ 'Apple A13 Bionic @ 2.66 GHz', 2660 ],
+		// iPhone 11 Pro
+		'iPhone12,3': [ 'Apple A13 Bionic @ 2.66 GHz', 2660 ],
+		// iPhone 11
+		'iPhone12,1': [ 'Apple A13 Bionic @ 2.66 GHz', 2660 ],
 		// iPhone XR
 		'iPhone11,8': [ 'Apple A12 Bionic @ 2.49 GHz', 2490 ],
 		// iPhone XS Max
@@ -337,7 +343,7 @@ if (isIOS) {
 	 */
 	const cpuModelAndSpeed = (model) => {
 		const trimmed = model.replace(' (Simulator)', '').trim();
-		return AppleMap[trimmed];
+		return AppleMap[trimmed] || [ 'Unknown', 0 ];
 	};
 	// override cpus impl
 	OS.cpus = () => {


### PR DESCRIPTION
- Include new iPhone models into `os` extension
- Prevent `cpuModelAndSpeed` from failing
- Fixes ` ios.os.#cpus() returns array of objects whose length matches Ti.Platform.processorCount` test case

##### TEST CASE
```JS
const os = require('os');
console.log(JSON.stringify(os.cpus(), 1));

```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-27395)