### PR TITLE
fix(android): amend constants for showSoftKeyboard()

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiUIHelper.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiUIHelper.java
@@ -1119,7 +1119,9 @@ public class TiUIHelper
 		final InputMethodManager imm =
 			(InputMethodManager) view.getContext().getSystemService(Activity.INPUT_METHOD_SERVICE);
 		if (imm != null) {
-			view.requestFocus();
+			if (!view.hasFocus()) {
+				view.requestFocus();
+			}
 			if (show) {
 				imm.showSoftInput(view, InputMethodManager.SHOW_FORCED);
 			} else {

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiUIHelper.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiUIHelper.java
@@ -1121,9 +1121,9 @@ public class TiUIHelper
 		if (imm != null) {
 			view.requestFocus();
 			if (show) {
-				imm.showSoftInput(view, InputMethodManager.SHOW_IMPLICIT);
+				imm.showSoftInput(view, InputMethodManager.SHOW_FORCED);
 			} else {
-				imm.hideSoftInputFromWindow(view.getWindowToken(), InputMethodManager.HIDE_IMPLICIT_ONLY);
+				imm.hideSoftInputFromWindow(view.getWindowToken(), 0);
 			}
 		}
 	}


### PR DESCRIPTION
- Amend constants used in `showSoftKeyboard()`

##### TEST CASE \#1
```JS
const win = Ti.UI.createWindow({
    backgroundColor: 'white',
    layout: 'vertical'
});
const textField = Ti.UI.createTextField({
    backgroundColor: '#fafafa',
    color: 'green',
    width: 250,
    top: 30,
    height: 40
});
const test = Ti.UI.createButton({
    title: 'test',
    height: 50,
    width: 100,
    top: 30
});

test.addEventListener('click', _ => {
    Ti.UI.Android.hideSoftKeyboard();
});

win.add([ textField, test ]);
win.open();
```

##### TEST CASE \#2
```JS
const win = Ti.UI.createWindow({
    backgroundColor: 'gray',
    layout: 'vertical'
});

const txt_a = Ti.UI.createTextField({
    hintText: 'Text Field #1',
    width: '90%'
});
const txt_b = Ti.UI.createTextField({
    hintText: 'Text Field #2',
    width: '90%'
});
const txt_c = Ti.UI.createTextField({
    hintText: 'Text Field #3',
    width: '90%',
    softKeyboardOnFocus: Ti.UI.Android.SOFT_KEYBOARD_SHOW_ON_FOCUS
});

txt_a.addEventListener('return', _ => {
    Ti.API.info(`'return' event fired on 'Text Field #1'`);
    txt_c.focus();
    Ti.API.info(`Set focus to 'Text Field #3'`);
});

win.add([ txt_a, txt_b, txt_c ]);
win.open();
```
1. Enter text into `Text Field #1`
2. Press `Enter`
3. `Text Field #3` should focus and allow text entry

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-27512)