### PR TITLE
fix(android): Intl formatToParts() on Android 4.4

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,7 @@ def isMainlineBranch = (env.BRANCH_NAME ==~ MAINLINE_BRANCH_REGEXP)
 def targetBranch = isPR ? env.CHANGE_TARGET : (env.BRANCH_NAME ?: 'master')
 def runDanger = isPR // run Danger.JS if it's a PR by default. (should we also run on origin branches that aren't mainline?)
 def publishToS3 = isMainlineBranch // publish zips to S3 if on mainline branch, by default
-def testOnDevices = isMainlineBranch // run tests on devices
+def testOnDevices = true // run tests on devices
 
 // Variables we can change
 def nodeVersion = '10.17.0' // NOTE that changing this requires we set up the desired version on jenkins master first!


### PR DESCRIPTION
**JIRA:**
- https://jira.appcelerator.org/browse/TIMOB-27240
- https://jira.appcelerator.org/browse/TIMOB-27890

**Summary:**
The `DateTimeFormat.formatToParts()` and `NumberFormat.formatToParts()` methods were incorrectly returning a single "literal" string on Android 4.4. Only worked on Android 5.0 and higher. Modified (and optimized) code to work on all Android OS versions.

**Test:**
Unit tests automatically covers this.
