### PR TITLE
docs: extract out common types

### DIFF
--- a/apidoc/Titanium/App/App.yml
+++ b/apidoc/Titanium/App/App.yml
@@ -361,7 +361,7 @@ events:
     properties:
       - name: keyboardFrame
         summary: A dictionary with keys x, y, width and height representing the frame of keyboard on screen.
-        type: Dictionary
+        type: Dimension
 
       - name: animationDuration
         summary: The duration of the keyboard animation. This parameter is only available on Titanium SDK 4.0.0 and later.

--- a/apidoc/Titanium/Blob.yml
+++ b/apidoc/Titanium/Blob.yml
@@ -119,8 +119,11 @@ methods:
     since: {android: "3.0.0"}
     parameters:
       - name: options
-        summary: Image cropping options.
-        type: Dictionary<ImageAsCroppedDict>
+        summary: |
+          Image cropping options. <Dimension> properties are all optional for this use case.
+
+          Defaults will be to use the current image's `height`/`width` and to center the cropped rectangle horizontally/vertically on the original image (`x`/`y`).
+        type: Dimension
     returns:
         type: Titanium.Blob
         summary: Cropped image as a blob.
@@ -237,30 +240,3 @@ methods:
     returns:
         type: Titanium.Blob
         summary: The image with a transparent border in a blob, or `null` if this blob is not an image.
----
-name: ImageAsCroppedDict
-summary: Simple object used to specify options for [imageAsCropped](Titanium.Blob.imageAsCropped).
-properties:
-  - name: width
-    type: Number
-    summary: Width to crop this image to.
-    optional: true
-    default: Current image width.
-
-  - name: height
-    type: Number
-    summary: Height to crop this image to.
-    optional: true
-    default: Current image height.
-
-  - name: x
-    type: Number
-    summary: Left coordinate of the cropped rectangle within the source image.
-    optional: true
-    default: Cropped rectangle is centered horizontally on the original image.
-
-  - name: y
-    type: Number
-    summary: Top coordinate of the cropped rectangle within the source image.
-    optional: true
-    default: Cropped rectangle is centered vertically on the original image.

--- a/apidoc/Titanium/Database/ResultSet.yml
+++ b/apidoc/Titanium/Database/ResultSet.yml
@@ -44,9 +44,8 @@ methods:
         
         Returns null if the value in the table is NULL.
     returns:
-      - type: String
-      - type: Number
-      - type: Titanium.Blob
+      type: [String, Number, Titanium.Blob]
+      summary: return type varies based on the underlying data and optional `type` argument. If BLOB, we return a Titanium.Blob. If TEXT, we return String. If any kind of number, we return a Number.
     parameters:
       - name: index
         summary: A zero-based column index.
@@ -76,9 +75,8 @@ methods:
         
         Returns null if the value in the table is NULL.        
     returns:
-      - type: String
-      - type: Number
-      - type: Titanium.Blob
+      type: [String, Number, Titanium.Blob]
+      summary: return type varies based on the underlying data and optional `type` argument. If BLOB, we return a Titanium.Blob. If TEXT, we return String. If any kind of number, we return a Number.
     parameters:
       - name: name
         summary: A column name or alias used in the SQL query.

--- a/apidoc/Titanium/Filesystem/File.yml
+++ b/apidoc/Titanium/Filesystem/File.yml
@@ -215,8 +215,8 @@ methods:
             reference instead. If you wish to receive the path, use the `nativePath`
             property of that reference instead.
     returns:
-      - type: String
-      - type: Titanium.Filesystem.File
+      type: [String, Titanium.Filesystem.File]
+      summary: Returns a String on iOS, a `Titanium.Filesystem.File` on Android
 
   - name: getProtectionKey
     summary: |

--- a/apidoc/Titanium/Media/Media.yml
+++ b/apidoc/Titanium/Media/Media.yml
@@ -2242,7 +2242,9 @@ since: "3.4.2"
 properties:
   - name: inputs
     summary: An Array of current input ports for the session. See the `AUDIO_SESSION_PORT` constants.
-    type: Array<Object>
+    type: Array<String>
+    constants: Titanium.Media.AUDIO_SESSION_PORT_*
   - name: outputs
     summary: An Array of current output ports for the session. See the `AUDIO_SESSION_PORT` constants.
-    type: Array<Object>
+    type: Array<String>
+    constants: Titanium.Media.AUDIO_SESSION_PORT_*

--- a/apidoc/Titanium/Media/Media.yml
+++ b/apidoc/Titanium/Media/Media.yml
@@ -2176,7 +2176,7 @@ properties:
     accessors: false
   - name: success
     summary: Function to be called back if the preview succeeds. No info is passed.
-    type: Callback<Object>
+    type: Callback<SuccessResponse>
     accessors: false
   - name: error
     summary: Function called back if the preview fails. Check the `message` property of passed back parameter.

--- a/apidoc/Titanium/Media/Media.yml
+++ b/apidoc/Titanium/Media/Media.yml
@@ -1899,6 +1899,7 @@ properties:
     summary: Whether or not the predicate is for an exact match.  The
         default is `true`.
     type: Boolean
+    default: true
 
 # Camera options pseudo-type
 ---
@@ -2108,11 +2109,12 @@ properties:
     summary: The type of media, either `MEDIA_TYPE_PHOTO`, `MEDIA_TYPE_LIVEPHOTO` or `MEDIA_TYPE_VIDEO` defined in <Titanium.Media>.
     type: String
   - name: cropRect
-    summary: Simple object defining the user's selected crop rectangle, or `null` if the user has not edited the photo.
-    type: CropRectType
+    summary: Simple object defining the user's selected crop rectangle, or `null` if the user has not edited the photo. `width`/`height` values are assumed to be in pixels.
+    type: Dimension
+    optional: true
   - name: previewRect
-    summary: Simple object defining the preview image size.
-    type: PreviewRectType
+    summary: Simple object defining the preview image size. This will be undefined when custom camera overlay is not used. Values are assumed to be in pixels.
+    type: Size
     platforms: [android]
   - name: success
     summary: Indicates if the operation succeeded. Returns `true`.
@@ -2137,34 +2139,6 @@ properties:
     since: "5.2.0"
     osver: {ios: {min: "9.1"}}
 
-# Arguably we might need a global Rect pseudotype. For now, define locally
----
-name: CropRectType
-summary: Simple object for describing the crop rectangle for an image.
-properties:
-  - name: x
-    summary: X coordinate of the crop rectangle's upper-left corner.
-    type: Number
-  - name: y
-    summary: Y coordinate of the crop rectangle's upper-left corner.
-    type: Number
-  - name: width
-    summary: Width of the crop rectangle, in pixels.
-    type: Number
-  - name: height
-    summary: Height of the crop rectangle, in pixels.
-    type: Number
----
-name: PreviewRectType
-summary: |
-    Simple object for describing the preview image rectangle. This will be undefined when custom camera overlay is not used.
-properties:
-  - name: width
-    summary: Width preview image, in pixels.
-    type: Number
-  - name: height
-    summary: Height preview image, in pixels.
-    type: Number
 ---
 name: PreviewImageOptions
 summary: Options passed to <Titanium.Media.previewImage>.

--- a/apidoc/Titanium/Network/Network.yml
+++ b/apidoc/Titanium/Network/Network.yml
@@ -821,7 +821,6 @@ properties:
         Reference](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623013-application)
     type: Dictionary
   - name: inBackground
-    summary: |
-        Boolean indicating if notification was received while app was in background.
-        This property became available in Titanium Mobile 3.1.0 for iOS.
+    summary: Boolean indicating if notification was received while app was in background.
     type: Boolean
+    since: "3.1.0"

