### PR TITLE
fix(ios): guard new picker types

### DIFF
--- a/iphone/Classes/TiUIPicker.m
+++ b/iphone/Classes/TiUIPicker.m
@@ -177,7 +177,7 @@ USE_PROXY_FOR_VERIFY_AUTORESIZING
   }
 }
 
-#if IS_SDK_IOS_134
+#if IS_SDK_IOS_13_4
 - (void)setDatePickerStyle_:(id)style
 {
   if (![TiUtils isIOSVersionOrGreater:@"13.4"]) {

--- a/iphone/Classes/TiUIPicker.m
+++ b/iphone/Classes/TiUIPicker.m
@@ -177,13 +177,19 @@ USE_PROXY_FOR_VERIFY_AUTORESIZING
   }
 }
 
+#if IS_SDK_IOS_134
 - (void)setDatePickerStyle_:(id)style
 {
+  if (![TiUtils isIOSVersionOrGreater:@"13.4"]) {
+    DebugLog(@"setDatePickerStyle is only supported on iOS 13.4 and above");
+    return;
+  }
   UIControl *picker = [self picker];
   if ([self isDatePicker]) {
     [(UIDatePicker *)picker setPreferredDatePickerStyle:[TiUtils intValue:style]];
   }
 }
+#endif
 
 // We're order-dependent on type being set first, so we need to make sure that anything that relies
 // on whether or not this is a date picker needs to be set AFTER the initial configuration.

--- a/iphone/Classes/TiUIiOSProxy.m
+++ b/iphone/Classes/TiUIiOSProxy.m
@@ -192,7 +192,7 @@
 
 #ifdef USE_TI_UIPICKER
 
-#if __IPHONE_13_4
+#if IS_SDK_IOS_134
 - (NSNumber *)DATE_PICKER_STYLE_AUTOMATIC
 {
   if (![TiUtils isIOSVersionOrGreater:@"13.4"]) {

--- a/iphone/Classes/TiUIiOSProxy.m
+++ b/iphone/Classes/TiUIiOSProxy.m
@@ -192,6 +192,7 @@
 
 #ifdef USE_TI_UIPICKER
 
+#if __IPHONE_13_4
 - (NSNumber *)DATE_PICKER_STYLE_AUTOMATIC
 {
   if (![TiUtils isIOSVersionOrGreater:@"13.4"]) {
@@ -218,6 +219,7 @@
 
   return @(UIDatePickerStyleCompact);
 }
+#endif
 
 #if IS_SDK_IOS_14
 - (NSNumber *)DATE_PICKER_STYLE_INLINE

--- a/iphone/Classes/TiUIiOSProxy.m
+++ b/iphone/Classes/TiUIiOSProxy.m
@@ -192,7 +192,7 @@
 
 #ifdef USE_TI_UIPICKER
 
-#if IS_SDK_IOS_134
+#if IS_SDK_IOS_13_4
 - (NSNumber *)DATE_PICKER_STYLE_AUTOMATIC
 {
   if (![TiUtils isIOSVersionOrGreater:@"13.4"]) {

--- a/iphone/iphone/Titanium_Prefix.pch
+++ b/iphone/iphone/Titanium_Prefix.pch
@@ -18,9 +18,9 @@
 #endif
 
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 130400
-#define IS_SDK_IOS_134 true
+#define IS_SDK_IOS_13_4 true
 #else
-#define IS_SDK_IOS_134 false
+#define IS_SDK_IOS_13_4 false
 #endif
 
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000

--- a/iphone/iphone/Titanium_Prefix.pch
+++ b/iphone/iphone/Titanium_Prefix.pch
@@ -17,6 +17,12 @@
 #define IS_SDK_IOS_14 false
 #endif
 
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 130400
+#define IS_SDK_IOS_134 true
+#else
+#define IS_SDK_IOS_134 false
+#endif
+
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
 #define IS_SDK_IOS_13 true
 #else


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-28112

Keeps compatibility with the stated xcode versions, from what I can tell this seems safe to use? It fixes the issue on 11.3.1 for me and I assume it's backwards compatible