### PR TITLE
fix(android)(9_3_X): AudioRecorder recording/stopped property handling

### DIFF
--- a/android/cli/hooks/run.js
+++ b/android/cli/hooks/run.js
@@ -227,6 +227,10 @@ exports.init = function (logger, config, cli) {
 				},
 
 				function (next) {
+					cli.emit('build.post.install', builder, next);
+				},
+
+				function (next) {
 					if (!cli.argv.launch) {
 						logger.info(__('Skipping launch of: %s', (builder.appid + '/.' + builder.classname + 'Activity').cyan));
 						return next(true);

--- a/android/modules/media/src/java/ti/modules/titanium/media/AudioRecorderProxy.java
+++ b/android/modules/media/src/java/ti/modules/titanium/media/AudioRecorderProxy.java
@@ -9,6 +9,7 @@ package ti.modules.titanium.media;
 import org.appcelerator.kroll.KrollProxy;
 import org.appcelerator.kroll.annotations.Kroll;
 import org.appcelerator.titanium.TiFileProxy;
+import org.appcelerator.titanium.io.TiBaseFile;
 import org.appcelerator.titanium.io.TiFileFactory;
 
 @Kroll.proxy(creatableInModule = MediaModule.class)
@@ -72,7 +73,14 @@ public class AudioRecorderProxy extends KrollProxy
 	@Kroll.method
 	public TiFileProxy stop()
 	{
-		return new TiFileProxy(TiFileFactory.createTitaniumFile(tiAudioRecorder.stopRecording(), false));
+		String filePath = tiAudioRecorder.stopRecording();
+		if (filePath != null) {
+			TiBaseFile tiBaseFile = TiFileFactory.createTitaniumFile(filePath, false);
+			if (tiBaseFile != null) {
+				return new TiFileProxy(tiBaseFile);
+			}
+		}
+		return null;
 	}
 
 	@Kroll.method
@@ -85,5 +93,11 @@ public class AudioRecorderProxy extends KrollProxy
 	public void pause()
 	{
 		tiAudioRecorder.pauseRecording();
+	}
+
+	@Override
+	public String getApiName()
+	{
+		return "Ti.Media.AudioRecorder";
 	}
 }

--- a/android/modules/media/src/java/ti/modules/titanium/media/AudioRecorderProxy.java
+++ b/android/modules/media/src/java/ti/modules/titanium/media/AudioRecorderProxy.java
@@ -6,8 +6,9 @@
  */
 package ti.modules.titanium.media;
 
-import org.appcelerator.kroll.KrollProxy;
 import org.appcelerator.kroll.annotations.Kroll;
+import org.appcelerator.kroll.KrollProxy;
+import org.appcelerator.kroll.KrollRuntime;
 import org.appcelerator.titanium.TiFileProxy;
 import org.appcelerator.titanium.io.TiBaseFile;
 import org.appcelerator.titanium.io.TiFileFactory;
@@ -15,7 +16,24 @@ import org.appcelerator.titanium.io.TiFileFactory;
 @Kroll.proxy(creatableInModule = MediaModule.class)
 public class AudioRecorderProxy extends KrollProxy
 {
-	TiAudioRecorder tiAudioRecorder = new TiAudioRecorder();
+	TiAudioRecorder tiAudioRecorder;
+	KrollRuntime.OnDisposingListener runtimeOnDisposingListener;
+
+	public AudioRecorderProxy()
+	{
+		// Create the microphone handler.
+		this.tiAudioRecorder = new TiAudioRecorder();
+
+		// Stop recording when the JavaScript runtime is being terminated.
+		// This releases the microphone to be used by another audio recorder instance.
+		this.runtimeOnDisposingListener = new KrollRuntime.OnDisposingListener() {
+			@Override
+			public void onDisposing(KrollRuntime runtime)
+			{
+				stop();
+			}
+		};
+	}
 
 	@Kroll.method
 	@Kroll.setProperty
@@ -67,13 +85,15 @@ public class AudioRecorderProxy extends KrollProxy
 	@Kroll.method
 	public void start()
 	{
-		tiAudioRecorder.startRecording();
+		this.tiAudioRecorder.startRecording();
+		KrollRuntime.addOnDisposingListener(this.runtimeOnDisposingListener);
 	}
 
 	@Kroll.method
 	public TiFileProxy stop()
 	{
-		String filePath = tiAudioRecorder.stopRecording();
+		KrollRuntime.removeOnDisposingListener(this.runtimeOnDisposingListener);
+		String filePath = this.tiAudioRecorder.stopRecording();
 		if (filePath != null) {
 			TiBaseFile tiBaseFile = TiFileFactory.createTitaniumFile(filePath, false);
 			if (tiBaseFile != null) {
@@ -93,6 +113,13 @@ public class AudioRecorderProxy extends KrollProxy
 	public void pause()
 	{
 		tiAudioRecorder.pauseRecording();
+	}
+
+	@Override
+	public void release()
+	{
+		stop();
+		super.release();
 	}
 
 	@Override

--- a/android/modules/media/src/java/ti/modules/titanium/media/TiAudioRecorder.java
+++ b/android/modules/media/src/java/ti/modules/titanium/media/TiAudioRecorder.java
@@ -49,17 +49,17 @@ public class TiAudioRecorder
 
 	public boolean isPaused()
 	{
-		return paused;
+		return this.paused;
 	}
 
 	public boolean isRecording()
 	{
-		return recording;
+		return this.recording;
 	}
 
 	public boolean isStopped()
 	{
-		return stopped;
+		return this.stopped;
 	}
 
 	public void startRecording()
@@ -82,7 +82,9 @@ public class TiAudioRecorder
 			audioRecord.setPositionNotificationPeriod(bufferSize / 4);
 			audioRecord.startRecording();
 			audioRecord.read(audioData, 0, bufferSize);
-			recording = true;
+			this.recording = true;
+			this.paused = false;
+			this.stopped = false;
 		}
 	}
 
@@ -91,6 +93,12 @@ public class TiAudioRecorder
 		File resultFile = null;
 		//Guard for calling stop before starting the recording
 		if (audioRecord != null) {
+			// Update state.
+			this.recording = false;
+			this.paused = false;
+			this.stopped = true;
+
+			// Stop recording.
 			int recordState = audioRecord.getState();
 			if (recordState == 1) {
 				audioRecord.stop();
@@ -98,6 +106,8 @@ public class TiAudioRecorder
 			audioRecord.setRecordPositionUpdateListener(null);
 			audioRecord.release();
 			audioRecord = null;
+
+			// Write recording to file.
 			try {
 				resultFile = TiFileHelper.getInstance().getTempFile(AUDIO_RECORDER_FILE_EXT_WAV, true);
 				createWaveFile(resultFile.getAbsolutePath());
@@ -105,15 +115,17 @@ public class TiAudioRecorder
 				e.printStackTrace();
 			}
 		}
-		return resultFile != null ? resultFile.getAbsolutePath() : "";
+		return resultFile != null ? resultFile.getAbsolutePath() : null;
 	}
 
 	public void pauseRecording()
 	{
 		//Guard for calling pause before starting the recording
 		if (audioRecord != null) {
-			paused = true;
 			audioRecord.stop();
+			this.recording = false;
+			this.paused = true;
+			this.stopped = false;
 		}
 	}
 
@@ -121,9 +133,11 @@ public class TiAudioRecorder
 	{
 		//Guard for calling resume before starting the recording
 		if (audioRecord != null) {
-			paused = false;
 			audioRecord.startRecording();
 			audioRecord.read(audioData, 0, bufferSize);
+			this.recording = true;
+			this.paused = false;
+			this.stopped = false;
 		}
 	}
 

--- a/build/lib/test/test.js
+++ b/build/lib/test/test.js
@@ -202,6 +202,7 @@ async function addTiAppProperties() {
 		content.push('\t\t\t\t</activity>');
 		content.push('\t\t\t</application>');
 		content.push('\t\t\t<uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>');
+		content.push('\t\t\t<uses-permission android:name="android.permission.RECORD_AUDIO"/>');
 	};
 	let insertPlistSettings = () => {
 		// Enable i18n support for the following languages.
@@ -212,6 +213,12 @@ async function addTiAppProperties() {
 		content.push('\t\t\t\t</array>');
 		content.push('\t\t\t\t<key>CFBundleAllowMixedLocalizations</key>');
 		content.push('\t\t\t\t<true/>');
+
+		// Add permission usage descriptions.
+		content.push('\t\t\t\t<key>NSLocationWhenInUseUsageDescription</key>');
+		content.push('\t\t\t\t<string>Requesting location permission</string>');
+		content.push('\t\t\t\t<key>NSMicrophoneUsageDescription</key>');
+		content.push('\t\t\t\t<string>Requesting microphone permission</string>');
 
 		// Add a static shortcut.
 		content.push('\t\t\t\t<key>UIApplicationShortcutItems</key>');

--- a/iphone/cli/hooks/install.js
+++ b/iphone/cli/hooks/install.js
@@ -126,7 +126,7 @@ exports.init = function (logger, config, cli) {
 									}
 								}, 50);
 							}
-							next();
+							cli.emit('build.post.install', builder, next);
 						})
 						.on('app-started', function () {
 							runningCount++;

--- a/iphone/cli/hooks/run.js
+++ b/iphone/cli/hooks/run.js
@@ -161,8 +161,11 @@ exports.init = function (logger, config, cli) {
 						logger.error('[' + simHandle.appName + '] ' + msg);
 					})
 					.on('app-started', function () {
-						finished && finished();
-						finished = null;
+						// TODO: Add "installed" event to "ioslib" module for simulators and emit below event from there.
+						cli.emit('build.post.install', builder, () => {
+							finished && finished();
+							finished = null;
+						});
 					})
 					.on('app-quit', function (code) {
 						if (code) {

--- a/tests/Resources/app.js
+++ b/tests/Resources/app.js
@@ -117,6 +117,7 @@ function loadTests() {
 	require('./ti.locale.test');
 	require('./ti.media.test');
 	require('./ti.media.audioplayer.test');
+	require('./ti.media.audiorecorder.test');
 	require('./ti.media.sound.test');
 	require('./ti.media.videoplayer.test');
 	require('./ti.network.test');

--- a/tests/Resources/ti.media.audiorecorder.test.js
+++ b/tests/Resources/ti.media.audiorecorder.test.js
@@ -1,0 +1,92 @@
+/*
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2020-Present by Axway, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+/* global OS_IOS */
+/* eslint-env mocha */
+/* eslint no-unused-expressions: "off" */
+'use strict';
+const should = require('./utilities/assertions');
+
+describe('Titanium.Media', () => {
+	it('#createAudioRecorder()', () => should(Ti.Media.createAudioRecorder).be.a.Function());
+});
+
+describe('Titanium.Media.AudioRecorder', function () {
+	this.timeout(5000);
+
+	it('apiName', () => {
+		const recorder = Ti.Media.createAudioRecorder();
+		should(recorder).have.a.readOnlyProperty('apiName').which.is.a.String();
+		should(recorder.apiName).be.eql('Ti.Media.AudioRecorder');
+	});
+
+	it('#start, #pause, #resume, #stop', (finish) => {
+		const recorder = Ti.Media.createAudioRecorder();
+		should(recorder.start).be.a.Function();
+		should(recorder.pause).be.a.Function();
+		should(recorder.resume).be.a.Function();
+		should(recorder.stop).be.a.Function();
+
+		should(recorder.recording).be.false();
+		should(recorder.paused).be.false();
+		should(recorder.stopped).be.true();
+
+		// Required to start recording on iOS.
+		if (OS_IOS) {
+			Ti.Media.audioSessionCategory = Ti.Media.AUDIO_SESSION_CATEGORY_PLAY_AND_RECORD;
+		}
+
+		// We can't do the below tests unless we have permission to use the microphone.
+		if (!Ti.Media.hasAudioRecorderPermissions()) {
+			return finish();
+		}
+
+		Promise.resolve()
+			.then(() => {
+				recorder.start();
+				should(recorder.recording).be.true();
+				should(recorder.paused).be.false();
+				should(recorder.stopped).be.false();
+				return new Promise((resolve) => setTimeout(resolve, 100));
+			})
+			.then(() => {
+				recorder.pause();
+				should(recorder.recording).be.false();
+				should(recorder.paused).be.true();
+				should(recorder.stopped).be.false();
+				return new Promise((resolve) => setTimeout(resolve, 100));
+			})
+			.then(() => {
+				recorder.pause();
+				should(recorder.recording).be.false();
+				should(recorder.paused).be.true();
+				should(recorder.stopped).be.false();
+				return new Promise((resolve) => setTimeout(resolve, 100));
+			})
+			.then(() => {
+				recorder.resume();
+				should(recorder.recording).be.true();
+				should(recorder.paused).be.false();
+				should(recorder.stopped).be.false();
+				return new Promise((resolve) => setTimeout(resolve, 100));
+			})
+			.then(() => {
+				const file = recorder.stop();
+				should(file).be.an.Object();
+				should(file.exists()).be.true();
+				should(recorder.recording).be.false();
+				should(recorder.paused).be.false();
+				should(recorder.stopped).be.true();
+				return finish();
+			})
+			.catch(finish);
+	});
+
+	it('#stop without starting', () => {
+		const recorder = Ti.Media.createAudioRecorder();
+		should(recorder.stop()).be.equalOneOf([ null, undefined ]);
+	});
+});

--- a/tests/Resources/ti.media.audiorecorder.test.js
+++ b/tests/Resources/ti.media.audiorecorder.test.js
@@ -15,7 +15,8 @@ describe('Titanium.Media', () => {
 });
 
 describe('Titanium.Media.AudioRecorder', function () {
-	this.timeout(5000);
+	this.slow(5000);
+	this.timeout(15000);
 
 	it('apiName', () => {
 		const recorder = Ti.Media.createAudioRecorder();


### PR DESCRIPTION
**JIRA:**
https://jira.appcelerator.org/browse/TIMOB-28105

**Summary:**
- `AudioRecoder` changes:
  * Fixed bug where it reports the wrongs states via `recording` and `stopped` properties 
  * Now auto-stops when JS object is garbage collected or JS runtime is terminated.
  * Removed blocking calls from `start()` and `resume()` methods. _(Can block up to 10 sec.)_
  * Now checks if recording has actually started. _(Can't start if microphone is already in use.)_
  * Significantly optimized `stop()` method. _(No longer creates 2nd audio file.)_
- Added a new "build.post.install" build hook for Android and iOS.
- Added `AudioRecorder` unit tests for Android and iOS.
- Updated test suite's plugin to grant app permissions to iOS simulator and Android after app install.

**Test:**
1. Create a "Classic" app.
2. Add the below permission to the "tiapp.xml".
3. Use `AudioRecorderStatusTest.js` attached to [TIMOB-28105](https://jira.appcelerator.org/browse/TIMOB-28105) for the "app.js".
4. Build and run on Android.
5. Verify "Stopped" label is `true` and the other labels are `false`.
6. Tap on the "Start Recording" button.
7. Verify "Recording" label is `true` and the other labels are `false`.
8. Tap on the "Pause Recording" button.
9. Verify "Paused" label is `true` and the other labels are `false`.
10. Tap on the "Resume Recording" button.
11. Verify "Recording" label is `true` and the other labels are `false`.
12. Tap on the "Stop Recording" button.
13. Verify "Stopped" label is `true` and the other labels are `false`.

tiapp.xml
```xml
<ti:app>
	<android>
		<manifest>
			<uses-permission android:name="android.permission.RECORD_AUDIO"/>
		</manifest>
	</android>
</ti:app>
```
