### PR TITLE
docs: fix Attribute.value

### DIFF
--- a/apidoc/Titanium/UI/Attribute.yml
+++ b/apidoc/Titanium/UI/Attribute.yml
@@ -112,7 +112,7 @@ properties:
           * <Titanium.UI.ATTRIBUTE_LINE_BREAK_BY_TRUNCATING_MIDDLE>
 
         These can also be combined the same way as the underline styles.
-    type: Number
+    type: [String, Number]
     constants: [ Titanium.UI.ATTRIBUTE_UNDERLINE_STYLE_*,
                  Titanium.UI.ATTRIBUTE_WRITING_DIRECTION_*,
                  Titanium.UI.ATTRIBUTE_LETTERPRESS_STYLE ]


### PR DESCRIPTION
Attribute.value is optional:
```javascript
var text =  'Bacon ipsum dolor Appcelerator Titanium rocks! sit amet fatback leberkas salami sausage tongue strip steak.';

var attr = Titanium.UI.createAttributedString({
    text: text
});

// Underlines text
attr.addAttribute({
    type: Titanium.UI.ATTRIBUTE_UNDERLINES_STYLE,
    range: [0, text.length]
});
```

Atttibute.value can be of `string` type:
```javascript
// Sets a background color
{
    type: Titanium.UI.ATTRIBUTE_BACKGROUND_COLOR,
    value: "red",
    range: [text.indexOf('Appcelerator'), ('Appcelerator').length]
},
```

Examples from `apidoc/Titanium/UI/AttributedString.yml`