### PR TITLE
feat: webpack support

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -61,6 +61,13 @@
         "node/no-unsupported-features/es-syntax": "off",
         "node/no-unsupported-features/node-builtins": ["warn", { "version": "10.11.0" }]
       }
+    },
+    {
+      "files": [ "cli/lib/tasks/*.js", "cli/hooks/webpack.js", "cli/lib/webpack/**/*.js" ],
+      "parserOptions": {
+        "ecmaVersion": 2017,
+        "sourceType": "module"
+      }
     }
   ]
 }

--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -1530,8 +1530,8 @@ AndroidBuilder.prototype.run = async function run(logger, config, cli, finished)
 		await this.checkIfNeedToRecompile();
 
 		// Notify plugins that we're prepping to compile.
-		await new Promise((resolve) => {
-			cli.emit('build.pre.compile', this, resolve);
+		await new Promise((resolve, reject) => {
+			cli.emit('build.pre.compile', this, e => (e ? reject(e) : resolve()));
 		});
 
 		// Make sure we have an "app.js" script. Will exit with a build failure if not found.
@@ -2874,7 +2874,16 @@ AndroidBuilder.prototype.copyResources = function copyResources(next) {
 				});
 			})
 			.then(() => {
-				this.tiSymbols = task.data.tiSymbols;
+				if (this.useWebpack) {
+					// Merge Ti symbols from Webpack with the ones from legacy js processing
+					Object.keys(task.data.tiSymbols).forEach(file => {
+						const existingSymbols = this.tiSymbols[file] || [];
+						const additionalSymbols = task.data.tiSymbols[file];
+						this.tiSymbols[file] = Array.from(new Set(existingSymbols.concat(additionalSymbols)));
+					});
+				} else {
+					this.tiSymbols = task.data.tiSymbols;
+				}
 
 				// Copy all unprocessed files to "app" project's APK "assets" directory.
 				appc.async.parallel(this, copyUnmodified.map(relPath => {

--- a/cli/hooks/webpack.js
+++ b/cli/hooks/webpack.js
@@ -1,0 +1,177 @@
+// eslint-disable-next-line security/detect-child-process
+const { execSync } = require('child_process');
+const fs = require('fs-extra');
+const path = require('path');
+const semver = require('semver');
+const util = require('util');
+require('colors');
+
+const appcd = require('../lib/webpack/appcd');
+const WebpackService = require('../lib/webpack/service');
+
+const MIN_APPCD_VERSION = '3.2.0';
+
+const createWebpackLogger = (logger) => {
+	const webpackLogger = {
+		formatWithBadge(args) {
+			return `${' WEBPACK '.bgCyan.black} ${util.format(...args)}`;
+		}
+	};
+	[ 'info', 'debug', 'warn', 'error' ].forEach(level => {
+		webpackLogger[level] = (...args) => logger[level](webpackLogger.formatWithBadge(args));
+	});
+	return webpackLogger;
+};
+
+exports.id = 'ti.webpack';
+exports.init = (logger, config, cli) => {
+	const isAppcCli = typeof process.env.APPC_ENV !== 'undefined';
+	let commandName;
+	let isWebpackEnabled = false;
+	let projectType;
+	let client;
+
+	cli.on('cli:command-loaded', (hookData) => {
+		const command = hookData.command;
+		commandName = command.name;
+	});
+
+	cli.on('cli:post-validate', () => {
+		projectType = getWebpackProjectType(cli.argv['project-dir']);
+		if (projectType === null) {
+			return;
+		}
+		isWebpackEnabled = true;
+		process.env.TI_USE_WEBPACK = true;
+
+		if (commandName !== 'build') {
+			return;
+		}
+
+		let appcdRootPath;
+		if (isAppcCli) {
+			// we were invoked by appc-cli, load bundled daemon client.
+			appcdRootPath = resolveModuleRoot('appcd');
+			if (!fs.existsSync(appcdRootPath)) {
+				throw new Error('Unable to find Appcelerator Daemon inside the appc-cli. Please make sure to use a recent appc-cli version. You can install/select it with  "appc use latest".');
+			}
+		} else {
+			// plain ti-cli, load daemon from global modules
+			const globalModulesPath = execSync('npm root -g').toString().replace(/\s+$/, '');
+			appcdRootPath = resolveModuleRoot('appcd', [ globalModulesPath ]);
+			if (!fs.existsSync(appcdRootPath)) {
+				throw new Error('Unable to find global Appcelerator Daemon install. You can install it with "npm i appcd -g".');
+			}
+		}
+		ensureAppcdVersion(appcdRootPath, MIN_APPCD_VERSION, isAppcCli);
+		const AppcdClient = resolveAppcdClient(appcdRootPath);
+		const baseClient = new AppcdClient();
+		if (isAppcCli) {
+			baseClient.appcd = path.resolve(appcdRootPath, '..', '.bin', 'appcd');
+			if (process.platform === 'win32') {
+				baseClient.appcd += '.cmd';
+			}
+		}
+		client = appcd(baseClient);
+	});
+
+	cli.on('build.pre.compile', {
+		priority: 800,
+		post(builder, callback) {
+			if (!isWebpackEnabled) {
+				return callback();
+			}
+
+			builder.useWebpack = true;
+
+			const badgedLogger = createWebpackLogger(logger);
+			const webpackService = new WebpackService({
+				client,
+				logger: badgedLogger,
+				cli,
+				builder,
+				projectType
+			});
+			Promise.resolve().then(async () => {
+				await webpackService.build();
+				return callback();
+			}).catch(e => {
+				if (e.status === 404) {
+					badgedLogger.info('Daemon was unable to find the Webpack plugin. To continue you need to:');
+					badgedLogger.info('');
+					const installCommand = 'npm i -g @appcd/webpack-plugin';
+					badgedLogger.info(`- Install it with ${installCommand.cyan}`);
+					const restartCommand = `${isAppcCli ? 'appc ' : ''}appcd restart`;
+					badgedLogger.info(`- Restart the daemon with ${restartCommand.cyan}`);
+					badgedLogger.info('');
+				}
+
+				if (cli.argv.platform === 'ios') {
+					// The iOS build shows the error message only, log the stack manually
+					// to make sure it get printed as well
+					logger.error(e.stack);
+				}
+
+				callback(e);
+			});
+		}
+	});
+};
+
+function getWebpackProjectType(projectDir) {
+	if (typeof projectDir !== 'string') {
+		return null;
+	}
+	const pkgPath = path.join(projectDir, 'package.json');
+	if (!fs.existsSync(pkgPath)) {
+		return null;
+	}
+
+	const tiPlugins = [
+		'@titanium-sdk/webpack-plugin-classic',
+		'@titanium-sdk/webpack-plugin-alloy',
+		'@titanium-sdk/webpack-plugin-vue',
+		'@titanium-sdk/webpack-plugin-angular'
+	];
+	// eslint-disable-next-line security/detect-non-literal-require
+	const pkg = require(pkgPath);
+	const allDeps = Object.keys(pkg.devDependencies || {})
+		.concat(Object.keys(pkg.dependencies || {}));
+	const pluginId = tiPlugins.find(id => allDeps.includes(id));
+	if (!pluginId) {
+		return null;
+	}
+	return pluginId.substring(pluginId.lastIndexOf('-') + 1);
+}
+
+function resolveModuleRoot(name, paths) {
+	try {
+		let resolvedPath;
+		if (paths) {
+			resolvedPath = require.resolve(name, { paths });
+		} else {
+			resolvedPath = require.resolve(name);
+		}
+		return resolvedPath.substr(0, resolvedPath.indexOf(`${path.sep}appcd${path.sep}`) + 7);
+	} catch (e) {
+		return null;
+	}
+}
+
+function ensureAppcdVersion(appcdRootPath, version, isAppcCli = false) {
+	// eslint-disable-next-line security/detect-non-literal-require
+	const pkg = require(path.join(appcdRootPath, 'package.json'));
+	if (!semver.gte(pkg.version, version)) {
+		throw new Error(`The Webpack build system requires Appcelerator Daemon v${MIN_APPCD_VERSION}+ (installed: ${pkg.version}). Please update your ${isAppcCli ? 'appc-cli with "appc use latest"' : 'global daemon install with "npm i appcd -g"'}.`);
+	}
+}
+
+function resolveAppcdClient(appcdPackagePath) {
+	const appcdClientPath = require.resolve('appcd-client', {
+		paths: [
+			path.join(appcdPackagePath, 'node_modules')
+		]
+	});
+	// eslint-disable-next-line security/detect-non-literal-require
+	return require(appcdClientPath).default;
+}

--- a/cli/lib/webpack/appcd.js
+++ b/cli/lib/webpack/appcd.js
@@ -1,0 +1,88 @@
+const EventEmitter = require('events');
+
+/**
+ * Creates a simplified promise-based client for Appcd
+ *
+ * @param {object} client A appcd-client instance
+ * @return {object} Promisified wrapper around appcd-client
+ */
+const appcd = (client) => ({
+	host: client.host,
+	port: client.port,
+	async connect(options) {
+		return new Promise((resolve, reject) => {
+			client.connect(options)
+				.once('connected', resolve)
+				.once('error', reject);
+		});
+	},
+	disconnect() {
+		client.disconnect();
+	},
+	async get(path) {
+		return this.request({ path });
+	},
+	async post(path, data = {}) {
+		return this.request({ path, data });
+	},
+	async request(options) {
+		return new Promise((resolve, reject) => {
+			client
+				.request(options)
+				.once('response', response => resolve(response))
+				.once('error', e => reject(e));
+		});
+	},
+	async subscribe(path) {
+		return new Promise((resolve, reject) => {
+			const subscription = new Subscription(path);
+			client
+				.request({
+					path,
+					type: 'subscribe'
+				})
+				.on('response', (data, response) => {
+					if (typeof data === 'string' && data === 'Subscribed') {
+						subscription.sid = response.sid;
+						return resolve(subscription);
+					}
+
+					subscription.emit('message', data);
+				})
+				.once('close', () => {
+					subscription.emit('close');
+				})
+				.once('finish', () => {
+					subscription.emit('close');
+				})
+				.once('error', e => {
+					if (!subscription.sid) {
+						reject(e);
+					} else {
+						subscription.emit('error', e);
+					}
+				});
+		});
+	}
+});
+
+class Subscription extends EventEmitter {
+	constructor(path) {
+		super();
+		this.path = path;
+		this.sid = null;
+	}
+	async unsubscribe() {
+		if (!this.sid) {
+			return;
+		}
+
+		await appcd.request({
+			path: this.path,
+			sid: this.sid
+		});
+		this.sid = null;
+	}
+}
+
+module.exports = appcd;

--- a/cli/lib/webpack/log-update.js
+++ b/cli/lib/webpack/log-update.js
@@ -1,0 +1,120 @@
+/**
+ * Copied from https://github.com/nuxt/webpackbar
+ *
+ * @see https://github.com/nuxt/webpackbar/blob/894a16bcb000c448570ccdc96ddd9a5cef9dfc95/src/utils/log-update.js
+ */
+
+const ansiEscapes = require('ansi-escapes');
+const wrapAnsi = require('wrap-ansi');
+
+// Based on https://github.com/sindresorhus/log-update/blob/master/index.js
+
+const originalWrite = Symbol('webpackbarWrite');
+
+class LogUpdate {
+	constructor () {
+		this.prevLineCount = 0;
+		this.listening = false;
+		this.extraLines = '';
+		this._onData = this._onData.bind(this);
+		this._streams = [ process.stdout, process.stderr ];
+	}
+
+	render (lines) {
+		this.listen();
+
+		const wrappedLines = wrapAnsi(lines, this.columns, {
+			trim: false,
+			hard: true,
+			wordWrap: false
+		});
+
+		const data = ansiEscapes.eraseLines(this.prevLineCount)
+			+ wrappedLines
+			+ '\n'
+			+ this.extraLines;
+
+		this.write(data);
+
+		this.prevLineCount = data.split('\n').length;
+	}
+
+	get columns () {
+		return (process.stderr.columns || 80) - 2;
+	}
+
+	write (data) {
+		const stream = process.stderr;
+		if (stream.write[originalWrite]) {
+			stream.write[originalWrite].call(stream, data, 'utf-8');
+		} else {
+			stream.write(data, 'utf-8');
+		}
+	}
+
+	clear () {
+		this.done();
+		this.write(ansiEscapes.eraseLines(this.prevLineCount));
+	}
+
+	done () {
+		this.stopListen();
+
+		this.prevLineCount = 0;
+		this.extraLines = '';
+	}
+
+	_onData (data) {
+		const str = String(data);
+		const lines = str.split('\n').length - 1;
+		if (lines > 0) {
+			this.prevLineCount += lines;
+			this.extraLines += data;
+		}
+	}
+
+	listen () {
+		// Prevent listening more than once
+		if (this.listening) {
+			return;
+		}
+
+		// Spy on all streams
+		for (const stream of this._streams) {
+			// Prevent overriding more than once
+			if (stream.write[originalWrite]) {
+				continue;
+			}
+
+			// Create a wrapper fn
+			const write = (data, ...args) => {
+				if (!stream.write[originalWrite]) {
+					return stream.write(data, ...args);
+				}
+				this._onData(data);
+				return stream.write[originalWrite].call(stream, data, ...args);
+			};
+
+			// Backup original write fn
+			write[originalWrite] = stream.write;
+
+			// Override write fn
+			stream.write = write;
+		}
+
+		this.listening = true;
+	}
+
+	stopListen () {
+		// Restore original write fns
+		for (const stream of this._streams) {
+			if (stream.write[originalWrite]) {
+				stream.write = stream.write[originalWrite];
+			}
+		}
+
+		this.listening = false;
+	}
+}
+
+module.exports = LogUpdate;

--- a/cli/lib/webpack/reporter.js
+++ b/cli/lib/webpack/reporter.js
@@ -1,0 +1,118 @@
+const LogUpdate = require('./log-update');
+
+/**
+ * Webpack progress reporter.
+ *
+ * Based on the fancy reporter from webpackbar, modified to work with the
+ * progress data reported from appcd-plugin-webpack.
+ *
+ * @see https://github.com/nuxt/webpackbar/blob/894a16bcb000c448570ccdc96ddd9a5cef9dfc95/src/reporters/fancy.js
+ */
+class ProgressBarReporter {
+	constructor() {
+		this.lastRender = Date.now();
+		this.logUpdate = new LogUpdate();
+	}
+
+	start() {
+		this.renderProgress({
+			progress: -1,
+			message: 'Starting ...'
+		});
+	}
+
+	done(data) {
+		this.renderProgress({
+			progress: 100,
+			message: '',
+			hasErrors: data.hasErrors
+		});
+		this.logUpdate.done();
+	}
+
+	progress(state) {
+		if (Date.now() - this.lastRender > 50) {
+			this.renderProgress(state);
+		}
+	}
+
+	renderProgress(state) {
+		let line1;
+		let line2;
+		let details = state.details || [];
+
+		if (state.progress >= 0 && state.progress < 100) {
+			line1 = [
+				'● webpack'.green,
+				this.renderBar(state.progress),
+				state.message,
+				`(${state.progress || 0}%)`,
+				`${details[0] || ''}`.gray,
+				`${details[1] || ''}`.gray
+			].join(' ');
+
+			let colorizedRequest = '';
+			if (state.request) {
+				colorizedRequest = state.request.split('❱')
+					.map(v => v.gray)
+					.join(' ❱ '.blue);
+			}
+			line2 = colorizedRequest;
+		} else {
+			let icon = ' ';
+
+			if (state.hasErrors) {
+				icon = '✖';
+			} else if (state.progress === 100) {
+				icon = '✔';
+			} else if (state.progress === -1) {
+				icon = '◯';
+			}
+
+			line1 = `${icon} webpack`.green;
+			line2 = `  ${state.message}`.gray;
+		}
+
+		this.lastRender = Date.now();
+		this.logUpdate.render(`\n${line1}\n${line2}\n`);
+	}
+
+	renderBar(progress) {
+		const barLength = 25;
+		const fillWidth = progress * (barLength / 100);
+		const background = '█'.white;
+		const foreground = '█'.green;
+		const range = [];
+		for (let i = 0; i < barLength; i++) {
+			range.push(i);
+		}
+
+		return range
+			.map(i => (i < fillWidth ? foreground : background))
+			.join('');
+	}
+}
+
+class SimpleReporter {
+	constructor(logger) {
+		this.logger = logger;
+	}
+
+	start() {
+		const badge = ' WAIT '.bgCyan.black;
+		this.logger.info(`${badge} ${'Compiling ...'.cyan}`);
+	}
+
+	progress() {
+
+	}
+
+	done() {
+
+	}
+}
+
+module.exports = {
+	ProgressBarReporter,
+	SimpleReporter
+};

--- a/cli/lib/webpack/service.js
+++ b/cli/lib/webpack/service.js
@@ -1,0 +1,354 @@
+const boxen = require('boxen');
+const crypto = require('crypto');
+const EventEmitter = require('events');
+const fs = require('fs');
+const path = require('path');
+const util = require('util');
+
+const { ProgressBarReporter, SimpleReporter } = require('./reporter');
+
+const STATE_READY = 'ready';
+const STATE_BUILDING = 'building';
+const STATE_STOPPED = 'stopped';
+const STATE_ERROR = 'error';
+
+/**
+ * @typedef ServiceOptions
+ * @property {object} client Appcd client
+ * @property {object} builder Platform speciifc builder
+ * @property {object} cli Titanium CLI
+ * @property {object} logger CLI logger
+ * @property {string} projectType Type of the current project
+ */
+
+/**
+ * Service communicating with @appcd/plugin-webpack to start/stop Webpack
+ * builds, query current build status and stream progress/status changes.
+ */
+class WebpackService extends EventEmitter {
+	/**
+	 * Constructs a new Webpack service instance.
+	 *
+	 * @param {ServiceOptions} options Webpack service options
+	 */
+	constructor({ client, builder, cli, logger, projectType }) {
+		super();
+
+		this.client = client;
+		this.logger = logger;
+		this.builder = builder;
+		const tiapp = cli.tiapp;
+		this.type = projectType;
+		this.projectData = {
+			path: cli.argv['project-dir'],
+			name: tiapp.name,
+		};
+		this.loadBuildSettings(builder, cli);
+		this.shouldWatch = builder.deployType !== 'production' && !builder.buildOnly;
+
+		this.forceRebuild = this.shouldForceRebuild(builder, cli);
+		this.jobIdentifier = this.generateJobIdentifier();
+		this.pluginVersion = process.env.APPCD_WEBPACK_VERSION || 'latest';
+		this.basePath = `/webpack/${this.pluginVersion}`;
+		this.webpackStatus = { state: 'unknown' };
+		this.reporter = (!cli.argv.quiet && cli.argv['progress-bars'])
+			? new ProgressBarReporter()
+			: new SimpleReporter(logger);
+		this.webUiUrl = null;
+		this.updateTimeout = null;
+	}
+
+	/**
+	 * Loads various builds settings from the Builder and CLI.
+	 *
+	 * @param {object} builder Platform builder
+	 * @param {object} cli Titanium CLI
+	 */
+	loadBuildSettings(builder, cli) {
+		const platform = cli.argv.platform;
+		const buildSettings = {
+			platform,
+			deployType: builder.deployType,
+			target: cli.argv.target,
+			sdk: {
+				path: cli.sdk.path,
+				version: cli.sdk.name,
+				gitHash: cli.sdk.manifest.githash,
+				buildDate: cli.sdk.manifest.timestamp
+			}
+		};
+
+		if (platform === 'ios') {
+			buildSettings.ios = {
+				deviceFamily: builder.deviceFamily
+			};
+		}
+
+		this.buildSettings = buildSettings;
+	}
+
+	/**
+	 * Checks whether the build should be forcefully restarted.
+	 *
+	 * @param {object} builder Platform builder
+	 * @param {object} cli Titanium CLI
+	 * @return {boolean} True when a Webpack rebuild should be forced, false if not.
+	 */
+	shouldForceRebuild(builder, cli) {
+		if (cli.argv.force) {
+			this.logger.debug('Force flag is set, starting new Webpack build.');
+			return true;
+		}
+
+		if (!fs.existsSync(path.join(this.projectData.path, 'Resources'))) {
+			this.logger.debug('Resources directory doesn\'t exist, starting new Webpack build.');
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Runs a Webpack build via the daemon.
+	 */
+	async build() {
+		await this.ensureDaemonIsRunning();
+		await this.notifyPluginUpdateIfAvailable();
+		this.printWebUiUrl();
+		await this.ensureWebpackIsRunning();
+		await this.waitForCompilationComplete();
+	}
+
+	/**
+	 * Checks if the daemon is running and, if not, automatically starts it.
+	 */
+	async ensureDaemonIsRunning() {
+		try {
+			await this.client.connect();
+		} catch (e) {
+			if (e.code === 'ECONNREFUSED') {
+				this.logger.info('Starting Appcelerator Daemon (subsequent builds will be faster) ...');
+				await this.client.connect({ startDaemon: true });
+			} else {
+				throw e;
+			}
+		}
+	}
+
+	async notifyPluginUpdateIfAvailable() {
+		const update = await this.client.get(`${this.basePath}/update/info`);
+		if (update.available && !update.fromCache) {
+			const { current, latest } = update;
+			const updateCommand = 'npm i -g @appcd/plugin-webpack';
+			const message = `Update available ${current.dim} → ${latest.green}\nRun ${updateCommand.cyan} to update`;
+			const output = boxen(message, {
+				padding: 1,
+				margin: 1,
+				align: 'center',
+				borderColor: 'yellow',
+				borderStyle: 'round'
+			});
+			output.split('\n').forEach(l => this.logger.info(l));
+		}
+	}
+
+	/**
+	 * Ensures that Webpack is running.
+	 *
+	 * If Webpack is not already running it will be started. If Webpack is
+	 * already running the current options will be validated. If they do not
+	 * match with the options from this build, Webpack will be restarted.
+	 */
+	async ensureWebpackIsRunning() {
+		const options = {
+			identifier: this.jobIdentifier,
+			type: this.type,
+			task: 'build', // this.buildSettings.deployType === 'production' ? 'build' : 'serve',
+			watch: this.shouldWatch,
+			project: this.projectData,
+			build: this.buildSettings
+		};
+
+		if (this.forceRebuild) {
+			return this.startWebpack(options);
+		}
+
+		let response;
+		try {
+			response = await this.client.get(`${this.basePath}/status/${options.identifier}`);
+		} catch (e) {
+			if (e.status === 404) {
+				return this.startWebpack(options);
+			}
+			throw e;
+		}
+		this.webpackStatus = response;
+
+		if (this.webpackStatus.state === STATE_STOPPED || this.webpackStatus.state === STATE_ERROR) {
+			this.logger.debug('Webpack not running, starting new Webpack build.');
+			return this.startWebpack(options);
+		}
+
+		if (!this.validateOptions(response.options, options)) {
+			this.logger.debug('Build options changed, restarting Webpack build.');
+			return this.startWebpack(options);
+		}
+
+		if (this.webpackStatus.state === STATE_READY) {
+			this.builder.tiSymbols = response.tiSymbols;
+		}
+	}
+
+	/**
+	 * Prints the url to the web ui.
+	 */
+	printWebUiUrl() {
+		const { host, port } = this.client;
+		this.webUiUrl = `http://${host}:${port}${this.basePath}/web`;
+		this.logger.info(`Web UI ready on ${this.webUiUrl.cyan}`);
+	}
+
+	/**
+	 * Waits for the Webpack build to signal that compilation is complete.
+	 */
+	async waitForCompilationComplete() {
+		if (this.webpackStatus.state === STATE_READY) {
+			this.logger.info(`Build is up-to-date and ${'ready'.green}!`);
+			if (this.shouldWatch) {
+				await this.subcribeToWebpackStatusChanges();
+			} else {
+				this.client.disconnect();
+			}
+			return;
+		}
+
+		await this.subcribeToWebpackStatusChanges();
+
+		return new Promise((resolve, reject) => {
+			const handler = e => {
+				if (e.state === STATE_READY || e.state === STATE_ERROR) {
+					this.off('status', handler);
+
+					if (e.state === STATE_READY) {
+						if (!this.shouldWatch) {
+							this.client.disconnect();
+							this.off('timeout', showTimeoutInfo);
+						}
+						return resolve();
+					}
+
+					return reject(new Error('Webpack compilation failed.'));
+				}
+			};
+			const showTimeoutInfo = () => {
+				const buildUrl = `${this.webUiUrl}/build/${this.jobIdentifier}`.cyan;
+				const logcatCommand = `${process.env.APPC_ENV ? 'appc ' : ''}appcd logcat "*webpack*"`;
+				this.logger.info('Did not receive any Webpack status updates in the last 30 seconds while waiting');
+				this.logger.info('for the build to complete.');
+				this.logger.info('');
+				this.logger.info(`  - Open ${buildUrl.cyan} to see full build details`);
+				this.logger.info(`  - Use ${'--force'.grey} to restart the Webpack build`);
+				this.logger.info(`  - View Daemon logs from Webpack with ${logcatCommand.grey}`);
+				this.logger.info('');
+				const error = new Error('Timeout while waiting for the Webpack build to complete.');
+				reject(error);
+			};
+			this.on('status', handler);
+			this.on('timeout', showTimeoutInfo);
+		});
+	}
+
+	/**
+	 * Starts a Webpack build with the given options.
+	 *
+	 * @param {object} options Webpack build options
+	 * @return {Promise}
+	 */
+	startWebpack(options) {
+		this.logger.debug(`Starting Webpack with options: ${util.inspect(options, { breakLength: Infinity, colors: true })}`);
+		this.logger.info('Initial build may take a while');
+		this.webpackStatus = { state: STATE_BUILDING };
+		this.reporter.start();
+		return this.client.post(`${this.basePath}/start`, options);
+	}
+
+	/**
+	 * Subscribes to status updates of the Webpack build for the current project.
+	 */
+	async subcribeToWebpackStatusChanges() {
+		const subscription = await this.client.subscribe(`${this.basePath}/status/${this.jobIdentifier}`);
+		subscription.on('message', data => {
+			if (this.updateTimeout) {
+				clearTimeout(this.updateTimeout);
+			}
+
+			if (data.event === 'state') {
+				this.webpackStatus = data;
+				this.emit('status', data);
+			} else if (data.event === 'output') {
+				data.output
+					.replace(/\s+$/, '')
+					.split('\n')
+					.forEach(m => this.logger.info(m));
+			} else if (data.event === 'progress') {
+				this.reporter.progress(data.progress);
+			} else if (data.event === 'done') {
+				this.reporter.done(data);
+			} else if (data.event === 'api-usage') {
+				this.builder.tiSymbols = data.tiSymbols;
+			}
+
+			if (this.webpackStatus.state === STATE_BUILDING) {
+				this.updateTimeout = setTimeout(() => {
+					this.emit('timeout');
+				}, 30000);
+			}
+		});
+		subscription.on('close', () => {
+			this.logger.warn('Daemon connection lost');
+		});
+		subscription.on('error', e => {
+			this.logger.error(e);
+			this.webpackStatus.state = STATE_ERROR;
+			this.emit('status');
+		});
+	}
+
+	/**
+	 * Generates a unique identifier for the Webpack build.
+	 *
+	 * @return {string}
+	 */
+	generateJobIdentifier() {
+		const hash = crypto.createHash('sha1');
+		hash.update(this.projectData.path);
+		return hash.digest('hex');
+	}
+
+	/**
+	 * Validates options from already running Webpack build to match expected
+	 * options determined from current Titanium build.
+	 *
+	 * @param {object} currentOptions Currently active Webpack options
+	 * @param {object} newOptions New options based on current build
+	 * @return {boolean}
+	 */
+	validateOptions(currentOptions, newOptions) {
+		const checkProperties = [
+			'project',
+			'build'
+		];
+		const pluck = (obj, props) => {
+			return props.reduce((acc, prop) => {
+				acc[prop] = obj[prop];
+				return acc;
+			}, {});
+		};
+		return util.isDeepStrictEqual(
+			pluck(currentOptions, checkProperties),
+			pluck(newOptions, checkProperties)
+		);
+	}
+}
+
+module.exports = WebpackService;

--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -6027,7 +6027,16 @@ iOSBuilder.prototype.copyResources = function copyResources(next) {
 					});
 					task.run()
 						.then(() => {
-							this.tiSymbols = task.data.tiSymbols;
+							if (this.useWebpack) {
+								// Merge Ti symbols from Webpack with the ones from legacy js processing
+								Object.keys(task.data.tiSymbols).forEach(file => {
+									const existingSymbols = this.tiSymbols[file] || [];
+									const additionalSymbols = task.data.tiSymbols[file];
+									this.tiSymbols[file] = Array.from(new Set(existingSymbols.concat(additionalSymbols)));
+								});
+							} else {
+								this.tiSymbols = task.data.tiSymbols;
+							}
 
 							return next(); // eslint-disable-line promise/no-callback-in-promise
 						})

--- a/package-lock.json
+++ b/package-lock.json
@@ -307,6 +307,19 @@
             "lodash": "^4.17.13",
             "to-fast-properties": "^2.0.0"
           }
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
@@ -2774,6 +2787,7 @@
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -2781,7 +2795,8 @@
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
         }
       }
     },
@@ -3783,8 +3798,7 @@
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
-      "dev": true
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
     },
     "@types/estree": {
       "version": "0.0.39",
@@ -3922,6 +3936,44 @@
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
     },
+    "ansi-align": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.0.tgz",
+      "integrity": "sha512-ZpClVKqXN3RGBmKibdfWzqCY4lnjEuoNzU5T0oEFpfd/z5qJHVarukridD4juLO2FXMiwUQxr9WqQtaYa8XRYw==",
+      "requires": {
+        "string-width": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
+    },
     "ansi-colors": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
@@ -3929,10 +3981,12 @@
       "dev": true
     },
     "ansi-escapes": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
