### PR TITLE
docs: mark as optional property "animated" of AnimationOption

### DIFF
--- a/apidoc/Titanium/UI/View.yml
+++ b/apidoc/Titanium/UI/View.yml
@@ -2017,6 +2017,7 @@ properties:
     summary: Determines whether to enable a circular reveal animation.
     type: Boolean
     default: false
+    optional: true
     osver: {android: {min: 5.0}}
 
 ---


### PR DESCRIPTION
Property "animated" is not required by View's "hide" and "show" methods.
Also it will cause errors in TypeScript declaration file (if you'll try to build one from docs) for methods "hide" and "show" of "Titanium.UI.iPad.Popover" class.

```typescript

declare interface AnimationOption {
    animated?: boolean;  // "animated: boolean;" will cause "Error TS2416"
}

declare interface PopoverParams {
    animated?: boolean;
    rect?: Dimension;
    view: Titanium.UI.View;
}

class View extends Titanium.Proxy {
    hide(options?: AnimationOption): void;
    show(options?: AnimationOption): void;
}

class Popover extends Titanium.UI.View {
    hide(options: PopoverParams): void;
    show(params: PopoverParams): void;
}
```

P.S. TypeScript declaration file is generated with [this](https://github.com/appcelerator/docs-devkit/pull/8).