### PR TITLE
chore(deps): update node-ios-device dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10606,9 +10606,9 @@
       }
     },
     "node-pre-gyp-init": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/node-pre-gyp-init/-/node-pre-gyp-init-1.2.0.tgz",
-      "integrity": "sha512-55LE26FXkNw6i0WrUBYkQryYYWxExT5LK3WtRjBGlQYfO3GsSs4phs0K4anfq2CW4u7+mebRou40gNIEMDNpzg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/node-pre-gyp-init/-/node-pre-gyp-init-1.2.1.tgz",
+      "integrity": "sha512-gbC2fERRmWbJFvj54f4yyiY/O6J1kkLrN7jkwRvzNmgMgPCufZLv76l2luzWjj+Ge0xQF6zDalZ6iIgzCHJ95Q==",
       "requires": {
         "@mapbox/node-pre-gyp": "^1.0.1"
       }

--- a/package.json
+++ b/package.json
@@ -98,7 +98,6 @@
     "markdown": "0.5.0",
     "moment": "^2.29.1",
     "node-appc": "^1.1.2",
-    "node-ios-device": "^1.9.0",
     "node-titanium-sdk": "^5.1.2",
     "node-uuid": "1.4.8",
     "nodeify": "^1.0.1",


### PR DESCRIPTION
Backport of #12579

Dependencies are at expected versions

```
$npm ls node-ios-device
titanium-mobile@10.0.0 /Users/awam/git/titanium_mobile
└─┬ ioslib@1.7.23
  └── node-ios-device@1.9.1 

awam@~/git/titanium_mobile
$npm ls @mapbox/node-pre-gyp
titanium-mobile@10.0.0 /Users/awam/git/titanium_mobile
└─┬ ioslib@1.7.23
  └─┬ node-ios-device@1.9.1
    ├── @mapbox/node-pre-gyp@1.0.1 
    └─┬ node-pre-gyp-init@1.2.1
      └── @mapbox/node-pre-gyp@1.0.1  deduped

awam@~/git/titanium_mobile
$npm ls node-pre-gyp-init
titanium-mobile@10.0.0 /Users/awam/git/titanium_mobile
└─┬ ioslib@1.7.23
  └─┬ node-ios-device@1.9.1
    └── node-pre-gyp-init@1.2.1 
```