### PR TITLE
docs: add "repeatable" property on methods parameters

### DIFF
--- a/apidoc/Global/Console/Console.yml
+++ b/apidoc/Global/Console/Console.yml
@@ -25,6 +25,7 @@ methods:
       - name: message
         summary: The message(s) to log.
         type: Object
+        repeatable: true
 
   - name: info
     summary: Log a message at the `info` level.
@@ -36,6 +37,7 @@ methods:
       - name: message
         summary: The message(s) to log.
         type: Object
+        repeatable: true
 
   - name: warn
     summary: Log a message at the `warn` level.
@@ -47,6 +49,7 @@ methods:
       - name: message
         summary: The message(s) to log.
         type: Object
+        repeatable: true
             
   - name: error
     summary: Log a message at the `error` level.
@@ -58,6 +61,7 @@ methods:
       - name: message
         summary: The message(s) to log.
         type: Object
+        repeatable: true
         
   - name: debug
     summary: Log a message at the `debug` level.
@@ -69,6 +73,7 @@ methods:
       - name: message
         summary: The message(s) to log.
         type: Object
+        repeatable: true
 
   - name: time
     summary: Start a timer to track duration of an operation.
@@ -117,4 +122,5 @@ methods:
         summary: Extra log data to be provided when logging, can be a single argument or any number of arguments.
         type: Object
         optional: true
+        repeatable: true
     since: 7.5.0

--- a/apidoc/Titanium/Database/DB.yml
+++ b/apidoc/Titanium/Database/DB.yml
@@ -29,6 +29,7 @@ methods:
           to be substituted with the respective `?` placeholder of the query.
         type: [String, Array<String>, Object, Array<Object>]
         optional: true
+        repeatable: true
     examples:
     - title: Executing a Query
       example: |

--- a/apidoc/Titanium/Filesystem/Filesystem.yml
+++ b/apidoc/Titanium/Filesystem/Filesystem.yml
@@ -69,6 +69,7 @@ methods:
         summary: One or more path components. Path arguments are joined together using
             the platform specific path separator to form the full path.
         type: [String, Array<String>]
+        repeatable: true
 
   - name: getAsset
     summary: Returns a `Blob` object representing the asset catalog image identified by the path
@@ -104,6 +105,7 @@ methods:
         summary: One or more path components. Path arguments are joined together using
             the platform specific path separator to form the full path.
         type: String
+        repeatable: true
     platforms: [iphone, ipad]
     osver: {ios: {min: "9.0"}}
     since: "5.4.0"


### PR DESCRIPTION
https://github.com/appcelerator/titanium_mobile/pull/11464#issuecomment-583501478

The only method I known that still has undocumented "vararg" is `Ti.Database.DB.executeAsync`.