### PR TITLE
docs: remove duplicate prop "category" from "localnotificationaction"

### DIFF
--- a/apidoc/Titanium/App/iOS/iOS.yml
+++ b/apidoc/Titanium/App/iOS/iOS.yml
@@ -909,10 +909,6 @@ events:
         summary: Application badge value.
         type: Number
 
-      - name: category
-        summary: Identifier of the category of the interactive notification.
-        type: String
-
       - name: date
         summary: Date and time when the notification was configured to fire.
         type: Date


### PR DESCRIPTION
Property `category` is defined twice on the `localnotificationaction` event.
Remove the least informative.