### PR TITLE
[Backport 9_2_X] fix(ios): ignore duplicate and unnecessary framework search paths

### DIFF
--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -42,7 +42,8 @@ const appc = require('node-appc'),
 	parallel = appc.async.parallel,
 	series = appc.async.series,
 	plist = require('simple-plist'),
-	version = appc.version;
+	version = appc.version,
+	merge = require('lodash.merge');
 const platformsRegExp = new RegExp('^(' + ti.allPlatformNames.join('|') + ')$'); // eslint-disable-line security/detect-non-literal-regexp
 const pemCertRegExp = /(^-----BEGIN CERTIFICATE-----)|(-----END CERTIFICATE-----.*$)|\n/g;
 
@@ -3255,7 +3256,7 @@ iOSBuilder.prototype.createXcodeProject = function createXcodeProject(next) {
 
 	// set the target-specific build settings
 	xobjs.XCConfigurationList[xobjs.PBXNativeTarget[mainTargetUuid].buildConfigurationList].buildConfigurations.forEach(function (buildConf) {
-		const bs = appc.util.mix(xobjs.XCBuildConfiguration[buildConf.value].buildSettings, buildSettings);
+		const bs = merge(xobjs.XCBuildConfiguration[buildConf.value].buildSettings, buildSettings);
 		delete bs['"CODE_SIGN_IDENTITY[sdk=iphoneos*]"'];
 
 		bs.PRODUCT_BUNDLE_IDENTIFIER = '"' + this.tiapp.id + '"';

--- a/iphone/cli/hooks/frameworks.js
+++ b/iphone/cli/hooks/frameworks.js
@@ -533,7 +533,12 @@ class FrameworkIntegrator {
 		if (frameworkInfo.type === FRAMEWORK_TYPE_DYNAMIC) {
 			this.addEmbedFrameworkBuildPhase(frameworkInfo, fileRefUuid);
 		}
-		this.addFrameworkSearchPath(frameworkInfo.searchPath);
+		// Xcode has a special build phase step that handles XCFrameworks and
+		// extracts the correct .framework for an architecture. This works without
+		// consulting FRAMEWORK_SEARCH_PATHS so we don't need to modify it.
+		if (!frameworkInfo.isBinaryFramework) {
+			this.addFrameworkSearchPath(frameworkInfo.searchPath);
+		}
 	}
 
 	/**

--- a/package-lock.json
+++ b/package-lock.json
@@ -10391,6 +10391,11 @@
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
       "dev": true
     },
+    "lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+    },
     "lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "fs-extra": "^9.0.1",
     "ioslib": "^1.7.21",
     "liveview": "^1.5.4",
+    "lodash.merge": "^4.6.2",
     "markdown": "0.5.0",
     "moment": "^2.28.0",
     "node-appc": "^1.1.1",


### PR DESCRIPTION
Backport of #12146.
See that PR for full details.