### PR TITLE
fix(android)(8_3_X): add extension to encrypted assets

### DIFF
--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -2832,7 +2832,7 @@ AndroidBuilder.prototype.copyResources = function copyResources(next) {
 				await Promise.all(
 					jsFilesToEncrypt.map(async file => {
 						const from = path.join(this.buildAssetsDir, file);
-						const to = path.join(this.buildBinAssetsResourcesDir, file);
+						const to = path.join(this.buildBinAssetsResourcesDir, file + '.bin');
 
 						this.logger.debug(__('Encrypting: %s', from.cyan));
 						await fs.ensureDir(path.dirname(to));

--- a/android/templates/build/AssetCryptImpl.java
+++ b/android/templates/build/AssetCryptImpl.java
@@ -22,6 +22,8 @@ public class AssetCryptImpl implements KrollAssetHelper.AssetCrypt
 {
 	private static final String TAG = "AssetCryptImpl";
 
+	private static final String BIN_EXT = ".bin";
+
 	private static byte[] salt = {
 		<% for (let i = 0; i < salt.length - 1; i++){ -%>
 <%- '(byte)' + salt.readUInt8(i) + ', ' -%>
@@ -72,6 +74,9 @@ public class AssetCryptImpl implements KrollAssetHelper.AssetCrypt
 	{
 		if (!assets.contains(path)) {
 			return null;
+		}
+		if (!path.endsWith(BIN_EXT)) {
+			path = path + BIN_EXT;
 		}
 		try {
 			Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");


### PR DESCRIPTION
- Append `.bin` to encrypted assets, preventing unintended behaviour

##### TEST CASE \#1
- Run Titanium application as `test`
  - `appc run -p android -D test`
- Application should run without issues

##### TEST CASE \#2
- Debug Titanium application on device via Studio

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-27610)