### PR TITLE
[Backport 9_3_X] fix(android): do not override ListView itemId type

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/ListItemProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/ListItemProxy.java
@@ -146,7 +146,7 @@ public class ListItemProxy extends TiViewProxy
 				payload.put(TiC.PROPERTY_ITEM_INDEX, getIndexInSection());
 			}
 
-			final String itemId = getProperties().optString(TiC.PROPERTY_ITEM_ID, null);
+			final Object itemId = getProperties().get(TiC.PROPERTY_ITEM_ID);
 			if (itemId != null) {
 
 				// Include `itemId` if specified.


### PR DESCRIPTION
Backport of #12468.
See that PR for full details.