--- a/apidoc/Titanium/Platform/Platform.yml
+++ b/apidoc/Titanium/Platform/Platform.yml
@@ -95,7 +95,7 @@ methods:
                 * `UIApplicationOpenURLOptionsOpenInPlaceKey` (Boolean value)
                 * `UIApplicationOpenURLOptionUniversalLinksOnly` (Boolean value)
             Read more about the available keys in the [Apple documentation](https://developer.apple.com/documentation/uikit/uiapplicationopenurloptionskey?language=objc).
-        type: Dictionary
+        type: OpenURLOptions
         optional: true
       - name: callback
         summary: The optional callback that is called once the URL is opened (iOS 10+).
@@ -407,3 +407,34 @@ properties:
   - name: irq
     summary: The number of milliseconds the CPU has spent in irq mode.
     type: Number
+
+---
+name: OpenURLOptions
+summary: |
+    The optional options to pass to the URL handling (iOS 10+). Pass a
+    dictionary with one or more of the following string-keys:
+        * `UIApplicationOpenURLOptionsSourceApplicationKey` (String value)
+        * `UIApplicationOpenURLOptionsAnnotationKey` (Array value)
+        * `UIApplicationOpenURLOptionsOpenInPlaceKey` (Boolean value)
+        * `UIApplicationOpenURLOptionUniversalLinksOnly` (Boolean value)
+    Read more about the available keys in the [Apple documentation](https://developer.apple.com/documentation/uikit/uiapplicationopenurloptionskey?language=objc).
+properties:
+  - name: UIApplicationOpenURLOptionsSourceApplicationKey
+    type: String
+    summary: The value of this key is an String containing the bundle ID of the app that made the request. If the request originated from another app belonging to your team, UIKit sets the value of this key to the ID of that app. If the team identifier of the originating app is different than the team identifier of the current app, the value of the key is nil.
+    optional: true
+
+  - name: UIApplicationOpenURLOptionsAnnotationKey
+    type: Array
+    summary: contains the information passed to a document interaction controller object’s annotation property.
+    optional: true
+
+  - name: UIApplicationOpenURLOptionsOpenInPlaceKey
+    type: Boolean
+    summary: When the value of this property is `false`, you must copy the document to maintain access to it. If the flag is not set, you also must copy the document before you can use it.
+    optional: true
+
+  - name: UIApplicationOpenURLOptionUniversalLinksOnly
+    type: Boolean
+    summary: When you include this key in the options dictionary, the method opens the URL only if the URL is a valid universal link and there is an installed app capable of opening that URL.
+    optional: true

--- a/apidoc/Titanium/Platform/Platform.yml
+++ b/apidoc/Titanium/Platform/Platform.yml
@@ -426,7 +426,7 @@ properties:
 
   - name: UIApplicationOpenURLOptionsAnnotationKey
     type: Array
-    summary: contains the information passed to a document interaction controller object’s annotation property.
+    summary: contains the information passed to a document interaction controller object's annotation property.
     optional: true
 
   - name: UIApplicationOpenURLOptionsOpenInPlaceKey

--- a/apidoc/Titanium/Proxy.yml
+++ b/apidoc/Titanium/Proxy.yml
@@ -26,7 +26,7 @@ methods:
         type: String
       - name: callback
         summary: Callback function to invoke when the event is fired.
-        type: Callback<Object>
+        type: Callback<Titanium.Event>
 
   - name: removeEventListener
     summary: Removes the specified callback as an event listener for the named event.
@@ -49,7 +49,7 @@ methods:
         type: String
       - name: callback
         summary: Callback function to remove. Must be the same function passed to `addEventListener`.
-        type: Callback<Object>
+        type: Callback<Titanium.Event>
 
   - name: fireEvent
     summary: Fires a synthesized event to any registered listeners.

--- a/apidoc/Titanium/UI/2DMatrix.yml
+++ b/apidoc/Titanium/UI/2DMatrix.yml
@@ -123,7 +123,7 @@ methods:
 
       - name: angle
         summary: |
-            Angle to rotate to, in degrees. On Android, if `angleTo` is specified, this specifies
+            Angle to rotate to, in degrees. On Android, if `toAngle` is specified, this specifies
             the starting angle for a rotation animation.
         type: Number
 

--- a/apidoc/Titanium/UI/2DMatrix.yml
+++ b/apidoc/Titanium/UI/2DMatrix.yml
@@ -291,7 +291,7 @@ properties:
         Point to rotate around, specified as a dictionary object with `x` and `y`
         properties, where { x: 0.5, y: 0.5 } represents the center of whatever is being
         rotated.
-    type: Dictionary
+    type: Point
     optional: true
     default: (0.5, 0.5)
     platforms: [android]

--- a/apidoc/Titanium/UI/AnimatedOptions.yml
+++ b/apidoc/Titanium/UI/AnimatedOptions.yml
@@ -1,0 +1,9 @@
+---
+name: AnimatedOptions
+summary: A JavaScript object holding an `animated` property. Used for many UI methods as a means of specifying some transition should be animated.
+properties:
+  - name: animated
+    type: Boolean
+    default: false # Is this true in all cases? Seems to be so far...
+    optional: true
+    summary: If true, animate a transition for the method/value change

--- a/apidoc/Titanium/UI/AnimatedOptions.yml
+++ b/apidoc/Titanium/UI/AnimatedOptions.yml
@@ -4,9 +4,12 @@ summary: A JavaScript object holding an `animated` property. Used for many UI me
 properties:
   - name: animated
     type: Boolean
-    default: false # Is this true in all cases? Seems to be so far...
+    default: false # This isn't true in absolutely every case, but the heavy majority
     optional: true
-    summary: If `true`, animate a transition for the method/value change
+    summary: |
+        If `true`, animate a transition for the method/value change.
+
+        Note that for most uses cases the default is assumed to be `false`. The exceptions tend to be <Titanium.UI.Window> methods.
 
 ---
 name: AnimatedWithDurationOptions

--- a/apidoc/Titanium/UI/AnimatedOptions.yml
+++ b/apidoc/Titanium/UI/AnimatedOptions.yml
@@ -6,4 +6,15 @@ properties:
     type: Boolean
     default: false # Is this true in all cases? Seems to be so far...
     optional: true
-    summary: If true, animate a transition for the method/value change
+    summary: If `true`, animate a transition for the method/value change
+
+---
+name: AnimatedWithDurationOptions
+extends: AnimatedOptions
+summary: A JavaScript object holding `animated` and `duration` properties. Used on iOS For [TablewView](Titanium.UI.TableView) and [ListView](Titanium.UI.ListView) content offset transitions.
+properties:
+  - name: duration
+    type: Number
+    summary: The duration in `milliseconds` for animation
+    optional: true
+    default: 300

--- a/apidoc/Titanium/UI/Animation.yml
+++ b/apidoc/Titanium/UI/Animation.yml
@@ -73,7 +73,6 @@ properties:
     type: Boolean
     default: false
 
-
   - name: backgroundColor
     summary: |
         Value of the `backgroundColor` property at the end of the animation, as a color name
@@ -89,8 +88,7 @@ properties:
 
   - name: center
     summary: Value of the `center` property at the end of the animation.
-    type: Object
-
+    type: Point
 
   - name: color
     summary: |
@@ -128,6 +126,7 @@ properties:
   - name: height
     summary: Value of the `height` property at the end of the animation.
     type: Number
+
   - name: left
     summary: Value of the `left` property at the end of the animation.
     type: Number

--- a/apidoc/Titanium/UI/Button.yml
+++ b/apidoc/Titanium/UI/Button.yml
@@ -223,7 +223,7 @@ properties:
     summary: Shadow offset of the [title](Titanium.UI.Button.title), as a dictionary with the properties `x` and `y`.
     description: |
         Use in conjunction with [shadowColor](Titanium.UI.Button.shadowColor) and [shadowRadius](Titanium.UI.Button.shadowRadius).
-    type: Dictionary
+    type: Point
     platforms: [android]
     since: "3.2.0"
 

--- a/apidoc/Titanium/UI/Clipboard/Clipboard.yml
+++ b/apidoc/Titanium/UI/Clipboard/Clipboard.yml
@@ -52,7 +52,7 @@ methods:
   - name: getData
     summary: Gets data of the specified MIME type stored in the clipboard. Returns null if non-text mimetype on Android.
     returns:
-        type: [String, Titanium.Blob, null]
+        type: [String,Titanium.Blob]
     parameters:
       - name: type
         summary: MIME type. Must be 'text' or 'text/plain' on Android, or else null is returned.

--- a/apidoc/Titanium/UI/Clipboard/Clipboard.yml
+++ b/apidoc/Titanium/UI/Clipboard/Clipboard.yml
@@ -50,13 +50,12 @@ methods:
         `text/plain` MIME type.
 
   - name: getData
-    summary: Gets data of the specified MIME type stored in the clipboard.
+    summary: Gets data of the specified MIME type stored in the clipboard. Returns null if non-text mimetype on Android.
     returns:
-        - type: String
-        - type: Titanium.Blob
+        type: [String, Titanium.Blob, null]
     parameters:
       - name: type
-        summary: MIME type. Must be text type on Android.
+        summary: MIME type. Must be 'text' or 'text/plain' on Android, or else null is returned.
         type: String
 
   - name: getText
@@ -70,8 +69,9 @@ methods:
         type: Boolean
     parameters:
       - name: type
-        summary: MIME type. Must be text type on Android.
+        summary: MIME type. Must be 'text' or 'text/plain' on Android (or it will return false).
         type: String
+        optional: true
 
   - name: hasText
     summary: Indicates whether any text data is stored in the clipboard.
@@ -112,7 +112,7 @@ methods:
         enables different representations/formats of a data item to be saved.
     parameters:
       - name: type
-        summary: MIME type. Must be text type on Android.
+        summary: MIME type. Must be 'text' or 'text/plain' on Android.
         type: String
 
       - name: data

--- a/apidoc/Titanium/UI/DashboardItem.yml
+++ b/apidoc/Titanium/UI/DashboardItem.yml
@@ -14,7 +14,7 @@ events:
     properties:
       - name: location
         summary: Coordinates `x` and `y` of the event from the parent view's coordinate system.
-        type: Dictionary
+        type: Point
         
       - name: item
         summary: Item that was clicked.

--- a/apidoc/Titanium/UI/DashboardView.yml
+++ b/apidoc/Titanium/UI/DashboardView.yml
@@ -45,7 +45,7 @@ events:
 
       - name: location
         summary: Coordinates x and y of the event from the parent view's coordinate system.
-        type: Dictionary
+        type: Point
 
   - name: commit
     summary: Fired when edit mode ends.

--- a/apidoc/Titanium/UI/Dimension.yml
+++ b/apidoc/Titanium/UI/Dimension.yml
@@ -11,9 +11,24 @@ description: |
   to 0.
 properties:
   - name: x
-    summary: The x-axis coordinate of the position.
+    summary: The x-axis coordinate of the position. When returned by <Titanium.UI.View.rect> the position is relative to it's parent.
     type: Number
 
   - name: y
-    summary: The y-axis coordinate of the position.
+    summary: The y-axis coordinate of the position. When returned by <Titanium.UI.View.rect> the position is relative to it's parent.
     type: Number
+
+---
+name: DimensionWithAbsolutes
+extends: Dimension
+summary: An extension of <Dimension> where Android returns additional absolute X/Y values/properties for <Titanium.UI.View.rect>
+properties:
+  - name: absoluteX
+    summary: The x-axis coordinate of the position relative to the main window.
+    type: Number
+    platforms: [android]
+
+  - name: absoluteY
+    summary: The y-axis coordinate of the position relative to the main window.
+    type: Number
+    platforms: [android]

--- a/apidoc/Titanium/UI/Dimension.yml
+++ b/apidoc/Titanium/UI/Dimension.yml
@@ -1,0 +1,19 @@
+---
+name: Dimension
+extends: Size
+summary: A simple object consisting of the position and size measurements. Effectively combines <Size> and <Point> but ensures numeric x/y values.
+since: "2.0.0"
+description: |
+  When a dimension is returned by the [rect](Titanium.UI.View.rect) property, `x` represents the
+  view's left position, and `y` represents the view's top position.
+
+  The [size](Titanium.UI.View.size) property returns a dimension object with `x` and `y` both set
+  to 0.
+properties:
+  - name: x
+    summary: The x-axis coordinate of the position.
+    type: Number
+
+  - name: y
+    summary: The y-axis coordinate of the position.
+    type: Number

--- a/apidoc/Titanium/UI/EmailDialog.yml
+++ b/apidoc/Titanium/UI/EmailDialog.yml
@@ -70,7 +70,7 @@ methods:
     parameters:
       - name: options
         summary: |
-            Supported on iOS only. Simple object to override animation. Note that the default here is equivalent to `{ animated: true }` (while typically the default for <AnimationOptions> is false)
+            Supported on iOS only. Simple object to override animation. Note that the default here is equivalent to passing in `{ animated: true }` (while typically the default for <AnimationOptions> is false)
         type: AnimatedOptions
         optional: true
 

--- a/apidoc/Titanium/UI/EmailDialog.yml
+++ b/apidoc/Titanium/UI/EmailDialog.yml
@@ -68,6 +68,7 @@ methods:
   - name: open
     summary: Opens this email dialog.
     parameters:
+      # FIXME: This should be AnimatedOptions, but this particular case defaults to animated being true!
       - name: properties
         summary: |
             Animation properties. Set `animated` Boolean property to `true` to animate dialog

--- a/apidoc/Titanium/UI/EmailDialog.yml
+++ b/apidoc/Titanium/UI/EmailDialog.yml
@@ -73,6 +73,7 @@ methods:
             Supported on iOS only. Simple object to override animation. Note that the default here is equivalent to passing in `{ animated: true }` (while typically the default for <AnimationOptions> is false)
         type: AnimatedOptions
         optional: true
+        default: "{ animated: true }"
 
 events:
   - name: complete

--- a/apidoc/Titanium/UI/EmailDialog.yml
+++ b/apidoc/Titanium/UI/EmailDialog.yml
@@ -68,12 +68,11 @@ methods:
   - name: open
     summary: Opens this email dialog.
     parameters:
-      # FIXME: This should be AnimatedOptions, but this particular case defaults to animated being true!
-      - name: properties
+      - name: options
         summary: |
-            Animation properties. Set `animated` Boolean property to `true` to animate dialog
-            on open. (iPhone, iPad only)
-        type: Object
+            Supported on iOS only. Simple object to override animation. Note that the default here is equivalent to `{ animated: true }` (while typically the default for <AnimationOptions> is false)
+        type: AnimatedOptions
+        optional: true
 
 events:
   - name: complete

--- a/apidoc/Titanium/UI/Label.yml
+++ b/apidoc/Titanium/UI/Label.yml
@@ -138,7 +138,7 @@ properties:
   - name: lineSpacing
     summary: Line spacing of the [text](Titanium.UI.Label.text), as a dictionary with the properties `add` and `multiply`.
     platforms: [android]
-    type: Dictionary
+    type: LabelLineSpacing
     since: "5.4.0"
 
   - name: maxLines
@@ -316,3 +316,14 @@ examples:
                     </Label>
                 </Window>
             </Alloy>
+---
+name: LabelLineSpacing
+summary: See [TextView.setLineSpacing](https://developer.android.com/reference/android/widget/TextView#setLineSpacing(float,%20float))
+platforms: [android]
+properties:
+  - name: add
+    summary: The value in pixels that should be added to each line other than the last line. This will be applied after the multiplier
+    type: Number
+  - name: multiply
+    summary: The value by which each line height other than the last line will be multiplied by
+    type: Number

--- a/apidoc/Titanium/UI/Label.yml
+++ b/apidoc/Titanium/UI/Label.yml
@@ -172,7 +172,7 @@ properties:
     summary: Shadow offset of the [text](Titanium.UI.Label.text), as a dictionary with the properties `x` and `y`.
     description: |
         Use in conjunction with [shadowColor](Titanium.UI.Label.shadowColor) and [shadowRadius](Titanium.UI.Label.shadowRadius).
-    type: Dictionary
+    type: Point
     platforms: [android, iphone, ipad]
     since: {android: "3.2.0"}
 

--- a/apidoc/Titanium/UI/ListSection.yml
+++ b/apidoc/Titanium/UI/ListSection.yml
@@ -147,7 +147,7 @@ methods:
         summary: Index of where to retrieve an item.
         type: Number
     returns:
-      - type: ListDataItem
+      type: ListDataItem
 
   - name: updateItemAt
     summary: |

--- a/apidoc/Titanium/UI/ListView.yml
+++ b/apidoc/Titanium/UI/ListView.yml
@@ -1343,6 +1343,7 @@ methods:
             Pass in `{ animated: true }` to animate the transition. Note that the default here is equivalent to passing in `{ animated: false }`
         type: AnimatedOptions
         optional: true
+        default: "{ animated: false }"
     since: 3.4.0
 
   - name: setMarker

--- a/apidoc/Titanium/UI/ListView.yml
+++ b/apidoc/Titanium/UI/ListView.yml
@@ -1321,7 +1321,9 @@ methods:
         type: Padding
 
       - name: options
-        summary: Determines whether, and how, the content inset change should be animated.
+        summary: |
+            Determines whether, and how, the content inset change should be animated.
+            Note that the default here is equivalent to passing in `{ animated: false, duration: 300 }`
         type: AnimatedWithDurationOptions
         optional: true
     platforms: [iphone, ipad]
@@ -1338,7 +1340,7 @@ methods:
         type: Point
       - name: options
         summary: |
-            Pass in `{ animated: true }` to animate the transition.
+            Pass in `{ animated: true }` to animate the transition. Note that the default here is equivalent to passing in `{ animated: false }`
         type: AnimatedOptions
         optional: true
     since: 3.4.0

--- a/apidoc/Titanium/UI/ListView.yml
+++ b/apidoc/Titanium/UI/ListView.yml
@@ -1313,8 +1313,12 @@ methods:
         Typically used with the [pullView](Titanium.UI.ListView.pullView) property.
     parameters:
       - name: edgeInsets
-        summary: Dictionary to describe the insets.
-        type: ListViewEdgeInsets
+        summary: |
+          Sets the distance that the content view is inset from the enclosing scroll view of the list view.
+          For example
+
+              setContentInset({top:50,bottom:10,right:10,left:10}, {animated:true})
+        type: Padding
 
       - name: animated
         summary: Determines whether, and how, the content inset change should be animated.
@@ -1841,34 +1845,6 @@ properties:
     type: Number
   - name: itemIndex
     summary: The itemIndex of the reference item.
-    type: Number
-
----
-name: ListViewEdgeInsets
-summary: The parameter for [setContentInsets](Titanium.UI.TableView.setContentInsets) method.
-description: |
-    On iOS, the parameter `edgeInsets` can be specified to set the distance(`top`, `bottom`,
-    `right`, `left`) that the content view is inset from the enclosing scroll view of the list view.
-    For example
-
-        setContentInset({top:50,bottom:10,right:10,left:10}, {animated:true})
-since: 3.2.0
-platforms: [iphone, ipad]
-properties:
-  - name: top
-    summary: Value specifying the top insets for the enclosing scroll view of the list view.
-    type: Number
-
-  - name: left
-    summary: Value specifying the left insets for the enclosing scroll view of the list view.
-    type: Number
-
-  - name: right
-    summary: Value specifying the right insets for the enclosing scroll view of the list view.
-    type: Number
-
-  - name: bottom
-    summary: Value specifying the bottom insets for the enclosing scroll view of the list view.
     type: Number
 
 ---

--- a/apidoc/Titanium/UI/ListView.yml
+++ b/apidoc/Titanium/UI/ListView.yml
@@ -1028,7 +1028,7 @@ properties:
         Cell separators do not extend all the way to the edge of the list view.
         This property sets the default inset for all cells in the table.
         Set this to a dictionary with two keys, `left` specifying inset from left edge and `right` specifying the inset from the right edge.
-    type: Dictionary
+    type: HorizontalInsets
     since: 3.2.0
     osver: {ios: {min: "7.0"}}
     platforms: [iphone, ipad]
@@ -1068,7 +1068,7 @@ properties:
              });
 
 
-    type: Dictionary
+    type: HorizontalInsets
     since: "5.2.0"
     osver: {ios: {min: "7.0"}}
     platforms: [iphone, ipad]
@@ -1088,7 +1088,7 @@ properties:
              });
 
 
-    type: Dictionary
+    type: HorizontalInsets
     since: "5.4.0"
     osver: {ios: {min: "7.0"}}
     platforms: [iphone, ipad]
@@ -1107,7 +1107,7 @@ properties:
                  right:10
              });
 
-    type: Dictionary
+    type: HorizontalInsets
     since: "5.2.0"
     osver: {ios: {min: "7.0"}}
     platforms: [iphone, ipad]
@@ -1178,8 +1178,8 @@ properties:
         This property sets the default inset for all cells in the table.
         Set this to a dictionary with two keys, `left` specifying inset from left edge and `right`
         specifying the inset from the right edge.
-    type: Dictionary
-    since: 6.1.0
+    type: HorizontalInsets
+    since: "6.1.0"
     platforms: [iphone, ipad]
     availability: creation
 

--- a/apidoc/Titanium/UI/ListView.yml
+++ b/apidoc/Titanium/UI/ListView.yml
@@ -1320,9 +1320,9 @@ methods:
               setContentInset({top:50,bottom:10,right:10,left:10}, {animated:true})
         type: Padding
 
-      - name: animated
+      - name: options
         summary: Determines whether, and how, the content inset change should be animated.
-        type: ListViewContentInsetOption
+        type: AnimatedWithDurationOptions
         optional: true
     platforms: [iphone, ipad]
     since: 3.2.0
@@ -1813,26 +1813,6 @@ properties:
   - name: index
     summary: Section index associated with this title.
     type: Number
-
----
-name: ListViewContentInsetOption
-summary: Optional parameter for [setContentInsets](Titanium.UI.ListView.setContentInsets) method.
-description: |
-    On iOS, the optional parameters `animated` and `duration` to enable the animation and duration
-    for animation while the content insets are updated. For example
-
-        setContentInset({top:50,bottom:100}, {animated:true, duration:3000})
-since: 3.2.0
-platforms: [iphone, ipad]
-properties:
-  - name: animated
-    summary: Determines whether the list view's content inset change is animated.
-    type: Boolean
-    default: false
-  - name: duration
-    summary: The duration in `milliseconds` for animation while the content inset is being changed.
-    type: Number
-    default: 300
 
 ---
 name: ListViewMarkerProps

--- a/apidoc/Titanium/UI/ListView.yml
+++ b/apidoc/Titanium/UI/ListView.yml
@@ -604,8 +604,8 @@ events:
         type: Number
 
       - name: firstVisibleItem
-        summary: The first visible item in the list view when the event fires; this item might not be fully visible.
-        type: Object
+        summary: The first visible item in the list view when the event fires; this item might not be fully visible. May be -1 on iOS.
+        type: [Object, Number]
 
       - name: firstVisibleSection
         summary: The first visible section in the list view when the event fires.
