### PR TITLE
(9_0_X) fix(ios): usernotificationsettings event missing success property

### DIFF
--- a/iphone/Classes/TiAppiOSProxy.m
+++ b/iphone/Classes/TiAppiOSProxy.m
@@ -465,18 +465,20 @@
                                                                         }
 
                                                                         if ([self _hasListeners:@"usernotificationsettings"]) {
-                                                                          NSMutableDictionary *event = [NSMutableDictionary dictionaryWithDictionary:@{ @"success" : NUMBOOL(granted) }];
-
                                                                           if (error) {
-                                                                            [event setValue:[error localizedDescription] forKey:@"error"];
-                                                                            [event setValue:NUMINTEGER([error code]) forKey:@"code"];
-                                                                            [self fireEvent:@"usernotificationsettings" withObject:event];
+                                                                            [self fireEvent:@"usernotificationsettings"
+                                                                                 withObject:@{
+                                                                                   @"success" : NUMBOOL(granted),
+                                                                                   @"error" : [error localizedDescription],
+                                                                                   @"code" : NUMINTEGER([error code])
+                                                                                 }];
                                                                           } else {
                                                                             [[UNUserNotificationCenter currentNotificationCenter] getNotificationSettingsWithCompletionHandler:^(UNNotificationSettings *_Nonnull settings) {
                                                                               // Assign the granted types
-                                                                              [event setDictionary:[self formatUserNotificationSettings:settings]];
+                                                                              NSMutableDictionary *event = [[self formatUserNotificationSettings:settings] mutableCopy];
+                                                                              [event setValue:NUMBOOL(granted) forKey:@"success"];
                                                                               // Assign the granted categories
-                                                                              [event setValue:categories forKey:@"categories"];
+                                                                              [event setValue:((categories != nil) ? categories : @{}) forKey:@"categories"];
                                                                               [self fireEvent:@"usernotificationsettings" withObject:event];
                                                                             }];
                                                                           }


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-27763

**Optional Description:**
After calling `Ti.App.iOS.registerUserNotificationSettings()`, the `usernotificationsettings` event should be fired with a `success` property indicating whether notifications were granted. It was being set but later wiped before being fired to the listeners.

Test code:
```js
var win = Ti.UI.createWindow({
	backgroundColor : 'white',
	layout : 'vertical',
	exitOnClose : true
});
 
var subscribeBtn = Ti.UI.createButton({
	title : 'Subscribe',
	top : 50,
});

// Retrieve Device token
let deviceToken = null;

function registerForPush(e) {
	console.log(e);
	if (e.success) {
	  Ti.Network.registerForPushNotifications({
		success: deviceTokenSuccess,
		error: deviceTokenError,
		callback: receivePush
	  });
	  // Remove event listener once registered for push notifications
	  Ti.App.iOS.removeEventListener('usernotificationsettings', registerForPush);
	} else {
	  alert('Error registering for user notification settings, user likely denied notifications:\n' + ((e.error && e.message) || JSON.stringify(e)));
	}
};

// Wait for user settings to be registered before registering for push notifications
Ti.App.iOS.addEventListener('usernotificationsettings', registerForPush);

// Register notification types to use
Ti.App.iOS.registerUserNotificationSettings({
	types : [Ti.App.iOS.USER_NOTIFICATION_TYPE_ALERT, Ti.App.iOS.USER_NOTIFICATION_TYPE_SOUND, Ti.App.iOS.USER_NOTIFICATION_TYPE_BADGE]
});

 
// Process incoming push notifications
function receivePush(e) {
	alert('Received push: ' + JSON.stringify(e));
}
 
// Save the device token for subsequent API calls
function deviceTokenSuccess(e) {
	deviceToken = e.deviceToken;
	alert('success cb ' + JSON.stringify(e));
}
 
function deviceTokenError(e) {
	alert('Failed to register for push notifications! ' + e.error);
}
```

Just start the app and you'll get prompted to allow or disallow notifications. In either case, the event was being fired without the success property before this PR. (And also the `categories` property may not exist if the value was supposed to be an empty array. I fixed it to always be set in non-error cases to an array - empty or not)