### PR TITLE
[Backport 9_3_X] build(deps-dev): bump cz-conventional-changelog from 3.2.1 to 3.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6272,9 +6272,9 @@
       "dev": true
     },
     "cz-conventional-changelog": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/cz-conventional-changelog/-/cz-conventional-changelog-3.2.1.tgz",
-      "integrity": "sha512-MroXCfO8sahklT0KSwZ1oaNwKxZaZ2A8ONc+MH+is8QDZ2zBhGOFFiAXuWpcWFJLpxlGPvnYlhvOlYiSOAGc7w==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/cz-conventional-changelog/-/cz-conventional-changelog-3.3.0.tgz",
+      "integrity": "sha512-U466fIzU5U22eES5lTNiNbZ+d8dfcHcssH4o7QsdWaCcRs/feIPCxKYSWkYBNs5mny7MvEfwpTLWjvbm94hecw==",
       "dev": true,
       "requires": {
         "@commitlint/load": ">6.1.1",

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "commitizen": "^4.2.0",
     "conventional-changelog-cli": "^2.1.0",
     "core-js": "^3.6.5",
-    "cz-conventional-changelog": "^3.2.1",
+    "cz-conventional-changelog": "^3.3.0",
     "danger": "^10.4.0",
     "dateformat": "^3.0.3",
     "eslint": "^7.7.0",


### PR DESCRIPTION
Backport of #11971.
See that PR for full details.