### PR TITLE
[Backport 9_3_X] fix(ios): do not update properties if transition animation

### DIFF
--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiAnimation.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiAnimation.m
@@ -282,7 +282,7 @@
 
   // Update the modified properties on the view!
   if (animatedViewProxy != nil) {
-    if (!isReverse && ![autoreverse boolValue] && properties != nil) {
+    if (!isReverse && ![self isTransitionAnimation] && ![autoreverse boolValue] && properties != nil) {
       [animatedViewProxy applyProperties:properties];
     }
     // TODO: What about center?

--- a/tests/Resources/ti.ui.view.test.js
+++ b/tests/Resources/ti.ui.view.test.js
@@ -654,6 +654,38 @@ describe('Titanium.UI.View', function () {
 		win.open();
 	});
 
+	it.ios('animate (transition) - FLIP (app should not crash)', function (finish) {
+		win = Ti.UI.createWindow();
+		const controlView = Ti.UI.createView({
+			backgroundColor: 'red',
+			width: 100, height: 100,
+			left: 100,  top: 100
+		});
+
+		win.addEventListener('open', function () {
+			const view = Ti.UI.createView({
+				top: 150,
+				left: 150,
+				width: 150,
+				height: 150,
+				backgroundColor: 'green'
+			});
+			controlView.add(view);
+			try {
+				controlView.animate({
+					view: view,
+					backgroundColor: 'green',
+					transition: Ti.UI.iOS.AnimationStyle.FLIP_FROM_LEFT
+				});
+			} catch (err) {
+				return finish(err);
+			}
+			finish();
+		});
+		win.add(controlView);
+		win.open();
+	});
+
 	// FIXME: I think there's a parity issue here!
 	// Android returns x/y values as pixels *always*. while the input '100' uses the default unit (dip)
 	// which may vary based on screen density (Ti.Platform.DisplayCaps.ydpi) - so may be 100 or 200 pixels!


### PR DESCRIPTION
Backport of #12028.
See that PR for full details.