### PR TITLE
fix(node): add missing console.trace

### DIFF
--- a/common/Resources/ti.internal/extensions/js/console.js
+++ b/common/Resources/ti.internal/extensions/js/console.js
@@ -87,7 +87,7 @@ class Console {
 			this._apiModule[level](string);
 		} else {
 			// Support Node.JS streams like stdout/stderr which don't have log levels
-			const useStdErr = (level === 'warn' || level === 'error');
+			const useStdErr = (level === 'warn' || level === 'error' || level === 'trace');
 			const stream = useStdErr ? this._stderr : this._stdout;
 
 			if (this._ignoreErrors === false) {

--- a/common/Resources/ti.internal/extensions/js/console.js
+++ b/common/Resources/ti.internal/extensions/js/console.js
@@ -134,6 +134,10 @@ class Console {
 		this._writeToConsole('debug', formatWithOptions(kColorInspectOptions, ...args));
 	}
 
+	trace(...args) {
+		this._writeToConsole('trace', formatWithOptions(kColorInspectOptions, ...args));
+	}
+
 	clear() {} // no-op
 
 	group(...data) {

--- a/tests/Resources/console.test.js
+++ b/tests/Resources/console.test.js
@@ -39,6 +39,10 @@ describe('console', function () {
 		should(console.warn).be.a.Function;
 	});
 
+	it('#trace', () => {
+		should(console.trace).be.a.Function;
+	});
+
 	it('#time', () => {
 		should(console.time).be.a.Function;
 	});
@@ -294,6 +298,7 @@ describe('console', function () {
 			console.dirxml('dirxml'); // stdout
 			console.warn('warn'); // stderr
 			console.error('error'); // stderr
+			console.trace('trace'); // stderr
 			stdout.logs.length.should.eql(3);
 			stdout.logs[0].should.eql('log');
 			stdout.logs[1].should.eql('info');
@@ -301,6 +306,7 @@ describe('console', function () {
 			stderr.logs.length.should.eql(2);
 			stderr.logs[0].should.eql('warn');
 			stderr.logs[1].should.eql('error');
+			stderr.logs[1].should.eql('trace');
 		});
 
 		it('squashes sync errors on stdout write by default (ignoreErrors = true)', () => {


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-27808

Add missing `console.trace` back to the `console` rewrite. Looks like we missed that.

Note that on NodeJS, `trace` does prefix the message with `Trace: ` and captures a stack trace that will also be printed. I didn't add that since we had `trace` in our native `console` implementation which just printed with the `trace` log level. I decided to just fix the regression and not adopt any additional functionality from Node here.