### PR TITLE
fix(android): do not override ListView itemId type

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/ListItemProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/ListItemProxy.java
@@ -146,7 +146,7 @@ public class ListItemProxy extends TiViewProxy
 				payload.put(TiC.PROPERTY_ITEM_INDEX, getIndexInSection());
 			}
 
-			final String itemId = getProperties().optString(TiC.PROPERTY_ITEM_ID, null);
+			final Object itemId = getProperties().get(TiC.PROPERTY_ITEM_ID);
 			if (itemId != null) {
 
 				// Include `itemId` if specified.


### PR DESCRIPTION
- Do not interpret `itemId` as a string to match iOS

##### TEST CASE
```JS
const win = Ti.UI.createWindow({
    backgroundColor: 'gray'
});
const listView = Ti.UI.createListView({
    backgroundColor: 'white',
    templates: {
        template: {
            properties: {
                borderRadius: 16,
                height: 50
            },
            childTemplates: [{
                type: 'Ti.UI.Label',
                bindId: 'label',
                properties: {
                    color: 'white'
                },
                events: {
                    click(e) {
                        alert(`itemId: ${e.itemId} (${typeof(e.itemId)})`);
                    }
                }
            }]
        }
    },
    defaultItemTemplate: 'template'
});
listView.sections = [
    Ti.UI.createListSection({
        items: [{
                properties: {
                    backgroundColor: 'red',
                    itemId: '1'
                },
                label: {
                    text: '1 - String'
                }
            },
            {
                properties: {
                    backgroundColor: 'green',
                    itemId: 2
                },
                label: {
                    text: '2 - Number'
                }
            },
            ,
			{
				properties: {
					backgroundColor: 'blue'
				},
				label: {
					text: '3 - Undefined'
				}
			}
        ]
    })
];

win.add(listView);
win.open();
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-28326)