### PR TITLE
[Backport 9_2_X] chore(deps): upgrade ti.applesignin to 2.0.0

### DIFF
--- a/support/module/packaged/modules.json
+++ b/support/module/packaged/modules.json
@@ -25,8 +25,8 @@
 			"integrity": "sha512-jZ/RgyWFprQlVpdNvboZYL90tghgBgKIKeQGyABPLqWBsqsvoCjYqcRMKbD1CJRCFH4amQ3yMkTY9tKdsyMz3g=="
 		},
 		"ti.applesignin": {
-			"url": "https://github.com/appcelerator-modules/titanium-apple-sign-in/releases/download/v1.1.1/ti.applesignin-iphone-1.1.1.zip",
-			"integrity": "sha512-h+l9pLfs9xooX4TXK47QiZUO7wQpvc9SseMciOmK6yUCXS8ZJz/DDsrXnAAwZEol4A31diJvK7vykDAQ+zvpkQ=="
+			"url": "https://github.com/appcelerator-modules/titanium-apple-sign-in/releases/download/v2.0.0/ti.applesignin-iphone-2.0.0.zip",
+			"integrity": "sha512-/e2FIA/SNY3YoHAy9fKCCrV1Y0KHXUvMnXtrqe25/5KtlcFH++K08z1dWuaa38CYIGKHYrhDp87yO1p1uosUQQ=="
 		}
 	},
 	"android": {


### PR DESCRIPTION
Backport of #12065.
See that PR for full details.