### PR TITLE
fix(ios): avoid over release of list item proxies

### DIFF
--- a/iphone/Classes/TiUIListView.m
+++ b/iphone/Classes/TiUIListView.m
@@ -29,7 +29,7 @@ static TiViewProxy *FindViewProxyWithBindIdContainingPoint(UIView *view, CGPoint
 
 @implementation TiUIListView {
   UITableView *_tableView;
-  NSDictionary *_templates;
+  NSDictionary<id, TiViewTemplate *> *_templates;
   id _defaultItemTemplate;
 
   TiDimension _rowHeight;
@@ -46,10 +46,10 @@ static TiViewProxy *FindViewProxyWithBindIdContainingPoint(UIView *view, CGPoint
   UISearchController *searchController;
   UIViewController *searchControllerPresenter;
 
-  NSMutableArray *sectionTitles;
-  NSMutableArray *sectionIndices;
-  NSMutableArray *filteredTitles;
-  NSMutableArray *filteredIndices;
+  NSMutableArray<NSString *> *sectionTitles;
+  NSMutableArray<NSNumber *> *sectionIndices;
+  NSMutableArray<NSString *> *filteredTitles;
+  NSMutableArray<NSNumber *> *filteredIndices;
 
   UIView *_pullViewWrapper;
   CGFloat pullThreshhold;
@@ -67,7 +67,7 @@ static TiViewProxy *FindViewProxyWithBindIdContainingPoint(UIView *view, CGPoint
   UIEdgeInsets _defaultSeparatorInsets;
   UIEdgeInsets _rowSeparatorInsets;
 
-  NSMutableDictionary *_measureProxies;
+  NSMutableDictionary<id, TiUIListItem *> *_measureProxies;
 
   BOOL canFireScrollStart;
   BOOL canFireScrollEnd;
@@ -509,7 +509,7 @@ static TiViewProxy *FindViewProxyWithBindIdContainingPoint(UIView *view, CGPoint
         if (sectionTitles != nil && sectionIndices != nil) {
           NSNumber *theIndex = [NSNumber numberWithInt:i];
           if ([sectionIndices containsObject:theIndex]) {
-            id theTitle = [sectionTitles objectAtIndex:[sectionIndices indexOfObject:theIndex]];
+            NSString *theTitle = [sectionTitles objectAtIndex:[sectionIndices indexOfObject:theIndex]];
             if (filteredTitles == nil) {
               filteredTitles = [[NSMutableArray alloc] init];
             }
@@ -989,7 +989,7 @@ static TiViewProxy *FindViewProxyWithBindIdContainingPoint(UIView *view, CGPoint
 
 #pragma mark - SectionIndexTitle Support Datasource methods.
 
-- (NSArray *)sectionIndexTitlesForTableView:(UITableView *)tableView
+- (NSArray<NSString *> *)sectionIndexTitlesForTableView:(UITableView *)tableView
 {
   if (editing) {
     return nil;

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiProxy.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiProxy.m
@@ -425,7 +425,6 @@ void TiClassSelectorFunction(TiBindingRunLoop runloop, void *payload)
 #if PROXY_MEMORY_TRACK == 1
   NSLog(@"[DEBUG] DEALLOC: %@ (%d)", self, [self hash]);
 #endif
-  RELEASE_TO_NIL(modelDelegate);
   [self _destroy];
   pthread_rwlock_destroy(&listenerLock);
   pthread_rwlock_destroy(&dynpropsLock);


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-28127

**Optional Description:**
TiProxy is blindly releasing `modelDelegate` in its `dealloc` method. This is a problem for two reasons:
- `_destroy` already handles releasing `modelDelegate` (and `dealloc` called `_destroy` on the very next line)
- `modelDelegate` may be `== self` resulting in the recursive `dealloc` that prompts the warning from macOS.

This likely affected other proxies that assigned `self` to `modelDelegate`: 
- `TiUIListItemProxy`
- `TiUINavBarButton`
- `TiUITableViewRowProxy`
- `TiUITableViewSectionProxy`

To reproduce, run this app on macOS target, click label and list view entries multiple times, then let app sit idle in bg for a while to kick in GC:
``` js
var win = Ti.UI.createWindow({
    backgroundColor: '#fff'
});
 
var btn = Ti.UI.createButton({
    title: 'Trigger'
});
 
btn.addEventListener('click', function() {
 
			var myTemplate = {
				childTemplates: [
					{
						type: 'Ti.UI.ImageView',
						bindId: 'pic',
						properties: {
							width: '50', height: '50', left: 0
						}
					},
					{
						type: 'Ti.UI.Label',
						bindId: 'info',
						properties: {
							color: 'black',
							font: { fontSize: '20', fontWeight: 'bold' },
							left: '60', top: 0,
						}
					},
					{
						type: 'Ti.UI.Label',
						bindId: 'es_info',
						properties: {
							color: 'gray',
							font: { fontSize: '14' },
							left: '60', top: '25',
						}
					}
				]
			},
			listView = Ti.UI.createListView({
				templates: { template: myTemplate },
				defaultItemTemplate: 'template'
			}),
			sections = [],
			fruitSection,
			fruitDataSet,
			vegSection,
			vegDataSet,
			grainSection,
			grainDataSet;
		    window = Ti.UI.createWindow({ backgroundColor: 'green' });
 
		fruitSection = Ti.UI.createListSection({ headerTitle: 'Fruits / Frutas' });
		fruitDataSet = [
			{ info: { text: 'Apple' }, es_info: { text: 'Manzana' }, pic: { image: 'Logo.png' } },
			{ info: { text: 'Apple' }, es_info: { text: 'Manzana' }, pic: { image: 'Logo.png' } },
			{ info: { text: 'Apple' }, es_info: { text: 'Manzana' }, pic: { image: 'Logo.png' } },
			{ info: { text: 'Apple' }, es_info: { text: 'Manzana' }, pic: { image: 'Logo.png' } },
			{ info: { text: 'Apple' }, es_info: { text: 'Manzana' }, pic: { image: 'Logo.png' } },
			{ info: { text: 'Apple' }, es_info: { text: 'Manzana' }, pic: { image: 'Logo.png' } },
			{ info: { text: 'Apple' }, es_info: { text: 'Manzana' }, pic: { image: 'Logo.png' } },
			{ info: { text: 'Banana' }, es_info: { text: 'Banana' }, pic: { image: 'Logo.png' } }
		];
		fruitSection.setItems(fruitDataSet);
		sections.push(fruitSection);
 
		vegSection = Ti.UI.createListSection({ headerTitle: 'Vegetables / Verduras' });
		vegDataSet = [
			{ info: { text: 'Carrot' }, es_info: { text: 'Zanahoria' }, pic: { image: 'Logo.png' } },
			{ info: { text: 'Carrot' }, es_info: { text: 'Zanahoria' }, pic: { image: 'Logo.png' } },
			{ info: { text: 'Carrot' }, es_info: { text: 'Zanahoria' }, pic: { image: 'Logo.png' } },
			{ info: { text: 'Carrot' }, es_info: { text: 'Zanahoria' }, pic: { image: 'Logo.png' } },
			{ info: { text: 'Carrot' }, es_info: { text: 'Zanahoria' }, pic: { image: 'Logo.png' } },
			{ info: { text: 'Carrot' }, es_info: { text: 'Zanahoria' }, pic: { image: 'Logo.png' } },
			{ info: { text: 'Carrot' }, es_info: { text: 'Zanahoria' }, pic: { image: 'Logo.png' } },
			{ info: { text: 'Carrot' }, es_info: { text: 'Zanahoria' }, pic: { image: 'Logo.png' } },
			{ info: { text: 'Carrot' }, es_info: { text: 'Zanahoria' }, pic: { image: 'Logo.png' } },
			{ info: { text: 'Carrot' }, es_info: { text: 'Zanahoria' }, pic: { image: 'Logo.png' } },
			{ info: { text: 'Carrot' }, es_info: { text: 'Zanahoria' }, pic: { image: 'Logo.png' } },
			{ info: { text: 'Potato' }, es_info: { text: 'Patata' }, pic: { image: 'Logo.png' } }
		];
		vegSection.setItems(vegDataSet);
		sections.push(vegSection);
 
		grainSection = Ti.UI.createListSection({ headerTitle: 'Grains / Granos' });
		grainDataSet = [
			{ info: { text: 'Corn' }, es_info: { text: 'Maiz' }, pic: { image: 'Logo.png' } },
			{ info: { text: 'Corn' }, es_info: { text: 'Maiz' }, pic: { image: 'Logo.png' } },
			{ info: { text: 'Corn' }, es_info: { text: 'Maiz' }, pic: { image: 'Logo.png' } },
			{ info: { text: 'Corn' }, es_info: { text: 'Maiz' }, pic: { image: 'Logo.png' } },
			{ info: { text: 'Corn' }, es_info: { text: 'Maiz' }, pic: { image: 'Logo.png' } },
			{ info: { text: 'Corn' }, es_info: { text: 'Maiz' }, pic: { image: 'Logo.png' } },
			{ info: { text: 'Corn' }, es_info: { text: 'Maiz' }, pic: { image: 'Logo.png' } },
			{ info: { text: 'Corn' }, es_info: { text: 'Maiz' }, pic: { image: 'Logo.png' } },
			{ info: { text: 'Rice' }, es_info: { text: 'Arroz' }, pic: { image: 'Logo.png' } }
		];
		grainSection.setItems(grainDataSet);
		sections.push(grainSection);
 
		listView.setSections(sections);
 
		window.addEventListener('focus', function () {
 
		});
		listView.addEventListener('itemclick',  function(e){
			window.close();
		});
 
		window.add(listView);
		window.open();
});
 
win.add(btn);
win.open();
```

I suspect it's how we're generating the sections/rows for the `data` property items. The code returns proxies tagged as `autorelease`, when I suspect they should not be. The general flow here seems shaky:
https://github.com/appcelerator/titanium_mobile/blob/master/iphone/Classes/TiUITableViewProxy.m#L694-L746