### PR TITLE
Remove Accessors

### DIFF
--- a/android/kroll-apt/src/main/resources/org/appcelerator/kroll/annotations/generator/ProxyBindingV8.cpp.fm
+++ b/android/kroll-apt/src/main/resources/org/appcelerator/kroll/annotations/generator/ProxyBindingV8.cpp.fm
@@ -276,22 +276,14 @@ void ${className}::${method.apiName}(const FunctionCallbackInfo<Value>& args)
 	jvalue* jArguments = 0;
 	</#if>
 
-	<#if method.args?size == 0 && name[0..2] == "get" && isDynamic>
+	<#if method.args?size == 0 && name[0..2] == "get" && isDynamic && !isTitaniumSdk>
 		<#assign propertyName = name[3]?lower_case + name[4..]>
 	const char *deprecationMessage = "Getter method deprecated, please use \"obj.${propertyName};\" or \"obj['${propertyName}'];\" instead.";
-		<#if isTitaniumSdk>
-	Proxy::logDeprecation(isolate, deprecationMessage);
-		<#else>
 	LOGW(TAG, deprecationMessage);
-		</#if>
-	<#elseif method.args?size == 1 && name[0..2] == "set" && isDynamic>
+	<#elseif method.args?size == 1 && name[0..2] == "set" && isDynamic && !isTitaniumSdk>
 		<#assign propertyName = name[3]?lower_case + name[4..]>
 	const char *deprecationMessage = "Setter method deprecated, please use \"obj.${propertyName} = val;\" or \"obj['${propertyName}'] = val;\" instead.";
-		<#if isTitaniumSdk>
-	Proxy::logDeprecation(isolate, deprecationMessage);
-		<#else>
 	LOGW(TAG, deprecationMessage);
-		</#if>
 	</#if>
 
 	jobject javaProxy = proxy->getJavaObject();

--- a/android/kroll-apt/src/main/resources/org/appcelerator/kroll/annotations/generator/ProxyBindingV8.cpp.fm
+++ b/android/kroll-apt/src/main/resources/org/appcelerator/kroll/annotations/generator/ProxyBindingV8.cpp.fm
@@ -232,12 +232,6 @@ Local<FunctionTemplate> ${className}::getProxyTemplate(v8::Isolate* isolate)
 		titanium::Proxy::getProperty,
 		titanium::Proxy::onPropertyChanged);
 	</#if>
-	<#if !methods?? || !methods?keys?seq_contains(getter)>
-	DEFINE_PROTOTYPE_METHOD_DATA(isolate, t, "${getter}", titanium::Proxy::getProperty, ${name});
-	</#if>
-	<#if !methods?? || !methods?keys?seq_contains(setter)>
-	DEFINE_PROTOTYPE_METHOD_DATA(isolate, t, "${setter}", titanium::Proxy::onPropertyChanged, ${name});
-	</#if>
 	</@Proxy.listPropertyAccessors>
 
 	<#if interceptor??>

