### PR TITLE
feat(android): add NDK side-by-side support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,14 +34,14 @@
           }
         },
         "caniuse-lite": {
-          "version": "1.0.30001038",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001038.tgz",
-          "integrity": "sha512-zii9quPo96XfOiRD4TrfYGs+QsGZpb2cGiMAzPjtf/hpFgB6zCPZgJb7I1+EATeMw/o+lG8FyRAnI+CWStHcaQ=="
+          "version": "1.0.30001041",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001041.tgz",
+          "integrity": "sha512-fqDtRCApddNrQuBxBS7kEiSGdBsgO4wiVw4G/IClfqzfhW45MbTumfN4cuUJGTM0YGFNn97DCXPJ683PS6zwvA=="
         },
         "electron-to-chromium": {
-          "version": "1.3.392",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.392.tgz",
-          "integrity": "sha512-/hsgeVdReDsyTBE0aU9FRdh1wnNPrX3xlz3t61F+CJPOT+Umfi9DXHsCX85TEgWZQqlow0Rw44/4/jbU2Sqgkg=="
+          "version": "1.3.403",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.403.tgz",
+          "integrity": "sha512-JaoxV4RzdBAZOnsF4dAlZ2ijJW72MbqO5lNfOBHUWiBQl3Rwe+mk2RCUMrRI3rSClLJ8HSNQNqcry12H+0ZjFw=="
         },
         "node-releases": {
           "version": "1.1.53",
@@ -194,7 +194,6 @@
       "version": "7.9.4",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.4.tgz",
       "integrity": "sha512-rjP8ahaDy/ouhrvCoU1E5mqaitWrxwuNGU+dy1EpaoK48jZay4MdkskKGIMHLZNewg8sAsqpGSREJwP0zH3YQA==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.9.0",
         "jsesc": "^2.5.1",
@@ -206,7 +205,6 @@
           "version": "7.9.0",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.0.tgz",
           "integrity": "sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==",
-          "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.9.0",
             "lodash": "^4.17.13",
@@ -391,14 +389,14 @@
           }
         },
         "caniuse-lite": {
-          "version": "1.0.30001038",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001038.tgz",
-          "integrity": "sha512-zii9quPo96XfOiRD4TrfYGs+QsGZpb2cGiMAzPjtf/hpFgB6zCPZgJb7I1+EATeMw/o+lG8FyRAnI+CWStHcaQ=="
+          "version": "1.0.30001041",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001041.tgz",
+          "integrity": "sha512-fqDtRCApddNrQuBxBS7kEiSGdBsgO4wiVw4G/IClfqzfhW45MbTumfN4cuUJGTM0YGFNn97DCXPJ683PS6zwvA=="
         },
         "electron-to-chromium": {
-          "version": "1.3.392",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.392.tgz",
-          "integrity": "sha512-/hsgeVdReDsyTBE0aU9FRdh1wnNPrX3xlz3t61F+CJPOT+Umfi9DXHsCX85TEgWZQqlow0Rw44/4/jbU2Sqgkg=="
+          "version": "1.3.403",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.403.tgz",
+          "integrity": "sha512-JaoxV4RzdBAZOnsF4dAlZ2ijJW72MbqO5lNfOBHUWiBQl3Rwe+mk2RCUMrRI3rSClLJ8HSNQNqcry12H+0ZjFw=="
         },
         "node-releases": {
           "version": "1.1.53",
@@ -590,7 +588,6 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
       "integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
-      "dev": true,
       "requires": {
         "@babel/helper-get-function-arity": "^7.8.3",
         "@babel/template": "^7.8.3",
@@ -601,7 +598,6 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
       "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.8.3"
       }
@@ -1010,7 +1006,6 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
       "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.8.3"
       }
@@ -2044,7 +2039,6 @@
       "version": "7.8.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
       "integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
-      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.8.3",
         "@babel/parser": "^7.8.6",
@@ -2055,7 +2049,6 @@
           "version": "7.8.3",
           "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
           "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
-          "dev": true,
           "requires": {
             "@babel/highlight": "^7.8.3"
           }
