### PR TITLE
fix(ios): report width/height of Blob as pixels, not points

### DIFF
--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiBlob.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiBlob.m
@@ -68,7 +68,7 @@ static NSString *const MIMETYPE_JPEG = @"image/jpeg";
 {
   [self ensureImageLoaded];
   if (image != nil) {
-    return image.size.width;
+    return image.size.width * image.scale;
   }
   return 0;
 }
@@ -78,7 +78,7 @@ GETTER_IMPL(NSUInteger, width, Width);
 {
   [self ensureImageLoaded];
   if (image != nil) {
-    return image.size.height;
+    return image.size.height * image.scale;
   }
   return 0;
 }
@@ -88,7 +88,7 @@ GETTER_IMPL(NSUInteger, height, Height);
 {
   [self ensureImageLoaded];
   if (image != nil) {
-    return image.size.width * image.size.height;
+    return image.size.width * image.size.height * image.scale * image.scale;
   }
   switch (type) {
   case TiBlobTypeData: {

--- a/tests/Resources/ti.blob.addontest.js
+++ b/tests/Resources/ti.blob.addontest.js
@@ -1,0 +1,57 @@
+/*
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2011-Present by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+/* eslint-env mocha */
+/* eslint no-unused-expressions: "off" */
+'use strict';
+const should = require('./utilities/assertions');
+
+describe('Titnaium.Blob', function () {
+	this.slow(2000);
+	this.timeout(5000);
+
+	let win;
+	afterEach(done => { // fires after every test in sub-suites too...
+		if (win && !win.closed) {
+			win.addEventListener('close', function listener () {
+				win.removeEventListener('close', listener);
+				win = null;
+				done();
+			});
+			win.close();
+		} else {
+			win = null;
+			done();
+		}
+	});
+
+	// iOS had a bug where it reported Blob width/height as pts, but Android reported px
+	// And worse - numbers not divisble by the device scale (2, 3, etc) we could not reliably reproduce the *real* pixel size
+	// i.e. a 10 x 10 pixel image/view on a 3x device woudl report width/height of 3 and scale of 3, so just multiplying those we'd get 9
+	// when the real image was actually 10px.
+	// However, natively we *can* properly generate true pixel size because image would report scale like 3.33 that we coudl multiply by before returning
+	it('image dimensions should be reported in pixels', finish => {
+		win = Ti.UI.createWindow();
+		const view = Ti.UI.createView({
+			backgroundColor: 'green',
+			width: '11px',
+			height: '13px'
+		});
+		win.add(view);
+		win.addEventListener('postlayout', function postlayout() {
+			win.removeEventListener('postlayout', postlayout); // only run once
+			try {
+				const blob = view.toImage();
+				should(blob.width).equal(11);
+				should(blob.height).equal(13);
+			} catch (e) {
+				return finish(e);
+			}
+			finish();
+		});
+		win.open();
+	});
+});


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-27997

**Optional Description:**
With some sizes and scales, it is impossible to reconstruct the true number of pixels
in JS just with screen density/scale. We need to multiple image scale vs pts natively.
i.e. 10px square image on a 3x device reported width/height of 3, device scale of 3.
Multiplying in JS naively we'd get image size of 9px x 9px, which was incorrect.

Found when an image comparison test failed on #11699 which was the result of using a 10px x 10px view/image on a 3x simulator. (I knew about the points vs pixels issue, but had to work around it by forcing the view to use a multiple of 3 for it's size, since `blob.width * Ti.Platform.displayCaps.logicalDensityFactor` gave us `9`)