### PR TITLE
[Backport 9_2_X] chore(ios): update ti.map for ios to 4.0.1

### DIFF
--- a/support/module/packaged/modules.json
+++ b/support/module/packaged/modules.json
@@ -13,8 +13,8 @@
 			"integrity": "sha512-qr7W/JYkAjDUCj80kH2wB9B6V9T7jsxs+4MdrEMyCev6v/JvkMWwEu4yz7z1hf7s/TKhbmZ/nHlTNYUd96+oQg=="
 		},
 		"ti.map": {
-			"url": "https://github.com/appcelerator-modules/ti.map/releases/download/v4.0.0-iphone/ti.map-iphone-4.0.0.zip",
-			"integrity": "sha512-gU0iIJnkQOG5sxpEOAiwpBssgkPTpwdqer2nqVallhLvdL1DXZoL9561mzpg3seQwinlB2YN4ReLFK7fD1jpmg=="
+			"url": "https://github.com/appcelerator-modules/ti.map/releases/download/v4.0.1-iphone/ti.map-iphone-4.0.1.zip",
+			"integrity": "sha512-eZ+t+kSiCDnLuCsQRl0y15JrzGhfpTbeuIzyf2uF0Qo2q9tsdkn7Xp5HbcekefEXWiLpuS53URqV1RyTB+metA=="
 		},
 		"ti.webdialog": {
 			"url": "https://github.com/appcelerator-modules/titanium-web-dialog/releases/download/v2.0.0-iphone/ti.webdialog-iphone-2.0.0.zip",


### PR DESCRIPTION
Backport of #12150.
See that PR for full details.