### PR TITLE
[Backport 9_3_X] build(deps): bump archiver from 5.0.1 to 5.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4154,16 +4154,16 @@
       "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
     },
     "archiver": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/archiver/-/archiver-5.0.1.tgz",
-      "integrity": "sha512-DnYH6anESMM9w1gzi0dp2iNXNTsFUYGs0x90Qlm8OhmlxMESZXQLY3800HwKaFASgyqaw4Yri9I8K4DApgnfRg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-5.0.2.tgz",
+      "integrity": "sha512-Tq3yV/T4wxBsD2Wign8W9VQKhaUxzzRmjEiSoOK0SLqPgDP/N1TKdYyBeIEu56T4I9iO4fKTTR0mN9NWkBA0sg==",
       "requires": {
         "archiver-utils": "^2.1.0",
         "async": "^3.2.0",
         "buffer-crc32": "^0.2.1",
         "readable-stream": "^3.6.0",
         "readdir-glob": "^1.0.0",
-        "tar-stream": "^2.1.2",
+        "tar-stream": "^2.1.4",
         "zip-stream": "^4.0.0"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "adm-zip": "^0.4.16",
     "ansi-escapes": "^4.3.1",
     "appc-tasks": "^1.0.2",
-    "archiver": "^5.0.1",
+    "archiver": "^5.0.2",
     "async": "^3.2.0",
     "boxen": "^4.2.0",
     "buffer-equal": "1.0.0",


### PR DESCRIPTION
Backport of #12050.
See that PR for full details.