### PR TITLE
[Backport 9_2_X] fix(ios): use TITANIUM_SDK variable to point at xcframework path in xcode project

### DIFF
--- a/iphone/templates/module/objc/template/ios/{{ModuleName}}.xcodeproj/project.pbxproj.ejs
+++ b/iphone/templates/module/objc/template/ios/{{ModuleName}}.xcodeproj/project.pbxproj.ejs
@@ -49,7 +49,7 @@
 		24DE9E1011C5FE74003F90F6 /* <%- moduleIdAsIdentifier %>ModuleAssets.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "<%- moduleIdAsIdentifier %>ModuleAssets.m"; path = "Classes/<%- moduleIdAsIdentifier %>ModuleAssets.m"; sourceTree = "<group>"; };
 		AA747D9E0F9514B9006C5449 /* <%- moduleIdAsIdentifier %>_Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "<%- moduleIdAsIdentifier %>_Prefix.pch"; sourceTree = SOURCE_ROOT; };
 		AACBBE490F95108600F1A2B1 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
-		B11E042B241AC5C100EFA7DC /* TitaniumKit.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = TitaniumKit.xcframework; path = "<%- tisdkPath %>/iphone/Frameworks/TitaniumKit.xcframework"; sourceTree = "<group>"; };
+		B11E042B241AC5C100EFA7DC /* TitaniumKit.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = TitaniumKit.xcframework; path = "$(TITANIUM_SDK)/iphone/Frameworks/TitaniumKit.xcframework"; sourceTree = "<group>"; };
 		D2AAC07E0554694100DB518D /* lib<%- moduleId %>.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "lib<%- moduleId %>.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 

--- a/iphone/templates/module/swift/template/ios/{{ModuleName}}.xcodeproj/project.pbxproj.ejs
+++ b/iphone/templates/module/swift/template/ios/{{ModuleName}}.xcodeproj/project.pbxproj.ejs
@@ -18,7 +18,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-    B1E00E64241D179500C384C1 /* TitaniumKit.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = TitaniumKit.xcframework; path = "<%- tisdkPath %>/iphone/Frameworks/TitaniumKit.xcframework"; sourceTree = "<group>"; };
+    B1E00E64241D179500C384C1 /* TitaniumKit.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = TitaniumKit.xcframework; path = $(TITANIUM_SDK)/iphone/Frameworks/TitaniumKit.xcframework"; sourceTree = "<group>"; };
     DB24E03B20766AC90033B2B1 /* <%- moduleIdAsIdentifier %>ExampleProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = <%- moduleIdAsIdentifier %>ExampleProxy.swift; path = Classes/<%- moduleIdAsIdentifier %>ExampleProxy.swift; sourceTree = "<group>"; };
     DB34CDDE207B998A005F8E8C /* <%- moduleIdAsIdentifier %>ModuleAssets.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = <%- moduleIdAsIdentifier %>ModuleAssets.m; path = Classes/<%- moduleIdAsIdentifier %>ModuleAssets.m; sourceTree = SOURCE_ROOT; };
     DB34CDDF207B998A005F8E8C /* <%- moduleIdAsIdentifier %>ModuleAssets.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = <%- moduleIdAsIdentifier %>ModuleAssets.h; path = Classes/<%- moduleIdAsIdentifier %>ModuleAssets.h; sourceTree = SOURCE_ROOT; };


### PR DESCRIPTION
Backport of #12090.
See that PR for full details.