### PR TITLE
chore(android): update v8 to 8.6.395.25

### DIFF
--- a/android/package.json
+++ b/android/package.json
@@ -19,9 +19,9 @@
 	],
 	"architectures": ["arm64-v8a", "armeabi-v7a", "x86", "x86_64"],
 	"v8": {
-		"version": "8.6.395.10",
+		"version": "8.6.395.25",
 		"mode": "release",
-		"integrity": "sha512-0b+/oiaae52wbTY6svDWAGJn7wyfBfBzGHNREY5uu1VTAbG8g962SwphhB0798pM1YMLR76RO7JvKQBv6sGP9A=="
+		"integrity": "sha512-zD/4Eb9VpCYvPQXTtU/4U+O1LRYi3p15tpZqeBJZyoqJ+ycxGu1WHtZfzmG4mo8HTTpUtCgo9VXd5UFJ4Aacvg=="
 	},
 	"minSDKVersion": "19",
 	"compileSDKVersion": "30",


### PR DESCRIPTION
- Update V8 to `8.6.395.25`
  - Fix broken compatibility with native modules built using <9.3.0 https://github.com/appcelerator/v8_titanium/commit/9706e5944cb8ecae1ba3fd840076db4ad5b7ffb2

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-28252)

**Test:**
1. Create a Classic project with the below "tiapp.xml" and "app.js".
2. Add module `ti.java.zip` from [TIMOB-28252](https://jira.appcelerator.org/browse/TIMOB-28252) to the project.
3. Build and run on Android.
4. Verify the following is logged. It must be `null`. _(The bug was it used to be an empty string.)_
`@@@ type: [object]`
`@@@ value: null`

tiapp.xml
```xml
<ti:app>
	<modules>
		<module version="1.0.0">ti.java</module>
	</modules>
</ti:app>
```

app.js
```javascript
var value = require("ti.java").text;
console.info("@@@ type: " + (typeof value));
console.info("@@@ value: " + value);
```
