### PR TITLE
ci: use node 12.18.0

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,7 +33,7 @@ def testOnAndroidDevices = false // testOnDevices // FIXME: Our android device i
 def testOnIOSDevices = testOnDevices
 
 // Variables we can change
-def nodeVersion = '10.17.0' // NOTE that changing this requires we set up the desired version on jenkins master first!
+def nodeVersion = '12.18.0' // NOTE that changing this requires we set up the desired version on jenkins master first!
 def npmVersion = 'latest' // We can change this without any changes to Jenkins. 5.7.1 is minimum to use 'npm ci'
 
 // Variables which we assign and share between nodes


### PR DESCRIPTION
Use node 12 on 9_3_X to prevent builds failing due to errors like as follows

```
[2021-02-10T13:05:56.395Z] { Error: Command failed: node "/Users/build/jenkins/workspace/tanium-sdk_titanium_mobile_9_3_X/node_modules/titanium/lib/titanium.js" sdk select 9.3.2.v20210210045808

[2021-02-10T13:05:56.395Z] [ERROR] :   Titanium SDK 10.0.0.v20210209110034 is incompatible with Node.js v10.17.0
```