### PR TITLE
docs(changelog): update script to include bundled module versions

### DIFF
--- a/changelog/templates/modules.hbs
+++ b/changelog/templates/modules.hbs
@@ -1,0 +1,10 @@
+{{#if modules~}}
+## SDK Module Versions
+
+| Module      | Android version | iOS Version |
+| ----------- | --------------- | ----------- |
+{{#each modules}}
+| {{this.name}} | {{this.android}} | {{this.ios}} |
+{{/each}}
+{{~/if}}
+

--- a/changelog/templates/template.hbs
+++ b/changelog/templates/template.hbs
@@ -19,3 +19,5 @@
 {{/each}}
 {{> footer}}
 
+{{> modules}}
+


### PR DESCRIPTION
After manually preparing the 8.3.0 SDK RC release notes, I found another spot to improve generation - the bundled modules table listing.

So now when we generate the changelog we also include the listing of pre-packaged modules and the versions for each of Android and iOS.