### PR TITLE
[Backport 9_3_X] build(ios): fallback to xcode 11 dir name for ios xcframework if we can't find xcode 12 variant

### DIFF
--- a/build/lib/ios.js
+++ b/build/lib/ios.js
@@ -88,7 +88,13 @@ class IOS {
 	async copyLegacyHeaders(DEST_IOS) {
 		// Gather all the *.h files in TitaniumKit, create "redirecting" headers in iphone/include that point to the TitaniumKit ones
 		await fs.ensureDir(path.join(DEST_IOS, 'include'));
-		const subdirs = await fs.readdir(path.join(IOS_ROOT, 'TitaniumKit/build/TitaniumKit.xcframework/ios-arm64_armv7/TitaniumKit.framework/Headers'));
+		let headersDir = path.join(IOS_ROOT, 'TitaniumKit/build/TitaniumKit.xcframework/ios-arm64_armv7/TitaniumKit.framework/Headers');
+		if (!(await fs.pathExists(headersDir))) {
+			// fall back to xcode 11 dir name
+			console.warn('Looks like you\'re building with Xcode 11. The resulting binaries will not include arm64 ios sim support, which is expected in upcoming Apple Silicon devices.');
+			headersDir = path.join(IOS_ROOT, 'TitaniumKit/build/TitaniumKit.xcframework/ios-armv7_arm64/TitaniumKit.framework/Headers');
+		}
+		const subdirs = await fs.readdir(headersDir);
 		// create them all in parallel
 		await Promise.all(subdirs.map(file => {
 			// TODO: Inject a deprecation warning if used and remove in SDK 9.0.0?

--- a/iphone/cli/commands/_buildModule.js
+++ b/iphone/cli/commands/_buildModule.js
@@ -615,7 +615,14 @@ iOSModuleBuilder.prototype.verifyBuildArch = function verifyBuildArch(next) {
 
 	let lib = findLib('ios-arm64_armv7');
 	if (lib instanceof Error) {
-		this.logger.warn(__('The module is missing 64-bit support.'));
+		// fallback to xcode 11 xcframework
+		lib = findLib('ios-armv7_arm64');
+		if (lib instanceof Error) {
+			this.logger.warn(__('The module is missing 64-bit support.'));
+		} else {
+			buildArchs.add('armv7');
+			buildArchs.add('arm64');
+		}
 	} else {
 		buildArchs.add('armv7');
 		buildArchs.add('arm64');
@@ -636,7 +643,7 @@ iOSModuleBuilder.prototype.verifyBuildArch = function verifyBuildArch(next) {
 	} else {
 		buildArchs.add('i386');
 		buildArchs.add('x86_64');
-		buildArchs.add('arm64');
+		// buildArchs.add('arm64'); // Don't include as we traditionally meant 'arm64' to be ios device arm64 (not sim!)
 	}
 
 	lib = findLib('ios-arm64_x86_64-maccatalyst');


### PR DESCRIPTION
Backport of #12058.
See that PR for full details.