### PR TITLE
feat(android): improve "kroll-apt" incremental build times for SDK

### DIFF
--- a/android/kroll-apt/src/main/java/org/appcelerator/kroll/annotations/generator/KrollBindingGenerator.java
+++ b/android/kroll-apt/src/main/java/org/appcelerator/kroll/annotations/generator/KrollBindingGenerator.java
@@ -47,6 +47,7 @@ public class KrollBindingGenerator
 	private HashMap<String, Object> tiModules = new HashMap<String, Object>();
 
 	private JSONUtils jsonUtils;
+	private boolean canOverwrite = true;
 
 	public KrollBindingGenerator(String outPath, String moduleId)
 	{
@@ -88,15 +89,16 @@ public class KrollBindingGenerator
 		Writer writer = null;
 		try {
 			File file = new File(outPath, outFile);
-			System.out.println("Generating " + file.getAbsolutePath());
-
 			File parent = file.getParentFile();
 			if (!parent.exists()) {
 				parent.mkdirs();
 			}
 
-			writer = new FileWriter(file);
-			template.process(root, writer);
+			if (this.canOverwrite || !file.exists()) {
+				System.out.println("Generating " + file.getAbsolutePath());
+				writer = new FileWriter(file);
+				template.process(root, writer);
+			}
 
 		} catch (Exception e) {
 			e.printStackTrace();
@@ -227,6 +229,16 @@ public class KrollBindingGenerator
 			properties = (Map<Object, Object>) JSONValue.parseWithException(reader);
 		}
 		loadBindingsFrom(properties);
+	}
+
+	public boolean getCanOverwrite()
+	{
+		return this.canOverwrite;
+	}
+
+	public void setCanOverwrite(boolean value)
+	{
+		this.canOverwrite = value;
 	}
 
 	public void loadBindingsFrom(Map<Object, Object> properties)

--- a/android/kroll-apt/src/main/java/org/appcelerator/kroll/annotations/generator/KrollJSONGenerator.java
+++ b/android/kroll-apt/src/main/java/org/appcelerator/kroll/annotations/generator/KrollJSONGenerator.java
@@ -6,6 +6,7 @@
  */
 package org.appcelerator.kroll.annotations.generator;
 
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.FileWriter;
@@ -112,6 +113,7 @@ public class KrollJSONGenerator extends AbstractProcessor
 	protected String jarJsonFileName;
 	protected String jsonFilePath;
 	protected boolean initialized = false;
+	private boolean hasPropertiesChanged = true;
 
 	@Override
 	public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv)
@@ -756,8 +758,14 @@ public class KrollJSONGenerator extends AbstractProcessor
 
 	protected void generateJSON()
 	{
+		// Flag that JSON bindings/properties have changed since last write, unless the below says otherwise.
+		this.hasPropertiesChanged = true;
+
 		// Generate a JSON string from the "properties" dictionary.
 		String jsonString = JSONValue.toJSONString(this.properties);
+		if (jsonString == null) {
+			jsonString = "";
+		}
 
 		// Write a JSON file to the Java project we just read the annotations from.
 		// This will cause the JSON file to be bundled into the project's JAR file.
@@ -777,19 +785,39 @@ public class KrollJSONGenerator extends AbstractProcessor
 
 		// Write a JSON file to the given file system path.
 		if (this.jsonFilePath != null) {
-			FileWriter writer = null;
-			try {
-				File filePath = new File(this.jsonFilePath);
-				filePath.getParentFile().mkdirs();
-				writer = new FileWriter(filePath);
-				writer.write(jsonString);
-			} catch (Exception e) {
-				debug("Exception trying to generate JSON file: %s, %s", this.jsonFilePath, e.getMessage());
-			} finally {
-				if (writer != null) {
-					try {
-						writer.close();
-					} catch (Exception e) {
+			// Determine if bindings have changed by reading last written JSON file, if it exists.
+			try (BufferedReader reader = new BufferedReader(new FileReader(this.jsonFilePath))) {
+				StringBuffer stringBuffer = new StringBuffer(Math.max(jsonString.length(), 32768));
+				char[] charBuffer = new char[2048];
+				while (true) {
+					int readBytes = reader.read(charBuffer, 0, charBuffer.length);
+					if (readBytes <= 0) {
+						break;
+					}
+					stringBuffer.append(charBuffer, 0, readBytes);
+				}
+				if (jsonString.contentEquals(stringBuffer)) {
+					this.hasPropertiesChanged = false;
+				}
+			} catch (Exception ex) {
+			}
+
+			// Write the JSON file if changed.
+			if (this.hasPropertiesChanged) {
+				FileWriter writer = null;
+				try {
+					File filePath = new File(this.jsonFilePath);
+					filePath.getParentFile().mkdirs();
+					writer = new FileWriter(filePath);
+					writer.write(jsonString);
+				} catch (Exception e) {
+					debug("Exception trying to generate JSON file: %s, %s", this.jsonFilePath, e.getMessage());
+				} finally {
+					if (writer != null) {
+						try {
+							writer.close();
+						} catch (Exception e) {
+						}
 					}
 				}
 			}
@@ -819,7 +847,12 @@ public class KrollJSONGenerator extends AbstractProcessor
 			KrollBindingGenerator generator = new KrollBindingGenerator(directoryPath, jsModuleName);
 			generator.loadBindingsFrom(this.properties);
 			if (tiBindingsJsonFilePath != null) {
+				// Load Titanium SDK library's bindings. We only do this for module builds.
 				generator.loadTitaniumBindingsFromJsonFile(tiBindingsJsonFilePath);
+			} else {
+				// Do incremental-like builds by only overwriting last C++ files if bindings have changed.
+				// Only do this for SDK builds. Can't do it for modules since we'd have to track SDK binding changes.
+				generator.setCanOverwrite(this.hasPropertiesChanged);
 			}
 			generator.generateBindings();
 		} catch (Exception ex) {


### PR DESCRIPTION
**JIRA:**
https://jira.appcelerator.org/browse/TIMOB-27794

**Summary:**
Modified "kroll-apt" Java annotation processor to only re-generate C++ files if Java proxy bindings have changed (or if C++ files are missing/cleaned). So, changing the Titanium SDK library's Java code will no longer re-generate proxy C++ classes... unless you add/remove/change a Kroll proxy annotation.

Reduces SDK incremental build times on my machine by about `5` seconds.

**Test:**
This is for @garymathews to test, not QE. His Titanium SDK C++ incremental builds are not working and takes about `1` minute (versus `20` seconds for me).
