### PR TITLE
fix(android): handle shortcut exception

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/ShortcutItemProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/ShortcutItemProxy.java
@@ -52,6 +52,21 @@ public class ShortcutItemProxy extends KrollProxy
 		}
 	}
 
+	@SuppressLint("NewApi")
+	private void setShortcuts()
+	{
+		if (shortcuts.size() > shortcutManager.getMaxShortcutCountPerActivity()) {
+			Log.w(TAG, "Could not set shortcuts, max shortcuts exceeded.");
+			return;
+		}
+
+		try {
+			shortcutManager.setDynamicShortcuts(shortcuts);
+		} catch (Exception e) {
+			Log.e(TAG, e.getMessage());
+		}
+	}
+
 	public void handleCreationDict(KrollDict dict)
 	{
 		// only supported on Android 7.1 and above
@@ -102,7 +117,7 @@ public class ShortcutItemProxy extends KrollProxy
 				this.shortcuts.remove(shortcut);
 			}
 		}
-		createShortcut();
+		setShortcuts();
 		for (ShortcutInfo shortcut : this.shortcutManager.getDynamicShortcuts()) {
 			if (shortcut.getId().equals(this.shortcut.getId())) {
 				if (shortcut.isEnabled()) {
@@ -116,26 +131,24 @@ public class ShortcutItemProxy extends KrollProxy
 		super.handleCreationDict(dict);
 	}
 
-	@SuppressLint("NewApi")
 	@Kroll.method
 	public void show()
 	{
 		if (shortcut != null) {
 			if (!shortcuts.contains(shortcut)) {
 				shortcuts.add(shortcut);
-				createShortcut();
+				setShortcuts();
 			}
 		}
 	}
 
-	@SuppressLint("NewApi")
 	@Kroll.method
 	public void hide()
 	{
 		if (shortcut != null) {
 			if (shortcuts.contains(shortcut)) {
 				shortcuts.remove(shortcut);
-				createShortcut();
+				setShortcuts();
 			}
 		}
 	}
@@ -180,26 +193,15 @@ public class ShortcutItemProxy extends KrollProxy
 		return false;
 	}
 
-	@SuppressLint("NewApi")
 	@Override
 	public void release()
 	{
 		if (shortcut != null) {
 			shortcuts.remove(shortcut);
-			createShortcut();
+			setShortcuts();
 			shortcut = null;
 		}
 		super.release();
-	}
-
-	@SuppressLint("NewApi")
-	private void createShortcut()
-	{
-		try {
-			shortcutManager.setDynamicShortcuts(shortcuts);
-		} catch (Exception ex) {
-			Log.e(TAG, "Shortcut count exceeded");
-		}
 	}
 
 	@Override

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/ShortcutItemProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/ShortcutItemProxy.java
@@ -102,7 +102,7 @@ public class ShortcutItemProxy extends KrollProxy
 				this.shortcuts.remove(shortcut);
 			}
 		}
-		this.shortcutManager.setDynamicShortcuts(shortcuts);
+		createShortcut();
 		for (ShortcutInfo shortcut : this.shortcutManager.getDynamicShortcuts()) {
 			if (shortcut.getId().equals(this.shortcut.getId())) {
 				if (shortcut.isEnabled()) {
@@ -123,7 +123,7 @@ public class ShortcutItemProxy extends KrollProxy
 		if (shortcut != null) {
 			if (!shortcuts.contains(shortcut)) {
 				shortcuts.add(shortcut);
-				shortcutManager.setDynamicShortcuts(shortcuts);
+				createShortcut();
 			}
 		}
 	}
@@ -135,7 +135,7 @@ public class ShortcutItemProxy extends KrollProxy
 		if (shortcut != null) {
 			if (shortcuts.contains(shortcut)) {
 				shortcuts.remove(shortcut);
-				shortcutManager.setDynamicShortcuts(shortcuts);
+				createShortcut();
 			}
 		}
 	}
@@ -186,10 +186,20 @@ public class ShortcutItemProxy extends KrollProxy
 	{
 		if (shortcut != null) {
 			shortcuts.remove(shortcut);
-			shortcutManager.setDynamicShortcuts(shortcuts);
+			createShortcut();
 			shortcut = null;
 		}
 		super.release();
+	}
+
+	@SuppressLint("NewApi")
+	private void createShortcut()
+	{
+		try {
+			shortcutManager.setDynamicShortcuts(shortcuts);
+		} catch (Exception ex) {
+			Log.e(TAG, "Shortcut count exceeded");
+		}
 	}
 
 	@Override


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/AC-6564

**Optional Description:**

Won't crash with an unhandled exception:

```
var win = Ti.UI.createWindow({
		backgroundColor: 'grey'
	}),
	btn = Ti.UI.createButton({
		top: 0,
		title: 'TOGGLE SHORTCUT'
	})

Ti.App.addEventListener('shortcutitemclick', function() {
	win.backgroundColor = 'blue';
});

btn.addEventListener('click', function() {
	for (var i = 0; i < 10; ++i) {
		var shortcut = Ti.UI.createShortcutItem({
			id: 'test_shortcut' + i,
			title: 'TEST' + i,
			description: 'DESCRIPTION' + i
		});
		if (shortcut.visible) {
			win.backgroundColor = 'red';
			shortcut.hide();
		} else {
			win.backgroundColor = 'green';
			shortcut.show();
		}
	}
});

win.add(btn);
win.open();
```