### PR TITLE
fix(android)(9_0_X): improve textColorStateList validation

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIAbstractTabGroup.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIAbstractTabGroup.java
@@ -252,6 +252,10 @@ public abstract class TiUIAbstractTabGroup extends TiUIView
 	 */
 	protected ColorStateList textColorStateList(TiViewProxy tabProxy, int stateToUse)
 	{
+		if (getProxy() == null || tabProxy == null) {
+			return null;
+		}
+
 		int[][] textColorStates = new int[][] { new int[] { -stateToUse }, new int[] { stateToUse } };
 		int[] textColors = { this.textColorInt, this.textColorInt };
 

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUITabLayoutTabGroup.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUITabLayoutTabGroup.java
@@ -6,6 +6,7 @@
  */
 package ti.modules.titanium.ui.widget.tabgroup;
 
+import android.content.res.ColorStateList;
 import android.content.res.Configuration;
 import android.graphics.Rect;
 import android.graphics.drawable.Drawable;
@@ -245,8 +246,10 @@ public class TiUITabLayoutTabGroup extends TiUIAbstractTabGroup implements TabLa
 					//TIMOB-27830: Update text color after layout for change to take effect.
 					tabLayout.addOnLayoutChangeListener(
 						(v, left, top, right, bottom, oldLeft, oldTop, oldRight, oldBottom) -> {
-							if (tabProxy != null) {
-								textView.setTextColor(textColorStateList(tabProxy, android.R.attr.state_selected));
+							final ColorStateList colorStateList =
+								textColorStateList(tabProxy, android.R.attr.state_selected);
+							if (colorStateList != null) {
+								textView.setTextColor(colorStateList);
 							}
 						});
 				}


### PR DESCRIPTION
- Fix proxy validation in `TiUIAbstractTabGroup.java.textColorStateList()` for instances the `TabGroup` proxy is `null`
  - It appears the `OnLayoutChangeListener` can fire after a proxy has been destroyed. This behaviour only occurs during our `7.1` device tests.