### PR TITLE
test: use threshold for image diff

### DIFF
--- a/tests/Resources/utilities/assertions.js
+++ b/tests/Resources/utilities/assertions.js
@@ -123,7 +123,7 @@ function saveImage(blob, imageFilePath) {
 	return file;
 }
 
-should.Assertion.add('matchImage', function (imageFilePath) {
+should.Assertion.add('matchImage', function (imageFilePath, threshold = 0.1) {
 	this.params = { operator: `view to match snapshot image: ${imageFilePath}` };
 	if (this.obj.apiName) {
 		this.params.obj = this.obj.apiName;
@@ -165,7 +165,7 @@ should.Assertion.add('matchImage', function (imageFilePath) {
 
 	const { width, height } = actualImg;
 	const diff = new PNG({ width, height });
-	const pixelsDiff = pixelmatch(actualImg.data, expectedImg.data, diff.data, width, height, { threshold: 0 });
+	const pixelsDiff = pixelmatch(actualImg.data, expectedImg.data, diff.data, width, height, { threshold });
 	if (pixelsDiff !== 0) {
 		const file = saveImage(blob, imageFilePath); // save "actual"
 		// Save diff image!

--- a/tests/Resources/utilities/assertions.js
+++ b/tests/Resources/utilities/assertions.js
@@ -138,7 +138,7 @@ should.Assertion.add('matchImage', function (imageFilePath, threshold = 0.1) {
 		// No snapshot. Generate one, then fail test
 		const file = saveImage(blob, imageFilePath);
 		console.log(`!IMAGE: {"path":"${file.nativePath}","platform":"${OS_ANDROID ? 'android' : 'ios'}","relativePath":"${imageFilePath}"}`);
-		should.fail(`No snapshot image to compare for platform "${OS_ANDROID ? 'android' : 'ios'}": ${imageFilePath}\nGenerated image at ${file.nativePath}`);
+		should.fail(undefined, undefined, `No snapshot image to compare for platform "${OS_ANDROID ? 'android' : 'ios'}": ${imageFilePath}\nGenerated image at ${file.nativePath}`);
 		return;
 	}
 
@@ -173,7 +173,7 @@ should.Assertion.add('matchImage', function (imageFilePath, threshold = 0.1) {
 		const diffFilePath = imageFilePath.slice(0, -4) + '_diff.png';
 		saveImage(diffBuffer.toTiBuffer().toBlob(), diffFilePath); // TODO Pass along path to diff file?
 		console.log(`!IMG_DIFF: {"path":"${file.nativePath}","platform":"${OS_ANDROID ? 'android' : 'ios'}","relativePath":"${imageFilePath}"}`);
-		should.fail(`Image ${imageFilePath} failed to match, had ${pixelsDiff} differing pixels. View actual/expected/diff images to compare manually.`);
+		should.fail(undefined, undefined, `Image ${imageFilePath} failed to match, had ${pixelsDiff} differing pixels. View actual/expected/diff images to compare manually.`);
 	}
 });
 


### PR DESCRIPTION
- Add `threshold` parameter to `matchImage`
- Use 10% threshold by default to ignore image defects