### PR TITLE
fix(android): use of right property in child of horizontal layout

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiCompositeLayout.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiCompositeLayout.java
@@ -1004,13 +1004,17 @@ public class TiCompositeLayout extends ViewGroup implements OnHierarchyChangeLis
 
 		TiDimension optionLeft = params.optionLeft;
 		TiDimension optionRight = params.optionRight;
+		boolean lastChild = currentIndex == getChildCount() - 1;
 		int left = horizontalLayoutCurrentLeft + horiztonalLayoutPreviousRight;
+		horiztonalLayoutPreviousRight = (optionRight == null) ? 0 : optionRight.getAsPixels(this);
 		int optionLeftValue = 0;
 		if (optionLeft != null) {
 			optionLeftValue = optionLeft.getAsPixels(this);
 			left += optionLeftValue;
+		} else if (horiztonalLayoutPreviousRight > 0 && lastChild) {
+			// Take into account 'right' value for last child in row.
+			left = layoutRight - measuredWidth - horiztonalLayoutPreviousRight;
 		}
-		horiztonalLayoutPreviousRight = (optionRight == null) ? 0 : optionRight.getAsPixels(this);
 
 		// If it's fill width with horizontal wrap, just take up remaining
 		// space.


### PR DESCRIPTION
- Correct behavior of `right` property when applied to last child in `horizontal` layout for parity with iOS

##### TEST CASE
```JS
const win = Ti.UI.createWindow({
	backgroundColor: 'gray'
});
const row = Ti.UI.createView({
	layout: 'horizontal',
	backgroundColor: 'white',
	width: Ti.UI.FILL,
	height: 50
});
const view_a = Ti.UI.createView({
	backgroundColor: 'green',
	left: 50,
	// right: 50,
	width: 50,
	height: 50
});
const view_b = Ti.UI.createView({
	backgroundColor: 'red',
	// left: 50,
	right: 50,
	width: 50,
	height: 50
});

row.add([ view_a, view_b ]);
win.add(row);
win.open();
```
- Last child of horizontal layout should align to the right.
- In all other cases (where both `left` and `right` properties are defined), view should stack from left with expected padding.

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-28197)