### PR TITLE
feat(android): create WebP images

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/TiBlob.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiBlob.java
@@ -873,7 +873,7 @@ public class TiBlob extends KrollProxy
 	}
 
 	@Kroll.method
-	public TiBlob imageAsWebp(Number compressionQuality)
+	public TiBlob imageAsWebP(Number compressionQuality)
 	{
 		Bitmap img = getImage();
 		if (img == null) {

--- a/apidoc/Titanium/Blob.yml
+++ b/apidoc/Titanium/Blob.yml
@@ -241,6 +241,22 @@ methods:
         optional: true
         default: 0
 
+  - name: imageAsWebp
+    summary: Creates a new blob by compressing the underlying image to the specified quality.
+    description: |
+        Returns the compressed or uncompressed WebP image as a blob.
+
+        If this blob doesn't represent an image, returns `null`.
+    platforms: [android]
+    since: {andorid: "10.0.0"}
+    parameters:
+      - name: quality
+        type: Number
+        summary: Quality to compress this image to. From 0.0 (lowest quality) to 1.0 (highest quality, lossless WebP).
+    returns:
+        type: Titanium.Blob
+        summary: Compressed WebP image as a blob.
+
   - name: imageWithAlpha
     summary: Returns a copy of the underlying image with an added alpha channel.
     description: |

--- a/apidoc/Titanium/Blob.yml
+++ b/apidoc/Titanium/Blob.yml
@@ -248,7 +248,7 @@ methods:
 
         If this blob doesn't represent an image, returns `null`.
     platforms: [android]
-    since: {andorid: "10.0.0"}
+    since: {android: "10.0.0"}
     parameters:
       - name: quality
         type: Number

--- a/apidoc/Titanium/Blob.yml
+++ b/apidoc/Titanium/Blob.yml
@@ -241,7 +241,7 @@ methods:
         optional: true
         default: 0
 
-  - name: imageAsWebp
+  - name: imageAsWebP
     summary: Creates a new blob by compressing the underlying image to the specified quality.
     description: |
         Returns the compressed or uncompressed WebP image as a blob.


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/AC-6657

Provide a clear PR title prefixed with `[TICKET]`

**Optional Description:**

Create WebP images on Android (lower filesize, needed for e.g. Whatsapp Sticker packs,...)

**Example**
```javascript

// Place an image named "img.jpg" in the root folder

var win = Ti.UI.createWindow({
	title: "img",
	backgroundColor: '#fff',
	layout: "vertical"
});

var file = Ti.Filesystem.getFile("img.jpg");

var img1 = Ti.UI.createImageView({
	image: file,
	width: 400,
	height: Ti.UI.SIZE,
	top: 10
});
win.add(img1);
console.log("JPG filesize: ", file.size);

// create webp
var blob = file.read();
var webp = blob.imageAsWebP(0.5);
console.log("WebP filesize: ", webp.size);
var img = Ti.UI.createImageView({
	image: webp,
	width: 400,
	height: Ti.UI.SIZE,
	top: 10
});
win.add(img);

win.open();
```

![Screenshot_20201227-151342](https://user-images.githubusercontent.com/4334997/103172894-17961b00-4857-11eb-9ab9-5f33e5223e79.png)
[INFO]  JPG filesize:  871399
[INFO]  WebP filesize:  176528
