### PR TITLE
fix(android): strip xmlns definitions from child elements in AndroidManifest.xml

### DIFF
--- a/android/cli/lib/android-manifest.js
+++ b/android/cli/lib/android-manifest.js
@@ -75,8 +75,8 @@ class AndroidManifest {
 			let startReplaceIndex = text.indexOf('<manifest');
 			if (startReplaceIndex >= 0) {
 				startReplaceIndex = text.indexOf('>', startReplaceIndex);
-				text = text.replace(/xmlns:android=".*?"/g, (match, p1) => {
-					return (p1 <= startReplaceIndex) ? match : '';
+				text = text.replace(/\sxmlns:android=".*?"/g, (match, offset) => {
+					return (offset <= startReplaceIndex) ? match : '';
 				});
 			}
 		}
@@ -651,8 +651,8 @@ class AndroidManifest {
 			// Remove "xmlns:android" namespace attributes from all child elements. Only supported in <manifest/>.
 			// Note: CLI used to wrongly inject these after updating "tiapp.xml" if missing from root element.
 			const manifestEndIndex = text.indexOf('>', manifestIndex);
-			text = text.replace(/xmlns:android=".*?"/g, (match, p1) => {
-				return (p1 <= manifestEndIndex) ? match : '';
+			text = text.replace(/\sxmlns:android=".*?"/g, (match, offset) => {
+				return (offset <= manifestEndIndex) ? match : '';
 			});
 		}
 

--- a/android/cli/lib/android-manifest.js
+++ b/android/cli/lib/android-manifest.js
@@ -67,7 +67,18 @@ class AndroidManifest {
 	toString() {
 		let text = '<?xml version="1.0" encoding="utf-8"?>' + os.EOL;
 		if (this._xmlDomDocument && this._xmlDomDocument.documentElement) {
+			// Write XML content to string.
 			text += this._xmlDomDocument.documentElement + os.EOL;
+
+			// Remove all "xmlns:android=<url>"" namespace definitions from child elements.
+			// Google only allows it in root <manifest/> element or else a build/validation error will occur.
+			let startReplaceIndex = text.indexOf('<manifest');
+			if (startReplaceIndex >= 0) {
+				startReplaceIndex = text.indexOf('>', startReplaceIndex);
+				text = text.replace(/xmlns:android=".*?"/g, (match, p1) => {
+					return (p1 <= startReplaceIndex) ? match : '';
+				});
+			}
 		}
 		return text;
 	}


### PR DESCRIPTION
**JIRA:**
https://jira.appcelerator.org/browse/TIMOB-27746

**Note:**
The damage has already been done to the 9.0.0 built modules "ti.map" and "ti.playservices" since this issue is already in their "AndroidManfiest.xml" files packaged within their AARs. We will need to rebuild the ticket's listed modules after merging this PR.
