### PR TITLE
[Backport master] chore(deps): upgrade hyperloop to 6.0.1

### DIFF
--- a/support/module/packaged/modules.json
+++ b/support/module/packaged/modules.json
@@ -63,8 +63,8 @@
 	},
 	"hyperloop": {
 		"hyperloop": {
-			"url": "https://github.com/appcelerator-modules/hyperloop-builds/releases/download/v6.0.0/hyperloop-6.0.0.zip",
-			"integrity": "sha512-kPjwQT5PV5JcBzshyni8o34JsMkNrCPrh3PKyAPBYEpPaFYenPYMVaGA1uLSQo4tKPhWbgmq5OSafjghHtjhfQ=="
+			"url":"https://github.com/appcelerator-modules/hyperloop-builds/releases/download/v6.0.1/hyperloop-6.0.1.zip",
+			"integrity":"sha512-okDVPvoUHnyHB2PZOolFa2VH8TbKDJ7Q+165K0uV7M63QpDb5HgQ5rPlMfMfUPMRPXWOYKM7tFH4ECRH6he4lA=="
 		}
 	}
 }


### PR DESCRIPTION
Backport of #12126.
See that PR for full details.