### PR TITLE
build(changelog): don't discard community commits of fix or feat type

### DIFF
--- a/changelog/config.js
+++ b/changelog/config.js
@@ -210,8 +210,10 @@ module.exports = {
 			// Limit to features, bug fixes and performance improvements
 			if (commit.type === 'feat') {
 				commit.type = 'Features';
+				discard = false;
 			} else if (commit.type === 'fix') {
 				commit.type = 'Bug Fixes';
+				discard = false;
 			} else if (commit.type === 'perf') {
 				commit.type = 'Performance Improvements';
 			} else if (discard && !community && !breaking) {


### PR DESCRIPTION
We want these to exist in community credits and the relevant section