### PR TITLE
fix(android)(9_1_X): also fire click events on Shortcut instances

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/UIModule.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/UIModule.java
@@ -393,9 +393,11 @@ public class UIModule extends KrollModule
 
 	protected static final int MSG_LAST_ID = KrollProxy.MSG_LAST_ID + 101;
 
+	private static ShortcutProxy shortcutProxy = null;
+
 	public UIModule()
 	{
-		super();
+		super("UI");
 
 		// Register the module's broadcast receiver.
 		final UIModule.Receiver broadcastReceiver = new UIModule.Receiver(this);
@@ -562,6 +564,11 @@ public class UIModule extends KrollModule
 	@Kroll.method
 	public KrollProxy createShortcut()
 	{
-		return new ShortcutProxy();
+		// Always return same `Ti.UI.Shortcut` instance.
+		// This is so we can fire `click` events without needing to track multiple `ShortcutProxy` instances.
+		if (shortcutProxy == null) {
+			shortcutProxy = new ShortcutProxy();
+		}
+		return shortcutProxy;
 	}
 }

--- a/android/titanium/src/java/org/appcelerator/titanium/TiRootActivity.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiRootActivity.java
@@ -35,6 +35,8 @@ import android.os.Looper;
 import android.view.Window;
 
 import ti.modules.titanium.ui.ShortcutItemProxy;
+import ti.modules.titanium.ui.ShortcutProxy;
+import ti.modules.titanium.ui.UIModule;
 
 public class TiRootActivity extends TiLaunchActivity implements TiActivitySupport
 {
@@ -382,17 +384,30 @@ public class TiRootActivity extends TiLaunchActivity implements TiActivitySuppor
 			if (shortcutId != null) {
 				final KrollModule appModule = getTiApp().getModuleByName("App");
 				final KrollModule shortcutModule = getTiApp().getModuleByName("Shortcut");
+				final KrollModule uiModule = getTiApp().getModuleByName("UI");
+
 				if (appModule != null) {
 					KrollDict data = new KrollDict();
 					data.put(TiC.PROPERTY_ID, shortcutId);
 					appModule.fireEvent(TiC.EVENT_SHORTCUT_ITEM_CLICK, data);
 				}
-				if (shortcutModule != null && shortcutProperties != null) {
+				if (shortcutProperties != null) {
 					final KrollDict data = new KrollDict();
 					final ShortcutItemProxy item = new ShortcutItemProxy();
+
 					item.handleCreationDict(shortcutProperties);
 					data.put(TiC.PROPERTY_ITEM, item);
-					shortcutModule.fireEvent(TiC.EVENT_CLICK, data);
+
+					if (shortcutModule != null) {
+						shortcutModule.fireEvent(TiC.EVENT_CLICK, data);
+					}
+					if (uiModule != null) {
+						final ShortcutProxy shortcutProxy = (ShortcutProxy) ((UIModule) uiModule).createShortcut();
+
+						if (shortcutProxy != null) {
+							shortcutProxy.fireEvent(TiC.EVENT_CLICK, data);
+						}
+					}
 				}
 			}
 


### PR DESCRIPTION
- Fire `click` events on `Ti.UI.Shortcut` instances

##### TEST CASE
```JS
const window = Ti.UI.createWindow({
	backgroundColor: 'grey',
	layout: 'vertical'
});
const shortcut = Ti.UI.createShortcut();

function test(title, callback) {
	const button = Ti.UI.createButton({ title, top: 50 });
	button.addEventListener('click', callback);
	window.add(button);
}

test('ADD SHORTCUT', _ => {
	const rand = Math.floor(Math.random() * (999 - 1)) + 1;
	const item = Ti.UI.createShortcutItem({
    	    	id: `test_shortcut_${rand}`,
    	    	title: `SHORTCUT_${rand}`,
    	    	description: `DESCRIPTION_${rand}`
        	});

    	shortcut.addEventListener('click', e => {
    	    	console.log('shortcut: ' + JSON.stringify(e, null, 1))
    	});

    	shortcut.add(item);
});

test('REMOVE ALL SHORTCUTS', _ => {
	shortcut.removeAll();
});

window.open();
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-27889)