### PR TITLE
[Backport 9_3_X] build(deps-dev): bump rollup from 2.26.9 to 2.26.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13601,9 +13601,9 @@
       }
     },
     "rollup": {
-      "version": "2.26.9",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.26.9.tgz",
-      "integrity": "sha512-XIiWYLayLqV+oY4S2Lub/shJq4uk/QQLwWToYCL4LjZbYHbFK3czea4UDVRUJu+zNmKmxq5Zb/OG7c5HSvH2TQ==",
+      "version": "2.26.10",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.26.10.tgz",
+      "integrity": "sha512-dUnjCWOA0h9qNX6qtcHidyatz8FAFZxVxt1dbcGtKdlJkpSxGK3G9+DLCYvtZr9v94D129ij9zUhG+xbRoqepw==",
       "dev": true,
       "requires": {
         "fsevents": "~2.1.2"

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "npm-run-all": "^4.1.5",
     "nyc": "^15.1.0",
     "request-promise-native": "^1.0.9",
-    "rollup": "^2.26.9",
+    "rollup": "^2.26.10",
     "rollup-plugin-babel": "^4.4.0",
     "rollup-plugin-commonjs": "^10.1.0",
     "rollup-plugin-node-resolve": "^5.2.0",


### PR DESCRIPTION
Backport of #12015.
See that PR for full details.