### PR TITLE
fix(windows): fire analyzeJsFile hook for Windows

### DIFF
--- a/cli/lib/tasks/process-js-task.js
+++ b/cli/lib/tasks/process-js-task.js
@@ -51,6 +51,9 @@ class ProcessJsTask extends IncrementalFileTask {
 		this.defaultAnalyzeOptions = options.defaultAnalyzeOptions;
 
 		this.dataFilePath = path.join(this.incrementalDirectory, 'data.json');
+
+		this.fileContentsMap = new Map();
+
 		this.resetTaskData();
 
 		this.createHooks();
@@ -166,6 +169,18 @@ class ProcessJsTask extends IncrementalFileTask {
 			});
 		});
 
+		// Windows hyperloop requires that a build.windows.analyzeJsFile runs before compileJsFile
+		// so patch the compileJsFile hook to run that hook first and then fire the compileJsFile
+		// TODO: remove this in 9.0.0 TIMOB-27601
+		if (this.platform === 'windows') {
+			let origCompileJsHook = compileJsFileHook;
+
+			compileJsFileHook = this.builder.cli.createHook(`build.${this.platform}.analyzeJsFile`, this.builder, (from, to, cb) => {
+				const r = this.fileContentsMap.get(from);
+				origCompileJsHook(r, from, to, cb);
+			});
+		}
+
 		this.copyResourceHook = promisify(this.builder.cli.createHook(`build.${this.platform}.copyResource`, this.builder, (from, to, done) => {
 			const originalContents = fs.readFileSync(from).toString();
 
@@ -174,8 +189,15 @@ class ProcessJsTask extends IncrementalFileTask {
 				contents: originalContents,
 				symbols: []
 			};
+			if (this.platform === 'windows') {
+				// We can't pass the contents through the analyzeJsFile hook so store them in a map
+				// which we can then pull the contents from
+				this.fileContentsMap.set(from, r);
+				compileJsFileHook(from, to, done);
+			} else {
+				compileJsFileHook(r, from, to, done);
 
-			compileJsFileHook(r, from, to, done);
+			}
 		}));
 	}
 


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-27452

Fire a build.windows.analyzeJsFile hook to keep hyperloop on Windows working

Filed https://jira.appcelerator.org/browse/TIMOB-27601 to remove this in 9.0.0 (hopefully)

Backport for #11333