### PR TITLE
chore: add npm script to report deprecated but unremoved api

### DIFF
--- a/build/scons-deprecations.js
+++ b/build/scons-deprecations.js
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+'use strict';
+
+const path = require('path');
+const glob = require('glob');
+const yaml = require('js-yaml');
+const fs = require('fs-extra');
+const promisify = require('util').promisify;
+const semver = require('semver');
+const chalk = require('chalk');
+
+/**
+ * @param {object} thing type, property or method from docs
+ * @param {string} thingPath full API path of the object we're checking
+ */
+async function checkDeprecatedButNotRemoved(thing, thingPath) {
+	if (Object.prototype.hasOwnProperty.call(thing, 'deprecated')) {
+		// Do stuff!
+		if (!Object.prototype.hasOwnProperty.call(thing.deprecated, 'removed')) {
+			return { path: thingPath, deprecated: thing.deprecated };
+		}
+	}
+	return null;
+}
+
+async function checkMethod(m, methodOwner) {
+	return checkDeprecatedButNotRemoved(m, `${methodOwner}#${m.name}()`);
+}
+
+async function checkProperty(p, propertyOwner) {
+	return checkDeprecatedButNotRemoved(p, `${propertyOwner}.${p.name}`);
+}
+
+/**
+ * @param {Object} t type definition from YAML
+ * @return {Promise<object[]>} unremoved apis that are deprecated
+ */
+async function checkType(t) {
+	const unremovedDeprecations = [];
+	const typePossible = await checkDeprecatedButNotRemoved(t, t.name);
+	if (typePossible) {
+		unremovedDeprecations.push(typePossible);
+	}
+	const methods = await Promise.all((t.methods || []).map(m => checkMethod(m, t.name)));
+	unremovedDeprecations.push(...methods.filter(m => m));
+	const properties = await Promise.all((t.properties || []).map(p => checkProperty(p, t.name)));
+	unremovedDeprecations.push(...properties.filter(p => p));
+	// console.info(unremovedDeprecations);
+	return unremovedDeprecations;
+}
+
+/**
+ * @param {string} file filepath of a yml doc file to check
+ * @returns {Promise<object[]>}
+ */
+async function checkFile(file) {
+	const contents = await fs.readFile(file, 'utf8');
+	// remove comments
+	contents.replace(/\w*#.*/, '');
+	const doc = await yaml.safeLoadAll(contents);
+	const types = Array.isArray(doc) ? doc : [ doc ];
+	// go through the types in the document, for each one, check top-level for deprecated
+	// then check each property, event, method
+	const arr = await Promise.all(types.map(t => checkType(t)));
+	const flattened = [].concat(...arr);
+	return flattened;
+}
+
+/**
+ * @param {string|object} deprecatedSince string or object holding deprecated since value from yml docs
+ * @return {string}
+ */
+function pickFirstVersion(deprecatedSince) {
+	if (typeof deprecatedSince !== 'string') {
+		// deprecated.since may be an object with platform keys, version values!
+		// Hack to just pick first value we can
+		return Object.values(deprecatedSince)[0];
+	}
+	return deprecatedSince;
+}
+
+/**
+ * @param {string} a first version strign to comparse
+ * @param {string} b second version string to compare
+ * @returns {1|0|-1}
+ */
+function compareVersions(a, b) {
+	return semver.compare(a, b);
+}
+
+/**
+ * @param {object} a first type/method/property doc definition to compare
+ * @param {object} b second type/method/property doc definition to compare
+ * @returns {1|0|-1}
+ */
+function compareUnremoved(a, b) {
+	return compareVersions(pickFirstVersion(a.deprecated.since), pickFirstVersion(b.deprecated.since));
+}
+
+/**
+ * @returns {object[]}
+ */
+async function main() {
+	const apidocs = path.join(__dirname, '../apidoc');
+	const files = await promisify(glob)(`${apidocs}/**/*.yml`);
+	const arr = await Promise.all(files.map(f => checkFile(f)));
+	const flattened = [].concat(...arr);
+	// Sort by deprecated.since oldest to newest
+	flattened.sort(compareUnremoved);
+	return flattened;
+}
+
+main().then(results => {
+	if (results && results.length !== 0) {
+		results.forEach(f => {
+			console.error(`${chalk.cyan(f.path)} has been deprecated since ${chalk.red(pickFirstVersion(f.deprecated.since))}, but is not yet removed!`);
+		});
+		return process.exit(1);
+	}
+	return process.exit(0);
+}).catch(err => {
+	console.error(err);
+	process.exit(1);
+});

--- a/build/scons-removals.js
+++ b/build/scons-removals.js
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+'use strict';
+
+const path = require('path');
+const glob = require('glob');
+const yaml = require('js-yaml');
+const fs = require('fs-extra');
+const promisify = require('util').promisify;
+const semver = require('semver');
+const chalk = require('chalk');
+
+/**
+ * @param {object} thing type, property or method from docs
+ * @param {string} thingPath full API path of the object we're checking
+ */
+async function checkDeprecatedAndRemoved(thing, thingPath) {
+	if (Object.prototype.hasOwnProperty.call(thing, 'deprecated')
+		&& Object.prototype.hasOwnProperty.call(thing.deprecated, 'removed')) {
+		return { path: thingPath, deprecated: thing.deprecated };
+	}
+	return null;
+}
+
+async function checkMethod(m, methodOwner) {
+	return checkDeprecatedAndRemoved(m, `${methodOwner}#${m.name}()`);
+}
+
+async function checkProperty(p, propertyOwner) {
+	return checkDeprecatedAndRemoved(p, `${propertyOwner}.${p.name}`);
+}
+
+/**
+ * @param {Object} t type definition from YAML
+ * @return {Promise<object[]>} unremoved apis that are deprecated
+ */
+async function checkType(t) {
+	const unremovedDeprecations = [];
+	const typePossible = await checkDeprecatedAndRemoved(t, t.name);
+	if (typePossible) {
+		unremovedDeprecations.push(typePossible);
+	}
+	const methods = await Promise.all((t.methods || []).map(m => checkMethod(m, t.name)));
+	unremovedDeprecations.push(...methods.filter(m => m));
+	const properties = await Promise.all((t.properties || []).map(p => checkProperty(p, t.name)));
+	unremovedDeprecations.push(...properties.filter(p => p));
+	// console.info(unremovedDeprecations);
+	return unremovedDeprecations;
+}
+
+/**
+ * @param {string} file filepath of a yml doc file to check
+ * @returns {Promise<object[]>}
+ */
+async function checkFile(file) {
+	const contents = await fs.readFile(file, 'utf8');
+	// remove comments
+	contents.replace(/\w*#.*/, '');
+	const doc = await yaml.safeLoadAll(contents);
+	const types = Array.isArray(doc) ? doc : [ doc ];
+	// go through the types in the document, for each one, check top-level for deprecated
+	// then check each property, event, method
+	const arr = await Promise.all(types.map(t => checkType(t)));
+	const flattened = [].concat(...arr);
+	return flattened;
+}
+
+/**
+ * @param {string|object} deprecatedSince string or object holding deprecated since value from yml docs
+ * @return {string}
+ */
+function pickFirstVersion(deprecatedSince) {
+	if (typeof deprecatedSince !== 'string') {
+		// deprecated.since may be an object with platform keys, version values!
+		// Hack to just pick first value we can
+		return Object.values(deprecatedSince)[0];
+	}
+	return deprecatedSince;
+}
+
+/**
+ * @param {string} a first version strign to comparse
+ * @param {string} b second version string to compare
+ * @returns {1|0|-1}
+ */
+function compareVersions(a, b) {
+	return semver.compare(a, b);
+}
+
+/**
+ * @param {object} a first type/method/property doc definition to compare
+ * @param {object} b second type/method/property doc definition to compare
+ * @returns {1|0|-1}
+ */
+function compareRemoved(a, b) {
+	return compareVersions(pickFirstVersion(a.deprecated.removed), pickFirstVersion(b.deprecated.removed));
+}
+
+/**
+ * @param {string} version maximum version to include
+ * @returns {object[]}
+ */
+async function main(version) {
+	const apidocs = path.join(__dirname, '../apidoc');
+	const files = await promisify(glob)(`${apidocs}/**/*.yml`);
+	const arr = await Promise.all(files.map(f => checkFile(f)));
+	const flattened = [].concat(...arr).filter(f => compareVersions(pickFirstVersion(f.deprecated.removed), version) < 0);
+	// Sort by deprecated.since oldest to newest
+	flattened.sort(compareRemoved);
+	return flattened;
+}
+
+main(process.argv[2]).then(results => {
+	if (results && results.length !== 0) {
+		results.forEach(f => {
+			console.error(`${chalk.cyan(f.path)} has been removed since ${chalk.red(pickFirstVersion(f.deprecated.removed))}. Consider dropping from apidocs.`);
+		});
+		return process.exit(1);
+	}
+	return process.exit(0);
+}).catch(err => {
+	console.error(err);
+	process.exit(1);
+});

--- a/build/scons.js
+++ b/build/scons.js
@@ -19,4 +19,5 @@ commander
 	.command('check-ios-toplevel', 'Ensures we don\'t check in prefilled values for version/hash/timestamp')
 	.command('xcode-project-build <projectDir> <targetBuildDir> <productName>', 'Runs the portion of the xcode project setup')
 	.command('deprecations', 'Checks the apidocs for deprecated but unremoved types/properties/methods')
+	.command('removals <minVersion>', 'Checks the apidocs for deprecated and removed types/properties/methods older than a given version')
 	.parse(process.argv);

--- a/build/scons.js
+++ b/build/scons.js
@@ -18,4 +18,5 @@ commander
 	.command('xcode-test', 'Hacks the XCode project for iOS to copy in the unit test suite so it can be run under XCode\'s debugger')
 	.command('check-ios-toplevel', 'Ensures we don\'t check in prefilled values for version/hash/timestamp')
 	.command('xcode-project-build <projectDir> <targetBuildDir> <productName>', 'Runs the portion of the xcode project setup')
+	.command('deprecations', 'Checks the apidocs for deprecated but unremoved types/properties/methods')
 	.parse(process.argv);

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "clean:ios": "npm run clean -- ios",
     "commit": "git-cz",
     "deprecations": "./build/scons deprecations",
+    "docs:removed": "./build/scons removals 7.0.0",
     "format": "npm-run-all --parallel format:**",
     "format:android": "npm run lint:android -- --fix",
     "format:ios": "npm run lint:ios -- --fix",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "clean:android": "npm run clean -- android",
     "clean:ios": "npm run clean -- ios",
     "commit": "git-cz",
+    "deprecations": "./build/scons deprecations",
     "format": "npm-run-all --parallel format:**",
     "format:android": "npm run lint:android -- --fix",
     "format:ios": "npm run lint:ios -- --fix",


### PR DESCRIPTION
**Optional Description:**
This adds an npm script: `npm run deprecations` which will parse the apidocs and find types/properties/methods we've marked as deprecated but have not yet marked as removed.

Lists the APIs in order from oldest deprecated version to newest. This should give a good listing for things we need to get rid of in breaking change releases.

Gives me:
![Screen Shot 2019-11-25 at 4 11 10 PM](https://user-images.githubusercontent.com/3252/69578309-395f0780-0f9e-11ea-9090-3847d72c21ce.png)