### PR TITLE
[Backport 9_2_X] fix(ios): allow TableViewRow proxy to return correct view

### DIFF
--- a/iphone/Classes/TiUITableViewRowProxy.m
+++ b/iphone/Classes/TiUITableViewRowProxy.m
@@ -29,7 +29,7 @@ NSString *const defaultRowTableClass = @"_default_";
 #ifdef TI_USE_AUTOLAYOUT
 @interface TiUITableViewRowContainer : TiLayoutView
 #else
-@interface TiUITableViewRowContainer : UIView
+@interface TiUITableViewRowContainer : TiUIView
 #endif
 {
   TiProxy *hitTarget;

--- a/iphone/Classes/TiUITableViewRowProxy.m
+++ b/iphone/Classes/TiUITableViewRowProxy.m
@@ -528,7 +528,7 @@ TiProxy *DeepScanForProxyOfViewContainingPoint(UIView *targetView, CGPoint point
 
 - (UIView *)view
 {
-  return nil;
+  return rowContainerView;
 }
 
 //Private method : For internal use only

--- a/tests/Resources/ti.ui.tableview.test.js
+++ b/tests/Resources/ti.ui.tableview.test.js
@@ -1387,8 +1387,7 @@ describe('Titanium.UI.TableView', function () {
 		win.open();
 	});
 
-	it.iosBroken('row#rect', function (finish) {
-		// FIXME: TIMOB-27935
+	it('row#rect', function (finish) {
 		if (isCI && utilities.isMacOS()) { // FIXME: On macOS CI (maybe < 10.15.6?), times out! Does app need explicit focus added?
 			return finish(); // FIXME: skip when we move to official mocha package
 		}


### PR DESCRIPTION
Backport of #12225.
See that PR for full details.