@@ -2064,7 +2057,6 @@
           "version": "7.9.0",
           "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.9.0.tgz",
           "integrity": "sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==",
-          "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.9.0",
             "chalk": "^2.0.0",
@@ -2074,8 +2066,7 @@
         "@babel/parser": {
           "version": "7.9.4",
           "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.4.tgz",
-          "integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA==",
-          "dev": true
+          "integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA=="
         }
       }
     },
@@ -2083,7 +2074,6 @@
       "version": "7.9.0",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.9.0.tgz",
       "integrity": "sha512-jAZQj0+kn4WTHO5dUZkZKhbFrqZE7K5LAQ5JysMnmvGij+wOdr+8lWqPeW0BcF4wFwrEXXtdGO7wcV6YPJcf3w==",
-      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.8.3",
         "@babel/generator": "^7.9.0",
@@ -2100,7 +2090,6 @@
           "version": "7.8.3",
           "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
           "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
-          "dev": true,
           "requires": {
             "@babel/highlight": "^7.8.3"
           }
@@ -2109,7 +2098,6 @@
           "version": "7.9.0",
           "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.9.0.tgz",
           "integrity": "sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==",
-          "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.9.0",
             "chalk": "^2.0.0",
@@ -2119,14 +2107,12 @@
         "@babel/parser": {
           "version": "7.9.4",
           "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.4.tgz",
-          "integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA==",
-          "dev": true
+          "integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA=="
         },
         "@babel/types": {
           "version": "7.9.0",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.0.tgz",
           "integrity": "sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==",
-          "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.9.0",
             "lodash": "^4.17.13",
@@ -2137,7 +2123,6 @@
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -2145,8 +2130,7 @@
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
@@ -2367,15 +2351,13 @@
           "version": "4.17.14",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
           "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "resolve-from": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
           "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "supports-color": {
           "version": "5.5.0",
@@ -4123,7 +4105,7 @@
       "dependencies": {
         "slice-ansi": {
           "version": "0.0.4",
-          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+          "resolved": "http://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
           "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
           "dev": true
         }
@@ -4491,7 +4473,7 @@
     },
     "conventional-changelog-angular": {
       "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-1.6.6.tgz",
+      "resolved": "http://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-1.6.6.tgz",
       "integrity": "sha512-suQnFSqCxRwyBxY68pYTsFkG0taIdinHLNEAX5ivtw8bCRnIgnpvcHmlR/yjUyZIrNPYAoXlY1WiEKWgSE4BNg==",
       "dev": true,
       "requires": {
@@ -5345,7 +5327,7 @@
     },
     "es6-promisify": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "dev": true,
       "requires": {
@@ -6009,7 +5991,7 @@
     "file-state-monitor": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-state-monitor/-/file-state-monitor-1.0.0.tgz",
-      "integrity": "sha512-Tmn8VmqNW++Vyd0aMgNPR1F+56gp4GE9iY1rpM5X4YrN1yDxLVBfL2Q7qr6FCyoYyNiyOHCFidK1Mpl5t58BSA==",
+      "integrity": "sha1-sB6DdB3FijH828Bgk5Dinf49xDI=",
       "requires": {
         "fs-extra": "^4.0.0"
       },
@@ -9228,7 +9210,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -10220,9 +10202,9 @@
       }
     },
     "node-titanium-sdk": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/node-titanium-sdk/-/node-titanium-sdk-5.0.0.tgz",
-      "integrity": "sha512-Wlm5mqECSHUPClOyxy4rSb/MQkHjhawMw6fK+Wl+Q2W9Iwrfw0WLkPQzNG4Uq9skyFPAHkVExY6ogNKmzrtA9w==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/node-titanium-sdk/-/node-titanium-sdk-5.1.0.tgz",
+      "integrity": "sha512-cs1Ry/gAiGIMJlICQtnkTO7eYkx3i29KxqOQ3kmaY3PLbNq/plCyrrsQ4/j1v9vBHCUTo9mPoUS91//QNcYUcA==",
       "requires": {
         "@babel/core": "^7.8.0",
         "@babel/parser": "^7.8.3",
@@ -10271,17 +10253,6 @@
             "source-map": "^0.5.0"
           }
         },
