### PR TITLE
docs: fix keyboardToolbar property type

### DIFF
--- a/apidoc/Titanium/UI/TextArea.yml
+++ b/apidoc/Titanium/UI/TextArea.yml
@@ -338,7 +338,7 @@ properties:
         once, developers desiring textAreas or [textFields](Titanium.UI.TextField) to share a toolbar
         can instead use a single [toolbar](Titanium.UI.iOS.Toolbar) instead of having arrays sharing
         toolbar buttons.
-    type: [Array<Titanium.UI.View>, Titanium.UI.iOS.Toolbar]
+    type: [Array<Titanium.UI.View>, Titanium.UI.Toolbar, Titanium.UI.iOS.Toolbar]
     platforms: [iphone, ipad]
 
   - name: keyboardToolbarColor

--- a/apidoc/Titanium/UI/TextField.yml
+++ b/apidoc/Titanium/UI/TextField.yml
@@ -367,7 +367,7 @@ properties:
                     </KeyboardToolbar>
                 </TextField>
             </Alloy>
-    type: [Array<Titanium.UI.View>, Titanium.UI.iOS.Toolbar]
+    type: [Array<Titanium.UI.View>, Titanium.UI.Toolbar, Titanium.UI.iOS.Toolbar]
     platforms: [iphone, ipad]
 
   - name: keyboardToolbarColor


### PR DESCRIPTION
`Titanium.UI.iOS.Toolbar` is deprecated.
For the example below alloy  will generate `Ti.UI.Toolbar`.

https://github.com/appcelerator/alloy/blob/05622deff9b43bf4082c841cf8a1d6d4752feab5/test/apps/testing/ALOY-981/views/index.xml#L3-L17