### PR TITLE
[Backport 9_3_X] fix(ios): remove SDK guards for peek and pop

### DIFF
--- a/iphone/Classes/TiUIiOSPreviewContextProxy.m
+++ b/iphone/Classes/TiUIiOSPreviewContextProxy.m
@@ -14,11 +14,6 @@
 
 - (void)_initWithProperties:(NSDictionary *)properties
 {
-  if (![TiUtils forceTouchSupported]) {
-    NSLog(@"[WARN] 3DTouch is not available on this device.");
-    return;
-  }
-
   [self setPreview:[properties valueForKey:@"preview"]];
   [self setContentHeight:[TiUtils intValue:@"contentHeight" def:0]];
 

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiViewProxy.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiViewProxy.m
@@ -1329,11 +1329,6 @@ LAYOUTFLAGS_SETTER(setHorizontalWrap, horizontalWrap, horizontalWrap, [self will
 
 - (void)setPreviewContext:(id)context
 {
-  if (![TiUtils forceTouchSupported]) {
-    NSLog(@"[WARN] 3DTouch is not available on this device.");
-    return;
-  }
-
   Class TiUIiOSPreviewContextProxy = NSClassFromString(@"TiUIiOSPreviewContextProxy");
 
   ENSURE_TYPE(context, TiUIiOSPreviewContextProxy);


### PR DESCRIPTION
Backport of #12045.
See that PR for full details.