-        "@babel/generator": {
-          "version": "7.9.4",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.4.tgz",
-          "integrity": "sha512-rjP8ahaDy/ouhrvCoU1E5mqaitWrxwuNGU+dy1EpaoK48jZay4MdkskKGIMHLZNewg8sAsqpGSREJwP0zH3YQA==",
-          "requires": {
-            "@babel/types": "^7.9.0",
-            "jsesc": "^2.5.1",
-            "lodash": "^4.17.13",
-            "source-map": "^0.5.0"
-          }
-        },
         "@babel/helper-annotate-as-pure": {
           "version": "7.8.3",
           "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.8.3.tgz",
@@ -10325,24 +10296,6 @@
           "integrity": "sha512-N+8eW86/Kj147bO9G2uclsg5pwfs/fqqY5rwgIL7eTBklgXjcOJ3btzS5iM6AitJcftnY7pm2lGsrJVYLGjzIw==",
           "requires": {
             "@babel/traverse": "^7.8.3",
-            "@babel/types": "^7.8.3"
-          }
-        },
-        "@babel/helper-function-name": {
-          "version": "7.8.3",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
-          "integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
-          "requires": {
-            "@babel/helper-get-function-arity": "^7.8.3",
-            "@babel/template": "^7.8.3",
-            "@babel/types": "^7.8.3"
-          }
-        },
-        "@babel/helper-get-function-arity": {
-          "version": "7.8.3",
-          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
-          "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
-          "requires": {
             "@babel/types": "^7.8.3"
           }
         },
@@ -10429,14 +10382,6 @@
             "@babel/types": "^7.8.3"
           }
         },
