### PR TITLE
[Backport 9_2_X] chore(deps): upgrade ti.identity for ios to 2.0.0

### DIFF
--- a/support/module/packaged/modules.json
+++ b/support/module/packaged/modules.json
@@ -21,8 +21,8 @@
 			"integrity": "sha512-aFWIrGUk8J1/vU9seSz/wSz3YBFajCwrtGUu/wpulbZxfJQ1YdmMQH3xRW+RWCrvlV090vNH5IEcSllBhCD4fQ=="
 		},
 		"ti.identity": {
-			"url": "https://github.com/appcelerator-modules/titanium-identity/releases/download/v1.1.0-iphone/ti.identity-iphone-1.1.0.zip",
-			"integrity": "sha512-QAbhMon2oo8xbzfmb65PALgeBX+CRwVd1rdDif8rCMaltzE6dzaOr+uJAHZEkEexzakmcnIwf7Wc5iRLX7pCrg=="
+			"url": "https://github.com/appcelerator-modules/titanium-identity/releases/download/v2.0.0-iphone/ti.identity-iphone-2.0.0.zip",
+			"integrity": "sha512-jZ/RgyWFprQlVpdNvboZYL90tghgBgKIKeQGyABPLqWBsqsvoCjYqcRMKbD1CJRCFH4amQ3yMkTY9tKdsyMz3g=="
 		},
 		"ti.applesignin": {
 			"url": "https://github.com/appcelerator-modules/titanium-apple-sign-in/releases/download/v1.1.1/ti.applesignin-iphone-1.1.1.zip",

--- a/tests/Resources/require.test.js
+++ b/tests/Resources/require.test.js
@@ -200,8 +200,8 @@ describe('require()', function () {
 		should(abbrev('foo', 'fool', 'folding', 'flop')).eql({ fl: 'flop', flo: 'flop', flop: 'flop', fol: 'folding', fold: 'folding', foldi: 'folding', foldin: 'folding', folding: 'folding', foo: 'foo', fool: 'fool' });
 	});
 
-	// FIXME: We have no native ti.identity module for macOS and windows!
-	it.macAndWindowsMissing('loads native module by id', function () {
+	// FIXME: We have no native ti.identity module for windows!
+	it.windowsMissing('loads native module by id', function () {
 		var object = require('ti.identity');
 		should(object).have.property('apiName');
 		// Of course, the module's apiName is wrong, so we can't test that


### PR DESCRIPTION
Backport of #12063.
See that PR for full details.