### PR TITLE
feat(android): module build should add empty "build.gradle" if missing

### DIFF
--- a/android/cli/commands/_buildModule.js
+++ b/android/cli/commands/_buildModule.js
@@ -305,8 +305,8 @@ AndroidModuleBuilder.prototype.run = async function run(logger, config, cli, fin
 			cli.emit('build.module.pre.compile', this, resolve);
 		});
 
-		// If this is a "hybrid" module (has native and JS code), then make sure "manifest" is flagged as "commonjs".
-		await this.updateModuleManifest();
+		// Update module files such as "manifest" if needed.
+		await this.updateModuleFiles();
 
 		// Generate all gradle project files.
 		await this.generateRootProjectFiles();
@@ -459,7 +459,17 @@ AndroidModuleBuilder.prototype.cleanup = async function cleanup() {
 	}
 };
 
-AndroidModuleBuilder.prototype.updateModuleManifest = async function updateModuleManifest() {
+AndroidModuleBuilder.prototype.updateModuleFiles = async function updateModuleFiles() {
+	// Add empty "build.gradle" template file to project folder if missing. Used to define library dependencies.
+	// Note: Appcelerator Studio looks for this file to determine if this is an Android module project.
+	const buildGradleFileName = 'build.gradle';
+	const buildGradleFilePath = path.join(this.projectDir, buildGradleFileName);
+	if (!await fs.exists(buildGradleFilePath)) {
+		await fs.copyFile(
+			path.join(this.platformPath, 'templates', 'module', 'default', 'template', 'android', buildGradleFileName),
+			buildGradleFilePath);
+	}
+
 	// Determine if "assets" directory contains at least 1 JavaScript file.
 	let hasJSFile = false;
 	if (await fs.exists(this.assetsDir)) {

--- a/android/templates/module/default/template/android/build.gradle
+++ b/android/templates/module/default/template/android/build.gradle
@@ -1,9 +1,4 @@
 
-repositories {
-	google()
-	jcenter()
-}
-
 dependencies {
 	// Add the module's library dependencies here.
 	// See:  https://developer.android.com/studio/build/dependencies


### PR DESCRIPTION
**JIRA:**
https://jira.appcelerator.org/browse/TIMOB-27770

**Summary:**
When building module with Titanium 9.0.0 and higher, module template's empty "build.gradle" file should be copied to project if missing. Reasons...
- Compel devs to use it for library dependencies when migrating module to 9.0.0.
- Appcelerator Studio needs a "clue" to identify folder as an Android project to resolve [TISTUD-9204](https://jira.appcelerator.org/browse/TISTUD-9204). Will fail to build/package module without it.

**Test:**
1. Download a zip of [ti.imagefactory](https://github.com/appcelerator-modules/ti.imagefactory).
2. Unzip the module.
3. Open the "Terminal" and `CD` to: `./ti.imagefactory/android`
4. Notice that there is no `build.gradle` file in this directory. _(This is okay for now.)_
5. In Terminal, enter: `appc run -p android`
6. Verify module builds and example project runs in emulator successfully.
7. Verify a `build.gradle` file was add to directory `./ti.imagefactory/android`.
8. Open `build.gradle` file and add a code comment such as: `// This is a test.`
9. In Terminal, enter: `appc run -p android --build-only`
10. Open `build.gradle` file and verify comment is still there. _(ie: Verify file was not overwritten.)_
