### PR TITLE
style: fix eslint warnings

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,6 +3,9 @@
   "parserOptions": {
     "sourceType": "script"
   },
+  "rules": {
+    "promise/catch-or-return": [ "warn", { "terminationMethod": [ "catch", "finally" ]} ]
+  },
   "overrides": [
     {
       "files": [ "android/runtime/common/src/js/**/*.js", "android/modules/**/src/js/**/*.js" ],

--- a/android/cli/lib/gradle-wrapper.js
+++ b/android/cli/lib/gradle-wrapper.js
@@ -295,6 +295,7 @@ class GradleWrapper {
 			appc.subprocess.run('appc', [ '-q', 'config', 'get', 'proxyServer' ], runOptions, (exitCode, out) => {
 				try {
 					if (!exitCode && out && (out.length > 0)) {
+						// eslint-disable-next-line node/no-deprecated-api
 						proxyUrl = url.parse(out.trim());
 					}
 				} catch (ex) {

--- a/build/lib/test/generator.js
+++ b/build/lib/test/generator.js
@@ -65,8 +65,9 @@ async function generateTest(apidoc) {
 }
 
 /**
- * @param {string} constants
- * @returns {Promise<string[]}
+ * Fetches an array of fully qualified constant names based on the given wildcard string.
+ * @param {string} constants Wildcard string. Example: 'Ti.UI.ANIMATION_CURVE_*'
+ * @returns {Promise<string[]>} Returns array of fully qualified constant names.
  */
 async function expandWildcard(constants) {
 	// split by '.', find owning type, gather constants
@@ -92,7 +93,7 @@ async function expandWildcard(constants) {
 }
 
 /**
- * Generate a unit test givne an input apidoc yml file
+ * Generate a unit test given an input apidoc yml file
  * @param {string[]} args program args
  */
 async function main(args) {

--- a/build/lib/test/index.js
+++ b/build/lib/test/index.js
@@ -29,7 +29,8 @@ async function runTests(platforms, program) {
 }
 
 /**
- * @param {object} results
+ * Outputs the given test results to the console.
+ * @param {object} results Dictionary of test results to be outputted.
  * @returns {Promise<void>}
  */
 async function outputMultipleResults(results) {

--- a/build/lib/test/test.js
+++ b/build/lib/test/test.js
@@ -482,10 +482,9 @@ class DeviceTestDetails {
 	/**
 	 * Handle a new line of output for a given device/emulator
 	 * @param {string} token line of output (raw)
-	 * @param {string} stripped output stripped of ansi colors
 	 * @returns {boolean} true if successfully finished the test suite (completed, may have test failures/errors)
 	 */
-	handleLine(token, stripped) {
+	handleLine(token) {
 		if (this.testEndIncomplete) {
 			if (token.includes(TEST_START_PREFIX) || token.includes(TEST_SUITE_STOP)) {
 				// Make up a failed test result
@@ -769,6 +768,7 @@ async function handleBuild(prc, target, snapshotDir, snapshotPromises) {
 		splitter.encoding = 'utf8';
 
 		function getDeviceName(token) {
+			// eslint-disable-next-line security/detect-child-process
 			const matches = /^[\s\b]+\[([^\]]+)\]\s/g.exec(token.substring(token.indexOf(':') + 1));
 			if (matches && matches.length === 2) {
 				return matches[1];
@@ -826,7 +826,7 @@ async function handleBuild(prc, target, snapshotDir, snapshotPromises) {
 				deviceMap.set(device, new DeviceTestDetails(device, target, snapshotDir, snapshotPromises));
 			}
 			const curTest = deviceMap.get(device);
-			const done = curTest.handleLine(token, stripped);
+			const done = curTest.handleLine(token);
 			if (done) {
 				let results = [];
 				// check if all devices have completed tests
@@ -881,9 +881,9 @@ async function handleBuild(prc, target, snapshotDir, snapshotPromises) {
 }
 
 /**
- *
- * @param {string} testResults
- * @returns {string}
+ * Escapes given test output string so it can be used by JSON.parse() method.
+ * @param {string} testResults The test output to be escaped and parsed as JSON.
+ * @returns {string} Returns a string that can be passed to JSON.parse() method.
  */
 function massageJSONString(testResults) {
 	// preserve newlines, etc - use valid JSON

--- a/changelog/config.js
+++ b/changelog/config.js
@@ -96,7 +96,7 @@ function guessPreviousBranch(version) {
 }
 
 function urlToVersion(url) {
-	return /-(\d+\.\d+\.\d+)\.zip$/.exec(url)[1];
+	return /-(\d+\.\d+\.\d+)\.zip$/.exec(url)[1]; // eslint-disable-line security/detect-child-process
 }
 
 function gatherModules() {

--- a/cli/hooks/webpack.js
+++ b/cli/hooks/webpack.js
@@ -94,7 +94,7 @@ exports.init = (logger, config, cli) => {
 			});
 			Promise.resolve().then(async () => {
 				await webpackService.build();
-				return callback();
+				return callback(); // eslint-disable-line promise/no-callback-in-promise
 			}).catch(e => {
 				if (e.status === 404) {
 					badgedLogger.info('Daemon was unable to find the Webpack plugin. To continue you need to:');
@@ -120,7 +120,7 @@ exports.init = (logger, config, cli) => {
 					logger.error(e.stack);
 				}
 
-				callback(e);
+				callback(e); // eslint-disable-line promise/no-callback-in-promise
 			});
 		}
 	});

--- a/common/Resources/ti.internal/aca.js
+++ b/common/Resources/ti.internal/aca.js
@@ -8,6 +8,6 @@
  * This allows ACA to be the first module to load on startup.
  */
 
-import('com.appcelerator.aca').catch(e => {
+import('com.appcelerator.aca').catch(() => {
 	// No need to notify of ACA load failure.
 });

--- a/common/Resources/ti.internal/extensions/node/string_decoder.js
+++ b/common/Resources/ti.internal/extensions/node/string_decoder.js
@@ -101,7 +101,6 @@ class MultiByteStringDecoderImpl extends StringDecoderImpl {
 	 * - charLength: expected number of bytes for the incomplete character
 	 * - index: index in the buffer where the incomplete character begins
 	 * @param {Buffer} _buffer Buffer we are checking to see if it has an incompelte "character" at the end
-	 * @returns {IncompleteCharObject}
 	 */
 	_checkIncompleteBytes(_buffer) {
 		throw new Error('subclasses must override!');

--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -6227,7 +6227,7 @@ iOSBuilder.prototype.processLaunchLogos = async function processLaunchLogos(laun
 	}
 
 	// Resize the launch logo to the other dimensions needed
-	await new Promise((resolve, reject) => {
+	await new Promise((resolve) => {
 		appc.image.resize(launchLogo.src, missingLaunchLogos, error => {
 			if (error) {
 				this.logger.error(error);

--- a/iphone/cli/commands/_buildModule.js
+++ b/iphone/cli/commands/_buildModule.js
@@ -154,7 +154,8 @@ iOSModuleBuilder.prototype.run = function run(logger, config, cli, finished) {
 		'buildModule',
 		'createUniversalBinary',
 		function (next) {
-			this.verifyBuildArch().then(next, next);
+			// eslint-disable-next-line promise/no-callback-in-promise
+			this.verifyBuildArch().then(next).catch(next);
 		},
 		'packageModule',
 		function (next) {

--- a/iphone/cli/hooks/frameworks.js
+++ b/iphone/cli/hooks/frameworks.js
@@ -61,15 +61,19 @@ class FrameworkManager {
 	initialize() {
 		this._cli.on('build.pre.compile', {
 			priority: 1200,
-			post: (builder, callback) => {
-				this._logger.trace('Starting third-party framework detection');
-				this._builder = builder;
-				this.detectFrameworks().then(callback, e => {
+			post: async (builder, callback) => {
+				try {
+					this._logger.trace('Starting third-party framework detection');
+					this._builder = builder;
+					await this.detectFrameworks();
+				} catch (err) {
 					if (this._cli.argv.platform === 'ios') {
-						this._logger.error(e.stack);
+						this._logger.error(err.stack);
 					}
-					callback(e);
-				});
+					callback(err);
+					return;
+				}
+				callback();
 			}
 		});
 

--- a/iphone/cli/hooks/storyboard.js
+++ b/iphone/cli/hooks/storyboard.js
@@ -50,12 +50,16 @@ class StoryboardManager {
 	initialize() {
 		this._cli.on('build.pre.compile', {
 			priority: 1200,
-			post: (builder, callback) => {
-				this._logger.trace('Starting storyboard detection');
-				this._builder = builder;
-				this.detectStoryboards().then(callback, e => {
-					callback(e);
-				});
+			post: async (builder, callback) => {
+				try {
+					this._logger.trace('Starting storyboard detection');
+					this._builder = builder;
+					await this.detectStoryboards();
+				} catch (err) {
+					callback(err);
+					return;
+				}
+				callback();
 			}
 		});
 

--- a/tests/Resources/ti.contacts.group.test.js
+++ b/tests/Resources/ti.contacts.group.test.js
@@ -9,7 +9,6 @@
 /* eslint no-unused-expressions: "off" */
 'use strict';
 const should = require('./utilities/assertions');
-const utilities = require('./utilities/utilities');
 
 // Intentionally skip on Android, this type doesn't exist
 // FIXME This holds for permission prompt on iOS and hangs the tests. How can we "click OK" for user?

--- a/tests/Resources/ti.database.test.js
+++ b/tests/Resources/ti.database.test.js
@@ -502,11 +502,11 @@ describe('Titanium.Database', function () {
 						should(rows.rowCount).be.eql(1);
 						should(rows.fieldCount).be.eql(3);
 						should(rows.validRow).be.true();
-					} finally {
+					} finally { // eslint-disable-line promise/always-return
 						// Close the 'rows' object
 						rows.close();
 					}
-					finish();
+					return finish();
 				})
 				.catch(err => finish(err))
 				.finally(() => db.close());
@@ -698,7 +698,7 @@ describe('Titanium.Database', function () {
 					should(rows.rowCount).be.eql(1);
 					should(rows.fieldCount).be.eql(3);
 					should(rows.validRow).be.true();
-				} finally {
+				} finally { // eslint-disable-line promise/always-return
 					// Close the 'rows' object
 					rows.close();
 				}

--- a/tests/Resources/ti.geolocation.test.js
+++ b/tests/Resources/ti.geolocation.test.js
@@ -361,7 +361,7 @@ describe('Titanium.Geolocation', () => {
 				const result = Ti.Geolocation.requestLocationPermissions(permission);
 				result.should.be.a.Promise();
 				// just ensure it resolves/rejects?
-				result.then(() => finish(), _e => finish());
+				result.then(() => finish()).catch(() => finish());
 			});
 		});
 
@@ -541,7 +541,7 @@ describe('Titanium.Geolocation', () => {
 						} catch (err) {
 							return finish(err);
 						}
-						finish();
+						return finish();
 					}).catch(e => {
 						// Sometimes fails on Android device/emulator w/ 'passive/gps/network is unavailable'
 						if (OS_ANDROID) {

--- a/tests/Resources/ti.ui.attributedstring.test.js
+++ b/tests/Resources/ti.ui.attributedstring.test.js
@@ -4,7 +4,7 @@
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
-/* global OS_ANDROID, OS_IOS, OS_VERSION_MAJOR */
+/* global OS_IOS, OS_VERSION_MAJOR */
 /* eslint-env mocha */
 /* eslint no-unused-expressions: "off" */
 'use strict';

--- a/tests/Resources/ti.ui.clipboard.test.js
+++ b/tests/Resources/ti.ui.clipboard.test.js
@@ -11,7 +11,6 @@
 'use strict';
 
 const should = require('./utilities/assertions');
-const utilities = require('./utilities/utilities');
 
 describe('Titanium.UI.Clipboard', () => {
 

--- a/tests/Resources/ti.ui.navigationwindow.test.js
+++ b/tests/Resources/ti.ui.navigationwindow.test.js
@@ -6,6 +6,7 @@
  */
 /* eslint-env mocha */
 /* eslint no-unused-expressions: "off" */
+/* eslint promise/no-callback-in-promise: "off" */
 'use strict';
 const should = require('./utilities/assertions');
 
@@ -49,7 +50,7 @@ describe('Titanium.UI.NavigationWindow', function () {
 				openPromise.then(() => {
 					const result = nav.close();
 					result.should.be.a.Promise();
-					result.then(() => finish()).catch(e => finish(e));
+					return result.then(() => finish()).catch(e => finish(e)); // eslint-disable-line promise/no-nesting
 				}).catch(e => finish(e));
 			});
 
@@ -65,8 +66,10 @@ describe('Titanium.UI.NavigationWindow', function () {
 				nav = Ti.UI.createNavigationWindow({ window: Ti.UI.createWindow() });
 
 				nav.open().then(() => {
-					nav.close().then(() => {
-						nav.close().then(() => finish(new Error('Expected second #close() call on Window to be rejected'))).catch(e => finish());
+					// eslint-disable-next-line promise/no-nesting
+					return nav.close().then(() => {
+						// eslint-disable-next-line promise/no-nesting
+						return nav.close().then(() => finish(new Error('Expected second #close() call on Window to be rejected'))).catch(() => finish());
 					}).catch(e => finish(e));
 				}).catch(e => finish(e));
 			});
@@ -89,7 +92,7 @@ describe('Titanium.UI.NavigationWindow', function () {
 
 				const result = nav.open();
 				result.should.be.a.Promise();
-				result.then(() => finish(), e => finish(e));
+				result.then(() => finish()).catch(e => finish(e));
 			});
 
 			it('called twice on same Window rejects second Promise', finish => {
@@ -97,6 +100,7 @@ describe('Titanium.UI.NavigationWindow', function () {
 
 				const first = nav.open();
 				first.should.be.a.Promise();
+				// eslint-disable-next-line promise/catch-or-return
 				first.then(() => nav.open(), e => finish(e)).then(() => finish(new Error('Expected second #open() to be rejected')), _e => finish());
 			});
 		});
@@ -290,7 +294,7 @@ describe('Titanium.UI.Window', function () {
 
 	afterEach(done => {
 		if (nav) {
-			nav.close().then(() => done()).catch(e => done());
+			nav.close().then(() => done()).catch(() => done());
 		}
 		nav = null;
 	});

--- a/tests/Resources/ti.ui.tabgroup.test.js
+++ b/tests/Resources/ti.ui.tabgroup.test.js
@@ -7,6 +7,7 @@
 /* eslint-env mocha */
 /* eslint no-unused-expressions: "off" */
 /* eslint mocha/no-identical-title: "off" */
+/* eslint promise/no-callback-in-promise: "off" */
 'use strict';
 const should = require('./utilities/assertions'); // eslint-disable-line no-unused-vars
 const utilities = require('./utilities/utilities');
@@ -399,7 +400,7 @@ describe('Titanium.UI.TabGroup', function () {
 				openPromise.then(() => {
 					const result = tabGroup.close();
 					result.should.be.a.Promise();
-					result.then(() => finish()).catch(e => finish(e));
+					return result.then(() => finish()).catch(e => finish(e)); // eslint-disable-line promise/no-nesting
 				}).catch(e => finish(e));
 			});
 
@@ -425,8 +426,10 @@ describe('Titanium.UI.TabGroup', function () {
 				tabGroup.addTab(tabA);
 
 				tabGroup.open().then(() => {
-					tabGroup.close().then(() => {
-						tabGroup.close().then(() => finish(new Error('Expected second #close() call on TabGroup to be rejected'))).catch(_e => finish());
+					// eslint-disable-next-line promise/no-nesting
+					return tabGroup.close().then(() => {
+						// eslint-disable-next-line promise/no-nesting
+						return tabGroup.close().then(() => finish(new Error('Expected second #close() call on TabGroup to be rejected'))).catch(() => finish());
 					}).catch(e => finish(e));
 				}).catch(e => finish(e));
 			});
@@ -465,7 +468,8 @@ describe('Titanium.UI.TabGroup', function () {
 				first.then(() => {
 					const second = tabGroup.open();
 					second.should.be.a.Promise();
-					second.then(() => finish(new Error('Expected second #open() to be rejected'))).catch(_e => finish());
+					// eslint-disable-next-line promise/no-nesting
+					return second.then(() => finish(new Error('Expected second #open() to be rejected'))).catch(() => finish());
 				}).catch(e => finish(e));
 			});
 		});

--- a/tests/Resources/ti.ui.view.test.js
+++ b/tests/Resources/ti.ui.view.test.js
@@ -28,6 +28,7 @@ describe('Titanium.UI.View', function () {
 
 	function closeWindow(win, done) {
 		if (win && !win.closed) {
+			// eslint-disable-next-line promise/no-callback-in-promise
 			win.close().then(() => done()).catch(_e => done());
 		} else {
 			win = null;

--- a/tests/Resources/ti.ui.webview.test.js
+++ b/tests/Resources/ti.ui.webview.test.js
@@ -321,7 +321,7 @@ describe.androidARM64Broken('Titanium.UI.WebView', function () {
 
 		webView.addEventListener('load', function (e) {
 			const html = e.source.html;
-			const exp = /id="rawUa">rawUa: ([^<]+)<\/li/m.exec(html);
+			const exp = /id="rawUa">rawUa: ([^<]+)<\/li/m.exec(html); // eslint-disable-line security/detect-child-process
 			const userAgent = exp && exp.length > 1 ? exp[1] : undefined;
 			if (userAgent && userAgent === webView.userAgent) {
 				return finish();

--- a/tests/Resources/ti.ui.window.test.js
+++ b/tests/Resources/ti.ui.window.test.js
@@ -8,6 +8,7 @@
 /* eslint-env mocha */
 /* eslint no-unused-expressions: "off" */
 /* eslint mocha/no-identical-title: "off" */
+/* eslint promise/no-callback-in-promise: "off" */
 'use strict';
 const should = require('./utilities/assertions');
 const utilities = require('./utilities/utilities');
@@ -696,7 +697,8 @@ describe('Titanium.UI.Window', function () {
 				openPromise.then(() => {
 					const result = win.close();
 					result.should.be.a.Promise();
-					result.then(() => finish()).catch(e => finish(e));
+					// eslint-disable-next-line promise/no-nesting
+					return result.then(() => finish()).catch(e => finish(e));
 				}).catch(e => finish(e));
 			});
 
@@ -716,8 +718,10 @@ describe('Titanium.UI.Window', function () {
 				});
 
 				win.open().then(() => {
-					win.close().then(() => {
-						win.close().then(() => finish(new Error('Expected second #close() call on Window to be rejected'))).catch(e => finish());
+					// eslint-disable-next-line promise/no-nesting
+					return win.close().then(() => {
+						// eslint-disable-next-line promise/no-nesting
+						return win.close().then(() => finish(new Error('Expected second #close() call on Window to be rejected'))).catch(() => finish());
 					}).catch(e => finish(e));
 				}).catch(e => finish(e));
 			});
@@ -752,7 +756,8 @@ describe('Titanium.UI.Window', function () {
 				first.then(() => {
 					const second = win.open();
 					second.should.be.a.Promise();
-					second.then(() => finish(new Error('Expected second #open() to be rejected'))).catch(_e => finish());
+					// eslint-disable-next-line promise/no-nesting
+					return second.then(() => finish(new Error('Expected second #open() to be rejected'))).catch(() => finish());
 				}).catch(e => finish(e));
 			});
 		});


### PR DESCRIPTION
**Summary:**
Fixes JavaScript eslint warnings reported by github action.

**Notes:**
- Added Promise `finally` support to `.eslintrc`.
- The `exec()` warnings were false positives. Linter wrongly interpreted `RegExp.exec()` calls as `child_process.exec()` calls. This linter warning does not appear in VS Code.