@@ -640,8 +640,8 @@ events:
         type: Number
 
       - name: firstVisibleItem
-        summary: The first visible item in the list view when the event fires; this item might not be fully visible.
-        type: Object
+        summary: The first visible item in the list view when the event fires; this item might not be fully visible. May be -1 on iOS.
+        type: [Object, Number]
 
       - name: firstVisibleSection
         summary: The first visible section in the list view when the event fires.

--- a/apidoc/Titanium/UI/ListView.yml
+++ b/apidoc/Titanium/UI/ListView.yml
@@ -1333,10 +1333,14 @@ methods:
     parameters:
       - name: contentOffset
         summary: |
-            Dictionary with the properties `x`, `y`. Pass in `animated` `true` as a second dictionary parameter.
+            Dictionary with the properties `x`, `y`.
             The `x` and `y` coordinates reposition the top-left point of the scrollable region of the list view.
-            The `animated` property is optional and set to `false` by default.
-        type: Dictionary
+        type: Point
+      - name: options
+        summary: |
+            Pass in `{ animated: true }` to animate the transition.
+        type: AnimatedOptions
+        optional: true
     since: 3.4.0
 
   - name: setMarker
@@ -1826,8 +1830,9 @@ properties:
     type: Boolean
     default: false
   - name: duration
-    summary: The duration in `milliseconds` for animation while the content inset is  being changed.
+    summary: The duration in `milliseconds` for animation while the content inset is being changed.
     type: Number
+    default: 300
 
 ---
 name: ListViewMarkerProps

--- a/apidoc/Titanium/UI/Matrix2D.yml
+++ b/apidoc/Titanium/UI/Matrix2D.yml
@@ -119,7 +119,7 @@ methods:
 
       - name: angle
         summary: |
-            Angle to rotate to, in degrees. On Android, if `angleTo` is specified, this specifies
+            Angle to rotate to, in degrees. On Android, if `toAngle` is specified, this specifies
             the starting angle for a rotation animation.
         type: Number
 
@@ -288,7 +288,7 @@ properties:
         Point to rotate around, specified as a dictionary object with `x` and `y`
         properties, where { x: 0.5, y: 0.5 } represents the center of whatever is being
         rotated.
-    type: Dictionary
+    type: Point
     optional: true
     default: (0.5, 0.5)
     platforms: [android]

--- a/apidoc/Titanium/UI/NavigationWindow.yml
+++ b/apidoc/Titanium/UI/NavigationWindow.yml
@@ -54,7 +54,7 @@ methods:
         type: Titanium.UI.Window
 
       - name: options
-        # TODO: this should be of a type equivalent to Ti.Ui.Windows.open args!
+        # TODO: this should be of a type equivalent to Ti.Ui.Window.open args!
         summary: |
             Options supporting a single `animated` boolean property to determine whether the window
             will be animated (default) while being opened (default: true).

--- a/apidoc/Titanium/UI/NavigationWindow.yml
+++ b/apidoc/Titanium/UI/NavigationWindow.yml
@@ -58,7 +58,7 @@ methods:
         summary: |
             Options supporting a single `animated` boolean property to determine whether the window
             will be animated (default) while being opened (default: true).
-        type: Dictionary
+        type: AnimatedOptions
         optional: true
 
   - name: popToRootWindow

--- a/apidoc/Titanium/UI/NavigationWindow.yml
+++ b/apidoc/Titanium/UI/NavigationWindow.yml
@@ -40,6 +40,7 @@ methods:
         type: Titanium.UI.Window
 
       - name: options
+        # TODO: This should be AnimatedOptions on iOS, equivalent to Ti.UI.Window.close arg on Android!
         summary: |
             Options supporting a single `animated` boolean property to determine whether the window
             will be animated (default) while being closed (default: true).
@@ -53,16 +54,19 @@ methods:
         type: Titanium.UI.Window
 
       - name: options
+        # TODO: this should be of a type equivalent to Ti.Ui.Windows.open args!
         summary: |
             Options supporting a single `animated` boolean property to determine whether the window
             will be animated (default) while being opened (default: true).
         type: Dictionary
+        optional: true
 
   - name: popToRootWindow
     summary: Closes all windows that are currently opened inside the navigation window.
     description: Note that only the `close` event of the most recently opened window is fired.
     parameters:
       - name: options
+        # TODO: this should be of type equivalent to Ti.UI.Window.close arg on Android, AnimatedOptions on iOS!
         summary: |
             Options supporting a single `animated` boolean property to determine whether the windows
             will be animated while being closed (default: false).

--- a/apidoc/Titanium/UI/NavigationWindow.yml
+++ b/apidoc/Titanium/UI/NavigationWindow.yml
@@ -60,6 +60,7 @@ methods:
             will be animated (default) while being opened (default: true).
         type: AnimatedOptions
         optional: true
+        default: "{ animated: true }"
 
   - name: popToRootWindow
     summary: Closes all windows that are currently opened inside the navigation window.
@@ -72,6 +73,7 @@ methods:
             will be animated while being closed (default: false).
         type: AnimatedOptions
         optional: true
+        default: "{ animated: false }"
 
 examples:
   - title: Simple Navigation Window

--- a/apidoc/Titanium/UI/NavigationWindow.yml
+++ b/apidoc/Titanium/UI/NavigationWindow.yml
@@ -66,7 +66,8 @@ methods:
         summary: |
             Options supporting a single `animated` boolean property to determine whether the windows
             will be animated while being closed (default: false).
-        type: Dictionary
+        type: AnimatedOptions
+        optional: true
 
 examples:
   - title: Simple Navigation Window

--- a/apidoc/Titanium/UI/OptionDialog.yml
+++ b/apidoc/Titanium/UI/OptionDialog.yml
@@ -120,6 +120,7 @@ events:
         type: Number
         platforms: [iphone, ipad]
 
+# FIXME: I think Android does support AnimatedOptions for show/hide (separately, versus how ios only really takes show and uses the animated value for hide), defaulting to false
 methods:
   - name: show
     summary: Shows this dialog.
@@ -128,6 +129,7 @@ methods:
         `params` argument, as a popover-like dialog attached to another view or control.
     parameters:
       - name: params
+        # FIXME: I think this is used on iOS, not just iPad
         summary: Argument containing parameters for this method. Only used on iPad.
         type: showParams
         optional: true
@@ -363,6 +365,7 @@ examples:
                 $.dialog.show();
             }
 ---
+# FIXME: I don't think we actually take any args any more, it inherits the animated value from show on iOS!
 name: hideParams
 summary: Dictionary of options for the <Titanium.UI.OptionDialog.hide> method.
 since: 2.0.0
@@ -382,6 +385,7 @@ properties:
   - name: animated
     summary: Determines whether to animate the dialog as it is shown.
     type: Boolean
+    optional: true
 
   - name: view
     summary: View to which to attach the dialog.
@@ -393,3 +397,4 @@ properties:
         Setting the x, y coordinates to (0, 0) places the dialog in the top-left corner of the
         view object.  Set both the `width` and `height` properties to 1.
     type: Dimension
+    optional: true

--- a/apidoc/Titanium/UI/Padding.yml
+++ b/apidoc/Titanium/UI/Padding.yml
@@ -1,6 +1,6 @@
 ---
-name: Padding
-summary: Dictionary object of parameters for the padding/insets applied to all kinds of views.
+name: HorizontalInsets
+summary: Dictionary object of parameters for horizontal-only insets applied to [Table](Titanium.UI.TableView) and [List](Titanium.UI.ListView) views. Only `left` and `right` properties are used (see <Padding>).
 properties:
   - name: left
     type: Number
@@ -12,6 +12,11 @@ properties:
     summary: Right padding/inset
     default: 0
 
+---
+name: Padding
+extends: HorizontalInsets
+summary: Dictionary object of parameters for the padding/insets applied to all kinds of views.
+properties:
   - name: top
     type: Number
     summary: Top padding/inset
@@ -21,11 +26,3 @@ properties:
     type: Number
     summary: Bottom padding/inset
     default: 0
-
----
-# TODO: Should we invert the relationship here? (i.e. Padding extends from HorizontalInsets?)
-name: HorizontalInsets
-summary: Dictionary object of parameters for horizontal-only insets applied to [Table](Titanium.UI.TableView) and [List](Titanium.UI.ListView) views. Only `left` and `right` properties are used (see <Padding>).
-extends: Padding
-excludes:
-  properties: [top,bottom]

--- a/apidoc/Titanium/UI/Padding.yml
+++ b/apidoc/Titanium/UI/Padding.yml
@@ -1,0 +1,24 @@
+---
+  name: Padding
+  summary: Dictionary object of parameters for the padding/insets applied to all kinds of views.
+  properties:
+    - name: left
+      type: Number
+      summary: Left padding/inset
+      default: 0
+
+    - name: right
+      type: Number
+      summary: Right padding/inset
+      default: 0
+
+    - name: top
+      type: Number
+      summary: Top padding/inset
+      default: 0
+
+    - name: bottom
+      type: Number
+      summary: Bottom padding/inset
+      default: 0
+  

--- a/apidoc/Titanium/UI/Padding.yml
+++ b/apidoc/Titanium/UI/Padding.yml
@@ -1,24 +1,31 @@
 ---
-  name: Padding
-  summary: Dictionary object of parameters for the padding/insets applied to all kinds of views.
-  properties:
-    - name: left
-      type: Number
-      summary: Left padding/inset
-      default: 0
+name: Padding
+summary: Dictionary object of parameters for the padding/insets applied to all kinds of views.
+properties:
+  - name: left
+    type: Number
+    summary: Left padding/inset
+    default: 0
 
-    - name: right
-      type: Number
-      summary: Right padding/inset
-      default: 0
+  - name: right
+    type: Number
+    summary: Right padding/inset
+    default: 0
 
-    - name: top
-      type: Number
-      summary: Top padding/inset
-      default: 0
+  - name: top
+    type: Number
+    summary: Top padding/inset
+    default: 0
 
-    - name: bottom
-      type: Number
-      summary: Bottom padding/inset
-      default: 0
-  
+  - name: bottom
+    type: Number
+    summary: Bottom padding/inset
+    default: 0
+
+---
+# TODO: Should we invert the relationship here? (i.e. Padding extends from HorizontalInsets?)
+name: HorizontalInsets
+summary: Dictionary object of parameters for horizontal-only insets applied to [Table](Titanium.UI.TableView) and [List](Titanium.UI.ListView) views. Only `left` and `right` properties are used (see <Padding>).
+extends: Padding
+excludes:
+  properties: [top,bottom]

--- a/apidoc/Titanium/UI/ScrollView.yml
+++ b/apidoc/Titanium/UI/ScrollView.yml
@@ -45,7 +45,9 @@ methods:
       - name: options
         summary: |
             A simple object for specifying the animation properties when scrolling the view (since SDK 6.1.0).
-            When set to `{ animated: true }` it will scroll smoothly to the destination. On iOS the default value is `true`.
+            When set to `{ animated: true }` it will scroll smoothly to the destination.
+
+            Note that the default here is equivalent to passing in `{ animated: true }`
         type: AnimatedOptions
         optional: true
 
@@ -58,7 +60,10 @@ methods:
             X and Y coordinates to which to reposition the top-left point of the scrollable region.
         type: Point
       - name: animated
-        summary: A JS object with an `animated` property which determines whether the scrollable region reposition should be animated
+        summary: |
+            A JS object with an `animated` property which determines whether the scrollable region reposition should be animated.
+
+            Note that the default here is equivalent to passing in `{ animated: true }`
         type: AnimatedOptions
         optional: true
 
@@ -71,7 +76,10 @@ methods:
         type: Number
 
       - name: options
-        summary: A JS object with an `animated` property which determines whether the scrollable region reposition should be animated
+        summary: |
+            A JS object with an `animated` property which determines whether the scrollable region reposition should be animated
+
+            Note that the default here is equivalent to passing in `{ animated: false }`
         type: AnimatedOptions
         optional: true
 

--- a/apidoc/Titanium/UI/ScrollView.yml
+++ b/apidoc/Titanium/UI/ScrollView.yml
@@ -117,7 +117,7 @@ events:
       - name: contentSize
         summary: |
             The current content size of the scroll view defined by its `width` and `height` properties.
-        type: Dictionary
+        type: Size
         platforms: [android, iphone, ipad]
         since: { iphone: "5.2.0", ipad: "5.2.0", android: "8.3.0" }
 
@@ -230,7 +230,7 @@ properties:
     description: |
         On iOS, a new value causes the scroll view to perform an animated scroll to the new offset.
         The <Titanium.UI.ScrollView.setContentOffset> method can be used to prevent this animation.
-    type: Dictionary
+    type: Point
 
   - name: contentWidth
     summary: Width of the scrollable region.

--- a/apidoc/Titanium/UI/ScrollView.yml
+++ b/apidoc/Titanium/UI/ScrollView.yml
@@ -42,9 +42,11 @@ methods:
         summary: Y coordinate from the scrollable region's coordinate system.
         type: Number
 
-      - name: animation
-        summary: Animation properties (since SDK 6.1.0).
-        type: ScrollViewAnimationProperties
+      - name: options
+        summary: |
+            A simple object for specifying the animation properties when scrolling the view (since SDK 6.1.0).
+            When set to `{ animated: true }` it will scroll smoothly to the destination. On iOS the default value is `true`.
+        type: AnimatedOptions
         optional: true
 
   - name: setContentOffset
@@ -54,11 +56,12 @@ methods:
       - name: contentOffsetXY
         summary: |
             X and Y coordinates to which to reposition the top-left point of the scrollable region.
-        type: Dictionary
+        type: Point
       - name: animated
-        summary: Determines whether the scrollable region reposition should be animated
-        type: contentOffsetOption
+        summary: A JS object with an `animated` property which determines whether the scrollable region reposition should be animated
+        type: AnimatedOptions
         optional: true
+
   - name: setZoomScale
     summary: Sets the value of the [zoomScale](Titanium.UI.ScrollView.zoomScale) property.
     platforms: [iphone, ipad]
@@ -67,9 +70,9 @@ methods:
         summary: Scaling factor of the scroll view's content.
         type: Number
 
-      - name: animated
-        summary: Determines whether the scrollable region reposition should be animated
-        type: zoomScaleOption
+      - name: options
+        summary: A JS object with an `animated` property which determines whether the scrollable region reposition should be animated
+        type: AnimatedOptions
         optional: true
 
   - name: scrollToBottom
@@ -484,48 +487,4 @@ examples:
                    </ScrollView>
                </Window>
            </Alloy>
----
-name: contentOffsetOption
-summary: Optional parameter for [setContentOffset](Titanium.UI.ScrollView.setContentOffset) method.
-description: |
-    On iOS, the optional parameter `animated` to enable the animation while the scrollable region
-    scrolls. For example
 
