### PR TITLE
fix(android): shortcut click event payload parity

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/TiC.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiC.java
@@ -2002,6 +2002,11 @@ public class TiC
 	/**
 	 * @module.api
 	 */
+	public static final String PROPERTY_ITEM = "item";
+
+	/**
+	 * @module.api
+	 */
 	public static final String PROPERTY_ITEM_ID = "itemId";
 
 	/**

--- a/android/titanium/src/java/org/appcelerator/titanium/TiRootActivity.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiRootActivity.java
@@ -388,9 +388,11 @@ public class TiRootActivity extends TiLaunchActivity implements TiActivitySuppor
 					appModule.fireEvent(TiC.EVENT_SHORTCUT_ITEM_CLICK, data);
 				}
 				if (shortcutModule != null && shortcutProperties != null) {
+					final KrollDict data = new KrollDict();
 					final ShortcutItemProxy item = new ShortcutItemProxy();
 					item.handleCreationDict(shortcutProperties);
-					shortcutModule.fireEvent(TiC.EVENT_CLICK, item);
+					data.put(TiC.PROPERTY_ITEM, item);
+					shortcutModule.fireEvent(TiC.EVENT_CLICK, data);
 				}
 			}
 


### PR DESCRIPTION
- Amend `Ti.UI.Shortcut` `click` event to include `item` as `ShortcutItem` instead of directly emitting `ShortcutItem`

##### TEST CASE
```JS
const window = Ti.UI.createWindow({ backgroundColor: 'grey', layout: 'vertical' });
const shortcut = Ti.UI.createShortcut();

let lastShortcutItem;

function test(title, callback) {
	const button = Ti.UI.createButton({ title, top: 50 });
	button.addEventListener('click', callback);
	window.add(button);
}

test('ADD RANDOM SHORTCUT', _ => {
	const rand = Math.floor(Math.random() * (999 - 1)) + 1;
	const item = Ti.UI.createShortcutItem({
    	id: `test_shortcut_${rand}`,
    	title: `SHORTCUT_${rand}`,
    	description: `DESCRIPTION_${rand}`
    });
	lastShortcutId = item;
	shortcut.add(item);
});

test('REMOVE LAST SHORTCUT', _ => {
	try {
		shortcut.remove(lastShortcutItem);
	} catch { }
});

test('REMOVE ALL SHORTCUTS', _ => {
	shortcut.removeAll();
});

test('NUMBER OF SHORTCUTS', _ => {
	alert(`staticItems: ${shortcut.staticItems.length}`);
	alert(`items: ${shortcut.items.length}`);
});

Ti.UI.Shortcut.addEventListener('click', e => {
	// e should contain 'item' property
	console.log('shortcut: ' + JSON.stringify(e, null, 1))
});

window.open();
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-28020)