### PR TITLE
fix(android): add single/doubletap to scrollview TIMOB-13286

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIScrollView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIScrollView.java
@@ -76,6 +76,22 @@ public class TiUIScrollView extends TiUIView
 						fireEvent(TiC.EVENT_LONGPRESS, dictFromEvent(e));
 					}
 				}
+				@Override
+				public boolean onSingleTapConfirmed(MotionEvent e)
+				{
+					if (proxy.hierarchyHasListener(TiC.EVENT_SINGLE_TAP)) {
+						fireEvent(TiC.EVENT_SINGLE_TAP, dictFromEvent(e));
+					}
+					return true;
+				}
+				@Override
+				public boolean onDoubleTap(MotionEvent e)
+				{
+					if (proxy.hierarchyHasListener(TiC.EVENT_DOUBLE_TAP)) {
+						fireEvent(TiC.EVENT_DOUBLE_TAP, dictFromEvent(e));
+					}
+					return true;
+				}
 			});
 			setOnTouchListener(new OnTouchListener() {
 				@Override


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-13286

example code
```
    var win = Ti.UI.createWindow({
        backgroundColor: 'white'
    });
    var scrollview = Ti.UI.createScrollView({
        layout: 'vertical',
        height: '90%',
        contentWidth: 'auto',
        contentHeight: 'auto',
        showVerticalScrollIndicator: true,
        touchEnabled: true,
        backgroundColor: 'red'
    });

    win.add(scrollview);
    scrollview.addEventListener('click', function() {
        console.log('click');
    });

    scrollview.addEventListener('singletap', function() {
        console.log('single tap occured');
    });

    scrollview.addEventListener('doubletap', function() {
        console.log('doubletap tap occured');
    });

    win.open();
```