-        "@babel/helper-split-export-declaration": {
-          "version": "7.8.3",
-          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
-          "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
-          "requires": {
-            "@babel/types": "^7.8.3"
-          }
-        },
         "@babel/helper-wrap-function": {
           "version": "7.8.3",
           "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.8.3.tgz",
@@ -10502,12 +10447,13 @@
           }
         },
         "@babel/plugin-proposal-object-rest-spread": {
-          "version": "7.9.0",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.9.0.tgz",
-          "integrity": "sha512-UgqBv6bjq4fDb8uku9f+wcm1J7YxJ5nT7WO/jBr0cl0PLKb7t1O6RNR1kZbjgx2LQtsDI9hwoQVmn0yhXeQyow==",
+          "version": "7.9.5",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.9.5.tgz",
+          "integrity": "sha512-VP2oXvAf7KCYTthbUHwBlewbl1Iq059f6seJGsxMizaCdgHIeczOr7FBqELhSqfkIl04Fi8okzWzl63UKbQmmg==",
           "requires": {
             "@babel/helper-plugin-utils": "^7.8.3",
-            "@babel/plugin-syntax-object-rest-spread": "^7.8.0"
+            "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
+            "@babel/plugin-transform-parameters": "^7.9.5"
           }
         },
         "@babel/plugin-proposal-optional-catch-binding": {
@@ -10612,18 +10558,30 @@
           }
         },
         "@babel/plugin-transform-classes": {
-          "version": "7.9.2",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.9.2.tgz",
-          "integrity": "sha512-TC2p3bPzsfvSsqBZo0kJnuelnoK9O3welkUpqSqBQuBF6R5MN2rysopri8kNvtlGIb2jmUO7i15IooAZJjZuMQ==",
+          "version": "7.9.5",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.9.5.tgz",
+          "integrity": "sha512-x2kZoIuLC//O5iA7PEvecB105o7TLzZo8ofBVhP79N+DO3jaX+KYfww9TQcfBEZD0nikNyYcGB1IKtRq36rdmg==",
           "requires": {
             "@babel/helper-annotate-as-pure": "^7.8.3",
             "@babel/helper-define-map": "^7.8.3",
-            "@babel/helper-function-name": "^7.8.3",
+            "@babel/helper-function-name": "^7.9.5",
             "@babel/helper-optimise-call-expression": "^7.8.3",
             "@babel/helper-plugin-utils": "^7.8.3",
             "@babel/helper-replace-supers": "^7.8.6",
             "@babel/helper-split-export-declaration": "^7.8.3",
             "globals": "^11.1.0"
+          },
+          "dependencies": {
+            "@babel/helper-function-name": {
+              "version": "7.9.5",
+              "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.9.5.tgz",
+              "integrity": "sha512-JVcQZeXM59Cd1qanDUxv9fgJpt3NeKUaqBqUEvfmQ+BCOKq2xUgaWZW2hr0dkbyJgezYuplEoh5knmrnS68efw==",
+              "requires": {
+                "@babel/helper-get-function-arity": "^7.8.3",
+                "@babel/template": "^7.8.3",
+                "@babel/types": "^7.9.5"
+              }
+            }
           }
         },
         "@babel/plugin-transform-computed-properties": {
@@ -10635,9 +10593,9 @@
           }
         },
         "@babel/plugin-transform-destructuring": {
-          "version": "7.8.8",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.8.8.tgz",
-          "integrity": "sha512-eRJu4Vs2rmttFCdhPUM3bV0Yo/xPSdPw6ML9KHs/bjB4bLA5HXlbvYXPOD5yASodGod+krjYx21xm1QmL8dCJQ==",
+          "version": "7.9.5",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.9.5.tgz",
+          "integrity": "sha512-j3OEsGel8nHL/iusv/mRd5fYZ3DrOxWC82x0ogmdN/vHfAP4MYw+AFKYanzWlktNwikKvlzUV//afBW5FTp17Q==",
           "requires": {
             "@babel/helper-plugin-utils": "^7.8.3"
           }
@@ -10768,9 +10726,9 @@
           }
         },
         "@babel/plugin-transform-parameters": {
-          "version": "7.9.3",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.9.3.tgz",
-          "integrity": "sha512-fzrQFQhp7mIhOzmOtPiKffvCYQSK10NR8t6BBz2yPbeUHb9OLW8RZGtgDRBn8z2hGcwvKDL3vC7ojPTLNxmqEg==",
+          "version": "7.9.5",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.9.5.tgz",
+          "integrity": "sha512-0+1FhHnMfj6lIIhVvS4KGQJeuhe1GI//h5uptK4PvLt+BGBxsoUJbd3/IW002yk//6sZPlFgsG1hY6OHLcy6kA==",
           "requires": {
             "@babel/helper-get-function-arity": "^7.8.3",
             "@babel/helper-plugin-utils": "^7.8.3"
@@ -10852,9 +10810,9 @@
           }
         },
         "@babel/preset-env": {
-          "version": "7.9.0",
-          "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.9.0.tgz",
-          "integrity": "sha512-712DeRXT6dyKAM/FMbQTV/FvRCms2hPCx+3weRjZ8iQVQWZejWWk1wwG6ViWMyqb/ouBbGOl5b6aCk0+j1NmsQ==",
+          "version": "7.9.5",
+          "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.9.5.tgz",
+          "integrity": "sha512-eWGYeADTlPJH+wq1F0wNfPbVS1w1wtmMJiYk55Td5Yu28AsdR9AsC97sZ0Qq8fHqQuslVSIYSGJMcblr345GfQ==",
           "requires": {
             "@babel/compat-data": "^7.9.0",
             "@babel/helper-compilation-targets": "^7.8.7",
@@ -10865,7 +10823,7 @@
             "@babel/plugin-proposal-json-strings": "^7.8.3",
             "@babel/plugin-proposal-nullish-coalescing-operator": "^7.8.3",
             "@babel/plugin-proposal-numeric-separator": "^7.8.3",
-            "@babel/plugin-proposal-object-rest-spread": "^7.9.0",
+            "@babel/plugin-proposal-object-rest-spread": "^7.9.5",
             "@babel/plugin-proposal-optional-catch-binding": "^7.8.3",
             "@babel/plugin-proposal-optional-chaining": "^7.9.0",
             "@babel/plugin-proposal-unicode-property-regex": "^7.8.3",
@@ -10882,9 +10840,9 @@
             "@babel/plugin-transform-async-to-generator": "^7.8.3",
             "@babel/plugin-transform-block-scoped-functions": "^7.8.3",
             "@babel/plugin-transform-block-scoping": "^7.8.3",
-            "@babel/plugin-transform-classes": "^7.9.0",
+            "@babel/plugin-transform-classes": "^7.9.5",
             "@babel/plugin-transform-computed-properties": "^7.8.3",
-            "@babel/plugin-transform-destructuring": "^7.8.3",
+            "@babel/plugin-transform-destructuring": "^7.9.5",
             "@babel/plugin-transform-dotall-regex": "^7.8.3",
             "@babel/plugin-transform-duplicate-keys": "^7.8.3",
             "@babel/plugin-transform-exponentiation-operator": "^7.8.3",
@@ -10899,7 +10857,7 @@
             "@babel/plugin-transform-named-capturing-groups-regex": "^7.8.3",
             "@babel/plugin-transform-new-target": "^7.8.3",
             "@babel/plugin-transform-object-super": "^7.8.3",
-            "@babel/plugin-transform-parameters": "^7.8.7",
+            "@babel/plugin-transform-parameters": "^7.9.5",
             "@babel/plugin-transform-property-literals": "^7.8.3",
             "@babel/plugin-transform-regenerator": "^7.8.7",
             "@babel/plugin-transform-reserved-words": "^7.8.3",
@@ -10910,7 +10868,7 @@
             "@babel/plugin-transform-typeof-symbol": "^7.8.4",
             "@babel/plugin-transform-unicode-regex": "^7.8.3",
             "@babel/preset-modules": "^0.1.3",
-            "@babel/types": "^7.9.0",
+            "@babel/types": "^7.9.5",
             "browserslist": "^4.9.1",
             "core-js-compat": "^3.6.2",
             "invariant": "^2.2.2",
@@ -10926,40 +10884,21 @@
             "regenerator-runtime": "^0.13.4"
           }
         },
