### PR TITLE
fix(android): focus on TextInputEditText view

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIText.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIText.java
@@ -496,7 +496,7 @@ public class TiUIText extends TiUIView implements TextWatcher, OnEditorActionLis
 	public void focus()
 	{
 		super.focus();
-		if (tv != null) {
+		if (tv != null && proxy != null && proxy.getProperties() != null) {
 			final boolean editable = proxy.getProperties().optBoolean(TiC.PROPERTY_EDITABLE, false);
 			TiUIHelper.showSoftKeyboard(tv, editable);
 		}

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIText.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIText.java
@@ -497,12 +497,8 @@ public class TiUIText extends TiUIView implements TextWatcher, OnEditorActionLis
 	{
 		super.focus();
 		if (tv != null) {
-			if (proxy.hasProperty(TiC.PROPERTY_EDITABLE)
-				&& !(TiConvert.toBoolean(proxy.getProperty(TiC.PROPERTY_EDITABLE)))) {
-				TiUIHelper.showSoftKeyboard(tv, false);
-			} else {
-				TiUIHelper.showSoftKeyboard(tv, true);
-			}
+			final boolean editable = proxy.getProperties().optBoolean(TiC.PROPERTY_EDITABLE, false);
+			TiUIHelper.showSoftKeyboard(tv, editable);
 		}
 	}
 

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiUIHelper.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiUIHelper.java
@@ -1116,20 +1116,14 @@ public class TiUIHelper
 	 */
 	public static void showSoftKeyboard(View view, boolean show)
 	{
-		InputMethodManager imm = (InputMethodManager) view.getContext().getSystemService(Activity.INPUT_METHOD_SERVICE);
-
+		final InputMethodManager imm =
+			(InputMethodManager) view.getContext().getSystemService(Activity.INPUT_METHOD_SERVICE);
 		if (imm != null) {
-			boolean useForce =
-				(Build.VERSION.SDK_INT <= Build.VERSION_CODES.DONUT || Build.VERSION.SDK_INT >= 8) ? true : false;
-			String model = APSAnalyticsMeta.getModel();
-			if (model.toLowerCase().startsWith("droid")) {
-				useForce = true;
-			}
+			view.requestFocus();
 			if (show) {
-				imm.showSoftInput(view, useForce ? InputMethodManager.SHOW_FORCED : InputMethodManager.SHOW_IMPLICIT);
+				imm.showSoftInput(view, InputMethodManager.SHOW_IMPLICIT);
 			} else {
-				imm.hideSoftInputFromWindow(view.getWindowToken(),
-											useForce ? 0 : InputMethodManager.HIDE_IMPLICIT_ONLY);
+				imm.hideSoftInputFromWindow(view.getWindowToken(), InputMethodManager.HIDE_IMPLICIT_ONLY);
 			}
 		}
 	}


### PR DESCRIPTION
- Fix `TiUIText` from focusing on `TextInputLayout` instead of `TiUIEditText` on Android 8.0+

##### TEST CASE
```JS
const win = Ti.UI.createWindow({
    backgroundColor: 'gray',
    layout: 'vertical'
});

const txt_a = Ti.UI.createTextField({
    hintText: 'Text Field #1',
    width: '90%'
});
const txt_b = Ti.UI.createTextField({
    hintText: 'Text Field #2',
    width: '90%'
});
const txt_c = Ti.UI.createTextField({
    hintText: 'Text Field #3',
    width: '90%'
});

txt_a.addEventListener('return', _ => {
    Ti.API.info(`'return' event fired on 'Text Field #1'`);
    txt_c.focus();
    Ti.API.info(`Set focus to 'Text Field #3'`);
});

win.add([ txt_a, txt_b, txt_c ]);
win.open();
```
1. Enter text into `Text Field #1`
2. Press `Enter`
3. `Text Field #3` should focus and allow text entry

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-27426)