### PR TITLE
feat(android): semantic colors and night mode

### DIFF
--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -2375,7 +2375,10 @@ AndroidBuilder.prototype.generateAppProject = async function generateAppProject(
 		this.generateI18N(),
 
 		// Generate a "res/values" styles XML file if a custom theme was assigned in app's "AndroidManifest.xml".
-		this.generateTheme()
+		this.generateTheme(),
+
+		// Generate "semantic.colors.xml" in "res/values" and "res/values-night"
+		this.generateSemanticColors()
 	]);
 
 	// Generate an "AndroidManifest.xml" for the app and copy in any custom manifest settings from "tiapp.xml".
@@ -3341,6 +3344,101 @@ AndroidBuilder.prototype.generateI18N = async function generateI18N() {
 			process.exit(1);
 		}
 	}
+};
+
+AndroidBuilder.prototype.generateSemanticColors = async function generateSemanticColors() {
+	this.logger.info(__('Generating semantic colors resources'));
+	const _t = this;
+	const xmlFileName = 'semantic.colors.xml';
+	const valuesDirPath = path.join(this.buildAppMainResDir, 'values');
+	const valuesNightDirPath = path.join(this.buildAppMainResDir, 'values-night');
+	await fs.ensureDir(valuesDirPath);
+	await fs.ensureDir(valuesNightDirPath);
+	const destLight = path.join(valuesDirPath, xmlFileName);
+	const destNight = path.join(valuesNightDirPath, xmlFileName);
+
+	let colorsFile = path.join(this.projectDir, 'Resources', 'android', 'semantic.colors.json');
+
+	if (!fs.existsSync(colorsFile)) {
+		// Fallback to root of Resources folder for Classic applications
+		colorsFile = path.join(this.projectDir, 'Resources', 'semantic.colors.json');
+	}
+
+	if (!fs.existsSync(colorsFile)) {
+		this.logger.debug(__('Skipping colorset generation as "semantic.colors.json" file does not exist'));
+		return;
+	}
+
+	const shorthandRegex = /^#?([a-f\d])([a-f\d])([a-f\d])$/i;
+
+	function hexToRgb(hex) {
+		let alphaHex = 'ff';
+		let color = hex;
+		if (hex.color) {
+			color = hex.color;
+			let alpha = Math.round(255 * parseFloat(hex.alpha) / 100);
+			if (alpha <= 255) {
+				alphaHex = alpha.toString(16);
+				if (alpha < 16) {
+					alphaHex = '0' + alphaHex;
+				}
+			}
+		}
+		// Expand shorthand form (e.g. "03F") to full form (e.g. "0033FF")
+		color = color.replace(shorthandRegex, (m, r, g, b) => r + r + g + g + b + b);
+
+		var result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(color);
+		if (alphaHex === 'ff') {
+			return `#${result[1]}${result[2]}${result[3]}`;
+		} else {
+			return `#${alphaHex}${result[1]}${result[2]}${result[3]}`;
+		}
+	}
+
+	function appendToXml(dom, root, color, colorValue) {
+		const appnameNode = dom.createElement('color');
+
+		appnameNode.setAttribute('name', `${color}`);
+		appnameNode.appendChild(dom.createTextNode(hexToRgb(colorValue)));
+		root.appendChild(dom.createTextNode('\n\t'));
+		root.appendChild(appnameNode);
+	}
+
+	function writeXml(dom, dest, mode) {
+		if (fs.existsSync(dest)) {
+			_t.logger.debug(__('Merging %s semantic colors => %s', mode.cyan, dest.cyan));
+		} else {
+			_t.logger.debug(__('Writing %s semantic colors => %s', mode.cyan, dest.cyan));
+		}
+		return fs.writeFile(dest, '<?xml version="1.0" encoding="UTF-8"?>\n' + dom.documentElement.toString());
+	}
+
+	const colors = fs.readJSONSync(colorsFile);
+	const domLight = new DOMParser().parseFromString('<resources/>', 'text/xml');
+	const domNight = new DOMParser().parseFromString('<resources/>', 'text/xml');
+
+	const rootLight = domLight.documentElement;
+	const rootNight = domNight.documentElement;
+
+	for (const [ color, colorValue ] of Object.entries(colors)) {
+		if (!colorValue.light) {
+			this.logger.warn(`Skipping ${color} as it does not include a light value`);
+			continue;
+		}
+
+		if (!colorValue.dark) {
+			this.logger.warn(`Skipping ${color} as it does not include a dark value`);
+			continue;
+		}
+
+		appendToXml(domLight, rootLight, color, colorValue.light);
+		appendToXml(domNight, rootNight, color, colorValue.dark);
+	}
+
+	return Promise.all([
+		writeXml(domLight, destLight, 'light'),
+		writeXml(domNight, destNight, 'night')
+	]);
 };
 
 AndroidBuilder.prototype.generateTheme = async function generateTheme() {

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/android/AndroidModule.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/android/AndroidModule.java
@@ -18,6 +18,7 @@ import ti.modules.titanium.ui.widget.TiUIProgressIndicator;
 import ti.modules.titanium.ui.widget.webview.TiUIWebView;
 import android.app.Activity;
 import android.content.Intent;
+import android.content.res.Configuration;
 import android.graphics.PixelFormat;
 import android.text.util.Linkify;
 import android.view.Gravity;
@@ -217,6 +218,13 @@ public class AndroidModule extends KrollModule
 	@Kroll.constant
 	public static final int OVER_SCROLL_NEVER = 2; //android.view.View.OVER_SCROLL_NEVER;
 
+	@Kroll.constant
+	public static final int MODE_NIGHT_NO = Configuration.UI_MODE_NIGHT_NO;
+	@Kroll.constant
+	public static final int MODE_NIGHT_YES = Configuration.UI_MODE_NIGHT_YES;
+	@Kroll.constant
+	public static final int MODE_NIGHT_UNDEFINED = Configuration.UI_MODE_NIGHT_UNDEFINED;
+
 	public AndroidModule()
 	{
 		super();
@@ -257,6 +265,17 @@ public class AndroidModule extends KrollModule
 				}
 			}
 		});
