### PR TITLE
[Backport 9_2_X] chore(deps): update hyperloop to 6.0.2

### DIFF
--- a/support/module/packaged/modules.json
+++ b/support/module/packaged/modules.json
@@ -5,8 +5,8 @@
 			"integrity": "sha512-66Isv52+jqxSS7GGFmlxdU5Ir1e0ELZOQ5buZSdm84mof94o/r1brJi39T9womyiRoekkxkmO6kG4llW0tgbHA=="
 		},
 		"facebook": {
-			"url":"https://github.com/appcelerator-modules/ti.facebook/releases/download/v9.0.0-iphone/facebook-iphone-9.0.0.zip",
-			"integrity":"sha512-ydzmAwj3jqpnBf2suUIGJhqz3POo8HlIlshA+kbmLyP6edyIqIsvn+5iCvbZOUTPji3RGGkCVr9GLdwvO3Atww=="
+			"url": "https://github.com/appcelerator-modules/ti.facebook/releases/download/v9.0.0-iphone/facebook-iphone-9.0.0.zip",
+			"integrity": "sha512-ydzmAwj3jqpnBf2suUIGJhqz3POo8HlIlshA+kbmLyP6edyIqIsvn+5iCvbZOUTPji3RGGkCVr9GLdwvO3Atww=="
 		},
 		"ti.coremotion": {
 			"url": "https://github.com/appcelerator-modules/ti.coremotion/releases/download/v3.0.0/ti.coremotion-iphone-3.0.0.zip",
@@ -31,8 +31,8 @@
 	},
 	"android": {
 		"facebook": {
-			"url":"https://github.com/appcelerator-modules/ti.facebook/releases/download/v10.0.0-android/facebook-android-10.0.0.zip",
-			"integrity":"sha512-xoAmbzglL4TLLbaqHhDaarIYqhu2q/dlhZT49SRl7342TxdPRGKCnuxmNAbAy0R4X6z8Ueh9/5s4b8NsHoTdVQ=="
+			"url": "https://github.com/appcelerator-modules/ti.facebook/releases/download/v10.0.0-android/facebook-android-10.0.0.zip",
+			"integrity": "sha512-xoAmbzglL4TLLbaqHhDaarIYqhu2q/dlhZT49SRl7342TxdPRGKCnuxmNAbAy0R4X6z8Ueh9/5s4b8NsHoTdVQ=="
 		},
 		"ti.cloudpush": {
 			"url": "https://appcelerator-modules.s3.amazonaws.com/ti.cloudpush-android-7.1.0.zip",
@@ -63,8 +63,8 @@
 	},
 	"hyperloop": {
 		"hyperloop": {
-			"url":"https://github.com/appcelerator-modules/hyperloop-builds/releases/download/v6.0.1/hyperloop-6.0.1.zip",
-			"integrity":"sha512-okDVPvoUHnyHB2PZOolFa2VH8TbKDJ7Q+165K0uV7M63QpDb5HgQ5rPlMfMfUPMRPXWOYKM7tFH4ECRH6he4lA=="
+			"url": "https://github.com/appcelerator-modules/hyperloop-builds/releases/download/v6.0.2/hyperloop-6.0.2.zip",
+			"integrity": "sha512-Jd8tKVYCcommLKB9acNqZOMdUpteisCPRyQnGRtmQYoT0yQvF/9JIb21j9APBI/9be7qoYBZRunqB/sUDVYQWw=="
 		}
 	}
 }


### PR DESCRIPTION
Backport of #12156.
See that PR for full details.