-        setContentOffset({x:50,y:100}, {animated:true})
-since: 1.8.1
-platforms: [iphone, ipad]
-
-properties:
-  - name: animated
-    summary: Determines whether the scroll view's content area change is animated.
-    type: Boolean
----
-name: zoomScaleOption
-summary: Optional parameter for [setZoomScale](Titanium.UI.ScrollView.setZoomScale) method.
-description: |
-    On iOS, the optional parameter `animated` to enable the animation while the scroll view
-    zooms. For example
-
-        setZoomScale(2, {animated:true})
-since: 3.0.0
-platforms: [iphone, ipad]
-
-properties:
-  - name: animated
-    summary: Determines whether the scroll view's zooming is animated.
-    type: Boolean
-
----
-name: ScrollViewAnimationProperties
-summary: |
-    A simple object for specifying the animation properties when scrolling the view.
-platforms: [iphone, ipad, android]
-since: 6.1.0
-properties:
-  - name: animated
-    summary: When set to `true` it will scroll smoothly to the destination.
-    description: |
-        When set to `true` it will scroll smoothly to the destination.
-        On iOS the default value is `true`.
-    type: Boolean
-    default: false

--- a/apidoc/Titanium/UI/ScrollView.yml
+++ b/apidoc/Titanium/UI/ScrollView.yml
@@ -50,6 +50,7 @@ methods:
             Note that the default here is equivalent to passing in `{ animated: true }`
         type: AnimatedOptions
         optional: true
+        default: "{ animated: true }"
 
   - name: setContentOffset
     summary: Sets the value of the [contentOffset](Titanium.UI.ScrollView.contentOffset) property.
@@ -66,6 +67,7 @@ methods:
             Note that the default here is equivalent to passing in `{ animated: true }`
         type: AnimatedOptions
         optional: true
+        default: "{ animated: true }"
 
   - name: setZoomScale
     summary: Sets the value of the [zoomScale](Titanium.UI.ScrollView.zoomScale) property.
@@ -82,6 +84,7 @@ methods:
             Note that the default here is equivalent to passing in `{ animated: false }`
         type: AnimatedOptions
         optional: true
+        default: "{ animated: false }"
 
   - name: scrollToBottom
     summary: Moves the end of the scrollable region into the viewable area.

--- a/apidoc/Titanium/UI/ScrollableView.yml
+++ b/apidoc/Titanium/UI/ScrollableView.yml
@@ -379,7 +379,7 @@ properties:
   - name: padding
     summary: The padding applied to the scrollable view.
     platforms: [android]
-    type: ViewPadding
+    type: Padding
     since: "7.5.0"
 
 examples:

--- a/apidoc/Titanium/UI/SearchBar.yml
+++ b/apidoc/Titanium/UI/SearchBar.yml
@@ -97,7 +97,7 @@ methods:
         summary: |
             Dictionary of animation properties. Currently only a
             single boolean property, `animated` is supported. Only used on iOS.
-        type: Dictionary
+        type: AnimatedOptions
         optional: true
         default: No animation.
 events:

--- a/apidoc/Titanium/UI/SearchBar.yml
+++ b/apidoc/Titanium/UI/SearchBar.yml
@@ -93,15 +93,15 @@ methods:
         summary: New value for [showCancel](Titanium.UI.SearchBar.showCancel).
         type: Boolean
 
-      - name: animated
+      - name: options
         summary: |
             Dictionary of animation properties. Currently only a
             single boolean property, `animated` is supported. Only used on iOS.
         type: AnimatedOptions
         optional: true
         default: No animation.
-events:
 
+events:
   - name: blur
     summary: Fired when the search bar loses focus.
     properties:

--- a/apidoc/Titanium/UI/SearchBar.yml
+++ b/apidoc/Titanium/UI/SearchBar.yml
@@ -101,7 +101,7 @@ methods:
             Note that the default here is equivalent to passing in `{ animated: false }`
         type: AnimatedOptions
         optional: true
-        default: No animation.
+        default: "{ animated: false }"
 
 events:
   - name: blur

--- a/apidoc/Titanium/UI/SearchBar.yml
+++ b/apidoc/Titanium/UI/SearchBar.yml
@@ -97,6 +97,8 @@ methods:
         summary: |
             Dictionary of animation properties. Currently only a
             single boolean property, `animated` is supported. Only used on iOS.
+
+            Note that the default here is equivalent to passing in `{ animated: false }`
         type: AnimatedOptions
         optional: true
         default: No animation.

--- a/apidoc/Titanium/UI/Size.yml
+++ b/apidoc/Titanium/UI/Size.yml
@@ -1,0 +1,15 @@
+---
+  name: Size
+  summary: A simple object consisting of size measurements.
+  since: "2.0.0"
+  description: |
+    The [size](Titanium.UI.View.size) property returns a dimension object with `x` and `y` both set
+    to 0.
+  properties:
+    - name: height
+      summary: The height measurement.
+      type: Number
+
+    - name: width
+      summary: The width measurement.
+      type: Number

--- a/apidoc/Titanium/UI/Slider.yml
+++ b/apidoc/Titanium/UI/Slider.yml
@@ -110,7 +110,7 @@ methods:
             for this dictionary is the `animated` flag, which specifies whether
             the value change should be animated. `animated` is false by default. Only used
             on iOS.
-        type: Dictionary
+        type: AnimatedOptions
         optional: true
 
 events:
@@ -126,14 +126,14 @@ events:
         summary: |
             Dictionary with properties `width` and `height` of the size of the thumb.
             Available with custom thumb image.
-        type: Dictionary
+        type: Size
         platforms: [android]
 
       - name: thumbOffset
         summary: |
             Dictionary with properties `x` and `y` of the thumb's left-top corner in
             the control. Available with custom thumb image.
-        type: Dictionary
+        type: Point
         platforms: [android]
 
   - name: click

--- a/apidoc/Titanium/UI/Slider.yml
+++ b/apidoc/Titanium/UI/Slider.yml
@@ -112,6 +112,7 @@ methods:
             on iOS.
         type: AnimatedOptions
         optional: true
+        default: "{ animated: false }"
 
 events:
   - name: change

--- a/apidoc/Titanium/UI/Tab.yml
+++ b/apidoc/Titanium/UI/Tab.yml
@@ -74,7 +74,7 @@ methods:
             Dictionary of display and animation settings to use when opening the window.
             Identical to the `options` parameter to [Window.open](Titanium.UI.Window.open).
             iOS only supports the **animated** parameter.
-        type: Object
+        type: openWindowParams
         optional: true
 
   - name: close
@@ -124,6 +124,7 @@ methods:
         type: Titanium.UI.Window
 
   - name: popToRootWindow
+    # FIXME: I don't think this exists on Android!
     summary: Closes all windows that are currently opened inside the tab.
     description: Note that only the `close` event of the most recently opened window is fired.
     parameters:
@@ -131,7 +132,7 @@ methods:
         summary: |
             Options supporting a single `animated` boolean property to determine whether the windows
             will be animated while being closed (default: false).
-        type: Dictionary
+        type: AnimatedOptions
     since: "6.2.0"
 
 properties:

--- a/apidoc/Titanium/UI/Tab.yml
+++ b/apidoc/Titanium/UI/Tab.yml
@@ -133,6 +133,7 @@ methods:
             Options supporting a single `animated` boolean property to determine whether the windows
             will be animated while being closed (default: false).
         type: AnimatedOptions
+        optional: true
     since: "6.2.0"
 
 properties:

--- a/apidoc/Titanium/UI/Tab.yml
+++ b/apidoc/Titanium/UI/Tab.yml
@@ -396,14 +396,19 @@ examples:
 
 ---
 name: TabIconInsets
-summary: Dictionary to specify edge insets for <Titanium.UI.Tab.iconInsets>.
+extends: Padding
+summary: Dictionary to specify edge insets for <Titanium.UI.Tab.iconInsets>. Difference from typical <Padding> is that `right` and `bottom` are ignored and calculated internally from `top`/`left` values.
 since: "5.2.0"
 platforms: [iphone, ipad]
+excludes:
+  properties: [right, bottom]
 properties:
   - name: top
     summary: Top inset.
     type: Number
+    default: 0
 
   - name: left
     summary: Left inset.
     type: Number
+    default: 0

--- a/apidoc/Titanium/UI/Tab.yml
+++ b/apidoc/Titanium/UI/Tab.yml
@@ -134,6 +134,7 @@ methods:
             will be animated while being closed (default: false).
         type: AnimatedOptions
         optional: true
+        default: "{ animated: false }"
     since: "6.2.0"
 
 properties:

--- a/apidoc/Titanium/UI/TableView.yml
+++ b/apidoc/Titanium/UI/TableView.yml
@@ -977,6 +977,7 @@ methods:
             Note that the default here is equivalent to passing in `{ animated: false }`
         type: AnimatedOptions
         optional: true
+        default: "{ animated: false }"
     since: 3.4.0
 
   - name: selectRow

--- a/apidoc/Titanium/UI/TableView.yml
+++ b/apidoc/Titanium/UI/TableView.yml
@@ -952,7 +952,10 @@ methods:
         type: Padding
 
       - name: options
-        summary: Determines whether, and how, the content inset change should be animated.
+        summary: |
+            Determines whether, and how, the content inset change should be animated.
+
+            Note that the default here is equivalent to passing in `{ animated: false }`
         type: AnimatedWithDurationOptions
         optional: true
     platforms: [iphone, ipad]
@@ -970,6 +973,8 @@ methods:
       - name: options
         summary: |
             Pass in `{ animated: true }` to animate the transition.
+
+            Note that the default here is equivalent to passing in `{ animated: false }`
         type: AnimatedOptions
         optional: true
     since: 3.4.0

--- a/apidoc/Titanium/UI/TableView.yml
+++ b/apidoc/Titanium/UI/TableView.yml
@@ -951,9 +951,9 @@ methods:
               setContentInset({top:50,bottom:10,right:10,left:10}, {animated:true})
         type: Padding
 
-      - name: animated
+      - name: options
         summary: Determines whether, and how, the content inset change should be animated.
-        type: TableViewContentInsetOption
+        type: AnimatedWithDurationOptions
         optional: true
     platforms: [iphone, ipad]
     since: "2.1.0"
@@ -964,10 +964,14 @@ methods:
     parameters:
       - name: contentOffset
         summary: |
-            Dictionary with the properties `x`, `y`, and `animated`. The `x` and `y` coordinates
-            reposition the top-left point of the scrollable region of the table view.
-            The `animated` property is optional and set to `false` by default.
-        type: Dictionary
+            Dictionary with the properties `x`, `y`.
+            The `x` and `y` coordinates reposition the top-left point of the scrollable region of the table view.
+        type: Point
+      - name: options
+        summary: |
+            Pass in `{ animated: true }` to animate the transition.
+        type: AnimatedOptions
+        optional: true
     since: 3.4.0
 
   - name: selectRow
@@ -1779,27 +1783,6 @@ properties:
 
   - name: index
     summary: Row index associated with this item.
-    type: Number
-
----
-name: TableViewContentInsetOption
-summary: Optional parameter for [setContentInsets](Titanium.UI.TableView.setContentInsets) method.
-description: |
-    On iOS, the optional parameters `animated` and `duration`to enable the animation and duration
-    for animation while the content insets are updated. For example
-
-        setContentInset({top:50,bottom:100}, {animated:true, duration:3000})
-since: 2.1.0
-platforms: [iphone, ipad]
-
-properties:
-  - name: animated
-    summary: Determines whether the table view's content inset change is animated.
-    type: Boolean
-    default: false
-
-  - name: duration
-    summary: The duration in `milleseconds` for animation while the content inset is  being changed.
     type: Number
 
 ---

--- a/apidoc/Titanium/UI/TableView.yml
+++ b/apidoc/Titanium/UI/TableView.yml
@@ -379,7 +379,7 @@ events:
         summary: |
             Dictionary with `width` and `height` properties containing the size of the content
             (regardless of the display size in the case of scrolling).
-        type: Dictionary
+        type: Size
         platforms: [iphone, ipad]
 
       - name: firstVisibleItem
@@ -391,7 +391,7 @@ events:
         summary: |
             Dictionary with `width` and `height` properties containing the size of the visible
             table view
-        type: Dictionary
+        type: Size
 
       - name: totalItemCount
         summary: Total number of rows in the view.
@@ -410,7 +410,7 @@ events:
         summary: |
             Dictionary with `width` and `height` properties containing the size of the content
             (regardless of the display size in the case of scrolling).
-        type: Dictionary
+        type: Size
         platforms: [iphone, ipad]
 
       - name: contentOffset
@@ -422,7 +422,7 @@ events:
         summary: |
             Dictionary with `width` and `height` properties containing the size of the visible
             table view.
-        type: Dictionary
+        type: Size
 
       - name: x
         summary: X coordinate of the event from the `source` view's coordinate system.
@@ -1475,7 +1475,7 @@ properties:
                 right:10
             });
 
-    type: Dictionary
+    type: Dictionary # TODO: Use Padding?
     since: 3.2.0
     osver: {ios: {min: "7.0"}}
     platforms: [iphone, ipad]
@@ -1495,7 +1495,7 @@ properties:
             });
 
 
-    type: Dictionary
+    type: Dictionary # TODO: Use Padding?
     since: "5.2.0"
     osver: {ios: {min: "7.0"}}
     platforms: [iphone, ipad]
@@ -1515,7 +1515,7 @@ properties:
             });
 
 
-    type: Dictionary
+    type: Dictionary # TODO: Use Padding?
     since: "5.2.0"
     osver: {ios: {min: "7.0"}}
     platforms: [iphone, ipad]
@@ -1585,7 +1585,7 @@ properties:
         This property sets the default inset for all cells in the table.
         Set this to a dictionary with two keys, `left` specifying inset from left edge and `right`
         specifying the inset from the right edge.
-    type: Dictionary
+    type: Dictionary # TODO: Use Padding?
     since: 7.3.0
     platforms: [iphone, ipad]
     availability: creation

--- a/apidoc/Titanium/UI/TableView.yml
+++ b/apidoc/Titanium/UI/TableView.yml
@@ -944,8 +944,12 @@ methods:
         Typically used with the [headerPullView](Titanium.UI.TableView.headerPullView) property.
     parameters:
       - name: edgeInsets
-        summary: Dictionary to describe the insets.
-        type: TableViewEdgeInsets
+        summary: |
+          Sets the distance that the content view is inset from the enclosing scroll view of the table.
+          For example
+
+              setContentInset({top:50,bottom:10,right:10,left:10}, {animated:true})
+        type: Padding
 
       - name: animated
         summary: Determines whether, and how, the content inset change should be animated.
@@ -1796,35 +1800,6 @@ properties:
 
   - name: duration
     summary: The duration in `milleseconds` for animation while the content inset is  being changed.
-    type: Number
-
----
-name: TableViewEdgeInsets
-summary: The parameter for [setContentInsets](Titanium.UI.TableView.setContentInsets) method.
-description: |
-    On iOS, the parameter `edgeInsets` can be specified to set the distance(`top`, `bottom`,
-    `right`, `left`) that the content view is inset from the enclosing scroll view of the table.
-    For example
-
-        setContentInset({top:50,bottom:10,right:10,left:10}, {animated:true})
-since: 2.1.0
-platforms: [iphone, ipad]
-
-properties:
-  - name: top
-    summary: Value specifying the top insets for the enclosing scroll view of the table.
-    type: Number
-
-  - name: left
-    summary: Value specifying the left insets for the enclosing scroll view of the table.
-    type: Number
-
-  - name: right
-    summary: Value specifying the right insets for the enclosing scroll view of the table.
-    type: Number
-
-  - name: bottom
-    summary: Value specifying the bottom insets for the enclosing scroll view of the table.
     type: Number
 
 ---

