### PR TITLE
fix(ios): guard PHPicker usage with openPhotoGallery

### DIFF
--- a/iphone/Classes/MediaModule.m
+++ b/iphone/Classes/MediaModule.m
@@ -1784,7 +1784,7 @@ MAKE_SYSTEM_PROP(VIDEO_REPEAT_MODE_ONE, VideoRepeatModeOne);
 }
 #endif
 
-#if IS_SDK_IOS_14
+#if IS_SDK_IOS_14 && defined(USE_TI_MEDIAOPENPHOTOGALLERY)
 - (void)showPHPicker:(NSDictionary *)args
 {
   if (_phPicker != nil) {


### PR DESCRIPTION
Fixes TIMOB-28151

**JIRA:** https://jira.appcelerator.org/browse/TIMOB-28151

Guard the usage of PHPicker with `defined(USE_TI_MEDIAOPENPHOTOGALLERY)` otherwise 💥 