### PR TITLE
fix(android): bad Titanium version logged on app startup

### DIFF
--- a/android/titanium/libv8-services.js
+++ b/android/titanium/libv8-services.js
@@ -53,11 +53,11 @@ async function createSnapshot() {
 	const rollupOutputFilePath = path.join(rollupOutputDirPath, 'ti.main.js');
 	await fs.ensureDir(rollupOutputDirPath);
 
-	const program = { args: [ 'ios' ] };
+	const program = { args: [ 'android' ] };
 	const mainBuilder = new Builder(program);
 	await mainBuilder.ensureGitHash();
 	const androidBuilder = new AndroidBuilder({
-		sdkVersion: require('../package.json').version,
+		sdkVersion: require('../../package.json').version,
 		gitHash: program.gitHash,
 		timestamp: program.timestamp
 	});


### PR DESCRIPTION
**JIRA:**
https://jira.appcelerator.org/browse/TIMOB-27916

**Summary:**
On app startup, Android was logging `(Powered by Titanium __VERSION__.<Hash>)` with the literal `__VERSION__` string instead of the actual Titanium version.
This issue was introduced into "master" and was caught before release.

**Test:**
1. Build and run an app for Android.
2. Verify the following gets logged on startup. Titanium version must be `9.1.0`.
`<AppName> <AppVersion> (Powered by Titanium 9.1.0.<BuildHash>)`
