### PR TITLE
[Backport 9_2_X] fix: always load aca module first on startup

### DIFF
--- a/common/Resources/ti.internal/aca.js
+++ b/common/Resources/ti.internal/aca.js
@@ -1,0 +1,15 @@
+/**
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2020 by Axway, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ *
+ * This script is used to load ACA (Axway Crash Analytics).
+ * This allows ACA to be the first module to load on startup.
+ */
+
+try {
+	import('com.appcelerator.aca');
+} catch (e) {
+	// Could not load module, silently ignore exception.
+}

--- a/common/Resources/ti.main.js
+++ b/common/Resources/ti.main.js
@@ -11,16 +11,12 @@
  * - Load the app developer's main "app.js" script after doing all of the above.
  */
 
+// Attempt to load crash analytics module.
+// NOTE: This should always be the first module that loads on startup.
+import './ti.internal/aca';
+
 // Log the app name, app version, and Titanium version on startup.
 Ti.API.info(`${Ti.App.name} ${Ti.App.version} (Powered by Titanium ${Ti.version}.${Ti.buildHash})`);
-
-// Attempt to load crash analytics module.
-// NOTE: This should be the first module that loads on startup.
-try {
-	require('com.appcelerator.aca');
-} catch (e) {
-	// Could not load module, silently ignore exception.
-}
 
 // Load JS language polyfills
 import 'core-js/es';


### PR DESCRIPTION
Backport of #12205.
See that PR for full details.