### PR TITLE
[Backport 9_3_X] fix: add version to new "datePickerStyle" property

### DIFF
--- a/apidoc/Titanium/UI/Picker.yml
+++ b/apidoc/Titanium/UI/Picker.yml
@@ -371,6 +371,7 @@ properties:
         generate a layout pass to display correctly.
     type: Number
     platforms: [iphone, ipad]
+    since: "9.2.0"
     constants: Titanium.UI.iOS.DATE_PICKER_STYLE_*
     default: <Titanium.UI.iOS.DATE_PICKER_STYLE_AUTOMATIC>
     osver: { ios: { min: "13.4" } }


### PR DESCRIPTION
Backport of #12043.
See that PR for full details.