### PR TITLE
feat(ios): add tabsTransparent and tabsBackgroundView properties

### DIFF
--- a/apidoc/Titanium/UI/TabGroup.yml
+++ b/apidoc/Titanium/UI/TabGroup.yml
@@ -509,7 +509,7 @@ properties:
     default: true
     platforms: [iphone, ipad]
     
-  - name: tabsTranparent
+  - name: tabsTransparent
     summary: A Boolean value that indicates whether the tab bar is transparent.
     description: |
         When the value of this property is `true`, the tab group bar is completely transparent.

--- a/apidoc/Titanium/UI/TabGroup.yml
+++ b/apidoc/Titanium/UI/TabGroup.yml
@@ -467,6 +467,14 @@ properties:
     since: {android: "3.0.0", iphone: "3.0.0", ipad: "3.0.0"}
     platforms: [android, iphone, ipad]
 
+  - name: tabsBackgroundView
+    summary: Set a view for the TabGroup bar.
+    description: |
+        Adds a Ti.UI.View as a child of the TabGroup bar and sends it to back
+    type: [Titanium.UI.View]
+    since: {iphone: "9.1.0", ipad: "9.1.0"}
+    platforms: [iphone, ipad]
+
   - name: tabsTintColor
     summary: The tintColor to apply to the tabs.
     description: |
@@ -499,6 +507,16 @@ properties:
     type: Boolean
     since: "6.2.0"
     default: true
+    platforms: [iphone, ipad]
+    
+  - name: tabsTranparent
+    summary: A Boolean value that indicates whether the tab bar is transparent.
+    description: |
+        When the value of this property is `true`, the tab group bar is completely transparent.
+        You can use in combination with `tabsBackgroundView` to give a custom shape to your tab bar.
+    type: Boolean
+    since: "9.1.0"
+    default: false
     platforms: [iphone, ipad]
 
   - name: activeTintColor

--- a/iphone/Classes/TiUITabGroup.m
+++ b/iphone/Classes/TiUITabGroup.m
@@ -391,6 +391,40 @@ DEFINE_EXCEPTIONS
   controller.tabBar.selectionIndicatorImage = [self loadImage:value];
 }
 
+- (void)setTabsTransparent_:(id)value
+{
+  UITabBar *tabBar = [controller tabBar];
+
+  if ([TiUtils boolValue:value def:NO]) {
+    if (@available(iOS 13, *)) {
+      UITabBarAppearance *appearance = [tabBar.standardAppearance copy];
+
+      if ([TiUtils boolValue:value def:YES]) {
+        [appearance configureWithTransparentBackground];
+      } else {
+        [appearance configureWithDefaultBackground];
+      }
+
+      tabBar.standardAppearance = appearance;
+    } else {
+      UIGraphicsBeginImageContextWithOptions(CGSizeMake(1, 1), NO, 0.0);
+      UIImage *blank = UIGraphicsGetImageFromCurrentImageContext();
+      UIGraphicsEndImageContext();
+
+      tabBar.backgroundImage = blank;
+      tabBar.shadowImage = blank;
+    }
+  }
+}
+
+- (void)setTabsBackgroundView_:(id)value
+{
+  TiViewProxy *child = (TiViewProxy *)value;
+
+  [controller.tabBar addSubview:child.view];
+  [controller.tabBar sendSubviewToBack:child.view];
+}
+
 - (void)setShadowImage_:(id)value
 {
   //Because we still support XCode 4.3, we cannot use the shadowImage property


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/AC-6533

In an app that I'm developing I need to create a custom shape for the TabGroup. 
So I need to add a custom view to use as background. There no way with the current TabGroup properties to set the it with transparent background. 
So I added both `tabsBackgroundView` and `tabsTransparent` properties in order to achieve a result like this:

![Schermata 2020-06-11 alle 15 09 51](https://user-images.githubusercontent.com/2265079/84389279-17556b80-abf6-11ea-978c-26dab5b951ca.png)
