### PR TITLE
[Backport 9_2_X] fix(ios): remove old tiverify.xcframework references from project

### DIFF
--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -3946,7 +3946,9 @@ iOSBuilder.prototype.createXcodeProject = function createXcodeProject(next) {
 	});
 
 	// add tiverify.framework
-	xcodeProject.removeFramework('tiverify.xcframework', { customFramework: true, embed: true });
+	// technically the `lastKNownFileType` option is wrong, but the xcode module
+	// does not properly handle `.xcframework` extensions without it yet
+	xcodeProject.removeFramework('tiverify.xcframework', { lastKnownFileType: 'wrapper.framework' });
 
 	const tiverifyFrameworkFileRefUuid = this.generateXcodeUuid(xcodeProject);
 	const tiverifyFrameworkBuildFileUuid = this.generateXcodeUuid(xcodeProject);


### PR DESCRIPTION
Backport of #12094.
See that PR for full details.