### PR TITLE
Fix incremental builds

### DIFF
--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -6687,13 +6687,19 @@ iOSBuilder.prototype.removeFiles = function removeFiles(next) {
 	this.unmarkBuildDirFiles(path.join(this.buildDir, 'export_options.plist'));
 	this.unmarkBuildDirFiles(path.join(this.buildDir, this.tiapp.name + '.xcarchive'));
 
+	const productsDir = path.join(this.buildDir, 'build', 'Products');
 	try {
-		const releaseDir = path.join(this.buildDir, 'build', 'Products', 'Release-iphoneos');
+		const releaseDir = path.join(productsDir, 'Release-iphoneos');
 		if (fs.lstatSync(path.join(releaseDir, this.tiapp.name + '.app')).isSymbolicLink()) {
 			this.unmarkBuildDirFiles(releaseDir);
 		}
 	} catch (e) {
 		// ignore
+	}
+
+	const product = `${this.xcodeTarget}-${this.xcodeTargetOS}`;
+	if (fs.existsSync(path.join(productsDir, product))) {
+		this.unmarkBuildDirFiles(path.join(productsDir, product));
 	}
 
 	this.logger.info(__('Removing files'));

--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -4708,6 +4708,10 @@ iOSBuilder.prototype.copyTitaniumiOSFiles = function copyTitaniumiOSFiles() {
 						// The content of Frameworks directory only change if we change SDK version. So it is safe to copy whole directory.
 						// Copy whole 'Frameworks' directory from SDK to build directory, to preserve symlink available in Titaniumkit.xcframework.
 						// TODO: Is there any better way to do this?
+
+						// We remove the directory before copying due to frameworks making extensive use of symlinks
+						// when copying symlinks over we commonly get errors about trying to place a directory under itself
+						// so if anything needs copying, then blow the whole thing away and start fresh
 						fs.emptyDirSync(path.join(this.buildDir, dir));
 						fs.copySync(path.join(this.platformPath, dir), path.join(this.buildDir, dir));
 						copyFrameworks = false;

--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -4708,7 +4708,7 @@ iOSBuilder.prototype.copyTitaniumiOSFiles = function copyTitaniumiOSFiles() {
 						// The content of Frameworks directory only change if we change SDK version. So it is safe to copy whole directory.
 						// Copy whole 'Frameworks' directory from SDK to build directory, to preserve symlink available in Titaniumkit.xcframework.
 						// TODO: Is there any better way to do this?
-
+						fs.emptyDirSync(path.join(this.buildDir, dir));
 						fs.copySync(path.join(this.platformPath, dir), path.join(this.buildDir, dir));
 						copyFrameworks = false;
 					}

--- a/iphone/cli/commands/_buildModule.js
+++ b/iphone/cli/commands/_buildModule.js
@@ -658,8 +658,8 @@ iOSModuleBuilder.prototype.verifyBuildArch = function verifyBuildArch(next) {
 	const manifestArchs = new Set(this.manifest.architectures.split(' '));
 	if (buildArchs.size !== manifestArchs.size) {
 		this.logger.error(__('There is discrepancy between the architectures specified in module manifest and compiled binary.'));
-		this.logger.error(__('Architectures in manifest: %s', manifestArchs));
-		this.logger.error(__('Compiled binary architectures: %s', buildArchs));
+		this.logger.error(__('Architectures in manifest: %s', Array.from(manifestArchs)));
+		this.logger.error(__('Compiled binary architectures: %s', Array.from(buildArchs)));
 		this.logger.error(__('Please update manifest to match module binary architectures.') + '\n');
 		process.exit(1);
 	}


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-28130

* Unmarks the Product directory to prevent us removing required files like the tiverify lib and TitaniumKit framework
* Small change to the buildModule file to call `Array.from` on the architectures set when logging it to  avoid it being logged as `[object Set]`