### PR TITLE
docs: deprecate Ti.Analytics.navEvent

### DIFF
--- a/apidoc/Titanium/Analytics/Analytics.yml
+++ b/apidoc/Titanium/Analytics/Analytics.yml
@@ -102,6 +102,8 @@ methods:
     summary: |
         Sends a navigation event for this application session. 
         **Not displayed in Analytics UI**.
+    deprecated: 
+        since: "8.3.0"
     parameters:
 
       - name: from


### PR DESCRIPTION
- Deprecate old and unused method `Titanium.Analytics.navEvent`

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-27476)