### PR TITLE
[Backport 9_3_X] build(deps-dev): bump commitizen from 4.1.5 to 4.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5455,9 +5455,9 @@
       "dev": true
     },
     "commitizen": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/commitizen/-/commitizen-4.1.5.tgz",
-      "integrity": "sha512-oGNNeOARhunAPi5VF7FnLJAUPwajgt7DaC9hrDXFVo+qFlHaCtMtjY+iXOvfIrMBV3qmDZZyjgBsrTQMN5u1rg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/commitizen/-/commitizen-4.2.0.tgz",
+      "integrity": "sha512-dMTgCkmxDOaH32HViVyvoGqVzCAyvBsgMViWnIDQxVHlEwHS1d6d8rweCGE7fjCROryBZmHRQrWVWN9GTw2F/g==",
       "dev": true,
       "requires": {
         "cachedir": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "chai": "^4.2.0",
     "clang-format": "1.4.0",
     "commander": "^6.0.0",
-    "commitizen": "^4.1.5",
+    "commitizen": "^4.2.0",
     "conventional-changelog-cli": "^2.1.0",
     "core-js": "^3.6.5",
     "cz-conventional-changelog": "^3.2.0",


### PR DESCRIPTION
Backport of #11956.
See that PR for full details.