### PR TITLE
fix(android): amend ImageView tintColor

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiImageView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiImageView.java
@@ -489,12 +489,13 @@ public class TiImageView extends ViewGroup implements Handler.Callback, OnClickL
 
 	public void setTintColor(String color)
 	{
-		this.tintColor = TiColorHelper.parseColor(color);
-		if (this.tintColor == 0) {
+		if (color == null || color.isEmpty()) {
 			imageView.clearColorFilter();
-		} else {
-			imageView.setColorFilter(this.tintColor, Mode.SRC_ATOP);
+			return;
 		}
+
+		this.tintColor = TiColorHelper.parseColor(color);
+		imageView.setColorFilter(this.tintColor, Mode.SRC_IN);
 	}
 
 	public int getTintColor()


### PR DESCRIPTION
- Amend behaviour of `Ti.UI.ImageView.tintColor`

##### TEST CASE
```JS
const win = Ti.UI.createWindow({ backgroundColor: 'white' });
const img = Ti.UI.createImageView({
  width: '80%',
  image: 'https://about.gitlab.com/images/press/logo/png/gitlab-icon-1-color-black-rgb.png',
  tintColor: 'red'
});

win.add(img);
win.open();
```
- Image should tint `red`

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-27881)