### PR TITLE
feat(android): target Java8 and Kotlin support for native modules

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -29,6 +29,10 @@ android {
 			]
 		}
 	}
+	compileOptions {
+		sourceCompatibility JavaVersion.VERSION_1_8
+		targetCompatibility JavaVersion.VERSION_1_8
+	}
 }
 
 dependencies {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,12 +6,15 @@
  */
 
 buildscript {
+	ext.kotlin_version = '1.3.61'
+
 	repositories {
 		google()
 		jcenter()
 	}
 	dependencies {
 		classpath 'com.android.tools.build:gradle:3.4.2'
+		classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 	}
 }
 

--- a/android/kroll-apt/build.gradle
+++ b/android/kroll-apt/build.gradle
@@ -7,8 +7,8 @@
 
 apply plugin: 'java'
 
-sourceCompatibility = JavaVersion.VERSION_1_7
-targetCompatibility = JavaVersion.VERSION_1_7
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
 
 tasks.withType(JavaCompile) {
 	// Suppress compiler warning "bootstrap class path not set in conjunction with source" which happens when

--- a/android/kroll-apt/src/main/java/org/appcelerator/kroll/annotations/generator/KrollJSONGenerator.java
+++ b/android/kroll-apt/src/main/java/org/appcelerator/kroll/annotations/generator/KrollJSONGenerator.java
@@ -36,7 +36,7 @@ import javax.tools.StandardLocation;
 
 import org.json.simple.JSONValue;
 
-@SupportedSourceVersion(SourceVersion.RELEASE_7)
+@SupportedSourceVersion(SourceVersion.RELEASE_8)
 @SuppressWarnings("unchecked")
 // clang-format off
 @SupportedAnnotationTypes({

--- a/android/templates/build/app.build.gradle
+++ b/android/templates/build/app.build.gradle
@@ -28,7 +28,6 @@ android {
 		}
 <% } %>
 	}
-	// TODO: Add Java 8 support in the future.
 	compileOptions {
 		sourceCompatibility JavaVersion.VERSION_1_8
 		targetCompatibility JavaVersion.VERSION_1_8

--- a/android/templates/build/app.build.gradle
+++ b/android/templates/build/app.build.gradle
@@ -30,8 +30,8 @@ android {
 	}
 	// TODO: Add Java 8 support in the future.
 	compileOptions {
-		sourceCompatibility JavaVersion.VERSION_1_7
-		targetCompatibility JavaVersion.VERSION_1_7
+		sourceCompatibility JavaVersion.VERSION_1_8
+		targetCompatibility JavaVersion.VERSION_1_8
 	}
 	signingConfigs {
 		def tiKeystoreFilePath = <%- "'" + tiSdkAndroidDir.replace(/\\/g, '\\\\') + "/dev_keystore'" %>

--- a/android/templates/build/root.build.gradle
+++ b/android/templates/build/root.build.gradle
@@ -1,11 +1,14 @@
 
 buildscript {
+	ext.kotlin_version = '1.3.61'
+
 	repositories {
 		google()
 		jcenter()
 	}
 	dependencies {
 		classpath 'com.android.tools.build:gradle:3.4.2'
+		classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 	}
 }
 

--- a/android/templates/module/generated/build.gradle
+++ b/android/templates/module/generated/build.gradle
@@ -120,7 +120,7 @@ android {
 			}
 		}
 	}
-	// TODO: Add Java 8 support in the future.
+
 	compileOptions {
 		sourceCompatibility JavaVersion.VERSION_1_8
 		targetCompatibility JavaVersion.VERSION_1_8
@@ -130,6 +130,10 @@ android {
 	packagingOptions {
 		exclude '/lib/**/libc++_shared.so'
 		exclude '/lib/**/libkroll-v8.so'
+	}
+	// Sets the JVM target in order to allow usage of Java 8 features in Kotlin native modules.
+	kotlinOptions {
+		jvmTarget = '1.8'
 	}
 }
 

--- a/android/templates/module/generated/build.gradle
+++ b/android/templates/module/generated/build.gradle
@@ -1,6 +1,8 @@
 
 apply plugin: 'com.android.library'
 apply plugin: 'maven-publish'
+apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-kapt'
 
 repositories {
 	maven {
@@ -120,8 +122,8 @@ android {
 	}
 	// TODO: Add Java 8 support in the future.
 	compileOptions {
-		sourceCompatibility JavaVersion.VERSION_1_7
-		targetCompatibility JavaVersion.VERSION_1_7
+		sourceCompatibility JavaVersion.VERSION_1_8
+		targetCompatibility JavaVersion.VERSION_1_8
 	}
 	// Exclude the C++ runtime and Titanium kroll libraries for all architectures when packaging the AAR file.
 	// Avoids app build failure due to library file name collision. (Apps will use "titanium.aar" bundled *.so files.)
@@ -158,12 +160,15 @@ dependencies {
 	def krollAptJarPath = '<%- krollAptJarPath.replace(/\\/g, '\\\\') %>'
 	annotationProcessor files(krollAptJarPath)
 	compileOnly files(krollAptJarPath)
+	kapt files(krollAptJarPath)
 
 	// Reference this module's local AAR/JAR file dependencies.
 	implementation fileTree(dir: "${projectDir}/../../lib", include: ['*.aar', '*.jar'])
 
 	// Reference the main Titanium library.
 	implementation 'org.appcelerator:titanium:<%- tiSdkVersion %>'
+
+	implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 }
 
 // This block is used when we run "gradlew :module:publish" at the command line.

--- a/android/templates/module/generated/build.gradle
+++ b/android/templates/module/generated/build.gradle
@@ -159,6 +159,9 @@ tasks.withType(JavaCompile) {
 	}
 }
 
+// Titanium does not support incremental @Kroll annotation processing. Disable it in kotlin to avoid build warnings.
+project.ext['kapt.incremental.apt'] = false
+
 dependencies {
 	// This reads the code's @Kroll annotations and generates code which interops between V8 and proxy classes.
 	def krollAptJarPath = '<%- krollAptJarPath.replace(/\\/g, '\\\\') %>'

--- a/android/titanium/build.gradle
+++ b/android/titanium/build.gradle
@@ -103,7 +103,6 @@ android {
 			]
 		}
 	}
-	// TODO: Add Java 8 support in the future.
 	compileOptions {
 		sourceCompatibility JavaVersion.VERSION_1_8
 		targetCompatibility JavaVersion.VERSION_1_8

--- a/android/titanium/build.gradle
+++ b/android/titanium/build.gradle
@@ -105,8 +105,8 @@ android {
 	}
 	// TODO: Add Java 8 support in the future.
 	compileOptions {
-		sourceCompatibility JavaVersion.VERSION_1_7
-		targetCompatibility JavaVersion.VERSION_1_7
+		sourceCompatibility JavaVersion.VERSION_1_8
+		targetCompatibility JavaVersion.VERSION_1_8
 	}
 }
 


### PR DESCRIPTION
**JIRA:**
- https://jira.appcelerator.org/browse/TIMOB-25896
- https://jira.appcelerator.org/browse/TIMOB-27472

**Description:**
Targets Java 8 and adds support for Kotlin for developing native android modules.

**Test case:**
1. Download `ti.kotlin.zip` attached to [TIMOB-25896](https://jira.appcelerator.org/browse/TIMOB-25896).
2. Unzip it.
3. Open the terminal.
4. `CD` to directory: `./ti.kotlin/android`
5. Run: `appc run -p android`
6. Above builds the module and builds/runs its "example" app.
7. Verify example app shows a white background with a red square.
8. Verify that you see the following messages in the log.
```
[INFO]   TiKotlinModule: (main) [0,106] @@@ Java8Interface.printMessage1() called.
[INFO]   Java8: (main) [0,106] @@@ Java8Interface.printMessage2() called.
[INFO]   ExampleProxy: (main) [3,109] @@@ Example creation property 'message' set to: Creating an example Proxy
[INFO]   ExampleProxy: (main) [0,109] @@@ Example.printMessage() called: Hello world!
[INFO]   ExampleProxy: (main) [0,109] @@@ Example.setMessage() called: Hi world!.  It's me again.
[INFO]   ExampleProxy: (main) [0,109] @@@ Example.printMessage() called: Hello world!
```
