### PR TITLE
[Backport 9_3_X] fix(android): allow node to clear event loop

### DIFF
--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -2494,7 +2494,7 @@ AndroidBuilder.prototype.copyResources = function copyResources(next) {
 
 		async.whilst(
 			function (cb) {
-				return cb(null, files.length);
+				process.nextTick(() => cb(null, files.length));
 			},
 
 			function (next) {


### PR DESCRIPTION
Backport of #11938.
See that PR for full details.