-      "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
-      "dev": true
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.0.tgz",
+      "integrity": "sha512-EiYhwo0v255HUL6eDyuLrXEkTi7WwVCLAw+SeOQ7M7qdun1z1pum4DEm/nuqIVbPvi9RPPc9k9LbyBv6H0DwVg==",
+      "requires": {
+        "type-fest": "^0.8.1"
+      }
     },
     "ansi-regex": {
       "version": "2.1.1",
@@ -4675,6 +4729,105 @@
         }
       }
     },
+    "boxen": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-4.2.0.tgz",
+      "integrity": "sha512-eB4uT9RGzg2odpER62bBwSLvUeGC+WbRjjyyFhGsKnc8wp/m0+hQsMUvUe3H2V0D5vw0nBdO1hCJoZo5mKeuIQ==",
+      "requires": {
+        "ansi-align": "^3.0.0",
+        "camelcase": "^5.3.1",
+        "chalk": "^3.0.0",
+        "cli-boxes": "^2.2.0",
+        "string-width": "^4.1.0",
+        "term-size": "^2.1.0",
+        "type-fest": "^0.8.1",
+        "widest-line": "^3.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+        },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "bplist-creator": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.0.8.tgz",
@@ -4968,6 +5121,11 @@
       "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
       "dev": true
     },
