### PR TITLE
fix: fix crashing Ti.Platform.openURL

### DIFF
--- a/iphone/Classes/PlatformModule.m
+++ b/iphone/Classes/PlatformModule.m
@@ -314,7 +314,11 @@ GETTER_IMPL(NSNumber *, availableMemory, AvailableMemory);
     [[UIApplication sharedApplication] openURL:newUrl
                                        options:optionsDict
                              completionHandler:^(BOOL success) {
-                               if (callback != nil) {
+                               JSContextRef context = callback.context.JSGlobalContextRef;
+                               BOOL isUndefined = JSValueIsUndefined(context, callback.JSValueRef);
+                               BOOL isNull = JSValueIsNull(context, callback.JSValueRef);
+      
+                               if (!isUndefined && !isNull) {
                                  [callback callWithArguments:@[ @{@"success" : @(success)} ]];
                                }
                              }];


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-27846

This is a severe regression from the SDK 9 changes related to the refactoring of several core module like "Ti.Platform" and "Ti.Geolocation". `JSValue` here are never nil (in this case, by default they are "JS-undefined"). It can probably also have caused other regressions, so please check on those as well. An example test case is added in JIRA, which could be added to the test suite, if it doesn't cause trouble for other test cases because the app is backgrounded.