### PR TITLE
[Backport 9_2_X] build(deps): bump node-appc from 1.1.0 to 1.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11388,9 +11388,9 @@
       "dev": true
     },
     "node-appc": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/node-appc/-/node-appc-1.1.0.tgz",
-      "integrity": "sha512-lKi9ZKfvgxBSM7KoMFPeZhSgzPBYE3cci6D145i92T/lhaDbEAoWDf9EAJPX0MRFNTZP1C8gDIlug8y6Oykp2g==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/node-appc/-/node-appc-1.1.1.tgz",
+      "integrity": "sha512-QYOmRUq9B0LfVZ5MWQlbv8tHa4pzQ+YbagjUUvMIx6lVjhCjG9pPMRyPFK7/HXiQ+WrsiuydSbJgsBZt1p18Rg==",
       "requires": {
         "async": "^3.2.0",
         "colors": "~1.4.0",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "liveview": "^1.5.4",
     "markdown": "0.5.0",
     "moment": "^2.28.0",
-    "node-appc": "^1.1.0",
+    "node-appc": "^1.1.1",
     "node-titanium-sdk": "^5.1.1",
     "node-uuid": "1.4.8",
     "nodeify": "^1.0.1",


### PR DESCRIPTION
Backport of #12084.
See that PR for full details.