### PR TITLE
[Backport 9_3_X] fix(android): amend method to obtain view in TableViewRowProxy.releaseViews()

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TableViewRowProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TableViewRowProxy.java
@@ -416,7 +416,7 @@ public class TableViewRowProxy extends TiViewProxy
 			}
 		}
 
-		final RowView rowView = (RowView) handleGetView();
+		final RowView rowView = (RowView) peekView();
 		if (rowView != null) {
 
 			// Set `nativeView` back to original content to release correctly.


### PR DESCRIPTION
Backport of #12386.
See that PR for full details.