### PR TITLE
fix: add version to new "datePickerStyle" property

### DIFF
--- a/apidoc/Titanium/UI/Picker.yml
+++ b/apidoc/Titanium/UI/Picker.yml
@@ -371,6 +371,7 @@ properties:
         generate a layout pass to display correctly.
     type: Number
     platforms: [iphone, ipad]
+    since: "9.2.0"
     constants: Titanium.UI.iOS.DATE_PICKER_STYLE_*
     default: <Titanium.UI.iOS.DATE_PICKER_STYLE_AUTOMATIC>
     osver: { ios: { min: "13.4" } }


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-28104

Also, the `default` value does not seem to be picked up correctly?!

<img width="772" alt="Bildschirmfoto 2020-09-12 um 16 10 27" src="https://user-images.githubusercontent.com/10667698/92997308-9a969e00-f512-11ea-94bc-bee957abc40f.png">
