### PR TITLE
docs: fix global methods and properties

### DIFF
--- a/apidoc/Global/Console/Console.yml
+++ b/apidoc/Global/Console/Console.yml
@@ -1,5 +1,5 @@
 ---
-name: Global.console
+name: Console
 summary: Console logging facilities.
 description: |
     The toplevel `console` support is intended to supplement <Titanium.API>
@@ -88,7 +88,7 @@ methods:
   - name: timeEnd
     summary: Stop a timer that was previously started.
     description: |
-          Stop a timer that was started by calling [console.time](Global.console.time), and
+          Stop a timer that was started by calling [console.time](Console.time), and
           output the time since the timer was begun to the console in milliseconds.
           If no timer exists a warning will be logged to the console.
     parameters:
@@ -103,7 +103,7 @@ methods:
     summary: Log duration taken so far for an operation.
     description: |
           Output the time since a timer was started by calling
-          [console.time](Global.console.time) to the console, as well as any
+          [console.time](Console.time) to the console, as well as any
           other `data` arguments provided. To log extra data a label must
           be provided. If no timer exists a warning will be logged to the
           console.

--- a/apidoc/Global/Global.yml
+++ b/apidoc/Global/Global.yml
@@ -65,6 +65,7 @@ methods:
       - name: timerId
         summary: Unique timer identifier returned by [setInterval](Global.setInterval).
         type: Number
+        optional: true
 
   - name: clearTimeout
     summary: Cancels a one-time timer.
@@ -72,6 +73,7 @@ methods:
       - name: timerId
         summary: Unique timer identifier returned by [setTimeout](Global.setTimeout).
         type: Number
+        optional: true
 
   - name: decodeURIComponent
     summary: |
@@ -240,6 +242,7 @@ methods:
       - name: delay
         summary: Time in milliseconds to wait between calls to function.
         type: Number
+        optional: true
     examples:
       - title: Update a label once every second, and stop at 10 seconds
         example: |
@@ -275,6 +278,7 @@ methods:
       - name: delay
         summary: Time in milliseconds to wait before the function is called.
         type: Number
+        optional: true
     examples:
       - title: Execute a function in 500 milliseconds
         example: |

--- a/apidoc/Global/Global.yml
+++ b/apidoc/Global/Global.yml
@@ -282,3 +282,17 @@ methods:
                 setTimeout(function(){
                     Ti.API.debug('Called using setTimeout');
                 }, 500);
+
+
+properties:
+  - name: console
+    summary: Console logging facilities.
+    type: Console
+    accessors: false
+
+  - name: JSON
+    summary: |
+        An intrinsic object that provides functions to convert JavaScript values to and from
+        the JavaScript Object Notation (JSON) format.
+    type: JSON
+    accessors: false

--- a/apidoc/Global/JSON/JSON.yml
+++ b/apidoc/Global/JSON/JSON.yml
@@ -1,8 +1,8 @@
 # JSON module doc adapted from Public Domain json2 reference implementation by Douglas Crockford
 # https://github.com/douglascrockford/JSON-js
 ---
-name: Global.JSON
-summary: Global JSON object providing the [parse](Global.JSON.parse) and [stringify](Global.JSON.stringify) methods.
+name: JSON
+summary: Global JSON object providing the [parse](JSON.parse) and [stringify](JSON.stringify) methods.
 platforms: [android, iphone, ipad]
 methods:
 


### PR DESCRIPTION
In this PR:
 - `Console` and `JSON` describe interfaces, whereas `console` and `JSON` (yeah, same name) are properties of the global object (this will allow to define them in the same way as in TypeScript's [lib.dom.d.ts](https://github.com/microsoft/TypeScript/blob/master/lib/lib.dom.d.ts)).
 - second parameter of `setTimeout`, `setInterval` and first parameter of `clearTimeout`, `clearInterval` were made optional.

Also worth to mention, that parameters of `console` methods (`log`/`error` etc.) actually are "varargs", but there is no (established) way to describe this in docs.