### PR TITLE
fix(android): amend ListView marker behaviour

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/ListSectionProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/ListSectionProxy.java
@@ -177,7 +177,11 @@ public class ListSectionProxy extends TiViewProxy
 	 */
 	public ListItemProxy getListItemAt(int index)
 	{
-		return this.items.get(index);
+		try {
+			return this.items.get(index);
+		} catch (Exception e) {
+		}
+		return null;
 	}
 
 	/**


### PR DESCRIPTION
- Allow markers to be added prior to item or section existing
- Prevent errors from occurring when invalid markers are added
- Validate list item is visible before firing `marker` event

##### TEST CASE
```JS
const win = Ti.UI.createWindow({ backgroundColor: 'gray' });

const items = [];
for (let i = 0; i < 100; i++) {
	items.push({ properties: { title: `Item #${i}` }});
}

const listView = Ti.UI.createListView({
	sections: [ Ti.UI.createListSection({ items }) ]
});

// Add valid marker.
listView.addMarker({
	sectionIndex: 0,
	itemIndex: 32
});

// Add invalid marker.
listView.addMarker({
	sectionIndex: 1,
	itemIndex: 1
});

// Add invalid marker.
listView.addMarker({
	sectionIndex: 0,
	itemIndex: -1
});

// Add invalid marker.
listView.addMarker({
	sectionIndex: -1,
	itemIndex: 1
});

// Add invalid marker.
listView.addMarker({
	sectionIndex: 0,
	itemIndex: 101
});

listView.addEventListener('marker', e => {
	alert(JSON.stringify({
		sectionIndex: e.sectionIndex,
		itemIndex: e.itemIndex
	}, null, 1));
});

win.add(listView);
win.open();
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-28293)