### PR TITLE
[Backport 9_3_X] build(deps-dev): bump cz-conventional-changelog from 3.2.0 to 3.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5476,6 +5476,21 @@
         "strip-json-comments": "3.0.1"
       },
       "dependencies": {
+        "cz-conventional-changelog": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/cz-conventional-changelog/-/cz-conventional-changelog-3.2.0.tgz",
+          "integrity": "sha512-yAYxeGpVi27hqIilG1nh4A9Bnx4J3Ov+eXy4koL3drrR+IO9GaWPsKjik20ht608Asqi8TQPf0mczhEeyAtMzg==",
+          "dev": true,
+          "requires": {
+            "@commitlint/load": ">6.1.1",
+            "chalk": "^2.4.1",
+            "commitizen": "^4.0.3",
+            "conventional-commit-types": "^3.0.0",
+            "lodash.map": "^4.5.1",
+            "longest": "^2.0.1",
+            "word-wrap": "^1.0.3"
+          }
+        },
         "fs-extra": {
           "version": "8.1.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
@@ -6048,6 +6063,12 @@
         }
       }
     },
+    "conventional-commit-types": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-commit-types/-/conventional-commit-types-3.0.0.tgz",
+      "integrity": "sha512-SmmCYnOniSsAa9GqWOeLqc179lfr5TRu5b4QFDkbsrJ5TZjPJx85wtOr3zn+1dbeNiXDKGPbZ72IKbPhLXh/Lg==",
+      "dev": true
+    },
     "conventional-commits-filter": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-2.0.6.tgz",
@@ -6227,9 +6248,9 @@
       "dev": true
     },
     "cz-conventional-changelog": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/cz-conventional-changelog/-/cz-conventional-changelog-3.2.0.tgz",
-      "integrity": "sha512-yAYxeGpVi27hqIilG1nh4A9Bnx4J3Ov+eXy4koL3drrR+IO9GaWPsKjik20ht608Asqi8TQPf0mczhEeyAtMzg==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/cz-conventional-changelog/-/cz-conventional-changelog-3.2.1.tgz",
+      "integrity": "sha512-MroXCfO8sahklT0KSwZ1oaNwKxZaZ2A8ONc+MH+is8QDZ2zBhGOFFiAXuWpcWFJLpxlGPvnYlhvOlYiSOAGc7w==",
       "dev": true,
       "requires": {
         "@commitlint/load": ">6.1.1",
@@ -6239,14 +6260,6 @@
         "lodash.map": "^4.5.1",
         "longest": "^2.0.1",
         "word-wrap": "^1.0.3"
-      },
-      "dependencies": {
-        "conventional-commit-types": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/conventional-commit-types/-/conventional-commit-types-3.0.0.tgz",
-          "integrity": "sha512-SmmCYnOniSsAa9GqWOeLqc179lfr5TRu5b4QFDkbsrJ5TZjPJx85wtOr3zn+1dbeNiXDKGPbZ72IKbPhLXh/Lg==",
-          "dev": true
-        }
       }
     },
     "danger": {

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "commitizen": "^4.1.5",
     "conventional-changelog-cli": "^2.1.0",
     "core-js": "^3.6.5",
-    "cz-conventional-changelog": "^3.2.0",
+    "cz-conventional-changelog": "^3.2.1",
     "danger": "^10.4.0",
     "dateformat": "^3.0.3",
     "eslint": "^7.7.0",


### PR DESCRIPTION
Backport of #11957.
See that PR for full details.