### PR TITLE
fix(android): expose builder property for hyperloop to mark js files not to process

### DIFF
--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -2418,6 +2418,7 @@ AndroidBuilder.prototype.gatherResources = async function gatherResources() {
 
 	// Fire an event requesting additional "Resources" paths from plugins. (used by hyperloop)
 	this.logger.info(__('Analyzing plugin-contributed files'));
+	this.htmlJsFiles = {}; // for hyperloop to mark files it doesn't want processed
 	const hook = this.cli.createHook('build.android.requestResourcesDirPaths', this, async (paths, done) => {
 		try {
 			const newTasks = [];
@@ -2490,6 +2491,7 @@ AndroidBuilder.prototype.gatherResources = async function gatherResources() {
 	// now categorize (i.e. lump into buckets of js/css/html/assets/generic resources)
 	const categorizer = new gather.Categorizer({
 		tiappIcon: this.tiapp.icon,
+		jsFilesNotToProcess: Object.keys(this.htmlJsFiles)
 	});
 	return await categorizer.run(combined);
 };

--- a/cli/lib/gather.js
+++ b/cli/lib/gather.js
@@ -203,10 +203,12 @@ class Categorizer {
 	/**
 	 * @param {object} options options
 	 * @param {string} options.tiappIcon tiapp icon filename
+	 * @param {string[]} [options.jsFilesNotToProcess=[]] listing of JS files explicitly not to process
 	 * @param {boolean} [options.useAppThinning=false] use app thinning?
 	 */
 	constructor(options) {
 		this.useAppThinning = options.useAppThinning;
+		this.jsFilesNotToProcess = options.jsFilesNotToProcess || [];
 
 		const appIcon = options.tiappIcon.match(FILENAME_REGEXP);
 		this.appIconRegExp = appIcon && new RegExp('^' + appIcon[1].replace(/\./g, '\\.') + '(.*)\\.png$'); // eslint-disable-line security/detect-non-literal-regexp
@@ -222,6 +224,7 @@ class Categorizer {
 		map.forEach((value, key) => {
 			this._handleFile(results, key, value);
 		});
+		this.jsFilesNotToProcess.forEach(file => results.htmlJsFiles.add(file));
 		results.dontProcessJsFilesReferencedFromHTML();
 		return results;
 	}


### PR DESCRIPTION
**Optional Description:**
This adds back the builder property `htmlJsFiles` for android hyperloop and then shuttles the file listing into the CLI gather code to use as a file listing to explicitly not process.