-        "@babel/template": {
-          "version": "7.8.6",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
-          "integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
-          "requires": {
-            "@babel/code-frame": "^7.8.3",
-            "@babel/parser": "^7.8.6",
-            "@babel/types": "^7.8.6"
-          }
-        },
-        "@babel/traverse": {
-          "version": "7.9.0",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.9.0.tgz",
-          "integrity": "sha512-jAZQj0+kn4WTHO5dUZkZKhbFrqZE7K5LAQ5JysMnmvGij+wOdr+8lWqPeW0BcF4wFwrEXXtdGO7wcV6YPJcf3w==",
-          "requires": {
-            "@babel/code-frame": "^7.8.3",
-            "@babel/generator": "^7.9.0",
-            "@babel/helper-function-name": "^7.8.3",
-            "@babel/helper-split-export-declaration": "^7.8.3",
-            "@babel/parser": "^7.9.0",
-            "@babel/types": "^7.9.0",
-            "debug": "^4.1.0",
-            "globals": "^11.1.0",
-            "lodash": "^4.17.13"
-          }
-        },
         "@babel/types": {
-          "version": "7.9.0",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.0.tgz",
-          "integrity": "sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==",
+          "version": "7.9.5",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
+          "integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
           "requires": {
-            "@babel/helper-validator-identifier": "^7.9.0",
+            "@babel/helper-validator-identifier": "^7.9.5",
             "lodash": "^4.17.13",
             "to-fast-properties": "^2.0.0"
+          },
+          "dependencies": {
+            "@babel/helper-validator-identifier": {
+              "version": "7.9.5",
+              "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz",
+              "integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g=="
+            }
           }
         },
         "async": {
@@ -10979,16 +10918,16 @@
           }
         },
         "caniuse-lite": {
-          "version": "1.0.30001038",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001038.tgz",
-          "integrity": "sha512-zii9quPo96XfOiRD4TrfYGs+QsGZpb2cGiMAzPjtf/hpFgB6zCPZgJb7I1+EATeMw/o+lG8FyRAnI+CWStHcaQ=="
+          "version": "1.0.30001041",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001041.tgz",
+          "integrity": "sha512-fqDtRCApddNrQuBxBS7kEiSGdBsgO4wiVw4G/IClfqzfhW45MbTumfN4cuUJGTM0YGFNn97DCXPJ683PS6zwvA=="
         },
         "core-js-compat": {
-          "version": "3.6.4",
-          "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.6.4.tgz",
-          "integrity": "sha512-zAa3IZPvsJ0slViBQ2z+vgyyTuhd3MFn1rBQjZSKVEgB0UMYhUkCj9jJUVPgGTGqWvsBVmfnruXgTcNyTlEiSA==",
+          "version": "3.6.5",
+          "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.6.5.tgz",
+          "integrity": "sha512-7ItTKOhOZbznhXAQ2g/slGg1PJV5zDO/WdkTwi7UEOJmkvsE32PWvx6mKtDjiMpjnR2CNf6BAD6sSxIlv7ptng==",
           "requires": {
-            "browserslist": "^4.8.3",
+            "browserslist": "^4.8.5",
             "semver": "7.0.0"
           },
           "dependencies": {
@@ -11008,14 +10947,19 @@
           }
         },
         "electron-to-chromium": {
-          "version": "1.3.392",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.392.tgz",
-          "integrity": "sha512-/hsgeVdReDsyTBE0aU9FRdh1wnNPrX3xlz3t61F+CJPOT+Umfi9DXHsCX85TEgWZQqlow0Rw44/4/jbU2Sqgkg=="
+          "version": "1.3.403",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.403.tgz",
+          "integrity": "sha512-JaoxV4RzdBAZOnsF4dAlZ2ijJW72MbqO5lNfOBHUWiBQl3Rwe+mk2RCUMrRI3rSClLJ8HSNQNqcry12H+0ZjFw=="
+        },
+        "jsesc": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
         },
         "json5": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.2.tgz",
