### PR TITLE
[8_3_X] fix(android): default Ti.Ui.TextField.editable is true in #focus()

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIText.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIText.java
@@ -497,7 +497,7 @@ public class TiUIText extends TiUIView implements TextWatcher, OnEditorActionLis
 	{
 		super.focus();
 		if (tv != null && proxy != null && proxy.getProperties() != null) {
-			final boolean editable = proxy.getProperties().optBoolean(TiC.PROPERTY_EDITABLE, false);
+			final boolean editable = proxy.getProperties().optBoolean(TiC.PROPERTY_EDITABLE, true);
 			TiUIHelper.showSoftKeyboard(tv, editable);
 		}
 	}


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-27694

**Optional Description:**
If the proxy doesn't have an explicit value set for editable, assume true by default

**Test Case**:
```js
var win = Ti.UI.createWindow({
  title : "Focus Test",
  backgroundColor : 'red',
  layout : "vertical"
});
 
// Create a TextField.
var aTextField = Ti.UI.createTextField({
  height : 40,
  top : 30,
  left : 20,
  right : 20,
  backgroundColor : "gray",
  hintText : 'This is hint text',
  softKeyboardOnFocus : Ti.UI.Android.SOFT_KEYBOARD_DEFAULT_ON_FOCUS, // Android only
  keyboardType : Ti.UI.KEYBOARD_DEFAULT,
  returnKeyType : Ti.UI.RETURNKEY_DEFAULT,
  borderStyle : Ti.UI.INPUT_BORDERSTYLE_ROUNDED
});
 
// Listen for return events.
aTextField.addEventListener('return', function(e) {
  aTextField.blur();
  alert('Input was: ' + aTextField.value);
});
 
// Add to the parent view.
win.add(aTextField);
 
// Create a Button.
var test = Ti.UI.createButton({
  title : 'Focus Test',
  height : Ti.UI.SIZE,
  width : Ti.UI.SIZE,
  top : 50,
});
 
// Listen for click events.
test.addEventListener('click', function() {
  aTextField.focus();
  //alert('\'aButton\' was clicked!');
});
 
// Add to the parent view.
win.add(test);
 
win.open();
```