### PR TITLE
[Backport 9_3_X] chore(android): update v8 to 8.6.395.25

### DIFF
--- a/android/package.json
+++ b/android/package.json
@@ -19,9 +19,9 @@
 	],
 	"architectures": ["arm64-v8a", "armeabi-v7a", "x86", "x86_64"],
 	"v8": {
-		"version": "8.6.395.10",
+		"version": "8.6.395.25",
 		"mode": "release",
-		"integrity": "sha512-0b+/oiaae52wbTY6svDWAGJn7wyfBfBzGHNREY5uu1VTAbG8g962SwphhB0798pM1YMLR76RO7JvKQBv6sGP9A=="
+		"integrity": "sha512-zD/4Eb9VpCYvPQXTtU/4U+O1LRYi3p15tpZqeBJZyoqJ+ycxGu1WHtZfzmG4mo8HTTpUtCgo9VXd5UFJ4Aacvg=="
 	},
 	"minSDKVersion": "19",
 	"compileSDKVersion": "30",


### PR DESCRIPTION
Backport of #12293.
See that PR for full details.