### PR TITLE
docs: use fenced code blocks

### DIFF
--- a/apidoc/Titanium/Android/ActionBar.yml
+++ b/apidoc/Titanium/Android/ActionBar.yml
@@ -43,9 +43,9 @@ description: |
     (API level 21) or higher, the action bar icon may not display. Google is discouraging
     the use of icons in toolbars:
 
-        In modern Android UIs developers should lean more on a visually distinct color scheme for toolbars
-        than on their application icon. The use of application icon plus title as a standard layout is
-        discouraged on API 21 devices and newer.
+    > In modern Android UIs developers should lean more on a visually distinct color scheme for toolbars
+    > than on their application icon. The use of application icon plus title as a standard layout is
+    > discouraged on API 21 devices and newer.
 
     Source: [Android Developer: Toolbar API reference](https://developer.android.com/reference/android/support/v7/widget/Toolbar.html)
 

--- a/apidoc/Titanium/UI/ListView.yml
+++ b/apidoc/Titanium/UI/ListView.yml
@@ -27,15 +27,17 @@ description: |
     objects that are, in turn, containers for [ListItem](Titanium.UI.ListItem) objects. This is
     easily visualized as an Alloy view:
 
-        <Alloy>
-            <ListView id="list">
-                <ListSection>
-                    <ListItem title="List item 1"></ListItem>
-                    <ListItem title="List item 2"></ListItem>
-                    <ListItem title="List item 3"></ListItem>
-                </ListSection>
-            </ListView>
-        </Alloy>
+    ``` xml
+    <Alloy>
+        <ListView id="list">
+            <ListSection>
+                <ListItem title="List item 1"></ListItem>
+                <ListItem title="List item 2"></ListItem>
+                <ListItem title="List item 3"></ListItem>
+            </ListSection>
+        </ListView>
+    </Alloy>
+    ```
 
     For more instructions and examples of using `ListView`, refer to the
     [ListViews guide](https://docs.appcelerator.com/platform/latest/#!/guide/ListViews).
@@ -1765,7 +1767,7 @@ examples:
         </Alloy>
         ```
 
-  - title: Alloy example of <PullView> element
+  - title: Alloy example of `<PullView>` element
     example: |
         The example below demonstrates how to use a `<PullView>` Alloy element.
 


### PR DESCRIPTION
Minor follow up on 33a40e2 that fixes a missed indented block and converts another block into a quote.