### PR TITLE
chore(package): update titanium-docgen

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5372,7 +5372,7 @@
     },
     "es6-promisify": {
       "version": "5.0.0",
-      "resolved": "http://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "dev": true,
       "requires": {
@@ -6036,7 +6036,7 @@
     "file-state-monitor": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-state-monitor/-/file-state-monitor-1.0.0.tgz",
-      "integrity": "sha1-sB6DdB3FijH828Bgk5Dinf49xDI=",
+      "integrity": "sha512-Tmn8VmqNW++Vyd0aMgNPR1F+56gp4GE9iY1rpM5X4YrN1yDxLVBfL2Q7qr6FCyoYyNiyOHCFidK1Mpl5t58BSA==",
       "requires": {
         "fs-extra": "^4.0.0"
       },
@@ -9255,7 +9255,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -11090,7 +11090,7 @@
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
+      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
         "hosted-git-info": "^2.1.4",
@@ -13473,9 +13473,9 @@
       }
     },
     "titanium-docgen": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/titanium-docgen/-/titanium-docgen-4.3.0.tgz",
-      "integrity": "sha512-qQL0B6B5+zgnrP4DhEyIHxWse6Jox7p90vEGkxpk7DQPkvYKJ+eImmguN+K1Q+3L/KsWoZ+1rKWjOcj+UV4gDA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/titanium-docgen/-/titanium-docgen-4.3.1.tgz",
+      "integrity": "sha512-vq7/N3bEfvUUVgXFkpkqx/qX/BeoNc12t6NH1xgf+ZVrXcsaQi3C5iXdQA6vzD7TckMAC4ILrwb2wgk7ZZBnHQ==",
       "dev": true,
       "requires": {
         "colors": "^1.4.0",
@@ -13485,12 +13485,6 @@
         "node-appc": "^0.3.4"
       },
       "dependencies": {
-        "ejs": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.0.1.tgz",
-          "integrity": "sha512-cuIMtJwxvzumSAkqaaoGY/L6Fc/t6YvoP9/VIaK0V/CyqKLEQ8sqODmYfy/cjXEdZ9+OOL8TecbJu+1RsofGDw==",
-          "dev": true
-        },
         "fs-extra": {
           "version": "7.0.1",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
     "rollup-plugin-commonjs": "^10.1.0",
     "rollup-plugin-node-resolve": "^5.2.0",
     "ssri": "^8.0.0",
-    "titanium-docgen": "^4.3.0"
+    "titanium-docgen": "^4.3.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
update titanium-docgen to the latest version to include a [fix](https://github.com/appcelerator/docs-devkit/commit/774051ddeed275dcb18f7e3c132b5056e947ab5e) for typescript typings. the published typings for 9.0 already used this version, so they are up-to-date.