### PR TITLE
chore(android): auto-download NDK r21c for module builds if needed

### DIFF
--- a/android/templates/module/generated/build.gradle
+++ b/android/templates/module/generated/build.gradle
@@ -58,6 +58,7 @@ android {
 				cppFlags '-std=c++11'
 				arguments.addAll([
 					'APP_STL:=c++_shared',
+					"--output-sync=none",
 					"-j${Runtime.runtime.availableProcessors()}".toString()
 				])
 			}

--- a/android/templates/module/generated/build.gradle
+++ b/android/templates/module/generated/build.gradle
@@ -14,6 +14,28 @@ repositories {
 // Path to proxy binding JSON file created by "kroll-apt" annotation processor and used to do C/C++ code generation.
 def tiModuleBindingsJsonPath = "${buildDir}/ti-generated/json/<%- moduleName %>.json".toString()
 
+// Fetch Android NDK version assigned to the "local.properties" file. (Will be missing if NDK not installed.)
+def ndkVersionString = null;
+try {
+	def localProperties = new Properties()
+	localProperties.load(file("${rootDir}/local.properties").newDataInputStream())
+	def ndkDir = localProperties.get('ndk.dir')
+	if (ndkDir != null) {
+		def ndkSourceProperties = new Properties()
+		ndkSourceProperties.load(file("${ndkDir}/source.properties").newDataInputStream())
+		ndkVersionString = ndkSourceProperties.get('Pkg.Revision')
+	}
+} catch (Throwable) {
+}
+
+// If Titanium failed to set Android NDK path in "local.properties", then assume NDK is not installed.
+// Have gradle auto-download NDK by setting the version we want below. (Will fail if a different version is installed.)
+// Must be set to a stable release version listed here: https://developer.android.com/ndk/downloads
+if (ndkVersionString == null) {
+	ndkVersionString = '21.2.6472646'
+	android.ndkVersion ndkVersionString
+}
+
 android {
 	compileSdkVersion <%- compileSdkVersion %>
 	defaultConfig {
@@ -58,9 +80,13 @@ android {
 				cppFlags '-std=c++11'
 				arguments.addAll([
 					'APP_STL:=c++_shared',
-					"--output-sync=none",
 					"-j${Runtime.runtime.availableProcessors()}".toString()
 				])
+				if (Integer.parseInt(ndkVersionString.split('\\.')[0]) >= 21) {
+					// Work-around issue where Google sets "--output-sync=target" by default for NDK v21+
+					// which causes "bad file descriptor" errors when using "-j" parallel executions argument.
+					arguments.add('--output-sync=none')
+				}
 			}
 		}
 		ndk {
@@ -152,6 +178,7 @@ preBuild.doFirst {
 	}
 }
 
+/*
 // If Titanium failed to set Android NDK path in "local.properties", then assume NDK is not installed.
 // Have gradle auto-download NDK by setting the version we want below. (Will fail if a different version is installed.)
 // Must be set to a stable release version listed here: https://developer.android.com/ndk/downloads
@@ -160,6 +187,7 @@ localProperties.load(file("${rootDir}/local.properties").newDataInputStream())
 if (localProperties.get('ndk.dir') == null) {
 	android.ndkVersion '21.2.6472646'
 }
+*/
 
 // Set up project to compile Java side before compiling the C/C++ side.
 // We must do this because our "kroll-apt" Java annotation processor generates C++ source files.

--- a/android/templates/module/generated/build.gradle
+++ b/android/templates/module/generated/build.gradle
@@ -157,7 +157,7 @@ preBuild.doFirst {
 def localProperties = new Properties()
 localProperties.load(file("${rootDir}/local.properties").newDataInputStream())
 if (localProperties.get('ndk.dir') == null) {
-	android.ndkVersion '20.1.5948944'
+	android.ndkVersion '21.2.6472646'
 }
 
 // Set up project to compile Java side before compiling the C/C++ side.

--- a/android/templates/module/generated/build.gradle
+++ b/android/templates/module/generated/build.gradle
@@ -178,17 +178,6 @@ preBuild.doFirst {
 	}
 }
 
-/*
-// If Titanium failed to set Android NDK path in "local.properties", then assume NDK is not installed.
-// Have gradle auto-download NDK by setting the version we want below. (Will fail if a different version is installed.)
-// Must be set to a stable release version listed here: https://developer.android.com/ndk/downloads
-def localProperties = new Properties()
-localProperties.load(file("${rootDir}/local.properties").newDataInputStream())
-if (localProperties.get('ndk.dir') == null) {
-	android.ndkVersion '21.2.6472646'
-}
-*/
-
 // Set up project to compile Java side before compiling the C/C++ side.
 // We must do this because our "kroll-apt" Java annotation processor generates C++ source files.
 project.afterEvaluate {

--- a/android/titanium/build.gradle
+++ b/android/titanium/build.gradle
@@ -65,6 +65,7 @@ android {
 					'APP_STL:=c++_shared',
 					"TI_DIST_DIR=${projectDir}/../../dist".replace('\\', '\\\\'),
 					"NDK_MODULE_PATH+=${projectDir}/../runtime/v8/src/ndk-modules".replace('\\', '\\\\'),
+					"--output-sync=none",
 					"-j${Runtime.runtime.availableProcessors()}".toString()
 				])
 				if (System.getProperty('os.name').toLowerCase().contains('windows')) {

--- a/android/titanium/build.gradle
+++ b/android/titanium/build.gradle
@@ -37,6 +37,26 @@ for (nextString in tiBuildVersionString.split('\\.')) {
 	}
 }
 
+// Fetch Android NDK major version set via "local.properties" or "ANDROID_NDK_HOME" environment variable.
+def ndkVersionMajor = 0
+try {
+	def localProperties = new Properties()
+	localProperties.load(file("${rootDir}/local.properties").newDataInputStream())
+	def ndkDir = localProperties.get('ndk.dir')
+	if (ndkDir == null) {
+		ndkDir = System.env.ANDROID_NDK_HOME
+	}
+	if (ndkDir != null) {
+		def ndkSourceProperties = new Properties()
+		ndkSourceProperties.load(file("${ndkDir}/source.properties").newDataInputStream())
+		def ndkVersionString = ndkSourceProperties.get('Pkg.Revision')
+		if (ndkVersionString != null) {
+			ndkVersionMajor = Integer.parseInt(ndkVersionString.split('\\.')[0])
+		}
+	}
+} catch (Throwable) {
+}
+
 android {
 	compileSdkVersion 29
 	defaultConfig {
@@ -65,9 +85,13 @@ android {
 					'APP_STL:=c++_shared',
 					"TI_DIST_DIR=${projectDir}/../../dist".replace('\\', '\\\\'),
 					"NDK_MODULE_PATH+=${projectDir}/../runtime/v8/src/ndk-modules".replace('\\', '\\\\'),
-					"--output-sync=none",
 					"-j${Runtime.runtime.availableProcessors()}".toString()
 				])
+				if (ndkVersionMajor >= 21) {
+					// Work-around issue where Google sets "--output-sync=target" by default for NDK v21+
+					// which causes "bad file descriptor" errors when using "-j" parallel executions argument.
+					arguments.add('--output-sync=none')
+				}
 				if (System.getProperty('os.name').toLowerCase().contains('windows')) {
 					// Reduces length of NDK command line strings by writing source file list to text files.
 					arguments.add('APP_SHORT_COMMANDS=true')


### PR DESCRIPTION
**JIRA:**
- https://jira.appcelerator.org/browse/TIMOB-27939
- https://jira.appcelerator.org/browse/TIMOB-27776

**Summary:**
- The macOS distribution of Android NDK r21c has been "notarized" by Google. This means macOS Catalina will no longer show security popups when attempting to do a module build.
- Will only auto-download this NDK version for module builds if no installation was found.
- Fixed builds with NDK r21 to no longer log harmless "Bad file descriptor" errors.

**Module Test:**
1. Use a macOS Catalina machine that does not have the NDK installed.
2. Download the zipped source of module [ti.imagefactory](https://github.com/appcelerator-modules/ti.imagefactory).
3. Open the Terminal.
4. `CD` to directory: `./ti.imagefactory/android`
5. Enter: `appc run -p android`
6. Verify that you see log message similar to the below. This may take a few minutes.
`[INFO]  [GRADLE] Preparing "Install NDK (revision: 21.2.6472646)"`
7. Verify that the module builds and its example project runs.
