### PR TITLE
fix(android): allow TiDownloadManager to fire fail listener

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiDownloadManager.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiDownloadManager.java
@@ -6,7 +6,6 @@
  */
 package org.appcelerator.titanium.util;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.lang.ref.SoftReference;
 import java.lang.reflect.Constructor;

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiDownloadManager.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiDownloadManager.java
@@ -6,6 +6,7 @@
  */
 package org.appcelerator.titanium.util;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.lang.ref.SoftReference;
 import java.lang.reflect.Constructor;
@@ -88,7 +89,7 @@ public class TiDownloadManager implements Handler.Callback
 	 * <p>
 	 * Returns null if failed to download content or if given an invalid argument.
 	 */
-	public InputStream blockingDownload(final URI uri)
+	public InputStream blockingDownload(final URI uri) throws Exception
 	{
 		// Validate.
 		if (uri == null) {
@@ -146,13 +147,7 @@ public class TiDownloadManager implements Handler.Callback
 
 		// Convert the given URI to a URL object.
 		// Note: This object will validate the string and throw an exception if malformed.
-		URL url = null;
-		try {
-			url = new URL(uri.toString());
-		} catch (Exception ex) {
-			Log.e(TAG, "Failed to parse URL: " + uri.toString(), ex);
-			return null;
-		}
+		URL url = new URL(uri.toString());
 
 		// Attempt to download the file.
 		URLConnection connection = null;
@@ -215,9 +210,6 @@ public class TiDownloadManager implements Handler.Callback
 				}
 				break;
 			}
-		} catch (Exception ex) {
-			// Failed to download file/content.
-			Log.e(TAG, "Failed to download from: " + uri.toString(), ex);
 		} finally {
 			// Close the connection if we don't have a stream to the response body. (Nothing to download.)
 			if ((inputStream == null) && (connection instanceof HttpURLConnection)) {
@@ -356,7 +348,7 @@ public class TiDownloadManager implements Handler.Callback
 
 				// fire a download fail event if we are unable to download
 				sendMessage(uri, MSG_FIRE_DOWNLOAD_FAILED);
-				Log.e(TAG, "Exception downloading from: " + uri, e);
+				Log.e(TAG, "Exception downloading from: " + uri + "\n" + e.getMessage());
 			}
 		}
 	}

--- a/tests/Resources/ti.ui.imageview.addontest.js
+++ b/tests/Resources/ti.ui.imageview.addontest.js
@@ -1,0 +1,55 @@
+/*
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2011-Present by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+/* eslint-env mocha */
+/* eslint no-unused-expressions: "off" */
+'use strict';
+
+describe('Titanium.UI.ImageView', function () {
+	var win;
+	this.timeout(5000);
+
+	afterEach(function (done) {
+		if (win) {
+			// If `win` is already closed, we're done.
+			let t = setTimeout(function () {
+				if (win) {
+					win = null;
+					done();
+				}
+			}, 3000);
+
+			win.addEventListener('close', function listener () {
+				clearTimeout(t);
+
+				if (win) {
+					win.removeEventListener('close', listener);
+				}
+				win = null;
+				done();
+			});
+			win.close();
+		} else {
+			win = null;
+			done();
+		}
+	});
+
+	it('image error event', function (finish) {
+		win = Ti.UI.createWindow();
+
+		const img = Ti.UI.createImageView({
+			image: 'https://invalid.host.com/image.jpg'
+		});
+
+		img.addEventListener('error', () => {
+			finish();
+		});
+
+		win.add(img);
+		win.open();
+	});
+});


### PR DESCRIPTION
- Allow `TiDownloadManager` to fire fail listener, which prevented `error` events for some components

##### TEST CASE
```JS
const win = Ti.UI.createWindow();
const img = Ti.UI.createImageView({
	image: 'https://invalid.host.com/image.jpg'
});

img.addEventListener('error', e => {
	console.error(JSON.stringify(e, null, 4));
});

win.add(img);
win.open();
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-27797)