### PR TITLE
[Backport 9_3_X] build(deps-dev): bump eslint-config-axway from 4.7.2 to 4.7.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7052,9 +7052,9 @@
       }
     },
     "eslint-config-axway": {
-      "version": "4.7.2",
-      "resolved": "https://registry.npmjs.org/eslint-config-axway/-/eslint-config-axway-4.7.2.tgz",
-      "integrity": "sha512-cUCJ4JTz+ZT7jB6gHlO7ZfcQ9XHODG5yaTSzvNciTPLnBjPMtoU4xQSTZLQXHRVz6Kkb/qVajtxX+lRC/407UQ==",
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/eslint-config-axway/-/eslint-config-axway-4.7.3.tgz",
+      "integrity": "sha512-L/ULVxLeQUIrSx+xARrOnGg65nxPHytXQWTf20MTc0+iX7zbiyeqpGEqA+TykM8CzV9Pd9L1+rnBXvlpMWBvug==",
       "dev": true,
       "requires": {
         "eslint-plugin-chai-expect": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "danger": "^10.4.0",
     "dateformat": "^3.0.3",
     "eslint": "^7.8.1",
-    "eslint-config-axway": "^4.7.2",
+    "eslint-config-axway": "^4.7.3",
     "eslint-plugin-mocha": "^8.0.0",
     "folder-hash": "^3.3.3",
     "glob": "^7.1.6",


### PR DESCRIPTION
Backport of #12006.
See that PR for full details.