### PR TITLE
fix(android): move buildOnly assignment into pre-validate hook

### DIFF
--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -77,8 +77,6 @@ AndroidBuilder.prototype.config = function config(logger, config, cli) {
 
 	const _t = this;
 
-	this.buildOnly = cli.argv['build-only'] !== undefined;
-
 	function assertIssue(logger, issues, name) {
 		for (let i = 0; i < issues.length; i++) {
 			if ((typeof name === 'string' && issues[i].id === name) || (typeof name === 'object' && name.test(issues[i].id))) {
@@ -104,6 +102,8 @@ AndroidBuilder.prototype.config = function config(logger, config, cli) {
 		if (cli.argv.platform && cli.argv.platform !== 'android') {
 			return callback();
 		}
+
+		_t.buildOnly = cli.argv['build-only'];
 
 		async.series([
 			function (next) {


### PR DESCRIPTION
The parsing of aliases has not been performed by the time config is called so by waiting until
pre-validate we know that the build-only option has been parsed and handled. Changing the previous
check to also check for b will not work because the cli has not determined it as an alias of
--build-only so the value is still undefined

Closes TIMOB-28345

**JIRA:** https://jira.appcelerator.org/browse/TIMOB-28345
