### PR TITLE
[Backport 9_3_X] fix(ios): showSearchBarInNavBar does not work with custom item templates

### DIFF
--- a/iphone/Classes/TiUIListViewProxy.m
+++ b/iphone/Classes/TiUIListViewProxy.m
@@ -207,7 +207,7 @@
   static dispatch_once_t onceToken;
   static NSArray *keySequence = nil;
   dispatch_once(&onceToken, ^{
-    keySequence = [[NSArray alloc] initWithObjects:@"style", @"templates", @"defaultItemTemplate", @"sections", @"backgroundColor", nil];
+    keySequence = [[NSArray alloc] initWithObjects:@"style", @"showSearchBarInNavBar", @"templates", @"defaultItemTemplate", @"sections", @"backgroundColor", nil];
   });
   return keySequence;
 }


### PR DESCRIPTION
Backport of #12486.
See that PR for full details.