### PR TITLE
refactor(wepback): recommend installing plugin via appcd pm for appcd 4 and above

### DIFF
--- a/cli/hooks/webpack.js
+++ b/cli/hooks/webpack.js
@@ -30,6 +30,7 @@ exports.init = (logger, config, cli) => {
 	let isWebpackEnabled = false;
 	let projectType;
 	let client;
+	let appcdRootPath;
 
 	cli.on('cli:command-loaded', (hookData) => {
 		const command = hookData.command;
@@ -48,7 +49,6 @@ exports.init = (logger, config, cli) => {
 			return;
 		}
 
-		let appcdRootPath;
 		if (isAppcCli) {
 			// we were invoked by appc-cli, load bundled daemon client.
 			appcdRootPath = resolveModuleRoot('appcd');
@@ -99,10 +99,18 @@ exports.init = (logger, config, cli) => {
 				if (e.status === 404) {
 					badgedLogger.info('Daemon was unable to find the Webpack plugin. To continue you need to:');
 					badgedLogger.info('');
-					const installCommand = 'npm i -g @appcd/plugin-webpack';
-					badgedLogger.info(`- Install it with ${installCommand.cyan}`);
-					const restartCommand = `${isAppcCli ? 'appc ' : ''}appcd restart`;
-					badgedLogger.info(`- Restart the daemon with ${restartCommand.cyan}`);
+
+					const appcdVersion = getAppcdVersion(appcdRootPath);
+					const appcdCommand = isAppcCli ? 'appc appcd' : 'appcd';
+					const pluginName = '@appcd/plugin-webpack';
+
+					if (semver.gte(appcdVersion, '4.0.0')) {
+						badgedLogger.info(`- Install it with ${appcdCommand} pm install ${pluginName}`);
+					} else {
+						badgedLogger.info(`- Install it with npm i -g ${pluginName}`);
+						badgedLogger.info(`- Restart the daemon with ${appcdCommand} restart`);
+					}
+
 					badgedLogger.info('');
 				}
 
@@ -159,11 +167,16 @@ function resolveModuleRoot(name, paths) {
 }
 
 function ensureAppcdVersion(appcdRootPath, version, isAppcCli = false) {
+	const appcdVersion = getAppcdVersion(appcdRootPath);
+	if (!semver.gte(appcdVersion, version)) {
+		throw new Error(`The Webpack build system requires Appcelerator Daemon v${MIN_APPCD_VERSION}+ (installed: ${appcdVersion}). Please update your ${isAppcCli ? 'appc-cli with "appc use latest"' : 'global daemon install with "npm i appcd -g"'}.`);
+	}
+}
+
+function getAppcdVersion(appcdRootPath) {
 	// eslint-disable-next-line security/detect-non-literal-require
 	const pkg = require(path.join(appcdRootPath, 'package.json'));
-	if (!semver.gte(pkg.version, version)) {
-		throw new Error(`The Webpack build system requires Appcelerator Daemon v${MIN_APPCD_VERSION}+ (installed: ${pkg.version}). Please update your ${isAppcCli ? 'appc-cli with "appc use latest"' : 'global daemon install with "npm i appcd -g"'}.`);
-	}
+	return pkg.version;
 }
 
 function resolveAppcdClient(appcdPackagePath) {


### PR DESCRIPTION
Closes TIMOB-28328

**JIRA:** https://jira.appcelerator.org/browse/TIMOB-28328

To test:

1. Uninstall the webpack plugin `npm uninstall -g @appcd/plugin-webpack`
2. Restart the daemon to reload the plugins `appc appcd restart`
3. Build a webpack project using Appc CLI 8.1.1 - it should log to install via npm
4. Build a webpack project using Appc CLI 9.0.0 (or current 8.2.0 on preprod) - it should log to install via appc appcd pm