-          "integrity": "sha512-MoUOQ4WdiN3yxhm7NEVJSJrieAo5hNSLQ5sj05OTRHPL9HOBy8u4Bu88jsC1jvqAdN+E1bJmsUcZH+1HQxliqQ==",
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+          "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
           "requires": {
             "minimist": "^1.2.5"
           }
@@ -11076,13 +11020,6 @@
           "integrity": "sha512-64O87/dPDgfk8/RQqC4gkZoGyyWFIEUTTh80CU6CWuK5vkCGyekIx+oKcEIYtP/RAxSQltCZHCNu/mdd7fqlJw==",
           "requires": {
             "jsesc": "~0.5.0"
-          },
-          "dependencies": {
-            "jsesc": {
-              "version": "0.5.0",
-              "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-              "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
-            }
           }
         },
         "semver": {
@@ -11130,7 +11067,7 @@
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
       "dev": true,
       "requires": {
         "hosted-git-info": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "markdown": "0.5.0",
     "moment": "^2.24.0",
     "node-appc": "^1.0.0",
-    "node-titanium-sdk": "^5.0.0",
+    "node-titanium-sdk": "^5.1.0",
     "node-uuid": "1.4.8",
     "nodeify": "^1.0.1",
     "p-limit": "^2.3.0",


### PR DESCRIPTION
**JIRA:**
https://jira.appcelerator.org/browse/TIMOB-27755

**Summary:**
- Added NDK side-by-side folder lookup.
  * This is where Android Studio currently installs NDK as of 2019.
  * This folder contains multiple NDK installations.
  * The "ndk-bundle" subdirectory is now deprecated.
- Updated "node-titanium_sdk" from `5.0.0` to `5.1.0`.

**Test:**
1. Uninstall NDK if currently installed.
2. Open Android Studio's preferences window.
3. Go to: Appearances & Behavior -> System Settings -> Android SDK
4. Click on the "SDK Tools" tab.
5. Check the "NDK (Side by side)" option.
6. Click the OK button.
7. Verify that you can build a Titanium app without failure.
