### PR TITLE
style(java): run incremental checkstyle on git commit

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -38,11 +38,41 @@ android {
 
 // Checks our Java code against our style guidelines and for common coding mistakes using "checkstyle.xml".
 // Will trigger a build failure if any violations have been detected.
-task checkJavaStyle(type: Checkstyle) {
-	source android.sourceSets.main.java.srcDirs
-	include '**/*.java'
+// Customize all the Checkstyle tasks
+tasks.withType(Checkstyle) {
+	// Specify all files that should be checked
 	classpath = files()
+	source android.sourceSets.main.java.srcDirs
 }
+// Execute Checkstyle on all files
+task checkJavaStyle(type: Checkstyle) {
+	// include '**/*.java'
+}
+// Execute Checkstyle on all modified files
+task checkstyleChanged(type: Checkstyle) {
+	include getChangedFiles()
+}
+
+// Used to strip the src dir prefixes from the changed java files
+def getChangedFiles() {
+	if (!project.hasProperty('changedFiles')) {
+		return new ArrayList<>()
+	}
+	def allFiles = project.changedFiles.split(',')
+
+	// Remove the prefix
+	List<String> files = new ArrayList<>()
+	for (file in allFiles) {
+		def index = file.indexOf('src/main/java/')
+		if (index != -1) {
+			files.add(file.substring(index + 14))
+		}
+	}
+
+	// Return the list of touched files
+	files
+}
+
 tasks.withType(JavaCompile) {
 	dependsOn checkJavaStyle
 }

--- a/android/kroll-apt/build.gradle
+++ b/android/kroll-apt/build.gradle
@@ -12,10 +12,38 @@ targetCompatibility = JavaVersion.VERSION_1_8
 
 // Checks our Java code against our style guidelines and for common coding mistakes using "checkstyle.xml".
 // Will trigger a build failure if any violations have been detected.
-task checkJavaStyle(type: Checkstyle) {
-	source 'src/main/java'
-	include '**/*.java'
+// Customize all the Checkstyle tasks
+tasks.withType(Checkstyle) {
+	// Specify all files that should be checked
 	classpath = files()
+	source 'src/main/java'
+}
+// Execute Checkstyle on all files
+task checkJavaStyle(type: Checkstyle) {
+	// include '**/*.java'
+}
+task checkstyleChanged(type: Checkstyle) {
+	include getChangedFiles()
+}
+
+// Used to strip the src dir prefixes from the changed java files
+def getChangedFiles() {
+	if (!project.hasProperty('changedFiles')) {
+		return new ArrayList<>()
+	}
+	def allFiles = project.changedFiles.split(',')
+
+	// Remove the prefix
+	List<String> files = new ArrayList<>()
+	for (file in allFiles) {
+		def index = file.indexOf('src/main/java/')
+		if (index != -1) {
+			files.add(file.substring(index + 14))
+		}
+	}
+
+	// Return the list of touched files
+	files
 }
 
 // Hook into Java compile task.

--- a/android/titanium/build.gradle
+++ b/android/titanium/build.gradle
@@ -141,10 +141,39 @@ tasks.withType(com.android.build.gradle.tasks.ExternalNativeCleanTask) {
 
 // Checks our Java code against our style guidelines and for common coding mistakes using "checkstyle.xml".
 // Will trigger a build failure if any violations have been detected.
-task checkJavaStyle(type: Checkstyle) {
-	source android.sourceSets.main.java.srcDirs
-	include '**/*.java'
+// Customize all the Checkstyle tasks
+tasks.withType(Checkstyle) {
+	// Specify all files that should be checked
 	classpath = files()
+	source android.sourceSets.main.java.srcDirs
+}
+// Execute Checkstyle on all files
+task checkJavaStyle(type: Checkstyle) {
+	// include '**/*.java'
+}
+// Execute Checkstyle on all modified files
+task checkstyleChanged(type: Checkstyle) {
+	include getChangedFiles()
+}
+
+// Used to strip the src dir prefixes from the changed java files
+def getChangedFiles() {
+	if (!project.hasProperty('changedFiles')) {
+		return new ArrayList<>()
+	}
+	def allFiles = project.changedFiles.split(',')
+
+	// Remove the prefix
+	List<String> files = new ArrayList<>()
+	for (file in allFiles) {
+		def index = file.indexOf('src/java/')
+		if (index != -1) {
+			files.add(file.substring(index + 9))
+		}
+	}
+
+	// Return the list of touched files
+	files
 }
 
 // Performs a transpile/polyfill/rollup of our "titanium_mobile/common/Resources" directory tree's JS files,

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,0 +1,14 @@
+'use strict';
+
+module.exports = {
+	'android/**/*.java': filenames => {
+		return `./android/gradlew checkJavaStyle -p ./android --console plain -PchangedFiles='${filenames.join(',')}'`;
+	},
+	'iphone/**/*.{m,h}': [
+		'npx clang-format -style=file -i'
+	],
+	'iphone/TitaniumKit/TitaniumKit/Sources/API/TopTiModule.m': [
+		'npm run ios-sanity-check --'
+	],
+	'!(**/locales/**/*).js': 'eslint'
+};

--- a/package.json
+++ b/package.json
@@ -63,15 +63,6 @@
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
     }
   },
-  "lint-staged": {
-    "iphone/**/*.{m,h}": [
-      "npx clang-format -style=file -i"
-    ],
-    "iphone/TitaniumKit/TitaniumKit/Sources/API/TopTiModule.m": [
-      "npm run ios-sanity-check --"
-    ],
-    "!(**/locales/**/*).js": "eslint"
-  },
   "commitlint": {
     "extends": [
       "@commitlint/config-conventional"


### PR DESCRIPTION
**Description:**
Follow-on for #11516

This attempts to hook lint-staged/husky to run checkstyle on only modified files when doing a `git commit`. Basically lint-staged/husky will pass along the list of changed files for *.java, then in our lint-staged config file we transform that to run gradlew and pass along the file listing comma-separated as a project property. We then invoke checkstyle with those values as the includes (after chopping off the src dir prefix).

I tested this locally by "messing up" a file or two and trying to commit. It does impact java file commits by slowing them down by a few seconds to run this through gradle. But it should help block bad commits locally that would fail linting on Jenkins (i.e. catch the issue earlier in the process)