### PR TITLE
[Backport 9_3_X] build(deps-dev): bump rollup from 2.26.5 to 2.26.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13557,9 +13557,9 @@
       }
     },
     "rollup": {
-      "version": "2.26.5",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.26.5.tgz",
-      "integrity": "sha512-rCyFG3ZtQdnn9YwfuAVH0l/Om34BdO5lwCA0W6Hq+bNB21dVEBbCRxhaHOmu1G7OBFDWytbzAC104u7rxHwGjA==",
+      "version": "2.26.6",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.26.6.tgz",
+      "integrity": "sha512-iSB7eE3k/VNQHnI7ckS++4yIqTamoUCB1xo7MswhJ/fg22oFYR5+xCrUZVviBj97jvc5A31MPbVMw1Wc3jWxmw==",
       "dev": true,
       "requires": {
         "fsevents": "~2.1.2"

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "npm-run-all": "^4.1.5",
     "nyc": "^15.1.0",
     "request-promise-native": "^1.0.9",
-    "rollup": "^2.26.5",
+    "rollup": "^2.26.6",
     "rollup-plugin-babel": "^4.4.0",
     "rollup-plugin-commonjs": "^10.1.0",
     "rollup-plugin-node-resolve": "^5.2.0",


### PR DESCRIPTION
Backport of #11972.
See that PR for full details.