### PR TITLE
feat(ios): update facebook module to 7.0.0

### DIFF
--- a/support/module/packaged/modules.json
+++ b/support/module/packaged/modules.json
@@ -5,8 +5,8 @@
 			"integrity": "sha512-fyilD5d27RYZaq/s3XEWxJDzUSEjKiTeu+2W552q8JDk33kmTq3nA1yX6Q5k7Tyl3RFhkSPJ0cPgEzREvwCCzg=="
 		},
 		"facebook": {
-			"url": "https://github.com/appcelerator-modules/ti.facebook/releases/download/ios-6.0.0/facebook-iphone-6.0.0.zip",
-			"integrity": "sha512-SgXiave5OyG5xL74GYHsMJ5m51JwCWGxf9Umtwea8KXVB+OEtm6LYWOTAThsuqrT15NNZVDZtdUihsGsc7xSmw=="
+			"url": "https://github.com/appcelerator-modules/ti.facebook/releases/download/v7.0.0-iphone/facebook-iphone-7.0.0.zip",
+			"integrity": "sha512-XqozizQjlNB8SfCW7gq8U/ljqzH8T+lPZmHLSHzH420UNwy8V1GixpYTBLqJnz+SIV8EyQF07y+M1gTOWEVDoA=="
 		},
 		"ti.coremotion": {
 			"url": "https://github.com/appcelerator-modules/ti.coremotion/releases/download/v2.0.1/ti.coremotion-iphone-2.0.1.zip",


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/MOD-2534

**Description:**
Include the latest iOS Facebook module (7.0.0) with iOS 13 fix (and breaking change for removed messenger button)

(from appcelerator-modules/ti.facebook#103)