### PR TITLE
fix(android): hyperloop build fails if NDK not installed

### DIFF
--- a/support/module/packaged/modules.json
+++ b/support/module/packaged/modules.json
@@ -63,8 +63,8 @@
 	},
 	"hyperloop": {
 		"hyperloop": {
-			"url": "https://github.com/appcelerator-modules/hyperloop-builds/releases/download/v5.0.0/hyperloop-5.0.0.zip",
-			"integrity": "sha512-uG+/v6Yym7dT/EZ4Y0fMm8S76D59XbCG/96y18s2F4y4KvcWjoI70KiecoL1DZEn3IaCy/V99bASPIUpadATxA=="
+			"url": "https://github.com/appcelerator-modules/hyperloop-builds/releases/download/v5.0.1/hyperloop-5.0.1.zip",
+			"integrity": "sha512-eXrt/lCD77PRhkvJzhcezVeeoq7PGFjOa4FnkF+59Vc4F416vf1uGq+NTMqnl/+oUiHaTmuB8pxfZ+2AC/TN7A=="
 		}
 	}
 }


### PR DESCRIPTION
**JIRA:**
https://jira.appcelerator.org/browse/TIMOB-27771

**Test:**
1. Use a machine that does not have the Android NDK set up or configured.
2. Download the [hyperloop-examples](https://github.com/appcelerator/hyperloop-examples) project.
3. Update "tiapp.xml" hyperloop module version to `5.0.1`.
4. Build and run on Android.
5. Verify it builds and runs successfully. _(It used to fail to build.)_
