### PR TITLE
[Backport 9_2_X] fix(angular): declare missing nodejs namespace for zone.js

### DIFF
--- a/templates/app/angular-default/template/tsconfig.json
+++ b/templates/app/angular-default/template/tsconfig.json
@@ -14,7 +14,11 @@
       "es2018",
       "dom"
     ],
-    "preserveSymlinks": true
+    "preserveSymlinks": true,
+    "typeRoots": [
+      "typings",
+      "node_modules/@types"
+    ]
   },
   "files": [
     "src/main.ts",

--- a/templates/app/angular-default/template/typings/node/index.d.ts
+++ b/templates/app/angular-default/template/typings/node/index.d.ts
@@ -1,0 +1,5 @@
+// Alias NodeJS.Global definition to make zone.js typings happy
+// including @types/node clashes with @types/titanium
+declare namespace NodeJS {
+  type Global = Titanium.Global
+}


### PR DESCRIPTION
Backport of #12199.
See that PR for full details.