### PR TITLE
Fix xcodebuild dest, bump min iOS target to 9, disable ONLY_ACTIVE_ARCH for 32-bit sims

### DIFF
--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -181,7 +181,12 @@ function iOSBuilder() {
 	this.defaultLaunchScreenStoryboard = true;
 	this.defaultBackgroundColor = null;
 
-	// only build active arch simulator is 64-bit (iPhone 5s or newer, iPhone 5 and older are not 64-bit)
+	// sim builds will auto-select an xcodebuild destination regardless of the actual simulator
+	// selected and since all modern iOS simulator devices are 64-bit only, that means that the
+	// ONLY_ACTIVE_ARCH flag only build a 64-bit only app
+	//
+	// if the selected sim is 32-bit (iPhone 5 and older, iPad 4th gen or older), then the app
+	// won't run, so we need to track the ONLY_ACTIVE_ARCH flag and disable it for 32-bit sims
 	this.simOnlyActiveArch = null;
 }
 

--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -6802,11 +6802,15 @@ iOSBuilder.prototype.invokeXcodeBuild = function invokeXcodeBuild(next) {
 					break;
 				}
 			}
+			if (dest) {
+				break;
+			}
 		}
 
 		if (!dest) {
 			// couldn't find a simulator!
 			// this shouldn't happen, but just in case, fall back to the selected simulator
+			this.logger.debug(`Couldn't find a simulator compatible with Xcode ${this.xcodeEnv.version}, falling back to selected simulator`);
 			dest = `platform=iOS Simulator,id=${this.simHandle.udid},OS=${appc.version.format(this.simHandle.version, 2, 2)}`;
 		}
 

