### PR TITLE
fix(ios): start initial timer id from one (9_0_X)

### DIFF
--- a/iphone/TitaniumKit/TitaniumKit/Sources/Kroll/KrollTimerManager.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/Kroll/KrollTimerManager.m
@@ -65,7 +65,7 @@
     return nil;
   }
 
-  self.nextTimerIdentifier = 0;
+  self.nextTimerIdentifier = 1;
   self.timers = [NSMapTable strongToWeakObjectsMapTable];
 
   NSUInteger (^setInterval)(JSValue *, double) = ^(JSValue *callback, double interval) {


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-27898

9_0_X backport of #11734 
