### PR TITLE
[Backport 9_3_X] build(deps): bump moment from 2.27.0 to 2.28.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11191,9 +11191,9 @@
       "dev": true
     },
     "moment": {
-      "version": "2.27.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.27.0.tgz",
-      "integrity": "sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ=="
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.28.0.tgz",
+      "integrity": "sha512-Z5KOjYmnHyd/ukynmFd/WwyXHd7L4J9vTI/nn5Ap9AVUgaAE15VvQ9MOGmJJygEUklupqIrFnor/tjTwRU+tQw=="
     },
     "ms": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "ioslib": "^1.7.21",
     "liveview": "^1.5.4",
     "markdown": "0.5.0",
-    "moment": "^2.27.0",
+    "moment": "^2.28.0",
     "node-appc": "^1.0.1",
     "node-titanium-sdk": "^5.1.1",
     "node-uuid": "1.4.8",


### PR DESCRIPTION
Backport of #12047.
See that PR for full details.