### PR TITLE
fix(ios): Ti.Locale.parseDecimal() whitespace separator handling

### DIFF
--- a/iphone/Classes/LocaleModule.m
+++ b/iphone/Classes/LocaleModule.m
@@ -83,8 +83,16 @@ GETTER_IMPL(NSString *, currentLocale, CurrentLocale);
   }
 
   // Remove localized thousands separators from string if they exist. NSScanner fails to parse them.
+  // Note: If locale uses whitespace separators (like French), then remove all whitespace character types.
   NSString *thousandsSeparator = [locale objectForKey:NSLocaleGroupingSeparator];
-  text = [text stringByReplacingOccurrencesOfString:thousandsSeparator withString:@""];
+  NSCharacterSet *whitespaceCharSet = [NSCharacterSet whitespaceCharacterSet];
+  if ([thousandsSeparator rangeOfCharacterFromSet: whitespaceCharSet].location != NSNotFound) {
+    if ([text rangeOfCharacterFromSet: whitespaceCharSet].location != NSNotFound) {
+      text = [[text componentsSeparatedByCharactersInSet: whitespaceCharSet] componentsJoinedByString: @""];
+    }
+  } else {
+    text = [text stringByReplacingOccurrencesOfString:thousandsSeparator withString:@""];
+  }
 
   // Attempt to parse a number from given text. Return not-a-number if failed.
   NSScanner *scanner = [NSScanner localizedScannerWithString:text];

--- a/iphone/Classes/LocaleModule.m
+++ b/iphone/Classes/LocaleModule.m
@@ -86,9 +86,9 @@ GETTER_IMPL(NSString *, currentLocale, CurrentLocale);
   // Note: If locale uses whitespace separators (like French), then remove all whitespace character types.
   NSString *thousandsSeparator = [locale objectForKey:NSLocaleGroupingSeparator];
   NSCharacterSet *whitespaceCharSet = [NSCharacterSet whitespaceCharacterSet];
-  if ([thousandsSeparator rangeOfCharacterFromSet: whitespaceCharSet].location != NSNotFound) {
-    if ([text rangeOfCharacterFromSet: whitespaceCharSet].location != NSNotFound) {
-      text = [[text componentsSeparatedByCharactersInSet: whitespaceCharSet] componentsJoinedByString: @""];
+  if ([thousandsSeparator rangeOfCharacterFromSet:whitespaceCharSet].location != NSNotFound) {
+    if ([text rangeOfCharacterFromSet:whitespaceCharSet].location != NSNotFound) {
+      text = [[text componentsSeparatedByCharactersInSet:whitespaceCharSet] componentsJoinedByString:@""];
     }
   } else {
     text = [text stringByReplacingOccurrencesOfString:thousandsSeparator withString:@""];


### PR DESCRIPTION
**JIRA:**
https://jira.appcelerator.org/browse/TIMOB-27874

**Summary:**
- If locale uses a whitespace char for a number's thousands/group separator (like French), then all whitespace char types should be handled.
- For French locale, iOS 13 defaults to `\u202F` and older iOS versions default to `\u00A0`.
- Was causing a unit test failure on iOS 13.
