### PR TITLE
build: no longer generate parity report or JSCA file for Studio

### DIFF
--- a/build/lib/docs.js
+++ b/build/lib/docs.js
@@ -35,24 +35,12 @@ class Documentation {
 		});
 	}
 
-	async generateParityReport() {
-		return this.generateReport('parity', 'parity.html');
-	}
-
-	async generateJSCA() {
-		return this.generateReport('jsca', 'api.jsca');
-	}
-
 	async generateTypeScriptTypeDefinitions() {
 		return this.generateReport('typescript', 'index.d.ts');
 	}
 
 	async generate() {
-		return Promise.all([
-			this.generateParityReport(),
-			this.generateJSCA(),
-			this.generateTypeScriptTypeDefinitions()
-		]);
+		return this.generateTypeScriptTypeDefinitions();
 	}
 }
 module.exports = Documentation;

--- a/build/lib/packager.js
+++ b/build/lib/packager.js
@@ -95,10 +95,6 @@ class Packager {
 			// copy over support/
 			this.copySupportDir()
 		];
-		if (this.options.docs) {
-			// copy api.jsca file
-			tasks.push(fs.copy(path.join(this.outputDir, 'api.jsca'), path.join(this.zipSDKDir, 'api.jsca')));
-		}
 		await Promise.all(tasks);
 
 		// Zip up all the platforms!


### PR DESCRIPTION
**Description:**
We currently generate a parity report (API parity across platforms, which was more useful when we were actively developing Windows Mobile), and a `jsca` file from our docs.

The `jsca` file is a specialized JSON file for content assist used by Studio. Given the OL/EOS of Studio, we should stop generating and packaging it. It bloats unzipped SDK install size by ~34Mb!

I don't know if VSCode/Atom also use this file, or if they rely on typescript definitions (which we do generate during builds but don't actually package into the zip - we manually try to push them to DefinitelyTyped as part of GA release process)