### PR TITLE
feat(ios): support new date picker styles

### DIFF
--- a/apidoc/Titanium/UI/Picker.yml
+++ b/apidoc/Titanium/UI/Picker.yml
@@ -364,6 +364,17 @@ properties:
     platforms: [android]
     since: "5.0.0"
 
+  - name: datePickerStyle
+    summary: Request a style if the picker is a date picker (`PICKER_TYPE_DATE`).
+    description: |
+        If the style changed, then the date picker may need to be resized and will
+        generate a layout pass to display correctly.
+    type: Number
+    platforms: [iphone, ipad]
+    constants: Titanium.UI.iOS.DATE_PICKER_STYLE_*
+    default: <Titanium.UI.iOS.DATE_PICKER_STYLE_AUTOMATIC>
+    osver: { ios: { min: "13.4" } }
+
   - name: type
     summary: Determines the type of picker displayed
     description: |

--- a/apidoc/Titanium/UI/iOS/iOS.yml
+++ b/apidoc/Titanium/UI/iOS/iOS.yml
@@ -1348,6 +1348,41 @@ properties:
     since: "3.2.0"
     osver: {ios: {min: "7.0"}}
 
+  - name: DATE_PICKER_STYLE_AUTOMATIC
+    summary: |
+        Use with <Titanium.UI.Picker.datePickerStyle> to automatically pick the best style
+        available for the current platform & mode.
+    description: "Note: Prior to iOS 14, this property is only used on iOS Catalyst apps."
+    type: Number
+    permission: read-only
+    since: "9.2.0"
+    osver: { ios: { min: "13.4" } }
+
+  - name: DATE_PICKER_STYLE_WHEELS
+    summary: |
+        Use with <Titanium.UI.Picker.datePickerStyle> to show the picker the wheels. Editing occurs inline.
+    type: Number
+    permission: read-only
+    since: "9.2.0"
+    osver: { ios: { min: "13.4" } }
+
+  - name: DATE_PICKER_STYLE_COMPACT
+    summary: |
+        Use with <Titanium.UI.Picker.datePickerStyle> to show the picker with a compact style. Editing occurs in an overlay.
+    description: "Note: Prior to iOS 14, this property is only used on iOS Catalyst apps."
+    type: Number
+    permission: read-only
+    since: "9.2.0"
+    osver: { ios: { min: "13.4" } }
+
+  - name: DATE_PICKER_STYLE_INLINE
+    summary: |
+        Use with <Titanium.UI.Picker.datePickerStyle> to allow editing in place (as a calendar).
+    type: Number
+    permission: read-only
+    since: "9.2.0"
+    osver: { ios: { min: "14.0" } }
+
   - name: forceTouchSupported
     summary: Determines if the 3D-Touch capability "Force Touch" is supported (`true`) or not (`false`) by the device.
     description: |

--- a/iphone/Classes/TiUIPicker.m
+++ b/iphone/Classes/TiUIPicker.m
@@ -177,6 +177,14 @@ USE_PROXY_FOR_VERIFY_AUTORESIZING
   }
 }
 
+- (void)setDatePickerStyle_:(id)style
+{
+  UIControl *picker = [self picker];
+  if ([self isDatePicker]) {
+    [(UIDatePicker *)picker setPreferredDatePickerStyle:[TiUtils intValue:style]];
+  }
+}
+
 // We're order-dependent on type being set first, so we need to make sure that anything that relies
 // on whether or not this is a date picker needs to be set AFTER the initial configuration.
 - (void)setSelectionIndicator_:(id)value

--- a/iphone/Classes/TiUIiOSProxy.m
+++ b/iphone/Classes/TiUIiOSProxy.m
@@ -190,6 +190,48 @@
 }
 #endif
 
+#ifdef USE_TI_UIPICKER
+
+- (NSNumber *)DATE_PICKER_STYLE_AUTOMATIC
+{
+  if (![TiUtils isIOSVersionOrGreater:@"13.4"]) {
+    return @(-1);
+  }
+
+  return @(UIDatePickerStyleAutomatic);
+}
+
+- (NSNumber *)DATE_PICKER_STYLE_WHEELS
+{
+  if (![TiUtils isIOSVersionOrGreater:@"13.4"]) {
+    return @(-1);
+  }
+
+  return @(UIDatePickerStyleWheels);
+}
+
+- (NSNumber *)DATE_PICKER_STYLE_COMPACT
+{
+  if (![TiUtils isIOSVersionOrGreater:@"13.4"]) {
+    return @(-1);
+  }
+
+  return @(UIDatePickerStyleCompact);
+}
+
+#if IS_SDK_IOS_14
+- (NSNumber *)DATE_PICKER_STYLE_INLINE
+{
+  if (![TiUtils isIOSVersionOrGreater:@"14.0"]) {
+    return @(-1);
+  }
+
+  return @(UIDatePickerStyleInline);
+}
+#endif
+
+#endif
+
 #ifdef USE_TI_UIIOSPREVIEWCONTEXT
 - (NSNumber *)PREVIEW_ACTION_STYLE_DEFAULT
 {


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-28104

Note: Without these, default pickers will look off on iOS 14+, so developers should very carefully check their apps for pickers.

<img src="https://user-images.githubusercontent.com/10667698/91562855-2a96ee00-e93e-11ea-9362-619bae7b4cd9.png" width="350" />
