### PR TITLE
[Backport 9_2_X] fix(ios): fix crash for dateTimeColor property on mac

### DIFF
--- a/apidoc/Titanium/UI/Picker.yml
+++ b/apidoc/Titanium/UI/Picker.yml
@@ -256,7 +256,7 @@ properties:
         Important: On iOS 14+, you also have to set the <Titanium.UI.Picker.datePickerStyle> to <Titanium.UI.iOS.DATE_PICKER_STYLE_WHEELS>
         in order to use this property.
     type: [String, Titanium.UI.Color]
-    platforms: [iphone, ipad, macos]
+    platforms: [iphone, ipad]
     since: "5.2.0"
     default: "black"
 

--- a/iphone/Classes/TiUIPicker.m
+++ b/iphone/Classes/TiUIPicker.m
@@ -233,7 +233,7 @@ USE_PROXY_FOR_VERIFY_AUTORESIZING
 - (void)setDateTimeColor_:(id)value
 {
   // Guard date picker and iOS 14+ date picker style
-  if (![self isDatePicker]) {
+  if (![self isDatePicker] || [TiUtils isMacOS]) {
     return;
   }
 #if IS_SDK_IOS_13_4


### PR DESCRIPTION
Backport of #12249.
See that PR for full details.