### PR TITLE
fix(conditions): Change from ifdef to if due to variable always being defined

### DIFF
--- a/iphone/Classes/TiUIApplicationShortcutsProxy.m
+++ b/iphone/Classes/TiUIApplicationShortcutsProxy.m
@@ -212,7 +212,7 @@
     return [UIApplicationShortcutIcon iconWithTemplateImageName:[self urlInAssetCatalog:value]];
   }
 
-#ifdef IS_SDK_IOS_13
+#if IS_SDK_IOS_13
   if ([value isKindOfClass:[TiBlob class]] && [TiUtils isIOSVersionOrGreater:@"13.0"]) {
     TiBlob *blob = (TiBlob *)value;
     if (blob.type == TiBlobTypeSystemImage) {

--- a/iphone/Classes/TiUIiOSApplicationShortcutsProxy.m
+++ b/iphone/Classes/TiUIiOSApplicationShortcutsProxy.m
@@ -212,7 +212,7 @@
     return [UIApplicationShortcutIcon iconWithTemplateImageName:[self urlInAssetCatalog:value]];
   }
 
-#ifdef IS_SDK_IOS_13
+#if IS_SDK_IOS_13
   if ([value isKindOfClass:[TiBlob class]] && [TiUtils isIOSVersionOrGreater:@"13.0"]) {
     TiBlob *blob = (TiBlob *)value;
     if (blob.type == TiBlobTypeSystemImage) {


### PR DESCRIPTION
The test for whether or not we're using iOS 13 was using an ifdef condition, but this is always
defined as either true or false in the Titanium_Prefix.pch

https://jira.appcelerator.org/browse/TIMOB-27435
