### PR TITLE
fix(android): update debugging prefix for chrome

### DIFF
--- a/android/runtime/v8/src/java/org/appcelerator/kroll/runtime/v8/JSDebugger.java
+++ b/android/runtime/v8/src/java/org/appcelerator/kroll/runtime/v8/JSDebugger.java
@@ -128,7 +128,7 @@ public final class JSDebugger
 				Log.w(TAG, "Debugger listening on ws://" + url);
 				Log.w(
 					TAG,
-					"To connect Chrome DevTools, open Chrome to chrome-devtools://devtools/bundled/inspector.html?experiments=true&v8only=true&ws="
+					"To connect Chrome DevTools, open Chrome to devtools://devtools/bundled/inspector.html?experiments=true&v8only=true&ws="
 						+ url);
 				Log.w(TAG, "Waiting for debugger to connect for next 60 seconds...");
 				this.waitLock.wait(60000); // wait up to 60 seconds for debugger


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-27912

Chrome 83 drops the chrome prefix and moves to just devtools://

Fixes TIMOB-27912

