### PR TITLE
fix(android): tiapp.xml setting <navbar-hidden/> ignored since 9.0.0

### DIFF
--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -3537,10 +3537,9 @@ AndroidBuilder.prototype.generateAndroidManifest = async function generateAndroi
 
 	// Choose app theme to be used by all activities depending on following "tiapp.xml" settings.
 	let appThemeName = '@style/Theme.AppCompat';
-	if (this.tiapp.fullscreen || this.tiapp['statusbar-hidden']) {
-		if (this.tiapp['navbar-hidden']) {
-			appThemeName += '.NoTitleBar';
-		} else {
+	if (this.tiapp.fullscreen || this.tiapp['statusbar-hidden'] || this.tiapp['navbar-hidden']) {
+		appThemeName += '.NoTitleBar';
+		if (this.tiapp.fullscreen || this.tiapp['statusbar-hidden']) {
 			appThemeName += '.Fullscreen';
 		}
 	}


### PR DESCRIPTION
**JIRA:**
https://jira.appcelerator.org/browse/TIMOB-27950

**Summary:**
If "tiapp.xml" setting `<navbar-hidden/>` is set `true` while `<fullscreen/>` and `<statusbar-hidden/>` are not set, then it will be ignored. This was a regression since Titanium 9.0.0.

**Test:**
1. Create a Titanium app project.
2. Set the following in the "tiapp.xml" file.
```xml
<ti:app>
	<fullscreen>false</fullscreen>
	<navbar-hidden>true</navbar-hidden>
	<statusbar-hidden>false</statusbar-hidden>
</ti:app>
```
3. Build and run on Android.
4. Verify title bar is **NOT** shown, but the status bar is still shown. _(This is the fix.)_
5. Set the following in the "tiapp.xml" file.
```xml
<ti:app>
	<fullscreen>true</fullscreen>
	<navbar-hidden>false</navbar-hidden>
	<statusbar-hidden>false</statusbar-hidden>
</ti:app>
```
6. Build and run on Android.
7. Verify both title bar and status bar are **NOT** shown.
