### PR TITLE
feat(android): exclude x86/x86_64 in production builds by default

### DIFF
--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -1200,6 +1200,13 @@ AndroidBuilder.prototype.validate = function validate(logger, config, cli) {
 	// determine the abis to support
 	this.abis = this.validABIs;
 	const customABIs = cli.tiapp.android && cli.tiapp.android.abi && cli.tiapp.android.abi.indexOf('all') === -1;
+	if (!customABIs && (this.deployType === 'production')) {
+		// If "tiapp.xml" does not have <abi/> entry, then exclude "x86" and "x86_64" from production builds by default.
+		// These abis are mostly needed for testing in an emulator. Physical x86 devices are extremely rare.
+		this.abis = this.abis.filter(abi => {
+			return !abi.startsWith('x86');
+		});
+	}
 	if (customABIs) {
 		this.abis = cli.tiapp.android.abi;
 		this.abis.forEach(function (abi) {


### PR DESCRIPTION
**JIRA:**
https://jira.appcelerator.org/browse/TIMOB-27752

**Summary:**
- When doing a "production" build, Titanium should exclude `x86` and `x86_64` architectures from app by default.
- You can override this behavior via `<abi/>` setting in "tiapp.xml".
- This maintains the same behavior we had since Titanium 7.0.0.

**Test:**
1. Build an app for Android depoyment type "development" or "test".
2. Go to folder: `./build/android/app/build/outputs/apk/debug`
3. Unzip the APK file.
4. Verify that you see the following unzipped sub-folders:
  * `./lib/armeabi-v7a`
  * `./lib/arm64-v8a`
  * `./lib/x86`
  * `./lib/x86_64`
5. Build an Android "production" app.
6. Unzip the APK.
7. Verify that you see the following unzipped sub-folders:
  * `./lib/armeabi-v7a`
  * `./lib/arm64-v8a`
8. Add the below `<abi/>` entry to the "tiapp.xml" file.
```xml
<ti:app xmlns:ti="http://ti.appcelerator.org">
	<android>
		<abi>armeabi-v7a,arm64-v8a,x86,x86_64</abi>
	</android>
</ti:app>
```
9. Build an Android "production" app.
10. Unzip the APK.
11. Verify that you see the following unzipped sub-folders:
  * `./lib/armeabi-v7a`
  * `./lib/arm64-v8a`
  * `./lib/x86`
  * `./lib/x86_64`
