### PR TITLE
fix(ios): format js errors in cli output

### DIFF
--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/KrollBridge.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/KrollBridge.m
@@ -876,7 +876,7 @@ CFMutableSetRef krollBridgeRegistry = nil;
   KrollWrapper *module = [self loadCommonJSModule:data withSourceURL:url_];
 
   if (![module respondsToSelector:@selector(replaceValue:forKey:notification:)]) {
-    @throw [NSException exceptionWithName:@"org.appcelerator.kroll"
+    @throw [NSException exceptionWithName:@"org.appcelerator.kroll.invalidmodule"
                                    reason:[NSString stringWithFormat:@"Module \"%@\" failed to leave a valid exports object", filename]
                                  userInfo:nil];
   }
@@ -1325,6 +1325,11 @@ CFMutableSetRef krollBridgeRegistry = nil;
 
     default:
       break;
+    }
+  }
+  @catch (NSException *exception) {
+    if ([exception.name isEqualToString:@"org.appcelerator.kroll.invalidmodule"]) {
+      return nil;
     }
   }
   @finally {

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiExceptionHandler.h
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiExceptionHandler.h
@@ -59,6 +59,11 @@
  */
 @property (nonatomic, readonly) NSArray<NSString *> *nativeStack;
 
+/**
+ * Returns the pre-formated and cleaned native stack trace.
+ */
+@property (nonatomic, readonly) NSArray<NSString *> *formattedNativeStack;
+
 - (id)initWithMessage:(NSString *)message sourceURL:(NSString *)sourceURL lineNo:(NSInteger)lineNo;
 - (id)initWithDictionary:(NSDictionary *)dictionary;
 
@@ -66,11 +71,6 @@
  * Returns detailed description.
  */
 - (NSString *)detailedDescription;
-
-/**
- * Returns the pre-formated and cleaned native stack trace.
- */
-- (NSArray<NSString *> *)formattedNativeStack;
 
 @end
 

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiExceptionHandler.h
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiExceptionHandler.h
@@ -25,6 +25,11 @@
 @property (nonatomic, readonly) NSString *sourceURL;
 
 /**
+ * Returns the actual source code line as a string where the error happened.
+ */
+@property (nonatomic, readonly) NSString *sourceLine;
+
+/**
  * Returns line number where error happened.
  */
 @property (nonatomic, readonly) NSInteger lineNo;
@@ -61,6 +66,11 @@
  * Returns detailed description.
  */
 - (NSString *)detailedDescription;
+
+/**
+ * Returns the pre-formated and cleaned native stack trace.
+ */
+- (NSArray<NSString *> *)formattedNativeStack;
 
 @end
 

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiExceptionHandler.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiExceptionHandler.m
@@ -73,7 +73,7 @@ static NSUncaughtExceptionHandler *prevUncaughtExceptionHandler = NULL;
 
 - (void)reportScriptError:(TiScriptError *)scriptError
 {
-  DebugLog(@"[ERROR] Script Error %@", [scriptError detailedDescription]);
+  DebugLog(@"[ERROR] %@", scriptError);
 
   id<TiExceptionHandlerDelegate> currentDelegate = _delegate;
   if (currentDelegate == nil) {
@@ -94,43 +94,13 @@ static NSUncaughtExceptionHandler *prevUncaughtExceptionHandler = NULL;
 
 - (void)showScriptError:(TiScriptError *)error
 {
-  NSArray<NSString *> *exceptionStackTrace = [error valueForKey:@"nativeStack"];
-  if (exceptionStackTrace == nil) {
-    exceptionStackTrace = [NSThread callStackSymbols];
-  }
-
   NSMutableDictionary *errorDict = [error.dictionaryValue mutableCopy];
   [errorDict setObject:[NSNumber numberWithLong:error.column] forKey:@"column"];
   [errorDict setObject:[NSNumber numberWithLong:error.lineNo] forKey:@"line"];
-  if (exceptionStackTrace == nil) {
-    [[TiApp app] showModalError:[error description]];
-  } else {
-    NSMutableArray<NSString *> *formattedStackTrace = [[[NSMutableArray alloc] init] autorelease];
-    NSUInteger exceptionStackTraceLength = [exceptionStackTrace count];
-
-    // re-size stack trace and format results. Starting at index = 1 to not include showScriptError call
-    for (NSInteger i = 1; i < (exceptionStackTraceLength >= 20 ? 20 : exceptionStackTraceLength); i++) {
-      NSString *line = [self removeWhitespace:[exceptionStackTrace objectAtIndex:i]];
-
-      // remove stack index
-      line = [line substringFromIndex:[line rangeOfString:@" "].location + 1];
-
-      [formattedStackTrace addObject:line];
-    }
-    NSString *stackTrace = [formattedStackTrace componentsJoinedByString:@"\n"];
-    [errorDict setObject:stackTrace forKey:@"nativeStack"];
-
-    [[TiApp app] showModalError:[NSString stringWithFormat:@"%@\n\n%@", [error description], stackTrace]];
-  }
+  NSString *stackTrace = [error.formattedNativeStack componentsJoinedByString:@"\n"];
+  [errorDict setObject:stackTrace forKey:@"nativeStack"];
+  [[TiApp app] showModalError:[error description]];
   [[NSNotificationCenter defaultCenter] postNotificationName:kTiErrorNotification object:self userInfo:errorDict];
-}
-
-- (NSString *)removeWhitespace:(NSString *)line
-{
-  while ([line rangeOfString:@"  "].length > 0) {
-    line = [line stringByReplacingOccurrencesOfString:@"  " withString:@" "];
-  }
-  return line;
 }
 
 #pragma mark - TiExceptionHandlerDelegate
@@ -143,6 +113,13 @@ static NSUncaughtExceptionHandler *prevUncaughtExceptionHandler = NULL;
 - (void)handleScriptError:(TiScriptError *)error
 {
   [self showScriptError:error];
+}
+
+@end
+
+@interface TiScriptError () {
+  NSArray<NSString *> *_preparedNativeStack;
+  NSString *_sourceLine;
 }
 
 @end
@@ -197,38 +174,109 @@ static NSUncaughtExceptionHandler *prevUncaughtExceptionHandler = NULL;
   RELEASE_TO_NIL(_backtrace);
   RELEASE_TO_NIL(_dictionaryValue);
   RELEASE_TO_NIL(_nativeStack);
+  RELEASE_TO_NIL(_preparedNativeStack);
+  RELEASE_TO_NIL(_sourceLine);
   [super dealloc];
 }
 
 - (NSString *)description
 {
-  if (self.sourceURL != nil) {
-    // attempt to load encrypted source code
-    NSURL *sourceURL = [NSURL URLWithString:self.sourceURL];
-    NSData *data = [TiUtils loadAppResource:sourceURL];
-    NSString *source = nil;
-    if (data == nil) {
-      source = [NSString stringWithContentsOfFile:[sourceURL path] encoding:NSUTF8StringEncoding error:NULL];
-    } else {
-      source = [[[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding] autorelease];
-    }
-    NSArray *lines = [source componentsSeparatedByCharactersInSet:[NSCharacterSet newlineCharacterSet]];
-    NSString *line = [lines objectAtIndex:self.lineNo - 1];
-    NSString *linePointer = [@"" stringByPaddingToLength:self.column withString:@" " startingAtIndex:0];
+  NSMutableString *message = [[NSMutableString new] autorelease];
+  NSString *encodedBundlePath = [NSString stringWithFormat:@"file://%@", [[NSBundle mainBundle].bundlePath stringByReplacingOccurrencesOfString:@" " withString:@"%20"]];
 
-    // remove bundle path from source paths
-    NSString *encodedBundlePath = [NSString stringWithFormat:@"file://%@", [[NSBundle mainBundle].bundlePath stringByReplacingOccurrencesOfString:@" " withString:@"%20"]];
-    NSString *jsStack = [self.backtrace stringByReplacingOccurrencesOfString:encodedBundlePath withString:@""];
-
-    return [NSString stringWithFormat:@"/%@:%ld\n%@\n%@^\n%@\n%@", [self.sourceURL lastPathComponent], (long)self.lineNo, line, linePointer, self.message, jsStack];
-  } else {
-    return [NSString stringWithFormat:@"%@", self.message];
+  if (self.sourceURL) {
+    [message appendFormat:@"%@:%ld\n", [self.sourceURL stringByReplacingOccurrencesOfString:encodedBundlePath withString:@""], (long)self.lineNo];
+    [message appendFormat:@"%@\n", self.sourceLine];
+    NSString *columnIndicatorPadding = [@"" stringByPaddingToLength:self.column withString:@" " startingAtIndex:0];
+    [message appendFormat:@"%@^\n\n", columnIndicatorPadding];
   }
+
+  NSString *type = self.dictionaryValue[@"type"] != nil ? self.dictionaryValue[@"type"] : @"Error";
+  [message appendFormat:@"%@: %@", type, self.message];
+
+  NSString *jsStack = [self.backtrace stringByReplacingOccurrencesOfString:encodedBundlePath withString:@""];
+  NSArray *jsStackLines = [jsStack componentsSeparatedByCharactersInSet:NSCharacterSet.newlineCharacterSet];
+  NSMutableString *formattedJsStack = [[NSMutableString new] autorelease];
+  for (NSString *line in jsStackLines) {
+    NSRange atSymbolRange = [line rangeOfString:@"@"];
+    NSInteger atSymbolIndex = atSymbolRange.location == NSNotFound ? -1 : atSymbolRange.location;
+    NSString *source = [line substringFromIndex:atSymbolIndex + 1];
+    NSString *symbolName = @"Object.<anonymous>";
+    if (atSymbolIndex != -1) {
+      symbolName = [line substringWithRange:NSMakeRange(0, atSymbolIndex)];
+    }
+    // global code is our module wrapper code which can be ignored
+    if ([symbolName isEqualToString:@"global code"]) {
+      continue;
+    }
+    [formattedJsStack appendFormat:@"\n    at %@ (%@)", symbolName, source];
+  }
+  [message appendString:formattedJsStack];
+
+  [message appendFormat:@"\n\nNative Stack:\n    %@", [self.formattedNativeStack componentsJoinedByString:@"\n    "]];
+
+  return message;
 }
 
 - (NSString *)detailedDescription
 {
   return _dictionaryValue != nil ? [_dictionaryValue description] : [self description];
+}
+
+- (NSArray<NSString *> *)formattedNativeStack
+{
+  if (_preparedNativeStack != nil) {
+    return _preparedNativeStack;
+  }
+
+  NSArray<NSString *> *stackTrace = self.nativeStack;
+  if (stackTrace == nil) {
+    stackTrace = [NSThread callStackSymbols];
+  }
+  NSMutableArray<NSString *> *formattedStackTrace = [[[NSMutableArray alloc] init] autorelease];
+  NSUInteger stackTraceLength = [stackTrace count];
+  // re-size stack trace and format results. starting at index = 2 to not include this method and callee
+  for (NSInteger i = 1; i < (stackTraceLength >= 20 ? 20 : stackTraceLength); i++) {
+    NSString *line = [self removeWhitespace:stackTrace[i]];
+    // remove stack index
+    line = [line substringFromIndex:[line rangeOfString:@" "].location + 1];
+    [formattedStackTrace addObject:line];
+  }
+  _preparedNativeStack = [formattedStackTrace copy];
+
+  return _preparedNativeStack;
+}
+
+- (NSString *)sourceLine
+{
+  if (_sourceURL == nil) {
+    return nil;
+  }
+
+  if (_sourceLine != nil) {
+    return _sourceLine;
+  }
+
+  NSURL *sourceURL = [NSURL URLWithString:self.sourceURL];
+  NSData *data = [TiUtils loadAppResource:sourceURL];
+  NSString *source = nil;
+  if (data == nil) {
+    source = [NSString stringWithContentsOfFile:[sourceURL path] encoding:NSUTF8StringEncoding error:NULL];
+  } else {
+    source = [[[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding] autorelease];
+  }
+  NSArray<NSString *> *lines = [source componentsSeparatedByCharactersInSet:[NSCharacterSet newlineCharacterSet]];
+  _sourceLine = [[lines objectAtIndex:self.lineNo - 1] retain];
+
+  return _sourceLine;
+}
+
+- (NSString *)removeWhitespace:(NSString *)line
+{
+  while ([line rangeOfString:@"  "].length > 0) {
+    line = [line stringByReplacingOccurrencesOfString:@"  " withString:@" "];
+  }
+  return line;
 }
 
 @end


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-27812

This properly formats the error output in the CLI and prints JS/native stack traces from any runtime errors. The format is similar to Node/V8 with added native stack trace. It will also prevent showing the unrelated error modal for "Module xy failed to leave a valid exports object".