### PR TITLE
Module hooks

### DIFF
--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -1515,9 +1515,7 @@ AndroidBuilder.prototype.run = async function run(logger, config, cli, finished)
 		Builder.prototype.run.apply(this, arguments);
 
 		// Notify plugins that we're about to begin.
-		await new Promise((resolve) => {
-			cli.emit('build.pre.construct', this, resolve);
-		});
+		await new Promise(resolve => cli.emit('build.pre.construct', this, resolve));
 
 		// Post build anlytics.
 		await this.doAnalytics();
@@ -1545,13 +1543,9 @@ AndroidBuilder.prototype.run = async function run(logger, config, cli, finished)
 		await this.generateAppProject();
 
 		// Build the app.
-		await new Promise((resolve) => {
-			cli.emit('build.pre.build', this, resolve);
-		});
+		await new Promise(resolve => cli.emit('build.pre.build', this, resolve));
 		await this.buildAppProject();
-		await new Promise((resolve) => {
-			cli.emit('build.post.build', this, resolve);
-		});
+		await new Promise(resolve => cli.emit('build.post.build', this, resolve));
 
 		// Write Titanium build settings to file. Used to determine if next build can be incremental or not.
 		await this.writeBuildManifest();
@@ -1563,12 +1557,8 @@ AndroidBuilder.prototype.run = async function run(logger, config, cli, finished)
 		}
 
 		// Notify plugins that the build is done.
-		await new Promise((resolve) => {
-			cli.emit('build.post.compile', this, resolve);
-		});
-		await new Promise((resolve) => {
-			cli.emit('build.finalize', this, resolve);
-		});
+		await new Promise(resolve => cli.emit('build.post.compile', this, resolve));
+		await new Promise(resolve => cli.emit('build.finalize', this, resolve));
 	} catch (err) {
 		// Failed to build app. Print the error message and stack trace (if possible), then exit out.
 		// Note: "err" can be whatever type (including undefined) that was passed into Promise.reject().

--- a/android/cli/commands/_buildModule.js
+++ b/android/cli/commands/_buildModule.js
@@ -309,18 +309,19 @@ AndroidModuleBuilder.prototype.run = async function run(logger, config, cli, fin
 
 		// Build the library and output it to "dist" directory.
 		await this.buildModuleProject();
-		await this.packageZip();
-
-		// Run the built module via "example" project.
-		await this.runModule();
-
 		// Notify plugins that the build is done.
 		await new Promise((resolve) => {
 			cli.emit('build.module.post.compile', this, resolve);
 		});
+
+		await this.packageZip();
+
 		await new Promise((resolve) => {
 			cli.emit('build.module.finalize', this, resolve);
 		});
+
+		// Run the built module via "example" project.
+		await this.runModule(cli);
 	} catch (err) {
 		// Failed to build module. Print the error message and stack trace (if possible).
 		// Note: "err" can be whatever type (including undefined) that was passed into Promise.reject().
@@ -801,7 +802,7 @@ AndroidModuleBuilder.prototype.packageZip = async function () {
 	dest.finalize();
 };
 
-AndroidModuleBuilder.prototype.runModule = async function () {
+AndroidModuleBuilder.prototype.runModule = async function (cli) {
 	// Do not run built module in an app if given command line argument "--build-only".
 	if (this.buildOnly) {
 		return;
@@ -900,6 +901,9 @@ AndroidModuleBuilder.prototype.runModule = async function () {
 	// Unzip module into temp app's "modules" directory.
 	const zip = new AdmZip(this.moduleZipPath);
 	zip.extractAllTo(tmpProjectDir, true);
+
+	// Emit hook so modules can also alter project before launch
+	await new Promise(resolve => cli.emit('create.module.app.finalize', [ this, tmpProjectDir ], resolve));
 
 	// Run the temp app.
 	this.logger.debug(__('Running example project...', tmpDir.cyan));

--- a/iphone/cli/commands/_buildModule.js
+++ b/iphone/cli/commands/_buildModule.js
@@ -157,7 +157,9 @@ iOSModuleBuilder.prototype.run = function run(logger, config, cli, finished) {
 			this.verifyBuildArch().then(next, next);
 		},
 		'packageModule',
-		'runModule',
+		function (next) {
+			this.runModule(cli, next);
+		},
 
 		function (next) {
 			cli.emit('build.module.post.compile', this, next);
@@ -967,7 +969,7 @@ iOSModuleBuilder.prototype.packageModule = function packageModule(next) {
 	}
 };
 
-iOSModuleBuilder.prototype.runModule = function runModule(next) {
+iOSModuleBuilder.prototype.runModule = function runModule(cli, next) {
 	if (this.buildOnly) {
 		return next();
 	}
@@ -1050,6 +1052,11 @@ iOSModuleBuilder.prototype.runModule = function runModule(next) {
 			proc.stderr.on('data', data => this.logger.error(data.toString().trimEnd()));
 			proc.once('error', err => cb(err));
 			proc.on('exit', () => cb());
+		},
+
+		// Emit hook so modules can also alter project before launch
+		function (cb) {
+			cli.emit('create.module.app.finalize', [ this, tmpProjectDir ], cb);
 		},
 
 		function (cb) {


### PR DESCRIPTION
**Description:**
This is a very minor tweak to our module builds so that we emit an event `'create.module.app.finalize'` after we've created a temp app (and extracted the module to it, modified the tiapp.xml) and before we've launched it. This allows us to add hooks to native modules to alter the created project pre-launch. This is useful for this native modules whose example apps require some modifications to actually work (i.e. Facebook injecting an app id, ti.map injecting android manifest permissions/api keys, etc).

We likely don't want to bake in our api keys/app ids in the module - but we could at least add hooks that do 99% of there work and have some placeholder file that's intended to hold the api key/app id that a dev could pop the value into (and that we could add to .gitiggore to avoid checking the value in).