--- a/apidoc/Titanium/UI/TableView.yml
+++ b/apidoc/Titanium/UI/TableView.yml
@@ -1475,7 +1475,7 @@ properties:
                 right:10
             });
 
-    type: Dictionary # TODO: Use Padding?
+    type: HorizontalInsets
     since: 3.2.0
     osver: {ios: {min: "7.0"}}
     platforms: [iphone, ipad]
@@ -1495,7 +1495,7 @@ properties:
             });
 
 
-    type: Dictionary # TODO: Use Padding?
+    type: HorizontalInsets
     since: "5.2.0"
     osver: {ios: {min: "7.0"}}
     platforms: [iphone, ipad]
@@ -1515,7 +1515,7 @@ properties:
             });
 
 
-    type: Dictionary # TODO: Use Padding?
+    type: HorizontalInsets
     since: "5.2.0"
     osver: {ios: {min: "7.0"}}
     platforms: [iphone, ipad]
@@ -1585,8 +1585,8 @@ properties:
         This property sets the default inset for all cells in the table.
         Set this to a dictionary with two keys, `left` specifying inset from left edge and `right`
         specifying the inset from the right edge.
-    type: Dictionary # TODO: Use Padding?
-    since: 7.3.0
+    type: HorizontalInsets
+    since: "7.3.0"
     platforms: [iphone, ipad]
     availability: creation
 

--- a/apidoc/Titanium/UI/TextArea.yml
+++ b/apidoc/Titanium/UI/TextArea.yml
@@ -390,7 +390,7 @@ properties:
 
   - name: padding
     summary: Sets the left and right padding of this TextArea. The text will always be vertically centered.
-    type: ViewPadding
+    type: Padding
     platforms: [android, iphone, ipad]
     since: {android: "6.0.0", iphone: "6.1.0", ipad: "6.1.0"}
 

--- a/apidoc/Titanium/UI/TextField.yml
+++ b/apidoc/Titanium/UI/TextField.yml
@@ -419,7 +419,7 @@ properties:
                     </TextField>
                 </Window>
             </Alloy>
-    type: Object
+    type: Titanium.UI.View
     platforms: [iphone, ipad]
 
   - name: leftButtonMode
@@ -515,7 +515,7 @@ properties:
             </Alloy>
 
         The `sayHi` and `doAlert` methods are defined in the Alloy controller.
-    type: Object
+    type: Titanium.UI.View
     platforms: [iphone, ipad]
 
   - name: rightButtonMode

--- a/apidoc/Titanium/UI/TextField.yml
+++ b/apidoc/Titanium/UI/TextField.yml
@@ -443,7 +443,7 @@ properties:
 
   - name: padding
     summary: Sets the padding of this text field.
-    type: ViewPadding
+    type: TextFieldPadding
     platforms: [android, iphone, ipad]
     since: "6.0.0"
 
@@ -749,7 +749,8 @@ properties:
     type: Number
 ---
 name: TextFieldPadding
-summary: Dictionary object of parameters for the <Titanium.UI.TextField.padding>  that describes the padding
+extends: Padding
+summary: Dictionary object of parameters for the <Titanium.UI.TextField.padding> that describes the padding. Most notable difference from typical <Padding> is that `top`/`bottom` are only supported on Android.
 since: "6.0.0"
 platforms: [android, iphone, ipad]
 properties:
@@ -764,7 +765,11 @@ properties:
   - name: top
     type: Number
     summary: Top padding (Android only, since 6.1.0)
+    since: {"android": "6.1.0"}
+    platforms: [android]
 
   - name: bottom
     type: Number
     summary: Bottom padding (Android only, since 6.1.0)
+    since: {"android": "6.1.0"}
+    platforms: [android]

--- a/apidoc/Titanium/UI/View.yml
+++ b/apidoc/Titanium/UI/View.yml
@@ -866,6 +866,7 @@ methods:
             Note that the default here is equivalent to passing in `{ animated: false }`
         type: AnimatedOptions
         optional: true
+        default: "{ animated: false }"
         # FIXME: Allow setting platforms/osver on parameters. Sucks we have to stick this in summary!
 
   - name: insertAt
@@ -914,6 +915,7 @@ methods:
             Note that the default here is equivalent to passing in `{ animated: false }`
         type: AnimatedOptions
         optional: true
+        default: "{ animated: false }"
         # FIXME: Support platfroms/osver/since on parameters!
 
   - name: startLayout

--- a/apidoc/Titanium/UI/View.yml
+++ b/apidoc/Titanium/UI/View.yml
@@ -1660,7 +1660,7 @@ properties:
         The correct values will only be available when layout is complete.
         To determine when layout is complete, add a listener for the
         [postlayout](Titanium.UI.View.postlayout) event.
-    type: Dimension # TODO: Define an extension of Dimension with the android-only absolute properties!
+    type: DimensionWithAbsolutes
     permission: read-only
     since: "2.0.0"
 

--- a/apidoc/Titanium/UI/View.yml
+++ b/apidoc/Titanium/UI/View.yml
@@ -406,7 +406,7 @@ events:
 
       - name: inProgress
         summary: Returns `true` if a scale gesture is in progress, `false` otherwise.
-        type: Number
+        type: Boolean
         since: "7.5.0"
         platforms: [android]
 
@@ -482,6 +482,7 @@ events:
             Maximum possible value of the force property.
             Note: This property is only available for iOS devices that support 3D-Touch and run 9.0 or later.
         type: Number
+        platforms: [iphone, ipad]
 
       - name: altitudeAngle
         summary: |
@@ -489,25 +490,28 @@ events:
             being used, the value will be Pi/2. If the stylus is parallel to the screen, the value will be 0.
             Note: This property is only available for iOS devices that support 3D-Touch and are 9.1 or later.
         type: Number
+        platforms: [iphone, ipad]
 
       - name: timestamp
         summary: |
             The time (in seconds) when the touch was used in correlation with the system start up.
             Note: This property is only available for iOS devices that support 3D-Touch and run 9.0 or later.
         type: Number
+        platforms: [iphone, ipad]
 
       - name: azimuthUnitVectorInViewX
         summary: |
             The x value of the unit vector that points in the direction of the azimuth of the stylus.
             Note: This property is only available for iOS devices that support the Apple Pencil and are 9.1 or later.
         type: Number
+        platforms: [iphone, ipad]
 
       - name: azimuthUnitVectorInViewY
         summary: |
             The y value of the unit vector that points in the direction of the azimuth of the stylus.
             Note: This property is only available for iOS devices that support the Apple Pencil and are 9.1 or later.
         type: Number
-
+        platforms: [iphone, ipad]
 
   - name: touchend
     summary: Fired when a touch event is completed.
@@ -539,6 +543,7 @@ events:
             Maximum possible value of the force property.
             Note: This property is only available for iOS devices that support 3D-Touch and run 9.0 or later.
         type: Number
+        platforms: [iphone, ipad]
 
       - name: altitudeAngle
         summary: |
@@ -546,24 +551,28 @@ events:
             being used, the value will be Pi/2. If the stylus is parallel to the screen, the value will be 0.
             Note: This property is only available for iOS devices that support 3D-Touch and are 9.1 or later.
         type: Number
+        platforms: [iphone, ipad]
 
       - name: timestamp
         summary: |
             The time (in seconds) when the touch was used in correlation with the system start up.
             Note: This property is only available for iOS devices that support 3D-Touch and run 9.0 or later.
         type: Number
+        platforms: [iphone, ipad]
 
       - name: azimuthUnitVectorInViewX
         summary: |
             The x value of the unit vector that points in the direction of the azimuth of the stylus.
             Note: This property is only available for iOS devices that support the Apple Pencil and are 9.1 or later.
         type: Number
+        platforms: [iphone, ipad]
 
       - name: azimuthUnitVectorInViewY
         summary: |
             The y value of the unit vector that points in the direction of the azimuth of the stylus.
             Note: This property is only available for iOS devices that support the Apple Penciland are 9.1 or later.
         type: Number
+        platforms: [iphone, ipad]
 
   - name: touchmove
     summary: Fired as soon as the device detects movement of a touch.
@@ -594,6 +603,7 @@ events:
             Maximum possible value of the force property.
             Note: This property is only available for iOS devices that support 3D-Touch and run 9.0 or later.
         type: Number
+        platforms: [iphone, ipad]
 
       - name: altitudeAngle
         summary: |
@@ -601,24 +611,28 @@ events:
             being used, the value will be Pi/2. If the stylus is parallel to the screen, the value will be 0.
             Note: This property is only available for iOS devices that support 3D-Touch and are 9.1 or later.
         type: Number
+        platforms: [iphone, ipad]
 
       - name: timestamp
         summary: |
             The time (in seconds) when the touch was used in correlation with the system start up.
             Note: This property is only available for iOS devices that support 3D-Touch and run 9.0 or later.
         type: Number
+        platforms: [iphone, ipad]
 
       - name: azimuthUnitVectorInViewX
         summary: |
             The x value of the unit vector that points in the direction of the azimuth of the stylus.
             Note: This property is only available for iOS devices that support the Apple Pencil and are 9.1 or later.
         type: Number
+        platforms: [iphone, ipad]
 
       - name: azimuthUnitVectorInViewY
         summary: |
             The y value of the unit vector that points in the direction of the azimuth of the stylus.
             Note: This property is only available for iOS devices that support the Apple Pencil and are 9.1 or later.
         type: Number
+        platforms: [iphone, ipad]
 
   - name: touchstart
     summary: Fired as soon as the device detects a touch gesture.
@@ -647,6 +661,7 @@ events:
             Maximum possible value of the force property.
             Note: This property is only available for iOS devices that support 3D-Touch and run 9.0 or later.
         type: Number
+        platforms: [iphone, ipad]
 
       - name: altitudeAngle
         summary: |
@@ -654,24 +669,28 @@ events:
             being used, the value will be Pi/2. If the stylus is parallel to the screen, the value will be 0.
             Note: This property is only available for iOS devices that support 3D-Touch and are 9.1 or later.
         type: Number
+        platforms: [iphone, ipad]
 
       - name: timestamp
         summary: |
             The time (in seconds) when the touch was used in correlation with the system start up.
             Note: This property is only available for iOS devices that support 3D-Touch and run 9.0 or later.
         type: Number
+        platforms: [iphone, ipad]
 
       - name: azimuthUnitVectorInViewX
         summary: |
             The x value of the unit vector that points in the direction of the azimuth of the stylus.
             Note: This property is only available for iOS devices that support the Apple Pencil and are 9.1 or later.
         type: Number
+        platforms: [iphone, ipad]
 
       - name: azimuthUnitVectorInViewY
         summary: |
             The y value of the unit vector that points in the direction of the azimuth of the stylus.
             Note: This property is only available for iOS devices that support the Apple Pencil and are 9.1 or later.
         type: Number
+        platforms: [iphone, ipad]
 
   - name: twofingertap
     summary: Fired when the device detects a two-finger tap against the view.
@@ -810,7 +829,7 @@ methods:
 
       - name: callback
         summary: Function to be invoked upon completion of the animation.
-        type: Callback<Object>
+        type: Callback<Object> # FIXME: iOS appears to fire with the Ti.UI.Animation object, whiel Android fires with an empty object
         optional: true
 
   - name: clearMotionEffects
@@ -841,9 +860,12 @@ methods:
     parameters:
       - name: options
         summary: |
-            Animation options for Android. **Since Release 5.1.0.**
-        type: AnimationOption
+            Animation options for Android only. **Since SDK 5.1.0 and used only on Android 5.0+**
+
+            Determines whether to enable a circular reveal animation.
+        type: AnimatedOptions
         optional: true
+        # FIXME: Allow setting platforms/osver on parameters. Sucks we have to stick this in summary!
 
   - name: insertAt
     summary: Inserts a view at the specified position in the [children](Titanium.UI.View.children) array.
@@ -852,12 +874,8 @@ methods:
     parameters:
       - name: params
         summary: |
-            Pass an object with the following key-value pairs:
-
-             * `view` (Titanium.UI.View): View to insert
-             * `position` (Number): Position in the [children](Titanium.UI.View.children) array to
-               insert the view. If omitted, inserts the view to the end of the array.
-        type: Dictionary
+            Pass an object that specifies the view to insert and optionally at which position (defaults to end)
+        type: ViewPositionOptions
     since: 3.3.0
     platforms: [android, iphone, ipad]
 
@@ -879,12 +897,8 @@ methods:
     parameters:
       - name: params
         summary: |
-            Pass an object with the following key-value pairs:
-
-             * `view` (Titanium.UI.View): View to insert
-             * `position` (Number): Position in the [children](Titanium.UI.View.children) array of
-               the view elment to replace.
-        type: Dictionary
+            Pass an object with the view to insert and the position of the view to replace. In this case the `position` property is required.
+        type: ViewPositionOptions
     since: 3.3.0
     platforms: [android, iphone, ipad]
 
@@ -893,9 +907,12 @@ methods:
     parameters:
       - name: options
         summary: |
-            Animation options for Android. **Since Release 5.1.0.**
-        type: AnimationOption
+            Animation options for Android only. **Since SDK 5.1.0 and only used on Android 5.0+**
+
+            Determines whether to enable a circular reveal animation.
+        type: AnimatedOptions
         optional: true
+        # FIXME: Support platfroms/osver/since on parameters!
 
   - name: startLayout
     summary: Starts a batch update of this view's layout properties.
@@ -929,7 +946,7 @@ methods:
   - name: toImage
     summary: Returns an image of the rendered view, as a Blob.
     description: |
-        The `honorScaleFactor` method is only supported on iOS.
+        The `honorScaleFactor` argument is only supported on iOS.
     returns:
         type: Titanium.Blob
     platforms: [android, iphone, ipad]
@@ -1330,7 +1347,6 @@ properties:
         Defaults to `undefined`.
     type: Point
 
-
   - name: children
     summary: Array of this view's child views.
     type: Array<Titanium.UI.View>
@@ -1406,21 +1422,16 @@ properties:
     type: Number
     constants: [Titanium.UI.HIDDEN_BEHAVIOR_INVISIBLE, Titanium.UI.HIDDEN_BEHAVIOR_GONE]
     platforms: [android]
-    since: 6.1.0
+    since: "6.1.0"
 
   - name: horizontalMotionEffect
     summary: Adds a horizontal parallax effect to the view
     description: |
-        Pass an object with the following key-value pairs:
-
-         * `min` (Number): Minimum amount it can move horizontally (-10 for example)
-         * `max` (Number): Maximum amount it can move horizontally (10 for example)
-
-         Note that the parallax effect only happens by tilting the device so results can not be seen on Simulator.
-         To clear all motion effects, use the <Titanium.UI.clearMotionEffects> method.
-    type: Dictionary
+        Note that the parallax effect only happens by tilting the device so results can not be seen on Simulator.
+        To clear all motion effects, use the <Titanium.UI.clearMotionEffects> method.
+    type: MinMaxOptions
     platforms: [iphone, ipad]
-    since: 7.3.0
+    since: "7.3.0"
 
   - name: id
     summary: View's identifier.
@@ -1645,7 +1656,7 @@ properties:
         The correct values will only be available when layout is complete.
         To determine when layout is complete, add a listener for the
         [postlayout](Titanium.UI.View.postlayout) event.
