### PR TITLE
[Backport 9_2_X] chore(deps): update hyperloop to 6.0.0

### DIFF
--- a/support/module/packaged/modules.json
+++ b/support/module/packaged/modules.json
@@ -63,8 +63,8 @@
 	},
 	"hyperloop": {
 		"hyperloop": {
-			"url": "https://github.com/appcelerator-modules/hyperloop-builds/releases/download/v5.0.3/hyperloop-5.0.3.zip",
-			"integrity": "sha512-4vHEggtcmag7lF25yubM2Gt2jstrexx41ADFYWKGAyPely3A2+HVnifiY/em8r4eMLy0W0tKATop7bP9g/oLnA=="
+			"url": "https://github.com/appcelerator-modules/hyperloop-builds/releases/download/v6.0.0/hyperloop-6.0.0.zip",
+			"integrity": "sha512-kPjwQT5PV5JcBzshyni8o34JsMkNrCPrh3PKyAPBYEpPaFYenPYMVaGA1uLSQo4tKPhWbgmq5OSafjghHtjhfQ=="
 		}
 	}
 }


### PR DESCRIPTION
Backport of #12112.
See that PR for full details.