### PR TITLE
[Backport 9_2_X] fix(ios): check for thirdparty framework path

### DIFF
--- a/iphone/cli/commands/_buildModule.js
+++ b/iphone/cli/commands/_buildModule.js
@@ -518,11 +518,13 @@ iOSModuleBuilder.prototype.buildModule = function buildModule(next) {
 			const frameworksPath = path.join(this.projectDir, 'platform');
 			const legacyFrameworks = new Set();
 
-			fs.readdirSync(frameworksPath).forEach(filename => {
-				if (filename.endsWith('.framework')) {
-					legacyFrameworks.add(filename);
-				}
-			});
+			if (fs.existsSync(frameworksPath)) {
+				fs.readdirSync(frameworksPath).forEach(filename => {
+					if (filename.endsWith('.framework')) {
+						legacyFrameworks.add(filename);
+					}
+				});
+			}
 			if (legacyFrameworks.size > 0) {
 				const pbxFilePath = path.join(this.projectDir, `${this.moduleName}.xcodeproj`, 'project.pbxproj');
 				const proj = xcode.project(pbxFilePath).parseSync();


### PR DESCRIPTION
Backport of #12142.
See that PR for full details.