### PR TITLE
[Backport 9_3_X] build(deps-dev): bump mocha from 8.1.2 to 8.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11021,9 +11021,9 @@
       }
     },
     "mocha": {
-      "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.1.2.tgz",
-      "integrity": "sha512-I8FRAcuACNMLQn3lS4qeWLxXqLvGf6r2CaLstDpZmMUUSmvW6Cnm1AuHxgbc7ctZVRcfwspCRbDHymPsi3dkJw==",
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.1.3.tgz",
+      "integrity": "sha512-ZbaYib4hT4PpF4bdSO2DohooKXIn4lDeiYqB+vTmCdr6l2woW0b6H3pf5x4sM5nwQMru9RvjjHYWVGltR50ZBw==",
       "dev": true,
       "requires": {
         "ansi-colors": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "glob": "^7.1.6",
     "husky": "^4.2.5",
     "lint-staged": "^10.2.13",
-    "mocha": "^8.1.2",
+    "mocha": "^8.1.3",
     "mocha-jenkins-reporter": "^0.4.5",
     "npm-run-all": "^4.1.5",
     "nyc": "^15.1.0",


### PR DESCRIPTION
Backport of #11989.
See that PR for full details.