--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -4013,140 +4013,140 @@ iOSBuilder.prototype.writeInfoPlist = function writeInfoPlist() {
 	delete plist.UILaunchImageFile;
 
 	const i18nLaunchScreens = {};
+	ti.i18n.findLaunchScreens(this.projectDir, this.logger, { ignoreDirs: this.ignoreDirs }).forEach(function (p) {
+		i18nLaunchScreens[path.basename(p)] = 1;
+	});
 
-	if (appc.version.lt(this.xcodeEnv.version, '11.0.0')) {
-		ti.i18n.findLaunchScreens(this.projectDir, this.logger, { ignoreDirs: this.ignoreDirs }).forEach(function (p) {
-			i18nLaunchScreens[path.basename(p)] = 1;
-		});
+	[ {
+		orientation: 'Portrait',
+		'minimum-system-version': '12.0',
+		name: 'Default-Portrait',
+		subtype: '2688h',
+		scale: [ '3x' ],
+		size: '{414, 896}'
+	},
+	{
+		orientation: 'Landscape',
+		'minimum-system-version': '12.0',
+		name: 'Default-Landscape',
+		subtype: '2688h',
+		scale: [ '3x' ],
+		size: '{414, 896}'
+	},
+	{
+		orientation: 'Portrait',
+		'minimum-system-version': '12.0',
+		name: 'Default-Portrait',
+		subtype: '1792h',
+		scale: [ '2x' ],
+		size: '{414, 896}'
+	},
+	{
+		orientation: 'Landscape',
+		'minimum-system-version': '12.0',
+		name: 'Default-Landscape',
+		subtype: '1792h',
+		scale: [ '2x' ],
+		size: '{414, 896}'
+	},
+	{
+		orientation: 'Portrait',
+		'minimum-system-version': '11.0',
+		name: 'Default-Portrait',
+		subtype: '2436h',
+		scale: [ '3x' ],
+		size: '{375, 812}'
+	},
+	{
+		orientation: 'Landscape',
+		'minimum-system-version': '11.0',
+		name: 'Default-Landscape',
+		subtype: '2436h',
+		scale: [ '3x' ],
+		size: '{375, 812}'
+	},
+	{
+		orientation: 'Portrait',
+		'minimum-system-version': '8.0',
+		name: 'Default-Portrait',
+		subtype: '736h',
+		scale: [ '3x' ],
+		size: '{414, 736}'
+	},
+	{
+		orientation: 'Landscape',
+		'minimum-system-version': '8.0',
+		name: 'Default-Landscape',
+		subtype: '736h',
+		scale: [ '3x' ],
+		size: '{414, 736}'
+	},
+	{
+		orientation: 'Portrait',
+		'minimum-system-version': '8.0',
+		name: 'Default',
+		subtype: '667h',
+		scale: [ '2x' ],
+		size: '{375, 667}'
+	},
+	{
+		orientation: 'Portrait',
+		'minimum-system-version': '7.0',
+		name: 'Default',
+		scale: [ '2x', '1x' ],
+		size: '{320, 480}'
+	},
+	{
+		orientation: 'Portrait',
+		'minimum-system-version': '7.0',
+		name: 'Default',
+		subtype: '568h',
+		scale: [ '2x' ],
+		size: '{320, 568}'
+	},
+	{
+		orientation: 'Portrait',
+		idiom: 'ipad',
+		'minimum-system-version': '7.0',
+		name: 'Default-Portrait',
+		scale: [ '2x', '1x' ],
+		size: '{768, 1024}'
+	},
+	{
+		orientation: 'Landscape',
+		idiom: 'ipad',
+		'minimum-system-version': '7.0',
+		name: 'Default-Landscape',
+		scale: [ '2x', '1x' ],
+		size: '{768, 1024}'
+	} ].forEach(function (asset) {
+		asset.scale.some(function (scale) {
+			let key;
+			const basefilename = asset.name + (asset.subtype ? '-' + asset.subtype : ''),
+				filename = basefilename + (scale !== '1x' ? '@' + scale : '') + '.png';
 
-		[ {
-			orientation: 'Portrait',
-			'minimum-system-version': '12.0',
-			name: 'Default-Portrait',
-			subtype: '2688h',
-			scale: [ '3x' ],
-			size: '{414, 896}'
-		},
-		{
-			orientation: 'Landscape',
-			'minimum-system-version': '12.0',
-			name: 'Default-Landscape',
-			subtype: '2688h',
-			scale: [ '3x' ],
-			size: '{414, 896}'
-		},
-		{
-			orientation: 'Portrait',
-			'minimum-system-version': '12.0',
-			name: 'Default-Portrait',
-			subtype: '1792h',
-			scale: [ '2x' ],
-			size: '{414, 896}'
-		},
-		{
-			orientation: 'Landscape',
-			'minimum-system-version': '12.0',
-			name: 'Default-Landscape',
-			subtype: '1792h',
-			scale: [ '2x' ],
-			size: '{414, 896}'
-		},
-		{
-			orientation: 'Portrait',
-			'minimum-system-version': '11.0',
-			name: 'Default-Portrait',
-			subtype: '2436h',
-			scale: [ '3x' ],
-			size: '{375, 812}'
-		},
-		{
-			orientation: 'Landscape',
-			'minimum-system-version': '11.0',
-			name: 'Default-Landscape',
-			subtype: '2436h',
-			scale: [ '3x' ],
-			size: '{375, 812}'
-		},
-		{
-			orientation: 'Portrait',
-			'minimum-system-version': '8.0',
-			name: 'Default-Portrait',
-			subtype: '736h',
-			scale: [ '3x' ],
-			size: '{414, 736}'
-		},
-		{
-			orientation: 'Landscape',
-			'minimum-system-version': '8.0',
-			name: 'Default-Landscape',
-			subtype: '736h',
-			scale: [ '3x' ],
-			size: '{414, 736}'
-		},
-		{
-			orientation: 'Portrait',
-			'minimum-system-version': '8.0',
-			name: 'Default',
-			subtype: '667h',
-			scale: [ '2x' ],
-			size: '{375, 667}'
-		},
-		{
-			orientation: 'Portrait',
-			'minimum-system-version': '7.0',
-			name: 'Default',
-			scale: [ '2x', '1x' ],
-			size: '{320, 480}'
-		},
-		{
-			orientation: 'Portrait',
-			'minimum-system-version': '7.0',
-			name: 'Default',
-			subtype: '568h',
-			scale: [ '2x' ],
-			size: '{320, 568}'
-		},
-		{
-			orientation: 'Portrait',
-			idiom: 'ipad',
-			'minimum-system-version': '7.0',
-			name: 'Default-Portrait',
-			scale: [ '2x', '1x' ],
-			size: '{768, 1024}'
-		},
-		{
-			orientation: 'Landscape',
-			idiom: 'ipad',
-			'minimum-system-version': '7.0',
-			name: 'Default-Landscape',
-			scale: [ '2x', '1x' ],
-			size: '{768, 1024}'
-		} ].forEach(function (asset) {
-			asset.scale.some(function (scale) {
-				let key;
-				const basefilename = asset.name + (asset.subtype ? '-' + asset.subtype : ''),
-					filename = basefilename + (scale !== '1x' ? '@' + scale : '') + '.png';
-
-				// if we have a launch image and if we're doing iPhone only, don't include iPad launch images
-				if (i18nLaunchScreens[filename] && (this.deviceFamily !== 'iphone' || asset.idiom === 'iphone')) {
-					key = 'UILaunchImages' + (asset.idiom === 'ipad' ? '~ipad' : '');
-					Array.isArray(plist[key]) || (plist[key] = []);
-					plist[key].push({
-						UILaunchImageName: basefilename,
-						UILaunchImageOrientation: asset.orientation,
-						UILaunchImageSize: asset.size,
-						UILaunchImageMinimumOSVersion: asset['minimum-system-version']
-					});
-					return true;
-				}
-				return false;
-			}, this);
+			// if we have a launch image and if we're doing iPhone only, don't include iPad launch images
+			if (i18nLaunchScreens[filename] && (this.deviceFamily !== 'iphone' || asset.idiom === 'iphone')) {
+				key = 'UILaunchImages' + (asset.idiom === 'ipad' ? '~ipad' : '');
+				Array.isArray(plist[key]) || (plist[key] = []);
+				plist[key].push({
+					UILaunchImageName: basefilename,
+					UILaunchImageOrientation: asset.orientation,
+					UILaunchImageSize: asset.size,
+					UILaunchImageMinimumOSVersion: asset['minimum-system-version']
+				});
+				return true;
+			}
+			return false;
 		}, this);
-	}
+	}, this);
 
 	if (this.enableLaunchScreenStoryboard) {
 		plist.UILaunchStoryboardName = 'LaunchScreen';
 	} else {
+		if (appc.version.gte(this.xcodeEnv.version, '11.0.0')) {
+			this.logger.warn(__('Launch images are deprecated by Xcode 11 and you will need to adopt a storyboard-based launch screen'));
+		}
 		delete plist.UILaunchStoryboardName;
 	}
 
@@ -4269,7 +4269,7 @@ iOSBuilder.prototype.writeInfoPlist = function writeInfoPlist() {
 		this.logger.warn(__('Removing custom Info.plist "CFBundleIconFiles" since we now use an asset catalog for app icons.'));
 		delete plist.CFBundleIconFiles;
 	}
-	if (appc.version.lt(this.xcodeEnv.version, '11.0.0') && !Object.keys(i18nLaunchScreens).length) {
+	if (!Object.keys(i18nLaunchScreens).length) {
 		// no i18n launch images, so nuke the launch image related keys
 		if (plist.UILaunchImages) {
 			this.logger.warn(__('Removing custom Info.plist "UILaunchImages" since we now use an asset catalog for launch images.'));
@@ -5029,22 +5029,20 @@ iOSBuilder.prototype.copyResources = function copyResources(next) {
 		walk(path.join(module.modulePath, 'Resources', 'ios'),    this.xcodeAppDir);
 	}, this);
 
-	if (appc.version.lt(this.xcodeEnv.version, '11.0.0')) {
-		this.logger.info(__('Analyzing localized launch images'));
-		ti.i18n.findLaunchScreens(this.projectDir, this.logger, { ignoreDirs: this.ignoreDirs }).forEach(function (launchImage) {
-			const parts = launchImage.split('/'),
-				file = parts.pop(),
-				lang = parts.pop(),
-				relPath = path.join(lang + '.lproj', file);
+	this.logger.info(__('Analyzing localized launch images'));
+	ti.i18n.findLaunchScreens(this.projectDir, this.logger, { ignoreDirs: this.ignoreDirs }).forEach(function (launchImage) {
+		const parts = launchImage.split('/'),
+			file = parts.pop(),
+			lang = parts.pop(),
+			relPath = path.join(lang + '.lproj', file);
 
-			launchImages[relPath] = {
-				i18n: lang,
-				src: launchImage,
-				dest: path.join(this.xcodeAppDir, relPath),
-				srcStat: fs.statSync(launchImage)
-			};
-		}, this);
-	}
+		launchImages[relPath] = {
+			i18n: lang,
+			src: launchImage,
+			dest: path.join(this.xcodeAppDir, relPath),
+			srcStat: fs.statSync(launchImage)
+		};
+	}, this);
 
 	// detect ambiguous modules
 	this.modules.forEach(function (module) {
@@ -5629,11 +5627,6 @@ iOSBuilder.prototype.copyResources = function copyResources(next) {
 				},
 
 				function createLaunchImageSet() {
-					if (appc.version.gte(this.xcodeEnv.version, '11.0.0')) {
-						this.logger.info(__('Skipping launch image set since it\'s deprecated in Xcode 11'));
-						return;
-					}
-
 					this.logger.info(__('Creating launch image set'));
 
 					const launchImageDir = path.join(this.buildDir, 'Assets.xcassets', 'LaunchImage.launchimage'),

--- a/iphone/iphone/Titanium.xcodeproj/project.pbxproj
+++ b/iphone/iphone/Titanium.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 48;
+	objectVersion = 50;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -2048,7 +2048,7 @@
 				};
 			};
 			buildConfigurationList = C01FCF4E08A954540054247B /* Build configuration list for PBXProject "Titanium" */;
-			compatibilityVersion = "Xcode 8.0";
+			compatibilityVersion = "Xcode 9.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 1;
 			knownRegions = (
@@ -2495,7 +2495,7 @@
 					"${\"SDKROOT\"}/usr/include/libxml2",
 					../headers,
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "-DDEBUG";
 				OTHER_LDFLAGS = "-ObjC";
@@ -2555,7 +2555,7 @@
 					"${\"SDKROOT\"}/usr/include/libxml2",
 					../headers,
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				OTHER_LDFLAGS = "-ObjC";
 				PROVISIONING_PROFILE = "";
 				"PROVISIONING_PROFILE[sdk=iphoneos*]" = "";

--- a/package-lock.json
+++ b/package-lock.json
@@ -2677,9 +2677,9 @@
       "integrity": "sha1-6Flo+iNfIXc9OIxhevCFvyEEQlo="
     },
     "chownr": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.2.tgz",
-      "integrity": "sha512-GkfeAQh+QNy3wquu9oIZr6SS5x7wGdSgNQvD10X3r+AZr1Oys22HW8kAmDMvNg2+Dm0TeGaEuO8gFwdBXxwO8A=="
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.3.tgz",
+      "integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw=="
     },
     "ci-info": {
       "version": "2.0.0",
@@ -6730,9 +6730,9 @@
       "dev": true
     },
     "ignore-walk": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.2.tgz",
-      "integrity": "sha512-EXyErtpHbn75ZTsOADsfx6J/FPo6/5cjev46PXrcTpd8z3BoRkXgYu9/JVqrI7tusjmwCZutGeRJeU0Wo1e4Cw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
+      "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
       "requires": {
         "minimatch": "^3.0.4"
       }
@@ -6930,9 +6930,9 @@
       "dev": true
     },
     "ioslib": {
-      "version": "1.7.14",
-      "resolved": "https://registry.npmjs.org/ioslib/-/ioslib-1.7.14.tgz",
-      "integrity": "sha512-diEgu3U8vLgkj7wFpX0pjQZbauR1w4OFeLqCauUP3mPWgaNc9WALsZ/pzlCSzzfEq2e13zOdcNaT7QGDZhzaVw==",
+      "version": "1.7.15",
+      "resolved": "https://registry.npmjs.org/ioslib/-/ioslib-1.7.15.tgz",
+      "integrity": "sha512-J/dUFk3fuHJqgskhyeEh7Ffjs2X8Yke+Ybu7mHP+CoffqDxY3+cfJ8lsX2MsaWMDLkfXQikOQas86x0TCLRFFA==",
       "requires": {
         "always-tail": "0.2.0",
         "async": "^2.6.3",
@@ -6940,7 +6940,7 @@
         "debug": "^3.2.6",
         "mkdirp": "0.5.1",
         "node-appc": "^0.3.4",
-        "node-ios-device": "^1.6.3"
+        "node-ios-device": "^1.7.0"
       },
       "dependencies": {
         "async": {
@@ -8758,13 +8758,13 @@
       "dev": true
     },
     "node-ios-device": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/node-ios-device/-/node-ios-device-1.6.3.tgz",
-      "integrity": "sha512-ERmLRacvOWSJJxLiuJSOqR+RzjzSL7xMKClvuU5Gb5T//pXXpH4HVAQymthfD0Fjq4caqEMzSw2HkdBbvP3oWw==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/node-ios-device/-/node-ios-device-1.7.0.tgz",
+      "integrity": "sha512-Gp+2Rir6IVN2Dl04ckU/rO2LvXfR8YSNFKSlkoPNPwKtRpPqAnXWs5hHTk2Yj78bTHBF7xGtgBLKZD+I44vfUw==",
       "requires": {
-        "debug": "^4.1.0",
-        "nan": "^2.11.1",
-        "node-pre-gyp": "^0.12.0",
+        "debug": "^4.1.1",
+        "nan": "^2.14.0",
+        "node-pre-gyp": "^0.13.0",
         "node-pre-gyp-init": "^1.1.0"
       },
       "dependencies": {
@@ -8801,7 +8801,7 @@
           }
         },
         "chownr": {
-          "version": "1.1.1",
+          "version": "1.1.3",
           "bundled": true
         },
         "code-point-at": {
@@ -8841,10 +8841,10 @@
           "bundled": true
         },
         "fs-minipass": {
-          "version": "1.2.5",
+          "version": "1.2.7",
           "bundled": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "^2.6.0"
           }
         },
         "fs.realpath": {
@@ -8866,7 +8866,7 @@
           }
         },
         "glob": {
-          "version": "7.1.3",
+          "version": "7.1.4",
           "bundled": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -8889,7 +8889,7 @@
           }
         },
         "ignore-walk": {
-          "version": "3.0.1",
+          "version": "3.0.2",
           "bundled": true,
           "requires": {
             "minimatch": "^3.0.4"
@@ -8904,7 +8904,7 @@
           }
         },
         "inherits": {
-          "version": "2.0.3",
+          "version": "2.0.4",
           "bundled": true
         },
         "ini": {
@@ -8934,7 +8934,7 @@
           "bundled": true
         },
         "minipass": {
-          "version": "2.3.5",
+          "version": "2.8.6",
           "bundled": true,
           "requires": {
             "safe-buffer": "^5.1.2",
@@ -8942,10 +8942,20 @@
           }
         },
         "minizlib": {
-          "version": "1.1.1",
+          "version": "1.3.2",
           "bundled": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "^2.9.0"
+          },
+          "dependencies": {
+            "minipass": {
+              "version": "2.9.0",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.0"
+              }
+            }
           }
         },
         "mkdirp": {
@@ -8957,33 +8967,28 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+          "bundled": true
         },
         "needle": {
-          "version": "2.2.4",
+          "version": "2.4.0",
           "bundled": true,
           "requires": {
-            "debug": "^2.1.2",
+            "debug": "^3.2.6",
             "iconv-lite": "^0.4.4",
             "sax": "^1.2.4"
           },
           "dependencies": {
             "debug": {
-              "version": "2.6.9",
+              "version": "3.2.6",
               "bundled": true,
               "requires": {
-                "ms": "2.0.0"
+                "ms": "^2.1.1"
               }
-            },
-            "ms": {
-              "version": "2.0.0",
-              "bundled": true
             }
           }
         },
         "node-pre-gyp": {
-          "version": "0.12.0",
+          "version": "0.13.0",
           "bundled": true,
           "requires": {
             "detect-libc": "^1.0.2",
@@ -9007,11 +9012,11 @@
           }
         },
         "npm-bundled": {
-          "version": "1.0.5",
+          "version": "1.0.6",
           "bundled": true
         },
         "npm-packlist": {
-          "version": "1.1.12",
+          "version": "1.4.4",
           "bundled": true,
           "requires": {
             "ignore-walk": "^3.0.1",
@@ -9064,7 +9069,7 @@
           "bundled": true
         },
         "process-nextick-args": {
-          "version": "2.0.0",
+          "version": "2.0.1",
           "bundled": true
         },
         "rc": {
@@ -9094,17 +9099,23 @@
             "safe-buffer": "~5.1.1",
             "string_decoder": "~1.1.1",
             "util-deprecate": "~1.0.1"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.1.2",
+              "bundled": true
+            }
           }
         },
         "rimraf": {
-          "version": "2.6.2",
+          "version": "2.7.1",
           "bundled": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "^7.1.3"
           }
         },
         "safe-buffer": {
-          "version": "5.1.2",
+          "version": "5.2.0",
           "bundled": true
         },
         "safer-buffer": {
@@ -9116,7 +9127,7 @@
           "bundled": true
         },
         "semver": {
-          "version": "5.6.0",
+          "version": "5.7.1",
           "bundled": true
         },
         "set-blocking": {
@@ -9141,6 +9152,12 @@
           "bundled": true,
           "requires": {
             "safe-buffer": "~5.1.0"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.1.2",
+              "bundled": true
+            }
           }
         },
         "strip-ansi": {
@@ -9155,16 +9172,16 @@
           "bundled": true
         },
         "tar": {
-          "version": "4.4.8",
+          "version": "4.4.13",
           "bundled": true,
           "requires": {
             "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
-            "minipass": "^2.3.4",
-            "minizlib": "^1.1.1",
+            "minipass": "^2.8.6",
+            "minizlib": "^1.2.1",
             "mkdirp": "^0.5.0",
             "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.2"
+            "yallist": "^3.0.3"
           }
         },
         "util-deprecate": {
@@ -9208,7 +9225,7 @@
           "bundled": true
         },
         "yallist": {
-          "version": "3.0.3",
+          "version": "3.1.0",
           "bundled": true
         }
       }