+    "cli-boxes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.0.tgz",
+      "integrity": "sha512-gpaBrMAizVEANOpfZp/EEUixTXDyGt7DFzdK5hU+UbWt/J0lB0w20ncZj59Z9a93xHb9u12zF5BS6i9RKbtg4w=="
+    },
     "cli-cursor": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
@@ -5117,6 +5275,17 @@
           "requires": {
             "ansi-regex": "^4.1.0"
           }
+        },
+        "wrap-ansi": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+          "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.0",
+            "string-width": "^3.0.0",
+            "strip-ansi": "^5.0.0"
+          }
         }
       }
     },
@@ -5194,6 +5363,12 @@
         "strip-json-comments": "3.0.1"
       },
       "dependencies": {
+        "ansi-escapes": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+          "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+          "dev": true
+        },
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
@@ -7100,8 +7275,7 @@
     "emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-      "dev": true
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
     },
     "encoding": {
       "version": "0.1.12",
@@ -7183,7 +7357,7 @@
     },
     "es6-promisify": {
       "version": "5.0.0",
-      "resolved": "http://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "dev": true,
       "requires": {
@@ -7911,7 +8085,7 @@
     "file-state-monitor": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-state-monitor/-/file-state-monitor-1.0.0.tgz",
-      "integrity": "sha1-sB6DdB3FijH828Bgk5Dinf49xDI=",
+      "integrity": "sha512-Tmn8VmqNW++Vyd0aMgNPR1F+56gp4GE9iY1rpM5X4YrN1yDxLVBfL2Q7qr6FCyoYyNiyOHCFidK1Mpl5t58BSA==",
       "requires": {
         "fs-extra": "^4.0.0"
       },
@@ -11547,7 +11721,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -12683,7 +12857,7 @@
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
+      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
         "hosted-git-info": "^2.1.4",
@@ -15040,6 +15214,11 @@
         "uuid": "^3.3.2"
       }
     },
