### PR TITLE
[Backport 9_3_X] build(deps-dev): bump rollup from 2.26.4 to 2.26.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13428,9 +13428,9 @@
       }
     },
     "rollup": {
-      "version": "2.26.4",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.26.4.tgz",
-      "integrity": "sha512-6+qsGuP0MXGd7vlYmk72utm1MrgZj5GfXibGL+cRkKQ9+ZL/BnFThDl0D5bcl7AqlzMjAQXRAwZX1HVm22M/4Q==",
+      "version": "2.26.5",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.26.5.tgz",
+      "integrity": "sha512-rCyFG3ZtQdnn9YwfuAVH0l/Om34BdO5lwCA0W6Hq+bNB21dVEBbCRxhaHOmu1G7OBFDWytbzAC104u7rxHwGjA==",
       "dev": true,
       "requires": {
         "fsevents": "~2.1.2"

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "npm-run-all": "^4.1.5",
     "nyc": "^15.1.0",
     "request-promise-native": "^1.0.9",
-    "rollup": "^2.26.4",
+    "rollup": "^2.26.5",
     "rollup-plugin-babel": "^4.4.0",
     "rollup-plugin-commonjs": "^10.1.0",
     "rollup-plugin-node-resolve": "^5.2.0",


### PR DESCRIPTION
Backport 36f70dc8031137d847cc8d09694815a68b9ed7a8 from #11944