### PR TITLE
chore: extend get/set property method removal from 9.0.0 to 10.0.0

### DIFF
--- a/android/kroll-apt/src/main/resources/org/appcelerator/kroll/annotations/generator/ProxyBindingV8.cpp.fm
+++ b/android/kroll-apt/src/main/resources/org/appcelerator/kroll/annotations/generator/ProxyBindingV8.cpp.fm
@@ -273,10 +273,10 @@ void ${className}::${method.apiName}(const FunctionCallbackInfo<Value>& args)
 
 	<#if method.args?size == 0 && name[0..2] == "get" && isDynamic>
 		<#assign propertyName = name[3]?lower_case + name[4..]>
-	LOGW(TAG, "Automatic getter methods for properties are deprecated in SDK 8.0.0 and will be removed in SDK 9.0.0. Please access the property in standard JS style: obj.${propertyName}; or obj['${propertyName}'];");
+	LOGW(TAG, "Automatic getter methods for properties are deprecated in SDK 8.0.0 and will be removed in SDK 10.0.0. Please access the property in standard JS style: obj.${propertyName}; or obj['${propertyName}'];");
 	<#elseif method.args?size == 1 && name[0..2] == "set" && isDynamic>
 		<#assign propertyName = name[3]?lower_case + name[4..]>
-	LOGW(TAG, "Automatic setter methods for properties are deprecated in SDK 8.0.0 and will be removed in SDK 9.0.0. Please modify the property in standard JS style: obj.${propertyName} = value; or obj['${propertyName}'] = value;");
+	LOGW(TAG, "Automatic setter methods for properties are deprecated in SDK 8.0.0 and will be removed in SDK 10.0.0. Please modify the property in standard JS style: obj.${propertyName} = value; or obj['${propertyName}'] = value;");
 	</#if>
 
 	jobject javaProxy = proxy->getJavaObject();

--- a/android/runtime/v8/src/native/Proxy.cpp
+++ b/android/runtime/v8/src/native/Proxy.cpp
@@ -124,7 +124,7 @@ void Proxy::getProperty(const FunctionCallbackInfo<Value>& args)
 
 	// Spit out deprecation notice to use normal property getter
 	v8::String::Utf8Value propertyKey(isolate, name);
-	LOGW(TAG, "Automatic getter methods for properties are deprecated in SDK 8.0.0 and will be removed in SDK 9.0.0. Please access the property in standard JS style: obj.%s; or obj['%s'];", *propertyKey, *propertyKey);
+	LOGW(TAG, "Automatic getter methods for properties are deprecated in SDK 8.0.0 and will be removed in SDK 10.0.0. Please access the property in standard JS style: obj.%s; or obj['%s'];", *propertyKey, *propertyKey);
 
 	args.GetReturnValue().Set(getPropertyForProxy(isolate, name, args.Holder()));
 }
@@ -213,7 +213,7 @@ void Proxy::onPropertyChanged(const v8::FunctionCallbackInfo<v8::Value>& args)
 	Local<Name> name = args.Data().As<Name>();
 	// Spit out deprecation notice to use normal property setter, not setX() style method.
 	v8::String::Utf8Value propertyKey(isolate, name);
-	LOGW(TAG, "Automatic setter methods for properties are deprecated in SDK 8.0.0 and will be removed in SDK 9.0.0. Please modify the property in standard JS style: obj.%s = value; or obj['%s'] = value;", *propertyKey, *propertyKey);
+	LOGW(TAG, "Automatic setter methods for properties are deprecated in SDK 8.0.0 and will be removed in SDK 10.0.0. Please modify the property in standard JS style: obj.%s = value; or obj['%s'] = value;", *propertyKey, *propertyKey);
 
 	Local<Value> value = args[0];
 	Local<Context> context = isolate->GetCurrentContext();

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/ObjcProxy.h
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/ObjcProxy.h
@@ -8,7 +8,7 @@
 #import <JavaScriptCore/JavaScriptCore.h>
 #import <pthread.h>
 
-// Macros to make life easier for defining properties with getters/setter accessor methods (which we'll remove in SDK 9.0.0
+// Macros to make life easier for defining properties with getters/setter accessor methods (which we'll remove in SDK 10.0.0
 
 // Defines a setProp() accessor method in JS-world that points to setterProp:(TYPE)value in native code
 #define SETTER(TYPE, NAME) JSExportAs(set##NAME, -(void)setter##NAME \