+    "term-size": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.0.tgz",
+      "integrity": "sha512-a6sumDlzyHVJWb8+YofY4TW112G6p2FCPEAFk+59gIYHv3XHRhm9ltVQ9kli4hNWeQBwSpe8cRN25x0ROunMOw=="
+    },
     "test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -15446,8 +15625,7 @@
     "type-fest": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-      "dev": true
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="
     },
     "typedarray-to-buffer": {
       "version": "3.1.5",
@@ -15698,6 +15876,49 @@
         "string-width": "^1.0.2 || 2"
       }
     },
+    "widest-line": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
+      "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
+      "requires": {
+        "string-width": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+        },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        }
+      }
+    },
     "win-fork": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/win-fork/-/win-fork-1.1.1.tgz",
@@ -15753,46 +15974,68 @@
       "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
     },
     "wrap-ansi": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
-      "dev": true,
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
       "requires": {
-        "ansi-styles": "^3.2.0",
-        "string-width": "^3.0.0",
-        "strip-ansi": "^5.0.0"
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
         },
         "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
         },
         "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "dev": true,
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
           "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
           }
         },
         "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "dev": true,
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
           "requires": {
-            "ansi-regex": "^4.1.0"
+            "ansi-regex": "^5.0.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -82,9 +82,11 @@
   },
   "dependencies": {
     "adm-zip": "^0.4.16",
+    "ansi-escapes": "^4.3.0",
     "appc-tasks": "^1.0.2",
     "archiver": "^5.0.0",
     "async": "^2.6.1",
+    "boxen": "^4.2.0",
     "buffer-equal": "1.0.0",
     "clean-css": "4.2.3",
     "colors": "^1.4.0",
@@ -106,6 +108,7 @@
     "semver": "^7.3.2",
     "sprintf": "0.1.5",
     "temp": "0.9.1",
+    "wrap-ansi": "^6.2.0",
     "xcode": "^3.0.1",
     "xmldom": "^0.3.0"
   },


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-27429

