### PR TITLE
feat: add OS version major/minor integer constants

### DIFF
--- a/android/modules/platform/src/java/ti/modules/titanium/platform/PlatformModule.java
+++ b/android/modules/platform/src/java/ti/modules/titanium/platform/PlatformModule.java
@@ -71,7 +71,8 @@ public class PlatformModule extends KrollModule
 	protected DisplayCapsProxy displayCaps;
 
 	private List<Processor> processors;
-
+	private int versionMajor;
+	private int versionMinor;
 	protected int batteryState;
 	protected double batteryLevel;
 	protected boolean batteryStateReady;
@@ -84,6 +85,17 @@ public class PlatformModule extends KrollModule
 
 		batteryState = BATTERY_STATE_UNKNOWN;
 		batteryLevel = -1;
+
+		// Extract "<major>.<minor>" integers from OS version string.
+		String[] versionComponents = Build.VERSION.RELEASE.split("\\.");
+		try {
+			this.versionMajor = Integer.parseInt(versionComponents[0]);
+			if (versionComponents.length >= 2) {
+				this.versionMinor = Integer.parseInt(versionComponents[1]);
+			}
+		} catch (Exception ex) {
+			Log.e(TAG, "Failed to parse OS version string.", ex);
+		}
 	}
 
 	@Kroll.method
@@ -137,6 +149,18 @@ public class PlatformModule extends KrollModule
 	public String getVersion()
 	{
 		return APSAnalyticsMeta.getOsVersion();
+	}
+
+	@Kroll.getProperty
+	public int getVersionMajor()
+	{
+		return this.versionMajor;
+	}
+
+	@Kroll.getProperty
+	public int getVersionMinor()
+	{
+		return this.versionMinor;
 	}
 
 	@Kroll.method

--- a/apidoc/Global/Global.yml
+++ b/apidoc/Global/Global.yml
@@ -323,6 +323,8 @@ properties:
   - name: OS_VERSION_MAJOR
     summary: The operation system's major version number.
     description: |
