### PR TITLE
docs(api): loosen type on attributed string attribute value

### DIFF
--- a/apidoc/Titanium/UI/Attribute.yml
+++ b/apidoc/Titanium/UI/Attribute.yml
@@ -112,7 +112,7 @@ properties:
           * <Titanium.UI.ATTRIBUTE_LINE_BREAK_BY_TRUNCATING_MIDDLE>
 
         These can also be combined the same way as the underline styles.
-    type: Number
+    type: Object
     constants: [ Titanium.UI.ATTRIBUTE_UNDERLINE_STYLE_*,
                  Titanium.UI.ATTRIBUTE_WRITING_DIRECTION_*,
                  Titanium.UI.ATTRIBUTE_LETTERPRESS_STYLE ]


### PR DESCRIPTION
The `value` of an [Attribute](https://docs.appcelerator.com/platform/latest/#!/api/Attribute) definition can actually be various different things, depending on its `type` property. A type of `Number` is therefore not correct. I noticed this while working with TypeScript, which was complaining about the following example:

```ts
const hint = Ti.UI.createLabel({
  attributedString: Ti.UI.createAttributedString({
    text: 'Edit search.js to change this view!',
    attributes: [{
      type: Ti.UI.ATTRIBUTE_FOREGROUND_COLOR,
      value: '#E82C2A',
      range: [5, 9]
    }, {
      type: Ti.UI.ATTRIBUTE_FONT,
      value: {
        fontFamily: 'monospace',
      },
      range: [5, 9]
    }]
  }),
  color: '#aaa',
  top: 60
});
```

I wasn't sure if we have something like `any` in our doc spec, so i just set it to `Object` which correctly translates to `any` in TypeScript definitions.