### PR TITLE
[Backport 9_3_X] fix(iOS): swift enabling in Objc module should build

### DIFF
--- a/iphone/cli/commands/_buildModule.js
+++ b/iphone/cli/commands/_buildModule.js
@@ -572,9 +572,13 @@ iOSModuleBuilder.prototype.buildModule = function buildModule(next) {
 			'-archivePath', path.join(this.projectDir, 'build', target + '.xcarchive'),
 			'-UseNewBuildSystem=YES',
 			'ONLY_ACTIVE_ARCH=NO',
-			'BUILD_LIBRARY_FOR_DISTRIBUTION=YES',
 			'SKIP_INSTALL=NO',
 		];
+
+		if (this.isFramework) {
+			args.push('BUILD_LIBRARY_FOR_DISTRIBUTION=YES');
+		}
+
 		const scheme = this.isFramework ? this.moduleIdAsIdentifier : this.moduleName;
 		args.push('-scheme');
 		args.push(scheme);


### PR DESCRIPTION
Backport of #12372.
See that PR for full details.