### PR TITLE
buidl(ios): exclude arm64 architecture while building for simulator

### DIFF
--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -6842,6 +6842,11 @@ iOSBuilder.prototype.invokeXcodeBuild = function invokeXcodeBuild(next) {
 		}
 	}
 
+	// Exclude arm64 architecture from simulator build in XCode 12+ - TIMOB-28042
+	if (this.target === 'simulator' && parseFloat(this.xcodeEnv.version) >= 12.0) {
+		args.push('EXCLUDED_ARCHS=arm64');
+	}
+	
 	xcodebuildHook(
 		this.xcodeEnv.executables.xcodebuild,
 		args,

--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -6846,7 +6846,7 @@ iOSBuilder.prototype.invokeXcodeBuild = function invokeXcodeBuild(next) {
 	if (this.target === 'simulator' && parseFloat(this.xcodeEnv.version) >= 12.0) {
 		args.push('EXCLUDED_ARCHS=arm64');
 	}
-	
+
 	xcodebuildHook(
 		this.xcodeEnv.executables.xcodebuild,
 		args,


### PR DESCRIPTION
 https://jira.appcelerator.org/browse/TIMOB-28042
