### PR TITLE
[Backport 9_3_X] build(deps-dev): bump rollup from 2.26.10 to 2.26.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13558,9 +13558,9 @@
       }
     },
     "rollup": {
-      "version": "2.26.10",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.26.10.tgz",
-      "integrity": "sha512-dUnjCWOA0h9qNX6qtcHidyatz8FAFZxVxt1dbcGtKdlJkpSxGK3G9+DLCYvtZr9v94D129ij9zUhG+xbRoqepw==",
+      "version": "2.26.11",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.26.11.tgz",
+      "integrity": "sha512-xyfxxhsE6hW57xhfL1I+ixH8l2bdoIMaAecdQiWF3N7IgJEMu99JG+daBiSZQjnBpzFxa0/xZm+3pbCdAQehHw==",
       "dev": true,
       "requires": {
         "fsevents": "~2.1.2"

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "npm-run-all": "^4.1.5",
     "nyc": "^15.1.0",
     "request-promise-native": "^1.0.9",
-    "rollup": "^2.26.10",
+    "rollup": "^2.26.11",
     "rollup-plugin-babel": "^4.4.0",
     "rollup-plugin-commonjs": "^10.1.0",
     "rollup-plugin-node-resolve": "^5.2.0",


### PR DESCRIPTION
Backport of #12019.
See that PR for full details.