+        This returns the same value as the <Titanium.Platform.versionMajor> property.
+
         ``` js
         if (OS_IOS && (OS_VERSION_MAJOR >= 13)) {
             // Do something on iOS 13 or higher only.
@@ -334,8 +336,12 @@ properties:
 
   - name: OS_VERSION_MINOR
     summary: The operating system's minor version number.
-    description: Will return zero if OS does not have a minor version.
+    description: |
+        This returns the same value as the <Titanium.Platform.versionMinor> property.
+
+        Will return zero if the OS does not have a minor version.
     type: Number
+    default: 0
     permission: read-only
     since: "9.2.0"
 

--- a/apidoc/Global/Global.yml
+++ b/apidoc/Global/Global.yml
@@ -320,6 +320,25 @@ properties:
     permission: read-only
     since: "9.0.0"
 
+  - name: OS_VERSION_MAJOR
+    summary: The operation system's major version number.
+    description: |
+        ``` js
+        if (OS_IOS && (OS_VERSION_MAJOR >= 13)) {
+            // Do something on iOS 13 or higher only.
+        }
+        ```
+    type: Number
+    permission: read-only
+    since: "9.2.0"
+
+  - name: OS_VERSION_MINOR
+    summary: The operating system's minor version number.
+    description: Will return zero if OS does not have a minor version.
+    type: Number
+    permission: read-only
+    since: "9.2.0"
+
   - name: ENV_DEV
     summary: Alias for <ENV_DEVELOPMENT>
     type: Boolean

--- a/apidoc/Titanium/Platform/Platform.yml
+++ b/apidoc/Titanium/Platform/Platform.yml
@@ -363,14 +363,20 @@ properties:
 
   - name: versionMajor
     summary: The operating system's major version number.
+    description: |
+      This returns the same value as the [OS_VERSION_MAJOR](Global.OS_VERSION_MAJOR) constant.
     type: Number
     permission: read-only
     since: "9.2.0"
 
   - name: versionMinor
     summary: The operating system's minor version number.
-    description: Will return zero if OS does not have a minor version.
+    description: |
+      This returns the same value as the [OS_VERSION_MINOR](Global.OS_VERSION_MINOR) constant.
+
+      Will return zero if the OS does not have a minor version.
     type: Number
+    default: 0
     permission: read-only
     since: "9.2.0"
 

--- a/apidoc/Titanium/Platform/Platform.yml
+++ b/apidoc/Titanium/Platform/Platform.yml
@@ -357,9 +357,22 @@ properties:
     platforms: [android, iphone, ipad]
 
   - name: version
-    summary: System's OS version.
+    summary: The operating system's version string.
     type: String
     permission: read-only
+
+  - name: versionMajor
+    summary: The operating system's major version number.
+    type: Number
+    permission: read-only
+    since: "9.2.0"
+
+  - name: versionMinor
+    summary: The operating system's minor version number.
+    description: Will return zero if OS does not have a minor version.
+    type: Number
+    permission: read-only
+    since: "9.2.0"
 
 examples:
   - title: Battery Event Example

--- a/common/Resources/ti.internal/extensions/globals.js
+++ b/common/Resources/ti.internal/extensions/globals.js
@@ -1,0 +1,12 @@
+/**
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2020 by Axway, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+
+// Add global constants.
+Object.defineProperties(global, {
+	OS_VERSION_MAJOR: { value: Ti.Platform.versionMajor, writable: false },
+	OS_VERSION_MINOR: { value: Ti.Platform.versionMinor, writable: false }
+});

--- a/common/Resources/ti.internal/extensions/globals.js
+++ b/common/Resources/ti.internal/extensions/globals.js
@@ -4,9 +4,13 @@
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
+/* eslint-disable quote-props */
+/* globals OS_ANDROID, OS_IOS */
 
 // Add global constants.
 Object.defineProperties(global, {
+	'OS_ANDROID': { value: OS_ANDROID, writable: false },
+	'OS_IOS': { value: OS_IOS, writable: false },
 	OS_VERSION_MAJOR: { value: Ti.Platform.versionMajor, writable: false },
 	OS_VERSION_MINOR: { value: Ti.Platform.versionMinor, writable: false }
 });

--- a/common/Resources/ti.internal/extensions/index.js
+++ b/common/Resources/ti.internal/extensions/index.js
@@ -1,3 +1,6 @@
+// First, load our globals. Our other extensions depend on these.
+import './globals';
+
 // Load all JavaScript extensions/polyfills
 import './js';
 // Load extensions to polyfill our own APIs

--- a/common/Resources/ti.internal/extensions/ti/ti.blob.js
+++ b/common/Resources/ti.internal/extensions/ti/ti.blob.js
@@ -1,11 +1,12 @@
 /**
  * Appcelerator Titanium Mobile
- * Copyright (c) 2019 by Axway, Inc. All Rights Reserved.
+ * Copyright (c) 2019-2020 by Axway, Inc. All Rights Reserved.
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
+/* globals OS_IOS, OS_VERSION_MAJOR */
 
-if (Ti.Platform.osname === 'iphone' || Ti.Platform.osname === 'ipad') {
+if (OS_IOS) {
 	const buffer = Ti.createBuffer({ value: '' });
 	const blob = buffer.toBlob();
 	blob.constructor.prototype.toString = function () {
@@ -13,7 +14,7 @@ if (Ti.Platform.osname === 'iphone' || Ti.Platform.osname === 'ipad') {
 		return (value === undefined) ? '[object TiBlob]' :  value;
 	};
 
-	if ((parseInt(Ti.Platform.version.split('.')[0]) < 11)) {
+	if (OS_VERSION_MAJOR < 11) {
 		// This is hack to fix TIMOB-27707. Remove it after minimum target set iOS 11+
 		setTimeout(function () {}, Infinity);
 	}

--- a/common/Resources/ti.internal/extensions/ti/ti.ui.js
+++ b/common/Resources/ti.internal/extensions/ti/ti.ui.js
@@ -4,9 +4,9 @@
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
-/* globals OS_ANDROID,OS_IOS */
+/* globals OS_ANDROID,OS_IOS, OS_VERSION_MAJOR */
 import Color from '../../../../lib/color';
-const isIOS13Plus = OS_IOS && parseInt(Ti.Platform.version.split('.')[0]) >= 13;
+const isIOS13Plus = OS_IOS && (OS_VERSION_MAJOR >= 13);
 
 // As Android passes a new instance of Ti.UI to every JS file we can't just
 // Ti.UI within this file, we must call kroll.binding to get the Titanium

--- a/iphone/Classes/PlatformModule.h
+++ b/iphone/Classes/PlatformModule.h
@@ -46,6 +46,8 @@ READONLY_PROPERTY(NSNumber *, totalMemory, TotalMemory);
 READONLY_PROPERTY(NSNumber *, uptime, Uptime);
 READONLY_PROPERTY(NSString *, username, Username);
 READONLY_PROPERTY(NSString *, version, Version);
+READONLY_PROPERTY(NSNumber *, versionMajor, VersionMajor);
+READONLY_PROPERTY(NSNumber *, versionMinor, VersionMinor);
 
 // Methods
 - (BOOL)canOpenURL:(NSString *)url;

--- a/iphone/Classes/PlatformModule.m
+++ b/iphone/Classes/PlatformModule.m
@@ -30,7 +30,7 @@ NSString *const DATA_IFACE = @"pdp_ip0";
 
 @implementation PlatformModule
 
-@synthesize architecture, availableMemory, model, name, osname, ostype, processorCount, totalMemory, uptime, username, version;
+@synthesize architecture, availableMemory, model, name, osname, ostype, processorCount, totalMemory, uptime, username, version, versionMajor, versionMinor;
 
 #pragma mark Internal
 
@@ -40,6 +40,15 @@ NSString *const DATA_IFACE = @"pdp_ip0";
     UIDevice *theDevice = [UIDevice currentDevice];
     name = [[theDevice systemName] retain];
     version = [[theDevice systemVersion] retain];
+
+    // Extract "<major>.<minor>" integers from OS version string.
+    NSArray *versionComponents = [version componentsSeparatedByString:@"."];
+    versionMajor = [NSNumber numberWithInt:[versionComponents[0] intValue]];
+    if ([versionComponents count] >= 2) {
+      versionMinor = [NSNumber numberWithInt:[versionComponents[1] intValue]];
+    } else {
+      versionMinor = @0;
+    }
 
     // grab logical CPUs
     int cores = 1;
@@ -90,6 +99,8 @@ NSString *const DATA_IFACE = @"pdp_ip0";
   RELEASE_TO_NIL(name);
   RELEASE_TO_NIL(model);
   RELEASE_TO_NIL(version);
+  RELEASE_TO_NIL(versionMajor);
+  RELEASE_TO_NIL(versionMinor);
   RELEASE_TO_NIL(architecture);
   RELEASE_TO_NIL(processorCount);
   RELEASE_TO_NIL(username);
@@ -460,6 +471,8 @@ GETTER_IMPL(NSNumber *, totalMemory, TotalMemory);
 GETTER_IMPL(NSNumber *, uptime, Uptime);
 GETTER_IMPL(NSString *, username, Username);
 GETTER_IMPL(NSString *, version, Version);
+GETTER_IMPL(NSNumber *, versionMajor, VersionMajor);
+GETTER_IMPL(NSNumber *, versionMinor, VersionMinor);
 
 MAKE_SYSTEM_PROP(BATTERY_STATE_UNKNOWN, UIDeviceBatteryStateUnknown);
 MAKE_SYSTEM_PROP(BATTERY_STATE_UNPLUGGED, UIDeviceBatteryStateUnplugged);

--- a/iphone/Resources/app.js
+++ b/iphone/Resources/app.js
@@ -20,6 +20,3 @@ btn.addEventListener('click', function() {
 
 win.add(btn);
 win.open();
-
-console.log("@@@ OS_VERSION_MAJOR: " + OS_VERSION_MAJOR);
-console.log("@@@ OS_VERSION_MINOR: " + OS_VERSION_MINOR);

--- a/iphone/Resources/app.js
+++ b/iphone/Resources/app.js
@@ -20,3 +20,6 @@ btn.addEventListener('click', function() {
 
 win.add(btn);
 win.open();
+
+console.log("@@@ OS_VERSION_MAJOR: " + OS_VERSION_MAJOR);
+console.log("@@@ OS_VERSION_MINOR: " + OS_VERSION_MINOR);

--- a/tests/Resources/intl.numberformat.test.js
+++ b/tests/Resources/intl.numberformat.test.js
@@ -4,7 +4,7 @@
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
-/* global OS_IOS */
+/* global OS_IOS, OS_VERSION_MAJOR */
 /* eslint-env mocha */
 /* eslint no-unused-expressions: "off" */
 'use strict';
@@ -141,7 +141,7 @@ describe('Intl.NumberFormat', () => {
 	});
 
 	describe('#formatToParts()', () => {
-		if (OS_IOS && (parseInt(Ti.Platform.version.split('.')[0]) < 13)) {
+		if (OS_IOS && (OS_VERSION_MAJOR < 13)) {
 			return;
 		}
 

--- a/tests/Resources/ti.app.ios.test.js
+++ b/tests/Resources/ti.app.ios.test.js
@@ -4,6 +4,7 @@
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
+/* global OS_VERSION_MAJOR */
 /* eslint-env mocha */
 /* eslint no-unused-expressions: "off" */
 'use strict';
@@ -191,8 +192,7 @@ describe.ios('Titanium.App.iOS', function () {
 		should(Ti.App.iOS.EVENT_ACCESSIBILITY_LAYOUT_CHANGED).be.a.String();
 		should(Ti.App.iOS.EVENT_ACCESSIBILITY_SCREEN_CHANGED).be.a.String();
 
-		const isiOS13 = parseInt(Ti.Platform.version.split('.')[0]) >= 13;
-		if (isiOS13) {
+		if (OS_VERSION_MAJOR >= 13) {
 			should(Ti.App.iOS.USER_INTERFACE_STYLE_UNSPECIFIED).be.a.Number();
 			should(Ti.App.iOS.USER_INTERFACE_STYLE_LIGHT).be.a.Number();
 			should(Ti.App.iOS.USER_INTERFACE_STYLE_DARK).be.a.Number();
@@ -261,8 +261,7 @@ describe.ios('Titanium.App.iOS', function () {
 	});
 
 	it.ios('.userInterfaceStyle', () => {
-		const isiOS13 = parseInt(Ti.Platform.version.split('.')[0]) >= 13;
-		if (isiOS13) {
+		if (OS_VERSION_MAJOR >= 13) {
 			// We only check for the type, since the value (light, dark, unspecified)
 			// can vary between device configs
 			should(Ti.App.iOS.userInterfaceStyle).be.a.Number();

--- a/tests/Resources/ti.network.httpclient.test.js
+++ b/tests/Resources/ti.network.httpclient.test.js
@@ -653,7 +653,7 @@ describe('Titanium.Network.HTTPClient', function () {
 
 	it.android('TLSv3 support', function (finish) {
 		// Only supported on Android 10+
-		if (parseInt(Ti.Platform.version.split('.')[0]) < 10) {
+		if (Ti.Platform.Android.API_LEVEL < 29) {
 			return finish();
 		}
 

--- a/tests/Resources/ti.platform.test.js
+++ b/tests/Resources/ti.platform.test.js
@@ -283,11 +283,16 @@ describe('Titanium.Platform', function () {
 	it('.versionMajor', () => {
 		should(Ti.Platform).have.readOnlyProperty('versionMajor').which.is.a.Number();
 		should(Ti.Platform.versionMajor).be.eql(OS_VERSION_MAJOR);
+		should(Ti.Platform.versionMajor).be.eql(parseInt(Ti.Platform.version.split('.')[0]));
 	});
 
 	it('.versionMinor', () => {
 		should(Ti.Platform).have.readOnlyProperty('versionMinor').which.is.a.Number();
 		should(Ti.Platform.versionMinor).be.eql(OS_VERSION_MINOR);
+
+		const versionComponents = Ti.Platform.version.split('.');
+		const versionMinor = (versionComponents.length >= 2) ? parseInt(versionComponents[1]) : 0;
+		should(Ti.Platform.versionMinor).be.eql(versionMinor);
 	});
 
 	it.ios('.identifierForVendor', () => {

--- a/tests/Resources/ti.platform.test.js
+++ b/tests/Resources/ti.platform.test.js
@@ -4,6 +4,7 @@
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
+/* global OS_VERSION_MAJOR, OS_VERSION_MINOR */
 /* eslint-env mocha */
 /* eslint no-unused-expressions: "off" */
 'use strict';
@@ -277,6 +278,16 @@ describe('Titanium.Platform', function () {
 
 	it('.version', () => {
 		should(Ti.Platform).have.readOnlyProperty('version').which.is.a.String();
+	});
+
+	it('.versionMajor', () => {
+		should(Ti.Platform).have.readOnlyProperty('versionMajor').which.is.a.Number();
+		should(Ti.Platform.versionMajor).be.eql(OS_VERSION_MAJOR);
+	});
+
+	it('.versionMinor', () => {
+		should(Ti.Platform).have.readOnlyProperty('versionMinor').which.is.a.Number();
+		should(Ti.Platform.versionMinor).be.eql(OS_VERSION_MINOR);
 	});
 
 	it.ios('.identifierForVendor', () => {

--- a/tests/Resources/ti.ui.ios.tableviewstyle.test.js
+++ b/tests/Resources/ti.ui.ios.tableviewstyle.test.js
@@ -4,6 +4,7 @@
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
+/* global OS_VERSION_MAJOR */
 /* eslint-env mocha */
 /* eslint no-unused-expressions: "off" */
 'use strict';
@@ -14,8 +15,7 @@ describe.ios('Titanium.UI.iOS.TableViewStyle', function () {
 	it('#constants', function () {
 		should(Titanium.UI.iOS.TableViewStyle.PLAIN).be.a.Number();
 		should(Titanium.UI.iOS.TableViewStyle.GROUPED).be.a.Number();
-		const isiOS13 = parseInt(Ti.Platform.version.split('.')[0]) >= 13;
-		if (isiOS13) {
+		if (OS_VERSION_MAJOR >= 13) {
 			should(Titanium.UI.iOS.TableViewStyle.INSET_GROUPED).be.a.Number();
 		}
 	});

--- a/tests/Resources/ti.ui.ios.test.js
+++ b/tests/Resources/ti.ui.ios.test.js
@@ -4,14 +4,13 @@
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
+/* global OS_VERSION_MAJOR */
 /* eslint-env mocha */
 /* eslint no-unused-expressions: "off" */
 'use strict';
 const should = require('./utilities/assertions');
 
 describe.ios('Titanium.UI.iOS', function () {
-	const isiOS13 =  (parseInt(Ti.Platform.version.split('.')[0]) >= 13);
-
 	// --- properties ---
 	it.iosBroken('.appBadge', function () {
 		should(Ti.UI.iOS.appBadge).be.undefined(); // FIXME: Defaults to 0!
@@ -147,7 +146,7 @@ describe.ios('Titanium.UI.iOS', function () {
 	});
 
 	it('#systemImage()', function () {
-		if (isiOS13) {
+		if (OS_VERSION_MAJOR >= 13) {
 			should(Ti.UI.iOS.systemImage).not.be.undefined();
 			should(Ti.UI.iOS.systemImage).be.a.Function();
 			const systemImage = Ti.UI.iOS.systemImage('drop.triangle.fill');
@@ -157,7 +156,7 @@ describe.ios('Titanium.UI.iOS', function () {
 
 	it('.BLUR_EFFECT_STYLE_SYSTEM_* constants', function () {
 		// Used in BlurView.effect. Need to copy under #constatnt test case
-		if (isiOS13) {
+		if (OS_VERSION_MAJOR >= 13) {
 			should(Ti.UI.iOS.BLUR_EFFECT_STYLE_SYSTEM_ULTRA_THIN_MATERIAL).be.a.Number();
 			should(Ti.UI.iOS.BLUR_EFFECT_STYLE_SYSTEM_THIN_MATERIAL).be.a.Number();
 			should(Ti.UI.iOS.BLUR_EFFECT_STYLE_SYSTEM_MATERIAL).be.a.Number();

--- a/tests/Resources/ti.ui.test.js
+++ b/tests/Resources/ti.ui.test.js
@@ -5,7 +5,7 @@
  * Please see the LICENSE included with this distribution for details.
  */
 /* eslint-env mocha */
-/* globals OS_ANDROID,OS_IOS */
+/* globals OS_ANDROID, OS_IOS, OS_VERSION_MAJOR */
 /* eslint no-unused-expressions: "off" */
 'use strict';
 const should = require('./utilities/assertions');
@@ -218,7 +218,7 @@ describe('Titanium.UI', function () {
 	});
 
 	describe('Semantic Colors', () => {
-		const isIOS13Plus = OS_IOS && parseInt(Ti.Platform.version.split('.')[0]) >= 13;
+		const isIOS13Plus = OS_IOS && (OS_VERSION_MAJOR >= 13);
 
 		it('#fetchSemanticColor() with user colors', () => {
 			const semanticColors = require('./semantic.colors.json');


### PR DESCRIPTION
**JIRA:**
https://jira.appcelerator.org/browse/TIMOB-28061

**Summary:**
Added new integer constants...
- `Ti.Platform.versionMajor`
- `Ti.Platform.versionMinor`
- `OS_VERSION_MAJOR`
- `OS_VERSION_MINOR`

**Reason:**
Makes it easier to implement new OS features. For example...
```javascript
if (OS_IOS && (OS_VERSION_MAJOR >= 13)) {
	// Do something on iOS 13 or higher only.
}
```

---
**Test:**
_Run this test on different Android/iOS versions._
1. Build and run the below on Android or iOS.
2. Verify `versionMajor` and `versionMinor` match `Ti.Platform.version` string.
3. Verify `OS_VERSION_MAJOR` and `OS_VERSION_MINOR` match `Ti.Platform.version` string.

```javascript
var window = Ti.UI.createWindow({ layout: "vertical" });
window.add(Ti.UI.createView({ height: OS_IOS ? "20dp" : "10dp" }));
window.add(Ti.UI.createLabel({
	text: "Ti.Platform.version: " + Ti.Platform.version,
	top: "10dp",
}));
window.add(Ti.UI.createLabel({
	text: "Ti.Platform.versionMajor: " + Ti.Platform.versionMajor,
	top: "10dp",
}));
window.add(Ti.UI.createLabel({
	text: "Ti.Platform.versionMinor: " + Ti.Platform.versionMinor,
	top: "10dp",
}));
window.add(Ti.UI.createLabel({
	text: "OS_VERSION_MAJOR: " + OS_VERSION_MAJOR,
	top: "10dp",
}));
window.add(Ti.UI.createLabel({
	text: "OS_VERSION_MINOR: " + OS_VERSION_MINOR,
	top: "10dp",
}));
window.open();
```
