### PR TITLE
fix: inline short version string for Ti.version 

### DIFF
--- a/cli/lib/tasks/process-js-task.js
+++ b/cli/lib/tasks/process-js-task.js
@@ -55,9 +55,10 @@ class ProcessJsTask extends IncrementalFileTask {
 			deploytype: this.builder.deployType,
 			target: this.builder.target,
 			Ti: {
-				version: this.builder.cli.tiapp['sdk-version'],
-				// TODO: add buildHash
-				// TODO: add buildDate
+				version: this.builder.titaniumSdkVersion, // use the shortened version number, i.e. 9.1.0
+				// TODO: Do these work?
+				// buildHash: ti.manifest.githash,
+				// buildDate: ti.manifest.timestamp,
 				App: {
 					copyright: this.builder.cli.tiapp.copyright,
 					deployType: this.builder.deployType,
@@ -73,7 +74,6 @@ class ProcessJsTask extends IncrementalFileTask {
 					runtime: 'javascriptcore', // overridden below for android
 				},
 				Filesystem: {
-					// overridden below for windows
 					lineEnding: '\n',
 					separator: '/',
 				}
@@ -91,24 +91,6 @@ class ProcessJsTask extends IncrementalFileTask {
 					transform.Ti.Platform.osname = this.builder.deviceFamily;
 				}
 				transform.Ti.Platform.manufacturer = 'apple';
-				break;
-			case 'windows':
-				// override Ti.Filesystem property values
-				transform.Ti.Filesystem.separator = '\\';
-				transform.Ti.Filesystem.lineEnding = '\r\n';
-				switch (this.builder.target) {
-					// windows store targets
-					case 'ws-simulator':
-					case 'ws-local':
-					case 'ws-remote':
-					case 'dist-winstore':
-						transform.Ti.Platform.osname = 'windowsstore';
-						break;
-					default:
-						transform.Ti.Platform.osname = 'windowsphone'; // TODO: no longer support windows phones on SDK 9+!
-						break;
-				}
-				transform.Ti.Platform.name = 'windows';
 				break;
 		}
 

--- a/tests/Resources/ti.test.js
+++ b/tests/Resources/ti.test.js
@@ -1,0 +1,99 @@
+/*
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2011-Present by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+/* eslint-env mocha */
+/* eslint no-unused-expressions: "off" */
+'use strict';
+const should = require('./utilities/assertions');
+
+describe('Titanium', () => {
+	it('apiName', () => {
+		should(Ti).have.readOnlyProperty('apiName').which.is.a.String;
+		should(Ti.apiName).be.eql('Ti');
+	});
+
+	it('version', () => {
+		should(Ti).have.readOnlyProperty('version').which.is.a.String;
+		should(Ti.version).not.eql('__VERSION__'); // This is the placeholder value used in iOS, let's ensure we replaced it!
+		should(Ti.version).match(/\d+\.\d+\.\d+/); // i.e. '9.0.0' (the short version string, no timestamp qualifier)
+	});
+
+	it('#getVersion()', () => {
+		should(Ti.getVersion).be.a.Function;
+		should(Ti.getVersion()).eql(Ti.version);
+	});
+
+	it('buildDate', () => {
+		should(Ti).have.readOnlyProperty('buildDate').which.is.a.String;
+		should(Ti.buildDate).not.eql('__TIMESTAMP__'); // This is the placeholder value used in iOS, let's ensure we replaced it!
+		should(Ti.buildDate).match(/[01]?\d\/[0123]\d\/20\d{2} \d{2}:\d{2}/); // i.e. '4/14/2020 18:48'
+	});
+
+	it('#getBuildDate()', () => {
+		should(Ti.getBuildDate).be.a.Function;
+		should(Ti.getBuildDate()).eql(Ti.buildDate);
+	});
+
+	it('buildHash', () => {
+		should(Ti).have.readOnlyProperty('buildHash').which.is.a.String;
+		should(Ti.buildHash).not.eql('__GITHASH__'); // This is the placeholder value used in iOS, let's ensure we replaced it!
+		should(Ti.buildHash).match(/[a-f0-9]{10}/); // 10-character git sha
+	});
+
+	it('#getBuildHash()', () => {
+		should(Ti.getBuildHash).be.a.Function;
+		should(Ti.getBuildHash()).eql(Ti.buildHash);
+	});
+
+	// FIXME File a ticket in JIRA. Updating V8 fixes the property read/write issues, but exposes bug in that we set userAgent as read-only on Android and it shouldn't be
+	it.androidBroken('userAgent', function () {
+		should(Ti.userAgent).be.a.String;
+
+		const save = Ti.userAgent;
+		Ti.userAgent = 'Titanium_Mocha_Test';
+		should(Ti.userAgent).be.eql('Titanium_Mocha_Test');
+		Ti.userAgent = save;
+		should(Ti.userAgent).be.eql(save);
+	});
+
+	it('#getUserAgent()', () => {
+		should(Ti.getUserAgent).be.a.Function;
+		should(Ti.getUserAgent()).eql(Ti.userAgent);
+	});
+
+	// FIXME Get working on IOS/Android!
+	it.androidAndIosBroken('#setUserAgent()', function () {
+		should(Ti.setUserAgent).be.a.Function;
+		var save = Ti.getUserAgent();
+		Ti.setUserAgent('Titanium_Mocha_Test');
+		should(Ti.getUserAgent()).be.eql('Titanium_Mocha_Test');
+		should(Ti.userAgent).be.eql('Titanium_Mocha_Test');
+		Ti.setUserAgent(save);
+		should(Ti.getUserAgent()).be.eql(save);
+		should(Ti.userAgent).be.eql(save);
+	});
+
+	it('#addEventListener()', () => should(Ti.addEventListener).be.a.Function);
+
+	it('#removeEventListener()', () => should(Ti.removeEventListener).be.a.Function);
+
+	// FIXME Get working on IOS/Android!
+	it.androidAndIosBroken('#applyProperties()', function () {
+		should(Ti.applyProperties).be.a.Function;
+		Ti.mocha_test = undefined;
+		should(Ti.applyProperties({ mocha_test: 'mocha_test_value' }));
+		should(Ti.mocha_test !== undefined);
+		should(Ti.mocha_test).be.eql('mocha_test_value');
+		Ti.mocha_test = undefined;
+	});
+
+	it('#createBuffer()', () => should(Ti.createBuffer).be.a.Function);
+
+	// FIXME Is this really a method we want to expose on our API?
+	it('#createProxy()', () => should(Ti.createProxy).be.a.Function);
+
+	it('#fireEvent()', () => should(Ti.fireEvent).be.a.Function);
+});


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-27849

**Description:**
See appcelerator/titanium-mobile-mocha-suite#241

When transpiling an app's js code, references to Ti.version were getting replaced by the long-form version string (i.e. `9.1.0.v20200409133428`) vs the correct short form (i.e. `9.1.0`)