### PR TITLE
fix(ios): use supportedInterfaceOrientations of UINavigationController.topViewController instead of UINavigationController

### DIFF
--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiViewController.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiViewController.m
@@ -104,8 +104,11 @@
      If we are in a navigation controller, let us match so it doesn't get freaked 
      out in when pushing/popping. We are going to force orientation anyways.
      */
-  if ([self navigationController] != nil) {
-    return [[self navigationController] supportedInterfaceOrientations];
+  /*
+   TIMOB-28282. Shouldn't UINavigationController.topViewController decide the supported orientation?
+   */
+  if ([self navigationController] != nil && [[self navigationController] topViewController] != self) {
+    return [[[self navigationController] topViewController] supportedInterfaceOrientations];
   }
   //This would be for modal.
   return (UIInterfaceOrientationMask)_supportedOrientations;


### PR DESCRIPTION
 https://jira.appcelerator.org/browse/TIMOB-28282

If any third party framework has `UINavigationController` category which implements `supportedInterfaceOrientations`. It will create loop while checking the orientation with [this](https://github.com/appcelerator/titanium_mobile/blob/1168ef81ce95a8e11a6f275173b8211b08cb4fa0/iphone/TitaniumKit/TitaniumKit/Sources/API/TiViewController.m#L101). Due to that app will crash. It is happening with a customer.

It looks people use category on `UINavigationController` to check orientation. See [here](https://gist.github.com/NeilsUltimateLab/21d551126f0f03b11a0154a681a48e71).

I think, In titanium also we can check top view controller's orientation. 