--- a/iphone/TitaniumKit/TitaniumKit/Sources/Kroll/KrollMethod.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/Kroll/KrollMethod.m
@@ -229,7 +229,7 @@ JSValueRef KrollCallAsNamedFunction(JSContextRef jsContext, JSObjectRef func, JS
     // This is the code path followed for delegating access for soemthing like
     // Ti.UI.Label#setText(). Which delegates through TiProxy.m TiProxyDelegate code
     // Other code path is handled in KrollObject.m
-    DebugLog(@"[WARN] Automatic setter methods for properties are deprecated in SDK 8.0.0 and will be removed in SDK 9.0.0. Please modify the property in standard JS style: obj.%@ = value; or obj['%@'] = value;", name, name);
+    DebugLog(@"[WARN] Automatic setter methods for properties are deprecated in SDK 8.0.0 and will be removed in SDK 10.0.0. Please modify the property in standard JS style: obj.%@ = value; or obj['%@'] = value;", name, name);
     id newValue = [KrollObject nonNull:[args objectAtIndex:0]];
     [self updateJSObjectWithValue:newValue forKey:name];
     [target setValue:newValue forKey:name];
@@ -241,7 +241,7 @@ JSValueRef KrollCallAsNamedFunction(JSContextRef jsContext, JSObjectRef func, JS
     // This is the code path followed for delegating access for something like
     // Ti.UI.Label#getText(). Which delegates through TiProxy.m TiProxyDelegate code
     // Other code path is handled in KrollObject.m
-    DebugLog(@"[WARN] Automatic getter methods for properties are in SDK 8.0.0 and will be removed in SDK 9.0.0. Please access the property in standard JS style: obj.%@ or obj['%@']", name, name);
+    DebugLog(@"[WARN] Automatic getter methods for properties are deprecated in SDK 8.0.0 and will be removed in SDK 10.0.0. Please access the property in standard JS style: obj.%@ or obj['%@']", name, name);
     // hold, see below
     id result = [target valueForKey:name];
     [self updateJSObjectWithValue:result forKey:name];

--- a/iphone/TitaniumKit/TitaniumKit/Sources/Kroll/KrollObject.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/Kroll/KrollObject.m
@@ -580,7 +580,7 @@ bool KrollHasInstance(JSContextRef ctx, JSObjectRef constructor, JSValueRef poss
         if ([target respondsToSelector:NSSelectorFromString(propertyKey)]) {
           // This is the code path for delegating something like Ti.Filesystem.File#setHidden(), see KrollMethod for other cases (when type is KrollMethodPropertySetter, the last option in this if block below)
           // Spit out a deprecation warning to use normal property setter!
-          DebugLog(@"[WARN] Automatic setter methods for properties are deprecated in SDK 8.0.0 and will be removed in SDK 9.0.0. Please modify the property in standard JS style: obj.%@ = value; or obj['%@'] = value;", propertyKey, propertyKey);
+          DebugLog(@"[WARN] Automatic setter methods for properties are deprecated in SDK 8.0.0 and will be removed in SDK 10.0.0. Please modify the property in standard JS style: obj.%@ = value; or obj['%@'] = value;", propertyKey, propertyKey);
         }
         [result setSelector:selector];
       } else {
@@ -619,7 +619,7 @@ bool KrollHasInstance(JSContextRef ctx, JSObjectRef constructor, JSValueRef poss
     if ([target respondsToSelector:selector]) {
       // Spit out a deprecation warning to use normal property accessor!
       // This is the code path for delegating something like Ti.Filesystem.File#getHidden(), see KrollMethod for other cases (when type is KrollMethodPropertyGetter, the last option in this if block below)
-      DebugLog(@"[WARN] Automatic getter methods for properties are in SDK 8.0.0 and will be removed in SDK 9.0.0. Please access the property in standard JS style: obj.%@ or obj['%@']", partkey, partkey);
+      DebugLog(@"[WARN] Automatic getter methods for properties are deprecated in SDK 8.0.0 and will be removed in SDK 10.0.0. Please access the property in standard JS style: obj.%@ or obj['%@']", partkey, partkey);
       [result setSelector:selector];
       [result setType:KrollMethodGetter];
       return [result autorelease];


### PR DESCRIPTION
**JIRA:**
https://jira.appcelerator.org/browse/TIMOB-27740

---
**Test:**
1. Build and run the below code on Android.
2. In the log, verify you see 4 deprecation warnings stating these APIs will be removed in Titanium 10.0.0, not 9.0.0.
3. Build and run on iOS.
4. In the log, verify you see 4 deprecation warnings stating these APIs will be removed in Titanium 10.0.0, not 9.0.0.

---
Android log output...
```
[WARN]  Proxy: Automatic setter methods for properties are deprecated in SDK 8.0.0 and will be removed in SDK 10.0.0. Please modify the property in standard JS style: obj.text = value; or obj['text'] = value;
[WARN]  Proxy: Automatic getter methods for properties are deprecated in SDK 8.0.0 and will be removed in SDK 10.0.0. Please access the property in standard JS style: obj.text; or obj['text'];
[WARN]  AppModule: Automatic getter methods for properties are deprecated in SDK 8.0.0 and will be removed in SDK 10.0.0. Please access the property in standard JS style: obj.proximityDetection; or obj['proximityDetection'];
[WARN]  AppModule: Automatic setter methods for properties are deprecated in SDK 8.0.0 and will be removed in SDK 10.0.0. Please modify the property in standard JS style: obj.proximityDetection = value; or obj['proximityDetection'] = value;
```

iOS log output...
```
[WARN]  Automatic setter methods for properties are deprecated in SDK 8.0.0 and will be removed in SDK 10.0.0. Please modify the property in standard JS style: obj.text = value; or obj['text'] = value;
[WARN]  Automatic getter methods for properties are deprecated in SDK 8.0.0 and will be removed in SDK 10.0.0. Please access the property in standard JS style: obj.text or obj['text']
[WARN]  Automatic getter methods for properties are deprecated in SDK 8.0.0 and will be removed in SDK 10.0.0. Please access the property in standard JS style: obj.proximityDetection or obj['proximityDetection']
[WARN]  Automatic setter methods for properties are deprecated in SDK 8.0.0 and will be removed in SDK 10.0.0. Please modify the property in standard JS style: obj.proximityDetection = value; or obj['proximityDetection'] = value;
```

app.js
```javascript
var window = Ti.UI.createWindow();
var label = Ti.UI.createLabel();
label.setText("Hello World");  // <- Deprecated
label.getText();  // <- Deprecated
window.add(label);
window.open();

Ti.App.getProximityDetection();  // <- Deprecated
Ti.App.setProximityDetection(false);  // <- Deprecated
```
