### PR TITLE
fix(android): support border for search bar

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIListView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIListView.java
@@ -105,7 +105,7 @@ public class TiUIListView extends TiUIView
 				((TiUISearchView) search).setOnSearchChangeListener(listView);
 			}
 
-			final View searchView = search.getNativeView();
+			final View searchView = search.getOuterView();
 			final ViewGroup searchViewParent = (ViewGroup) searchView.getParent();
 			final ViewGroup listViewParent = (ViewGroup) listView.getParent();
 			searchView.setId(SEARCHVIEW_ID);

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUITableView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUITableView.java
@@ -115,7 +115,7 @@ public class TiUITableView extends TiUIView
 				}
 
 				if (searchAsChild) {
-					final View searchView = search.getNativeView();
+					final View searchView = search.getOuterView();
 					final ViewGroup searchViewParent = (ViewGroup) searchView.getParent();
 					final ViewGroup tableViewParent = (ViewGroup) tableView.getParent();
 					searchView.setId(SEARCHVIEW_ID);


### PR DESCRIPTION
- Support border for search bars added to ListView/TableView

##### TEST CASE
```JS
const win = Ti.UI.createWindow();
const search = Ti.UI.createSearchBar({
    borderRadius: 8,
    borderColor: 'red',
    borderWidth: 2,
    showCancel: true
});
const tableView = Ti.UI.createTableView({
    data: [
        Ti.UI.createTableViewRow({ title: 'Row 1' }),
        Ti.UI.createTableViewRow({ title: 'Row 2' }),
        Ti.UI.createTableViewRow({ title: 'Row 3' })
    ],
    search,
    filterAttribute: 'title'
});

win.add(tableView);
win.open();
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-28271)