### PR TITLE
feat: update hyperloop for 9.0.0 and gradle

### DIFF
--- a/support/module/packaged/modules.json
+++ b/support/module/packaged/modules.json
@@ -63,8 +63,8 @@
 	},
 	"hyperloop": {
 		"hyperloop": {
-			"url": "https://github.com/appcelerator-modules/hyperloop-builds/releases/download/v4.0.4/hyperloop-4.0.4.zip",
-			"integrity": "sha512-CMUMC9+d8QIr+m9qeWfEk49cIfoR5YVBQHsyvgsXvSA6sQY9VjIKu6oG5rjjPCSfQVDe87Qi8fYXTmtaPRHEXg=="
+			"url": "https://github.com/appcelerator-modules/hyperloop-builds/releases/download/v5.0.0/hyperloop-5.0.0.zip",
+			"integrity": "sha512-uG+/v6Yym7dT/EZ4Y0fMm8S76D59XbCG/96y18s2F4y4KvcWjoI70KiecoL1DZEn3IaCy/V99bASPIUpadATxA=="
 		}
 	}
 }


### PR DESCRIPTION
**JIRA:**
- https://jira.appcelerator.org/browse/TIMOB-27685
- https://jira.appcelerator.org/browse/TIMOB-27298
- https://jira.appcelerator.org/browse/TIMOB-27297

**Windows Notes:**
- No longer supports Windows apps.

**Android Notes:**
- [TIMOB-27685](https://jira.appcelerator.org/browse/TIMOB-27685) Updated hyperloop for Titanium 9.0.0 and gradle.
- [TIMOB-27298](https://jira.appcelerator.org/browse/TIMOB-27298) Fixed bug where you could not access a Java inner class from an inner class.
- [TIMOB-27297](https://jira.appcelerator.org/browse/TIMOB-27297) Added support for accessing Titanium library's Java classes.
- Added `x86_64` architecture support.
- Added support for optional `./platform/android/build.gradle` file in app project.
  * Intended to provide additional dependencies to hyperloop.
  * JAR/AAR libraries in this directory are still supported.
- Hyperloop app build times are now 2-3x faster.

---
**Android Benchmarks:**
Performed with [hyperloop-example](https://github.com/appcelerator/hyperloop-examples) between Titanium 8.3.0 and 9.0.0.
```
Non-encrypted emulator builds:
- Clean Build: 47s -> 30s  (1.6x faster)
- Incremental: 21s -> 12s  (1.8x faster)

Encrypted device/production builds:
- Clean Build: 98s -> 31s  (3.2x faster)
- Incremental: 41s -> 19s  (2.2x faster)

JS proxy files generated: 1406
```

---
**Android Testing:**
You'll need to use the updated hyperloop-example project from the PR below when testing with Titanium 9.0.0 and Android. The example project needed to be updated for AndroidX. You can no longer reference Google Support library Java classes.
https://github.com/appcelerator/hyperloop-examples/pull/84

