### PR TITLE
build: allow building a windows ti.main.js

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -294,7 +294,11 @@ timestamps {
 					// TODO parallelize the iOS/Android/Mobileweb/Windows portions?
 					dir('build') {
 						timeout(15) {
-							sh "node scons.js build --android-ndk ${env.ANDROID_NDK_R16B} --android-sdk ${env.ANDROID_SDK}"
+							if (includeWindows) {
+								sh "node scons.js build --android-ndk ${env.ANDROID_NDK_R16B} --android-sdk ${env.ANDROID_SDK} --all"
+							} else {
+								sh "node scons.js build --android-ndk ${env.ANDROID_NDK_R16B} --android-sdk ${env.ANDROID_SDK}"
+							}
 						} // timeout
 						ansiColor('xterm') {
 							timeout(15) {

--- a/build/scons-build.js
+++ b/build/scons-build.js
@@ -9,6 +9,7 @@ program
 	.option('-a, --api-level [number]', 'Explicitly set the Android SDK API level used for building')
 	.option('-s, --android-sdk [path]', 'Explicitly set the path to the Android SDK used for building', process.env.ANDROID_SDK)
 	.option('-n, --android-ndk [path]', 'Explicitly set the path to the Android NDK used for building', process.env.ANDROID_NDK)
+	.option('-a, --all', 'Build a ti.main.js file for every target OS')
 	.parse(process.argv);
 
 const Builder = require('./lib/builder');


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-27452

Allow specifying `--all` to the `scons build` command that will ensure we create a   `ti.main.js` entry for Windows when building. Then use this in Jenkins

Verified locally by pulling down Windows artifacts from the master branch, and setting up to match a mainline branch build. The Windows zip had the windows `ti.main.js` file. I think we need to update the Windows CLI to look for it there though