### PR TITLE
After ignoring warning for 8 years, move log to debug

### DIFF
--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiViewProxy.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiViewProxy.m
@@ -2734,7 +2734,7 @@ LAYOUTFLAGS_SETTER(setHorizontalWrap, horizontalWrap, horizontalWrap, [self will
   [child setSandboxBounds:bounds];
   if ([[child view] animating]) {
     // changing the layout while animating is bad, ignore for now
-    DebugLog(@"[WARN] New layout set while view %@ animating: Will relayout after animation.", child);
+    DebugLog(@"[DEBUG] New layout set while view %@ animating: Will relayout after animation.", child);
   } else {
     [child relayout];
   }


### PR DESCRIPTION
According to git blame, this line has been throwing warnings for 8 years (at least) while having no direct impact on actual functionality. 

Let's lower the log level to debug instead so it doesn't gobble up console space