### PR TITLE
ci: update to latest backport action

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,6 +1,6 @@
 name: Backport
 on:
-  pull_request:
+  pull_request_target:
     types:
       - closed
       - labeled
@@ -11,7 +11,7 @@ jobs:
     name: Backport
     steps:
       - name: Backport
-        uses: ewanharris/backport@v1.0.28-21
+        uses: ewanharris/backport@v1.0.28-24
         with:
           bot_username: build
           bot_token: d5bd2737eafb4b5b5c1040e2d71e86626f8ce1b5


### PR DESCRIPTION
Now installs npm-merge-driver so that any package-lock conflicts are fixed,
and also only attempts to apply labels to the new PR if there are actually
labels

Also tries out the `pull_request_target` event again, just incase it works now 🤞🏻 