### PR TITLE
Blob width walle

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -129,7 +129,7 @@ def androidUnitTests(nodeVersion, npmVersion, testOnDevices) {
 
 def macosUnitTests(nodeVersion, npmVersion) {
 	return {
-		node('git && osx && xcode-12 && osx-10.15') {
+		node('macos-walle') {
 			// TODO: Do a shallow checkout rather than stash/unstash?
 			unstash 'mocha-tests'
 			try {
@@ -352,11 +352,11 @@ timestamps {
 		// Run unit tests in parallel for android/iOS
 		stage('Test') {
 			parallel(
-				'android unit tests': androidUnitTests(nodeVersion, npmVersion, testOnDevices),
-				'iPhone unit tests': iosUnitTests('iphone', nodeVersion, npmVersion, testOnDevices),
-				'iPad unit tests': iosUnitTests('ipad', nodeVersion, npmVersion, testOnDevices),
+				// 'android unit tests': androidUnitTests(nodeVersion, npmVersion, testOnDevices),
+				// 'iPhone unit tests': iosUnitTests('iphone', nodeVersion, npmVersion, testOnDevices),
+				// 'iPad unit tests': iosUnitTests('ipad', nodeVersion, npmVersion, testOnDevices),
 				'macOS unit tests': macosUnitTests(nodeVersion, npmVersion),
-				'cli unit tests': cliUnitTests(nodeVersion, npmVersion),
+				// 'cli unit tests': cliUnitTests(nodeVersion, npmVersion),
 				failFast: false
 			)
 		}

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiBlob.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiBlob.m
@@ -67,6 +67,7 @@ static NSString *const MIMETYPE_JPEG = @"image/jpeg";
 {
   [self ensureImageLoaded];
   if (image != nil) {
+    NSLog(@"[ERROR] image scale: %f", image.scale);
     return image.size.width * image.scale;
   }
   return 0;

--- a/tests/Resources/ti.blob.test.js
+++ b/tests/Resources/ti.blob.test.js
@@ -468,7 +468,7 @@ describe('Titanium.Blob', function () {
 	// i.e. a 10 x 10 pixel image/view on a 3x device woudl report width/height of 3 and scale of 3, so just multiplying those we'd get 9
 	// when the real image was actually 10px.
 	// However, natively we *can* properly generate true pixel size because image would report scale like 3.33 that we coudl multiply by before returning
-	it('image dimensions should be reported in pixels', finish => {
+	it.only('image dimensions should be reported in pixels', finish => {
 		win = Ti.UI.createWindow();
 		const view = Ti.UI.createView({
 			backgroundColor: 'green',
@@ -479,8 +479,11 @@ describe('Titanium.Blob', function () {
 		win.addEventListener('postlayout', function postlayout() {
 			win.removeEventListener('postlayout', postlayout); // only run once
 			try {
+				Ti.API.info('Got postlayout event');
+				Ti.API.info(JSON.stringify(view.rect));
+				Ti.API.info(JSON.stringify(view.size));
 				const blob = view.toImage();
-				should(blob.width).equal(11);
+				should(blob.width).equal(11); // we're getting 6 here on macos-walle
 				should(blob.height).equal(13);
 			} catch (e) {
 				return finish(e);

--- a/tests/Resources/ti.blob.test.js
+++ b/tests/Resources/ti.blob.test.js
@@ -468,7 +468,7 @@ describe('Titanium.Blob', function () {
 	// i.e. a 10 x 10 pixel image/view on a 3x device woudl report width/height of 3 and scale of 3, so just multiplying those we'd get 9
 	// when the real image was actually 10px.
 	// However, natively we *can* properly generate true pixel size because image would report scale like 3.33 that we coudl multiply by before returning
-	it.only('image dimensions should be reported in pixels', finish => {
+	it('image dimensions should be reported in pixels', finish => {
 		win = Ti.UI.createWindow();
 		const view = Ti.UI.createView({
 			backgroundColor: 'green',

--- a/tests/Resources/ti.blob.test.js
+++ b/tests/Resources/ti.blob.test.js
@@ -479,6 +479,8 @@ describe('Titanium.Blob', function () {
 		win.addEventListener('postlayout', function postlayout() {
 			win.removeEventListener('postlayout', postlayout); // only run once
 			try {
+				Ti.API.info('Density: ' + Ti.Platform.displayCaps.density);
+				Ti.API.info('logicalDensityFactor: ' + Ti.Platform.displayCaps.logicalDensityFactor);
 				Ti.API.info('Got postlayout event');
 				Ti.API.info(JSON.stringify(view.rect));
 				Ti.API.info(JSON.stringify(view.size));


### PR DESCRIPTION
**Description:**
Work in progress PR to determine why macOS-walle appears to be reporting blob images using points and not pixels.

In trying to reproduce, this doesn't seem to happen on-demand just running the one test. I cannot figure out why *sometimes* it seems to act like it's scale is 2 but is actually 1 (an 11px view rendered to image reports a width of 6).