### PR TITLE
fix(android): openPhotoGallery() crash selecting multiple files as of 9.1.0

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/TiBlob.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiBlob.java
@@ -564,19 +564,13 @@ public class TiBlob extends KrollProxy
 	@Kroll.getProperty
 	public TiFileProxy getFile()
 	{
-		if (data == null) {
-			return null;
-		}
-		if (this.type != TYPE_FILE) {
+		TiFileProxy fileProxy = null;
+		if (data instanceof TiBaseFile) {
+			fileProxy = new TiFileProxy((TiBaseFile) data);
+		} else if (data != null) {
 			Log.w(TAG, "getFile not supported for non-file blob types.");
-			return null;
-		} else if (!(data instanceof TiBaseFile)) {
-			Log.w(TAG,
-				  "getFile unable to return value: underlying data is not file, rather " + data.getClass().getName());
-			return null;
-		} else {
-			return new TiFileProxy((TiBaseFile) data);
 		}
+		return fileProxy;
 	}
 
 	@Kroll.method


### PR DESCRIPTION
**JIRA:**
https://jira.appcelerator.org/browse/TIMOB-28193

**Summary:**
- Fixed regression introduced in 9.1.0 where `Ti.Media.openPhotoGallery()` might crash when selecting multiple photos and/or videos.
- Modified `e.media.file` property to return a `Ti.Filesystem.File` object for `content://` URLs.

**Test:**
1. Build and run `PhotoVideoMultiselectTest.js` attached to [TIMOB-28193](https://jira.appcelerator.org/browse/TIMOB-28193).
2. Tap on the "Add" button and select "Photo" from the dialog.
3. Tap on the "Back" button.
4. Verify you are returned to the app.
5. Tap on the "Add" button and select "Photo" from the dialog.
6. Select only 1 photo from the gallery.
7. Verify app lists that 1 photo and displays it when tapped on.
8. Tap on the "Add" button and select "Photo" from the dialog.
9. Select 2 or more photos from the gallery.
10. Verify app lists those photos and displays them correctly when tapped on.
