### PR TITLE
docs(apidoc): fix backgroundSelectedColor type

### DIFF
--- a/apidoc/Titanium/UI/View.yml
+++ b/apidoc/Titanium/UI/View.yml
@@ -1308,7 +1308,7 @@ properties:
         `focusable` must be true for normal views.
 
         Defaults to background color of this view.
-    type: String
+    type: [String, Titanium.UI.Color]
     platforms: [android]
 
   - name: backgroundSelectedImage


### PR DESCRIPTION
Align type for `backgroundSelectedColor` property in `Ti.UI.View` with all other views that inherit from it. This is required for proper generation of TypeScript typings.