+	}
+
+	// clang-format off
+	@Kroll.method
+	@Kroll.getProperty
+	public int getNightModeStatus()
+	// clang-format on
+	{
+		int status = TiApplication.getInstance().getApplicationContext().getResources().getConfiguration().uiMode
+					 & Configuration.UI_MODE_NIGHT_MASK;
+		return status;
 	}
 
 	@Override

--- a/apidoc/Titanium/UI/Android/Android.yml
+++ b/apidoc/Titanium/UI/Android/Android.yml
@@ -237,6 +237,43 @@ properties:
     type: Number
     permission: read-only
 
+  - name: MODE_NIGHT_NO
+    summary: |
+        Constant for <Titanium.UI.Android.nightModeStatus>
+    description: |
+        Value indicating that night mode type has been set.
+        Used in the `nightModeStatus` property.
+        See [UI_MODE_NIGHT_NO](https://developer.android.com/reference/android/content/res/Configuration.html#UI_MODE_NIGHT_NO)
+    type: Number
+    permission: read-only
+    platforms: [android]
+    since: '9.0.0'
+
+  - name: MODE_NIGHT_UNDEFINED
+    summary: |
+        Constant for <Titanium.UI.Android.nightModeStatus>
+    description: |
+        Value indicating that no mode type has been set.
+        Used in the `nightModeStatus` property.
+        See [UI_MODE_NIGHT_UNDEFINED](https://developer.android.com/reference/android/content/res/Configuration.html#UI_MODE_NIGHT_UNDEFINED)
+    type: Number
+    permission: read-only
+    platforms: [android]
+    since: '9.0.0'
+
+  - name: MODE_NIGHT_YES
+    summary: |
+        Constant for <Titanium.UI.Android.nightModeStatus>
+    description: |
+        Value indicating that night mode type has been set.
+        Used in the `nightModeStatus` property.
+        See [UI_MODE_NIGHT_YES](https://developer.android.com/reference/android/content/res/Configuration.html#UI_MODE_NIGHT_YES)
+    type: Number
+    permission: read-only
+    platforms: [android]
+    since: '9.0.0'
+
+
   - name: OVER_SCROLL_ALWAYS
     summary: Always allow a user to over-scroll this view, provided it is a view that can scroll.
     description: |
@@ -841,6 +878,18 @@ properties:
     permission: read-only
     platforms: [android]
     since: "8.0.0"
+
+  - name: nightModeStatus
+    summary: The status of night mode of user interface.
+    description: |
+      Use this property to determine whether your interface should be configured with a dark or light appearance.
+      The default value of this trait is set to the corresponding appearance setting on the user's device.
+      See [UI_MODE_NIGHT_MASK](https://developer.android.com/reference/android/content/res/Configuration.html#UI_MODE_NIGHT_MASK).
+      See <Titanium.App.iOS.userInterfaceStyle>
+    type: Number
+    permission: read-only
+    platforms: [android]
+    since: "9.0.0"
 
 examples:
   - title: Android Preferences Example

--- a/tests/Resources/ti.ui.android.nightmodestatus.addontest.js
+++ b/tests/Resources/ti.ui.android.nightmodestatus.addontest.js
@@ -1,0 +1,25 @@
+/*
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2011-Present by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+/* eslint-env mocha */
+/* eslint no-unused-expressions: "off" */
+'use strict';
+var should = require('./utilities/assertions');
+
+describe.android('Ti.UI.Android', () => {
+	it('MODE_NIGHT_NO', () => {
+		should.exist(Ti.UI.Android.MODE_NIGHT_NO);
+	});
+	it('MODE_NIGHT_UNDEFINED', () => {
+		should.exist(Ti.UI.Android.MODE_NIGHT_UNDEFINED);
+	});
+	it('MODE_NIGHT_YES', () => {
+		should.exist(Ti.UI.Android.MODE_NIGHT_YES);
+	});
+	it('nightModeStatus', () => {
+		should.exist(Ti.UI.Android.nightModeStatus);
+	});
+});


### PR DESCRIPTION
- generate color resources from semantic.colors.json
- add Ti.UI.Android.nightModeStatus API
- add Ti.UI.Android.MODE_NIGHT_* constants

**JIRA:** https://jira.appcelerator.org/browse/TIMOB-27501

Sample app:
https://github.com/ewanharris/darkmode-example/pull/1


``` javascript
if (OS_ANDROID) {
￼	const mode = Ti.UI.Android.nightModeStatus;
￼	if (mode === Ti.UI.Android.MODE_NIGHT_YES) {
￼		Ti.UI.semanticColorType = Ti.UI.SEMANTIC_COLOR_TYPE_DARK;
￼	} else {
￼		Ti.UI.semanticColorType = Ti.UI.SEMANTIC_COLOR_TYPE_LIGHT;
￼	}
￼}
```