### PR TITLE
[Backport 9_3_X] build(iOS): fix to add resources and sources file in widget extension

### DIFF
--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -3462,7 +3462,8 @@ iOSBuilder.prototype.createXcodeProject = function createXcodeProject(next) {
 				// add the groups and files
 				let hasSwiftFiles = false;
 				extObjs.PBXGroup[extPBXProject.mainGroup].children.some(function (child) {
-					if (child.comment !== target.name) {
+					// While creating Widget Extention, in target name 'Extension' is appended.
+					if (child.comment !== target.name && `${child.comment}Extension` !== target.name) {
 						return false;
 					}
 


### PR DESCRIPTION
Backport of #11920.
See that PR for full details.