### PR TITLE
[Backport 9_3_X] fix(ios): largeTitleDisplayMode always is not working in iOS 14

### DIFF
--- a/iphone/TitaniumKit/TitaniumKit/Sources/Modules/TiUIWindowProxy.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/Modules/TiUIWindowProxy.m
@@ -905,6 +905,7 @@
 
   if ([TiUtils isIOSVersionOrGreater:@"11.0"] && shouldUpdateNavBar && controller != nil && [controller navigationController] != nil) {
     [[[controller navigationController] navigationBar] setPrefersLargeTitles:[TiUtils boolValue:value def:NO]];
+    [[[controller navigationController] navigationBar] sizeToFit];
   }
 }
 


### PR DESCRIPTION
Backport of #12490.
See that PR for full details.