### PR TITLE
fix(android): fix gradient background support for CardView

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUICardView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUICardView.java
@@ -24,6 +24,8 @@ import org.appcelerator.titanium.view.TiCompositeLayout.LayoutArrangement;
 import org.appcelerator.titanium.view.TiGradientDrawable;
 import org.appcelerator.titanium.view.TiUIView;
 
+import java.util.HashMap;
+
 public class TiUICardView extends TiUIView
 {
 	public int paddingLeft, paddingTop, paddingRight, paddingBottom;
@@ -150,9 +152,7 @@ public class TiUICardView extends TiUIView
 		super.processProperties(d);
 
 		if (d.containsKeyAndNotNull(TiC.PROPERTY_BACKGROUND_GRADIENT)) {
-			TiGradientDrawable tiGradientDrawable =
-				new TiGradientDrawable(this.cardView, d.getKrollDict(TiC.PROPERTY_BACKGROUND_GRADIENT));
-			this.cardView.setBackground(tiGradientDrawable);
+			setGradientBackground(d.getKrollDict(TiC.PROPERTY_BACKGROUND_GRADIENT));
 		}
 
 		if (d.containsKey(TiC.PROPERTY_BORDER_RADIUS)) {
@@ -264,33 +264,31 @@ public class TiUICardView extends TiUIView
 			Log.d(TAG, "Property: " + key + " old: " + oldValue + " new: " + newValue, Log.DEBUG_MODE);
 		}
 
-		TiCardView cardview = ((TiCardView) getNativeView());
-
-		if (key.equals(TiC.PROPERTY_BACKGROUND_COLOR)) {
-			cardview.setCardBackgroundColor(TiConvert.toColor(TiConvert.toString(newValue)));
-			cardview.requestLayout();
+		if (key.equals(TiC.PROPERTY_BACKGROUND_GRADIENT)) {
+			setGradientBackground(new KrollDict(((HashMap) newValue)));
+			this.cardView.requestLayout();
 		} else if (key.equals(TiC.PROPERTY_BORDER_RADIUS)) {
 			float radius = 0;
 			TiDimension radiusDim = TiConvert.toTiDimension(newValue, TiDimension.TYPE_WIDTH);
 			if (radiusDim != null) {
-				radius = (float) radiusDim.getPixels(cardview);
+				radius = (float) radiusDim.getPixels(this.cardView);
 			}
-			cardview.setRadius(radius);
-			cardview.requestLayout();
+			this.cardView.setRadius(radius);
+			this.cardView.requestLayout();
 		} else if (key.equals(TiC.PROPERTY_ELEVATION)) {
-			cardview.setCardElevation(TiConvert.toFloat(newValue));
-			cardview.requestLayout();
+			this.cardView.setCardElevation(TiConvert.toFloat(newValue));
+			this.cardView.requestLayout();
 		} else if (key.equals(TiC.PROPERTY_PREVENT_CORNER_OVERLAP)) {
-			cardview.setPreventCornerOverlap(TiConvert.toBoolean(newValue, false));
-			cardview.requestLayout();
+			this.cardView.setPreventCornerOverlap(TiConvert.toBoolean(newValue, false));
+			this.cardView.requestLayout();
 		} else if (key.equals(TiC.PROPERTY_USE_COMPAT_PADDING)) {
-			cardview.setUseCompatPadding(TiConvert.toBoolean(newValue, false));
-			cardview.requestLayout();
+			this.cardView.setUseCompatPadding(TiConvert.toBoolean(newValue, false));
+			this.cardView.requestLayout();
 		} else if (key.equals(TiC.PROPERTY_PADDING)) {
 			float radiusRight = 0;
 			TiDimension radiusDimRight = TiConvert.toTiDimension(TiConvert.toString(newValue), TiDimension.TYPE_RIGHT);
 			if (radiusDimRight != null) {
-				radiusRight = (float) radiusDimRight.getPixels(cardview);
+				radiusRight = (float) radiusDimRight.getPixels(this.cardView);
 			}
 			paddingRight = (int) radiusRight;
 
@@ -298,66 +296,72 @@ public class TiUICardView extends TiUIView
 			TiDimension radiusDimBottom =
 				TiConvert.toTiDimension(TiConvert.toString(newValue), TiDimension.TYPE_BOTTOM);
 			if (radiusDimBottom != null) {
-				radiusBottom = (float) radiusDimBottom.getPixels(cardview);
+				radiusBottom = (float) radiusDimBottom.getPixels(this.cardView);
 			}
 			paddingBottom = (int) radiusBottom;
 
 			float radiusLeft = 0;
 			TiDimension radiusDimLeft = TiConvert.toTiDimension(TiConvert.toString(newValue), TiDimension.TYPE_LEFT);
 			if (radiusDimLeft != null) {
-				radiusLeft = (float) radiusDimLeft.getPixels(cardview);
+				radiusLeft = (float) radiusDimLeft.getPixels(this.cardView);
 			}
 			paddingLeft = (int) radiusLeft;
 
 			float radiusTop = 0;
 			TiDimension radiusDimTop = TiConvert.toTiDimension(TiConvert.toString(newValue), TiDimension.TYPE_TOP);
 			if (radiusDimTop != null) {
-				radiusTop = (float) radiusDimTop.getPixels(cardview);
+				radiusTop = (float) radiusDimTop.getPixels(this.cardView);
 			}
 			paddingTop = (int) radiusTop;
 
-			cardview.setContentPadding(paddingLeft, paddingTop, paddingRight, paddingBottom);
-			cardview.requestLayout();
+			this.cardView.setContentPadding(paddingLeft, paddingTop, paddingRight, paddingBottom);
+			this.cardView.requestLayout();
 		} else if (key.equals(TiC.PROPERTY_PADDING_BOTTOM)) {
 			float radiusBottom = 0;
 			TiDimension radiusDimBottom =
 				TiConvert.toTiDimension(TiConvert.toString(newValue), TiDimension.TYPE_BOTTOM);
 			if (radiusDimBottom != null) {
-				radiusBottom = (float) radiusDimBottom.getPixels(cardview);
+				radiusBottom = (float) radiusDimBottom.getPixels(this.cardView);
 			}
 			paddingBottom = (int) radiusBottom;
-			cardview.setContentPadding(paddingLeft, paddingTop, paddingRight, paddingBottom);
-			cardview.requestLayout();
+			this.cardView.setContentPadding(paddingLeft, paddingTop, paddingRight, paddingBottom);
+			this.cardView.requestLayout();
 		} else if (key.equals(TiC.PROPERTY_PADDING_LEFT)) {
 			float radiusLeft = 0;
 			TiDimension radiusDimLeft = TiConvert.toTiDimension(TiConvert.toString(newValue), TiDimension.TYPE_LEFT);
 			if (radiusDimLeft != null) {
-				radiusLeft = (float) radiusDimLeft.getPixels(cardview);
+				radiusLeft = (float) radiusDimLeft.getPixels(this.cardView);
 			}
 			paddingLeft = (int) radiusLeft;
-			cardview.setContentPadding(paddingLeft, paddingTop, paddingRight, paddingBottom);
-			cardview.requestLayout();
+			this.cardView.setContentPadding(paddingLeft, paddingTop, paddingRight, paddingBottom);
+			this.cardView.requestLayout();
 		} else if (key.equals(TiC.PROPERTY_PADDING_RIGHT)) {
 			float radiusRight = 0;
 			TiDimension radiusDimRight = TiConvert.toTiDimension(TiConvert.toString(newValue), TiDimension.TYPE_RIGHT);
 			if (radiusDimRight != null) {
-				radiusRight = (float) radiusDimRight.getPixels(cardview);
+				radiusRight = (float) radiusDimRight.getPixels(this.cardView);
 			}
 			paddingRight = (int) radiusRight;
-			cardview.setContentPadding(paddingLeft, paddingTop, paddingRight, paddingBottom);
-			cardview.requestLayout();
+			this.cardView.setContentPadding(paddingLeft, paddingTop, paddingRight, paddingBottom);
+			this.cardView.requestLayout();
 		} else if (key.equals(TiC.PROPERTY_PADDING_TOP)) {
 			float radiusTop = 0;
 			TiDimension radiusDimTop = TiConvert.toTiDimension(TiConvert.toString(newValue), TiDimension.TYPE_TOP);
 			if (radiusDimTop != null) {
-				radiusTop = (float) radiusDimTop.getPixels(cardview);
+				radiusTop = (float) radiusDimTop.getPixels(this.cardView);
 			}
 			paddingTop = (int) radiusTop;
-			cardview.setContentPadding(paddingLeft, paddingTop, paddingRight, paddingBottom);
-			cardview.requestLayout();
+			this.cardView.setContentPadding(paddingLeft, paddingTop, paddingRight, paddingBottom);
+			this.cardView.requestLayout();
 		} else {
 			super.propertyChanged(key, oldValue, newValue, proxy);
 		}
+	}
+
+	private void setGradientBackground(KrollDict gradientBackgroundProperties)
+	{
+		TiGradientDrawable tiGradientDrawable = new TiGradientDrawable(this.cardView, gradientBackgroundProperties);
+		this.cardView.setBackground(tiGradientDrawable);
 	}
 
 	@Override

--- a/apidoc/Titanium/UI/Android/CardView.yml
+++ b/apidoc/Titanium/UI/Android/CardView.yml
@@ -18,7 +18,8 @@ description: |
     CardView does not support <Titanium.UI.View.backgroundImage>, <Titanium.UI.View.borderColor>, or <Titanium.UI.View.backgroundGradient>.
 extends: Titanium.UI.View
 excludes:
-    properties: [backgroundImage, backgroundRepeat, borderColor, backgroundGradient]
+    properties: [backgroundImage, backgroundRepeat, borderColor, backgroundDisabledColor, backgroundSelectedColor,
+                backgroundFocusedColor, backgroundDisabledImage, backgroundSelectedImage, backgroundFocusedImage]
 since: "5.1.0"
 platforms: [android]
 
@@ -31,6 +32,7 @@ properties:
     type: String
     deprecated:
       since: 5.1.2
+      removed: 6.0.0
       notes: Use [Titanium.UI.Android.CardView.backgroundColor](Titanium.UI.Android.CardView.backgroundColor) instead.
 
   - name: backgroundColor
@@ -45,6 +47,7 @@ properties:
     type: Number
     deprecated:
       since: 5.1.2
+      removed: 6.0.0
       notes: Use [Titanium.UI.Android.CardView.borderRadius](Titanium.UI.Android.CardView.borderRadius) instead.
 
   - name: borderRadius
@@ -57,6 +60,7 @@ properties:
     type: Number
     deprecated:
       since: 5.1.2
+      removed: 6.0.0
       notes: Use [Titanium.UI.Android.CardView.elevation](Titanium.UI.Android.CardView.elevation) instead.
 
   - name: elevation
@@ -70,6 +74,7 @@ properties:
     availability: creation
     deprecated:
       since: 5.1.2
+      removed: 6.0.0
       notes: Use [Titanium.UI.Android.CardView.maxElevation](Titanium.UI.Android.CardView.maxElevation) instead.
 
   - name: maxElevation
@@ -86,6 +91,7 @@ properties:
     default: false
     deprecated:
       since: 5.1.2
+      removed: 6.0.0
       notes: Use [Titanium.UI.Android.CardView.preventCornerOverlap](Titanium.UI.Android.CardView.preventCornerOverlap) instead.
 
   - name: preventCornerOverlap
@@ -102,6 +108,7 @@ properties:
     default: false
     deprecated:
       since: 5.1.2
+      removed: 6.0.0
       notes: Use [Titanium.UI.Android.CardView.useCompatPadding](Titanium.UI.Android.CardView.useCompatPadding) instead.
 
   - name: useCompatPadding
@@ -115,6 +122,7 @@ properties:
     type: Number
     deprecated:
       since: 5.1.2
+      removed: 6.0.0
       notes: Use [Titanium.UI.Android.CardView.padding](Titanium.UI.Android.CardView.padding) instead.
 
   - name: padding
@@ -127,6 +135,7 @@ properties:
     type: Number
     deprecated:
       since: 5.1.2
+      removed: 6.0.0
       notes: Use [Titanium.UI.Android.CardView.paddingBottom](Titanium.UI.Android.CardView.paddingBottom) instead.
 
   - name: paddingBottom
@@ -139,6 +148,7 @@ properties:
     type: Number
     deprecated:
       since: 5.1.2
+      removed: 6.0.0
       notes: Use [Titanium.UI.Android.CardView.paddingLeft](Titanium.UI.Android.CardView.paddingLeft) instead.
 
   - name: paddingLeft
@@ -151,6 +161,7 @@ properties:
     type: Number
     deprecated:
       since: 5.1.2
+      removed: 6.0.0
       notes: Use [Titanium.UI.Android.CardView.paddingRight](Titanium.UI.Android.CardView.paddingRight) instead.
 
   - name: paddingRight
@@ -163,6 +174,7 @@ properties:
     type: Number
     deprecated:
       since: 5.1.2
+      removed: 6.0.0
       notes: Use [Titanium.UI.Android.CardView.paddingTop](Titanium.UI.Android.CardView.paddingTop) instead.
 
   - name: paddingTop


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-27258

**Description:**
Fix support of Gradient background for Ti.UI.Android.CardView. Refactor the assigning of nativeView for TiUICardView in order to avoid duplicated execution of `processProperties()`. Add some "removed" properties in the docs and remove the color/image states properties. They are currently bugged, but I would not want to expand the scope of this PR.
Note: No unit tests, since this is a bug that is only visual. All the View's events are triggered but it remains invisible.

This PR's test case would be good to be ran again, since there are changes in the code it added:
https://github.com/appcelerator/titanium_mobile/pull/10045 

**Test case:**
_app.js_
```js
var win = Ti.UI.createWindow({layout: 'vertical'}),
	cardView1 = Ti.UI.Android.createCardView({
		width: 200,
		height: 200,
			backgroundGradient: {
			type: 'linear',
			colors: ['red', 'green'],
			startPoint: { x: '50%', y: 0 },
			endPoint: { x: '50%', y: '100%' },
			backFillStart: false
		},
	}),
	cardView2 = Ti.UI.Android.createCardView({
		top: 50,
		width: 200,
		height: 200,
		backgroundColor: 'red'
	});

cardView1.addEventListener('click', function() {
	cardView1.backgroundGradient = {
		type: 'linear',
		colors: ['yellow', 'magenta'],
		startPoint: { x: '50%', y: 0 },
		endPoint: { x: '50%', y: '100%' },
		backFillStart: false
	}
});

cardView2.addEventListener('click', function() {
	cardView2.backgroundColor = 'blue';
});

win.add([cardView1, cardView2]);
win.open();

```