### PR TITLE
docs: fix PickerColumn parent class

### DIFF
--- a/apidoc/Titanium/UI/Picker.yml
+++ b/apidoc/Titanium/UI/Picker.yml
@@ -49,7 +49,7 @@ excludes:
     properties: [
         anchorPoint,backgroundDisabledColor,backgroundDisabledImage,backgroundFocusedColor,children,
         backgroundFocusedImage,backgroundGradient,backgroundImage,backgroundLeftCap,backgroundRepeat,
-        backgroundSelectedColor,backgroundSelectedImage,backgroundTopCap,center,enabled,layout,tintColor,zIndex]
+        backgroundSelectedColor,backgroundSelectedImage,backgroundTopCap,center,layout,tintColor,zIndex]
     methods: [remove, removeAllChildren, replaceAt]
 since: "0.8"
 platforms: [android, iphone, ipad]

--- a/apidoc/Titanium/UI/PickerColumn.yml
+++ b/apidoc/Titanium/UI/PickerColumn.yml
@@ -10,7 +10,25 @@ description: |
     On Android, the `useSpinner` property must be enabled to support multiple columns.
 
     See <Titanium.UI.Picker> for further examples of usage.
-extends: Titanium.Proxy
+extends: Titanium.UI.View
+excludes:
+  properties: [
+    accessibilityHidden, accessibilityHint, accessibilityLabel, accessibilityValue, animatedCenter,
+    anchorPoint, backgroundColor, backgroundDisabledColor, backgroundDisabledImage,
+    backgroundFocusedColor, backgroundFocusedImage, backgroundGradient, backgroundImage,
+    backgroundLeftCap, backgroundRepeat, backgroundSelectedColor, backgroundSelectedImage,
+    backgroundTopCap, borderColor, borderRadius, borderWidth, bottom, center, children, clipMode,
+    elevation, focusable, height, hiddenBehavior, horizontalMotionEffect, left, layout, opacity,
+    overrideCurrentAnimation, pullBackgroundColor, previewContext, right, rect, rotation,
+    rotationX, rotationY, scaleX, scaleY, size, softKeyboardOnFocus, top, touchEnabled,
+    touchFeedback, touchFeedbackColor, transform, translationX, translationY, translationZ,
+    transitionName, verticalMotionEffect, viewShadowRadius, viewShadowColor, viewShadowOffset,
+    visible, width, horizontalWrap, keepScreenOn, tintColor, zIndex]
+  methods: [add, animate, clearMotionEffects, finishLayout, hide, insertAt, remove,
+    removeAllChildren, replaceAt, show, startLayout, toImage, updateLayout, convertPointToView,
+    getViewById]
+  events: [click, dblclick, doubletap, keypressed, longpress, pinch, singletap, swipe, touchcancel,
+    touchend, touchmove, touchstart, twofingertap]
 since: "0.9"
 platforms: [android, iphone, ipad]
 


### PR DESCRIPTION
Ti.UI.Picker:
- extends Ti.UI.View which extends Ti.Proxy and none of them have `enabled` property

Ti.UI.PickerColumn:
- is really extends Ti.UI.View (at least on [android](https://github.com/appcelerator/titanium_mobile/blob/33ea2fb0bc35f75a67674e8ba939538b12c7fe64/android/modules/ui/src/java/ti/modules/titanium/ui/PickerColumnProxy.java#L25))
- extending it from `Ti.Proxy` is [breaking typing](https://gist.github.com/drauggres/77a0bd495ca3e7d4a7dbd7e170156fb6#file-titanium-d-ts-L6995) for `Ti.UI.Picker` method `add`:

```typescript
declare namespace Titanium {

    namespace UI {

        class View extends Titanium.Proxy {
            // ...
            add(view: Titanium.UI.View|Array<Titanium.UI.View>): void;
        }

        class Picker extends Titanium.UI.View {
            // ...
            add(data: Array<Titanium.UI.PickerRow>|Titanium.UI.PickerRow|Array<Titanium.UI.PickerColumn>|Titanium.UI.PickerColumn): void;
        }

        class PickerColumn extends Titanium.Proxy {
            // ...
        }

        // ...
    }
}
```
First argument of `add` method MUST be `Ti.UI.View` or inherited from it (or `Ti.UI.View[]`)

Extending `Ti.UI.PickerColumn` from `Ti.UI.View` and later excluding all it properties, methods and events might seem stupid, but it is the real state of affairs.

P.S. TypeScript declaration file is generated with [this](https://github.com/appcelerator/docs-devkit/pull/8).