This adds a new CLI hook that will allow the use of Webpack with Titanium.

## Motivation

The current JavaScript processing pipeline in Titanium is mainly done in [node-titanium-sdk](https://github.com/appcelerator/node-titanium-sdk). Although we improved the implementation a lot in the last couple major releases, it still lacks the ability to be customized by users. The only configuration that can be done is to include additional Babel plugins.

With our continuing effort to improve compatibility with Node.js core modules the use of third-party Node modules should also be simplified. Depending on the project type, currently they have to be installed into `Resources/node_modules` (Classic) or `app/lib/node_modules` (Alloy). This is not very intuitive, since users are used to installing Node modules directly into the project root.

Last but not least, to support Angular and Vue.js implementations a Webpack build pipeline needs to be in place. The tooling around those is depending on Webpack.

## Features

To address the issues outlined above an alternative JavaScript build pipeline using Webpack is now in place. It comes with pre-configured configurations for existing Classic and Alloy projects, as well as for the upcoming Vue.js and Angular implementations (experimental). Webpack support is implemented as a [plugin](https://github.com/appcelerator/appcd-plugin-webpack) for the [Appc Daemon](https://github.com/appcelerator/appc-daemon).

Features for the initial release:

- Bundle source code and assets of apps using Webpack
- Pre-defined Webpack configurations for all Titanium projects. These should work out of the box for most projects but are fully configurable using hooks/plugins if need be.
- Webpack builds are performed in a background process and automatically re-build changed files to minimize incremental app build times.
- Easy use of Node modules. Install NPM packages directly into the project root directory and require them in Titanium code. Webpack then takes care of the rest and makes sure to properly resolve and bundle them into the app.
- Web UI to view build stats and control the Webpack builds.

## Migration

There is a detailed [migration guide](https://github.com/appcelerator/appcd-plugin-webpack/blob/master/migration.md) for existing projects. It describes all steps required to enable Webpack in existing projects and what changes are required for the project. Changes to the code base should be minimal and only affect `require`/`import` statements in most cases.

## How it works

The hook communicates with the Appc Daemon to start new Weback builds and query the current status of running builds. The majority of the work is then done by the daemon in the background. [appcd-plugin-webpack](https://github.com/appcelerator/appcd-plugin-webpack) will automatically configure Webpack based on the project type so users don't have to deal with Webpack configuration files.

Webpack uses `Resources` as its output directory so our build can continue as usual once Webpack is done. This ensures minimal changes to the existing build pipeline.

To get the most out of the "always running" approach of the daemon, once Webpack is started it keeps running for as long as you actively work on a project. After 10min of no activity it stops to save system resources. On the the next build it will automatically be started again. It is also possible to start and stop the Webpack build via the Web UI.

The Webpack plugin will make sure to restart the build when necessary, for example when

- Build settings change, like target or deploy type.
- Files change, like `tiapp.xml` or `babel.config.js`
- The `--force` flag is explicitly set

As a result, there are two kinds of clean builds when Webpack is enabled. The first one when Webpack is not started, which is basically the same as usual. Everything starts from scratch, including JS processing through Webpack. And all builds from then on will just query the daemon for the current Webpack build status. If everything is up-to-date the whole JS handling in our build will be skipped. This means that even subsequent clean builds are faster.

## Benchmarks

I currently only have benchmarks for Alloy apps since i don't have a decently large Classic project to test with. Anyway, let's talk some numbers. You will notice that there are two passes for clean builds. The first one is with Webpack not running, the second one with Webpack already running. All times are the average of three builds.

Timings with our very own KitchenSink v2:

|Task|Standard|Webpack|
|---|---|---|
|Clean build `#1`|32s|36s|
|Clean build `#2`|32s|30s|
|Incremental build|8s|789ms|

The first clean build where Webpack is not already running takes a little longer since there is the overhead of starting Webpack, which can take a couple of seconds.

Now, the bigger the app gets, the better the build time improvements become. The following benchmarks were done with a large real-world project that contains ~100 controllers/views, ~20 widgets and NPM dependencies.

|Task|Standard|Webpack|
|---|---|---|
|Clean build `#1`|2m 6s|1m 55s|
|Clean build `#2`|2m 6s|1m 36s|
|Incremental build|20s 965ms|1s 861ms|

## Action items

- [x] ~~The hooks tries to locate the appcd daemon either globally when run via `ti build` or the shipped version included in appc-cli when run with `appc run`. Depending on whether the appc-cli daemon can be updated to v3.1.0 or not this behavior needs to be adjusted.~~ `appc-cli@8.0.0`  ships with `appcd@3.1.0`!
- [x] Evaluate Webpack generated source maps.
- [x] Update `node-titanium-sdk` once https://github.com/appcelerator/node-titanium-sdk/pull/128 is merged.
- [ ] Create new project templates that have Webpack enabled by default.

## Testing Instructions

I've created a new branch of our Kitchensink App which can be used for easy testing: https://github.com/janvennemann/kitchensink-v2/tree/webpack

To enable Webpack in any other project follow the [migration guide](https://github.com/appcelerator/appcd-plugin-webpack/blob/develop/migration.md).

## Kown issues

- Webpack builds are not yet compatible with Hyperloop. All Hyperoop related requires need to be marked as external so Webpack doesn't try to bundle them