### PR TITLE
fix(android)(8_3_X): softRestart() must account for snapshots

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/TiApplication.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiApplication.java
@@ -820,7 +820,15 @@ public abstract class TiApplication extends Application implements KrollApplicat
 		runtime.initRuntime();
 
 		// manually re-launch app
-		runtime.doRunModuleBytes(KrollAssetHelper.readAssetBytes(appPath), appPath, rootActivity.getActivityProxy());
+		if (KrollAssetHelper.assetExists(appPath)) {
+			runtime.doRunModuleBytes(KrollAssetHelper.readAssetBytes(appPath), appPath,
+									 rootActivity.getActivityProxy());
+
+			// launch script does not exist, must be using snapshot
+			// execute startup method baked in snapshot
+		} else {
+			runtime.doRunModule("global.startSnapshot(global)", appPath, rootActivity.getActivityProxy());
+		}
 	}
 
 	@Override

--- a/android/titanium/src/java/org/appcelerator/titanium/TiApplication.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiApplication.java
@@ -827,7 +827,7 @@ public abstract class TiApplication extends Application implements KrollApplicat
 			// launch script does not exist, must be using snapshot
 			// execute startup method baked in snapshot
 		} else {
-			runtime.doRunModule("global.startSnapshot(global)", appPath, rootActivity.getActivityProxy());
+			runtime.doRunModule("global._startSnapshot(global)", appPath, rootActivity.getActivityProxy());
 		}
 	}
 

--- a/android/titanium/src/java/org/appcelerator/titanium/TiLaunchActivity.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiLaunchActivity.java
@@ -104,7 +104,7 @@ public abstract class TiLaunchActivity extends TiBaseActivity
 				// launch script does not exist, must be using snapshot
 				// execute startup method baked in snapshot
 			} else {
-				KrollRuntime.getInstance().runModule("global.startSnapshot(global)", fullUrl, activityProxy);
+				KrollRuntime.getInstance().runModule("global._startSnapshot(global)", fullUrl, activityProxy);
 			}
 		} finally {
 			Log.d(TAG, "Signal JS loaded", Log.DEBUG_MODE);

--- a/build/lib/android/startup.ejs
+++ b/build/lib/android/startup.ejs
@@ -1,4 +1,3 @@
-this.startSnapshot = function (global) {
-    delete global.startSnapshot;
+this._startSnapshot = function (global) {
 <%- script %>
 }


### PR DESCRIPTION
- `TiApplication.softRestart()` did not take into account the possibility for snapshots when restarting

##### TEST CASE
- Start LiveView with a Titanium Android project
- Make changes to project `*.js` files

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-27602)