### PR TITLE
fix(android): add V8Promise constructor with existing pointer value

### DIFF
--- a/android/runtime/v8/src/java/org/appcelerator/kroll/runtime/v8/V8Promise.java
+++ b/android/runtime/v8/src/java/org/appcelerator/kroll/runtime/v8/V8Promise.java
@@ -24,6 +24,11 @@ public class V8Promise<V extends Object> extends V8Object implements KrollPromis
 		super(nativeCreate());
 	}
 
+	public V8Promise(long ptr)
+	{
+		super(ptr);
+	}
+
 	@Override
 	public void resolve(V value)
 	{


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/[TICKET]

Provide a clear PR title prefixed with `[TICKET]`

**Optional Description:**
This is an assumed fix based on losing at Android emulator test suite logs. There's no constructor for taking an existing pointer value and passing it into the V8Promise java class wrapper. Theoretically a test that passed a Promise as a method argument might expose this bug?