### PR TITLE
refactor(ios): Ti.UI.Clipboard

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/clipboard/ClipboardModule.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/clipboard/ClipboardModule.java
@@ -75,7 +75,7 @@ public class ClipboardModule extends KrollModule
 	}
 
 	@Kroll.method
-	public boolean hasData(String type)
+	public boolean hasData(@Kroll.argument(optional = true) String type)
 	{
 		if (type == null || isTextType(type)) {
 			return hasText();

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/clipboard/ClipboardModule.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/clipboard/ClipboardModule.java
@@ -71,7 +71,11 @@ public class ClipboardModule extends KrollModule
 	@Kroll.getProperty
 	public String getText()
 	{
-		return board().getText().toString();
+		CharSequence text = board().getText();
+		if (text != null) {
+			return text.toString();
+		}
+		return null;
 	}
 
 	@Kroll.method
@@ -79,9 +83,8 @@ public class ClipboardModule extends KrollModule
 	{
 		if (type == null || isTextType(type)) {
 			return hasText();
-		} else {
-			return false;
 		}
+		return false;
 	}
 
 	@Kroll.method

--- a/apidoc/Titanium/UI/Clipboard/Clipboard.yml
+++ b/apidoc/Titanium/UI/Clipboard/Clipboard.yml
@@ -5,19 +5,21 @@ description: |
     The Clipboard is a temporary data store, used to save a single item of data that may then
     be accessed by the user using UI copy and paste interactions within an app or between apps.
 
-    On iOS, the module's `*Data()` methods enable multiple representations of the
+    On iOS, the module's `setData()` and `getData()` methods enable multiple representations of the
     same data item to be stored together with their respective
     [MIME type](http://en.wikipedia.org/wiki/Internet_media_type) to describe their format. For
     example, `'text'` and `'text/plain'` for text, and `'image/jpg'` and `'image/png'` for an image.
+    iOS Will report back the type of data representation in `getItems()` as 
+    [Universal Type Identifiers](https://developer.apple.com/library/archive/documentation/Miscellaneous/Reference/UTIRef/Articles/System-DeclaredUniformTypeIdentifiers.html).
 
-    When working with text, either the `*Data()` methods may be used with a `'text/plain'` type, or
-    the `*Text()` methods without the need to specify the type.
+    When working with text, either of the `getData()`/`setData()` methods may be used with a `'text/plain'` type, or
+    the `getText()`/`hasText()`/`setText()` methods without the need to specify the type.
 
-    Android currently only supports text type of data to be stored.
+    Android currently only supports text data to be stored.
 
     #### Clipboard Data Types
 
-    The `*Text()` methods are equivalent to calling `*Data()` with a `'text'` or `'text/plain'`
+    The `getText()`/`hasText()`/`setText()` methods are equivalent to calling `getData()`/`setData()` with a `'text'` or `'text/plain'`
     type. These work with plain Unicode strings.
 
     An image is stored using the `'image'` type, or an explicit image MIME type, and is returned as
@@ -35,7 +37,7 @@ methods:
     summary: |
         Deletes data of the specified MIME type stored in the clipboard. If MIME type omitted, all
         data is deleted.
-    description: On Android, identical to `clearText` method.
+    description: On Android, identical to the `clearText()` method.
     parameters:
       - name: type
         summary: MIME type. Ignored on Android.
@@ -51,7 +53,7 @@ methods:
   - name: getData
     summary: Gets data of the specified MIME type stored in the clipboard. Returns null if non-text mimetype on Android.
     returns:
-        type: [String,Titanium.Blob]
+        type: [String, Titanium.Blob]
     parameters:
       - name: type
         summary: MIME type. Must be 'text' or 'text/plain' on Android, or else null is returned.
@@ -112,7 +114,8 @@ methods:
       - name: type
         summary: |
             MIME type. Must be 'text' or 'text/plain' on Android.
-            Possible types include: `'text', 'text/plain', 'color', 'image', 'url', 'text/uri-list'`
+            Possible types include: `'text', 'text/plain', 'color', 'image', 'url', 'text/uri-list'`.
+            iOS also supports [Universal Type Identifiers](https://developer.apple.com/library/archive/documentation/Miscellaneous/Reference/UTIRef/Articles/System-DeclaredUniformTypeIdentifiers.html)
         type: String
 
       - name: data
@@ -147,6 +150,10 @@ methods:
 
   - name: getItems
     summary: Gets the items that have been specified earlier using <Titanium.UI.Clipboard.setItems>.
+    description: |
+        The returned Array contains simple Objects whose keys are the reported
+        [Universal Type Identifiers](https://developer.apple.com/library/archive/documentation/Miscellaneous/Reference/UTIRef/Articles/System-DeclaredUniformTypeIdentifiers.html)
+        reported by iOS; and values are the underlying object/data.
     returns:
         - type: Array<Dictionary>
     osver: {ios: {min: "10.0"}}
@@ -215,22 +222,23 @@ examples:
 
         ``` js
         var win = Ti.UI.createWindow({
-            backgroundColor : "#fff"
+            backgroundColor: "#fff"
         });
 
         var btn1 = Ti.UI.createButton({
-            title : "Set clipboard items",
+            title: "Set clipboard items",
             top: 40
         });
 
         var btn2 = Ti.UI.createButton({
-            title : "Get clipboard items",
+            title: "Get clipboard items",
             top: 80
         });
 
-        btn1.addEventListener("click", function() {
-          var localOnly = Ti.UI.CLIPBOARD_OPTION_LOCAL_ONLY;
-          var expirationDate = Ti.UI.CLIPBOARD_OPTION_EXPIRATION_DATE;
+        btn1.addEventListener("click", function () {
+          const options = {};
+          options[Ti.UI.CLIPBOARD_OPTION_LOCAL_ONLY] = true;
+          options[Ti.UI.CLIPBOARD_OPTION_EXPIRATION_DATE] = new Date(2030, 4, 20);
 
             Ti.UI.Clipboard.setItems({
               items: [{
@@ -238,14 +246,11 @@ examples:
               },{
                   "text/plain": "Doe"
               }],
-              options: {
-                  localOnly: true,
-                  expirationDate: new Date(2020, 04, 20)
-              }
+              options
           });
         });
 
-        btn2.addEventListener("click", function() {
+        btn2.addEventListener("click", function () {
             alert(Ti.UI.Clipboard.getItems());
         });
 
@@ -293,6 +298,7 @@ properties:
     summary: |
         An array of key-value items to add to the clipboard. The key must a valid mime-type
         matching the mime-type of the value.
+        Alterntaively, iOS supports using [Universal Type Identifiers](https://developer.apple.com/library/archive/documentation/Miscellaneous/Reference/UTIRef/Articles/System-DeclaredUniformTypeIdentifiers.html)
     type: Array<Dictionary>
 
   - name: options

--- a/apidoc/Titanium/UI/UI.yml
+++ b/apidoc/Titanium/UI/UI.yml
@@ -2135,7 +2135,10 @@ properties:
     since: "5.5.0"
 
   - name: CLIPBOARD_OPTION_EXPIRATION_DATE
-    summary: Specifies the time and date that you want the system to remove the clipboard items from the clipboard.
+    summary: |
+        Specifies the time and date that you want the system to remove the clipboard items from the clipboard.
+
+        Note that on macOS, setting a date in the past does not appear to invalidate items immediately, while on iOS it does.
     type: String
     permission: read-only
     platforms: [iphone, ipad, macos]

--- a/iphone/Classes/TiUIClipboardProxy.h
+++ b/iphone/Classes/TiUIClipboardProxy.h
@@ -1,33 +1,49 @@
 /**
  * Appcelerator Titanium Mobile
- * Copyright (c) 2009-2010 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2009-Present by Axway, Inc. All Rights Reserved.
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
 
 #ifdef USE_TI_UICLIPBOARD
-#import <TitaniumKit/TiProxy.h>
-@interface TiUIClipboardProxy : TiProxy {
+@import TitaniumKit.ObjcProxy;
+
+@protocol ClipboardExports <JSExport>
+
+// Properties (and accessors)
+READONLY_PROPERTY(bool, allowCreation, AllowCreation);
+READONLY_PROPERTY(NSString *, name, Name);
+READONLY_PROPERTY(bool, unique, Unique);
+
+// Methods
+- (void)clearData:(NSString *)type;
+- (void)clearText;
+- (JSValue *)getData:(NSString *)type;
+- (NSArray<NSDictionary<NSString *, id> *> *)getItems;
+- (NSString *)getText;
+- (bool)hasData:(id)type;
+- (bool)hasText;
+- (bool)hasURLs;
+- (bool)hasImages;
+- (bool)hasColors;
+JSExportAs(setData,
+           -(void)setData
+           : (NSString *)type withData
+           : (id)data);
+- (void)setText:(NSString *)text;
+- (void)setItems:(NSDictionary<NSString *, id> *)items;
+- (void)remove;
+
+@end
+
+@interface TiUIClipboardProxy : ObjcProxy <ClipboardExports> {
   @private
   UIPasteboard *_pasteboard;
-  NSString *pasteboardName;
   BOOL shouldCreatePasteboard;
-  BOOL isNamedPasteBoard;
   BOOL isUnique;
 }
 
-#pragma mark internal
 - (id)getData_:(NSString *)mimeType;
-
-- (void)clearData:(id)args;
-- (void)clearText:(id)args;
-- (id)getData:(id)args;
-- (NSString *)getText:(id)args;
-- (id)hasData:(id)args;
-- (id)hasText:(id)unused;
-- (void)setData:(id)args;
-- (void)setText:(id)args;
-- (void)remove:(id)unused;
 
 @end
 #endif

--- a/iphone/Classes/TiUIClipboardProxy.m
+++ b/iphone/Classes/TiUIClipboardProxy.m
@@ -1,16 +1,15 @@
 /**
  * Appcelerator Titanium Mobile
- * Copyright (c) 2009-2010 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2009-Present by Axway, Inc. All Rights Reserved.
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
 
 #ifdef USE_TI_UICLIPBOARD
 #import "TiUIClipboardProxy.h"
-#import <TitaniumKit/TiApp.h>
-#import <TitaniumKit/TiBlob.h>
-#import <TitaniumKit/TiFile.h>
-#import <TitaniumKit/TiUtils.h>
+@import TitaniumKit.TiBlob;
+@import TitaniumKit.TiFile;
+@import TitaniumKit.TiUtils;
 
 #import <MobileCoreServices/UTCoreTypes.h>
 #import <MobileCoreServices/UTType.h>
@@ -29,23 +28,44 @@ static ClipboardType mimeTypeToDataType(NSString *mimeType)
 
   // Types "URL" and "Text" are for IE compatibility. We want to have
   // a consistent interface with WebKit's HTML 5 DataTransfer.
-  if ([mimeType isEqualToString:@"text"] || [mimeType hasPrefix:@"text/plain"]) {
+  // support text, text.plain, public.text, public.plain-text, public.utf8-plain-text
+  if ([mimeType isEqualToString:@"text"] || [mimeType hasPrefix:@"text/plain"] || UTTypeConformsTo((CFStringRef)mimeType, kUTTypeText)) {
     return CLIPBOARD_TEXT;
-  } else if ([mimeType isEqualToString:@"url"] || [mimeType hasPrefix:@"text/uri-list"]) {
-    return CLIPBOARD_URI_LIST;
-  } else if ([mimeType hasPrefix:@"image"]) {
-    return CLIPBOARD_IMAGE;
-  } else if ([mimeType isEqualToString:@"color"]) {
-    return CLIPBOARD_COLOR;
-  } else {
-    // Something else, work from the MIME type.
-    return CLIPBOARD_UNKNOWN;
   }
+
+  if ([mimeType isEqualToString:@"url"] || [mimeType hasPrefix:@"text/uri-list"] || UTTypeConformsTo((CFStringRef)mimeType, kUTTypeURL)) {
+    return CLIPBOARD_URI_LIST;
+  }
+
+  if ([mimeType hasPrefix:@"image"] || UTTypeConformsTo((CFStringRef)mimeType, kUTTypeImage)) {
+    return CLIPBOARD_IMAGE;
+  }
+
+  if ([mimeType isEqualToString:@"color"] || [mimeType isEqualToString:@"com.apple.uikit.color"]) {
+    return CLIPBOARD_COLOR;
+  }
+
+  // Something else, work from the MIME type.
+  return CLIPBOARD_UNKNOWN;
 }
 
 static NSString *mimeTypeToUTType(NSString *mimeType)
 {
+  if ([mimeType isEqualToString:@"text"] || [mimeType hasPrefix:@"text/plain"]) {
+    return @"public.plain-text";
+  }
+  if ([mimeType isEqualToString:@"url"] || [mimeType hasPrefix:@"text/uri-list"]) {
+    return @"public.url";
+  }
+  if ([mimeType hasPrefix:@"image"]) {
+    return @"public.image";
+  }
+  if ([mimeType isEqualToString:@"color"]) {
+    return @"com.apple.uikit.color";
+  }
+
   NSString *uti = [(NSString *)UTTypeCreatePreferredIdentifierForTag(kUTTagClassMIMEType, (CFStringRef)mimeType, NULL) autorelease];
+  // FIXME: If we get back a dyn. prefix, something is up!
   if (uti == nil) {
     // Should we do this? Lets us copy/paste custom data, anyway.
     uti = mimeType;
@@ -54,16 +74,6 @@ static NSString *mimeTypeToUTType(NSString *mimeType)
 }
 
 @implementation TiUIClipboardProxy
-
-NSArray<NSString *> *clipboardKeySequence;
-
-- (NSArray<NSString *> *)keySequence
-{
-  if (clipboardKeySequence == nil) {
-    clipboardKeySequence = [[NSArray alloc] initWithObjects:@"unique", @"name", @"allowCreation", nil];
-  }
-  return clipboardKeySequence;
-}
 
 - (void)_destroy
 {
@@ -74,10 +84,25 @@ NSArray<NSString *> *clipboardKeySequence;
 - (id)init
 {
   if (self = [super init]) {
-    shouldCreatePasteboard = true;
-    isNamedPasteBoard = false;
+    _pasteboard = nil;
     isUnique = false;
-  };
+    shouldCreatePasteboard = false;
+  }
+  return self;
+}
+
+- (id)initWithProperties:(NSDictionary *)dict
+{
+  if (self = [super init]) {
+    isUnique = [TiUtils boolValue:dict[@"unique"] def:false];
+    shouldCreatePasteboard = [TiUtils boolValue:dict[@"allowCreation"] def:true];
+    if (isUnique) {
+      _pasteboard = [[UIPasteboard pasteboardWithUniqueName] retain];
+    } else {
+      NSString *pasteboardName = dict[@"name"];
+      _pasteboard = [[UIPasteboard pasteboardWithName:pasteboardName create:shouldCreatePasteboard] retain];
+    }
+  }
   return self;
 }
 
@@ -88,49 +113,31 @@ NSArray<NSString *> *clipboardKeySequence;
 
 - (UIPasteboard *)pasteboard
 {
-  if (isNamedPasteBoard) {
+  if (_pasteboard != nil) {
     return _pasteboard;
   }
   return UIPasteboard.generalPasteboard;
-}
-
-- (void)setName:(id)arg
-{
-  if (!isUnique) {
-    ENSURE_STRING(arg);
-    pasteboardName = arg;
-    _pasteboard = [[UIPasteboard pasteboardWithName:arg create:shouldCreatePasteboard] retain];
-    isNamedPasteBoard = true;
-  }
 }
 
 - (NSString *)name
 {
   return [self pasteboard].name;
 }
+GETTER_IMPL(NSString *, name, Name);
 
-- (void)setAllowCreation:(id)arg
+- (bool)unique
 {
-  BOOL value = [TiUtils boolValue:arg def:true];
-  shouldCreatePasteboard = value;
-  if (!isUnique && pasteboardName && !shouldCreatePasteboard) {
-    [self remove:nil];
-    _pasteboard = [[UIPasteboard pasteboardWithName:pasteboardName create:value] retain];
-    isNamedPasteBoard = true;
-  }
+  return isUnique;
 }
+GETTER_IMPL(bool, unique, Unique);
 
-- (void)setUnique:(id)arg
+- (bool)allowCreation
 {
-  BOOL value = [TiUtils boolValue:arg def:false];
-  isUnique = value;
-  if (isUnique) {
-    _pasteboard = [[UIPasteboard pasteboardWithUniqueName] retain];
-    isNamedPasteBoard = true;
-  }
+  return shouldCreatePasteboard;
 }
+GETTER_IMPL(bool, allowCreation, AllowCreation);
 
-- (void)remove:(id)unused
+- (void)remove
 {
   if (_pasteboard != nil) {
     [UIPasteboard removePasteboardWithName:[self pasteboard].name];
@@ -138,15 +145,14 @@ NSArray<NSString *> *clipboardKeySequence;
   }
 }
 
-- (void)clearData:(id)arg
+- (void)clearData:(NSString *)mimeType
 {
-  ENSURE_UI_THREAD(clearData, arg);
-  ENSURE_SINGLE_ARG_OR_NIL(arg, NSString);
-
-  NSString *mimeType = arg ?: @"application/octet-stream";
+  if (mimeType == nil) {
+    mimeType = @"application/octet-stream";
+  }
   UIPasteboard *board = [self pasteboard];
-  ClipboardType dataType = mimeTypeToDataType(mimeType);
 
+  ClipboardType dataType = mimeTypeToDataType(mimeType);
   switch (dataType) {
   case CLIPBOARD_TEXT: {
     board.strings = nil;
@@ -171,26 +177,15 @@ NSArray<NSString *> *clipboardKeySequence;
   }
 }
 
-- (void)clearText:(id)args
+- (void)clearText
 {
-  ENSURE_UI_THREAD(clearText, args);
-
   UIPasteboard *board = [self pasteboard];
   board.strings = nil;
 }
 
-- (id)getData:(id)args
+- (id)getData:(NSString *)mimeType
 {
-  id arg = nil;
-  if ([args isKindOfClass:[NSArray class]]) {
-    if ([args count] > 0) {
-      arg = [args objectAtIndex:0];
-    }
-  } else {
-    arg = args;
-  }
-  ENSURE_STRING(arg);
-  NSString *mimeType = arg;
+  // FIXME: Support array arg?
   __block id result;
   TiThreadPerformOnMainThread(
       ^{
@@ -236,24 +231,20 @@ NSArray<NSString *> *clipboardKeySequence;
   }
 }
 
-- (NSString *)getText:(id)args
+- (NSString *)getText
 {
   return [self getData:@"text/plain"];
 }
 
-- (id)hasData:(id)args
+- (bool)hasData:(id)type
 {
-  id arg = nil;
-  if ([args isKindOfClass:[NSArray class]]) {
-    if ([args count] > 0) {
-      arg = [args objectAtIndex:0];
-    }
-  } else {
-    arg = args;
-  }
-  ENSURE_STRING_OR_NIL(arg);
-  NSString *mimeType = arg;
   __block BOOL result = NO;
+  // type is an optional string
+  NSString *mimeType = @"text/plain";
+  if (type != nil) {
+    mimeType = [TiUtils stringValue:type];
+  }
+
   TiThreadPerformOnMainThread(
       ^{
         UIPasteboard *board = [self pasteboard];
@@ -284,40 +275,37 @@ NSArray<NSString *> *clipboardKeySequence;
         }
       },
       YES);
-  return NUMBOOL(result);
+  return result;
 }
 
-- (id)hasText:(id)unused
+- (bool)hasText
 {
-  return NUMBOOL([[self pasteboard] hasStrings]);
+  return [[self pasteboard] hasStrings];
 }
 
-- (id)hasColors:(id)unused
+- (bool)hasColors
 {
-  return NUMBOOL([[self pasteboard] hasColors]);
+  return [[self pasteboard] hasColors];
 }
 
-- (id)hasImages:(id)unused
+- (bool)hasImages
 {
-  return NUMBOOL([[self pasteboard] hasImages]);
+  return [[self pasteboard] hasImages];
 }
 
-- (id)hasURLs:(id)unused
+- (bool)hasURLs
 {
-  return NUMBOOL([[self pasteboard] hasURLs]);
+  return [[self pasteboard] hasURLs];
 }
 
-- (void)setItems:(id)args
+- (void)setItems:(NSDictionary<NSString *, id> *)args
 {
-  NSArray *items = [args objectForKey:@"items"];
-  NSDictionary *options = [args objectForKey:@"options"];
-
-  __block NSMutableArray *result = [[[NSMutableArray alloc] init] retain];
-
+  NSArray<NSDictionary<NSString *, id> *> *items = args[@"items"];
+  __block NSMutableArray<NSDictionary<NSString *, id> *> *result = [[[NSMutableArray alloc] init] retain];
   // The key of the items must be a string (mime-type)
-  for (id item in items) {
-    NSMutableDictionary *newDict = [[NSMutableDictionary alloc] init];
-    for (id key in item) {
+  for (NSDictionary<NSString *, id> *item in items) {
+    NSMutableDictionary<NSString *, id> *newDict = [[NSMutableDictionary alloc] init];
+    for (NSString *key in item) {
       ENSURE_TYPE(key, NSString);
       [newDict setValue:[item valueForKey:key] forKey:mimeTypeToUTType(key)];
     }
@@ -327,6 +315,7 @@ NSArray<NSString *> *clipboardKeySequence;
     RELEASE_TO_NIL(newDict);
   }
 
+  NSDictionary<UIPasteboardOption, id> *options = args[@"options"];
   TiThreadPerformOnMainThread(
       ^{
         if (options == nil) {
@@ -339,49 +328,58 @@ NSArray<NSString *> *clipboardKeySequence;
       YES);
 }
 
-- (id)getItems:(id)unused
+- (NSArray<NSDictionary<NSString *, id> *> *)getItems
 {
-  __block id items;
-
+  __block NSMutableArray<NSDictionary<NSString *, id> *> *result = [[[NSMutableArray alloc] init] retain];
   TiThreadPerformOnMainThread(
       ^{
-        items = [[[self pasteboard] items] retain];
+        NSArray<NSDictionary<NSString *, id> *> *items = [self pasteboard].items;
 
         // Check for invalid UTI's / mime-types to prevent a runtime-crash
-        for (NSDictionary *item in items) {
-          for (NSString *key in [item allKeys]) {
-            if ([key hasPrefix:@"dyn."]) {
-              NSLog(@"[ERROR] Invalid mime-type specified to setItems() before. Returning an empty result ...");
-
-              RELEASE_TO_NIL(items);
-              items = @[];
-              break;
+        for (NSDictionary<NSString *, id> *item in items) {
+          NSMutableDictionary<NSString *, id> *newItem = item.mutableCopy;
+          for (NSString *key in newItem.allKeys) {
+            if ([key isEqualToString:@"com.apple.uikit.color"]) {
+              // Convert colors back to hex strings
+              newItem[key] = [TiUtils hexColorValue:item[key]];
+            } else if (UTTypeConformsTo((CFStringRef)key, kUTTypeURL)) {
+              // Convert public.url and public.file-url values from NSURL to NSString
+              newItem[key] = [TiUtils stringValue:item[key]];
+            } else if (UTTypeConformsTo((CFStringRef)key, kUTTypeImage)) {
+              // Convert UIImage to TiBlob!
+              newItem[key] = [[[TiBlob alloc] initWithImage:(UIImage *)item[key]] autorelease];
             }
           }
-          if ([items count] == 0) {
-            break;
-          }
+          [result addObject:newItem];
         }
       },
       YES);
 
-  return [items autorelease];
+  return [result autorelease];
 }
 
-- (void)setData:(id)args
+- (void)setData:(NSString *)mimeType withData:(id)data
 {
-  ENSURE_ARG_COUNT(args, 2);
-  ENSURE_UI_THREAD(setData, args);
-
-  NSString *mimeType = [TiUtils stringValue:[args objectAtIndex:0]];
-  id data = [args objectAtIndex:1];
   if (data == nil) {
     DebugLog(@"[WARN] setData: data object was nil.");
     return;
   }
+  // FIXME: data doesn't get converted properly if it's a TiFile, because trhat's not one of the "new" proxies
+  // Can we convert id to JSValue* in the signature and handle it?\
+  // Or do we need ot keep this ugly code?
+  if ([data isKindOfClass:[NSDictionary class]]) {
+    NSDictionary *dict = (NSDictionary *)data;
+    if (dict.count == 0) {
+      id whatever = JSContext.currentArguments[1];
+      id converted = [self JSValueToNative:whatever];
+      if ([converted isKindOfClass:[TiFile class]]) {
+        data = converted;
+      }
+    }
+  }
+
   UIPasteboard *board = [self pasteboard];
   ClipboardType dataType = mimeTypeToDataType(mimeType);
-
   switch (dataType) {
   case CLIPBOARD_TEXT: {
     board.string = [TiUtils stringValue:data];
@@ -415,11 +413,9 @@ NSArray<NSString *> *clipboardKeySequence;
   }
 }
 
-- (void)setText:(id)arg
+- (void)setText:(NSString *)text
 {
-  ENSURE_STRING(arg);
-  NSString *text = arg;
-  [self setData:[NSArray arrayWithObjects:@"text/plain", text, nil]];
+  [self setData:@"text/plain" withData:text];
 }
 
 @end

--- a/iphone/Classes/TiUIClipboardProxy.m
+++ b/iphone/Classes/TiUIClipboardProxy.m
@@ -301,7 +301,7 @@ GETTER_IMPL(bool, allowCreation, AllowCreation);
 - (void)setItems:(NSDictionary<NSString *, id> *)args
 {
   NSArray<NSDictionary<NSString *, id> *> *items = args[@"items"];
-  __block NSMutableArray<NSDictionary<NSString *, id> *> *result = [[[NSMutableArray alloc] init] retain];
+  __block NSMutableArray<NSDictionary<NSString *, id> *> *result = [[NSMutableArray alloc] init];
   // The key of the items must be a string (mime-type)
   for (NSDictionary<NSString *, id> *item in items) {
     NSMutableDictionary<NSString *, id> *newDict = [[NSMutableDictionary alloc] init];
@@ -348,9 +348,12 @@ GETTER_IMPL(bool, allowCreation, AllowCreation);
             } else if (UTTypeConformsTo((CFStringRef)key, kUTTypeImage)) {
               // Convert UIImage to TiBlob!
               newItem[key] = [[[TiBlob alloc] initWithImage:(UIImage *)item[key]] autorelease];
+            } else if ([key hasPrefix:@"dyn."]) {
+              [newItem removeObjectForKey:key];
             }
           }
           [result addObject:newItem];
+          [newItem release];
         }
       },
       YES);

--- a/iphone/Classes/UIModule.m
+++ b/iphone/Classes/UIModule.m
@@ -494,7 +494,7 @@ MAKE_SYSTEM_PROP(EXTEND_EDGE_ALL, 15); //UIEdgeRectAll
 - (id)Clipboard
 {
   if (clipboard == nil) {
-    clipboard = [[[TiUIClipboardProxy alloc] _initWithPageContext:[self executionContext]] retain];
+    clipboard = [[TiUIClipboardProxy alloc] _initWithPageContext:[self executionContext]];
   }
   return clipboard;
 }

--- a/iphone/Classes/UIModule.m
+++ b/iphone/Classes/UIModule.m
@@ -58,7 +58,6 @@
   RELEASE_TO_NIL(ios);
 #endif
 #ifdef USE_TI_UICLIPBOARD
-  [self forgetProxy:clipboard];
   RELEASE_TO_NIL(clipboard);
 #endif
 #if defined(USE_TI_UISHORTCUT) || defined(USE_TI_UISHORTCUTITEM)
@@ -495,10 +494,19 @@ MAKE_SYSTEM_PROP(EXTEND_EDGE_ALL, 15); //UIEdgeRectAll
 - (id)Clipboard
 {
   if (clipboard == nil) {
-    clipboard = [[TiUIClipboardProxy alloc] _initWithPageContext:[self executionContext]];
-    [self rememberProxy:clipboard];
+    clipboard = [[[TiUIClipboardProxy alloc] _initWithPageContext:[self executionContext]] retain];
   }
   return clipboard;
+}
+
+- (id)createClipboard:(id)args
+{
+  if (args == nil || [args count] == 0) {
+    return [[[TiUIClipboardProxy alloc] init] autorelease];
+  }
+  ENSURE_SINGLE_ARG(args, NSDictionary);
+  TiUIClipboardProxy *clipboard = [[TiUIClipboardProxy alloc] initWithProperties:args];
+  return [clipboard autorelease];
 }
 #endif
 

--- a/tests/Resources/ti.ui.clipboard.test.js
+++ b/tests/Resources/ti.ui.clipboard.test.js
@@ -7,11 +7,21 @@
 /* eslint-env mocha */
 /* eslint no-unused-expressions: "off" */
 /* eslint no-undef: "off" */
+/* eslint mocha/no-identical-title: "off" */
 'use strict';
 
 const should = require('./utilities/assertions');
+const utilities = require('./utilities/utilities');
 
 describe('Titanium.UI.Clipboard', () => {
+
+	// FIXME: There's a huge mismatch in the named data "mimeTypes" we accept and what iOS reports/accepts in set/getItems:
+	// we take in 'text' -> they report 'public.plain-text'
+	// we take in 'color' -> they report 'com.apple.uikit.color'
+	// we take in 'text/plain' -> they report 'public.plain-text'
+	// we take in 'url' -> they report 'public.url'
+	// setting an url can also give us 'public.utf8-plain-text'
+	// setting an image can give us multiple types: 'com.apple.uikit.image', 'public.png', 'public.jpeg'
 
 	describe('properties', () => {
 		describe('.apiName', () => {
@@ -38,88 +48,402 @@ describe('Titanium.UI.Clipboard', () => {
 	});
 
 	describe('methods', () => {
-		describe('#clearData', () => {
-			it('is a Function', () => { // eslint-disable-line mocha/no-identical-title
+		describe('#clearData()', () => {
+			it('is a Function', () => {
 				should(Ti.UI.Clipboard.clearData).be.a.Function();
 			});
+
+			it('clears \'text\' data type', () => {
+				Ti.UI.Clipboard.clearData(); // delete all data
+				Ti.UI.Clipboard.setText('clearData');
+				should(Ti.UI.Clipboard.hasText()).be.true();
+				Ti.UI.Clipboard.clearData('text');
+				should(Ti.UI.Clipboard.hasText()).be.false();
+			});
+
+			// TODO: Try clearing only specific mime types on iOS!
+			it.ios('clears \'color\' data type', () => {
+				Ti.UI.Clipboard.clearData(); // delete all data
+				Ti.UI.Clipboard.setData('color', 'white');
+				should(Ti.UI.Clipboard.hasColors()).be.true();
+				should(Ti.UI.Clipboard.getData('color')).eql('#FFFFFF');
+				Ti.UI.Clipboard.clearData('color');
+				should(Ti.UI.Clipboard.hasColors()).be.false();
+			});
 		});
 
-		describe('#clearText', () => {
-			it('is a Function', () => { // eslint-disable-line mocha/no-identical-title
+		describe('#clearText()', () => {
+			it('is a Function', () => {
 				should(Ti.UI.Clipboard.clearText).be.a.Function();
 			});
-		});
 
-		describe('#getData', () => {
-			it('is a Function', () => { // eslint-disable-line mocha/no-identical-title
-				should(Ti.UI.Clipboard.getData).be.a.Function();
+			it('makes hasText() return false after being called', () => {
+				Ti.UI.Clipboard.clearData(); // delete all data
+				Ti.UI.Clipboard.setText('clearText');
+				should(Ti.UI.Clipboard.hasText()).be.true();
+				Ti.UI.Clipboard.clearText();
+				should(Ti.UI.Clipboard.hasText()).be.false();
 			});
 		});
 
-		describe.ios('#getItems', () => {
-			it('is a Function', () => { // eslint-disable-line mocha/no-identical-title
+		describe('#getData()', () => {
+			it('is a Function', () => {
+				should(Ti.UI.Clipboard.getData).be.a.Function();
+			});
+
+			// TODO: set and pull out data for each mime type: color, url, text, image
+			it.ios('returns \'color\' data type', () => {
+				Ti.UI.Clipboard.clearData(); // delete all data
+				Ti.UI.Clipboard.setData('color', 'white');
+				should(Ti.UI.Clipboard.hasColors()).be.true();
+				should(Ti.UI.Clipboard.getData('color')).eql('#FFFFFF');
+			});
+
+			it.android('returns null for non-text data type on Android', () => {
+				Ti.UI.Clipboard.clearData(); // delete all data
+				Ti.UI.Clipboard.setText('hi');
+				should(Ti.UI.Clipboard.getData('color')).be.null();
+				should(Ti.UI.Clipboard.getData('url')).be.null();
+				should(Ti.UI.Clipboard.getData('image')).be.null();
+			});
+
+			it('returns \'text\' data type', () => {
+				Ti.UI.Clipboard.clearData(); // delete all data
+				Ti.UI.Clipboard.setData('text', 'white');
+				should(Ti.UI.Clipboard.hasText()).be.true();
+				should(Ti.UI.Clipboard.getData('text')).eql('white');
+				should(Ti.UI.Clipboard.getData('text/plain')).eql('white');
+			});
+
+			it.ios('returns \'url\' data type', () => {
+				Ti.UI.Clipboard.clearData(); // delete all data
+				Ti.UI.Clipboard.setData('url', 'http://localhost:8080');
+				should(Ti.UI.Clipboard.hasURLs()).be.true();
+				should(Ti.UI.Clipboard.getData('url')).eql('http://localhost:8080');
+			});
+
+			it.ios('returns \'image\' data type as Ti.Blob when set as Ti.Filesystem.File', () => {
+				Ti.UI.Clipboard.clearData(); // delete all data
+				const file = Ti.Filesystem.getFile('Logo.png');
+				Ti.UI.Clipboard.setData('image', file);
+				const image = Ti.UI.Clipboard.getData('image');
+				should(image).be.an.Object();
+				should(image.apiName).eql('Ti.Blob');
+			});
+
+			it.ios('returns \'image\' data type as Ti.Blob when set as Ti.Blob', () => {
+				Ti.UI.Clipboard.clearData(); // delete all data
+				const blob = Ti.Filesystem.getFile('Logo.png').read();
+				Ti.UI.Clipboard.setData('image', blob);
+				const image = Ti.UI.Clipboard.getData('image');
+				should(image).be.an.Object();
+				should(image.apiName).eql('Ti.Blob');
+			});
+		});
+
+		describe.ios('#getItems()', () => {
+			it('is a Function', () => {
 				should(Ti.UI.Clipboard.getItems).be.a.Function();
 			});
 		});
 
-		describe('#getText', () => {
-			it('is a Function', () => { // eslint-disable-line mocha/no-identical-title
+		describe('#getText()', () => {
+			it('is a Function', () => {
 				should(Ti.UI.Clipboard.getText).be.a.Function();
 			});
+
+			it('returns empty string with empty clipboard', () => {
+				Ti.UI.Clipboard.clearData(); // delete all data
+				// should(Ti.UI.Clipboard.getText()).eql(''); // FIXME: undefined on iOS
+			});
+
+			it('returns given string after setText()', () => {
+				Ti.UI.Clipboard.clearData(); // delete all data
+				// should(Ti.UI.Clipboard.getText()).eql(''); // FIXME: undefined on iOS
+				Ti.UI.Clipboard.setText('setText');
+				should(Ti.UI.Clipboard.getText()).eql('setText');
+			});
+
+			it('returns given string after setData(\'text\')', () => {
+				Ti.UI.Clipboard.clearData(); // delete all data
+				// should(Ti.UI.Clipboard.getText()).eql(''); // FIXME: undefined on iOS
+				Ti.UI.Clipboard.setData('text', 'setData');
+				should(Ti.UI.Clipboard.getText()).eql('setData');
+			});
+
+			it('returns given string after setData(\'text/plain\')', () => {
+				Ti.UI.Clipboard.clearData(); // delete all data
+				// should(Ti.UI.Clipboard.getText()).eql(''); // FIXME: undefined on iOS
+				Ti.UI.Clipboard.setData('text/plain', 'setData');
+				should(Ti.UI.Clipboard.getText()).eql('setData');
+			});
+
+			it.ios('returns given string after setData(\'public.plain-text\')', () => {
+				Ti.UI.Clipboard.clearData(); // delete all data
+				// should(Ti.UI.Clipboard.getText()).eql(''); // FIXME: undefined on iOS
+				Ti.UI.Clipboard.setData('public.plain-text', 'setData');
+				should(Ti.UI.Clipboard.getText()).eql('setData');
+			});
 		});
 
-		describe.ios('#hasColors', () => {
-			it('is a Function', () => { // eslint-disable-line mocha/no-identical-title
+		describe.ios('#hasColors()', () => {
+			it('is a Function', () => {
 				should(Ti.UI.Clipboard.hasColors).be.a.Function();
 			});
+
+			it('return false with empty clipboard', () => {
+				Ti.UI.Clipboard.clearData(); // delete all data
+				should(Ti.UI.Clipboard.hasColors()).be.false();
+			});
+
+			it('returns true after setting named color data', () => {
+				Ti.UI.Clipboard.clearData(); // delete all data
+				should(Ti.UI.Clipboard.hasColors()).be.false();
+				Ti.UI.Clipboard.setData('color', 'white');
+				should(Ti.UI.Clipboard.hasColors()).be.true();
+			});
+
+			it('returns true after setting 3-digit hex color data', () => {
+				Ti.UI.Clipboard.clearData(); // delete all data
+				should(Ti.UI.Clipboard.hasColors()).be.false();
+				Ti.UI.Clipboard.setData('color', '#0FF');
+				should(Ti.UI.Clipboard.hasColors()).be.true();
+			});
+
+			// TODO: Test with Ti.UI.Color obj, rgb/rgba, 6-digit hex, 8-digit hex
 		});
 
-		describe('#hasData', () => {
-			it('is a Function', () => { // eslint-disable-line mocha/no-identical-title
+		describe('#hasData()', () => {
+			it('is a Function', () => {
 				should(Ti.UI.Clipboard.hasData).be.a.Function();
 			});
+
+			it('returns false with empty clipboard', () => {
+				Ti.UI.Clipboard.clearData(); // delete all data
+				should(Ti.UI.Clipboard.hasData()).be.false();
+				should(Ti.UI.Clipboard.hasData('text')).be.false();
+				should(Ti.UI.Clipboard.hasData('text/plain')).be.false();
+				should(Ti.UI.Clipboard.hasData('color')).be.false();
+				should(Ti.UI.Clipboard.hasData('image')).be.false();
+				should(Ti.UI.Clipboard.hasData('url')).be.false();
+			});
+
+			it('assumes text mimeType with no argument', () => {
+				Ti.UI.Clipboard.clearData(); // delete all data
+				should(Ti.UI.Clipboard.hasData()).be.false();
+				should(Ti.UI.Clipboard.hasData('text')).be.false();
+				should(Ti.UI.Clipboard.hasData('text/plain')).be.false();
+				Ti.UI.Clipboard.setText('hello there');
+				should(Ti.UI.Clipboard.hasData()).be.true();
+				should(Ti.UI.Clipboard.hasData('text')).be.true();
+				should(Ti.UI.Clipboard.hasData('text/plain')).be.true();
+			});
+
+			it('returns false for other mimeTypes', () => {
+				Ti.UI.Clipboard.clearData(); // delete all data
+				should(Ti.UI.Clipboard.hasData()).be.false();
+				should(Ti.UI.Clipboard.hasData('color')).be.false();
+				should(Ti.UI.Clipboard.hasData('image')).be.false();
+				should(Ti.UI.Clipboard.hasData('url')).be.false();
+				Ti.UI.Clipboard.setText('hello there');
+				should(Ti.UI.Clipboard.hasData()).be.true();
+				should(Ti.UI.Clipboard.hasData('text')).be.true();
+				should(Ti.UI.Clipboard.hasData('text/plain')).be.true();
+				should(Ti.UI.Clipboard.hasData('color')).be.false();
+				should(Ti.UI.Clipboard.hasData('image')).be.false();
+				should(Ti.UI.Clipboard.hasData('url')).be.false();
+			});
 		});
 
-		describe.ios('#hasImages', () => {
-			it('is a Function', () => { // eslint-disable-line mocha/no-identical-title
+		describe.ios('#hasImages()', () => {
+			it('is a Function', () => {
 				should(Ti.UI.Clipboard.hasImages).be.a.Function();
 			});
+
+			it('returns false when clipboard is empty', () => {
+				Ti.UI.Clipboard.clearData(); // delete all data
+				should(Ti.UI.Clipboard.hasImages()).be.false();
+			});
+
+			it('returns true when set with Ti.Blob', () => {
+				Ti.UI.Clipboard.clearData(); // delete all data
+				should(Ti.UI.Clipboard.hasImages()).be.false();
+				const blob = Ti.Filesystem.getFile('Logo.png').read();
+				Ti.UI.Clipboard.setData('image', blob);
+				should(Ti.UI.Clipboard.hasImages()).be.true();
+			});
+
+			it('returns true when set with Ti.Filesystem.File', () => {
+				Ti.UI.Clipboard.clearData(); // delete all data
+				should(Ti.UI.Clipboard.hasImages()).be.false();
+				const file = Ti.Filesystem.getFile('Logo.png');
+				Ti.UI.Clipboard.setData('image', file);
+				should(Ti.UI.Clipboard.hasImages()).be.true();
+			});
 		});
 
-		describe('#hasText', () => {
-			it('is a Function', () => { // eslint-disable-line mocha/no-identical-title
+		describe('#hasText()', () => {
+			it('is a Function', () => {
 				should(Ti.UI.Clipboard.hasText).be.a.Function();
 			});
+
+			it('returns false when clipboard is empty', () => {
+				Ti.UI.Clipboard.clearData(); // delete all data
+				should(Ti.UI.Clipboard.hasText()).be.false();
+			});
+
+			it('returns true after setText()', () => {
+				Ti.UI.Clipboard.clearData(); // delete all data
+				should(Ti.UI.Clipboard.hasText()).be.false();
+				Ti.UI.Clipboard.setText('I set it!');
+				should(Ti.UI.Clipboard.hasText()).be.true();
+			});
+
+			it('returns true after setData(\'text\', value)', () => {
+				Ti.UI.Clipboard.clearData(); // delete all data
+				should(Ti.UI.Clipboard.hasText()).be.false();
+				Ti.UI.Clipboard.setData('text', 'I set it!');
+				should(Ti.UI.Clipboard.hasText()).be.true();
+			});
+
+			it('returns true after setData(\'text/plain\', value)', () => {
+				Ti.UI.Clipboard.clearData(); // delete all data
+				should(Ti.UI.Clipboard.hasText()).be.false();
+				Ti.UI.Clipboard.setData('text/plain', 'I set it!');
+				should(Ti.UI.Clipboard.hasText()).be.true();
+			});
+
+			it.ios('returns true after setData(\'public.plain-text\', value)', () => {
+				Ti.UI.Clipboard.clearData(); // delete all data
+				should(Ti.UI.Clipboard.hasText()).be.false();
+				Ti.UI.Clipboard.setData('public.plain-text', 'I set it!');
+				should(Ti.UI.Clipboard.hasText()).be.true();
+			});
+
+			it('returns false after setData(\'color\', value)', () => {
+				Ti.UI.Clipboard.clearData(); // delete all data
+				should(Ti.UI.Clipboard.hasText()).be.false();
+				Ti.UI.Clipboard.setData('color', 'blue');
+				should(Ti.UI.Clipboard.hasText()).be.false();
+			});
 		});
 
-		describe.ios('#hasURLs', () => {
-			it('is a Function', () => { // eslint-disable-line mocha/no-identical-title
+		describe.ios('#hasURLs()', () => {
+			it('is a Function', () => {
 				should(Ti.UI.Clipboard.hasURLs).be.a.Function();
 			});
+
+			it('returns false when clipboard is empty', () => {
+				Ti.UI.Clipboard.clearData(); // delete all data
+				should(Ti.UI.Clipboard.hasURLs()).be.false();
+			});
+
+			it('returns true when set with valid URL string', () => {
+				Ti.UI.Clipboard.clearData(); // delete all data
+				should(Ti.UI.Clipboard.hasURLs()).be.false();
+				Ti.UI.Clipboard.setData('url', 'http://localhost:8080');
+				should(Ti.UI.Clipboard.hasURLs()).be.true();
+			});
+
+			// TODO: set with a bad URL
+			// TODO: set with 'text/uri-list' mimeType string
 		});
 
 		describe.ios('#remove', () => {
-			it('is a Function', () => { // eslint-disable-line mocha/no-identical-title
+			it('is a Function', () => {
 				should(Ti.UI.Clipboard.remove).be.a.Function();
 			});
 		});
 
-		describe('#setData', () => {
-			it('is a Function', () => { // eslint-disable-line mocha/no-identical-title
+		describe('#setData()', () => {
+			it('is a Function', () => {
 				should(Ti.UI.Clipboard.setData).be.a.Function();
 			});
 		});
 
-		describe.ios('#setItems', () => {
-			it('is a Function', () => { // eslint-disable-line mocha/no-identical-title
+		describe.ios('#setItems()', () => {
+			it('is a Function', () => {
 				should(Ti.UI.Clipboard.setItems).be.a.Function();
+			});
+
+			it('with no options', () => {
+				const items = [
+					{
+						'text/plain': 'John',
+					},
+					{
+						'text/plain': 'Doe'
+					}
+				];
+				Ti.UI.Clipboard.setItems({
+					items
+				});
+				// Should we reverse back the UT types iOS reports to the equivalent mimeType?
+				should(Ti.UI.Clipboard.getItems()).eql([
+					{
+						'public.plain-text': 'John',
+					},
+					{
+						'public.plain-text': 'Doe'
+					}
+				]);
+			});
+
+			it('filters out past expiration date items', () => {
+				if (utilities.isMacOS()) {
+					return; // skip on macOS, as setting a date in the past does not immediately invalidate items
+				}
+				const options = {};
+				// set date in the past
+				options[Ti.UI.CLIPBOARD_OPTION_EXPIRATION_DATE] = new Date(2020, 4, 20);
+				const items = [
+					{
+						'text/plain': 'John',
+					},
+					{
+						'text/plain': 'Doe'
+					}
+				];
+				Ti.UI.Clipboard.setItems({
+					items,
+					options
+				});
+				should(Ti.UI.Clipboard.getItems()).eql([]); // returns empty array, because items are past expiration
+			});
+
+			it('does not filter out items for yet-to-be-expired date', () => {
+				const options = {};
+				// set date in the future
+				options[Ti.UI.CLIPBOARD_OPTION_EXPIRATION_DATE] = new Date(2050, 4, 20);
+				const items = [
+					{
+						'text/plain': 'John',
+					},
+					{
+						'text/plain': 'Doe'
+					}
+				];
+				Ti.UI.Clipboard.setItems({
+					items,
+					options
+				});
+				// Should we reverse back the UT types iOS reports to the equivalent mimeType?
+				should(Ti.UI.Clipboard.getItems()).eql([
+					{
+						'public.plain-text': 'John',
+					},
+					{
+						'public.plain-text': 'Doe'
+					}
+				]);
 			});
 		});
 
-		describe('#setText', () => {
-			it('is a Function', () => { // eslint-disable-line mocha/no-identical-title
+		describe('#setText()', () => {
+			it('is a Function', () => {
 				should(Ti.UI.Clipboard.setText).be.a.Function();
 			});
+			// TODO: Test with null/undefined/no arg
 		});
 	});
 
@@ -165,5 +489,4 @@ describe('Titanium.UI.Clipboard', () => {
 			should(clipboard.getText()).eql('hello');
 		});
 	});
-
 });


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/[TICKET]

**Description:**
This is a refactor that moves the iOS implementation of `Ti.UI.Clipboard` to the newer Obj-C JavaScriptCore API. The only real snag I found here was trying to handle `Ti.Filesystem.File`s because they're still using the "old proxy" API, so it doesn't automagically convert them for us and I had to add a little hack in `setData()` to handle them.

In the process I also:
- fleshed out a lot more unit tests
- made the implementation able to consume [Universal Type Identifiers](https://developer.apple.com/library/archive/documentation/Miscellaneous/Reference/UTIRef/Articles/System-DeclaredUniformTypeIdentifiers.html) for the data type arguments
  - We documented using "mimeTypes", but we really only support some very specific string values that were semi-documented.
  - `getItems()` would (and still does) always report back UTIs, so us not accepting them was a big mismatch.
- Fixed iOS `getItems()` to convert `NSURL` to `String`s; `UIImage` to `Ti.Blob`s; `UIColor` to hex `String` values.
- found and fixed a bug on Android where `Ti.UI.Clipboard#hasData()` documented the `type` argument as optional but was enforcing it was supplied.