-    type: Dimension
+    type: Dimension # TODO: Define an extension of Dimension with the android-only absolute properties!
     permission: read-only
     since: "2.0.0"
 
@@ -1699,7 +1710,6 @@ properties:
         [postlayout](Titanium.UI.View.postlayout) event.
     type: Dimension
     permission: read-only
-
 
   - name: softKeyboardOnFocus
     summary: Determines keyboard behavior when this view is focused. Defaults to <Titanium.UI.Android.SOFT_KEYBOARD_DEFAULT_ON_FOCUS>.
@@ -1793,14 +1803,9 @@ properties:
   - name: verticalMotionEffect
     summary: Adds a vertical parallax effect to the view
     description: |
-        Pass an object with the following key-value pairs:
-
-         * `min` (Number): Minimum amount it can move vertically (-10 for example)
-         * `max` (Number): Maximum amount it can move vertically (10 for example)
-
-         Note that the parallax effect only happens by tilting the device so results can not be seen on Simulator.
-         To clear all motion effects, use the <Titanium.UI.clearMotionEffects> method.
-    type: Dictionary
+        Note that the parallax effect only happens by tilting the device so results can not be seen on Simulator.
+        To clear all motion effects, use the <Titanium.UI.clearMotionEffects> method.
+    type: MinMaxOptions
     platforms: [iphone, ipad]
     since: 7.3.0
 
@@ -1860,7 +1865,6 @@ properties:
     type: Boolean
     default: true
     since: "2.1.0"
-
 
   - name: zIndex
     summary: Z-index stack order position, relative to other sibling views.
@@ -1993,15 +1997,32 @@ properties:
     type: Number
 
 ---
-name: AnimationOption
-summary: Optional parameter to enable animation to [hide](Titanium.UI.View.hide) and [show](Titanium.UI.View.show).
-since: "5.1.0"
-platforms: [android]
+name: MinMaxOptions
+summary: An object for setting `min`/`max` value pairs.
 properties:
-  - name: animated
-    summary: Determines whether to enable a circular reveal animation.
-    type: Boolean
-    default: false
-    optional: true
-    osver: {android: {min: 5.0}}
+  - name: min
+    type: Number
+    summary: Minimum value
 
+  - name: max
+    type: Number
+    summary: Maximum value
+
+---
+name: ViewPositionOptions
+summary: |
+    Pass an object with the following key-value pairs:
+
+      * `view` (Titanium.UI.View): View to insert
+      * `position` (Number): Position in the [children](Titanium.UI.View.children) array of
+        the view elment to replace.
+properties:
+  - name: view
+    type: Titanium.UI.View
+    summary: View to insert. Required.
+    optional: false
+
+  - name: position
+    type: Number
+    summary: Position in the [children](Titanium.UI.View.children) array of the view element to replace.
+    optional: true

--- a/apidoc/Titanium/UI/View.yml
+++ b/apidoc/Titanium/UI/View.yml
@@ -863,6 +863,7 @@ methods:
             Animation options for Android only. **Since SDK 5.1.0 and used only on Android 5.0+**
 
             Determines whether to enable a circular reveal animation.
+            Note that the default here is equivalent to passing in `{ animated: false }`
         type: AnimatedOptions
         optional: true
         # FIXME: Allow setting platforms/osver on parameters. Sucks we have to stick this in summary!
@@ -910,6 +911,7 @@ methods:
             Animation options for Android only. **Since SDK 5.1.0 and only used on Android 5.0+**
 
             Determines whether to enable a circular reveal animation.
+            Note that the default here is equivalent to passing in `{ animated: false }`
         type: AnimatedOptions
         optional: true
         # FIXME: Support platfroms/osver/since on parameters!

--- a/apidoc/Titanium/UI/View.yml
+++ b/apidoc/Titanium/UI/View.yml
@@ -1993,33 +1993,6 @@ properties:
     type: Number
 
 ---
-name: Dimension
-summary: A simple object consisting of the position and size measurements.
-since: "2.0.0"
-description: |
-  When a dimension is returned by the [rect](Titanium.UI.View.rect) property, `x` represents the
-  view's left position, and `y` represents the view's top position.
-
-  The [size](Titanium.UI.View.size) property returns a dimension object with `x` and `y` both set
-  to 0.
-properties:
-  - name: height
-    summary: The height measurement.
-    type: Number
-
-  - name: width
-    summary: The width measurement.
-    type: Number
-
-  - name: x
-    summary: The x-axis coordinate of the position.
-    type: Number
-
-  - name: y
-    summary: The y-axis coordinate of the position.
-    type: Number
-
----
 name: AnimationOption
 summary: Optional parameter to enable animation to [hide](Titanium.UI.View.hide) and [show](Titanium.UI.View.show).
 since: "5.1.0"
@@ -2032,22 +2005,3 @@ properties:
     optional: true
     osver: {android: {min: 5.0}}
 
----
-name: ViewPadding
-summary: Dictionary object of parameters for the padding applied to all kinds of views.
-properties:
-  - name: left
-    type: Number
-    summary: Left padding
-
-  - name: right
-    type: Number
-    summary: Right padding
-
-  - name: top
-    type: Number
-    summary: Top padding
-
-  - name: bottom
-    type: Number
-    summary: Bottom padding

--- a/apidoc/Titanium/UI/Window.yml
+++ b/apidoc/Titanium/UI/Window.yml
@@ -468,7 +468,6 @@ methods:
             Options dictionary supporting a single `animated` boolean property to determine whether
             the navigation bar will be animated (default) while being hidden. Note that the default here is equivalent to `{ animated: true }`
         type: AnimatedOptions
-        # FIXME: default animated value here is true! Do we define a different type than AnimatedOptions?
         optional: true
     platforms: [iphone, ipad]
 
@@ -519,7 +518,6 @@ methods:
             Options dictionary supporting a single `animated` boolean property to determine whether
             the navigation bar will be animated (default) while being shown. Note that the default here is equivalent to `{ animated: true }`
         type: AnimatedOptions
-        # FIXME: default animated value here is true!
         optional: true
     platforms: [iphone, ipad]
 
@@ -535,7 +533,6 @@ methods:
             Options dictionary supporting a single `animated` boolean property to determine whether
             the toolbar will be animated (default) while being shown. Note that the default here is equivalent to `{ animated: true }`
         type: AnimatedOptions
-        # FIXME: default animated value here is true!
         optional: true
     platforms: [iphone, ipad]
     since: "5.4.0"
@@ -552,7 +549,6 @@ methods:
             Options dictionary supporting a single `animated` boolean property to determine whether
             the toolbar will be animated (default) while being hidden. Note that the default here is equivalent to `{ animated: true }`
         type: AnimatedOptions
-        # FIXME: default animated value here is true!
         optional: true
     platforms: [iphone, ipad]
     since: "5.4.0"

--- a/apidoc/Titanium/UI/Window.yml
+++ b/apidoc/Titanium/UI/Window.yml
@@ -2062,6 +2062,6 @@ properties:
 
   - name: offset
     summary: |
-        Dictionary with the properties `width` and `height` used as the horizontal
+        <Size> with the properties `width` and `height` used as the horizontal
         and vertical offset of the shadow, respectively.
-    type: Dictionary
+    type: Size

--- a/apidoc/Titanium/UI/Window.yml
+++ b/apidoc/Titanium/UI/Window.yml
@@ -1147,7 +1147,7 @@ properties:
     description: |
         This was separated from the <Titanium.UI.Window.androidback> event. You need to define this
         callback if you explicitly want to override the back button behavior.
-    type: Callback<Object>
+    type: Callback<void>
     platforms: [android]
 
   - name: orientationModes
@@ -1493,7 +1493,7 @@ properties:
             </Alloy>
 
     platforms: [iphone, ipad]
-    type: Array<Object>
+    type: Array<Titanium.UI.View>
 
   - name: top
     summary: Window's top position, in platform-specific units.

--- a/apidoc/Titanium/UI/Window.yml
+++ b/apidoc/Titanium/UI/Window.yml
@@ -1322,7 +1322,7 @@ properties:
             // Open the window.
             win.open();
 
-    type: Dimension
+    type: Padding
     permission: read-only
     since: {android: "7.5.0", iphone: "8.0.0", ipad: "8.0.0"}
 

--- a/apidoc/Titanium/UI/Window.yml
+++ b/apidoc/Titanium/UI/Window.yml
@@ -455,6 +455,7 @@ methods:
     parameters:
       - name: params
         summary: Animation or display properties to use when closing the window.
+        # FIXME: iOS supports many different styles: Ti.UI.Animation, Array<Ti.UI.Animation>, or Object like: { animated: false, animationDuration: 1000, animationStyle: itanium.UI.iOS.AnimationStyle.NONE }
         type: [Dictionary<Titanium.UI.Animation>, closeWindowParams]
         optional: true
 

--- a/apidoc/Titanium/UI/Window.yml
+++ b/apidoc/Titanium/UI/Window.yml
@@ -455,8 +455,7 @@ methods:
     parameters:
       - name: params
         summary: Animation or display properties to use when closing the window.
-        # FIXME: iOS supports many different styles: Ti.UI.Animation, Array<Ti.UI.Animation>, or Object like: { animated: false, animationDuration: 1000, animationStyle: itanium.UI.iOS.AnimationStyle.NONE }
-        type: [Dictionary<Titanium.UI.Animation>, closeWindowParams]
+        type: [Titanium.UI.Animation, Dictionary<Titanium.UI.Animation>, closeWindowParams]
         optional: true
 
   - name: hideNavBar
@@ -467,8 +466,9 @@ methods:
       - name: options
         summary: |
             Options dictionary supporting a single `animated` boolean property to determine whether
-            the navigation bar will be animated (default) while being hidden.
-        type: Dictionary
+            the navigation bar will be animated (default) while being hidden. Note that the default here is equivalent to `{ animated: true }`
+        type: AnimatedOptions
+        # FIXME: default animated value here is true! Do we define a different type than AnimatedOptions?
         optional: true
     platforms: [iphone, ipad]
 
@@ -517,8 +517,9 @@ methods:
       - name: options
         summary: |
             Options dictionary supporting a single `animated` boolean property to determine whether
-            the navigation bar will be animated (default) while being shown.
-        type: Dictionary
+            the navigation bar will be animated (default) while being shown. Note that the default here is equivalent to `{ animated: true }`
+        type: AnimatedOptions
+        # FIXME: default animated value here is true!
         optional: true
     platforms: [iphone, ipad]
 
@@ -532,10 +533,10 @@ methods:
       - name: options
         summary: |
             Options dictionary supporting a single `animated` boolean property to determine whether
-            the toolbar will be animated (default) while being shown.
-        type: Dictionary
+            the toolbar will be animated (default) while being shown. Note that the default here is equivalent to `{ animated: true }`
+        type: AnimatedOptions
+        # FIXME: default animated value here is true!
         optional: true
-        default: true
     platforms: [iphone, ipad]
     since: "5.4.0"
 
@@ -549,10 +550,10 @@ methods:
       - name: options
         summary: |
             Options dictionary supporting a single `animated` boolean property to determine whether
-            the toolbar will be animated (default) while being hidden.
-        type: Dictionary
+            the toolbar will be animated (default) while being hidden. Note that the default here is equivalent to `{ animated: true }`
+        type: AnimatedOptions
+        # FIXME: default animated value here is true!
         optional: true
-        default: true
     platforms: [iphone, ipad]
     since: "5.4.0"
 
@@ -1973,35 +1974,47 @@ properties:
 name: closeWindowParams
 summary: Dictionary of options for the <Titanium.UI.Window.close> method.
 since: 3.2.0
-platforms: [android]
-
+platforms: [android, ipad, iphone]
 properties:
-
   - name: animated
     summary: |
-        Determines whether to use an animated effect when the window is closed.
+        Determines whether to use an animated effect when the window is closed. Defaults to `true` on Android, `false` on iOS.
     description: |
         This property supports animated transitions on windows except for modal windows (`modal:true`).
         The transitions are on by default, but you can disable this behavior by setting this value
         to `false`.
     type: Boolean
-    default: true
+
+  - name: animationDuration
+    type: Number
+    default: 1000
+    summary: duration of the animation in milliseconds
+    platforms: [iphone, ipad]
+
+  - name: animationStyle
+    summary: Transition type to use during a transition animation.
+    type: Number
+    constants: Titanium.UI.iOS.AnimationStyle.*
+    default: <Titanium.UI.iOS.AnimationStyle.NONE>
+    platforms: [iphone, ipad]
 
   - name: activityEnterAnimation
     summary: Animation resource to use for the incoming activity.
     description: |
       This value will be ignored if `animated` is set to false.
-      See "Window Transitions in Android" in the main description of Titanium.UI.Window
+      See "Window Transitions in Android" in the main description of <Titanium.UI.Window>
       for more information.
     type: Number
+    platforms: [android]
 
   - name: activityExitAnimation
     summary: Animation resource to use for the outgoing activity.
     description: |
       This value will be ignored if `animated` is set to false.
-      See "Window Transitions in Android" in the main description of Titanium.UI.Window
+      See "Window Transitions in Android" in the main description of <Titanium.UI.Window>
       for more information.
     type: Number
+    platforms: [android]
     examples:
       - title: Fading out a Window
         example: |

--- a/apidoc/Titanium/UI/Window.yml
+++ b/apidoc/Titanium/UI/Window.yml
@@ -469,6 +469,7 @@ methods:
             the navigation bar will be animated (default) while being hidden. Note that the default here is equivalent to `{ animated: true }`
         type: AnimatedOptions
         optional: true
+        default: "{ animated: true }"
     platforms: [iphone, ipad]
 
   - name: hideTabBar
@@ -519,6 +520,7 @@ methods:
             the navigation bar will be animated (default) while being shown. Note that the default here is equivalent to `{ animated: true }`
         type: AnimatedOptions
         optional: true
+        default: "{ animated: true }"
     platforms: [iphone, ipad]
 
   - name: showToolbar
@@ -534,6 +536,7 @@ methods:
             the toolbar will be animated (default) while being shown. Note that the default here is equivalent to `{ animated: true }`
         type: AnimatedOptions
         optional: true
+        default: "{ animated: true }"
     platforms: [iphone, ipad]
     since: "5.4.0"
 
@@ -550,6 +553,7 @@ methods:
             the toolbar will be animated (default) while being hidden. Note that the default here is equivalent to `{ animated: true }`
         type: AnimatedOptions
         optional: true
+        default: "{ animated: true }"
     platforms: [iphone, ipad]
     since: "5.4.0"
 

--- a/apidoc/Titanium/UI/iOS/ApplicationShortcuts.yml
+++ b/apidoc/Titanium/UI/iOS/ApplicationShortcuts.yml
@@ -69,8 +69,8 @@ methods:
   - name: dynamicShortcutExists
     summary: Returns true or false depending if the provided shortcut object already exists.
     parameters:
-      - name: itemtype
-        summary: Checks if the dynamic application shortcut item identified by the `itemtype` exists.
+      - name: identifier
+        summary: Checks if the dynamic application shortcut item identified by the `identifier` exists.
         type: String
     returns:
         type: Boolean        
@@ -83,19 +83,19 @@ methods:
         type: ShortcutParams
 
   - name: removeDynamicShortcut