@@ -9371,9 +9388,9 @@
       "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g=="
     },
     "npm-packlist": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.4.tgz",
-      "integrity": "sha512-zTLo8UcVYtDU3gdeaFu2Xu0n0EvelfHDGuqtNIn5RO7yQj4H1TqNdBc/yZjxnWA0PVB8D3Woyp0i5B43JwQ6Vw==",
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.6.tgz",
+      "integrity": "sha512-u65uQdb+qwtGvEJh/DgQgW1Xg7sqeNbmxYyrvlNznaVTjV3E5P6F/EFjM+BVHXl7JJlsdG8A64M0XI8FI/IOlg==",
       "requires": {
         "ignore-walk": "^3.0.1",
         "npm-bundled": "^1.0.1"
@@ -11094,17 +11111,28 @@
       }
     },
     "tar": {
-      "version": "4.4.11",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.11.tgz",
-      "integrity": "sha512-iI4zh3ktLJKaDNZKZc+fUONiQrSn9HkCFzamtb7k8FFmVilHVob7QsLX/VySAW8lAviMzMbFw4QtFb4errwgYA==",
+      "version": "4.4.13",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
+      "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
       "requires": {
         "chownr": "^1.1.1",
         "fs-minipass": "^1.2.5",
-        "minipass": "^2.6.4",
+        "minipass": "^2.8.6",
         "minizlib": "^1.2.1",
         "mkdirp": "^0.5.0",
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.3"
+      },
+      "dependencies": {
+        "minipass": {
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+          "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+          "requires": {
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.0"
+          }
+        }
       }
     },
     "tar-stream": {
@@ -11906,9 +11934,9 @@
       "dev": true
     },
     "yallist": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-      "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     },
     "yargs": {
       "version": "11.1.0",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "ejs": "^2.6.1",
     "fields": "0.1.24",
     "fs-extra": "^8.0.1",
-    "ioslib": "^1.7.14",
+    "ioslib": "^1.7.15",
     "klaw-sync": "^6.0.0",
     "liveview": "^1.5.0",
     "lodash.defaultsdeep": "^4.6.1",


### PR DESCRIPTION
* Fixes the xcodebuild dest loop not breaking which fixes https://jira.appcelerator.org/browse/TIMOB-27338
* Fixes the app icon issue https://jira.appcelerator.org/browse/TIMOB-27470.