--- a/android/modules/analytics/src/java/ti/modules/titanium/analytics/AnalyticsModule.java
+++ b/android/modules/analytics/src/java/ti/modules/titanium/analytics/AnalyticsModule.java
@@ -48,14 +48,12 @@ public class AnalyticsModule extends KrollModule
 		super();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public boolean getOptedOut()
 	{
 		return APSAnalytics.getInstance().isOptedOut();
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setOptedOut(boolean optedOut)
 	{
@@ -194,7 +192,6 @@ public class AnalyticsModule extends KrollModule
 		return SUCCESS;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getLastEvent()
 	{

--- a/android/modules/android/src/java/ti/modules/titanium/android/AndroidModule.java
+++ b/android/modules/android/src/java/ti/modules/titanium/android/AndroidModule.java
@@ -611,7 +611,6 @@ public class AndroidModule extends KrollModule
 		return r;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public ActivityProxy getCurrentActivity()
 	{
@@ -622,7 +621,6 @@ public class AndroidModule extends KrollModule
 		return null;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public ActivityProxy getRootActivity()
 	{

--- a/android/modules/android/src/java/ti/modules/titanium/android/BroadcastReceiverProxy.java
+++ b/android/modules/android/src/java/ti/modules/titanium/android/BroadcastReceiverProxy.java
@@ -46,14 +46,12 @@ public class BroadcastReceiverProxy extends KrollProxy
 		}
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setUrl(String url)
 	{
 		receiver.setUrl(url);
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setOnReceived(Object callback)
 	{

--- a/android/modules/android/src/java/ti/modules/titanium/android/EnvironmentModule.java
+++ b/android/modules/android/src/java/ti/modules/titanium/android/EnvironmentModule.java
@@ -27,35 +27,30 @@ public class EnvironmentModule extends KrollModule
 	@Kroll.constant
 	public static final String MEDIA_UNMOUNTED = Environment.MEDIA_UNMOUNTED;
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getDataDirectory()
 	{
 		return Environment.getDataDirectory().getAbsolutePath();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getDownloadCacheDirectory()
 	{
 		return Environment.getDownloadCacheDirectory().getAbsolutePath();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getExternalStorageDirectory()
 	{
 		return Environment.getExternalStorageDirectory().getAbsolutePath();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getExternalStorageState()
 	{
 		return Environment.getExternalStorageState();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getRootDirectory()
 	{

--- a/android/modules/android/src/java/ti/modules/titanium/android/notificationmanager/BigPictureStyleProxy.java
+++ b/android/modules/android/src/java/ti/modules/titanium/android/notificationmanager/BigPictureStyleProxy.java
@@ -58,7 +58,6 @@ public class BigPictureStyleProxy extends StyleProxy
 		}
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setBigLargeIcon(Object icon)
 	{
@@ -81,7 +80,6 @@ public class BigPictureStyleProxy extends StyleProxy
 		setProperty(TiC.PROPERTY_BIG_LARGE_ICON, icon);
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setBigPicture(Object picture)
 	{
@@ -98,7 +96,6 @@ public class BigPictureStyleProxy extends StyleProxy
 		setProperty(TiC.PROPERTY_BIG_PICTURE, picture);
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setBigContentTitle(String title)
 	{
@@ -106,7 +103,6 @@ public class BigPictureStyleProxy extends StyleProxy
 		setProperty(TiC.PROPERTY_BIG_CONTENT_TITLE, title);
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setSummaryText(String text)
 	{

--- a/android/modules/android/src/java/ti/modules/titanium/android/notificationmanager/BigTextStyleProxy.java
+++ b/android/modules/android/src/java/ti/modules/titanium/android/notificationmanager/BigTextStyleProxy.java
@@ -46,7 +46,6 @@ public class BigTextStyleProxy extends StyleProxy
 		}
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setBigText(String text)
 	{
@@ -54,7 +53,6 @@ public class BigTextStyleProxy extends StyleProxy
 		setProperty(TiC.PROPERTY_BIG_TEXT, text);
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setBigContentTitle(String title)
 	{
@@ -62,7 +60,6 @@ public class BigTextStyleProxy extends StyleProxy
 		setProperty(TiC.PROPERTY_BIG_CONTENT_TITLE, title);
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setSummaryText(String text)
 	{

--- a/android/modules/android/src/java/ti/modules/titanium/android/notificationmanager/NotificationChannelProxy.java
+++ b/android/modules/android/src/java/ti/modules/titanium/android/notificationmanager/NotificationChannelProxy.java
@@ -76,154 +76,132 @@ public class NotificationChannelProxy extends KrollProxy
 		}
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getId()
 	{
 		return channel.getId();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public boolean getEnableLights()
 	{
 		return channel.shouldShowLights();
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setEnableLights(boolean lights)
 	{
 		channel.enableLights(lights);
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public boolean getEnableVibration()
 	{
 		return channel.shouldVibrate();
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setEnableVibration(boolean vibration)
 	{
 		channel.enableVibration(vibration);
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public boolean getBypassDnd()
 	{
 		return channel.canBypassDnd();
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setBypassDnd(boolean bypassDnd)
 	{
 		channel.setBypassDnd(bypassDnd);
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getDescription()
 	{
 		return channel.getDescription();
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setDescription(String description)
 	{
 		channel.setDescription(description);
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getGroupId()
 	{
 		return channel.getGroup();
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setGroupId(String groupId)
 	{
 		channel.setGroup(groupId);
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public int getImportance()
 	{
 		return channel.getImportance();
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setImportance(int importance)
 	{
 		channel.setImportance(importance);
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public int getLightColor()
 	{
 		return channel.getLightColor();
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setLightColor(int argb)
 	{
 		channel.setLightColor(argb);
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public int getLockscreenVisibility()
 	{
 		return channel.getLockscreenVisibility();
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setLockscreenVisibility(int lockscreenVisibility)
 	{
 		channel.setLockscreenVisibility(lockscreenVisibility);
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getName()
 	{
 		return channel.getName().toString();
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setName(String name)
 	{
 		channel.setName(name);
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public boolean getShowBadge()
 	{
 		return channel.canShowBadge();
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setShowBadge(boolean showBadge)
 	{
 		channel.setShowBadge(showBadge);
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getSound()
 	{
@@ -231,7 +209,6 @@ public class NotificationChannelProxy extends KrollProxy
 		return (uri != null) ? uri.toString() : null;
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setSound(String path)
 	{
@@ -241,7 +218,6 @@ public class NotificationChannelProxy extends KrollProxy
 		channel.setSound(Uri.parse(resolveUrl(null, path)), attributesBuilder.build());
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public Object getVibrationPattern()
 	{
@@ -253,7 +229,6 @@ public class NotificationChannelProxy extends KrollProxy
 		return patternArray;
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setVibrationPattern(Object patternObj)
 	{

--- a/android/modules/android/src/java/ti/modules/titanium/android/notificationmanager/NotificationProxy.java
+++ b/android/modules/android/src/java/ti/modules/titanium/android/notificationmanager/NotificationProxy.java
@@ -150,7 +150,6 @@ public class NotificationProxy extends KrollProxy
 		checkLatestEventInfoProperties(d);
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setCategory(String category)
 	{
@@ -158,7 +157,6 @@ public class NotificationProxy extends KrollProxy
 		setProperty(TiC.PROPERTY_CATEGORY, category);
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setIcon(Object icon)
 	{
@@ -176,7 +174,6 @@ public class NotificationProxy extends KrollProxy
 		setProperty(TiC.PROPERTY_ICON, icon);
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setLargeIcon(Object icon)
 	{
@@ -198,7 +195,6 @@ public class NotificationProxy extends KrollProxy
 		setProperty(TiC.PROPERTY_LARGE_ICON, icon);
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setColor(String color)
 	{
@@ -206,7 +202,6 @@ public class NotificationProxy extends KrollProxy
 		setProperty(TiC.PROPERTY_COLOR, color);
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setVisibility(int visibility)
 	{
@@ -214,7 +209,6 @@ public class NotificationProxy extends KrollProxy
 		setProperty(TiC.PROPERTY_VISIBILITY, visibility);
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setPriority(int priority)
 	{
@@ -222,7 +216,6 @@ public class NotificationProxy extends KrollProxy
 		setProperty(TiC.PROPERTY_PRIORITY, priority);
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setWakeLock(HashMap d)
 	{
@@ -232,7 +225,6 @@ public class NotificationProxy extends KrollProxy
 		wakeParams = d;
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setTickerText(String tickerText)
 	{
@@ -241,7 +233,6 @@ public class NotificationProxy extends KrollProxy
 		setProperty(TiC.PROPERTY_TICKER_TEXT, tickerText);
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setWhen(Object when)
 	{
@@ -253,7 +244,6 @@ public class NotificationProxy extends KrollProxy
 		setProperty(TiC.PROPERTY_WHEN, when);
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setAudioStreamType(int type)
 	{
@@ -264,7 +254,6 @@ public class NotificationProxy extends KrollProxy
 		setProperty(TiC.PROPERTY_AUDIO_STREAM_TYPE, type);
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setContentView(RemoteViewsProxy contentView)
 	{
@@ -272,7 +261,6 @@ public class NotificationProxy extends KrollProxy
 		setProperty(TiC.PROPERTY_CONTENT_VIEW, contentView);
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setContentIntent(PendingIntentProxy contentIntent)
 	{
@@ -280,7 +268,6 @@ public class NotificationProxy extends KrollProxy
 		setProperty(TiC.PROPERTY_CONTENT_INTENT, contentIntent);
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setDefaults(int defaults)
 	{
@@ -288,7 +275,6 @@ public class NotificationProxy extends KrollProxy
 		setProperty(TiC.PROPERTY_DEFAULTS, defaults);
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setDeleteIntent(PendingIntentProxy deleteIntent)
 	{
@@ -296,7 +282,6 @@ public class NotificationProxy extends KrollProxy
 		setProperty(TiC.PROPERTY_DELETE_INTENT, deleteIntent);
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setFlags(int flags)
 	{
@@ -304,7 +289,6 @@ public class NotificationProxy extends KrollProxy
 		setProperty(TiC.PROPERTY_FLAGS, flags);
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setLedARGB(int ledARGB)
 	{
@@ -313,7 +297,6 @@ public class NotificationProxy extends KrollProxy
 		setProperty(TiC.PROPERTY_LED_ARGB, ledARGB);
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setLedOffMS(int ledOffMS)
 	{
@@ -322,7 +305,6 @@ public class NotificationProxy extends KrollProxy
 		setProperty(TiC.PROPERTY_LED_OFF_MS, ledOffMS);
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setLedOnMS(int ledOnMS)
 	{
@@ -331,7 +313,6 @@ public class NotificationProxy extends KrollProxy
 		setProperty(TiC.PROPERTY_LED_ON_MS, ledOnMS);
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setNumber(int number)
 	{
@@ -339,7 +320,6 @@ public class NotificationProxy extends KrollProxy
 		setProperty(TiC.PROPERTY_NUMBER, number);
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setSound(String url)
 	{
@@ -358,7 +338,6 @@ public class NotificationProxy extends KrollProxy
 		setProperty(TiC.PROPERTY_SOUND, url);
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setStyle(StyleProxy style)
 	{
@@ -366,7 +345,6 @@ public class NotificationProxy extends KrollProxy
 		setProperty(TiC.PROPERTY_STYLE, style);
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setVibratePattern(Object[] pattern)
 	{
@@ -380,7 +358,6 @@ public class NotificationProxy extends KrollProxy
 		setProperty(TiC.PROPERTY_VIBRATE_PATTERN, pattern);
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setGroupKey(String groupKey)
 	{
@@ -388,7 +365,6 @@ public class NotificationProxy extends KrollProxy
 		setProperty(TiC.PROPERTY_GROUP_KEY, groupKey);
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setGroupAlertBehavior(int groupAlertBehavior)
 	{
@@ -396,7 +372,6 @@ public class NotificationProxy extends KrollProxy
 		setProperty(TiC.PROPERTY_GROUP_ALERT_BEHAVIOR, groupAlertBehavior);
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setGroupSummary(boolean isGroupSummary)
 	{
@@ -428,7 +403,6 @@ public class NotificationProxy extends KrollProxy
 			.setContentTitle(contentTitle);
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setChannelId(String channelId)
 	{

--- a/android/modules/android/src/java/ti/modules/titanium/android/quicksettings/QuickSettingsServiceProxy.java
+++ b/android/modules/android/src/java/ti/modules/titanium/android/quicksettings/QuickSettingsServiceProxy.java
@@ -43,6 +43,7 @@ public class QuickSettingsServiceProxy extends ServiceProxy
 
 	//Setting Tile's icon
 	@Kroll.method
+	@Kroll.setProperty
 	public void setIcon(Object path)
 	{
 		tileService.getQsTile().setIcon(Icon.createWithBitmap(
@@ -52,6 +53,7 @@ public class QuickSettingsServiceProxy extends ServiceProxy
 
 	//Setting Tile's state
 	@Kroll.method
+	@Kroll.setProperty
 	public void setState(int state)
 	{
 		tileService.getQsTile().setState(state);
@@ -59,6 +61,7 @@ public class QuickSettingsServiceProxy extends ServiceProxy
 
 	//Setting Tile's label
 	@Kroll.method
+	@Kroll.setProperty
 	public void setLabel(String label)
 	{
 		tileService.getQsTile().setLabel(label);
@@ -66,6 +69,7 @@ public class QuickSettingsServiceProxy extends ServiceProxy
 
 	//Getting Tile'c icon
 	@Kroll.method
+	@Kroll.getProperty
 	public Object getIcon()
 	{
 		return pathObject;
@@ -73,6 +77,7 @@ public class QuickSettingsServiceProxy extends ServiceProxy
 
 	//Getting Tile's state
 	@Kroll.method
+	@Kroll.getProperty
 	public int getState()
 	{
 		return tileService.getQsTile().getState();
@@ -80,6 +85,7 @@ public class QuickSettingsServiceProxy extends ServiceProxy
 
 	//Getting Tile's label
 	@Kroll.method
+	@Kroll.getProperty
 	public String getLabel()
 	{
 		return tileService.getQsTile().getLabel().toString();

--- a/android/modules/app/src/java/ti/modules/titanium/app/AndroidModule.java
+++ b/android/modules/app/src/java/ti/modules/titanium/app/AndroidModule.java
@@ -61,7 +61,6 @@ public class AndroidModule extends KrollModule
 		}
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public int getAppVersionCode()
 	{
@@ -71,7 +70,6 @@ public class AndroidModule extends KrollModule
 		return appVersionCode;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public IntentProxy getLaunchIntent()
 	{
@@ -85,7 +83,6 @@ public class AndroidModule extends KrollModule
 		return null;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getAppVersionName()
 	{

--- a/android/modules/app/src/java/ti/modules/titanium/app/AppModule.java
+++ b/android/modules/app/src/java/ti/modules/titanium/app/AppModule.java
@@ -59,7 +59,6 @@ public class AppModule extends KrollModule implements SensorEventListener
 		TiApplication.getInstance().removeAppEventProxy(this);
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getId()
 	{
@@ -72,28 +71,24 @@ public class AppModule extends KrollModule implements SensorEventListener
 		return getId();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getName()
 	{
 		return appInfo.getName();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getVersion()
 	{
 		return appInfo.getVersion();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getPublisher()
 	{
 		return appInfo.getPublisher();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getUrl()
 	{
@@ -106,21 +101,18 @@ public class AppModule extends KrollModule implements SensorEventListener
 		return getUrl();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getDescription()
 	{
 		return appInfo.getDescription();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getCopyright()
 	{
 		return appInfo.getCopyright();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getGuid()
 	{
@@ -133,21 +125,18 @@ public class AppModule extends KrollModule implements SensorEventListener
 		return getGuid();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getDeployType()
 	{
 		return TiApplication.getInstance().getDeployType();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getSessionId()
 	{
 		return APSAnalytics.getInstance().getCurrentSessionId();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public boolean getAnalytics()
 	{
@@ -160,7 +149,6 @@ public class AppModule extends KrollModule implements SensorEventListener
 		return resolveUrl(null, url);
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public boolean getAccessibilityEnabled()
 	{
@@ -236,14 +224,12 @@ public class AppModule extends KrollModule implements SensorEventListener
 		}
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public boolean getProximityDetection()
 	{
 		return proximityDetection;
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setProximityDetection(Object value)
 	{
@@ -257,7 +243,6 @@ public class AppModule extends KrollModule implements SensorEventListener
 		}
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public boolean getProximityState()
 	{

--- a/android/modules/calendar/src/java/ti/modules/titanium/calendar/AlertProxy.java
+++ b/android/modules/calendar/src/java/ti/modules/titanium/calendar/AlertProxy.java
@@ -123,49 +123,42 @@ public class AlertProxy extends KrollProxy
 
 	protected static final String EVENT_REMINDER_ACTION = "android.intent.action.EVENT_REMINDER";
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getId()
 	{
 		return id;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getEventId()
 	{
 		return eventId;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public Date getBegin()
 	{
 		return begin;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public Date getEnd()
 	{
 		return end;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public Date getAlarmTime()
 	{
 		return alarmTime;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public int getState()
 	{
 		return state;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public int getMinutes()
 	{

--- a/android/modules/calendar/src/java/ti/modules/titanium/calendar/CalendarModule.java
+++ b/android/modules/calendar/src/java/ti/modules/titanium/calendar/CalendarModule.java
@@ -149,7 +149,6 @@ public class CalendarModule extends KrollModule
 		});
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public CalendarProxy[] getAllCalendars()
 	{
@@ -157,7 +156,6 @@ public class CalendarModule extends KrollModule
 		return calendars.toArray(new CalendarProxy[calendars.size()]);
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public CalendarProxy[] getSelectableCalendars()
 	{
@@ -180,7 +178,6 @@ public class CalendarModule extends KrollModule
 		}
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public AlertProxy[] getAllAlerts()
 	{

--- a/android/modules/calendar/src/java/ti/modules/titanium/calendar/CalendarProxy.java
+++ b/android/modules/calendar/src/java/ti/modules/titanium/calendar/CalendarProxy.java
@@ -190,28 +190,24 @@ public class CalendarProxy extends KrollProxy
 		return EventProxy.createEvent(this, data);
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getName()
 	{
 		return name;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getId()
 	{
 		return id;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public boolean getSelected()
 	{
 		return selected;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public boolean getHidden()
 	{

--- a/android/modules/calendar/src/java/ti/modules/titanium/calendar/EventProxy.java
+++ b/android/modules/calendar/src/java/ti/modules/titanium/calendar/EventProxy.java
@@ -335,7 +335,6 @@ public class EventProxy extends KrollProxy
 		return result;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public ReminderProxy[] getReminders()
 	{
@@ -361,7 +360,6 @@ public class EventProxy extends KrollProxy
 		return new RecurrenceRuleProxy(data);
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public AlertProxy[] getAlerts()
 	{
@@ -376,84 +374,72 @@ public class EventProxy extends KrollProxy
 		return AlertProxy.createAlert(this, minutes);
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getId()
 	{
 		return id;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getTitle()
 	{
 		return title;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getDescription()
 	{
 		return description;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getLocation()
 	{
 		return location;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public Date getBegin()
 	{
 		return begin;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public Date getEnd()
 	{
 		return end;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public boolean getAllDay()
 	{
 		return allDay;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public AttendeeProxy[] getAttendees()
 	{
 		return getAttendeeProxies();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public boolean getHasAlarm()
 	{
 		return hasAlarm;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public boolean getHasExtendedProperties()
 	{
 		return hasExtendedProperties;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public int getStatus()
 	{
 		return status;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public int getVisibility()
 	{
@@ -469,35 +455,30 @@ public class EventProxy extends KrollProxy
 		setProperty(TiC.PROPERTY_RECURRENCE_RULES, result);
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getRecurrenceDate()
 	{
 		return recurrenceDate;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getRecurrenceExceptionRule()
 	{
 		return recurrenceExceptionRule;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getRecurrenceExceptionDate()
 	{
 		return recurrenceExceptionDate;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public Date getLastDate()
 	{
 		return lastDate;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public KrollDict getExtendedProperties()
 	{

--- a/android/modules/calendar/src/java/ti/modules/titanium/calendar/RecurrenceRuleProxy.java
+++ b/android/modules/calendar/src/java/ti/modules/titanium/calendar/RecurrenceRuleProxy.java
@@ -276,63 +276,54 @@ public class RecurrenceRuleProxy extends KrollProxy
 
 	//region kroll proxy methods
 	@Kroll.getProperty
-	@Kroll.method
 	public String getCalendarID()
 	{
 		return this.calendarID;
 	}
 
 	@Kroll.getProperty
-	@Kroll.method
 	public int[] getDaysOfTheMonth()
 	{
 		return this.daysOfTheMonth;
 	}
 
 	@Kroll.getProperty
-	@Kroll.method
 	public KrollDict[] getDaysOfTheWeek()
 	{
 		return this.daysOfTheWeek;
 	}
 
 	@Kroll.getProperty
-	@Kroll.method
 	public int[] getDaysOfTheYear()
 	{
 		return this.daysOfTheYear;
 	}
 
 	@Kroll.getProperty
-	@Kroll.method
 	public KrollDict getEnd()
 	{
 		return this.endDictionary;
 	}
 
 	@Kroll.getProperty
-	@Kroll.method
 	public int getFrequency()
 	{
 		return this.frequency.toTiIntId();
 	}
 
 	@Kroll.getProperty
-	@Kroll.method
 	public int getInterval()
 	{
 		return this.interval;
 	}
 
 	@Kroll.getProperty
-	@Kroll.method
 	public int[] monthsOfTheYear()
 	{
 		return this.monthsOfTheYear;
 	}
 
 	@Kroll.getProperty
-	@Kroll.method
 	public int[] getWeeksOfTheYear()
 	{
 		return this.weeksOfTheYear;

--- a/android/modules/calendar/src/java/ti/modules/titanium/calendar/ReminderProxy.java
+++ b/android/modules/calendar/src/java/ti/modules/titanium/calendar/ReminderProxy.java
@@ -93,21 +93,18 @@ public class ReminderProxy extends KrollProxy
 		return reminder;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getId()
 	{
 		return id;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public int getMinutes()
 	{
 		return minutes;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public int getMethod()
 	{

--- a/android/modules/contacts/src/java/ti/modules/titanium/contacts/ContactsModule.java
+++ b/android/modules/contacts/src/java/ti/modules/titanium/contacts/ContactsModule.java
@@ -64,7 +64,6 @@ public class ContactsModule extends KrollModule implements TiActivityResultHandl
 		contactsApi = CommonContactsApi.getInstance();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public int getContactsAuthorization()
 	{

--- a/android/modules/contacts/src/java/ti/modules/titanium/contacts/PersonProxy.java
+++ b/android/modules/contacts/src/java/ti/modules/titanium/contacts/PersonProxy.java
@@ -72,7 +72,6 @@ public class PersonProxy extends KrollProxy
 		modified.clear();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getFullName()
 	{
@@ -84,7 +83,6 @@ public class PersonProxy extends KrollProxy
 		fullName = fname;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public long getId()
 	{
@@ -96,7 +94,6 @@ public class PersonProxy extends KrollProxy
 		return (modified.containsKey(field) && modified.get(field));
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public TiBlob getImage()
 	{
@@ -113,7 +110,6 @@ public class PersonProxy extends KrollProxy
 		return this.image;
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setImage(TiBlob blob)
 	{

--- a/android/modules/database/src/java/ti/modules/titanium/database/TiDatabaseProxy.java
+++ b/android/modules/database/src/java/ti/modules/titanium/database/TiDatabaseProxy.java
@@ -394,7 +394,6 @@ public class TiDatabaseProxy extends KrollProxy
 	 * Get database name.
 	 * @return Database name.
 	 */
-	@Kroll.method
 	@Kroll.getProperty
 	public String getName()
 	{
@@ -405,7 +404,6 @@ public class TiDatabaseProxy extends KrollProxy
 	 * Get last inserted row identifier.
 	 * @return Row identifier.
 	 */
-	@Kroll.method
 	@Kroll.getProperty
 	public int getLastInsertRowId()
 	{
@@ -425,7 +423,6 @@ public class TiDatabaseProxy extends KrollProxy
 	 * Get number of rows affected by last query.
 	 * @return Number of rows.
 	 */
-	@Kroll.method
 	@Kroll.getProperty
 	public int getRowsAffected()
 	{
@@ -463,7 +460,6 @@ public class TiDatabaseProxy extends KrollProxy
 	 * Get database file.
 	 * @return `Ti.File` reference of SQLiteDatabase.
 	 */
-	@Kroll.method
 	@Kroll.getProperty
 	public TiFileProxy getFile()
 	{

--- a/android/modules/database/src/java/ti/modules/titanium/database/TiResultSetProxy.java
+++ b/android/modules/database/src/java/ti/modules/titanium/database/TiResultSetProxy.java
@@ -211,7 +211,6 @@ public class TiResultSetProxy extends KrollProxy
 		return result;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public int getFieldCount()
 	{
@@ -247,7 +246,6 @@ public class TiResultSetProxy extends KrollProxy
 		return null;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public int getRowCount()
 	{

--- a/android/modules/filesystem/src/java/ti/modules/titanium/filesystem/FilesystemModule.java
+++ b/android/modules/filesystem/src/java/ti/modules/titanium/filesystem/FilesystemModule.java
@@ -139,35 +139,30 @@ public class FilesystemModule extends KrollModule
 		});
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public FileProxy getApplicationDirectory()
 	{
 		return null;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getApplicationDataDirectory()
 	{
 		return TiFileFactory.APPDATA_PRIVATE_URL_SCHEME + "://";
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getResRawDirectory()
 	{
 		return "android.resource://" + TiApplication.getInstance().getPackageName() + "/raw/";
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getApplicationCacheDirectory()
 	{
 		return "file://" + TiApplication.getInstance().getCacheDir().getAbsolutePath();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getResourcesDirectory()
 	{
@@ -180,28 +175,24 @@ public class FilesystemModule extends KrollModule
 		return TiFileFactory.APPCACHE_EXTERNAL_URL_SCHEME + "://";
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getExternalStorageDirectory()
 	{
 		return TiFileFactory.APPDATA_URL_SCHEME + "://";
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getTempDirectory()
 	{
 		return "file://" + TiApplication.getInstance().getTiTempDir().getAbsolutePath();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getSeparator()
 	{
 		return File.separator;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getLineEnding()
 	{

--- a/android/modules/geolocation/src/java/ti/modules/titanium/geolocation/GeolocationModule.java
+++ b/android/modules/geolocation/src/java/ti/modules/titanium/geolocation/GeolocationModule.java
@@ -431,7 +431,6 @@ public class GeolocationModule extends KrollModule implements Handler.Callback, 
 	 *
 	 * @return			<code>true</code> if the device has a compass, <code>false</code> if not
 	 */
-	@Kroll.method
 	@Kroll.getProperty
 	public boolean getHasCompass()
 	{
@@ -454,7 +453,6 @@ public class GeolocationModule extends KrollModule implements Handler.Callback, 
 	 *
 	 * @return			String representing the last geolocation event
 	 */
-	@Kroll.method
 	@Kroll.getProperty
 	public String getLastGeolocation()
 	{
@@ -659,7 +657,6 @@ public class GeolocationModule extends KrollModule implements Handler.Callback, 
 	 * @return			<code>true</code> if a valid location service is available on the device,
 	 * 					<code>false</code> if not
 	 */
-	@Kroll.method
 	@Kroll.getProperty
 	public boolean getLocationServicesEnabled()
 	{

--- a/android/modules/geolocation/src/java/ti/modules/titanium/geolocation/android/AndroidModule.java
+++ b/android/modules/geolocation/src/java/ti/modules/titanium/geolocation/android/AndroidModule.java
@@ -100,7 +100,6 @@ public class AndroidModule extends KrollModule implements Handler.Callback
 	 * @return			<code>true</code> if the manual location providers are being
 	 * 					used, <code>false</code> if not
 	 */
-	@Kroll.method
 	@Kroll.getProperty
 	public boolean getManualMode()
 	{
@@ -115,7 +114,6 @@ public class AndroidModule extends KrollModule implements Handler.Callback
 	 * 								the manual providers should be used
 	 */
 	@SuppressWarnings("deprecation")
-	@Kroll.method
 	@Kroll.setProperty
 	public void setManualMode(boolean manualMode)
 	{

--- a/android/modules/geolocation/src/java/ti/modules/titanium/geolocation/android/LocationProviderProxy.java
+++ b/android/modules/geolocation/src/java/ti/modules/titanium/geolocation/android/LocationProviderProxy.java
@@ -174,7 +174,6 @@ public class LocationProviderProxy extends KrollProxy implements LocationListene
 	 *
 	 * @return name associated with this provider
 	 */
-	@Kroll.method
 	@Kroll.getProperty
 	public String getName()
 	{
@@ -193,7 +192,6 @@ public class LocationProviderProxy extends KrollProxy implements LocationListene
 	 *
 	 * @param value name to associate with this provider
 	 */
-	@Kroll.method
 	@Kroll.setProperty
 	public void setName(String value)
 	{
@@ -205,7 +203,6 @@ public class LocationProviderProxy extends KrollProxy implements LocationListene
 	 *
 	 * @return value minimum update distance for this provider
 	 */
-	@Kroll.method
 	@Kroll.getProperty
 	public double getMinUpdateDistance()
 	{
@@ -224,7 +221,6 @@ public class LocationProviderProxy extends KrollProxy implements LocationListene
 	 *
 	 * @param value minimum update distance to associate with this provider
 	 */
-	@Kroll.method
 	@Kroll.setProperty
 	public void setMinUpdateDistance(double value)
 	{
@@ -237,7 +233,6 @@ public class LocationProviderProxy extends KrollProxy implements LocationListene
 	 *
 	 * @return value minimum update time for this provider
 	 */
-	@Kroll.method
 	@Kroll.getProperty
 	public double getMinUpdateTime()
 	{
@@ -256,7 +251,6 @@ public class LocationProviderProxy extends KrollProxy implements LocationListene
 	 *
 	 * @param value minimum update time to associate with this provider
 	 */
-	@Kroll.method
 	@Kroll.setProperty
 	public void setMinUpdateTime(double value)
 	{

--- a/android/modules/gesture/src/java/ti/modules/titanium/gesture/GestureModule.java
+++ b/android/modules/gesture/src/java/ti/modules/titanium/gesture/GestureModule.java
@@ -171,21 +171,18 @@ public class GestureModule extends KrollModule implements SensorEventListener
 		}
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public boolean getPortrait()
 	{
 		return this.deviceOrientationMonitor.getLastReadOrientation().isPortrait();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public boolean getLandscape()
 	{
 		return this.deviceOrientationMonitor.getLastReadOrientation().isLandscape();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public int getOrientation()
 	{

--- a/android/modules/locale/src/java/ti/modules/titanium/locale/LocaleModule.java
+++ b/android/modules/locale/src/java/ti/modules/titanium/locale/LocaleModule.java
@@ -34,21 +34,18 @@ public class LocaleModule extends KrollModule
 		super("Locale");
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getCurrentLanguage()
 	{
 		return Locale.getDefault().getLanguage();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getCurrentCountry()
 	{
 		return Locale.getDefault().getCountry();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getCurrentLocale()
 	{

--- a/android/modules/media/src/java/ti/modules/titanium/media/AudioPlayerProxy.java
+++ b/android/modules/media/src/java/ti/modules/titanium/media/AudioPlayerProxy.java
@@ -106,14 +106,12 @@ public class AudioPlayerProxy extends KrollProxy implements OnLifecycleEvent, On
 			  Log.DEBUG_MODE);
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getUrl()
 	{
 		return TiConvert.toString(getProperty(TiC.PROPERTY_URL));
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setUrl(String url)
 	{
@@ -122,7 +120,6 @@ public class AudioPlayerProxy extends KrollProxy implements OnLifecycleEvent, On
 		}
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public int getDuration()
 	{
@@ -133,21 +130,18 @@ public class AudioPlayerProxy extends KrollProxy implements OnLifecycleEvent, On
 		return 0;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public int getAudioType()
 	{
 		return TiConvert.toInt(getProperty(TiC.PROPERTY_AUDIO_TYPE));
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setAudioType(int val)
 	{
 		setProperty(TiC.PROPERTY_AUDIO_TYPE, val);
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public boolean isPlaying()
 	{
@@ -158,7 +152,6 @@ public class AudioPlayerProxy extends KrollProxy implements OnLifecycleEvent, On
 		return false;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public boolean isPaused()
 	{
@@ -238,7 +231,6 @@ public class AudioPlayerProxy extends KrollProxy implements OnLifecycleEvent, On
 		return 0;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public boolean getMuted()
 	{
@@ -249,7 +241,6 @@ public class AudioPlayerProxy extends KrollProxy implements OnLifecycleEvent, On
 		return false;
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setMuted(boolean muted)
 	{
@@ -259,7 +250,6 @@ public class AudioPlayerProxy extends KrollProxy implements OnLifecycleEvent, On
 		}
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public double getTime()
 	{
@@ -271,7 +261,6 @@ public class AudioPlayerProxy extends KrollProxy implements OnLifecycleEvent, On
 		return TiConvert.toDouble(getProperty(TiC.PROPERTY_TIME));
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setTime(Object pos)
 	{

--- a/android/modules/media/src/java/ti/modules/titanium/media/AudioPlayerProxy.java
+++ b/android/modules/media/src/java/ti/modules/titanium/media/AudioPlayerProxy.java
@@ -222,6 +222,7 @@ public class AudioPlayerProxy extends KrollProxy implements OnLifecycleEvent, On
 	}
 
 	@Kroll.method
+	@Kroll.getProperty
 	public int getAudioSessionId()
 	{
 		TiSound s = getSound();

--- a/android/modules/media/src/java/ti/modules/titanium/media/AudioRecorderProxy.java
+++ b/android/modules/media/src/java/ti/modules/titanium/media/AudioRecorderProxy.java
@@ -35,47 +35,40 @@ public class AudioRecorderProxy extends KrollProxy
 		};
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setCompression(int value)
 	{
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setFormat(int value)
 	{
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public int getFormat()
 	{
 		return 0;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public int getCompression()
 	{
 		return 0;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public boolean getPaused()
 	{
 		return tiAudioRecorder.isPaused();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public boolean getRecording()
 	{
 		return tiAudioRecorder.isRecording();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public boolean getStopped()
 	{

--- a/android/modules/media/src/java/ti/modules/titanium/media/MediaModule.java
+++ b/android/modules/media/src/java/ti/modules/titanium/media/MediaModule.java
@@ -860,14 +860,12 @@ public class MediaModule extends KrollModule implements Handler.Callback
 		}
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setCameraFlashMode(int flashMode)
 	{
 		TiCameraActivity.setFlashMode(flashMode);
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public int getCameraFlashMode()
 	{
@@ -1411,14 +1409,12 @@ public class MediaModule extends KrollModule implements Handler.Callback
 		activity.switchCamera(whichCamera);
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public boolean getIsCameraSupported()
 	{
 		return Camera.getNumberOfCameras() > 0;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public int[] getAvailableCameras()
 	{
@@ -1449,7 +1445,6 @@ public class MediaModule extends KrollModule implements Handler.Callback
 		return result;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public boolean getCanRecord()
 	{

--- a/android/modules/media/src/java/ti/modules/titanium/media/SoundProxy.java
+++ b/android/modules/media/src/java/ti/modules/titanium/media/SoundProxy.java
@@ -174,6 +174,7 @@ public class SoundProxy extends KrollProxy implements org.appcelerator.titanium.
 		return false;
 	}
 
+	@Kroll.method
 	@Kroll.setProperty
 	public void setLooping(boolean looping)
 	{

--- a/android/modules/media/src/java/ti/modules/titanium/media/SoundProxy.java
+++ b/android/modules/media/src/java/ti/modules/titanium/media/SoundProxy.java
@@ -117,14 +117,12 @@ public class SoundProxy extends KrollProxy implements org.appcelerator.titanium.
 			  Log.DEBUG_MODE);
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getUrl()
 	{
 		return TiConvert.toString(getProperty(TiC.PROPERTY_URL));
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setUrl(Object url)
 	{
@@ -134,21 +132,18 @@ public class SoundProxy extends KrollProxy implements org.appcelerator.titanium.
 		}
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public int getAudioType()
 	{
 		return TiConvert.toInt(getProperty(TiC.PROPERTY_AUDIO_TYPE));
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setAudioType(int val)
 	{
 		setProperty(TiC.PROPERTY_AUDIO_TYPE, val);
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public boolean isPlaying()
 	{
@@ -159,7 +154,6 @@ public class SoundProxy extends KrollProxy implements org.appcelerator.titanium.
 		return false;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public boolean isPaused()
 	{
@@ -170,7 +164,6 @@ public class SoundProxy extends KrollProxy implements org.appcelerator.titanium.
 		return false;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public boolean isLooping()
 	{
@@ -181,7 +174,6 @@ public class SoundProxy extends KrollProxy implements org.appcelerator.titanium.
 		return false;
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setLooping(boolean looping)
 	{
@@ -250,7 +242,6 @@ public class SoundProxy extends KrollProxy implements org.appcelerator.titanium.
 		}
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public int getDuration()
 	{
@@ -262,7 +253,6 @@ public class SoundProxy extends KrollProxy implements org.appcelerator.titanium.
 		return 0;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public double getTime()
 	{
@@ -274,7 +264,6 @@ public class SoundProxy extends KrollProxy implements org.appcelerator.titanium.
 		return TiConvert.toDouble(getProperty(TiC.PROPERTY_TIME));
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setTime(Object pos)
 	{

--- a/android/modules/media/src/java/ti/modules/titanium/media/VideoPlayerProxy.java
+++ b/android/modules/media/src/java/ti/modules/titanium/media/VideoPlayerProxy.java
@@ -315,7 +315,6 @@ public class VideoPlayerProxy extends TiViewProxy implements TiLifecycle.OnLifec
 		}
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public boolean getPlaying()
 	{
@@ -326,28 +325,24 @@ public class VideoPlayerProxy extends TiViewProxy implements TiLifecycle.OnLifec
 		}
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public int getLoadState()
 	{
 		return loadState;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public int getPlaybackState()
 	{
 		return playbackState;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public int getRepeatMode()
 	{
 		return repeatMode;
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setRepeatMode(int mode)
 	{
@@ -447,14 +442,12 @@ public class VideoPlayerProxy extends TiViewProxy implements TiLifecycle.OnLifec
 		return handled;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public int getMediaControlStyle()
 	{
 		return mediaControlStyle;
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setMediaControlStyle(int style)
 	{
@@ -469,7 +462,6 @@ public class VideoPlayerProxy extends TiViewProxy implements TiLifecycle.OnLifec
 		}
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public int getMovieControlMode()
 	{
@@ -477,7 +469,6 @@ public class VideoPlayerProxy extends TiViewProxy implements TiLifecycle.OnLifec
 		return getMediaControlStyle();
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setMovieControlMode(int style)
 	{
@@ -491,7 +482,6 @@ public class VideoPlayerProxy extends TiViewProxy implements TiLifecycle.OnLifec
 	 * deprecated and cleaned up after TIMOB-2802 is resolved.
 	 * TODO
 	 */
-	@Kroll.method
 	@Kroll.getProperty
 	public int getMovieControlStyle()
 	{
@@ -499,7 +489,6 @@ public class VideoPlayerProxy extends TiViewProxy implements TiLifecycle.OnLifec
 		return getMediaControlStyle();
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setMovieControlStyle(int style)
 	{
@@ -507,14 +496,12 @@ public class VideoPlayerProxy extends TiViewProxy implements TiLifecycle.OnLifec
 		setMediaControlStyle(style);
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public int getScalingMode()
 	{
 		return scalingMode;
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setScalingMode(int mode)
 	{
@@ -539,7 +526,6 @@ public class VideoPlayerProxy extends TiViewProxy implements TiLifecycle.OnLifec
 		}
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public int getCurrentPlaybackTime()
 	{
@@ -560,7 +546,6 @@ public class VideoPlayerProxy extends TiViewProxy implements TiLifecycle.OnLifec
 		}
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setCurrentPlaybackTime(int milliseconds)
 	{

--- a/android/modules/network/src/java/ti/modules/titanium/network/CookieProxy.java
+++ b/android/modules/network/src/java/ti/modules/titanium/network/CookieProxy.java
@@ -156,7 +156,6 @@ public class CookieProxy extends KrollProxy
 		return httpCookie;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getName()
 	{

--- a/android/modules/network/src/java/ti/modules/titanium/network/HTTPClientProxy.java
+++ b/android/modules/network/src/java/ti/modules/titanium/network/HTTPClientProxy.java
@@ -112,21 +112,18 @@ public class HTTPClientProxy extends KrollProxy
 		return client.getResponseHeaders();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public int getReadyState()
 	{
 		return client.getReadyState();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public TiBlob getResponseData()
 	{
 		return client.getResponseData();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public KrollDict getResponseDictionary()
 	{
@@ -139,28 +136,24 @@ public class HTTPClientProxy extends KrollProxy
 		return client.getResponseHeader(header);
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getResponseText()
 	{
 		return client.getResponseText();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public DocumentProxy getResponseXML()
 	{
 		return client.getResponseXML();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public int getStatus()
 	{
 		return client.getStatus();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getStatusText()
 	{
@@ -191,84 +184,72 @@ public class HTTPClientProxy extends KrollProxy
 		client.setRequestHeader(header, value);
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setTimeout(int millis)
 	{
 		client.setTimeout(millis);
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getLocation()
 	{
 		return client.getLocation();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getConnectionType()
 	{
 		return client.getConnectionType();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public boolean getConnected()
 	{
 		return client.isConnected();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public boolean getAutoEncodeUrl()
 	{
 		return client.getAutoEncodeUrl();
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setAutoEncodeUrl(boolean value)
 	{
 		client.setAutoEncodeUrl(value);
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public boolean getAutoRedirect()
 	{
 		return client.getAutoRedirect();
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setAutoRedirect(boolean value)
 	{
 		client.setAutoRedirect(value);
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public boolean getValidatesSecureCertificate()
 	{
 		return client.validatesSecureCertificate();
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setValidatesSecureCertificate(boolean value)
 	{
 		this.setProperty("validatesSecureCertificate", value);
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setUsername(String value)
 	{
 		this.setProperty(TiC.PROPERTY_USERNAME, value);
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getUsername()
 	{
@@ -278,14 +259,12 @@ public class HTTPClientProxy extends KrollProxy
 		return null;
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setPassword(String value)
 	{
 		this.setProperty(TiC.PROPERTY_PASSWORD, value);
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getPassword()
 	{
@@ -295,14 +274,12 @@ public class HTTPClientProxy extends KrollProxy
 		return null;
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setDomain(String value)
 	{
 		this.setProperty(TiC.PROPERTY_DOMAIN, value);
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getDomain()
 	{
@@ -342,14 +319,12 @@ public class HTTPClientProxy extends KrollProxy
 		}
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setTlsVersion(int tlsVersion)
 	{
 		client.setTlsVersion(tlsVersion);
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public int getTlsVersion()
 	{

--- a/android/modules/network/src/java/ti/modules/titanium/network/NetworkModule.java
+++ b/android/modules/network/src/java/ti/modules/titanium/network/NetworkModule.java
@@ -174,7 +174,6 @@ public class NetworkModule extends KrollModule
 		}
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public boolean getOnline()
 	{
@@ -213,7 +212,6 @@ public class NetworkModule extends KrollModule
 		return type;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public int getNetworkType()
 	{
@@ -237,7 +235,6 @@ public class NetworkModule extends KrollModule
 		return type;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getNetworkTypeName()
 	{

--- a/android/modules/network/src/java/ti/modules/titanium/network/socket/TCPProxy.java
+++ b/android/modules/network/src/java/ti/modules/titanium/network/socket/TCPProxy.java
@@ -115,28 +115,24 @@ public class TCPProxy extends KrollProxy implements TiStream
 		}
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setHost(String host)
 	{
 		setSocketProperty("host", host);
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setPort(int port)
 	{
 		setSocketProperty("port", port);
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setTimeout(int timeout)
 	{
 		setSocketProperty("timeout", timeout);
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setOptions(KrollDict options)
 	{
@@ -144,28 +140,24 @@ public class TCPProxy extends KrollProxy implements TiStream
 		Log.i(TAG, "setting options on socket is not supported yet");
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setListenQueueSize(int listenQueueSize)
 	{
 		setSocketProperty("listenQueueSize", listenQueueSize);
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setConnected(KrollFunction connected)
 	{
 		setSocketProperty("connected", connected);
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setError(KrollFunction error)
 	{
 		setSocketProperty("error", error);
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setAccepted(KrollFunction accepted)
 	{
@@ -182,7 +174,6 @@ public class TCPProxy extends KrollProxy implements TiStream
 		}
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public int getState()
 	{

--- a/android/modules/platform/src/java/ti/modules/titanium/platform/AndroidModule.java
+++ b/android/modules/platform/src/java/ti/modules/titanium/platform/AndroidModule.java
@@ -23,7 +23,6 @@ public class AndroidModule extends PlatformModule
 	@Kroll.constant
 	public static final int PHYSICAL_SIZE_CATEGORY_XLARGE = 4; // Configuration.SCREENLAYOUT_SIZE_XLARGE (API 9)
 
-	@Kroll.method
 	@Kroll.getProperty
 	public int getPhysicalSizeCategory()
 	{

--- a/android/modules/platform/src/java/ti/modules/titanium/platform/DisplayCapsProxy.java
+++ b/android/modules/platform/src/java/ti/modules/titanium/platform/DisplayCapsProxy.java
@@ -38,7 +38,6 @@ public class DisplayCapsProxy extends KrollProxy
 		return softDisplay.get();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public int getPlatformWidth()
 	{
@@ -49,7 +48,6 @@ public class DisplayCapsProxy extends KrollProxy
 		}
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public int getPlatformHeight()
 	{
@@ -60,7 +58,6 @@ public class DisplayCapsProxy extends KrollProxy
 		}
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getDensity()
 	{
@@ -85,7 +82,6 @@ public class DisplayCapsProxy extends KrollProxy
 		}
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public float getDpi()
 	{
@@ -96,7 +92,6 @@ public class DisplayCapsProxy extends KrollProxy
 		}
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public float getXdpi()
 	{
@@ -107,7 +102,6 @@ public class DisplayCapsProxy extends KrollProxy
 		}
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public float getYdpi()
 	{
@@ -118,7 +112,6 @@ public class DisplayCapsProxy extends KrollProxy
 		}
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public float getLogicalDensityFactor()
 	{

--- a/android/modules/platform/src/java/ti/modules/titanium/platform/PlatformModule.java
+++ b/android/modules/platform/src/java/ti/modules/titanium/platform/PlatformModule.java
@@ -102,28 +102,24 @@ public class PlatformModule extends KrollModule
 		}
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getName()
 	{
 		return APSAnalyticsMeta.getPlatform();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getOsname()
 	{
 		return APSAnalyticsMeta.getPlatform();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getLocale()
 	{
 		return TiPlatformHelper.getInstance().getLocale();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public DisplayCapsProxy getDisplayCaps()
 	{
@@ -134,21 +130,18 @@ public class PlatformModule extends KrollModule
 		return displayCaps;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public int getProcessorCount()
 	{
 		return Runtime.getRuntime().availableProcessors();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getUsername()
 	{
 		return Build.USER;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getVersion()
 	{
@@ -173,56 +166,48 @@ public class PlatformModule extends KrollModule
 		return this.versionPatch;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public double getAvailableMemory()
 	{
 		return Runtime.getRuntime().freeMemory();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public double getTotalMemory()
 	{
 		return Runtime.getRuntime().totalMemory();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getModel()
 	{
 		return Build.MODEL;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getManufacturer()
 	{
 		return Build.MANUFACTURER;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getOstype()
 	{
 		return APSAnalyticsMeta.getOsType();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getArchitecture()
 	{
 		return APSAnalyticsMeta.getArchitecture();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getAddress()
 	{
 		return TiPlatformHelper.getInstance().getIpAddress();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getNetmask()
 	{
@@ -344,7 +329,6 @@ public class PlatformModule extends KrollModule
 		return wasSuccessful;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getMacaddress()
 	{
@@ -389,14 +373,12 @@ public class PlatformModule extends KrollModule
 		return macaddr;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getId()
 	{
 		return APSAnalytics.getInstance().getMachineId();
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setBatteryMonitoring(boolean monitor)
 	{
@@ -408,35 +390,30 @@ public class PlatformModule extends KrollModule
 		}
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public boolean getBatteryMonitoring()
 	{
 		return batteryStateReceiver != null;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public int getBatteryState()
 	{
 		return batteryState;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public double getBatteryLevel()
 	{
 		return batteryLevel;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getRuntime()
 	{
 		return KrollRuntime.getInstance().getRuntimeName();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public double getUptime()
 	{

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/ImageViewProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/ImageViewProxy.java
@@ -92,7 +92,6 @@ public class ImageViewProxy extends ViewProxy
 	}
 
 	@Kroll.setProperty(runOnUiThread = true)
-	@Kroll.method(runOnUiThread = true)
 	public void setReverse(boolean reverse)
 	{
 		getImageView().setReverse(reverse);
@@ -105,7 +104,6 @@ public class ImageViewProxy extends ViewProxy
 	}
 
 	@Kroll.setProperty(runOnUiThread = true)
-	@Kroll.method(runOnUiThread = true)
 	public void setTintColor(String color)
 	{
 		getImageView().setTintColor(color);

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/ImageViewProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/ImageViewProxy.java
@@ -73,21 +73,18 @@ public class ImageViewProxy extends ViewProxy
 		getImageView().resume();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public boolean getAnimating()
 	{
 		return getImageView().isAnimating();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public boolean getPaused()
 	{
 		return getImageView().isPaused();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public boolean getReverse()
 	{
@@ -114,7 +111,6 @@ public class ImageViewProxy extends ViewProxy
 		getImageView().setTintColor(color);
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public int getTintColor()
 	{

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/PickerColumnProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/PickerColumnProxy.java
@@ -122,7 +122,6 @@ public class PickerColumnProxy extends TiViewProxy implements PickerRowListener
 		}
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public PickerRowProxy[] getRows()
 	{
@@ -132,7 +131,6 @@ public class PickerColumnProxy extends TiViewProxy implements PickerRowListener
 		return children.toArray(new PickerRowProxy[children.size()]);
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setRows(Object[] rows)
 	{
@@ -153,7 +151,6 @@ public class PickerColumnProxy extends TiViewProxy implements PickerRowListener
 		}
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public int getRowCount()
 	{

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/PickerProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/PickerProxy.java
@@ -158,7 +158,6 @@ public class PickerProxy extends TiViewProxy implements PickerColumnListener
 		return new TiUIDateSpinner(this, activity);
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public boolean getUseSpinner()
 	{
@@ -166,7 +165,6 @@ public class PickerProxy extends TiViewProxy implements PickerColumnListener
 		return useSpinner;
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setUseSpinner(boolean value)
 	{
@@ -185,14 +183,12 @@ public class PickerProxy extends TiViewProxy implements PickerColumnListener
 		}
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public int getType()
 	{
 		return type;
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setType(int type)
 	{
@@ -322,7 +318,6 @@ public class PickerProxy extends TiViewProxy implements PickerColumnListener
 		return row;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public PickerColumnProxy[] getColumns()
 	{
@@ -337,7 +332,6 @@ public class PickerProxy extends TiViewProxy implements PickerColumnListener
 		}
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setColumns(Object passedColumns)
 	{

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/PickerRowProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/PickerRowProxy.java
@@ -29,14 +29,12 @@ public class PickerRowProxy extends TiViewProxy
 		super();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getColor()
 	{
 		return (String) getProperty(TiC.PROPERTY_COLOR);
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setColor(String color)
 	{
@@ -46,14 +44,12 @@ public class PickerRowProxy extends TiViewProxy
 		}
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getTitle()
 	{
 		return toString();
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setTitle(String value)
 	{

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/ScrollViewProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/ScrollViewProxy.java
@@ -65,14 +65,12 @@ public class ScrollViewProxy extends TiViewProxy
 		handleScrollTo(x, y, animated);
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setScrollingEnabled(Object enabled)
 	{
 		getScrollView().setScrollingEnabled(enabled);
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public boolean getScrollingEnabled()
 	{

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/ScrollableViewProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/ScrollableViewProxy.java
@@ -190,7 +190,6 @@ public class ScrollableViewProxy extends TiViewProxy
 		return handled;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public Object getViews()
 	{
@@ -202,7 +201,6 @@ public class ScrollableViewProxy extends TiViewProxy
 		return childViewArray;
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setViews(Object viewsObject)
 	{
@@ -317,14 +315,12 @@ public class ScrollableViewProxy extends TiViewProxy
 		}
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setScrollingEnabled(Object enabled)
 	{
 		getMainHandler().obtainMessage(MSG_SET_ENABLED, enabled).sendToTarget();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public boolean getScrollingEnabled()
 	{
@@ -332,7 +328,6 @@ public class ScrollableViewProxy extends TiViewProxy
 		return (view != null) ? view.getEnabled() : false;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public int getCurrentPage()
 	{
@@ -340,7 +335,6 @@ public class ScrollableViewProxy extends TiViewProxy
 		return (view != null) ? view.getCurrentPage() : 0;
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setCurrentPage(Object page)
 	{

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/ShortcutItemProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/ShortcutItemProxy.java
@@ -201,7 +201,6 @@ public class ShortcutItemProxy extends KrollProxy
 	}
 
 	@Deprecated
-	@Kroll.method
 	@Kroll.getProperty
 	public boolean getVisible()
 	{

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TabProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TabProxy.java
@@ -70,7 +70,6 @@ public class TabProxy extends TiViewProxy
 		}
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public boolean getActive()
 	{
@@ -81,7 +80,6 @@ public class TabProxy extends TiViewProxy
 		return false;
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setActive(boolean active)
 	{
@@ -122,7 +120,6 @@ public class TabProxy extends TiViewProxy
 		return this.window;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public TabGroupProxy getTabGroup()
 	{

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TableViewProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TableViewProxy.java
@@ -331,7 +331,6 @@ public class TableViewProxy extends RecyclerViewProxy
 	 * @return Array of TableViewRow or TableViewSection proxies.
 	 */
 	// clang-format off
-	@Kroll.method
 	@Kroll.getProperty
 	public Object[] getData()
 	// clang-format on
@@ -414,7 +413,6 @@ public class TableViewProxy extends RecyclerViewProxy
 	 *
 	 * @return Integer of section count.
 	 */
-	@Kroll.method
 	@Kroll.getProperty
 	public int getSectionCount()
 	{
@@ -426,7 +424,6 @@ public class TableViewProxy extends RecyclerViewProxy
 	 *
 	 * @return Array of TableViewSectionProxy
 	 */
-	@Kroll.method
 	@Kroll.getProperty
 	public TableViewSectionProxy[] getSections()
 	{

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TableViewSectionProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TableViewSectionProxy.java
@@ -112,7 +112,6 @@ public class TableViewSectionProxy extends TiViewProxy
 	 *
 	 * @return Integer of row count.
 	 */
-	@Kroll.method
 	@Kroll.getProperty
 	public int getRowCount()
 	{
@@ -155,7 +154,6 @@ public class TableViewSectionProxy extends TiViewProxy
 	 *
 	 * @return TableViewRowProxy array.
 	 */
-	@Kroll.method
 	@Kroll.getProperty
 	public TableViewRowProxy[] getRows()
 	{

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TextAreaProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TextAreaProxy.java
@@ -87,7 +87,6 @@ public class TextAreaProxy extends TiViewProxy
 		}
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public KrollDict getSelection()
 	{

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TextFieldProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TextFieldProxy.java
@@ -93,7 +93,6 @@ public class TextFieldProxy extends TiViewProxy
 		}
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public KrollDict getSelection()
 	{

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/UIModule.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/UIModule.java
@@ -414,7 +414,6 @@ public class UIModule extends KrollModule
 	}
 
 	@Kroll.setProperty(runOnUiThread = true)
-	@Kroll.method(runOnUiThread = true)
 	public void setBackgroundColor(String color)
 	{
 		doSetBackgroundColor(color);
@@ -429,7 +428,6 @@ public class UIModule extends KrollModule
 	}
 
 	@Kroll.setProperty(runOnUiThread = true)
-	@Kroll.method(runOnUiThread = true)
 	public void setBackgroundImage(Object image)
 	{
 		doSetBackgroundImage(image);

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/WebViewProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/WebViewProxy.java
@@ -149,7 +149,6 @@ public class WebViewProxy extends ViewProxy implements Handler.Callback, OnLifec
 		}
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getHtml()
 	{
@@ -228,7 +227,6 @@ public class WebViewProxy extends ViewProxy implements Handler.Callback, OnLifec
 		getWebView().setBasicAuthentication(username, password);
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setUserAgent(String userAgent)
 	{
@@ -238,7 +236,6 @@ public class WebViewProxy extends ViewProxy implements Handler.Callback, OnLifec
 		}
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getUserAgent()
 	{
@@ -249,7 +246,6 @@ public class WebViewProxy extends ViewProxy implements Handler.Callback, OnLifec
 		return "";
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setRequestHeaders(HashMap params)
 	{
@@ -261,7 +257,6 @@ public class WebViewProxy extends ViewProxy implements Handler.Callback, OnLifec
 		}
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public HashMap getRequestHeaders()
 	{
@@ -314,7 +309,6 @@ public class WebViewProxy extends ViewProxy implements Handler.Callback, OnLifec
 		getMainHandler().sendEmptyMessage(MSG_STOP_LOADING);
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public int getPluginState()
 	{
@@ -327,14 +321,12 @@ public class WebViewProxy extends ViewProxy implements Handler.Callback, OnLifec
 		return pluginState;
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setDisableContextMenu(boolean disableContextMenu)
 	{
 		setPropertyAndFire(TiC.PROPERTY_DISABLE_CONTEXT_MENU, disableContextMenu);
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public boolean getDisableContextMenu()
 	{
@@ -344,7 +336,6 @@ public class WebViewProxy extends ViewProxy implements Handler.Callback, OnLifec
 		return false;
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setPluginState(int pluginState)
 	{
@@ -382,7 +373,6 @@ public class WebViewProxy extends ViewProxy implements Handler.Callback, OnLifec
 		setPropertyAndFire(TiC.PROPERTY_ENABLE_ZOOM_CONTROLS, enabled);
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public boolean getEnableZoomControls()
 	{
@@ -394,7 +384,6 @@ public class WebViewProxy extends ViewProxy implements Handler.Callback, OnLifec
 		return enabled;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public float getZoomLevel()
 	{
@@ -406,7 +395,6 @@ public class WebViewProxy extends ViewProxy implements Handler.Callback, OnLifec
 		}
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setZoomLevel(float value)
 	{

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/WebViewProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/WebViewProxy.java
@@ -366,7 +366,6 @@ public class WebViewProxy extends ViewProxy implements Handler.Callback, OnLifec
 		}
 	}
 
-	@Kroll.method(runOnUiThread = true)
 	@Kroll.setProperty(runOnUiThread = true)
 	public void setEnableZoomControls(boolean enabled)
 	{

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/WindowProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/WindowProxy.java
@@ -429,7 +429,6 @@ public class WindowProxy extends TiWindowProxy implements TiActivityWindow
 
 	@Override
 	@Kroll.setProperty(retain = false)
-	@Kroll.method
 	public void setWidth(Object width)
 	{
 		if (opening || opened) {
@@ -444,7 +443,6 @@ public class WindowProxy extends TiWindowProxy implements TiActivityWindow
 
 	@Override
 	@Kroll.setProperty(retain = false)
-	@Kroll.method
 	public void setHeight(Object height)
 	{
 		if (opening || opened) {

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/WindowProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/WindowProxy.java
@@ -411,7 +411,6 @@ public class WindowProxy extends TiWindowProxy implements TiActivityWindow
 		super.onPropertyChanged(name, value);
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setSustainedPerformanceMode(boolean mode)
 	{
@@ -422,7 +421,6 @@ public class WindowProxy extends TiWindowProxy implements TiActivityWindow
 		}
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public boolean getSustainedPerformanceMode()
 	{

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/android/DrawerLayoutProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/android/DrawerLayoutProxy.java
@@ -94,70 +94,60 @@ public class DrawerLayoutProxy extends TiViewProxy
 		}
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public boolean getIsLeftOpen()
 	{
 		return drawer != null && drawer.isLeftOpen();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public boolean getIsRightOpen()
 	{
 		return drawer != null && drawer.isRightOpen();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public boolean getIsLeftVisible()
 	{
 		return drawer != null && drawer.isLeftVisible();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public boolean getIsRightVisible()
 	{
 		return drawer != null && drawer.isRightVisible();
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setLeftWidth(Object arg)
 	{
 		setPropertyAndFire(TiC.PROPERTY_LEFT_WIDTH, arg);
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setLeftView(Object arg)
 	{
 		setPropertyAndFire(TiC.PROPERTY_LEFT_VIEW, arg);
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setRightWidth(Object arg)
 	{
 		setPropertyAndFire(TiC.PROPERTY_RIGHT_WIDTH, arg);
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setRightView(Object arg)
 	{
 		setPropertyAndFire(TiC.PROPERTY_RIGHT_VIEW, arg);
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setCenterView(Object arg)
 	{
 		setPropertyAndFire(TiC.PROPERTY_CENTER_VIEW, arg);
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public boolean getDrawerIndicatorEnabled()
 	{
@@ -167,14 +157,12 @@ public class DrawerLayoutProxy extends TiViewProxy
 		return true;
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setDrawerIndicatorEnabled(Object arg)
 	{
 		setPropertyAndFire(TiC.PROPERTY_DRAWER_INDICATOR_ENABLED, arg);
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public int getDrawerLockMode()
 	{
@@ -184,7 +172,6 @@ public class DrawerLayoutProxy extends TiViewProxy
 		return LOCK_MODE_UNDEFINED;
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setDrawerLockMode(Object arg)
 	{
@@ -192,7 +179,6 @@ public class DrawerLayoutProxy extends TiViewProxy
 	}
 
 	// clang-format off
-	@Kroll.method
 	@Kroll.getProperty
 	public int getLeftDrawerLockMode()
 	// clang-format on
@@ -204,7 +190,6 @@ public class DrawerLayoutProxy extends TiViewProxy
 	}
 
 	// clang-format off
-	@Kroll.method
 	@Kroll.setProperty
 	public void setLeftDrawerLockMode(Object arg)
 	// clang-format on
@@ -213,7 +198,6 @@ public class DrawerLayoutProxy extends TiViewProxy
 	}
 
 	// clang-format off
-	@Kroll.method
 	@Kroll.getProperty
 	public int getRightDrawerLockMode()
 	// clang-format on
@@ -225,7 +209,6 @@ public class DrawerLayoutProxy extends TiViewProxy
 	}
 
 	// clang-format off
-	@Kroll.method
 	@Kroll.setProperty
 	public void setRightDrawerLockMode(Object arg)
 	// clang-format on
@@ -239,7 +222,6 @@ public class DrawerLayoutProxy extends TiViewProxy
 		view.getOrCreateView().getOuterView().getParent().requestDisallowInterceptTouchEvent(disallowIntercept);
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public boolean getToolbarEnabled()
 	{
@@ -249,7 +231,6 @@ public class DrawerLayoutProxy extends TiViewProxy
 		return true;
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setToolbarEnabled(Object arg)
 	{

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/ListSectionProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/ListSectionProxy.java
@@ -154,7 +154,6 @@ public class ListSectionProxy extends TiViewProxy
 	 *
 	 * @return ListDataItem dictionary array.
 	 */
-	@Kroll.method
 	@Kroll.getProperty
 	public KrollDict[] getItems()
 	{

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/ListViewProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/ListViewProxy.java
@@ -297,7 +297,6 @@ public class ListViewProxy extends RecyclerViewProxy
 	 *
 	 * @return Array of ListSections.
 	 */
-	@Kroll.method
 	@Kroll.getProperty
 	public ListSectionProxy[] getSections()
 	{
@@ -368,7 +367,6 @@ public class ListViewProxy extends RecyclerViewProxy
 	 *
 	 * @param sections Array of sections to set.
 	 */
-	@Kroll.method
 	@Kroll.setProperty
 	public void setSections(Object sections)
 	{

--- a/android/modules/xml/src/java/ti/modules/titanium/xml/AttrProxy.java
+++ b/android/modules/xml/src/java/ti/modules/titanium/xml/AttrProxy.java
@@ -27,21 +27,18 @@ public class AttrProxy extends NodeProxy
 		return attr;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getName()
 	{
 		return attr.getName();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public ElementProxy getOwnerElement()
 	{
 		return getProxy(attr.getOwnerElement());
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public boolean getSpecified()
 	{
@@ -55,14 +52,12 @@ public class AttrProxy extends NodeProxy
 		return attr.getSpecified();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getValue()
 	{
 		return attr.getValue();
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setValue(String value) throws DOMException
 	{

--- a/android/modules/xml/src/java/ti/modules/titanium/xml/CharacterDataProxy.java
+++ b/android/modules/xml/src/java/ti/modules/titanium/xml/CharacterDataProxy.java
@@ -33,21 +33,18 @@ public class CharacterDataProxy extends NodeProxy
 		data.deleteData(offset, count);
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getData() throws DOMException
 	{
 		return data.getData();
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setData(String data) throws DOMException
 	{
 		this.data.setData(data);
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public int getLength()
 	{

--- a/android/modules/xml/src/java/ti/modules/titanium/xml/DocumentProxy.java
+++ b/android/modules/xml/src/java/ti/modules/titanium/xml/DocumentProxy.java
@@ -95,14 +95,12 @@ public class DocumentProxy extends NodeProxy
 		return getProxy(doc.createTextNode(data));
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public DocumentTypeProxy getDoctype()
 	{
 		return getProxy(doc.getDoctype());
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public ElementProxy getDocumentElement()
 	{
@@ -127,7 +125,6 @@ public class DocumentProxy extends NodeProxy
 		return new NodeListProxy(doc.getElementsByTagNameNS(namespaceURI, localName));
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public DOMImplementationProxy getImplementation()
 	{

--- a/android/modules/xml/src/java/ti/modules/titanium/xml/DocumentTypeProxy.java
+++ b/android/modules/xml/src/java/ti/modules/titanium/xml/DocumentTypeProxy.java
@@ -21,49 +21,42 @@ public class DocumentTypeProxy extends NodeProxy
 		this.type = type;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public DocumentType getDocumentType()
 	{
 		return type;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public NamedNodeMapProxy getEntities()
 	{
 		return new NamedNodeMapProxy(type.getEntities());
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getInternalSubset()
 	{
 		return type.getInternalSubset();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getName()
 	{
 		return type.getName();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public NamedNodeMapProxy getNotations()
 	{
 		return new NamedNodeMapProxy(type.getNotations());
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getPublicId()
 	{
 		return type.getPublicId();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getSystemId()
 	{

--- a/android/modules/xml/src/java/ti/modules/titanium/xml/ElementProxy.java
+++ b/android/modules/xml/src/java/ti/modules/titanium/xml/ElementProxy.java
@@ -27,7 +27,6 @@ public class ElementProxy extends NodeProxy
 		this.element = element;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getTextContent()
 	{
@@ -106,7 +105,6 @@ public class ElementProxy extends NodeProxy
 		return filterThisFromNodeList(element.getElementsByTagNameNS(namespaceURI, localName));
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getTagName()
 	{

--- a/android/modules/xml/src/java/ti/modules/titanium/xml/EntityProxy.java
+++ b/android/modules/xml/src/java/ti/modules/titanium/xml/EntityProxy.java
@@ -21,21 +21,18 @@ public class EntityProxy extends NodeProxy
 		this.entity = entity;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getNotationName()
 	{
 		return entity.getNotationName();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getPublicId()
 	{
 		return entity.getPublicId();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getSystemId()
 	{

--- a/android/modules/xml/src/java/ti/modules/titanium/xml/NamedNodeMapProxy.java
+++ b/android/modules/xml/src/java/ti/modules/titanium/xml/NamedNodeMapProxy.java
@@ -22,7 +22,6 @@ public class NamedNodeMapProxy extends KrollProxy
 		this.map = map;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public int getLength()
 	{

--- a/android/modules/xml/src/java/ti/modules/titanium/xml/NodeListProxy.java
+++ b/android/modules/xml/src/java/ti/modules/titanium/xml/NodeListProxy.java
@@ -30,7 +30,6 @@ public class NodeListProxy extends KrollProxy
 		this.offset = offset;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public int getLength()
 	{

--- a/android/modules/xml/src/java/ti/modules/titanium/xml/NodeProxy.java
+++ b/android/modules/xml/src/java/ti/modules/titanium/xml/NodeProxy.java
@@ -143,98 +143,84 @@ public class NodeProxy extends KrollProxy
 		return getProxy(node.cloneNode(deep));
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public NamedNodeMapProxy getAttributes()
 	{
 		return new NamedNodeMapProxy(node.getAttributes());
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public NodeListProxy getChildNodes()
 	{
 		return new NodeListProxy(node.getChildNodes());
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public NodeProxy getFirstChild()
 	{
 		return getProxy(node.getFirstChild());
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public NodeProxy getLastChild()
 	{
 		return getProxy(node.getLastChild());
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getLocalName()
 	{
 		return node.getLocalName();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getNamespaceURI()
 	{
 		return node.getNamespaceURI();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public NodeProxy getNextSibling()
 	{
 		return getProxy(node.getNextSibling());
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getNodeName()
 	{
 		return node.getNodeName();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public short getNodeType()
 	{
 		return node.getNodeType();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getNodeValue() throws DOMException
 	{
 		return node.getNodeValue();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public DocumentProxy getOwnerDocument()
 	{
 		return new DocumentProxy(node.getOwnerDocument());
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public NodeProxy getParentNode()
 	{
 		return getProxy(node.getParentNode());
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getPrefix()
 	{
 		return node.getPrefix();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public NodeProxy getPreviousSibling()
 	{
@@ -285,14 +271,12 @@ public class NodeProxy extends KrollProxy
 		return removeProxyForNode(oldNode);
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setNodeValue(String nodeValue) throws DOMException
 	{
 		node.setNodeValue(nodeValue);
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setPrefix(String prefix) throws DOMException
 	{

--- a/android/modules/xml/src/java/ti/modules/titanium/xml/NotationProxy.java
+++ b/android/modules/xml/src/java/ti/modules/titanium/xml/NotationProxy.java
@@ -21,14 +21,12 @@ public class NotationProxy extends NodeProxy
 		this.notation = notation;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getPublicId()
 	{
 		return notation.getPublicId();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getSystemId()
 	{

--- a/android/modules/xml/src/java/ti/modules/titanium/xml/ProcessingInstructionProxy.java
+++ b/android/modules/xml/src/java/ti/modules/titanium/xml/ProcessingInstructionProxy.java
@@ -22,21 +22,18 @@ public class ProcessingInstructionProxy extends NodeProxy
 		this.pi = pi;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getData()
 	{
 		return pi.getData();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getTarget()
 	{
 		return pi.getTarget();
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setData(String data) throws DOMException
 	{

--- a/android/modules/xml/src/java/ti/modules/titanium/xml/TextProxy.java
+++ b/android/modules/xml/src/java/ti/modules/titanium/xml/TextProxy.java
@@ -64,7 +64,6 @@ public class TextProxy extends CharacterDataProxy
 		return getProxy(returnNode);
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getTextContent()
 	{

--- a/android/modules/xml/src/java/ti/modules/titanium/xml/XPathNodeListProxy.java
+++ b/android/modules/xml/src/java/ti/modules/titanium/xml/XPathNodeListProxy.java
@@ -23,7 +23,6 @@ public class XPathNodeListProxy extends KrollProxy
 		this.nodeList = nodeList;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public int getLength()
 	{

--- a/android/templates/module/java/template/android/src/{{ModuleIdAsFolder}}/{{ModuleNameCamel}}Module.java.ejs
+++ b/android/templates/module/java/template/android/src/{{ModuleIdAsFolder}}/{{ModuleNameCamel}}Module.java.ejs
@@ -48,7 +48,6 @@ public class <%- moduleNameCamel %>Module extends KrollModule
 	}
 
 	// Properties
-	@Kroll.method
 	@Kroll.getProperty
 	public String getExampleProp()
 	{
@@ -57,7 +56,6 @@ public class <%- moduleNameCamel %>Module extends KrollModule
 	}
 
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setExampleProp(String value) {
 		Log.d(LCAT, "set example property: " + value);

--- a/android/titanium/src/java/org/appcelerator/kroll/KrollProxy.java
+++ b/android/titanium/src/java/org/appcelerator/kroll/KrollProxy.java
@@ -764,14 +764,12 @@ public class KrollProxy implements Handler.Callback, KrollProxySupport, OnLifecy
 		krollObject.setProperty(name, value);
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public boolean getBubbleParent()
 	{
 		return bubbleParent;
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setBubbleParent(Object value)
 	{
@@ -1457,7 +1455,6 @@ public class KrollProxy implements Handler.Callback, KrollProxySupport, OnLifecy
 	}
 
 	// For subclasses to override
-	@Kroll.method
 	@Kroll.getProperty
 	public String getApiName()
 	{

--- a/android/titanium/src/java/org/appcelerator/titanium/TiBlob.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiBlob.java
@@ -347,7 +347,6 @@ public class TiBlob extends KrollProxy
 		return bytes;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public int getLength()
 	{
@@ -413,7 +412,6 @@ public class TiBlob extends KrollProxy
 		}
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getText()
 	{
@@ -436,7 +434,6 @@ public class TiBlob extends KrollProxy
 		return result;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getMimeType()
 	{
@@ -461,14 +458,12 @@ public class TiBlob extends KrollProxy
 	 * @see TiBlob#TYPE_STREAM
 	 * @module.api
 	 */
-	@Kroll.method
 	@Kroll.getProperty
 	public int getType()
 	{
 		return type;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public int getWidth()
 	{
@@ -481,7 +476,6 @@ public class TiBlob extends KrollProxy
 		return this.uprightWidth;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public int getSize()
 	{
@@ -493,7 +487,6 @@ public class TiBlob extends KrollProxy
 		return getLength();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public int getHeight()
 	{
@@ -532,7 +525,6 @@ public class TiBlob extends KrollProxy
 		return text;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getNativePath()
 	{
@@ -560,7 +552,6 @@ public class TiBlob extends KrollProxy
 		}
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public TiFileProxy getFile()
 	{

--- a/android/titanium/src/java/org/appcelerator/titanium/TiFileProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiFileProxy.java
@@ -121,14 +121,12 @@ public class TiFileProxy extends KrollProxy
 		return tbf.isDirectory();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public boolean getReadonly()
 	{
 		return tbf.isReadonly();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public boolean getWritable()
 	{
@@ -193,21 +191,18 @@ public class TiFileProxy extends KrollProxy
 		return tbf.extension();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public boolean getSymbolicLink()
 	{
 		return tbf.isSymbolicLink();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public boolean getExecutable()
 	{
 		return tbf.isExecutable();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public boolean getHidden()
 	{
@@ -224,7 +219,6 @@ public class TiFileProxy extends KrollProxy
 		return dl != null ? dl.toArray(new String[0]) : null;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public TiFileProxy getParent()
 	{
@@ -238,14 +232,12 @@ public class TiFileProxy extends KrollProxy
 		return tbf.move(destination);
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getName()
 	{
 		return tbf.name();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getNativePath()
 	{
@@ -276,7 +268,6 @@ public class TiFileProxy extends KrollProxy
 		return getNativePath();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public long getSize()
 	{

--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/ActionBarProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/ActionBarProxy.java
@@ -41,7 +41,6 @@ public class ActionBarProxy extends KrollProxy
 		}
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setDisplayHomeAsUp(boolean showHomeAsUp)
 	{
@@ -52,7 +51,6 @@ public class ActionBarProxy extends KrollProxy
 		}
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setHomeButtonEnabled(boolean homeButtonEnabled)
 	{
@@ -63,14 +61,12 @@ public class ActionBarProxy extends KrollProxy
 		}
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setNavigationMode(int navigationMode)
 	{
 		actionBar.setNavigationMode(navigationMode);
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setBackgroundImage(String url)
 	{
@@ -88,7 +84,6 @@ public class ActionBarProxy extends KrollProxy
 		}
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setTitle(String title)
 	{
@@ -99,7 +94,6 @@ public class ActionBarProxy extends KrollProxy
 		}
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setSubtitle(String subTitle)
 	{
@@ -128,7 +122,6 @@ public class ActionBarProxy extends KrollProxy
 		}
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getSubtitle()
 	{
@@ -138,7 +131,6 @@ public class ActionBarProxy extends KrollProxy
 		return (String) actionBar.getSubtitle();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getTitle()
 	{
@@ -148,7 +140,6 @@ public class ActionBarProxy extends KrollProxy
 		return (String) actionBar.getTitle();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public int getNavigationMode()
 	{
@@ -178,7 +169,6 @@ public class ActionBarProxy extends KrollProxy
 		}
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setLogo(String url)
 	{
@@ -193,7 +183,6 @@ public class ActionBarProxy extends KrollProxy
 		}
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setIcon(String url)
 	{

--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/ActivityProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/ActivityProxy.java
@@ -194,14 +194,12 @@ public class ActivityProxy extends KrollProxy implements TiActivityResultHandler
 		return application.getString(resId, formatArgs);
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public IntentProxy getIntent()
 	{
 		return intentProxy;
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setRequestedOrientation(int orientation)
 	{
@@ -247,7 +245,6 @@ public class ActivityProxy extends KrollProxy implements TiActivityResultHandler
 		return null;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public TiWindowProxy getWindow()
 	{
@@ -260,7 +257,6 @@ public class ActivityProxy extends KrollProxy implements TiActivityResultHandler
 		return tiActivity.getWindowProxy();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public ActionBarProxy getActionBar()
 	{

--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/IntentProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/IntentProxy.java
@@ -57,7 +57,6 @@ public class IntentProxy extends KrollProxy
 		this.intent = intent;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getPackageName()
 	{
@@ -71,7 +70,6 @@ public class IntentProxy extends KrollProxy
 		return null;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getClassName()
 	{
@@ -252,14 +250,12 @@ public class IntentProxy extends KrollProxy
 		intent.addFlags(flags);
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setFlags(int flags)
 	{
 		intent.setFlags(flags);
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public int getFlags()
 	{
@@ -425,7 +421,6 @@ public class IntentProxy extends KrollProxy
 		return null;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getData()
 	{
@@ -440,28 +435,24 @@ public class IntentProxy extends KrollProxy
 		return intent;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getType()
 	{
 		return intent.getType();
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setType(String type)
 	{
 		intent.setType(type);
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getAction()
 	{
 		return intent.getAction();
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setAction(String action)
 	{

--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/MenuItemProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/MenuItemProxy.java
@@ -55,35 +55,30 @@ public class MenuItemProxy extends KrollProxy
 		MenuItemCompat.setOnActionExpandListener(item, new CompatActionExpandListener());
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public int getGroupId()
 	{
 		return item.getGroupId();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public int getItemId()
 	{
 		return item.getItemId();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public int getOrder()
 	{
 		return item.getOrder();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getTitle()
 	{
 		return (String) item.getTitle();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getTitleCondensed()
 	{
@@ -96,49 +91,42 @@ public class MenuItemProxy extends KrollProxy
 		return item.hasSubMenu();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public boolean isChecked()
 	{
 		return item.isChecked();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public boolean isCheckable()
 	{
 		return item.isCheckable();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public boolean isEnabled()
 	{
 		return item.isEnabled();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public boolean isVisible()
 	{
 		return item.isVisible();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getAccessibilityLabel()
 	{
 		return TiConvert.toString(properties, TiC.PROPERTY_ACCESSIBILITY_LABEL);
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getAccessibilityHint()
 	{
 		return TiConvert.toString(properties, TiC.PROPERTY_ACCESSIBILITY_HINT);
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getAccessibilityValue()
 	{
@@ -171,7 +159,6 @@ public class MenuItemProxy extends KrollProxy
 		updateContentDescription();
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setAccessibilityLabel(String label)
 	{
@@ -183,7 +170,6 @@ public class MenuItemProxy extends KrollProxy
 		updateContentDescription();
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setAccessibilityHint(String hint)
 	{
@@ -195,7 +181,6 @@ public class MenuItemProxy extends KrollProxy
 		updateContentDescription();
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setAccessibilityValue(String value)
 	{
@@ -208,7 +193,6 @@ public class MenuItemProxy extends KrollProxy
 		updateContentDescription();
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public MenuItemProxy setCheckable(boolean checkable)
 	{
@@ -216,7 +200,6 @@ public class MenuItemProxy extends KrollProxy
 		return this;
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public MenuItemProxy setChecked(boolean checked)
 	{
@@ -224,7 +207,6 @@ public class MenuItemProxy extends KrollProxy
 		return this;
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public MenuItemProxy setEnabled(boolean enabled)
 	{
@@ -232,7 +214,6 @@ public class MenuItemProxy extends KrollProxy
 		return this;
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public MenuItemProxy setIcon(Object icon)
 	{
@@ -257,7 +238,6 @@ public class MenuItemProxy extends KrollProxy
 		return this;
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public MenuItemProxy setTitle(String title)
 	{
@@ -265,7 +245,6 @@ public class MenuItemProxy extends KrollProxy
 		return this;
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public MenuItemProxy setTitleCondensed(String title)
 	{
@@ -273,7 +252,6 @@ public class MenuItemProxy extends KrollProxy
 		return this;
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public MenuItemProxy setVisible(boolean visible)
 	{
@@ -281,7 +259,6 @@ public class MenuItemProxy extends KrollProxy
 		return this;
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setActionView(Object view)
 	{
@@ -299,7 +276,6 @@ public class MenuItemProxy extends KrollProxy
 		}
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setShowAsAction(final int flag)
 	{
@@ -336,7 +312,6 @@ public class MenuItemProxy extends KrollProxy
 		});
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public boolean isActionViewExpanded()
 	{

--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/MenuProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/MenuProxy.java
@@ -254,7 +254,6 @@ public class MenuProxy extends KrollProxy
 		return menu.size();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public MenuItemProxy[] getItems()
 	{

--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/ServiceProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/ServiceProxy.java
@@ -70,14 +70,12 @@ public class ServiceProxy extends KrollProxy
 		this.serviceInstanceId = serviceInstanceId;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public int getServiceInstanceId()
 	{
 		return serviceInstanceId;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public IntentProxy getIntent()
 	{

--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/TiViewProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/TiViewProxy.java
@@ -261,7 +261,6 @@ public abstract class TiViewProxy extends KrollProxy
 		return super.handleMessage(msg);
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public KrollDict getRect()
 	{
@@ -303,7 +302,6 @@ public abstract class TiViewProxy extends KrollProxy
 		return d;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public KrollDict getSize()
 	{
@@ -331,7 +329,6 @@ public abstract class TiViewProxy extends KrollProxy
 		return d;
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public Object getWidth()
 	{
@@ -349,7 +346,6 @@ public abstract class TiViewProxy extends KrollProxy
 		setPropertyAndFire(TiC.PROPERTY_WIDTH, width);
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public Object getHeight()
 	{
@@ -367,7 +363,6 @@ public abstract class TiViewProxy extends KrollProxy
 		setPropertyAndFire(TiC.PROPERTY_HEIGHT, height);
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public Object getCenter()
 	{
@@ -990,7 +985,6 @@ public abstract class TiViewProxy extends KrollProxy
 	 * @return The parent view proxy of this view proxy.
 	 * @module.api
 	 */
-	@Kroll.method
 	@Kroll.getProperty
 	public TiViewProxy getParent()
 	{
@@ -1000,7 +994,6 @@ public abstract class TiViewProxy extends KrollProxy
 		return this.parent.get();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getBackgroundColor()
 	{
@@ -1033,7 +1026,6 @@ public abstract class TiViewProxy extends KrollProxy
 		return TiUIHelper.getBackgroundColorForState(tiBackgroundDrawable, TiUIHelper.BACKGROUND_DEFAULT_STATE_1);
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getBackgroundSelectedColor()
 	{
@@ -1056,7 +1048,6 @@ public abstract class TiViewProxy extends KrollProxy
 		return TiUIHelper.getBackgroundColorForState(backgroundDrawable, TiUIHelper.BACKGROUND_SELECTED_STATE);
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getBackgroundFocusedColor()
 	{
@@ -1079,7 +1070,6 @@ public abstract class TiViewProxy extends KrollProxy
 		return TiUIHelper.getBackgroundColorForState(backgroundDrawable, TiUIHelper.BACKGROUND_FOCUSED_STATE);
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getBackgroundDisabledColor()
 	{
@@ -1133,7 +1123,6 @@ public abstract class TiViewProxy extends KrollProxy
 	 * @return An array of the children view proxies of this view.
 	 * @module.api
 	 */
-	@Kroll.method
 	@Kroll.getProperty
 	public TiViewProxy[] getChildren()
 	{
@@ -1194,7 +1183,6 @@ public abstract class TiViewProxy extends KrollProxy
 		extend(options);
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public boolean getKeepScreenOn()
 	{
@@ -1231,7 +1219,6 @@ public abstract class TiViewProxy extends KrollProxy
 		return keepScreenOn;
 	}
 
-	@Kroll.method
 	@Kroll.setProperty(retain = false)
 	public void setKeepScreenOn(boolean keepScreenOn)
 	{

--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/TiViewProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/TiViewProxy.java
@@ -340,7 +340,6 @@ public abstract class TiViewProxy extends KrollProxy
 	}
 
 	@Kroll.setProperty(retain = false)
-	@Kroll.method
 	public void setWidth(Object width)
 	{
 		setPropertyAndFire(TiC.PROPERTY_WIDTH, width);
@@ -357,7 +356,6 @@ public abstract class TiViewProxy extends KrollProxy
 	}
 
 	@Kroll.setProperty(retain = false)
-	@Kroll.method
 	public void setHeight(Object height)
 	{
 		setPropertyAndFire(TiC.PROPERTY_HEIGHT, height);
@@ -375,7 +373,6 @@ public abstract class TiViewProxy extends KrollProxy
 	}
 
 	@Kroll.setProperty(retain = false)
-	@Kroll.method
 	public void setCenter(Object center)
 	{
 		setPropertyAndFire(TiC.PROPERTY_CENTER, center);

--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/TiWindowProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/TiWindowProxy.java
@@ -222,29 +222,24 @@ public abstract class TiWindowProxy extends TiViewProxy
 		releaseViews();
 	}
 
-	@Kroll.method(name = "setTab")
 	@Kroll.setProperty(name = "tab")
 	public void setTabProxy(TiViewProxy tabProxy)
 	{
 		setParent(tabProxy);
 		this.tab = tabProxy;
 	}
-
-	@Kroll.method(name = "getTab")
 	@Kroll.getProperty(name = "tab")
 	public TiViewProxy getTabProxy()
 	{
 		return this.tab;
 	}
 
-	@Kroll.method(name = "setTabGroup")
 	@Kroll.setProperty(name = "tabGroup")
 	public void setTabGroupProxy(TiViewProxy tabGroupProxy)
 	{
 		this.tabGroup = tabGroupProxy;
 	}
 
-	@Kroll.method(name = "getTabGroup")
 	@Kroll.getProperty(name = "tabGroup")
 	public TiViewProxy getTabGroupProxy()
 	{

--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/TiWindowProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/TiWindowProxy.java
@@ -306,14 +306,12 @@ public abstract class TiWindowProxy extends TiViewProxy
 		TiUIHelper.firePostLayoutEvent(this);
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setLeftNavButton(Object button)
 	{
 		Log.w(TAG, "setLeftNavButton not supported in Android");
 	}
 
-	@Kroll.method
 	@Kroll.setProperty
 	public void setOrientationModes(int[] modes)
 	{
@@ -392,7 +390,6 @@ public abstract class TiWindowProxy extends TiViewProxy
 		}
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public int[] getOrientationModes()
 	{
@@ -417,7 +414,6 @@ public abstract class TiWindowProxy extends TiViewProxy
 		}
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public KrollDict getSafeAreaPadding()
 	{
@@ -593,7 +589,6 @@ public abstract class TiWindowProxy extends TiViewProxy
 		}
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public int getOrientation()
 	{
@@ -626,7 +621,6 @@ public abstract class TiWindowProxy extends TiViewProxy
 		sharedElementPairs.clear();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public TiWindowProxy getNavigationWindow()
 	{

--- a/android/titanium/src/java/ti/modules/titanium/BufferProxy.java
+++ b/android/titanium/src/java/ti/modules/titanium/BufferProxy.java
@@ -366,7 +366,6 @@ public class BufferProxy extends KrollProxy
 	 * @return The length of this buffer in bytes
 	 * @module.api
 	 */
-	@Kroll.method
 	@Kroll.getProperty
 	public int getLength()
 	{
@@ -379,7 +378,6 @@ public class BufferProxy extends KrollProxy
 	 * @param length The new length of this buffer proxy in bytes
 	 * @module.api
 	 */
-	@Kroll.method
 	@Kroll.setProperty
 	public void setLength(int length)
 	{

--- a/android/titanium/src/java/ti/modules/titanium/TitaniumModule.java
+++ b/android/titanium/src/java/ti/modules/titanium/TitaniumModule.java
@@ -58,7 +58,6 @@ public class TitaniumModule extends KrollModule
 		basePath.push(getCreationUrl().baseUrl);
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getUserAgent()
 	{
@@ -71,28 +70,24 @@ public class TitaniumModule extends KrollModule
 		return builder.toString();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getVersion()
 	{
 		return TiApplication.getInstance().getTiBuildVersion();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getBuildTimestamp()
 	{
 		return TiApplication.getInstance().getTiBuildTimestamp();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getBuildDate()
 	{
 		return TiApplication.getInstance().getTiBuildTimestamp();
 	}
 
-	@Kroll.method
 	@Kroll.getProperty
 	public String getBuildHash()
 	{

--- a/apidoc/Titanium/Android/QuickSettingsService.yml
+++ b/apidoc/Titanium/Android/QuickSettingsService.yml
@@ -30,6 +30,31 @@ description: |
 extends: Titanium.Android.Service
 platforms: [android]
 since: "7.0"
+properties:
+  - name: icon
+    summary: Changes the Tile's icon.
+    description: |
+      If no image is passed as Tile icon it will use the Application's one.
+    type: [String, Titanium.Blob, Titanium.Filesystem.File]
+    since: "10.0.0"
+
+  - name: state
+    summary: Sets the state of the Tile.
+    description: |
+      State can be one of the following: [TILE_STATE_UNAVAILABLE](Titanium.Android.TILE_STATE_UNAVAILABLE),
+      [TILE_STATE_INACTIVE](Titanium.Android.TILE_STATE_INACTIVE),
+      [TILE_STATE_ACTIVE](Titanium.Android.TILE_STATE_ACTIVE)
+    type: Number
+    constants: Titanium.Android.TILE_STATE_*
+    since: "10.0.0"
+
+  - name: label
+    summary: The Tile's label.
+    description: |
+      If no label is set the Tile uses the Application name.
+    type: String
+    since: "10.0.0"
+
 methods:
   - name: updateTile
     summary: Applies current tile's properties.
@@ -44,6 +69,9 @@ methods:
       - name: icon
         summary: Source of the icon image
         type: [String, Titanium.Blob, Titanium.Filesystem.File]
+    deprecated:
+      since: "10.0.0"
+      notes: Please use the [icon](Titanium.Android.QuickSettingsService.icon) property to get/set the value.
 
   - name: setState
     summary: Sets the state of the Tile.
@@ -56,6 +84,9 @@ methods:
         summary: State to be set.
         type: Number
         constants: Titanium.Android.TILE_STATE_*
+    deprecated:
+      since: "10.0.0"
+      notes: Please use the [state](Titanium.Android.QuickSettingsService.state) property to get/set the value.
 
   - name: setLabel
     summary: Changes the Tile's label.
@@ -65,22 +96,34 @@ methods:
       - name: label
         summary: String to be used.
         type: String
+    deprecated:
+      since: "10.0.0"
+      notes: Please use the [label](Titanium.Android.QuickSettingsService.label) property to get/set the value.
 
   - name: getIcon
     summary: Returns the Tile's current icon.
     returns:
         type: [String, Titanium.Blob, Titanium.Filesystem.File]
+    deprecated:
+      since: "10.0.0"
+      notes: Please use the [icon](Titanium.Android.QuickSettingsService.icon) property to get/set the value.
 
   - name: getState
     summary: Returns the Tile's current state.
     returns:
         type: Number
         constants: Titanium.Android.TILE_STATE_*
+    deprecated:
+      since: "10.0.0"
+      notes: Please use the [state](Titanium.Android.QuickSettingsService.state) property to get/set the value.
 
   - name: getLabel
     summary: Returns the Tile's current label.
     returns:
         type: String
+    deprecated:
+      since: "10.0.0"
+      notes: Please use the [label](Titanium.Android.QuickSettingsService.label) property to get/set the value.
 
   - name: isLocked
     summary: Returns 'true' if the device is currently locked, 'false' otherwise.

--- a/apidoc/Titanium/Database/Database.yml
+++ b/apidoc/Titanium/Database/Database.yml
@@ -76,10 +76,10 @@ methods:
         * `/Applications/apple_app_id/Library/Private Documents/mydb1Installed.sql` (Titanium 1.8.0.1)
         * `/Applications/apple_app_id/Library/Application Support/database/mydb1Installed.sql` (earlier versions)
 
-        To prevent the database file being automatically backed up to iCloud, use `setRemoteBackup`.
+        To prevent the database file being automatically backed up to iCloud, use [remoteBackup](Titanium.Filesystem.File.remoteBackup).
 
         ``` js
-        db1.file.setRemoteBackup(false);
+        db1.file.remoteBackup = false;
         ```
 
     - title: Install a Database to Internal Storage (Android)

--- a/apidoc/Titanium/Media/AudioPlayer.yml
+++ b/apidoc/Titanium/Media/AudioPlayer.yml
@@ -99,24 +99,40 @@ methods:
     returns:
         type: Boolean
     platforms: [iphone, ipad, macos]
+    deprecated:
+        since: "7.5.0"
+        removed: "10.0.0"
+        notes: Use the cross-platform API <Titanium.Media.AudioPlayer.paused> property instead.
 
   - name: isPaused
     summary: Returns the value of the [paused](Titanium.Media.AudioPlayer.paused) property.
     returns:
         type: Boolean
     platforms: [android]
+    deprecated:
+        since: "7.5.0"
+        removed: "10.0.0"
+        notes: Use the cross-platform API <Titanium.Media.AudioPlayer.paused> property instead.
 
   - name: getPlaying
     summary: Returns the value of the [playing](Titanium.Media.AudioPlayer.playing) property.
     returns:
         type: Boolean
     platforms: [iphone, ipad, macos]
+    deprecated:
+        since: "7.5.0"
+        removed: "10.0.0"
+        notes: Use the cross-platform API <Titanium.Media.AudioPlayer.playing> property instead.
 
   - name: isPlaying
     summary: Returns the value of the [playing](Titanium.Media.AudioPlayer.playing) property.
     returns:
         type: Boolean
     platforms: [android]
+    deprecated:
+        since: "7.5.0"
+        removed: "10.0.0"
+        notes: Use the cross-platform API <Titanium.Media.AudioPlayer.playing> property instead.
 
   - name: pause
     summary: Pauses audio playback.
@@ -150,6 +166,7 @@ methods:
         type: Boolean
     deprecated:
         since: "7.5.0"
+        removed: "10.0.0"
         notes: Use the cross-platform API [Titanium.Media.AudioPlayer.pause](Titanium.Media.AudioPlayer.pause) instead.
     platforms: [iphone, ipad, macos]
 
@@ -185,6 +202,9 @@ methods:
         type: Number
     since: "5.4.0"
     platforms: [android]
+    deprecated:
+      since: "10.0.0"
+      notes: Use the [audioSessionId](Titanium.Media.AudioPlayer.audioSessionId) property instead
 
   - name: start
     summary: Starts or resumes audio playback.
@@ -424,6 +444,13 @@ properties:
     default: false
     availability: creation
     platforms: [android]
+
+  - name: audioSessionId
+    summary: Returns the audio session id.
+    type: Number
+    since: "10.0.0"
+    platforms: [android]
+    permission: read-only
     
   - name: audioType
     summary: Changes the audio-stream-type.

--- a/apidoc/Titanium/Media/Sound.yml
+++ b/apidoc/Titanium/Media/Sound.yml
@@ -56,6 +56,9 @@ methods:
       - name: looping
         summary: New value for the `looping` property.
         type: Boolean
+    deprecated:
+      since: "10.0.0"
+      notes: Set the value of the [looping](Titanium.Media.Sound.looping) property directly.
 
   - name: setPaused
     summary: Sets the value of the [paused](Titanium.Media.Sound.paused) property.
@@ -68,6 +71,11 @@ methods:
         summary: Pass `true` to pause the current playback temporarily, `false` to unpause it.
         type: Boolean
     platforms: [iphone, ipad, macos]
+    deprecated:
+      since: "10.0.0"
+      notes: |
+          It is preferable to use the [pause](Titanium.Media.Sound.pause) and
+          [play](Titanium.Media.Sound.play) methods instead.
 
   - name: stop
     summary: Stops playing the audio and resets the playback position to the beginning of the clip.

--- a/apidoc/Titanium/Network/HTTPClient.yml
+++ b/apidoc/Titanium/Network/HTTPClient.yml
@@ -233,6 +233,18 @@ methods:
         type: String
     platforms: [android, iphone, ipad, macos]
 
+  - name: getAllResponseHeaders
+    summary: All of the response headers.
+    description: |
+        Contains a single string, or an empty string if no headers are available.
+
+        See also: [getResponseHeader](Titanium.Network.HTTPClient.getResponseHeader).
+
+        Intended to match the `XMLHTTPRequest` [getAllResponseHeaders API](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/getAllResponseHeaders).
+    returns:
+        type: String
+    since: {iphone: "10.0.0", ipad: "10.0.0", macos: "10.0.0"}
+
   - name: getResponseHeader
     summary: Returns the value of the specified response header.
     returns:

--- a/apidoc/Titanium/Network/HTTPClient.yml
+++ b/apidoc/Titanium/Network/HTTPClient.yml
@@ -243,7 +243,7 @@ methods:
         Intended to match the `XMLHTTPRequest` [getAllResponseHeaders API](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/getAllResponseHeaders).
     returns:
         type: String
-    since: {iphone: "10.0.0", ipad: "10.0.0", macos: "10.0.0"}
+    since: {iphone: "10.0.0", ipad: "10.0.0", macos: "10.0.0", android: "0.8"}
 
   - name: getResponseHeader
     summary: Returns the value of the specified response header.

--- a/apidoc/Titanium/Platform/Platform.yml
+++ b/apidoc/Titanium/Platform/Platform.yml
@@ -408,7 +408,6 @@ properties:
 
       Will return zero if the OS does not have a minor version.
     type: Number
-    default: 0
     permission: read-only
     since: "9.2.0"
 
@@ -419,7 +418,6 @@ properties:
 
       Will return zero if the OS does not have a patch version.
     type: Number
-    default: 0
     permission: read-only
     since: "9.2.0"
 

--- a/iphone/Classes/TiNetworkHTTPClientProxy.m
+++ b/iphone/Classes/TiNetworkHTTPClientProxy.m
@@ -471,6 +471,11 @@ extern NSString *const TI_APPLICATION_GUID;
 
 #pragma mark - Public getter properties
 
+- (NSString *)getAllResponseHeaders:(id)unused
+{
+  return [self allResponseHeaders];
+}
+
 - (NSString *)allResponseHeaders
 {
   NSDictionary *headers = [[self response] headers];

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/ObjcProxy.h
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/ObjcProxy.h
@@ -40,15 +40,13 @@
   SETTER_IMPL(TYPE, UPPER);
 
 #define PROPERTY(TYPE, LOWER, UPPER) \
-  @property TYPE LOWER;              \
-  READWRITE(TYPE, UPPER);
+  @property TYPE LOWER;
 
 #define CONSTANT(TYPE, NAME) \
   @property (readonly) TYPE NAME;
 
 #define READONLY_PROPERTY(TYPE, LOWER, UPPER) \
-  CONSTANT(TYPE, LOWER);                      \
-  GETTER(TYPE, UPPER);
+  CONSTANT(TYPE, LOWER);
 
 // TODO: Log a warning/error if negative?
 // We could also define as NSUInteger and do: if (arg - 1 == NSIntegerMax) as NaN check

--- a/iphone/TitaniumKit/TitaniumKit/Sources/Kroll/KrollMethod.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/Kroll/KrollMethod.m
@@ -224,31 +224,6 @@ JSValueRef KrollCallAsNamedFunction(JSContextRef jsContext, JSObjectRef func, JS
 
 - (id)call:(NSArray *)args
 {
-  // special property setter delegator against the target
-  if (type == KrollMethodPropertySetter && [args count] == 1) {
-    // Spit out a deprecation warning to use normal property setter!
-    // This is the code path followed for delegating access for soemthing like
-    // Ti.UI.Label#setText(). Which delegates through TiProxy.m TiProxyDelegate code
-    // Other code path is handled in KrollObject.m
-    DebugLog(@"[WARN] Automatic setter methods for properties are deprecated in SDK 8.0.0 and will be removed in SDK 10.0.0. Please modify the property in standard JS style: obj.%@ = value; or obj['%@'] = value;", name, name);
-    id newValue = [KrollObject nonNull:[args objectAtIndex:0]];
-    [self updateJSObjectWithValue:newValue forKey:name];
-    [target setValue:newValue forKey:name];
-    return self;
-  }
-  // special property getter delegator against the target
-  if (type == KrollMethodPropertyGetter) {
-    // Spit out a deprecation warning to use normal property accessor!
-    // This is the code path followed for delegating access for something like
-    // Ti.UI.Label#getText(). Which delegates through TiProxy.m TiProxyDelegate code
-    // Other code path is handled in KrollObject.m
-    DebugLog(@"[WARN] Automatic getter methods for properties are deprecated in SDK 8.0.0 and will be removed in SDK 10.0.0. Please access the property in standard JS style: obj.%@ or obj['%@']", name, name);
-    // hold, see below
-    id result = [target valueForKey:name];
-    [self updateJSObjectWithValue:result forKey:name];
-    return result;
-  }
-
   // special generic factory for creating proxy objects for modules
   if (type == KrollMethodFactory) {
     //TODO: This likely could be further optimized later
@@ -286,8 +261,8 @@ JSValueRef KrollCallAsNamedFunction(JSContextRef jsContext, JSObjectRef func, JS
 
   if (methodArgCount > 0 && argcount > 0) {
     if (argcount == 2 && methodArgCount == 4) {
-      arg1 = [KrollObject nonNull:args == nil ? nil : [args objectAtIndex:0]];
-      arg2 = [KrollObject nonNull:[args count] > 1 ? [args objectAtIndex:1] : nil];
+      arg1 = [KrollObject nonNull:(args == nil ? nil : args[0])];
+      arg2 = [KrollObject nonNull:(args.count > 1 ? args[1] : nil)];
       if (type == KrollMethodSetter) {
         [self updateJSObjectWithValue:arg1 forKey:propertyKey];
       }
@@ -296,7 +271,7 @@ JSValueRef KrollCallAsNamedFunction(JSContextRef jsContext, JSObjectRef func, JS
         arg1 = name;
         arg2 = args;
       } else if (type == KrollMethodSetter) {
-        arg1 = [KrollObject nonNull:[args count] == 1 ? [args objectAtIndex:0] : args];
+        arg1 = [KrollObject nonNull:(args.count == 1 ? args[0] : args)];
         [self updateJSObjectWithValue:arg1 forKey:propertyKey];
       } else if (args != nil) {
         arg1 = [KrollObject nonNull:args];

--- a/iphone/TitaniumKit/TitaniumKit/Sources/Kroll/KrollObject.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/Kroll/KrollObject.m
@@ -224,7 +224,6 @@ JSValueRef KrollGetProperty(JSContextRef jsContext, JSObjectRef object, JSString
       }
     }
 
-    // TODO USe a marking protocol to skip when
     if ([result conformsToProtocol:@protocol(JSExport)]) {
       JSContext *objcContext = [JSContext contextWithJSGlobalContextRef:[[o context] context]];
       return [[JSValue valueWithObject:result inContext:objcContext] JSValueRef];
@@ -552,228 +551,197 @@ bool KrollHasInstance(JSContextRef ctx, JSObjectRef constructor, JSValueRef poss
 
 - (id)_valueForKey:(NSString *)key
 {
-  //TODO: need to consult property_getAttributes to make sure we're not hitting readonly, etc. but do this
-  //only for non-production builds
+  // Is is special case toString or valueOf methods?
+  if ([key isEqualToString:@"toString"] || [key isEqualToString:@"valueOf"]) {
+    return [[[KrollMethod alloc] initWithTarget:target selector:@selector(toString:) argcount:0 type:KrollMethodInvoke name:nil context:[self context]] autorelease];
+  }
 
-  // TODO: We do a significant amount of magic here (set/get routing, and additionally "automatic"
-  // get/set based on what we assume the user is doing) that may need to be removed.
+  // Special handling for className due to conflict with NSObject private API
+  if ([key isEqualToString:@"className"]) {
+    return [target valueForUndefinedKey:key];
+  }
 
-  if ([key hasPrefix:@"set"] && ([key length] >= 4) &&
-      [[NSCharacterSet uppercaseLetterCharacterSet] characterIsMember:[key characterAtIndex:3]]) {
-    // This is PROBABLY a request for an internal setter (either setX('a') or setX('a','b')). But
-    // it could also be:
-    // * Pulling a user-defined property prefixed with 'set'
-    // * Autogenerating a getter/setter
-    // In the event of the former, we actually have to actually pull a jump to
-    // returning the property's appropriate type, as below in the general case.
+  // Is this a property on the Obj-C class? If so, invoke it's getter and return the value
+  objc_property_t p = class_getProperty([target class], key.UTF8String);
+  if (p != NULL) {
+    return [self valueForProperty:p withKey:key];
+  }
 
-    SEL selector;
-
+  // Check if this is a single-argument method
+  SEL selector = NSSelectorFromString([NSString stringWithFormat:@"%@:", key]);
+  // We need special handling for setters so that we "unwrap" arguments
+  // We have two flavors of setters:
+  // - setX:(id)value OR
+  // - setX:(id)value withObject:(id)options
+  if ([key hasPrefix:@"set"]) {
+    // this is a setter method, so let's tag it for special arg unwrapping
+    // special handling for setter methods to basically "unwrap" arguments array when invoking
+    // which aligns w/ obj-c property setter expectations
+    KrollMethod *method = [[[KrollMethod alloc] initWithTarget:target
+                                                      selector:selector
+                                                      argcount:1
+                                                          type:KrollMethodSetter
+                                                          name:nil
+                                                       context:[self context]] autorelease];
+    // Record the underlying property so the setter updates the property on the JS object (if necessary)
     NSString *propertyKey = [self _propertyGetterSetterKey:key];
-    KrollMethod *result = [[KrollMethod alloc] initWithTarget:target context:[self context]];
+    [method setPropertyKey:propertyKey];
+    [method setUpdatesProperty:[(TiProxy *)target retainsJsObjectForKey:propertyKey]];
 
-    [result setArgcount:1];
-    [result setPropertyKey:propertyKey];
-    [result setType:KrollMethodSetter];
-    [result setUpdatesProperty:[(TiProxy *)target retainsJsObjectForKey:propertyKey]];
-
-    selector = NSSelectorFromString([key stringByAppendingString:@":withObject:"]);
+    // Check for special setters that take additional optional options object
+    SEL selectorWithObject = NSSelectorFromString([key stringByAppendingString:@":withObject:"]);
+    if ([target respondsToSelector:selectorWithObject]) {
+      [method setSelector:selectorWithObject];
+      [method setArgcount:2];
+    }
+    // Responds to basic setter?
     if ([target respondsToSelector:selector]) {
-      [result setArgcount:2];
-      [result setSelector:selector];
-    } else {
-      selector = NSSelectorFromString([key stringByAppendingString:@":"]);
-      if ([target respondsToSelector:selector]) {
-        // Assume that if there's a getter with same property name, that this is just exposing the property's setter method to JS when it shouldn't be
-        if ([target respondsToSelector:NSSelectorFromString(propertyKey)]) {
-          // This is the code path for delegating something like Ti.Filesystem.File#setHidden(), see KrollMethod for other cases (when type is KrollMethodPropertySetter, the last option in this if block below)
-          // Spit out a deprecation warning to use normal property setter!
-          DebugLog(@"[WARN] Automatic setter methods for properties are deprecated in SDK 8.0.0 and will be removed in SDK 10.0.0. Please modify the property in standard JS style: obj.%@ = value; or obj['%@'] = value;", propertyKey, propertyKey);
-        }
-        [result setSelector:selector];
-      } else {
-        // Either a custom property, OR a request for an autogenerated setter
-        id value = [target valueForKey:key];
-        if (value != nil) {
-          [result release];
-          return [self convertValueToDelegate:value forKey:key];
-        } else {
-          [result setType:KrollMethodPropertySetter];
-          [result setName:propertyKey];
-        }
-      }
+      return method;
     }
-
-    return [result autorelease]; // we simply return a method delegator  against the target to set the property directly on the target
-  } else if ([key hasPrefix:@"get"]) {
-    KrollMethod *result = [[KrollMethod alloc] initWithTarget:target context:[self context]];
-    NSString *propertyKey = [self _propertyGetterSetterKey:key];
-    [result setPropertyKey:propertyKey];
-    [result setArgcount:1];
-    [result setUpdatesProperty:[(TiProxy *)target retainsJsObjectForKey:propertyKey]];
-
-    //first make sure we don't have a method with the fullname
-    SEL fullSelector = NSSelectorFromString([NSString stringWithFormat:@"%@:", key]);
-    if ([target respondsToSelector:fullSelector]) {
-      [result setSelector:fullSelector];
-      [result setType:KrollMethodInvoke];
-      return [result autorelease];
-    }
-
-    // this is a request for a getter method
-    // a.getFoo()
-    NSString *partkey = [self propercase:key index:3];
-    SEL selector = NSSelectorFromString(partkey);
-    if ([target respondsToSelector:selector]) {
-      // Spit out a deprecation warning to use normal property accessor!
-      // This is the code path for delegating something like Ti.Filesystem.File#getHidden(), see KrollMethod for other cases (when type is KrollMethodPropertyGetter, the last option in this if block below)
-      DebugLog(@"[WARN] Automatic getter methods for properties are deprecated in SDK 8.0.0 and will be removed in SDK 10.0.0. Please access the property in standard JS style: obj.%@ or obj['%@']", partkey, partkey);
-      [result setSelector:selector];
-      [result setType:KrollMethodGetter];
-      return [result autorelease];
-    }
-    // see if its an actual method that takes an arg instead
-    selector = NSSelectorFromString([NSString stringWithFormat:@"%@:", partkey]);
-    if ([target respondsToSelector:selector]) {
-      [result setSelector:selector];
-      [result setType:KrollMethodGetter];
-      return [result autorelease];
-    }
-
-    // Check for custom property before returning the autogenerated getter
-    id value = [target valueForKey:key];
-    if (value != nil) {
-      [result release];
-      return [self convertValueToDelegate:value forKey:key];
-    }
-
-    [result setName:propertyKey];
-    [result setArgcount:0];
-    [result setType:KrollMethodPropertyGetter];
-    return [result autorelease];
   } else {
-    // property accessor - need to determine if its a objc property of method
-    objc_property_t p = class_getProperty([target class], [key UTF8String]);
-    if (p == NULL) {
-      if ([key isEqualToString:@"toString"] || [key isEqualToString:@"valueOf"]) {
-        return [[[KrollMethod alloc] initWithTarget:target selector:@selector(toString:) argcount:0 type:KrollMethodInvoke name:nil context:[self context]] autorelease];
-      }
-
-      // For something like TiUiTextWidgetProxy focused:(id)unused - this will assume it's a function/method
-      // So to work around this, we need to explicitly declare a property named "focused" with a different underlying getter
-      // to expose it as a property to JS
-      SEL selector = NSSelectorFromString([NSString stringWithFormat:@"%@:", key]);
-      if ([target respondsToSelector:selector]) {
-        return [[[KrollMethod alloc] initWithTarget:target
-                                           selector:selector
-                                           argcount:1
-                                               type:KrollMethodInvoke
-                                               name:nil
-                                            context:[self context]] autorelease];
-      }
-      // Special handling for className due to conflict with NSObject private API
-      if ([key isEqualToString:@"className"]) {
-        return [target valueForUndefinedKey:key];
-      }
-      // attempt a function that has no args (basically a non-property property)
-      selector = NSSelectorFromString([NSString stringWithFormat:@"%@", key]);
-      if ([target respondsToSelector:selector]) {
-        return [target performSelector:selector];
-      }
-      id result = [target valueForKey:key];
-      if (result != nil) {
-        return [self convertValueToDelegate:result forKey:key];
-      }
-      // see if this is a create factory which we can do dynamically
-      if ([key hasPrefix:@"create"]) {
-        SEL selector = @selector(createProxy:forName:context:);
-        if ([target respondsToSelector:selector]) {
-          return [[[KrollMethod alloc] initWithTarget:target
-                                             selector:selector
-                                             argcount:2
-                                                 type:KrollMethodFactory
-                                                 name:key
-                                              context:[self context]] autorelease];
-        }
-      }
-    } else {
-      NSString *attributes = [NSString stringWithCString:property_getAttributes(p) encoding:NSUTF8StringEncoding];
-      // look up getter name from the property attributes
-      SEL selector;
-      const char *getterName = property_copyAttributeValue(p, "G");
-      if (getterName != nil) {
-        selector = sel_getUid(getterName);
-      } else {
-        // not set, so use the property name
-        selector = NSSelectorFromString([NSString stringWithCString:property_getName(p) encoding:NSUTF8StringEncoding]);
-      }
-
-      if ([attributes hasPrefix:@"T@"]) {
-        // this means its a return type of id
-        return [target performSelector:selector];
-      } else {
-        NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:[target methodSignatureForSelector:selector]];
-        [invocation setSelector:selector];
-        [invocation invokeWithTarget:target];
-        if ([attributes hasPrefix:@"Td,"]) {
-          double d;
-          [invocation getReturnValue:&d];
-          return [NSNumber numberWithDouble:d];
-        } else if ([attributes hasPrefix:@"Tf,"]) {
-          float f;
-          [invocation getReturnValue:&f];
-          return [NSNumber numberWithFloat:f];
-        } else if ([attributes hasPrefix:@"Ti,"]) {
-          int i;
-          [invocation getReturnValue:&i];
-          return [NSNumber numberWithInt:i];
-        } else if ([attributes hasPrefix:@"TI,"]) {
-          unsigned int ui;
-          [invocation getReturnValue:&ui];
-          return [NSNumber numberWithUnsignedInt:ui];
-        } else if ([attributes hasPrefix:@"Tl,"]) {
-          long l;
-          [invocation getReturnValue:&l];
-          return [NSNumber numberWithLong:l];
-        } else if ([attributes hasPrefix:@"TL,"]) {
-          unsigned long ul;
-          [invocation getReturnValue:&ul];
-          return [NSNumber numberWithUnsignedLong:ul];
-        } else if ([attributes hasPrefix:@"Tc,"]) {
-          char c;
-          [invocation getReturnValue:&c];
-          return [NSNumber numberWithChar:c];
-        } else if ([attributes hasPrefix:@"TC,"]) {
-          unsigned char uc;
-          [invocation getReturnValue:&uc];
-          return [NSNumber numberWithUnsignedChar:uc];
-        } else if ([attributes hasPrefix:@"Ts,"]) {
-          short s;
-          [invocation getReturnValue:&s];
-          return [NSNumber numberWithShort:s];
-        } else if ([attributes hasPrefix:@"TS,"]) {
-          unsigned short us;
-          [invocation getReturnValue:&us];
-          return [NSNumber numberWithUnsignedShort:us];
-        } else if ([attributes hasPrefix:@"Tq,"]) {
-          long long ll;
-          [invocation getReturnValue:&ll];
-          return [NSNumber numberWithLongLong:ll];
-        } else if ([attributes hasPrefix:@"TQ,"]) {
-          unsigned long long ull;
-          [invocation getReturnValue:&ull];
-          return [NSNumber numberWithUnsignedLongLong:ull];
-        } else if ([attributes hasPrefix:@"TB,"] || [attributes hasPrefix:@"Tb,"]) {
-          bool b;
-          [invocation getReturnValue:&b];
-          return [NSNumber numberWithBool:b];
-        } else {
-          // let it fall through and return undefined
-          DebugLog(@"[WARN] Unsupported property: %@ for %@, attributes = %@", key, target, attributes);
-        }
-      }
+    // Non-set* methods
+    if ([target respondsToSelector:selector]) {
+      return [[[KrollMethod alloc] initWithTarget:target
+                                         selector:selector
+                                         argcount:1
+                                             type:KrollMethodInvoke
+                                             name:nil
+                                          context:[self context]] autorelease];
     }
   }
+
+  // attempt a function that has no args (basically a non-property property)
+  selector = NSSelectorFromString([NSString stringWithFormat:@"%@", key]);
+  if ([target respondsToSelector:selector]) {
+    return [target performSelector:selector];
+  }
+
+  // see if this is a create factory which we can do dynamically
+  // NOTE: we do this after checking for matching create* method first!
+  // So something like UIModule can override createAnimation:
+  // (all TiModule subclasses will respond to this selector below)
+  if ([key hasPrefix:@"create"]) {
+    SEL selector = @selector(createProxy:forName:context:);
+    if ([target respondsToSelector:selector]) {
+      return [[[KrollMethod alloc] initWithTarget:target
+                                         selector:selector
+                                         argcount:2
+                                             type:KrollMethodFactory
+                                             name:key
+                                          context:[self context]] autorelease];
+    }
+  }
+
+  // generic fall back
+  id result = [target valueForKey:key];
+  if (result != nil) {
+    return [self convertValueToDelegate:result forKey:key];
+  }
+
+  return nil;
+}
+
+- (id)valueForProperty:(objc_property_t)p withKey:(NSString *)key
+{
+  // look up getter name from the property attributes
+  SEL selector;
+  const char *getterName = property_copyAttributeValue(p, "G");
+  if (getterName != nil) {
+    selector = sel_getUid(getterName);
+  } else {
+    // not set, so use the property name
+    selector = NSSelectorFromString([NSString stringWithCString:property_getName(p) encoding:NSUTF8StringEncoding]);
+  }
+
+  NSString *attributes = [NSString stringWithCString:property_getAttributes(p) encoding:NSUTF8StringEncoding];
+  if ([attributes hasPrefix:@"T@"]) {
+    // this means its a return type of id
+    return [target performSelector:selector];
+  }
+
+  NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:[target methodSignatureForSelector:selector]];
+  [invocation setSelector:selector];
+  [invocation invokeWithTarget:target];
+  if ([attributes hasPrefix:@"Td,"]) {
+    double d;
+    [invocation getReturnValue:&d];
+    return [NSNumber numberWithDouble:d];
+  }
+
+  if ([attributes hasPrefix:@"Tf,"]) {
+    float f;
+    [invocation getReturnValue:&f];
+    return [NSNumber numberWithFloat:f];
+  }
+
+  if ([attributes hasPrefix:@"Ti,"]) {
+    int i;
+    [invocation getReturnValue:&i];
+    return [NSNumber numberWithInt:i];
+  }
+
+  if ([attributes hasPrefix:@"TI,"]) {
+    unsigned int ui;
+    [invocation getReturnValue:&ui];
+    return [NSNumber numberWithUnsignedInt:ui];
+  }
+
+  if ([attributes hasPrefix:@"Tl,"]) {
+    long l;
+    [invocation getReturnValue:&l];
+    return [NSNumber numberWithLong:l];
+  }
+
+  if ([attributes hasPrefix:@"TL,"]) {
+    unsigned long ul;
+    [invocation getReturnValue:&ul];
+    return [NSNumber numberWithUnsignedLong:ul];
+  }
+
+  if ([attributes hasPrefix:@"Tc,"]) {
+    char c;
+    [invocation getReturnValue:&c];
+    return [NSNumber numberWithChar:c];
+  }
+
+  if ([attributes hasPrefix:@"TC,"]) {
+    unsigned char uc;
+    [invocation getReturnValue:&uc];
+    return [NSNumber numberWithUnsignedChar:uc];
+  }
+
+  if ([attributes hasPrefix:@"Ts,"]) {
+    short s;
+    [invocation getReturnValue:&s];
+    return [NSNumber numberWithShort:s];
+  }
+
+  if ([attributes hasPrefix:@"TS,"]) {
+    unsigned short us;
+    [invocation getReturnValue:&us];
+    return [NSNumber numberWithUnsignedShort:us];
+  }
+
+  if ([attributes hasPrefix:@"Tq,"]) {
+    long long ll;
+    [invocation getReturnValue:&ll];
+    return [NSNumber numberWithLongLong:ll];
+  }
+
+  if ([attributes hasPrefix:@"TQ,"]) {
+    unsigned long long ull;
+    [invocation getReturnValue:&ull];
+    return [NSNumber numberWithUnsignedLongLong:ull];
+  }
+
+  if ([attributes hasPrefix:@"TB,"] || [attributes hasPrefix:@"Tb,"]) {
+    bool b;
+    [invocation getReturnValue:&b];
+    return [NSNumber numberWithBool:b];
+  }
+
+  // let it fall through and return undefined
+  DebugLog(@"[WARN] Unsupported property: %@ for %@, attributes = %@", key, target, attributes);
   return nil;
 }
 
@@ -784,11 +752,6 @@ bool KrollHasInstance(JSContextRef ctx, JSObjectRef constructor, JSValueRef poss
   }
 
   if (properties != nil && properties[propertyName] != nil) {
-    return YES;
-  }
-
-  if (([propertyName hasPrefix:@"get"] || [propertyName hasPrefix:@"set"]) && (propertyName.length >= 4) &&
-      [NSCharacterSet.uppercaseLetterCharacterSet characterIsMember:[propertyName characterAtIndex:3]]) {
     return YES;
   }
 
@@ -889,6 +852,8 @@ bool KrollHasInstance(JSContextRef ctx, JSObjectRef constructor, JSValueRef poss
       value = nil;
     }
 
+    // TODO: Shouldn't we be checking for a property of this name, asking for it's setter and calling that?
+    // FIXME: Align with _valueForKey code which does similar stuff!
     NSString *name = [self propercase:key index:0];
     SEL selector = NSSelectorFromString([NSString stringWithFormat:@"set%@:withObject:", name]);
     if ([target respondsToSelector:selector]) {

--- a/tests/Resources/core.runtime.test.js
+++ b/tests/Resources/core.runtime.test.js
@@ -4,13 +4,13 @@
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
+/* global OS_IOS */
 /* eslint-env mocha */
 /* eslint no-unused-expressions: "off" */
 
 'use strict';
 
 const should = require('./utilities/assertions');
-const utilities = require('./utilities/utilities');
 
 describe.windowsBroken('Core', () => {
 	describe('Runtime', () => {
@@ -33,28 +33,6 @@ describe.windowsBroken('Core', () => {
 			});
 
 			describe('Proxy', () => {
-				describe('Getter/Setter', () => {
-					it('should check for existing getter method', () => {
-						const tabGroup = Ti.UI.createTabGroup();
-						tabGroup.should.have.property('getTabs');
-					});
-
-					it.ios('should check for dynamic getter method', () => {
-						const view = Ti.UI.createView();
-						view.should.have.property('getFoo');
-					});
-
-					it('should check for existing setter method', () => {
-						const webView = Ti.UI.createWebView();
-						webView.should.have.property('setHtml');
-					});
-
-					it.ios('should check for dynamic setter method', () => {
-						const view = Ti.UI.createView();
-						view.should.have.property('setFoo');
-					});
-				});
-
 				describe('Properties', () => {
 					it('should check for properties on the object\'s target', () => {
 						const view = Ti.UI.createView({
@@ -75,7 +53,7 @@ describe.windowsBroken('Core', () => {
 
 					it('should properly handle properties with value of nil (TIMOB-26452)', () => {
 						should(Ti.Geolocation).have.property('lastGeolocation');
-						if (utilities.isIOS()) {
+						if (OS_IOS) {
 							should.not.exist(Ti.Geolocation.lastGeolocation);
 						} else {
 							should(Ti.Geolocation.lastGeolocation).be.equal('{}');

--- a/tests/Resources/ti.analytics.test.js
+++ b/tests/Resources/ti.analytics.test.js
@@ -21,8 +21,8 @@ describe('Titanium.Analytics', () => {
 				should(Ti.Analytics.apiName).be.eql('Ti.Analytics');
 			});
 
-			it('has a getter', () => {
-				should(Ti.Analytics).have.a.getter('apiName');
+			it('has no getter', () => {
+				should(Ti.Analytics).not.have.a.getter('apiName');
 			});
 		});
 
@@ -32,8 +32,8 @@ describe('Titanium.Analytics', () => {
 				should(Ti.Analytics).have.a.readOnlyProperty('lastEvent').which.is.a.String();
 			});
 
-			it('has a getter', () => {
-				should(Ti.Analytics).have.a.getter('lastEvent');
+			it('has no getter', () => {
+				should(Ti.Analytics).not.have.a.getter('lastEvent');
 			});
 		});
 
@@ -51,8 +51,8 @@ describe('Titanium.Analytics', () => {
 				should(Ti.Analytics.optedOut).be.true();
 			});
 
-			it('has accessors', () => {
-				should(Ti.Analytics).have.accessors('optedOut');
+			it('has no accessors', () => {
+				should(Ti.Analytics).not.have.accessors('optedOut');
 			});
 		});
 	});

--- a/tests/Resources/ti.app.test.js
+++ b/tests/Resources/ti.app.test.js
@@ -32,8 +32,8 @@ describe('Titanium.App', () => {
 				should(Ti.App.apiName).be.eql('Ti.App');
 			});
 
-			it('has a getter', () => {
-				should(Ti.App).have.a.getter('apiName');
+			it('has no getter', () => {
+				should(Ti.App).not.have.a.getter('apiName');
 			});
 		});
 
@@ -42,8 +42,8 @@ describe('Titanium.App', () => {
 				should(Ti.App).have.a.readOnlyProperty('accessibilityEnabled').which.is.a.Boolean();
 			});
 
-			it('has a getter', () => {
-				should(Ti.App).have.a.getter('accessibilityEnabled');
+			it('has no getter', () => {
+				should(Ti.App).not.have.a.getter('accessibilityEnabled');
 			});
 		});
 
@@ -52,8 +52,8 @@ describe('Titanium.App', () => {
 				should(Ti.App).have.a.readOnlyProperty('analytics').which.is.a.Boolean();
 			});
 
-			it('has a getter', () => {
-				should(Ti.App).have.a.getter('analytics');
+			it('has no getter', () => {
+				should(Ti.App).not.have.a.getter('analytics');
 			});
 		});
 
@@ -62,8 +62,8 @@ describe('Titanium.App', () => {
 				should(Ti.App).have.a.readOnlyProperty('copyright').which.is.a.String();
 			});
 
-			it('has a getter', () => {
-				should(Ti.App).have.a.getter('copyright');
+			it('has no getter', () => {
+				should(Ti.App).not.have.a.getter('copyright');
 			});
 		});
 
@@ -72,8 +72,8 @@ describe('Titanium.App', () => {
 				should(Ti.App).have.a.readOnlyProperty('deployType').which.is.a.String();
 			});
 
-			it('has a getter', () => {
-				should(Ti.App).have.a.getter('deployType');
+			it('has no getter', () => {
+				should(Ti.App).not.have.a.getter('deployType');
 			});
 		});
 
@@ -82,8 +82,8 @@ describe('Titanium.App', () => {
 				should(Ti.App).have.a.readOnlyProperty('description').which.is.a.String();
 			});
 
-			it('has a getter', () => {
-				should(Ti.App).have.a.getter('description');
+			it('has no getter', () => {
+				should(Ti.App).not.have.a.getter('description');
 			});
 		});
 
@@ -101,8 +101,8 @@ describe('Titanium.App', () => {
 				should(Ti.App.disableNetworkActivityIndicator).be.true();
 			});
 
-			it('has accessors', () => {
-				should(Ti.App).have.accessors('disableNetworkActivityIndicator');
+			it('has no accessors', () => {
+				should(Ti.App).not.have.accessors('disableNetworkActivityIndicator');
 			});
 		});
 
@@ -116,8 +116,8 @@ describe('Titanium.App', () => {
 				should(Ti.App.forceSplashAsSnapshot).be.true();
 			});
 
-			it('has accessors', () => {
-				should(Ti.App).have.accessors('forceSplashAsSnapshot');
+			it('has no accessors', () => {
+				should(Ti.App).not.have.accessors('forceSplashAsSnapshot');
 			});
 		});
 
@@ -126,8 +126,8 @@ describe('Titanium.App', () => {
 				should(Ti.App).have.a.readOnlyProperty('guid').which.is.a.String();
 			});
 
-			it('has a getter', () => {
-				should(Ti.App).have.a.getter('guid');
+			it('has no getter', () => {
+				should(Ti.App).not.have.a.getter('guid');
 			});
 		});
 
@@ -136,8 +136,8 @@ describe('Titanium.App', () => {
 				should(Ti.App).have.a.readOnlyProperty('id').which.is.a.String();
 			});
 
-			it('has a getter', () => {
-				should(Ti.App).have.a.getter('id');
+			it('has no getter', () => {
+				should(Ti.App).not.have.a.getter('id');
 			});
 		});
 
@@ -151,8 +151,8 @@ describe('Titanium.App', () => {
 				should(Ti.App.idleTimerDisabled).be.true();
 			});
 
-			it('has accessors', () => {
-				should(Ti.App).have.accessors('idleTimerDisabled');
+			it('has no accessors', () => {
+				should(Ti.App).not.have.accessors('idleTimerDisabled');
 			});
 		});
 
@@ -161,8 +161,8 @@ describe('Titanium.App', () => {
 				should(Ti.App).have.a.readOnlyProperty('installId').which.is.a.String();
 			});
 
-			it('has a getter', () => {
-				should(Ti.App).have.a.getter('installId');
+			it('has no getter', () => {
+				should(Ti.App).not.have.a.getter('installId');
 			});
 		});
 
@@ -171,8 +171,8 @@ describe('Titanium.App', () => {
 				should(Ti.App).have.a.readOnlyProperty('keyboardVisible').which.is.a.Boolean();
 			});
 
-			it('has a getter', () => {
-				should(Ti.App).have.a.getter('keyboardVisible');
+			it('has no getter', () => {
+				should(Ti.App).not.have.a.getter('keyboardVisible');
 			});
 		});
 
@@ -181,8 +181,8 @@ describe('Titanium.App', () => {
 				should(Ti.App).have.a.readOnlyProperty('name').which.is.a.String();
 			});
 
-			it('has a getter', () => {
-				should(Ti.App).have.a.getter('name');
+			it('has no getter', () => {
+				should(Ti.App).not.have.a.getter('name');
 			});
 		});
 
@@ -200,8 +200,8 @@ describe('Titanium.App', () => {
 				should(Ti.App.proximityDetection).be.true();
 			});
 
-			it('has accessors', () => {
-				should(Ti.App).have.accessors('proximityDetection');
+			it('has no accessors', () => {
+				should(Ti.App).not.have.accessors('proximityDetection');
 			});
 		});
 
@@ -210,8 +210,8 @@ describe('Titanium.App', () => {
 				should(Ti.App).have.a.readOnlyProperty('proximityState').which.is.a.Boolean();
 			});
 
-			it('has a getter', () => {
-				should(Ti.App).have.a.getter('proximityState');
+			it('has no getter', () => {
+				should(Ti.App).not.have.a.getter('proximityState');
 			});
 		});
 
@@ -220,8 +220,8 @@ describe('Titanium.App', () => {
 				should(Ti.App).have.a.readOnlyProperty('publisher').which.is.a.String();
 			});
 
-			it('has a getter', () => {
-				should(Ti.App).have.a.getter('publisher');
+			it('has no getter', () => {
+				should(Ti.App).not.have.a.getter('publisher');
 			});
 		});
 
@@ -230,8 +230,8 @@ describe('Titanium.App', () => {
 				should(Ti.App).have.a.readOnlyProperty('sessionId').which.is.a.String();
 			});
 
-			it('has a getter', () => {
-				should(Ti.App).have.a.getter('sessionId');
+			it('has no getter', () => {
+				should(Ti.App).not.have.a.getter('sessionId');
 			});
 		});
 
@@ -240,8 +240,8 @@ describe('Titanium.App', () => {
 				should(Ti.App).have.a.readOnlyProperty('url').which.is.a.String();
 			});
 
-			it('has a getter', () => {
-				should(Ti.App).have.a.getter('url');
+			it('has no getter', () => {
+				should(Ti.App).not.have.a.getter('url');
 			});
 		});
 
@@ -250,8 +250,8 @@ describe('Titanium.App', () => {
 				should(Ti.App).have.a.readOnlyProperty('version').which.is.a.String();
 			});
 
-			it('has a getter', () => {
-				should(Ti.App).have.a.getter('version');
+			it('has no getter', () => {
+				should(Ti.App).not.have.a.getter('version');
 			});
 		});
 	});

--- a/tests/Resources/ti.app.test.js
+++ b/tests/Resources/ti.app.test.js
@@ -415,7 +415,7 @@ describe('Titanium.App', () => {
 			action: Ti.Android.ACTION_MAIN,
 		});
 		homeIntent.addCategory(Ti.Android.CATEGORY_HOME);
-		homeIntent.setFlags(Ti.Android.FLAG_ACTIVITY_NEW_TASK);
+		homeIntent.flags = Ti.Android.FLAG_ACTIVITY_NEW_TASK;
 		Ti.Android.currentActivity.startActivity(homeIntent);
 	});
 });

--- a/tests/Resources/ti.filesystem.file.test.js
+++ b/tests/Resources/ti.filesystem.file.test.js
@@ -784,9 +784,9 @@ describe('Titanium.Filesystem.File', function () {
 			}).not.throw();
 		});
 
-		it('has accessors', () => {
+		it('has no accessors', () => {
 			const file = Ti.Filesystem.getFile(Ti.Filesystem.applicationDataDirectory);
-			should(file).have.accessors('remoteBackup');
+			should(file).not.have.accessors('remoteBackup');
 		});
 	});
 

--- a/tests/Resources/ti.geolocation.test.js
+++ b/tests/Resources/ti.geolocation.test.js
@@ -103,8 +103,8 @@ describe.windowsBroken('Titanium.Geolocation', () => {
 				should(Ti.Geolocation.accuracy).eql(Ti.Geolocation.ACCURACY_BEST);
 			});
 
-			it('has accessors', () => {
-				should(Ti.Geolocation).have.accessors('accuracy');
+			it('has no accessors', () => {
+				should(Ti.Geolocation).not.have.accessors('accuracy');
 			});
 		});
 
@@ -118,8 +118,8 @@ describe.windowsBroken('Titanium.Geolocation', () => {
 				should(Ti.Geolocation.activityType).eql(Ti.Geolocation.ACTIVITYTYPE_FITNESS);
 			});
 
-			it('has accessors', () => {
-				should(Ti.Geolocation).have.accessors('activityType');
+			it('has no accessors', () => {
+				should(Ti.Geolocation).not.have.accessors('activityType');
 			});
 		});
 
@@ -137,8 +137,8 @@ describe.windowsBroken('Titanium.Geolocation', () => {
 				should(Ti.Geolocation.allowsBackgroundLocationUpdates).be.true();
 			});
 
-			it('has accessors', () => {
-				should(Ti.Geolocation).have.accessors('allowsBackgroundLocationUpdates');
+			it('has no accessors', () => {
+				should(Ti.Geolocation).not.have.accessors('allowsBackgroundLocationUpdates');
 			});
 		});
 
@@ -153,8 +153,8 @@ describe.windowsBroken('Titanium.Geolocation', () => {
 				should(Ti.Geolocation.distanceFilter).eql(1000);
 			});
 
-			it('has accessors', () => {
-				should(Ti.Geolocation).have.accessors('distanceFilter');
+			it('has no accessors', () => {
+				should(Ti.Geolocation).not.have.accessors('distanceFilter');
 			});
 		});
 
@@ -164,7 +164,7 @@ describe.windowsBroken('Titanium.Geolocation', () => {
 			});
 
 			it('has no getter', () => {
-				should(Ti.Geolocation).have.a.getter('hasCompass');
+				should(Ti.Geolocation).not.have.a.getter('hasCompass');
 			});
 		});
 
@@ -179,8 +179,8 @@ describe.windowsBroken('Titanium.Geolocation', () => {
 				should(Ti.Geolocation.headingFilter).eql(90);
 			});
 
-			it('has accessors', () => {
-				should(Ti.Geolocation).have.accessors('headingFilter');
+			it('has no accessors', () => {
+				should(Ti.Geolocation).not.have.accessors('headingFilter');
 			});
 		});
 
@@ -191,7 +191,7 @@ describe.windowsBroken('Titanium.Geolocation', () => {
 			});
 
 			it('has no getter', () => {
-				should(Ti.Geolocation).have.a.getter('lastGeolocation');
+				should(Ti.Geolocation).not.have.a.getter('lastGeolocation');
 			});
 		});
 
@@ -207,7 +207,7 @@ describe.windowsBroken('Titanium.Geolocation', () => {
 			});
 
 			it('has no getter', () => {
-				should(Ti.Geolocation).have.a.getter('locationServicesAuthorization');
+				should(Ti.Geolocation).not.have.a.getter('locationServicesAuthorization');
 			});
 		});
 
@@ -217,7 +217,7 @@ describe.windowsBroken('Titanium.Geolocation', () => {
 			});
 
 			it('has no getter', () => {
-				should(Ti.Geolocation).have.a.getter('locationServicesEnabled');
+				should(Ti.Geolocation).not.have.a.getter('locationServicesEnabled');
 			});
 		});
 
@@ -235,8 +235,8 @@ describe.windowsBroken('Titanium.Geolocation', () => {
 				should(Ti.Geolocation.pauseLocationUpdateAutomatically).be.true();
 			});
 
-			it('has accessors', () => {
-				should(Ti.Geolocation).have.accessors('pauseLocationUpdateAutomatically');
+			it('has no accessors', () => {
+				should(Ti.Geolocation).not.have.accessors('pauseLocationUpdateAutomatically');
 			});
 		});
 
@@ -258,8 +258,8 @@ describe.windowsBroken('Titanium.Geolocation', () => {
 				should(Ti.Geolocation.showBackgroundLocationIndicator).be.true();
 			});
 
-			it('has accessors', () => {
-				should(Ti.Geolocation).have.accessors('showBackgroundLocationIndicator');
+			it('has no accessors', () => {
+				should(Ti.Geolocation).not.have.accessors('showBackgroundLocationIndicator');
 			});
 		});
 
@@ -277,8 +277,8 @@ describe.windowsBroken('Titanium.Geolocation', () => {
 				should(Ti.Geolocation.showCalibration).be.false();
 			});
 
-			it('has accessors', () => {
-				should(Ti.Geolocation).have.accessors('showCalibration');
+			it('has no accessors', () => {
+				should(Ti.Geolocation).not.have.accessors('showCalibration');
 			});
 		});
 
@@ -296,8 +296,8 @@ describe.windowsBroken('Titanium.Geolocation', () => {
 				should(Ti.Geolocation.trackSignificantLocationChange).be.true();
 			});
 
-			it('has accessors', () => {
-				should(Ti.Geolocation).have.accessors('trackSignificantLocationChange');
+			it('has no accessors', () => {
+				should(Ti.Geolocation).not.have.accessors('trackSignificantLocationChange');
 			});
 		});
 	});

--- a/tests/Resources/ti.gesture.test.js
+++ b/tests/Resources/ti.gesture.test.js
@@ -33,7 +33,7 @@ describe('Titanium.Gesture', () => {
 			});
 
 			it('has no getter', () => {
-				should(Ti.Gesture).have.a.getter('landscape');
+				should(Ti.Gesture).not.have.a.getter('landscape');
 			});
 		});
 
@@ -43,7 +43,7 @@ describe('Titanium.Gesture', () => {
 			});
 
 			it('has no getter', () => {
-				should(Ti.Gesture).have.a.getter('orientation');
+				should(Ti.Gesture).not.have.a.getter('orientation');
 			});
 		});
 
@@ -53,7 +53,7 @@ describe('Titanium.Gesture', () => {
 			});
 
 			it('has no getter', () => {
-				should(Ti.Gesture).have.a.getter('portrait');
+				should(Ti.Gesture).not.have.a.getter('portrait');
 			});
 		});
 	});

--- a/tests/Resources/ti.locale.test.js
+++ b/tests/Resources/ti.locale.test.js
@@ -40,7 +40,7 @@ describe('Titanium.Locale', () => {
 			});
 
 			it('has no getter', () => {
-				should(Ti.Locale).have.a.getter('currentCountry');
+				should(Ti.Locale).not.have.a.getter('currentCountry');
 			});
 		});
 
@@ -54,7 +54,7 @@ describe('Titanium.Locale', () => {
 			});
 
 			it('has no getter', () => {
-				should(Ti.Locale).have.a.getter('currentLanguage');
+				should(Ti.Locale).not.have.a.getter('currentLanguage');
 			});
 		});
 
@@ -68,7 +68,7 @@ describe('Titanium.Locale', () => {
 			});
 
 			it('has no getter', () => {
-				should(Ti.Locale).have.a.getter('currentLocale');
+				should(Ti.Locale).not.have.a.getter('currentLocale');
 			});
 		});
 	});

--- a/tests/Resources/ti.media.audioplayer.test.js
+++ b/tests/Resources/ti.media.audioplayer.test.js
@@ -211,8 +211,8 @@ describe('Titanium.Media.AudioPlayer', () => {
 				should(audioPlayer).have.a.property('url').which.is.a.String();
 			});
 
-			it('has accessors', () => {
-				should(audioPlayer).have.accessors('url');
+			it('does not have accessors', () => {
+				should(audioPlayer).not.have.accessors('url');
 			});
 
 			it('re-setting does not crash (TIMOB-26334)', () => {

--- a/tests/Resources/ti.media.audioplayer.test.js
+++ b/tests/Resources/ti.media.audioplayer.test.js
@@ -76,6 +76,12 @@ describe('Titanium.Media.AudioPlayer', () => {
 		// 	});
 		// });
 
+		describe.android('audioSessionId', () => {
+			it('is a Number', () => {
+				should(audioPlayer).have.a.property('audioSessionId').which.is.a.Number();
+			});
+		});
+
 		describe.android('.audioType', () => {
 			it('is a Number', () => {
 				should(audioPlayer).have.a.property('audioType').which.is.a.Number();
@@ -156,11 +162,19 @@ describe('Titanium.Media.AudioPlayer', () => {
 			it('is a Boolean', () => {
 				should(audioPlayer).have.a.property('paused').which.is.a.Boolean();
 			});
+
+			it('does not have accessors', () => {
+				should(audioPlayer).not.have.accessors('paused');
+			});
 		});
 
 		describe('.playing', () => {
 			it('is a Boolean', () => {
 				should(audioPlayer).have.a.readOnlyProperty('playing').which.is.a.Boolean();
+			});
+
+			it('does not have accessors', () => {
+				should(audioPlayer).not.have.accessors('playing');
 			});
 		});
 
@@ -236,33 +250,10 @@ describe('Titanium.Media.AudioPlayer', () => {
 	});
 
 	describe('methods', () => {
+		// FIXME: This should probably be a read-only property!
 		describe.android('#getAudioSessionId', () => {
 			it('is a Function', () => {
 				should(audioPlayer.getAudioSessionId).be.a.Function();
-			});
-		});
-
-		describe.ios('#getPaused', () => {
-			it('is a Function', () => {
-				should(audioPlayer.getPaused).be.a.Function();
-			});
-		});
-
-		describe.ios('#getPlaying', () => {
-			it('is a Function', () => {
-				should(audioPlayer.getPlaying).be.a.Function();
-			});
-		});
-
-		describe.android('#isPaused', () => {
-			it('is a Function', () => {
-				should(audioPlayer.isPaused).be.a.Function();
-			});
-		});
-
-		describe.android('#isPlaying', () => {
-			it('is a Function', () => {
-				should(audioPlayer.isPlaying).be.a.Function();
 			});
 		});
 

--- a/tests/Resources/ti.network.bonjourservice.test.js
+++ b/tests/Resources/ti.network.bonjourservice.test.js
@@ -9,7 +9,7 @@
 'use strict';
 const should = require('./utilities/assertions');
 
-describe.ios('Ti.Network.BonjourService', () => {
+describe.ios('Titanium.Network.BonjourService', () => {
 	const service = Ti.Network.createBonjourService();
 
 	it('.apiName', () => {

--- a/tests/Resources/ti.network.httpclient.test.js
+++ b/tests/Resources/ti.network.httpclient.test.js
@@ -60,9 +60,9 @@ describe('Titanium.Network.HTTPClient', function () {
 			should(xhr.validatesSecureCertificate).be.false();
 		});
 
-		it('has accessors', () => {
+		it('has no accessors', () => {
 			const xhr = Ti.Network.createHTTPClient();
-			should(xhr).have.accessors('validatesSecureCertificate');
+			should(xhr).not.have.accessors('validatesSecureCertificate');
 		});
 	});
 

--- a/tests/Resources/ti.platform.displaycaps.test.js
+++ b/tests/Resources/ti.platform.displaycaps.test.js
@@ -40,7 +40,7 @@ describe('Titanium.Platform.DisplayCaps', () => {
 			});
 
 			it('has no getter', () => {
-				should(Ti.Platform.displayCaps).have.a.getter('density');
+				should(Ti.Platform.displayCaps).not.have.a.getter('density');
 			});
 		});
 
@@ -54,7 +54,7 @@ describe('Titanium.Platform.DisplayCaps', () => {
 			});
 
 			it('has no getter', () => {
-				should(Ti.Platform.displayCaps).have.a.getter('dpi');
+				should(Ti.Platform.displayCaps).not.have.a.getter('dpi');
 			});
 		});
 
@@ -68,7 +68,7 @@ describe('Titanium.Platform.DisplayCaps', () => {
 			});
 
 			it('has no getter', () => {
-				should(Ti.Platform.displayCaps).have.a.getter('logicalDensityFactor');
+				should(Ti.Platform.displayCaps).not.have.a.getter('logicalDensityFactor');
 			});
 		});
 
@@ -82,7 +82,7 @@ describe('Titanium.Platform.DisplayCaps', () => {
 			});
 
 			it('has no getter', () => {
-				should(Ti.Platform.displayCaps).have.a.getter('platformHeight');
+				should(Ti.Platform.displayCaps).not.have.a.getter('platformHeight');
 			});
 		});
 
@@ -96,7 +96,7 @@ describe('Titanium.Platform.DisplayCaps', () => {
 			});
 
 			it('has no getter', () => {
-				should(Ti.Platform.displayCaps).have.a.getter('platformWidth');
+				should(Ti.Platform.displayCaps).not.have.a.getter('platformWidth');
 			});
 		});
 
@@ -110,7 +110,7 @@ describe('Titanium.Platform.DisplayCaps', () => {
 			});
 
 			it('has no getter', () => {
-				should(Ti.Platform.displayCaps).have.a.getter('xdpi');
+				should(Ti.Platform.displayCaps).not.have.a.getter('xdpi');
 			});
 		});
 
@@ -124,7 +124,7 @@ describe('Titanium.Platform.DisplayCaps', () => {
 			});
 
 			it('has no getter', () => {
-				should(Ti.Platform.displayCaps).have.a.getter('ydpi');
+				should(Ti.Platform.displayCaps).not.have.a.getter('ydpi');
 			});
 		});
 	});

--- a/tests/Resources/ti.proxy.test.js
+++ b/tests/Resources/ti.proxy.test.js
@@ -7,26 +7,26 @@
 /* eslint-env titanium, mocha */
 /* eslint no-unused-expressions: "off" */
 'use strict';
-var should = require('./utilities/assertions');
+const should = require('./utilities/assertions');
 
-describe('Ti.Proxy', function () {
-	describe('#hasOwnProperty()', function () {
-		it('should report false for non-existent ownProperty', function () {
-			var label = Ti.UI.createLabel({
+describe('Titanium.Proxy', () => {
+	describe('#hasOwnProperty()', () => {
+		it('should report false for non-existent ownProperty', () => {
+			const label = Ti.UI.createLabel({
 				text: 'Hello World!'
 			});
 			should(label).not.have.ownProperty('madeup');
 		});
 
-		it('should report true for ownProperty set in create* function', function () {
-			var label = Ti.UI.createLabel({
+		it('should report true for ownProperty set in create* function', () => {
+			const label = Ti.UI.createLabel({
 				text: 'Hello World!'
 			});
 			should(label).have.ownProperty('text');
 		});
 
-		it('should report true for custom property set after construction', function () {
-			var label = Ti.UI.createLabel({
+		it('should report true for custom property set after construction', () => {
+			const label = Ti.UI.createLabel({
 				text: 'Hello World!'
 			});
 			should(label).not.have.ownProperty('madeup');
@@ -35,31 +35,30 @@ describe('Ti.Proxy', function () {
 		});
 	});
 
-	describe('#getOwnPropertyDescriptor()', function () {
-		it('should return undefined for non-existent property', function () {
-			var label = Ti.UI.createLabel({
-					text: 'Hello World!'
-				}),
-				desc = Object.getOwnPropertyDescriptor(label, 'madeup');
+	describe('#getOwnPropertyDescriptor()', () => {
+		it('should return undefined for non-existent property', () => {
+			const label = Ti.UI.createLabel({
+				text: 'Hello World!'
+			});
+			const desc = Object.getOwnPropertyDescriptor(label, 'madeup');
 			should(desc).not.be.ok(); // FIXME: We get null on iOS, according to spec we should get undefined!
 		});
 
-		it('should report descriptor for ownProperty set in create* function', function () {
-			var label = Ti.UI.createLabel({
-					text: 'Hello World!'
-				}),
-				desc = Object.getOwnPropertyDescriptor(label, 'text');
+		it('should report descriptor for ownProperty set in create* function', () => {
+			const label = Ti.UI.createLabel({
+				text: 'Hello World!'
+			});
+			const desc = Object.getOwnPropertyDescriptor(label, 'text');
 			// iOS gives: {"value":"Hello World!","writable":false,"enumerable":false,"configurable":true}
 			desc.value.should.eql('Hello World!');
 		});
 
-		it('should report descriptor for custom property set after construction', function () {
-			var label = Ti.UI.createLabel({
-					text: 'Hello World!'
-				}),
-				desc;
+		it('should report descriptor for custom property set after construction', () => {
+			const label = Ti.UI.createLabel({
+				text: 'Hello World!'
+			});
 			label.madeup = 123;
-			desc = Object.getOwnPropertyDescriptor(label, 'madeup');
+			const desc = Object.getOwnPropertyDescriptor(label, 'madeup');
 			desc.value.should.eql(123);
 			// iOS gives: {"value":123,"writable":false,"enumerable":false,"configurable":true}
 			// What do we expect in terms of those properties?

--- a/tests/Resources/ti.test.js
+++ b/tests/Resources/ti.test.js
@@ -21,8 +21,8 @@ describe('Titanium', () => {
 				should(Ti.apiName).be.eql('Ti');
 			});
 
-			it('has a getter', () => {
-				should(Ti).have.a.getter('apiName');
+			it('has no getter', () => {
+				should(Ti).not.have.a.getter('apiName');
 			});
 		});
 
@@ -38,8 +38,8 @@ describe('Titanium', () => {
 				should(Ti.version).eql(Ti.App.Properties.getString('Ti.version'));
 			});
 
-			it('has a getter', () => {
-				should(Ti).have.a.getter('version');
+			it('has no getter', () => {
+				should(Ti).not.have.a.getter('version');
 			});
 		});
 
@@ -53,8 +53,8 @@ describe('Titanium', () => {
 				should(Ti.buildDate).match(/[01]?\d\/[0123]?\d\/20\d{2} \d{2}:\d{2}/); // i.e. '4/14/2020 18:48'
 			});
 
-			it('has a getter', () => {
-				should(Ti).have.a.getter('buildDate');
+			it('has no getter', () => {
+				should(Ti).not.have.a.getter('buildDate');
 			});
 		});
 
@@ -68,8 +68,8 @@ describe('Titanium', () => {
 				should(Ti.buildHash).match(/[a-f0-9]{10}/); // 10-character git sha
 			});
 
-			it('has a getter', () => {
-				should(Ti).have.a.getter('buildHash');
+			it('has no getter', () => {
+				should(Ti).not.have.a.getter('buildHash');
 			});
 		});
 
@@ -87,8 +87,8 @@ describe('Titanium', () => {
 				should(Ti.userAgent).be.eql(save);
 			});
 
-			it.androidBroken('has accessors', () => { // Cannot read property '_hasJavaListener' of undefined
-				should(Ti).have.accessors('userAgent');
+			it.androidBroken('has no accessors', () => { // Cannot read property '_hasJavaListener' of undefined
+				should(Ti).not.have.accessors('userAgent');
 			});
 		});
 	});

--- a/tests/Resources/ti.ui.activityindicator.test.js
+++ b/tests/Resources/ti.ui.activityindicator.test.js
@@ -28,11 +28,11 @@ describe('Titanium.UI.ActivityIndicator', () => {
 			should(activityIndicator.color).eql('#000');
 		});
 
-		it('has accessors', () => {
+		it('has no accessors', () => {
 			const activityIndicator = Ti.UI.createActivityIndicator({
 				color: '#fff'
 			});
-			should(activityIndicator).have.accessors('color');
+			should(activityIndicator).not.have.accessors('color');
 		});
 	});
 
@@ -55,14 +55,14 @@ describe('Titanium.UI.ActivityIndicator', () => {
 			should(activityIndicator.font.fontFamily).eql('Segoe UI Semilight');
 		});
 
-		it('has accessors', () => {
+		it('has no accessors', () => {
 			const activityIndicator = Ti.UI.createActivityIndicator({
 				font: {
 					fontSize: 24,
 					fontFamily: 'Segoe UI'
 				}
 			});
-			should(activityIndicator).have.accessors('font');
+			should(activityIndicator).not.have.accessors('font');
 		});
 	});
 
@@ -77,11 +77,11 @@ describe('Titanium.UI.ActivityIndicator', () => {
 			should(activityIndicator.message).eql('other text');
 		});
 
-		it('has accessors', () => {
+		it('has no accessors', () => {
 			const activityIndicator = Ti.UI.createActivityIndicator({
 				message: 'this is some text'
 			});
-			should(activityIndicator).have.accessors('message');
+			should(activityIndicator).not.have.accessors('message');
 		});
 	});
 
@@ -96,11 +96,11 @@ describe('Titanium.UI.ActivityIndicator', () => {
 			should(activityIndicator.style).eql(Ti.UI.ActivityIndicatorStyle.DARK);
 		});
 
-		it('has accessors', () => {
+		it('has no accessors', () => {
 			const activityIndicator = Ti.UI.createActivityIndicator({
 				style: Ti.UI.ActivityIndicatorStyle.BIG
 			});
-			should(activityIndicator).have.accessors('style');
+			should(activityIndicator).not.have.accessors('style');
 		});
 	});
 
@@ -115,11 +115,11 @@ describe('Titanium.UI.ActivityIndicator', () => {
 			should(activityIndicator.indicatorColor).eql('#000');
 		});
 
-		it('has accessors', () => {
+		it('has no accessors', () => {
 			const activityIndicator = Ti.UI.createActivityIndicator({
 				indicatorColor: '#fff'
 			});
-			should(activityIndicator).have.accessors('indicatorColor');
+			should(activityIndicator).not.have.accessors('indicatorColor');
 		});
 	});
 });

--- a/tests/Resources/ti.ui.alertdialog.test.js
+++ b/tests/Resources/ti.ui.alertdialog.test.js
@@ -27,11 +27,11 @@ describe('Titanium.UI.AlertDialog', () => {
 			should(bar.title).eql('other text');
 		});
 
-		it('has accessors', () => {
+		it('has no accessors', () => {
 			const bar = Ti.UI.createAlertDialog({
 				title: 'this is some text'
 			});
-			should(bar).have.accessors('title');
+			should(bar).not.have.accessors('title');
 		});
 	});
 
@@ -49,11 +49,11 @@ describe('Titanium.UI.AlertDialog', () => {
 			should(bar.title).eql('this is my value'); // retains old value if key not found: https://jira.appcelerator.org/browse/TIMOB-23498
 		});
 
-		it('has accessors', () => {
+		it('has no accessors', () => {
 			const bar = Ti.UI.createAlertDialog({
 				title: 'this is some text'
 			});
-			should(bar).have.accessors('titleid');
+			should(bar).not.have.accessors('titleid');
 		});
 	});
 
@@ -68,11 +68,11 @@ describe('Titanium.UI.AlertDialog', () => {
 			should(bar.message).eql('other text');
 		});
 
-		it('has accessors', () => {
+		it('has no accessors', () => {
 			const bar = Ti.UI.createAlertDialog({
 				message: 'this is some text'
 			});
-			should(bar).have.accessors('message');
+			should(bar).not.have.accessors('message');
 		});
 	});
 
@@ -87,9 +87,9 @@ describe('Titanium.UI.AlertDialog', () => {
 			should(bar.buttonNames.length).eql(2);
 		});
 
-		it('has accessors', () => {
+		it('has no accessors', () => {
 			const bar = Ti.UI.createAlertDialog({});
-			should(bar).have.accessors('buttonNames');
+			should(bar).not.have.accessors('buttonNames');
 		});
 	});
 
@@ -103,9 +103,9 @@ describe('Titanium.UI.AlertDialog', () => {
 			should(bar.cancel).eql(1);
 		});
 
-		it('has accessors', () => {
+		it('has no accessors', () => {
 			const bar = Ti.UI.createAlertDialog({});
-			should(bar).have.accessors('cancel');
+			should(bar).not.have.accessors('cancel');
 		});
 	});
 
@@ -123,11 +123,11 @@ describe('Titanium.UI.AlertDialog', () => {
 			should(bar.tintColor).eql('#f00');
 		});
 
-		it('has accessors', () => {
+		it('has no accessors', () => {
 			const bar = Ti.UI.createAlertDialog({
 				tintColor: 'red'
 			});
-			should(bar).have.accessors('tintColor');
+			should(bar).not.have.accessors('tintColor');
 		});
 	});
 });

--- a/tests/Resources/ti.ui.button.test.js
+++ b/tests/Resources/ti.ui.button.test.js
@@ -46,11 +46,11 @@ describe('Titanium.UI.Button', function () {
 			should(button.title).eql('other text');
 		});
 
-		it('has accessors', () => {
+		it('has no accessors', () => {
 			const button = Ti.UI.createButton({
 				title: 'this is some text'
 			});
-			should(button).have.accessors('title');
+			should(button).not.have.accessors('title');
 		});
 	});
 
@@ -68,11 +68,11 @@ describe('Titanium.UI.Button', function () {
 			should(bar.title).eql('this is my value'); // should retain old value if can't find key! https://jira.appcelerator.org/browse/TIMOB-23498
 		});
 
-		it('has accessors', () => {
+		it('has no accessors', () => {
 			const button = Ti.UI.createButton({
 				titleid: 'this_is_my_key'
 			});
-			should(button).have.accessors('titleid');
+			should(button).not.have.accessors('titleid');
 		});
 	});
 

--- a/tests/Resources/ti.ui.emaildialog.test.js
+++ b/tests/Resources/ti.ui.emaildialog.test.js
@@ -51,11 +51,11 @@ describe('Titanium.UI.EmailDialog', () => {
 			should(email.subject).eql('other text');
 		});
 
-		it('has accessors', () => {
+		it('has no accessors', () => {
 			const email = Ti.UI.createEmailDialog({
 				subject: 'this is some text'
 			});
-			should(email).have.accessors('subject');
+			should(email).not.have.accessors('subject');
 		});
 	});
 
@@ -70,11 +70,11 @@ describe('Titanium.UI.EmailDialog', () => {
 			should(email.messageBody).eql('other text');
 		});
 
-		it('has accessors', () => {
+		it('has no accessors', () => {
 			const email = Ti.UI.createEmailDialog({
 				messageBody: 'this is some text'
 			});
-			should(email).have.accessors('messageBody');
+			should(email).not.have.accessors('messageBody');
 		});
 	});
 
@@ -89,11 +89,11 @@ describe('Titanium.UI.EmailDialog', () => {
 			should(email.toRecipients).eql([ 'other@example.com' ]);
 		});
 
-		it('has accessors', () => {
+		it('has no accessors', () => {
 			const email = Ti.UI.createEmailDialog({
 				toRecipients: [ 'me@example.com' ]
 			});
-			should(email).have.accessors('toRecipients');
+			should(email).not.have.accessors('toRecipients');
 		});
 	});
 
@@ -108,11 +108,11 @@ describe('Titanium.UI.EmailDialog', () => {
 			should(email.ccRecipients).eql([ 'other@example.com' ]);
 		});
 
-		it('has accessors', () => {
+		it('has no accessors', () => {
 			const email = Ti.UI.createEmailDialog({
 				ccRecipients: [ 'me@example.com' ]
 			});
-			should(email).have.accessors('ccRecipients');
+			should(email).not.have.accessors('ccRecipients');
 		});
 	});
 
@@ -127,11 +127,11 @@ describe('Titanium.UI.EmailDialog', () => {
 			should(email.bccRecipients).eql([ 'other@example.com' ]);
 		});
 
-		it('has accessors', () => {
+		it('has no accessors', () => {
 			const email = Ti.UI.createEmailDialog({
 				bccRecipients: [ 'me@example.com' ]
 			});
-			should(email).have.accessors('bccRecipients');
+			should(email).not.have.accessors('bccRecipients');
 		});
 	});
 

--- a/tests/Resources/ti.ui.imageview.test.js
+++ b/tests/Resources/ti.ui.imageview.test.js
@@ -35,9 +35,9 @@ describe('Titanium.UI.ImageView', function () {
 	});
 
 	describe('.image', () => {
-		it('has accessors', () => {
+		it('has no accessors', () => {
 			const imageView = Ti.UI.createImageView({});
-			should(imageView).have.accessors('image');
+			should(imageView).not.have.accessors('image');
 		});
 
 		it('with an URL', () => {

--- a/tests/Resources/ti.ui.ios.stepper.test.js
+++ b/tests/Resources/ti.ui.ios.stepper.test.js
@@ -41,14 +41,14 @@ describe.ios('Titanium.UI.iOS.Stepper', () => {
 			should(stepper.value).be.eql(30);
 		});
 
-		it('has accessors', () => {
+		it('has no accessors', () => {
 			const stepper = Ti.UI.iOS.createStepper({
 				steps: 3,
 				maximum: 30,
 				minimum: 0,
 				value: 20
 			});
-			should(stepper).have.accessors('value');
+			should(stepper).not.have.accessors('value');
 		});
 	});
 });

--- a/tests/Resources/ti.ui.label.test.js
+++ b/tests/Resources/ti.ui.label.test.js
@@ -46,12 +46,12 @@ describe('Titanium.UI.Label', function () {
 			should(label.maxLines).eql(1);
 		});
 
-		it('has accessors', () => {
+		it('has no accessors', () => {
 			const label = Ti.UI.createLabel({
 				text: 'This is a label with propably more than three lines of text. The quick brown fox jumps over the lazy dog. The quick brown fox jumps over the lazy dog.',
 				maxLines: 2
 			});
-			should(label).have.accessors('maxLines');
+			should(label).not.have.accessors('maxLines');
 		});
 
 		// Tests if "maxLines" correctly truncates strings with '\n' characters.
@@ -99,11 +99,11 @@ describe('Titanium.UI.Label', function () {
 			should(label.text).eql('other text');
 		});
 
-		it('has accessors', () => {
+		it('has no accessors', () => {
 			const label = Ti.UI.createLabel({
 				text: 'this is some text'
 			});
-			should(label).have.accessors('text');
+			should(label).not.have.accessors('text');
 		});
 	});
 
@@ -120,11 +120,11 @@ describe('Titanium.UI.Label', function () {
 			should(label.text).eql('this is my value'); // Windows issue
 		});
 
-		it('has accessors', () => {
+		it('has no accessors', () => {
 			const label = Ti.UI.createLabel({
 				textid: 'this_is_my_key'
 			});
-			should(label).have.accessors('textid');
+			should(label).not.have.accessors('textid');
 		});
 	});
 
@@ -150,12 +150,12 @@ describe('Titanium.UI.Label', function () {
 			}
 		});
 
-		it('has accessors', () => {
+		it('has no accessors', () => {
 			const label = Ti.UI.createLabel({
 				text: 'this is some text',
 				textAlign: Ti.UI.TEXT_ALIGNMENT_CENTER
 			});
-			should(label).have.accessors('textAlign');
+			should(label).not.have.accessors('textAlign');
 		});
 	});
 
@@ -175,12 +175,12 @@ describe('Titanium.UI.Label', function () {
 			should(label.verticalAlign).eql(Ti.UI.TEXT_VERTICAL_ALIGNMENT_TOP);
 		});
 
-		it('has accessors', () => {
+		it('has no accessors', () => {
 			const label = Ti.UI.createLabel({
 				text: 'this is some text',
 				verticalAlign: Ti.UI.TEXT_VERTICAL_ALIGNMENT_BOTTOM
 			});
-			should(label).have.accessors('verticalAlign');
+			should(label).not.have.accessors('verticalAlign');
 		});
 	});
 
@@ -197,11 +197,11 @@ describe('Titanium.UI.Label', function () {
 			should(label.ellipsize).eql(Ti.UI.TEXT_ELLIPSIZE_TRUNCATE_MIDDLE);
 		});
 
-		it('has accessors', () => {
+		it('has no accessors', () => {
 			const label = Ti.UI.createLabel({
 				text: 'this is some text'
 			});
-			should(label).have.accessors('ellipsize');
+			should(label).not.have.accessors('ellipsize');
 		});
 	});
 
@@ -313,7 +313,7 @@ describe('Titanium.UI.Label', function () {
 			should(label.minimumFontSize).eql(22);
 		});
 
-		it('has accessors', () => {
+		it('has no accessors', () => {
 			const label = Ti.UI.createLabel({
 				text: 'this is some text',
 				textAlign: 'left',
@@ -326,7 +326,7 @@ describe('Titanium.UI.Label', function () {
 				minimumFontSize: 28,
 				height: 50
 			});
-			should(label).have.accessors('minimumFontSize');
+			should(label).not.have.accessors('minimumFontSize');
 		});
 	});
 

--- a/tests/Resources/ti.ui.listview.test.js
+++ b/tests/Resources/ti.ui.listview.test.js
@@ -123,8 +123,8 @@ describe('Titanium.UI.ListView', function () {
 				should(list.allowsMultipleSelectionDuringEditing).be.false();
 			});
 
-			it('has accessors', () => {
-				should(list).have.accessors('allowsMultipleSelectionDuringEditing');
+			it('has no accessors', () => {
+				should(list).not.have.accessors('allowsMultipleSelectionDuringEditing');
 			});
 
 			it('lifecycle', function (finish) {

--- a/tests/Resources/ti.ui.optiondialog.test.js
+++ b/tests/Resources/ti.ui.optiondialog.test.js
@@ -44,8 +44,8 @@ describe('Titanium.UI.OptionDialog', () => {
 				should(dialog.buttonNames.length).eql(2);
 			});
 
-			it('has accessors', () => {
-				should(dialog).have.accessors('buttonNames');
+			it('has no accessors', () => {
+				should(dialog).not.have.accessors('buttonNames');
 			});
 		});
 
@@ -68,8 +68,8 @@ describe('Titanium.UI.OptionDialog', () => {
 				should(dialog.cancel).eql(1);
 			});
 
-			it('has accessors', () => {
-				should(dialog).have.accessors('cancel');
+			it('has no accessors', () => {
+				should(dialog).not.have.accessors('cancel');
 			});
 		});
 
@@ -96,8 +96,8 @@ describe('Titanium.UI.OptionDialog', () => {
 				should(dialog.options.length).eql(2);
 			});
 
-			it('has accessors', () => {
-				should(dialog).have.accessors('options');
+			it('has no accessors', () => {
+				should(dialog).not.have.accessors('options');
 			});
 		});
 
@@ -123,8 +123,8 @@ describe('Titanium.UI.OptionDialog', () => {
 				should(dialog.persistent).be.false();
 			});
 
-			it('has accessors', () => {
-				should(dialog).have.accessors('persistent');
+			it('has no accessors', () => {
+				should(dialog).not.have.accessors('persistent');
 			});
 		});
 
@@ -146,8 +146,8 @@ describe('Titanium.UI.OptionDialog', () => {
 				should(dialog.selectedIndex).eql(1);
 			});
 
-			it('has accessors', () => {
-				should(dialog).have.accessors('selectedIndex');
+			it('has no accessors', () => {
+				should(dialog).not.have.accessors('selectedIndex');
 			});
 		});
 
@@ -172,8 +172,8 @@ describe('Titanium.UI.OptionDialog', () => {
 				should(dialog.title).eql('other text');
 			});
 
-			it('has accessors', () => {
-				should(dialog).have.accessors('title');
+			it('has no accessors', () => {
+				should(dialog).not.have.accessors('title');
 			});
 		});
 
@@ -203,8 +203,8 @@ describe('Titanium.UI.OptionDialog', () => {
 				// should(dialog.title).eql('this is my value'); // broken on iOS
 			});
 
-			it('has accessors', () => {
-				should(dialog).have.accessors('titleid');
+			it('has no accessors', () => {
+				should(dialog).not.have.accessors('titleid');
 			});
 		});
 	});

--- a/tests/Resources/ti.ui.progressbar.test.js
+++ b/tests/Resources/ti.ui.progressbar.test.js
@@ -51,8 +51,8 @@ describe('Titanium.UI.ProgressBar', () => {
 				should(bar.color).eql('blue');
 			});
 
-			it('has accessors', () => {
-				should(bar).have.accessors('color');
+			it('has no accessors', () => {
+				should(bar).not.have.accessors('color');
 			});
 		});
 
@@ -71,8 +71,8 @@ describe('Titanium.UI.ProgressBar', () => {
 				should(bar).have.a.property('font').which.is.an.Object();
 			});
 
-			it('has accessors', () => {
-				should(bar).have.accessors('font');
+			it('has no accessors', () => {
+				should(bar).not.have.accessors('font');
 			});
 		});
 
@@ -96,8 +96,8 @@ describe('Titanium.UI.ProgressBar', () => {
 				should(bar.max).eql(100);
 			});
 
-			it('has accessors', () => {
-				should(bar).have.accessors('max');
+			it('has no accessors', () => {
+				should(bar).not.have.accessors('max');
 			});
 		});
 
@@ -121,8 +121,8 @@ describe('Titanium.UI.ProgressBar', () => {
 				should(bar.message).eql('other text');
 			});
 
-			it('has accessors', () => {
-				should(bar).have.accessors('message');
+			it('has no accessors', () => {
+				should(bar).not.have.accessors('message');
 			});
 		});
 
@@ -146,8 +146,8 @@ describe('Titanium.UI.ProgressBar', () => {
 				should(bar.min).eql(100);
 			});
 
-			it('has accessors', () => {
-				should(bar).have.accessors('min');
+			it('has no accessors', () => {
+				should(bar).not.have.accessors('min');
 			});
 		});
 
@@ -169,8 +169,8 @@ describe('Titanium.UI.ProgressBar', () => {
 				should(bar.style).eql(Ti.UI.iOS.ProgressBarStyle.PLAIN);
 			});
 
-			it('has accessors', () => {
-				should(bar).have.accessors('style');
+			it('has no accessors', () => {
+				should(bar).not.have.accessors('style');
 			});
 		});
 
@@ -192,8 +192,8 @@ describe('Titanium.UI.ProgressBar', () => {
 				should(bar.tintColor).eql('blue');
 			});
 
-			it('has accessors', () => {
-				should(bar).have.accessors('tintColor');
+			it('has no accessors', () => {
+				should(bar).not.have.accessors('tintColor');
 			});
 		});
 
@@ -215,8 +215,8 @@ describe('Titanium.UI.ProgressBar', () => {
 				should(bar.trackTintColor).eql('blue');
 			});
 
-			it('has accessors', () => {
-				should(bar).have.accessors('trackTintColor');
+			it('has no accessors', () => {
+				should(bar).not.have.accessors('trackTintColor');
 			});
 		});
 
@@ -238,8 +238,8 @@ describe('Titanium.UI.ProgressBar', () => {
 				should(bar.value).eql(100);
 			});
 
-			it('has accessors', () => {
-				should(bar).have.accessors('value');
+			it('has no accessors', () => {
+				should(bar).not.have.accessors('value');
 			});
 		});
 	});

--- a/tests/Resources/ti.ui.scrollableview.test.js
+++ b/tests/Resources/ti.ui.scrollableview.test.js
@@ -64,8 +64,8 @@ describe('Titanium.UI.ScrollableView', () => {
 				should(scrollableView.clipViews).be.false();
 			});
 
-			it('has accessors', () => {
-				should(scrollableView).have.accessors('clipViews');
+			it('has no accessors', () => {
+				should(scrollableView).not.have.accessors('clipViews');
 			});
 
 			it('lifecycle', function (finish) {
@@ -112,8 +112,8 @@ describe('Titanium.UI.ScrollableView', () => {
 				should(scrollableView.currentPage).eql(1); // Android gives 0
 			});
 
-			it('has accessors', () => {
-				should(scrollableView).have.accessors('currentPage');
+			it('has no accessors', () => {
+				should(scrollableView).not.have.accessors('currentPage');
 			});
 		});
 
@@ -138,8 +138,8 @@ describe('Titanium.UI.ScrollableView', () => {
 				should(scrollableView.padding).eql({ left: 10, right: 10 });
 			});
 
-			it('has accessors', () => {
-				should(scrollableView).have.accessors('padding');
+			it('has no accessors', () => {
+				should(scrollableView).not.have.accessors('padding');
 			});
 
 			it('lifecycle', function (finish) {
@@ -224,8 +224,8 @@ describe('Titanium.UI.ScrollableView', () => {
 				should(scrollableView.views.length).eql(2);
 			});
 
-			it('has accessors', () => {
-				should(scrollableView).have.accessors('views');
+			it('has no accessors', () => {
+				should(scrollableView).not.have.accessors('views');
 			});
 		});
 	});

--- a/tests/Resources/ti.ui.searchbar.test.js
+++ b/tests/Resources/ti.ui.searchbar.test.js
@@ -48,8 +48,8 @@ describe('Titanium.UI.SearchBar', () => {
 				should(searchBar.autocapitalization).eql(Ti.UI.TEXT_AUTOCAPITALIZATION_SENTENCES);
 			});
 
-			it('has accessors', () => {
-				should(searchBar).have.accessors('autocapitalization');
+			it('has no accessors', () => {
+				should(searchBar).not.have.accessors('autocapitalization');
 			});
 		});
 
@@ -74,8 +74,8 @@ describe('Titanium.UI.SearchBar', () => {
 				should(searchBar.autocorrect).be.false();
 			});
 
-			it('has accessors', () => {
-				should(searchBar).have.accessors('autocorrect');
+			it('has no accessors', () => {
+				should(searchBar).not.have.accessors('autocorrect');
 			});
 		});
 
@@ -100,8 +100,8 @@ describe('Titanium.UI.SearchBar', () => {
 				should(searchBar.color).eql('blue');
 			});
 
-			it('has accessors', () => {
-				should(searchBar).have.accessors('color');
+			it('has no accessors', () => {
+				should(searchBar).not.have.accessors('color');
 			});
 		});
 
@@ -184,8 +184,8 @@ describe('Titanium.UI.SearchBar', () => {
 				should(searchBar.hintText).eql('Updated search');
 			});
 
-			it('has accessors', () => {
-				should(searchBar).have.accessors('hintText');
+			it('has no accessors', () => {
+				should(searchBar).not.have.accessors('hintText');
 			});
 
 			it('change dynamically', function (finish) {
@@ -243,8 +243,8 @@ describe('Titanium.UI.SearchBar', () => {
 				should(searchBar.hintTextColor).eql('blue');
 			});
 
-			it('has accessors', () => {
-				should(searchBar).have.accessors('hintTextColor');
+			it('has no accessors', () => {
+				should(searchBar).not.have.accessors('hintTextColor');
 			});
 		});
 
@@ -269,8 +269,8 @@ describe('Titanium.UI.SearchBar', () => {
 				should(searchBar.keyboardAppearance).eql(Ti.UI.KEYBOARD_APPEARANCE_DARK);
 			});
 
-			it('has accessors', () => {
-				should(searchBar).have.accessors('keyboardAppearance');
+			it('has no accessors', () => {
+				should(searchBar).not.have.accessors('keyboardAppearance');
 			});
 		});
 
@@ -295,8 +295,8 @@ describe('Titanium.UI.SearchBar', () => {
 				should(searchBar.keyboardType).eql(Ti.UI.KEYBOARD_TYPE_EMAIL);
 			});
 
-			it('has accessors', () => {
-				should(searchBar).have.accessors('keyboardType');
+			it('has no accessors', () => {
+				should(searchBar).not.have.accessors('keyboardType');
 			});
 		});
 
@@ -321,8 +321,8 @@ describe('Titanium.UI.SearchBar', () => {
 				should(searchBar.prompt).eql('another value');
 			});
 
-			it('has accessors', () => {
-				should(searchBar).have.accessors('prompt');
+			it('has no accessors', () => {
+				should(searchBar).not.have.accessors('prompt');
 			});
 		});
 
@@ -347,8 +347,8 @@ describe('Titanium.UI.SearchBar', () => {
 				should(searchBar.showBookmark).be.false();
 			});
 
-			it('has accessors', () => {
-				should(searchBar).have.accessors('showBookmark');
+			it('has no accessors', () => {
+				should(searchBar).not.have.accessors('showBookmark');
 			});
 		});
 
@@ -373,8 +373,8 @@ describe('Titanium.UI.SearchBar', () => {
 				should(searchBar.style).eql(Ti.UI.iOS.SEARCH_BAR_STYLE_MINIMAL);
 			});
 
-			it('has accessors', () => {
-				should(searchBar).have.accessors('style');
+			it('has no accessors', () => {
+				should(searchBar).not.have.accessors('style');
 			});
 		});
 	});

--- a/tests/Resources/ti.ui.tab.test.js
+++ b/tests/Resources/ti.ui.tab.test.js
@@ -33,8 +33,8 @@ describe('Titanium.UI.Tab', () => {
 				should(tab.activeTintColor).eql('blue');
 			});
 
-			it('has accessors', () => {
-				should(tab).have.accessors('activeTintColor');
+			it('has no accessors', () => {
+				should(tab).not.have.accessors('activeTintColor');
 			});
 		});
 
@@ -59,8 +59,8 @@ describe('Titanium.UI.Tab', () => {
 				should(tab.activeTitleColor).eql('blue');
 			});
 
-			it('has accessors', () => {
-				should(tab).have.accessors('activeTitleColor');
+			it('has no accessors', () => {
+				should(tab).not.have.accessors('activeTitleColor');
 			});
 		});
 
@@ -99,8 +99,8 @@ describe('Titanium.UI.Tab', () => {
 				should(tab.badge).eql(2);
 			});
 
-			it('has accessors', () => {
-				should(tab).have.accessors('badge');
+			it('has no accessors', () => {
+				should(tab).not.have.accessors('badge');
 			});
 		});
 
@@ -126,8 +126,8 @@ describe('Titanium.UI.Tab', () => {
 				should(tab.badgeColor).eql('blue');
 			});
 
-			it('has accessors', () => {
-				should(tab).have.accessors('badgeColor');
+			it('has no accessors', () => {
+				should(tab).not.have.accessors('badgeColor');
 			});
 		});
 
@@ -152,8 +152,8 @@ describe('Titanium.UI.Tab', () => {
 				should(tab.tintColor).eql('blue');
 			});
 
-			it('has accessors', () => {
-				should(tab).have.accessors('tintColor');
+			it('has no accessors', () => {
+				should(tab).not.have.accessors('tintColor');
 			});
 		});
 
@@ -178,8 +178,8 @@ describe('Titanium.UI.Tab', () => {
 				should(tab.title).eql('other text');
 			});
 
-			it('has accessors', () => {
-				should(tab).have.accessors('title');
+			it('has no accessors', () => {
+				should(tab).not.have.accessors('title');
 			});
 		});
 
@@ -209,8 +209,8 @@ describe('Titanium.UI.Tab', () => {
 				should(tab.title).eql('this is my value');
 			});
 
-			it('has accessors', () => {
-				should(tab).have.accessors('titleid');
+			it('has no accessors', () => {
+				should(tab).not.have.accessors('titleid');
 			});
 		});
 
@@ -235,8 +235,8 @@ describe('Titanium.UI.Tab', () => {
 				should(tab.titleColor).eql('blue');
 			});
 
-			it('has accessors', () => {
-				should(tab).have.accessors('titleColor');
+			it('has no accessors', () => {
+				should(tab).not.have.accessors('titleColor');
 			});
 		});
 	});

--- a/tests/Resources/ti.ui.tabgroup.test.js
+++ b/tests/Resources/ti.ui.tabgroup.test.js
@@ -151,8 +151,8 @@ describe('Titanium.UI.TabGroup', function () {
 				should(tabGroup.activeTintColor).eql('blue');
 			});
 
-			it.androidBroken('has accessors', () => { // Windows are created during open
-				should(tabGroup).have.accessors('activeTintColor');
+			it.androidBroken('has no accessors', () => { // Windows are created during open
+				should(tabGroup).not.have.accessors('activeTintColor');
 			});
 		});
 
@@ -174,8 +174,8 @@ describe('Titanium.UI.TabGroup', function () {
 				should(tabGroup.allowUserCustomization).be.false();
 			});
 
-			it('has accessors', () => {
-				should(tabGroup).have.accessors('allowUserCustomization');
+			it('has no accessors', () => {
+				should(tabGroup).not.have.accessors('allowUserCustomization');
 			});
 		});
 
@@ -200,8 +200,8 @@ describe('Titanium.UI.TabGroup', function () {
 				should(tabGroup.barColor).eql('blue');
 			});
 
-			it.androidBroken('has accessors', () => { // Windows are created during open
-				should(tabGroup).have.accessors('barColor');
+			it.androidBroken('has no accessors', () => { // Windows are created during open
+				should(tabGroup).not.have.accessors('barColor');
 			});
 		});
 
@@ -230,8 +230,8 @@ describe('Titanium.UI.TabGroup', function () {
 				should(tabGroup.tabs).eql([ tabA, tabB ]);
 			});
 
-			it.androidBroken('has accessors', () => { // Windows are created during open
-				should(tabGroup).have.accessors('barColor');
+			it.androidBroken('has no accessors', () => { // Windows are created during open
+				should(tabGroup).not.have.accessors('barColor');
 			});
 
 			it('#addTab() and #removeTab() affect value', () => {
@@ -266,8 +266,8 @@ describe('Titanium.UI.TabGroup', function () {
 				should(tabGroup.tabsTranslucent).be.false();
 			});
 
-			it('has accessors', () => {
-				should(tabGroup).have.accessors('tabsTranslucent');
+			it('has no accessors', () => {
+				should(tabGroup).not.have.accessors('tabsTranslucent');
 			});
 		});
 
@@ -292,8 +292,8 @@ describe('Titanium.UI.TabGroup', function () {
 				should(tabGroup.tintColor).eql('blue');
 			});
 
-			it.androidBroken('has accessors', () => { // Windows are created during open
-				should(tabGroup).have.accessors('tintColor');
+			it.androidBroken('has no accessors', () => { // Windows are created during open
+				should(tabGroup).not.have.accessors('tintColor');
 			});
 		});
 
@@ -312,9 +312,9 @@ describe('Titanium.UI.TabGroup', function () {
 				should(tabGroup.title).eql('My title'); // null on Android!
 			});
 
-			it('has accessors', () => {
+			it('has no accessors', () => {
 				tabGroup = Ti.UI.createTabGroup();
-				should(tabGroup).have.accessors('title');
+				should(tabGroup).not.have.accessors('title');
 			});
 
 			it('assign after drawing the TabGroup', () => {

--- a/tests/Resources/ti.ui.textarea.test.js
+++ b/tests/Resources/ti.ui.textarea.test.js
@@ -61,8 +61,8 @@ describe('Titanium.UI.TextArea', () => {
 				should(textArea.backgroundColor).eql('blue');
 			});
 
-			it('has accessors', () => {
-				should(textArea).have.accessors('backgroundColor');
+			it('has no accessors', () => {
+				should(textArea).not.have.accessors('backgroundColor');
 			});
 		});
 
@@ -85,8 +85,8 @@ describe('Titanium.UI.TextArea', () => {
 				should(textArea.editable).be.false();
 			});
 
-			it('has accessors', () => {
-				should(textArea).have.accessors('editable');
+			it('has no accessors', () => {
+				should(textArea).not.have.accessors('editable');
 			});
 		});
 
@@ -156,8 +156,8 @@ describe('Titanium.UI.TextArea', () => {
 				should(textArea.lines).eql(2);
 			});
 
-			it('has accessors', () => {
-				should(textArea).have.accessors('lines');
+			it('has no accessors', () => {
+				should(textArea).not.have.accessors('lines');
 			});
 		});
 
@@ -183,8 +183,8 @@ describe('Titanium.UI.TextArea', () => {
 				should(textArea.maxLines).eql(6);
 			});
 
-			it('has accessors', () => {
-				should(textArea).have.accessors('maxLines');
+			it('has no accessors', () => {
+				should(textArea).not.have.accessors('maxLines');
 			});
 		});
 
@@ -219,8 +219,8 @@ describe('Titanium.UI.TextArea', () => {
 				should(textArea.padding.right).eql(10);
 			});
 
-			it('has accessors', () => {
-				should(textArea).have.accessors('padding');
+			it('has no accessors', () => {
+				should(textArea).not.have.accessors('padding');
 			});
 		});
 
@@ -243,8 +243,8 @@ describe('Titanium.UI.TextArea', () => {
 				should(textArea.scrollsToTop).be.false();
 			});
 
-			it('has accessors', () => {
-				should(textArea).have.accessors('scrollsToTop');
+			it('has no accessors', () => {
+				should(textArea).not.have.accessors('scrollsToTop');
 			});
 		});
 
@@ -277,8 +277,8 @@ describe('Titanium.UI.TextArea', () => {
 				should(textArea.textAlign).eql(Titanium.UI.TEXT_ALIGNMENT_RIGHT);
 			});
 
-			it('has accessors', () => {
-				should(textArea).have.accessors('textAlign');
+			it('has no accessors', () => {
+				should(textArea).not.have.accessors('textAlign');
 			});
 		});
 
@@ -303,8 +303,8 @@ describe('Titanium.UI.TextArea', () => {
 				should(textArea.value).eql('other text');
 			});
 
-			it('has accessors', () => {
-				should(textArea).have.accessors('value');
+			it('has no accessors', () => {
+				should(textArea).not.have.accessors('value');
 			});
 		});
 
@@ -331,8 +331,8 @@ describe('Titanium.UI.TextArea', () => {
 				should(textArea.verticalAlign).eql(Titanium.UI.TEXT_VERTICAL_ALIGNMENT_TOP);
 			});
 
-			it('has accessors', () => {
-				should(textArea).have.accessors('verticalAlign');
+			it('has no accessors', () => {
+				should(textArea).not.have.accessors('verticalAlign');
 			});
 		});
 	});

--- a/tests/Resources/ti.ui.textfield.test.js
+++ b/tests/Resources/ti.ui.textfield.test.js
@@ -131,8 +131,8 @@ describe('Titanium.UI.TextField', () => {
 				should(textField.hintText).eql('Enter Name ...');
 			});
 
-			it('has accessors', () => {
-				should(textField).have.accessors('hintText');
+			it('has no accessors', () => {
+				should(textField).not.have.accessors('hintText');
 			});
 		});
 
@@ -158,8 +158,8 @@ describe('Titanium.UI.TextField', () => {
 				should(textField.hintTextColor).eql('blue');
 			});
 
-			it('has accessors', () => {
-				should(textField).have.accessors('hintTextColor');
+			it('has no accessors', () => {
+				should(textField).not.have.accessors('hintTextColor');
 			});
 		});
 
@@ -185,8 +185,8 @@ describe('Titanium.UI.TextField', () => {
 				should(textField.hintType).eql(Ti.UI.HINT_TYPE_STATIC);
 			});
 
-			it('has accessors', () => {
-				should(textField).have.accessors('hintType');
+			it('has no accessors', () => {
+				should(textField).not.have.accessors('hintType');
 			});
 		});
 
@@ -222,8 +222,8 @@ describe('Titanium.UI.TextField', () => {
 				should(textField.padding.right).eql(10);
 			});
 
-			it('has accessors', () => {
-				should(textField).have.accessors('padding');
+			it('has no accessors', () => {
+				should(textField).not.have.accessors('padding');
 			});
 		});
 
@@ -276,8 +276,8 @@ describe('Titanium.UI.TextField', () => {
 				should(textField.textAlign).eql(Titanium.UI.TEXT_ALIGNMENT_RIGHT);
 			});
 
-			it('has accessors', () => {
-				should(textField).have.accessors('textAlign');
+			it('has no accessors', () => {
+				should(textField).not.have.accessors('textAlign');
 			});
 		});
 
@@ -302,8 +302,8 @@ describe('Titanium.UI.TextField', () => {
 				should(textField.value).eql('other text');
 			});
 
-			it('has accessors', () => {
-				should(textField).have.accessors('value');
+			it('has no accessors', () => {
+				should(textField).not.have.accessors('value');
 			});
 		});
 
@@ -334,8 +334,8 @@ describe('Titanium.UI.TextField', () => {
 				should(textField.verticalAlign).eql(Titanium.UI.TEXT_VERTICAL_ALIGNMENT_TOP);
 			});
 
-			it('has accessors', () => {
-				should(textField).have.accessors('verticalAlign');
+			it('has no accessors', () => {
+				should(textField).not.have.accessors('verticalAlign');
 			});
 		});
 

--- a/tests/Resources/ti.ui.window.test.js
+++ b/tests/Resources/ti.ui.window.test.js
@@ -115,8 +115,8 @@ describe('Titanium.UI.Window', function () {
 				should(win.hidesBackButton).be.false();
 			});
 
-			it('has accessors', () => {
-				should(win).have.accessors('hidesBackButton');
+			it('has no accessors', () => {
+				should(win).not.have.accessors('hidesBackButton');
 			});
 
 			// TODO: Add snapshot test
@@ -142,8 +142,8 @@ describe('Titanium.UI.Window', function () {
 				should(win.homeIndicatorAutoHidden).be.true();
 			});
 
-			it('has accessors', () => {
-				should(win).have.accessors('homeIndicatorAutoHidden');
+			it('has no accessors', () => {
+				should(win).not.have.accessors('homeIndicatorAutoHidden');
 			});
 		});
 
@@ -168,8 +168,8 @@ describe('Titanium.UI.Window', function () {
 				should(win.largeTitleEnabled).be.false();
 			});
 
-			it('has accessors', () => {
-				should(win).have.accessors('largeTitleEnabled');
+			it('has no accessors', () => {
+				should(win).not.have.accessors('largeTitleEnabled');
 			});
 		});
 
@@ -194,8 +194,8 @@ describe('Titanium.UI.Window', function () {
 				should(win.largeTitleDisplayMode).eql(Ti.UI.iOS.LARGE_TITLE_DISPLAY_MODE_AUTOMATIC);
 			});
 
-			it('has accessors', () => {
-				should(win).have.accessors('largeTitleDisplayMode');
+			it('has no accessors', () => {
+				should(win).not.have.accessors('largeTitleDisplayMode');
 			});
 		});
 
@@ -542,8 +542,8 @@ describe('Titanium.UI.Window', function () {
 				should(win.title).eql('other text');
 			});
 
-			it('has accessors', () => {
-				should(win).have.accessors('title');
+			it('has no accessors', () => {
+				should(win).not.have.accessors('title');
 			});
 		});
 
@@ -572,8 +572,8 @@ describe('Titanium.UI.Window', function () {
 				should(win.title).eql('this is my value'); // FIXME Windows: https://jira.appcelerator.org/browse/TIMOB-23498
 			});
 
-			it('has accessors', () => {
-				should(win).have.accessors('titleid');
+			it('has no accessors', () => {
+				should(win).not.have.accessors('titleid');
 			});
 		});
 


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-26119

**Description:**
This PR removes the getter/setter methods for properties where we can directly get/set the value for that property. If a get/set method is explicitly defined, it should not be removed. We've been threatening to remove these for years now. Time to rip off the band-aid.

Note that a lot of work is in the test suite. I needed to clean them up and explicitly test that many properties *don't* have accessors anymore to help me find what needed to be changed.

So the basic guideline I tried to follow here was:
- If an underlying get/set method was tagged as both `@Kroll.method` and `@Kroll.getProperty` (or `@Kroll.setProperty`) I'd remove the `@Kroll.method`.
- There are still get/set methods exposed to JS, but they should be "unusual" in the sense that they should accept additional arguments (i.e. a getter accepts some args, even optionally; a setter accepts two+ args)
  - For example `Ti.Network.HTTPClient.setRequestHeader('headerName', 'value');` 
- In a couple cases I left the getter/setter if we explicitly documented them and hadn't yet deprecated them (and they had properties you could access). I added deprecation notes in the api docs so we can eventually remove them.
- For `QuickSettingsService` it had getter/setter pairs for underlying properties *but did not expose the properties*. In that case, I exposed the properties, documented them and left the getter/setters but marked them as deprecated in api docs.
- **I did not remove the deprecation messages baked into Android's proxy code**
  - I assume we'll want to. I think at this point it's likely to just spit out false reports?