-    summary: Removes the dynamic application shortcut item identified by the `itemtype`.
+    summary: Removes the dynamic application shortcut item identified by the `identifier`.
     parameters:
-      - name: itemtype
+      - name: identifier
         summary: |
-            Use the `itemtype` property to determine which shortcut should be removed.
+            Use the `identifier` argument to determine which shortcut should be removed.
         type: String
 
   - name: getDynamicShortcut
-    summary: Gets the dynamic application shortcut item identified by the `itemtype`.
+    summary: Gets the dynamic application shortcut item identified by the `identifier`.
     parameters:
-      - name: itemtype
+      - name: identifier
         summary: |
-            Use the `itemtype` property to determine which shortcut should be returned.
+            Use the `identifier` argument to determine which shortcut should be returned.
         type: String
     returns:
       type: ShortcutParams
@@ -103,49 +103,49 @@ methods:
 examples:
   - title: Full example (get shortcuts, add shortcuts, remove shortcuts, check shortcuts).
     example: |
-        Ti.App.iOS.addEventListener("shortcutitemclick", function(e){
+        Ti.App.iOS.addEventListener("shortcutitemclick", function (e) {
             Ti.API.info("shortcutitemclick Event Fired");
             Ti.API.info("event payload:" + JSON.stringify(e));
         });
 
         var win = Titanium.UI.createWindow({
-            title:'Test', backgroundColor:'#fff', layout:"vertical"
+            title: 'Test', backgroundColor: '#fff', layout: "vertical"
         });
 
         var btn1 = Ti.UI.createButton({
-            top: 50, height:45, title:"Add Contact Us Application Shortcut"
+            top: 50, height: 45, title: "Add Contact Us Application Shortcut"
         });
         win.add(btn1);
 
-        btn1.addEventListener("click",function(){
+        btn1.addEventListener("click", function () {
             var appShortcuts = Ti.UI.iOS.createApplicationShortcuts();
             appShortcuts.addDynamicShortcut({
-                itemtype:"contact_us",
-                title:"Contact Us",
-                subtitle:"Tap to reach us",
+                identifier: "contact_us",
+                title: "Contact Us",
+                subtitle: "Tap to reach us",
                 icon: Ti.UI.iOS.SHORTCUT_ICON_TYPE_ADD,
-                userInfo:{
-                    infoKey:"contact_us"
+                userInfo: {
+                    infoKey: "contact_us"
                 }
             });
         });
 
         var btn2 = Ti.UI.createButton({
-            top: 10, height:45, title:"Remove Contact Us Application Shortcut"
+            top: 10, height: 45, title: "Remove Contact Us Application Shortcut"
         });
         win.add(btn2);
 
-        btn2.addEventListener("click",function(){
+        btn2.addEventListener("click", function () {
             var appShortcuts = Ti.UI.iOS.createApplicationShortcuts();
             appShortcuts.removeDynamicShortcut("contact_us");
         });
 
         var btn3 = Ti.UI.createButton({
-            top: 10, height:45, title:"Count Dynamic App Shortcuts"
+            top: 10, height: 45, title: "Count Dynamic App Shortcuts"
         });
         win.add(btn3);
 
-        btn3.addEventListener("click",function(){
+        btn3.addEventListener("click", function () {
             var appShortcuts = Ti.UI.iOS.createApplicationShortcuts();
             var shortcuts = appShortcuts.listDynamicShortcuts();
             Ti.API.info("Dynamic App Shortcut count:" + shortcuts.length);
@@ -153,11 +153,11 @@ examples:
         });
 
         var btn4 = Ti.UI.createButton({
-            top: 10, height:45, title:"Count Static App Shortcuts"
+            top: 10, height: 45, title: "Count Static App Shortcuts"
         });
         win.add(btn4);
 
-        btn4.addEventListener("click",function(){
+        btn4.addEventListener("click", function () {
             var appShortcuts = Ti.UI.iOS.createApplicationShortcuts();
             var shortcuts = appShortcuts.listStaticShortcuts();
             Ti.API.info("Static App Shortcut count:" + shortcuts.length);
@@ -165,11 +165,11 @@ examples:
         });
 
         var btn5 = Ti.UI.createButton({
-            top: 10, height:45, title:"Dynamic Shortcut Exists?"
+            top: 10, height: 45, title: "Dynamic Shortcut Exists?"
         });
         win.add(btn5);
 
-        btn5.addEventListener("click",function(){
+        btn5.addEventListener("click", function () {
             var appShortcuts = Ti.UI.iOS.createApplicationShortcuts();
             var exists = appShortcuts.dynamicShortcutExists("contact_us");
             var msg = (exists) ? "Icon exists" : "Sorry isn't there";
@@ -181,17 +181,17 @@ examples:
         });
         win.add(btn6);
 
-        btn6.addEventListener("click",function(){
+        btn6.addEventListener("click", function () {
             var appShortcuts = Ti.UI.iOS.createApplicationShortcuts();
             appShortcuts.removeAllDynamicShortcuts();
         });
 
         var btn7 = Ti.UI.createButton({
-            top: 10, height:45, title:"Get shortcut by itemtype \"contact_us\""
+            top: 10, height: 45, title: "Get shortcut by identifier \"contact_us\""
         });
         win.add(btn7);
 
-        btn7.addEventListener("click",function(){
+        btn7.addEventListener("click", function () {
             var appShortcuts = Ti.UI.iOS.createApplicationShortcuts();
             var shortcut = appShortcuts.getDynamicShortcut("contact_us");
             alert(shortcut);
@@ -203,24 +203,24 @@ examples:
     example: |
         Example:
 
-            Ti.App.iOS.addEventListener("shortcutitemclick", function(e){
+            Ti.App.iOS.addEventListener("shortcutitemclick", function (e) {
                 Ti.API.info("shortcutitemclick Event Fired");
                 Ti.API.info("person:" + JSON.stringify(e.userInfo.person));
             });
 
             var win = Titanium.UI.createWindow({
-                title:'Test', backgroundColor:'#fff', layout:"vertical"
+                title: 'Test', backgroundColor: '#fff', layout: "vertical"
             });
 
             var btn1 = Ti.UI.createButton({
-                top: 50, height:45, title:"Add Ti.Contacts Application Shortcut"
+                top: 50, height: 45, title: "Add Ti.Contacts Application Shortcut"
             });
             win.add(btn1);
 
-            btn1.addEventListener("click", function() {
-                if(!Ti.Contacts.hasContactsPermissions()) {
-                    Ti.Contacts.requestContactsPermissions(function(e) {
-                        if(e.success) {
+            btn1.addEventListener("click", function () {
+                if (!Ti.Contacts.hasContactsPermissions()) {
+                    Ti.Contacts.requestContactsPermissions(function (e) {
+                        if (e.success) {
                             createShortcut();
                         }
                     })
@@ -230,11 +230,11 @@ examples:
             });
 
             var btn2 = Ti.UI.createButton({
-                top: 10, height:45, title:"Remove Ti.Contacts Application Shortcut"
+                top: 10, height: 45, title: "Remove Ti.Contacts Application Shortcut"
             });
             win.add(btn2);
 
-            btn2.addEventListener("click", function(){
+            btn2.addEventListener("click", function () {
                 var appShortcuts = Ti.UI.iOS.createApplicationShortcuts();
                 appShortcuts.removeDynamicShortcut("contact_us");
             });
@@ -246,7 +246,7 @@ examples:
 
                         var appShortcuts = Ti.UI.iOS.createApplicationShortcuts();
                         appShortcuts.addDynamicShortcut({
-                            itemtype:"contact_us",
+                            identifier: "contact_us",
                             title: person.fullName,
                             subtitle: "Tap to call",
                             icon: person,
@@ -270,10 +270,10 @@ platforms: [iphone]
 since: 5.1.0
 description: |
     The parameters used when creating and receiving a shortcut. When used for creation, it must include 
-    at least the `itemtype` and `title` properties.
+    at least the `identifier` and `title` properties.
 properties:
-  - name: itemtype
-    summary: The unique key for the application shortcut.
+  - name: identifier
+    summary: The unique key for the application shortcut. Equates to the underlying `UIApplicationShortcutItemIconType` key
     type: String
     optional: false
 

--- a/apidoc/Titanium/UI/iOS/CollisionBehavior.yml
+++ b/apidoc/Titanium/UI/iOS/CollisionBehavior.yml
@@ -36,8 +36,9 @@ properties:
   - name: referenceInsets
     summary: Insets to apply when using the animator's reference view as the boundary.
     description: The `treatReferenceAsBoundary` property needs to be set to `true` to use this property.
-    type: ReferenceInsets
+    type: Padding
     default: All insets are zero.
+    osver: {ios: {min: "7.0"}}
 
   - name: treatReferenceAsBoundary
     summary: Use the animator's reference view as the boundary.
@@ -198,27 +199,3 @@ properties:
   - name: point2
     summary: End point for the boundary
     type: Point
-
----
-name: ReferenceInsets
-summary: Dictionary to specify edge insets for <Titanium.UI.iOS.CollisionBehavior.referenceInsets>.
-since: "3.2"
-platforms: [iphone, ipad]
-osver: {ios: {min: "7.0"}}
-properties:
-  - name: top 
-    summary: Top inset.
-    type: Number
-
-  - name: left
-    summary: Left inset.
-    type: Number
-
-  - name: right
-    summary: Right inset.
-    type: Number
-
-  - name: bottom
-    summary: Bottom inset.
-    type: Number
-

--- a/apidoc/Titanium/UI/iOS/MenuPopup.yml
+++ b/apidoc/Titanium/UI/iOS/MenuPopup.yml
@@ -39,6 +39,7 @@ methods:
             Note that the default here is equivalent to passing in `{ animated: true }` (while typically the default for <AnimationOptions> is false)
         type: AnimatedOptions
         optional: true
+        default: "{ animated: true }"
 
   - name: isVisible
     summary: Indicates whether the menu popup is currently visible.

--- a/apidoc/Titanium/UI/iOS/MenuPopup.yml
+++ b/apidoc/Titanium/UI/iOS/MenuPopup.yml
@@ -24,16 +24,19 @@ methods:
   - name: show
     summary: Shows the menu popup.
     parameters:
-      - name: params
-        summary: Includes options how the menu popup should be shown.
+      - name: options
+        summary: Includes options how the menu popup should be shown. Note that the default is to be animated.
         type: MenuPopupShowParams
         optional: false
 
   - name: hide
     summary: Hides the menu popup.
     parameters:
-      - name: params
-        summary: Includes options how the menu popup should be hidden. Introduced in SDK 5.2.0
+      - name: options
+        summary: |
+            Includes options how the menu popup should be hidden. Introduced in SDK 5.2.0.
+        
+            Note that the default here is equivalent to passing in `{ animated: true }` (while typically the default for <AnimationOptions> is false)
         type: AnimatedOptions
         optional: true
 
@@ -109,6 +112,7 @@ properties:
     summary: Indicates the arrow direction of the menu popup.
     description: Use this property to indicate the menu popups arrow to use. 
     type: Number
+    default: Titanium.UI.iOS.MENU_POPUP_ARROW_DIRECTION_DEFAULT
     constants: [ Titanium.UI.iOS.MENU_POPUP_ARROW_DIRECTION_UP,Titanium.UI.iOS.MENU_POPUP_ARROW_DIRECTION_DOWN,
                 Titanium.UI.iOS.MENU_POPUP_ARROW_DIRECTION_LEFT,Titanium.UI.iOS.MENU_POPUP_ARROW_DIRECTION_RIGHT,
                 Titanium.UI.iOS.MENU_POPUP_ARROW_DIRECTION_DEFAULT ]

--- a/apidoc/Titanium/UI/iOS/MenuPopup.yml
+++ b/apidoc/Titanium/UI/iOS/MenuPopup.yml
@@ -33,8 +33,8 @@ methods:
     summary: Hides the menu popup.
     parameters:
       - name: params
-        summary: Includes options how the menu popup should be hidden.
-        type: MenuPopupHideParams
+        summary: Includes options how the menu popup should be hidden. Introduced in SDK 5.2.0
+        type: AnimatedOptions
         optional: true
 
   - name: isVisible
@@ -87,7 +87,6 @@ examples:
             win.open();
 
 ---
-
 name: MenuPopupShowParams
 summary: Dictionary of options for showing a menu popup with <Titanium.UI.iOS.MenuPopup.show>.
 platforms: [iphone,ipad]
@@ -113,17 +112,3 @@ properties:
     constants: [ Titanium.UI.iOS.MENU_POPUP_ARROW_DIRECTION_UP,Titanium.UI.iOS.MENU_POPUP_ARROW_DIRECTION_DOWN,
                 Titanium.UI.iOS.MENU_POPUP_ARROW_DIRECTION_LEFT,Titanium.UI.iOS.MENU_POPUP_ARROW_DIRECTION_RIGHT,
                 Titanium.UI.iOS.MENU_POPUP_ARROW_DIRECTION_DEFAULT ]
-
----
-name: MenuPopupHideParams
-summary: Dictionary of options for hiding a menu popup with <Titanium.UI.iOS.MenuPopup.hide>.
-platforms: [iphone,ipad]
-since: "5.2.0"
-description: |
-    Set the `animated` property to `false` if you want to hide the menu popup without an animation.
-properties:
-  - name: animated
-    summary: Determines whether the menu popup should be opened or closed animated.
-    type: Boolean
-    default: true
-    optional: true

--- a/apidoc/Titanium/UI/iOS/SplitWindow.yml
+++ b/apidoc/Titanium/UI/iOS/SplitWindow.yml
@@ -52,6 +52,7 @@ methods:
           Note that the default here is equivalent to passing in `{ animated: false }`
         type: AnimatedOptions
         optional: true
+        default: "{ animated: false }"
 
   - name: setMasterIsOverlayed
     summary: Sets the value of the [masterIsOverlayed](Titanium.UI.iOS.SplitWindow.masterIsOverlayed) property.
@@ -69,6 +70,7 @@ methods:
           Note that the default here is equivalent to passing in `{ animated: false }`
         type: AnimatedOptions
         optional: true
+        default: "{ animated: false }"
 
 properties:
   - name: detailView

--- a/apidoc/Titanium/UI/iOS/SplitWindow.yml
+++ b/apidoc/Titanium/UI/iOS/SplitWindow.yml
@@ -48,6 +48,8 @@ methods:
           Determines whether the scrollable region reposition should be animated. On iOS, use the optional property `animated` to animate changes to masterView display mode in portrait orientation. For example
 
               setShowMasterInPortrait(true, {animated:true})
+
+          Note that the default here is equivalent to passing in `{ animated: false }`
         type: AnimatedOptions
         optional: true
 
@@ -63,6 +65,8 @@ methods:
           Determines whether the scrollable region reposition should be animated. On iOS, use the optional property `animated` to animate changes to masterView display mode in portrait orientation. For example
 
               setMasterIsOverlayed(true, {animated:true})
+
+          Note that the default here is equivalent to passing in `{ animated: false }`
         type: AnimatedOptions
         optional: true
 

--- a/apidoc/Titanium/UI/iOS/SplitWindow.yml
+++ b/apidoc/Titanium/UI/iOS/SplitWindow.yml
@@ -43,9 +43,12 @@ methods:
         summary: Determines whether to show the master view in portrait orientation.
         type: Boolean
 
-      - name: animated
-        summary: Determines whether the scrollable region reposition should be animated
-        type: animationOption
+      - name: options
+        summary: |
+          Determines whether the scrollable region reposition should be animated. On iOS, use the optional property `animated` to animate changes to masterView display mode in portrait orientation. For example
+
+              setShowMasterInPortrait(true, {animated:true})
+        type: AnimatedOptions
         optional: true
 
   - name: setMasterIsOverlayed
@@ -55,9 +58,12 @@ methods:
         summary: Determines whether to show the master view is overlayed in portrait orientation.
         type: Boolean
 
-      - name: animated
-        summary: Determines whether the scrollable region reposition should be animated
-        type: animationOption
+      - name: options
+        summary: |
+          Determines whether the scrollable region reposition should be animated. On iOS, use the optional property `animated` to animate changes to masterView display mode in portrait orientation. For example
+
+              setMasterIsOverlayed(true, {animated:true})
+        type: AnimatedOptions
         optional: true
 
 properties:
@@ -156,19 +162,3 @@ examples:
             **controllers/index.js:**
 
             $.index.open();
-
----
-name: animationOption
-summary: |
-    Optional parameter for [setShowMasterInPortrait](Titanium.UI.iOS.SplitWindow.setShowMasterInPortrait) and
-    [setMasterIsOverlayed](Titanium.UI.iOS.SplitWindow.setMasterIsOverlayed) methods.
-description: |
-    On iOS, use the optional parameter `animated` to animate changes to masterView display mode in portrait orientation. For example
-
-        setShowMasterInPortrait(true, {animated:true})
-platforms: [iphone, ipad]
-
-properties:
-  - name: animated
-    summary: Determines whether the change is animated.
-    type: Boolean

--- a/apidoc/Titanium/UI/iOS/TransitionAnimation.yml
+++ b/apidoc/Titanium/UI/iOS/TransitionAnimation.yml
@@ -1,0 +1,84 @@
+---
+name: Titanium.UI.iOS.TransitionAnimation
+summary: |
+    A transition animation when opening or closing windows in a
+    <Titanium.UI.NavigationWindow> or <Titanium.UI.Tab>.
+
+    Use this proxy with the Window's
+    [transitionAnimation](Titanium.UI.Window.transitionAnimation) property.
+extends: Titanium.Proxy
+since: "3.2.0"
+platforms: [iphone, ipad]
+osver: {ios: {min: "7.0"}}
+
+properties:
+  - name: duration
+    summary: Length of the transition in milliseconds.
+    type: Number
+
+  - name: transitionFrom
+    summary: Animation to hide the current window.
+    type: Titanium.UI.Animation
+
+  - name: transitionTo
+    summary: Animation to show the new window.
+    type: Titanium.UI.Animation
+    
+examples:
+  - title: Simple Example
+    example: |
+        In this example, the red window opens with a transition animation, while closing it uses the
+        default behavior where it slides off screen.  To add a transition animation when the red
+        window closes, define a transition animation for the blue window.
+
+            var transition = Ti.UI.iOS.createTransitionAnimation({
+                duration: 300,
+                // The show transition makes the window opaque and rotates it correctly
+                transitionTo: {
+                    opacity: 1,
+                    duration: 300,
+                    transform: Ti.UI.createMatrix2D()
+                },
+                // The hide transition makes the window transparent and rotates it upside down
+                transitionFrom: {
+                    opacity: 0,
+                    duration: 300 / 2,
+                    transform: Ti.UI.createMatrix2D().rotate(180),
+                }
+            });
+
+            var win2 = Ti.UI.createWindow({
+                backgroundColor: 'red',
+                title: 'Red Window',
+                transitionAnimation: transition,
+                opacity: 0,
+                transform: Ti.UI.createMatrix2D().rotate(180)
+            });
+            var button2 = Ti.UI.createButton({
+                title: 'Close Red Window'
+            });
+            button2.addEventListener('click', function(){
+                nav.closeWindow(win2);
+                // In order to see the blue window again,
+                // need to reverse the transition animation
+                win1.opacity = 1;
+                win1.transform = Ti.UI.createMatrix2D().rotate(0);
+            });
+            win2.add(button2);
+
+            var win1 = Ti.UI.createWindow({
+                backgroundColor: 'blue',
+                title: 'Blue Window',
+                // Uncomment to use a transition animation when the blue window is closed
+                // transitionAnimation: transition
+            });
+            var button1 = Ti.UI.createButton({title: 'Open Red Window'});
+            button1.addEventListener('click', function(){
+                nav.openWindow(win2);
+            });
+            win1.add(button1);
+
+            var nav = Ti.UI.createNavigationWindow({
+                window: win1
+            });
+            nav.open();

--- a/apidoc/Titanium/UI/iOS/iOS.yml
+++ b/apidoc/Titanium/UI/iOS/iOS.yml
@@ -8,22 +8,6 @@ since: "1.4"
 platforms: [iphone, ipad]
 
 methods:
-  - name: createTransitionAnimation
-    summary: |
-        Creates a transition animation when opening or closing windows in a
-        <Titanium.UI.NavigationWindow> or <Titanium.UI.Tab>.
-    description: |
-        Use the object returned by this method with the Window's
-        [transitionAnimation](Titanium.UI.Window.transitionAnimation) property.
-    parameters:
-      - name: transition
-        summary: Dictionary specifying the transition animation.
-        type: transitionAnimationParam
-    returns:
-      - type: Titanium.Proxy
-    since: "3.2.0"
-    osver: {ios: {min: "7.0"}}
-
   - name: createLivePhotoBadge
     summary: |
         Creates a live photo badge to be used together with the
@@ -36,7 +20,7 @@ methods:
         type: Number
         constants: [Titanium.UI.iOS.LIVEPHOTO_BADGE_OPTIONS_*]
     returns:
-      - type: Titanium.Blob
+      type: Titanium.Blob
     since: "5.2.0"
     osver: {ios: {min: "9.1"}}
 
@@ -52,7 +36,7 @@ methods:
         summary: Name of SF Symbol.
         type: String
     returns:
-      - type: Titanium.Blob
+      type: Titanium.Blob
     since: "8.2.0"
     osver: {ios: {min: "13.0"}}
 properties:
@@ -2328,83 +2312,3 @@ properties:
     type: Number
     since: "8.0.0"
     permission: read-only
-
----
-name: transitionAnimationParam
-summary: |
-    Dictionary specifying the transition animation used with the <Titanium.UI.iOS.createTransitionAnimation> method.
-platforms: [iphone, ipad]
-since: "3.2.0"
-osver: {ios: {min: "7.0"}}
-
-examples:
-  - title: Simple Example
-    example: |
-        In this example, the red window opens with a transition animation, while closing it uses the
-        default behavior where it slides off screen.  To add a transition animation when the red
-        window closes, define a transition animation for the blue window.
-
-            var transition = Ti.UI.iOS.createTransitionAnimation({
-                duration: 300,
-                // The show transition makes the window opaque and rotates it correctly
-                transitionTo: {
-                    opacity: 1,
-                    duration: 300,
-                    transform: Ti.UI.createMatrix2D()
-                },
-                // The hide transition makes the window transparent and rotates it upside down
-                transitionFrom: {
-                    opacity: 0,
-                    duration: 300 / 2,
-                    transform: Ti.UI.createMatrix2D().rotate(180),
-                }
-            });
-
-            var win2 = Ti.UI.createWindow({
-                backgroundColor: 'red',
-                title: 'Red Window',
-                transitionAnimation: transition,
-                opacity: 0,
-                transform: Ti.UI.createMatrix2D().rotate(180)
-            });
-            var button2 = Ti.UI.createButton({
-                title: 'Close Red Window'
-            });
-            button2.addEventListener('click', function(){
-                nav.closeWindow(win2);
-                // In order to see the blue window again,
-                // need to reverse the transition animation
-                win1.opacity = 1;
-                win1.transform = Ti.UI.createMatrix2D().rotate(0);
-            });
-            win2.add(button2);
-
-            var win1 = Ti.UI.createWindow({
-                backgroundColor: 'blue',
-                title: 'Blue Window',
-                // Uncomment to use a transition animation when the blue window is closed
-                // transitionAnimation: transition
-            });
-            var button1 = Ti.UI.createButton({title: 'Open Red Window'});
-            button1.addEventListener('click', function(){
-                nav.openWindow(win2);
-            });
-            win1.add(button1);
-
-            var nav = Ti.UI.createNavigationWindow({
-                window: win1
-            });
-            nav.open();
-
-properties:
-  - name: duration
-    summary: Length of the transition in milliseconds.
-    type: Number
-
-  - name: transitionFrom
-    summary: Animation to hide the current window.
-    type: Titanium.UI.Animation
-
-  - name: transitionTo
-    summary: Animation to show the new window.
-    type: Titanium.UI.Animation

--- a/apidoc/Titanium/UI/iPad/Popover.yml
+++ b/apidoc/Titanium/UI/iPad/Popover.yml
@@ -38,14 +38,18 @@ methods:
     summary: Hides the popover.
     parameters:
       - name: options
-        summary: Display properties to use when hiding the popover.
+        summary: |
+            Display properties to use when hiding the popover.
+            Note that the default here is equivalent to passing in `{ animated: false }`
         type: AnimatedOptions
 
   - name: show
     summary: Displays the popover.
     parameters:
-      - name: params
-        summary: Display properties to use when displaying the popover.
+      - name: options
+        summary: |
+            Display properties to use when displaying the popover.
+            Note that the default here is to be animated.
         type: ShowPopoverParams
 
 properties:

--- a/apidoc/Titanium/UI/iPad/Popover.yml
+++ b/apidoc/Titanium/UI/iPad/Popover.yml
@@ -42,6 +42,8 @@ methods:
             Display properties to use when hiding the popover.
             Note that the default here is equivalent to passing in `{ animated: false }`
         type: AnimatedOptions
+        optional: true
+        default: "{ animated: false }"
 
   - name: show
     summary: Displays the popover.

--- a/apidoc/Titanium/UI/iPad/Popover.yml
+++ b/apidoc/Titanium/UI/iPad/Popover.yml
@@ -39,14 +39,14 @@ methods:
     parameters:
       - name: options
         summary: Display properties to use when hiding the popover.
-        type: PopoverParams
+        type: AnimatedOptions
 
   - name: show
     summary: Displays the popover.
     parameters:
       - name: params
         summary: Display properties to use when displaying the popover.
-        type: PopoverParams
+        type: ShowPopoverParams
 
 properties:
   - name: arrowDirection
@@ -257,16 +257,14 @@ examples:
             // $.popover.rightNavButton = button;
 
 ---
-name: PopoverParams
-summary: Dictionary of options for <Titanium.UI.iPad.Popover.show> and <Titanium.UI.iPad.Popover.hide>.
+name: ShowPopoverParams
+summary: Dictionary of options for <Titanium.UI.iPad.Popover.show>.
 description: |
     All properties are optional except you need to specify the `view` property for the `show()`
     method to attach the popover to a view component.
-
-    The `hide()` method only supports the `animated` property.
 properties:
   - name: animated
-    summary: Indicates whether to animate showing or hiding the popover.
+    summary: Indicates whether to animate showing the popover.
     type: Boolean
     default: true
     optional: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1215,8 +1215,7 @@
     "@babel/parser": {
       "version": "7.5.5",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.5.5.tgz",
-      "integrity": "sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g==",
-      "dev": true
+      "integrity": "sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g=="
     },
     "@babel/plugin-proposal-async-generator-functions": {
       "version": "7.7.4",
@@ -8732,10 +8731,16 @@
         "commander": "~2.0.0",
         "debug": "~0.7.2",
         "hypar": "~0.1.0",
+        "node-titanium-sdk": "^3.0.1",
         "shelljs": "~0.2.6",
         "win-fork": "~1.1.1"
       },
       "dependencies": {
+        "async": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-3.1.0.tgz",
+          "integrity": "sha512-4vx/aaY6j/j3Lw3fbCHNWP0pPaTCew3F6F3hYyl/tHs/ndmV1q7NW9T5yuJ2XAGwdQrP+6Wu20x06U4APo/iQQ=="
+        },
         "commander": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.0.0.tgz",
@@ -8745,6 +8750,49 @@
           "version": "0.7.4",
           "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
           "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk="
+        },
+        "fs-extra": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+          "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        },
+        "node-titanium-sdk": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/node-titanium-sdk/-/node-titanium-sdk-3.2.2.tgz",
+          "integrity": "sha512-qASjqmnHNeohUh/F6PljkDyZNqcXjK4TPqVJ4ZXH8njs97ITpg+frG7S05IhqHxsPfyHWJv/I5qxcewv2voNcA==",
+          "requires": {
+            "@babel/core": "^7.5.5",
+            "@babel/parser": "^7.5.5",
+            "@babel/plugin-transform-property-literals": "^7.2.0",
+            "@babel/preset-env": "^7.5.5",
+            "async": "^3.1.0",
+            "babel-preset-minify": "^0.5.1",
+            "colors": "^1.3.3",
+            "fs-extra": "^8.1.0",
+            "node-appc": "^0.3.4",
+            "node-uuid": "^1.4.8",
+            "stream-splitter": "~0.3.2",
+            "unorm": "^1.6.0",
+            "xmldom": "0.1.27"
+          }
         }
       }
     },
@@ -12534,9 +12582,9 @@
       }
     },
     "titanium-docgen": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/titanium-docgen/-/titanium-docgen-4.0.0.tgz",
-      "integrity": "sha512-Qvz6bqROeZQVgK+Bzx5QAb94cFtsUQWPd91y7CfEhRAnKl/tnyc+0MaNRH3kny6zY2HI+pezOb95hjmfWk+jPQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/titanium-docgen/-/titanium-docgen-4.1.0.tgz",
+      "integrity": "sha512-GAnH9aJOevk+2QXYnvVH7YJT9V0bcYc+XvvpR60ayIBtvTMMvB4jQWDHvvojFkrlwLhs7sybSDNzyh/tHMO6AQ==",
       "dev": true,
       "requires": {
         "colors": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
     "rollup-plugin-commonjs": "^10.1.0",
     "rollup-plugin-node-resolve": "^5.2.0",
     "ssri": "^7.1.0",
-    "titanium-docgen": "^4.0.0"
+    "titanium-docgen": "^4.1.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
**JIRA**
https://jira.appcelerator.org/browse/TIMOB-27688

**Description:**
- Updates to titanium-docgen 4.1.0 which now warns about using generic `Dictionary`/`Object` types
- Extracted out `Size` type: `width` and `height`
- Extracted `Dimension` type from View's yml file, have it extend `Size` and add `x` and `y` properties
  - `Ti.Blob.#imagesAsCropped()` now refers to `Dimension` rather than a custom type that had the same properties.
  - `Ti.Media CameraMediaItemType` now refers to `Dimension` for `cropRect` and `Size` for `previewRect` rather the defining custom types with same properties.
- Extracted `Padding` type from `ViewPadding`. Attempted to clean up any special types that had the same concept (basically any padding/inset properties/types) to refer to it.
    - Kept `TabIconInsets`, had it extend `Padding` and noted right/bottom are excluded.
    - Kept `TextFieldPadding`, had it extend `Padding` and noted top/bottom are Android-only.
- Fix `Ti.DB.ResultSet` `#field()` and `#fieldByName()` returns to be a single entry with type as an array of possible return types.