### PR TITLE
[Backport 9_2_X] fix(ios): disable default animation while setting backgroundImage

### DIFF
--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiUIView.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiUIView.m
@@ -660,7 +660,7 @@ DEFINE_EXCEPTIONS
   } else {
     // To fix TIMOB-28150
     [CATransaction begin];
-    [CATransaction setValue:(id)kCFBooleanTrue forKey:kCATransactionDisableActions];
+    [CATransaction setDisableActions:YES];
     [self backgroundImageLayer].contents = (id)bgImage.CGImage;
     [CATransaction commit];
     if (bgImage != nil) {

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiUIView.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiUIView.m
@@ -658,7 +658,11 @@ DEFINE_EXCEPTIONS
   if (backgroundRepeat) {
     [self renderRepeatedBackground:bgImage];
   } else {
+    // To fix TIMOB-28150
+    [CATransaction begin];
+    [CATransaction setValue:(id)kCFBooleanTrue forKey:kCATransactionDisableActions];
     [self backgroundImageLayer].contents = (id)bgImage.CGImage;
+    [CATransaction commit];
     if (bgImage != nil) {
       [self backgroundImageLayer].contentsScale = [bgImage scale];
       [self backgroundImageLayer].contentsCenter = TiDimensionLayerContentCenter(topCap, leftCap, topCap, leftCap, [bgImage size]);


### PR DESCRIPTION
Backport of #12133.
See that PR for full details.