### PR TITLE
[Backport 9_3_X] fix(ios): rely on event flush interval

### DIFF
--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiExceptionHandler.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiExceptionHandler.m
@@ -252,7 +252,6 @@ static void TiUncaughtExceptionHandler(NSException *exception)
   insideException = YES;
 
   [[TiExceptionHandler defaultExceptionHandler] reportException:exception];
-  [[APSAnalytics sharedInstance] flush];
 
   insideException = NO;
   if (prevUncaughtExceptionHandler != NULL) {
@@ -275,6 +274,5 @@ static void TiSignalHandler(int code)
   }
   NSException *exception = [NSException exceptionWithName:@"SIGNAL_ERROR" reason:[NSString stringWithFormat:@"signal error code: %d", code] userInfo:nil];
   [[TiExceptionHandler defaultExceptionHandler] reportException:exception];
-  [[APSAnalytics sharedInstance] flush];
   signal(code, SIG_DFL);
 }


### PR DESCRIPTION
Backport of #12037.
See that PR for full details.