### PR TITLE
style(ios): add swift linting

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,7 @@
+disabled_rules: # rule identifiers to exclude from running
+  - orphaned_doc_comment
+  - line_length
+  - identifier_name
+included: # paths to include during linting. `--path` is ignored if present.
+  - iphone/Classes
+  

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -18,6 +18,9 @@ module.exports = {
 	'iphone/**/*.{m,h}': [
 		'npx clang-format -style=file -i'
 	],
+	'iphone/Classes/**/*.swift': [
+		'swiftlint autocorrect'
+	],
 	'iphone/TitaniumKit/TitaniumKit/Sources/API/TopTiModule.m': [
 		'npm run ios-sanity-check --'
 	],

--- a/package.json
+++ b/package.json
@@ -36,17 +36,21 @@
     "deprecations": "npm run docs:deprecated",
     "docs:deprecated": "./build/scons deprecations",
     "docs:removed": "./build/scons removals 7.0.0",
-    "format": "npm-run-all --parallel format:**",
+    "format": "npm-run-all --parallel format:!\\(ios\\|android\\)",
     "format:android": "echo Formatting Android code is not supported.",
-    "format:ios": "npm run lint:ios -- --fix",
+    "format:ios": "npm-run-all --parallel format:objc format:swift",
+    "format:objc": "npm run lint:objc -- --fix",
+    "format:swift": "npm run lint:swift -- autocorrect",
     "format:js": "npm run lint:js -- --fix",
     "ios": "./build/scons cleanbuild ios",
     "ios-sanity-check": "./build/scons check-ios-toplevel",
     "link": "npm run deploy -- --symlink",
-    "lint": "npm-run-all --parallel lint:**",
+    "lint": "npm-run-all --parallel lint:!\\(ios\\)",
     "lint:android": "./android/gradlew checkJavaStyle -p ./android --console plain",
     "lint:docs": "tdoc-validate ./apidoc",
-    "lint:ios": "clang-format-lint $npm_package_config_format_ios",
+    "lint:ios": "npm-run-all --parallel lint:objc lint:swift",
+    "lint:objc": "clang-format-lint $npm_package_config_format_objc",
+    "lint:swift": "swiftlint",
     "lint:js": "eslint .",
     "lint:lockfile": "./build/scons check-lockfile",
     "package": "./build/scons package",
@@ -76,8 +80,7 @@
       "path": "./node_modules/cz-conventional-changelog"
     },
     "format": {
-      "android": "android/!(app|templates)/**/*.java",
-      "ios": "iphone/Classes/*.{m,h} iphone/Classes/Layout/*.{m,h} iphone/TitaniumKit/TitaniumKit/*.h iphone/TitaniumKit/TitaniumKit/Sources/**/*.{m,h}"
+      "objc": "iphone/Classes/*.{m,h} iphone/Classes/Layout/*.{m,h} iphone/TitaniumKit/TitaniumKit/*.h iphone/TitaniumKit/TitaniumKit/Sources/**/*.{m,h}"
     }
   },
   "dependencies": {


### PR DESCRIPTION
**Description:**
This simply hooks up [SwiftLint](https://github.com/realm/SwiftLint#installation) config and adds npm scripts to use it to lint/format swift code. You need SwiftLint installed for it to work (easiest way is `brew install swiftlint`)

We already have it installed on CI build nodes for the [appcelerator.ble module](https://github.com/appcelerator/appcelerator.ble) linting.