### PR TITLE
[Backport 9_3_X] [TIMOB-28108] Allow tintColor to accept a semantic color

### DIFF
--- a/iphone/Classes/TiUIRefreshControlProxy.m
+++ b/iphone/Classes/TiUIRefreshControlProxy.m
@@ -69,7 +69,6 @@
 
 - (void)setTintColor:(id)value
 {
-  ENSURE_SINGLE_ARG_OR_NIL(value, NSString);
   [self replaceValue:value forKey:@"tintColor" notification:NO];
 
   TiThreadPerformOnMainThread(


### PR DESCRIPTION
Backport of #12002.
See that PR for full details.