### PR TITLE
fix(android): ignore additional require argument

### DIFF
--- a/android/runtime/common/src/js/module.js
+++ b/android/runtime/common/src/js/module.js
@@ -562,8 +562,8 @@ Module.prototype._runScript = function (source, filename) {
 	var self = this,
 		url = 'app://' + filename;
 
-	function require(path, context) {
-		return self.require(path, context);
+	function require(path) {
+		return self.require(path);
 	}
 	require.main = Module.main;
 


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-27633

@garymathews This is my naive solution, which just drops the additional parameter we currently support in our `require` on Android. I couldn't find any `require`s in our codebase that make use of this second parameter.

I'm note sure if this is just a relic from older versions or if we actually still use this. We could change this PR to something like this to avoid breaking changes:

```js
  function require(path, context) {
    if (typeof context !== 'object' || context === null) {
      context = {}
    }
    return self.require(path, context);
  }
```