### PR TITLE
[Backport 9_3_X] chore(deps): upgrade ti.map for ios to 4.0.0

### DIFF
--- a/support/module/packaged/modules.json
+++ b/support/module/packaged/modules.json
@@ -13,8 +13,8 @@
 			"integrity": "sha512-/37884hmpvg9XoGZy9BJ3nA6luz04Eff/oYRwCE+wadYvmoMMGZmHhmWRjkBC4wIhUj6YY6MuQlHr7X7MO/Ccw=="
 		},
 		"ti.map": {
-			"url": "https://github.com/appcelerator-modules/ti.map/releases/download/v3.3.0-iphone/ti.map-iphone-3.3.0.zip",
-			"integrity": "sha512-tC62tLMo0y84AmHMGRTmFuK/0zCbBHmynK8tvraySewweYpWsoADdJ9RGPUivtILVL1yck+Rl+gvLUpC/q1Jag=="
+			"url": "https://github.com/appcelerator-modules/ti.map/releases/download/v4.0.0-iphone/ti.map-iphone-4.0.0.zip",
+			"integrity": "sha512-gU0iIJnkQOG5sxpEOAiwpBssgkPTpwdqer2nqVallhLvdL1DXZoL9561mzpg3seQwinlB2YN4ReLFK7fD1jpmg=="
 		},
 		"ti.webdialog": {
 			"url": "https://github.com/appcelerator-modules/titanium-web-dialog/releases/download/v1.2.0-iphone/ti.webdialog-iphone-1.2.0.zip",

--- a/tests/Resources/app.js
+++ b/tests/Resources/app.js
@@ -193,9 +193,7 @@ function loadTests() {
 	require('./ti.xml.test');
 	// Modules
 	require('./ti.cloudpush.test');
-	if (!OS_MACOS) {
-		require('./ti.map.test');
-	}
+	require('./ti.map.test');
 	if (OS_ANDROID) {
 		require('./ti.playservices.test');
 	}

--- a/tests/Resources/ti.ui.tabgroup.test.js
+++ b/tests/Resources/ti.ui.tabgroup.test.js
@@ -57,8 +57,7 @@ describe('Titanium.UI.TabGroup', function () {
 		should(tabGroup.activeTintColor).eql('red');
 	});
 
-	// FIXME: macOS doesn't have ti.map module yet!
-	it.macMissingAndWindowsBroken('add Map.View to TabGroup', function (finish) {
+	it.windowsBroken('add Map.View to TabGroup', function (finish) {
 		this.slow(5000);
 		this.timeout(15000);
 


### PR DESCRIPTION
Backport of #12062.
See that PR for full details.