### PR TITLE
docs: Intl API edits

### DIFF
--- a/apidoc/Global/Intl/Collator.yml
+++ b/apidoc/Global/Intl/Collator.yml
@@ -1,5 +1,5 @@
 ---
-name: Collator
+name: Global.Intl.Collator
 summary: Immutable object used to perform language sensitive string comparisons.
 description: |
     A collator is used to perform a localized string compare or sort using a given language locale.
@@ -29,7 +29,7 @@ examples:
         console.log(collator.compare('a', 'A') === 0);  // Not Equal
         console.log(collator.compare('a', 'b') === 0);  // Not Equal
 
-        // Match strings that are the same case, ignoring accent marks.
+        // Case sensitive matching, ignoring accents marks.
         console.log('Case Sensitivity:');
         collator = new Intl.Collator(Ti.Locale.currentLocale, { sensitivity: 'case' });
         console.log(collator.compare('a', 'a') === 0);  // Equal
@@ -111,21 +111,27 @@ properties:
 
       #### Parameters
 
-      *    locales: [String](Global.String)/Array<[String](Global.String)> (optional)
+      *    `locales`: [String](Global.String)/[String](Global.String)`[]` (optional)
+
            The [BCP 47](https://www.unicode.org/reports/tr35/tr35.html#BCP_47_Conformance) language and country
            code(s) to use for localized string comparisons. Can provide multiple locales where the best-supported
            locale will be favored in the order provided by the array. If parameter is not assigned, then
-           the system may use the 'en-US' locale by default instead of the system's current locale.
+           the system may use the `'en-US'` locale by default instead of the system's current locale.
            It's recommended to set this parameter using <Titanium.Locale.currentLocale>.
-      *    options: <CollatorOptions> (optional)
+
+      *    `options`: <CollatorOptions> (optional)
+
            Provides settings indicating how strings should be compared.
 
-    type: Collator
+    type: Global.Intl.Collator
     permission: read-only
 
 ---
 name: CollatorOptions
-summary: Options to be passed into the <Collator.constructor> method.
+summary: Options to be passed into the <Global.Intl.Collator.constructor> method.
+platforms: [iphone, ipad, android]
+since: {iphone: "6.0.0", ipad: "6.0.0", android: "9.1.0"}
+osver: {ios: {min: "10.3"}}
 properties:
   - name: localeMatcher
     type: String

--- a/apidoc/Global/Intl/DateTimeFormat.yml
+++ b/apidoc/Global/Intl/DateTimeFormat.yml
@@ -1,5 +1,5 @@
 ---
-name: DateTimeFormat
+name: Global.Intl.DateTimeFormat
 summary: Immutable object used to generate localized date and time formatted strings.
 description: |
     A `DateTimeFormat` object is used to format a `Date` object to a localized date and/or time string.
@@ -142,21 +142,27 @@ properties:
 
       #### Parameters
 
-      *    locales: [String](Global.String)/Array<[String](Global.String)> (optional)
+      *    `locales`: [String](Global.String)/[String](Global.String)`[]` (optional)
+
            The [BCP 47](https://www.unicode.org/reports/tr35/tr35.html#BCP_47_Conformance) language and country
            code(s) to use for localized formatting. Can provide multiple locales where the best-supported
            locale will be favored in the order provided by the array. If parameter is not assigned, then
-           the system may use the 'en-US' locale by default instead of the system's current locale.
+           the system may use the `'en-US'` locale by default instead of the system's current locale.
            It's recommended to set this parameter using <Titanium.Locale.currentLocale>.
-      *    options: <DateTimeFormatOptions> (optional)
+
+      *    `options`: <DateTimeFormatOptions> (optional)
+
            Provides settings indicating how a `Date` object should be formatted to a `String`.
 
-    type: DateTimeFormat
+    type: Global.Intl.DateTimeFormat
     permission: read-only
 
 ---
 name: DateTimeFormatOptions
-summary: Options to be passed into the <DateTimeFormat.constructor> method.
+summary: Options to be passed into the <Global.Intl.DateTimeFormat.constructor> method.
+platforms: [iphone, ipad, android]
+since: {iphone: "6.0.0", ipad: "6.0.0", android: "9.1.0"}
+osver: {ios: {min: "10.3"}}
 properties:
   - name: dateStyle
     type: String
@@ -177,7 +183,7 @@ properties:
 
   - name: timeStyle
     type: String
-    summary: Specifies the locale's built-in hour, month, and second formatting styles.
+    summary: Specifies the locale's built-in hour, minute, and second formatting styles.
     description: |
       Can be set to one of the following:
 
@@ -348,5 +354,5 @@ properties:
     description: |
       Can be set to one of the following:
 
-      *    `'short'` Outputs the GMT offset such as `'GMT+8'` for US Pacific Time.
+      *    `'short'` Outputs the GMT offset such as `'GMT-8'` for US Pacific Time.
       *    `'long'` Outputs the full time zone name such as `'British Summer Time'`.

--- a/apidoc/Global/Intl/Intl.yml
+++ b/apidoc/Global/Intl/Intl.yml
@@ -1,5 +1,5 @@
 ---
-name: Intl
+name: Global.Intl
 summary: Namespace providing JavaScript's standard internationalization APIs.
 description: |
     Provides support for localized number formatting, date/time formatting,

--- a/apidoc/Global/Intl/NumberFormat.yml
+++ b/apidoc/Global/Intl/NumberFormat.yml
@@ -1,10 +1,10 @@
 ---
-name: NumberFormat
+name: Global.Intl.NumberFormat
 summary: Immutable object used to convert numbers to localized numeric strings.
 description: |
     A `NumberFormat` object is used to convert a `Number` value to a localized numeric string.
-    It provides various formatting options controlling the amount of integer and fractional digits
-    to be displayed. It can also output a currency values, percentage based values, and
+    It provides various formatting options controlling the number of integer and fractional digits
+    to be displayed. It can also output currency values, percentage based values, and
     scientific notation.
 
     For more detail, see the MDN website about
@@ -56,7 +56,7 @@ examples:
   - title: Currency Format
     example: |
         ``` js
-        // Set up currency style numeric format options.
+        // Set up currency style format options.
         const options = {
             style: 'currency',
             maximumFractionDigits: 2,
@@ -112,7 +112,7 @@ examples:
         ``` js
         // Logs: 1.235E5
         // Decimal point will be a period, comma, or space depending on the locale.
-        let formatter = new Intl.NumberFormat(Ti.Locale.currentLocale, { notation: 'scientific' });
+        const formatter = new Intl.NumberFormat(Ti.Locale.currentLocale, { notation: 'scientific' });
         console.log(formatter.format(123456.7));
         ```
 
@@ -135,8 +135,8 @@ methods:
     summary: Formats given number to an array of components describing what the formmated string would produce.
     description: |
       Returns an array of objects providing the "type" and "value" of each component the formatted
-      string would produce. Can be used to fetch localized separator chracters, currency character,
-      localized currency symbol position, etc.
+      string would produce. Can be used to fetch localized separator chracters, currency characters,
+      currency symbol positions, etc.
 
       For more detail, see the MDN website about
       [formatToParts](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/formatToParts).
@@ -147,7 +147,7 @@ methods:
     returns:
         type: Array<Object>
         summary: Array of objects providing the "type" and "value" of each component in formatted string.
-    osver: {ios: {min: "11.2"}}
+    osver: {ios: {min: "13.0"}}
 
   - name: resolvedOptions
     summary: Gets the object's formatting options.
@@ -185,21 +185,27 @@ properties:
 
       #### Parameters
 
-      *    locales: [String](Global.String)/Array<[String](Global.String)> (optional)
+      *    `locales`: [String](Global.String)/[String](Global.String)`[]` (optional)
+
            The [BCP 47](https://www.unicode.org/reports/tr35/tr35.html#BCP_47_Conformance) language and country
            code(s) to use for localized formatting. Can provide multiple locales where the best-supported
            locale will be favored in the order provided by the array. If parameter is not assigned, then
-           the system may use the 'en-US' locale by default instead of the system's current locale.
+           the system may use the `'en-US'` locale by default instead of the system's current locale.
            It's recommended to set this parameter using <Titanium.Locale.currentLocale>.
-      *    options: <NumberFormatOptions> (optional)
+
+      *    `options`: <NumberFormatOptions> (optional)
+
            Provides settings indicating how a number should be formatted to a string.
 
-    type: NumberFormat
+    type: Global.Intl.NumberFormat
     permission: read-only
 
 ---
 name: NumberFormatOptions
-summary: Options to be passed into the <NumberFormat.constructor> method.
+summary: Options to be passed into the <Global.Intl.NumberFormat.constructor> method.
+platforms: [iphone, ipad, android]
+since: {iphone: "6.0.0", ipad: "6.0.0", android: "9.1.0"}
+osver: {ios: {min: "10.3"}}
 properties:
   - name: style
     type: String
@@ -232,8 +238,8 @@ properties:
     summary: Set to the ISO 4217 currency code to use when formatting with the currency style.
     description: |
       If the <Global.Intl.NumberFormat.NumberFormatOptions.style> option is set to `'currency'`,
-      then you must also set this `currency` option to the
-      [ISO 4217](https://www.currency-iso.org/en/home/tables/table-a1.html) currency code to use
+      then you must also set this `currency` option to an
+      [ISO 4217](https://www.currency-iso.org/en/home/tables/table-a1.html) currency code
       such as `'USD'` for US dollars or `'EUR'` for euros.
 
   - name: currencyDisplay
@@ -242,7 +248,7 @@ properties:
     summary: Indicates how the currency symbol or name should be shown.
     description: |
       This option is only applicable if <Global.Intl.NumberFormat.NumberFormatOptions.style>
-      is set to `'currency'`
+      is set to `'currency'`.
 
       This option can be set to one of the following:
 
@@ -268,9 +274,9 @@ properties:
     default: 1
     summary: Applies leading zeros to the integer portion of the formatted number.
     description: |
-      A value ranging between `0` to `21` setting the minimum number of integer digits on the
-      side of the decimal separator to be shown. This will pad the formatted number with
-      leading zeros if below the minimum value.
+      A value ranging between `0` to `21` setting the minimum number of integer digits to be shown
+      on the left side of the decimal separator. This will pad the formatted number with
+      leading zeros if the number of digits is below this minimum value.
 
       ``` js
       // Pad with 3 leading zeros.


### PR DESCRIPTION
**JIRA:**
- https://jira.appcelerator.org/browse/TIMOB-27240
- https://jira.appcelerator.org/browse/TIMOB-27890
- https://jira.appcelerator.org/browse/TIMOB-27891

**Summary:**
- Fixed `Intl` docs to appear under `Global` doc tree.
  * Should appear under: https://docs.appcelerator.com/platform/latest/#!/api/Global
- Improved constructor parameters formatting.
- Added SDK and OS versions needed by all `Intl` constructor `*Options` types.
- Changed `Intl.NumberFormat.formatToParts()` to indicate it needs at least iOS13.
