### PR TITLE
[Backport 9_3_X] build(deps): bump archiver from 5.0.0 to 5.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4132,9 +4132,9 @@
       "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
     },
     "archiver": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/archiver/-/archiver-5.0.0.tgz",
-      "integrity": "sha512-AEWhJz6Yi6hWtN1Sqy/H4sZo/lLMJ/NftXxGaDy/TnOMmmjsRaZc/Ts+U4BsPoBQkuunTN6t8hk7iU9A+HBxLw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-5.0.1.tgz",
+      "integrity": "sha512-DnYH6anESMM9w1gzi0dp2iNXNTsFUYGs0x90Qlm8OhmlxMESZXQLY3800HwKaFASgyqaw4Yri9I8K4DApgnfRg==",
       "requires": {
         "archiver-utils": "^2.1.0",
         "async": "^3.2.0",
@@ -4145,11 +4145,6 @@
         "zip-stream": "^4.0.0"
       },
       "dependencies": {
-        "async": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
-          "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
-        },
         "readable-stream": {
           "version": "3.6.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
@@ -14491,11 +14486,11 @@
       }
     },
     "tar-stream": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.3.tgz",
-      "integrity": "sha512-Z9yri56Dih8IaK8gncVPx4Wqt86NDmQTSh49XLZgjWpGZL9GK9HKParS2scqHCC4w6X9Gh2jwaU45V47XTKwVA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.4.tgz",
+      "integrity": "sha512-o3pS2zlG4gxr67GmFYBLlq+dM8gyRGUOvsrHclSkvtVtQbjV0s/+ZE8OpICbaj8clrX3tjeHngYGP7rweaBnuw==",
       "requires": {
-        "bl": "^4.0.1",
+        "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
         "fs-constants": "^1.0.0",
         "inherits": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "adm-zip": "^0.4.16",
     "ansi-escapes": "^4.3.1",
     "appc-tasks": "^1.0.2",
-    "archiver": "^5.0.0",
+    "archiver": "^5.0.1",
     "async": "^3.2.0",
     "boxen": "^4.2.0",
     "buffer-equal": "1.0.0",


### PR DESCRIPTION
Backport of #12039.
See that PR for full details.