### PR TITLE
feat(android): animate color

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUILabel.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUILabel.java
@@ -667,6 +667,12 @@ public class TiUILabel extends TiUIView
 		return false;
 	}
 
+	public int getColor()
+	{
+		TextView tv = (TextView) getNativeView();
+		return tv.getCurrentTextColor();
+	}
+
 	/**
 	 * Updates this object's Android "TextView" with the current member variable settings that affect
 	 * how text is displayed, which includes the single-line/multiline and ellipsize related settings.

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiAnimationBuilder.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiAnimationBuilder.java
@@ -38,12 +38,15 @@ import android.view.animation.AlphaAnimation;
 import android.view.animation.Animation;
 import android.view.animation.AnimationSet;
 import android.view.animation.Transformation;
+import android.widget.TextView;
 
 import com.nineoldandroids.animation.Animator;
 import com.nineoldandroids.animation.AnimatorSet;
 import com.nineoldandroids.animation.ArgbEvaluator;
 import com.nineoldandroids.animation.ObjectAnimator;
 import com.nineoldandroids.animation.ValueAnimator;
+
+import ti.modules.titanium.ui.widget.TiUILabel;
 
 /**
  * Builds and starts animations. When possible, Honeycomb+ animations
@@ -116,6 +119,7 @@ public class TiAnimationBuilder
 	protected String centerX = null, centerY = null;
 	protected String width = null, height = null;
 	protected Integer backgroundColor = null;
+	protected Integer color = null;
 	protected TiAnimationCurve curve = TiAnimationBuilder.DEFAULT_CURVE;
 
 	protected TiAnimation animationProxy;
@@ -232,6 +236,10 @@ public class TiAnimationBuilder
 			backgroundColor = TiConvert.toColor(options, TiC.PROPERTY_BACKGROUND_COLOR);
 		}
 
+		if (options.containsKey(TiC.PROPERTY_COLOR)) {
+			color = TiConvert.toColor(options, TiC.PROPERTY_COLOR);
+		}
+
 		if (options.containsKey(TiC.PROPERTY_ELEVATION)) {
 			elevation = TiConvert.toFloat(options, TiC.PROPERTY_ELEVATION, -1);
 		}
@@ -311,6 +319,18 @@ public class TiAnimationBuilder
 				ObjectAnimator.ofInt(bgView, "backgroundColor", currentBackgroundColor, backgroundColor);
 			bgAnimator.setEvaluator(new ArgbEvaluator());
 			addAnimator(animators, bgAnimator);
+		}
+
+		if (color != null) {
+			if (viewProxy.peekView() instanceof TiUILabel) {
+				TiUILabel lblView = (TiUILabel) viewProxy.peekView();
+
+				int currentColor = lblView.getColor();
+				ObjectAnimator colAnimator =
+					ObjectAnimator.ofInt((TextView) lblView.getNativeView(), "textColor", currentColor, color);
+				colAnimator.setEvaluator(new ArgbEvaluator());
+				addAnimator(animators, colAnimator);
+			}
 		}
 
 		if (tdm != null) {

--- a/apidoc/Titanium/UI/Animation.yml
+++ b/apidoc/Titanium/UI/Animation.yml
@@ -96,7 +96,8 @@ properties:
     description: |
         For information about color values, see the "Colors" section of <Titanium.UI>.
     type: String
-    platforms: [iphone, ipad]
+    platforms: [android, iphone, ipad]
+    since: { android: "9.1.0" }
 
   - name: curve
     summary: Animation curve or easing function to apply to the animation.

--- a/tests/Resources/ti.ui.label.addontest.js
+++ b/tests/Resources/ti.ui.label.addontest.js
@@ -1,0 +1,70 @@
+/*
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2011-Present by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+/* eslint-env mocha */
+/* eslint no-unused-expressions: "off" */
+'use strict';
+const should = require('./utilities/assertions');
+const utilities = require('./utilities/utilities');
+
+describe('Titanium.UI.Label', function () {
+	let win;
+
+	afterEach(function (done) {
+		if (win) {
+			// If `win` is already closed, we're done.
+			let t = setTimeout(function () {
+				if (win) {
+					win = null;
+					done();
+				}
+			}, 3000);
+
+			win.addEventListener('close', function listener () {
+				clearTimeout(t);
+
+				if (win) {
+					win.removeEventListener('close', listener);
+				}
+				win = null;
+				done();
+			});
+			win.close();
+		} else {
+			win = null;
+			done();
+		}
+	});
+
+	it.allBroken('animate font color', function (finish) {
+		win = Ti.UI.createWindow();
+
+		const label = Ti.UI.createLabel({
+			text: 'this is some text',
+			color: '#f00',
+		});
+		const animation = Ti.UI.createAnimation({
+			color: '#fff',
+			duration: 1000
+		});
+		animation.addEventListener('complete', function () {
+			// FIXME: iOS appears to be firing this event immediately, not when the animation is actually done!
+			// test takes 206 ms, but fastest it could run is 1200ms due to 1s animation value
+			try {
+				should(label.color).be.eql('#fff'); // FIXME: animations don't update the view's properties when they complete!
+				// This is a longstanding issue and should be addressed
+			} catch (err) {
+				return finish(err);
+			}
+			finish();
+		});
+		win.addEventListener('open', function () {
+			setTimeout(() => label.animate(animation), 200);
+		});
+		win.add(label);
+		win.open();
+	});
+});


### PR DESCRIPTION
**merge after https://github.com/appcelerator/titanium_mobile/pull/11646**

Since the other PR #11646  is already approved I've used it as the master to this PR since it changing the same file.

**JIRA:** https://jira.appcelerator.org/browse/TIMOB-27855

Being able to animate the `color` value.

```
Ti.UI.setBackgroundColor('white');
var win = Ti.UI.createWindow({
	backgroundColor: 'white'
});
var l = Ti.UI.createLabel({
	text: "test",
	color: "#000"
});
win.add(l);

setTimeout(function() {
	l.animate({
		color: "#ff0",
		duration: 1000,
		repeat: 10,
		autoreverse: true
	});
}, 1000);
win.open();
```
