### PR TITLE
feat(android): target api level 29 by default

### DIFF
--- a/android/package.json
+++ b/android/package.json
@@ -25,7 +25,7 @@
 	"minSDKVersion": "19",
 	"compileSDKVersion": "29",
 	"vendorDependencies": {
-		"android sdk": ">=23.x <=28.x",
+		"android sdk": ">=23.x <=29.x",
 		"android build tools": ">=25.x <=29.x",
 		"android platform tools": "29.x",
 		"android tools": "<=26.x",


### PR DESCRIPTION
**JIRA:**
https://jira.appcelerator.org/browse/TIMOB-26951

**Summary:**
Titanium builds now "targets" Android Q by default, if installed on the machine.

**Test:**
1. Create a classic project.
2. Build for Android.
3. Open "Finder" or "Windows Explorer" and go to your project folder.
4. Go to subdirectory: `./build/android`
5. Open file "AndroidManifest.xml".
6. Verify XML attribute `android:targetSdkVersion` is set to `29`.
