### PR TITLE
chore(deps): update liveview to 1.5.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "fields": "0.1.24",
         "fs-extra": "^9.1.0",
         "ioslib": "^1.7.23",
-        "liveview": "^1.5.4",
+        "liveview": "^1.5.5",
         "lodash.merge": "^4.6.2",
         "markdown": "0.5.0",
         "moment": "^2.29.1",
@@ -10782,14 +10782,14 @@
       }
     },
     "node_modules/liveview": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/liveview/-/liveview-1.5.4.tgz",
-      "integrity": "sha512-Z3ineOi2m7NR4BaraUpohVinTr6OmHkY86R+hQkak7h9Gbgun1BJ29jomlMtOKT2c95cI/jm9cq66e15bcBwVg==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/liveview/-/liveview-1.5.5.tgz",
+      "integrity": "sha512-PNfRUXgtQ1B427K8lcien0BV8DLPsqu1Qen72IxOi22L1tayf+A7pwXoBGj8qvlimPG+VFen2Uci+y5Wwe59xQ==",
       "dependencies": {
         "chokidar": "^3.4.2",
         "coloring": "~0.1.0",
         "commander": "~2.0.0",
-        "debug": "~4.1.1",
+        "debug": "~4.2.0",
         "fs-extra": "^8.1.0",
         "hypar": "~0.1.0",
         "node-titanium-sdk": "^3.0.1",
@@ -10804,7 +10804,7 @@
         "liveview-server": "bin/liveview-server"
       },
       "engines": {
-        "node": ">=4.0"
+        "node": ">=10.0.0"
       }
     },
     "node_modules/liveview/node_modules/commander": {
@@ -10816,11 +10816,20 @@
       }
     },
     "node_modules/liveview/node_modules/debug": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+      "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+      "deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
       "dependencies": {
-        "ms": "^2.1.1"
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/liveview/node_modules/fs-extra": {
@@ -25760,14 +25769,14 @@
       }
     },
     "liveview": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/liveview/-/liveview-1.5.4.tgz",
-      "integrity": "sha512-Z3ineOi2m7NR4BaraUpohVinTr6OmHkY86R+hQkak7h9Gbgun1BJ29jomlMtOKT2c95cI/jm9cq66e15bcBwVg==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/liveview/-/liveview-1.5.5.tgz",
+      "integrity": "sha512-PNfRUXgtQ1B427K8lcien0BV8DLPsqu1Qen72IxOi22L1tayf+A7pwXoBGj8qvlimPG+VFen2Uci+y5Wwe59xQ==",
       "requires": {
         "chokidar": "^3.4.2",
         "coloring": "~0.1.0",
         "commander": "~2.0.0",
-        "debug": "~4.1.1",
+        "debug": "~4.2.0",
         "fs-extra": "^8.1.0",
         "hypar": "~0.1.0",
         "node-titanium-sdk": "^3.0.1",
@@ -25781,11 +25790,11 @@
           "integrity": "sha1-0bhvkB+LZL2UG96tr5JFMDk76Sg="
         },
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         },
         "fs-extra": {

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "fields": "0.1.24",
     "fs-extra": "^9.1.0",
     "ioslib": "^1.7.23",
-    "liveview": "^1.5.4",
+    "liveview": "^1.5.5",
     "lodash.merge": "^4.6.2",
     "markdown": "0.5.0",
     "moment": "^2.29.1",


### PR DESCRIPTION
**JIRA**: https://jira.appcelerator.org/browse/TIMOB-28382

**Description:**

Manual backport of #12562

What it says on the tin

Note that due to `package-lock.json` lock file version change, this needs to be manually back ported to `10_0_X`