### PR TITLE
style(android): fix java lint warnings

### DIFF
--- a/android/.idea/inspectionProfiles/Project_Default.xml
+++ b/android/.idea/inspectionProfiles/Project_Default.xml
@@ -89,6 +89,9 @@
     <inspection_tool class="OverflowingLoopIndex" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="OverwrittenKey" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="ParameterCanBeLocal" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="PointlessBooleanExpression" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="m_ignoreExpressionsContainingConstants" value="true" />
+    </inspection_tool>
     <inspection_tool class="PointlessNullCheck" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="PrimitiveArrayArgumentToVariableArgMethod" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="ReadWriteStringCanBeUsed" enabled="false" level="WARNING" enabled_by_default="false" />

--- a/android/kroll-apt/src/main/java/org/appcelerator/kroll/annotations/Kroll.java
+++ b/android/kroll-apt/src/main/java/org/appcelerator/kroll/annotations/Kroll.java
@@ -53,7 +53,6 @@ public @interface Kroll {
 		/**
 		 * The argument's name used in error messages and source code generation.<br>
 		 * @default The argument's name from Java source
-		 * @module.api
 		 */
 		String name() default DEFAULT_NAME;
 		/**
@@ -63,7 +62,6 @@ public @interface Kroll {
 		 * <b>Warning</b>: Make sure that <i>all</i> optional arguments are annotated in your {@link method}, or source code generation / binding may fail.
 		 * If the {@link method} has an optional argument in the middle of it's argument list, then all the methods after it should also be annotated as optional.
 		 * </p>
-		 * @module.api
 		 */
 		boolean optional() default false;
 	}
@@ -82,7 +80,6 @@ public @interface Kroll {
 		/**
 		 * The name that this constant is bound to.<br>
 		 * @default The name in Java source.
-		 * @module.api
 		 */
 		String name() default DEFAULT_NAME;
 	}
@@ -140,7 +137,6 @@ public @interface Kroll {
 		/**
 		 * The method's name in the API.<br>
 		 * @default The method's name in Java source.
-		 * @module.api
 		 */
 		String name() default DEFAULT_NAME;
 		/**
@@ -160,7 +156,6 @@ public @interface Kroll {
 		 *     return result.getResult();
 		 * }
 		 * </pre>
-		 * @module.api
 		 */
 		boolean runOnUiThread() default false;
 	}
@@ -188,7 +183,6 @@ public @interface Kroll {
 		 * If this module has a {@link module#parentModule parent module}, this name will be relative to the parent.
 		 * All modules are relative to the top level <pre>Titanium</pre> object. If you wish to bind to the global object, see {@link topLevel @Kroll.topLevel}</p>
 		 * @default If the class name follows the naming convention <pre>XYZModule</pre>, then the default API name is <pre>XYZ</pre>. Otherwise, the default name is the same as the class name.
-		 * @module.api
 		 */
 		String name() default DEFAULT_NAME;
 		/**
@@ -201,13 +195,11 @@ public @interface Kroll {
 		 * public class MyModule extends KrollModule { ... }
 		 * </pre>
 		 * @default The fully qualified class name of the module
-		 * @module.api
 		 */
 		String id() default DEFAULT_NAME;
 		/**
 		 * The parent module class of this module.
 		 * @default No parent module (binds directly to <pre>Titanium</pre>)
-		 * @module.api
 		 */
 		Class<?> parentModule() default DEFAULT.class;
 		/**
@@ -217,7 +209,6 @@ public @interface Kroll {
 		 * &#064;Kroll.module(propertyAccessors={"property1", "property2", "property3"})
 		 * </pre>
 		 * @default No dynamic property accessors are generated
-		 * @module.api
 		 */
 		String[] propertyAccessors() default {};
 	}
@@ -276,7 +267,6 @@ public @interface Kroll {
 		/**
 		 * The name of this property in the API.
 		 * @default The method name stripped of "get", and lower-camel-cased or the method name itself.
-		 * @module.api
 		 */
 		String name() default DEFAULT_NAME;
 		/**
@@ -306,7 +296,6 @@ public @interface Kroll {
 		/**
 		 * The name of this property in the API.<br>
 		 * @default The method name stripped of "set", and lower-camel-cased or the method name itself.
-		 * @module.api
 		 */
 		String name() default DEFAULT_NAME;
 		/**
@@ -344,7 +333,6 @@ public @interface Kroll {
 		/**
 		 * The name of this proxy. Used in debugging, toString(), and {@link proxy#creatableInModule()}.<br>
 		 * @default The name of the proxy class with the "Proxy" suffix removed.
-		 * @module.api
 		 */
 		String name() default DEFAULT_NAME;
 		/**
@@ -357,7 +345,6 @@ public @interface Kroll {
 		 * @default None (don't generate a create method)
 		 * @see org.appcelerator.kroll.KrollProxy#handleCreationArgs(org.appcelerator.kroll.KrollModule, Object[])
 		 * @see org.appcelerator.kroll.KrollProxy#handleCreationDict(org.appcelerator.kroll.KrollDict)
-		 * @module.api
 		 */
 		Class<?> creatableInModule() default DEFAULT.class;
 		/**
@@ -367,14 +354,12 @@ public @interface Kroll {
 		 * &#064;Kroll.proxy(propertyAccessors={"property1", "property2", "property3"})
 		 * </pre>
 		 * @default No dynamic property accessors are generated
-		 * @module.api
 		 */
 		String[] propertyAccessors() default {};
 		/**
 		 * Specify the parent module / namespace for this proxy (if you want this proxy to be expose via "create",
 		 * use {@link proxy#creatableInModule()} instead)
 		 * @default None (lives under the Titanium namespace)
-		 * @module.api
 		 */
 		Class<?> parentModule() default DEFAULT.class;
 	}
@@ -451,7 +436,6 @@ public @interface Kroll {
 	 *     // do something with app
 	 * }
 	 * </pre>
-	 * @module.api
 	 */
 	@Documented
 	@Retention(RetentionPolicy.SOURCE)

--- a/android/kroll-apt/src/main/java/org/appcelerator/kroll/annotations/generator/KrollAnnotationUtils.java
+++ b/android/kroll-apt/src/main/java/org/appcelerator/kroll/annotations/generator/KrollAnnotationUtils.java
@@ -114,7 +114,7 @@ public class KrollAnnotationUtils
 
 	public HashMap<String, Object> mapToHash(Map<? extends ExecutableElement, ? extends AnnotationValue> source)
 	{
-		HashMap<String, Object> result = new HashMap<String, Object>();
+		HashMap<String, Object> result = new HashMap<>();
 		for (Map.Entry<? extends ExecutableElement, ? extends AnnotationValue> mirrorEntry : source.entrySet()) {
 			String mirrorKey = mirrorEntry.getKey().getSimpleName().toString();
 			Object value = mirrorEntry.getValue().getValue();
@@ -167,7 +167,7 @@ public class KrollAnnotationUtils
 
 	public HashMap<String, Object> getAnnotationParams(Element element, String annotationClass)
 	{
-		final HashMap<String, Object> params = new HashMap<String, Object>();
+		final HashMap<String, Object> params = new HashMap<>();
 		acceptAnnotations(element, annotationClass, new KrollVisitor<AnnotationMirror>() {
 			@Override
 			public boolean visit(AnnotationMirror element, Object arg)

--- a/android/kroll-apt/src/main/java/org/appcelerator/kroll/annotations/generator/KrollBindingGenerator.java
+++ b/android/kroll-apt/src/main/java/org/appcelerator/kroll/annotations/generator/KrollBindingGenerator.java
@@ -39,13 +39,13 @@ public class KrollBindingGenerator
 	private String outPath, moduleId;
 	private Configuration fmConfig;
 	private Template v8SourceTemplate, v8HeaderTemplate;
-	private HashMap<String, Object> apiTree = new HashMap<String, Object>();
-	private HashMap<String, Object> proxies = new HashMap<String, Object>();
-	private HashMap<String, Object> modules = new HashMap<String, Object>();
+	private final HashMap<String, Object> apiTree = new HashMap<>();
+	private final HashMap<String, Object> proxies = new HashMap<>();
+	private final HashMap<String, Object> modules = new HashMap<>();
 
 	// These maps are used so we can load up Titanium JSON metadata when generating source for 3rd party modules
-	private HashMap<String, Object> tiProxies = new HashMap<String, Object>();
-	private HashMap<String, Object> tiModules = new HashMap<String, Object>();
+	private final HashMap<String, Object> tiProxies = new HashMap<>();
+	private final HashMap<String, Object> tiModules = new HashMap<>();
 
 	private JSONUtils jsonUtils;
 	private boolean canOverwrite = true;
@@ -165,7 +165,7 @@ public class KrollBindingGenerator
 			}
 
 			if (!tree.containsKey(api)) {
-				HashMap<String, Object> subTree = new HashMap<String, Object>();
+				HashMap<String, Object> subTree = new HashMap<>();
 				tree.put(api, subTree);
 			}
 
@@ -308,7 +308,7 @@ public class KrollBindingGenerator
 		for (String proxyName : proxies.keySet()) {
 			Map<Object, Object> proxy = jsonUtils.getMap(proxies, proxyName);
 
-			HashMap<Object, Object> root = new HashMap<Object, Object>(proxy);
+			HashMap<Object, Object> root = new HashMap<>(proxy);
 			root.put("allModules", modules);
 			root.put("allProxies", proxies);
 			root.put("moduleId", moduleId);

--- a/android/kroll-apt/src/main/java/org/appcelerator/kroll/annotations/generator/KrollJSONGenerator.java
+++ b/android/kroll-apt/src/main/java/org/appcelerator/kroll/annotations/generator/KrollJSONGenerator.java
@@ -103,8 +103,8 @@ public class KrollJSONGenerator extends AbstractProcessor
 	protected static final String OPTION_TI_BINDINGS_JSON_FILE_PATH_NAME = "kroll.tiBindingsJsonFilePath";
 
 	// we make these generic because they may be initialized by JSON
-	protected Map<Object, Object> properties = new HashMap<Object, Object>();
-	protected Map<Object, Object> proxyProperties = new HashMap<Object, Object>();
+	protected Map<Object, Object> properties = new HashMap<>();
+	protected Map<Object, Object> proxyProperties = new HashMap<>();
 	protected KrollAnnotationUtils utils;
 	protected JSONUtils jsonUtils;
 	protected String jarJsonPackageName;
@@ -226,7 +226,7 @@ public class KrollJSONGenerator extends AbstractProcessor
 				protected Map<Object, Object> getProxyProperties(String packageName, String proxyClassName)
 				{
 					if (properties == null) {
-						properties = new HashMap<Object, Object>();
+						properties = new HashMap<>();
 					}
 					return jsonUtils.getOrCreateMap(jsonUtils.getOrCreateMap(properties, "proxies"),
 													packageName + "." + proxyClassName);
@@ -235,7 +235,7 @@ public class KrollJSONGenerator extends AbstractProcessor
 				protected Map<Object, Object> getModule(String moduleClassName)
 				{
 					if (properties == null) {
-						properties = new HashMap<Object, Object>();
+						properties = new HashMap<>();
 					}
 					return jsonUtils.getOrCreateMap(jsonUtils.getOrCreateMap(properties, "modules"), moduleClassName);
 				}
@@ -298,7 +298,7 @@ public class KrollJSONGenerator extends AbstractProcessor
 						HashMap<String, Object> topLevelParams = utils.getAnnotationParams(element, Kroll_topLevel);
 						List<?> topLevelNames = (List<?>) topLevelParams.get("value");
 						if (topLevelNames.size() == 1 && topLevelNames.get(0).equals(DEFAULT_NAME)) {
-							topLevelNames = Arrays.asList(new String[] { apiName });
+							topLevelNames = Arrays.asList(apiName);
 						}
 
 						proxyAttrs.put("topLevelNames", topLevelNames);
@@ -411,7 +411,7 @@ public class KrollJSONGenerator extends AbstractProcessor
 
 			Map<Object, Object> methods = jsonUtils.getOrCreateMap(proxyProperties, "methods");
 			Map<Object, Object> methodAttrs = jsonUtils.getOrCreateMap(methods, methodName);
-			List<Object> args = new ArrayList<Object>();
+			List<Object> args = new ArrayList<>();
 			jsonUtils.updateObjectFromAnnotation(methodAttrs, annotation);
 
 			methodAttrs.put("hasInvocation", false);
@@ -424,7 +424,7 @@ public class KrollJSONGenerator extends AbstractProcessor
 
 				String paramName = utils.getName(var);
 
-				Map<Object, Object> argParams = new HashMap<Object, Object>();
+				Map<Object, Object> argParams = new HashMap<>();
 				argParams.put("sourceName", paramName);
 				argParams.put("type", paramType);
 				jsonUtils.updateObjectFromAnnotationParams(argParams, utils.getAnnotationParams(var, Kroll_argument));
@@ -506,7 +506,7 @@ public class KrollJSONGenerator extends AbstractProcessor
 		{
 			Map<Object, Object> dynamicProperties = jsonUtils.getOrCreateMap(proxyProperties, "dynamicProperties");
 			HashMap<String, Object> params = utils.getAnnotationParams(annotation);
-			Map<Object, Object> dynamicProperty = new HashMap<Object, Object>(params);
+			Map<Object, Object> dynamicProperty = new HashMap<>(params);
 
 			String methodName = utils.getName(element);
 			String defaultName = new String(methodName);
@@ -537,7 +537,7 @@ public class KrollJSONGenerator extends AbstractProcessor
 				dynamicProperty.put("defaultValueProvider", KrollConverter);
 			}
 
-			ArrayList<Map<Object, Object>> args = new ArrayList<Map<Object, Object>>();
+			ArrayList<Map<Object, Object>> args = new ArrayList<>();
 			for (VariableElement var : element.getParameters()) {
 				String paramType = utils.getType(var);
 				if (paramType.equals(KrollInvocation)) {
@@ -551,7 +551,7 @@ public class KrollJSONGenerator extends AbstractProcessor
 
 				String paramName = utils.getName(var);
 
-				Map<Object, Object> argParams = new HashMap<Object, Object>();
+				Map<Object, Object> argParams = new HashMap<>();
 				argParams.put("sourceName", paramName);
 				argParams.put("type", paramType);
 				jsonUtils.updateObjectFromAnnotationParams(argParams, utils.getAnnotationParams(var, Kroll_argument));
@@ -572,7 +572,7 @@ public class KrollJSONGenerator extends AbstractProcessor
 				args.add(argParams);
 			}
 
-			ArrayList<String> defaultProviders = new ArrayList<String>();
+			ArrayList<String> defaultProviders = new ArrayList<>();
 			for (VariableElement var : element.getParameters()) {
 				if (utils.hasAnnotation(var, Kroll_argument)) {
 					defaultProviders.add(

--- a/android/modules/analytics/src/java/ti/modules/titanium/analytics/AnalyticsModule.java
+++ b/android/modules/analytics/src/java/ti/modules/titanium/analytics/AnalyticsModule.java
@@ -32,7 +32,7 @@ public class AnalyticsModule extends KrollModule
 	protected static final String PROPERTY_APP_FEATURE = "app.feature";
 	protected static final String PROPERTY_APP_SETTINGS = "app.settings";
 	protected static final String PROPERTY_APP_USER = "app.user";
-	private APSAnalytics analytics = APSAnalytics.getInstance();
+	private final APSAnalytics analytics = APSAnalytics.getInstance();
 
 	public static final int MAX_LEVELS = 5;
 	public static final int MAX_SERLENGTH = 1000;

--- a/android/modules/android/src/java/ti/modules/titanium/android/AndroidModule.java
+++ b/android/modules/android/src/java/ti/modules/titanium/android/AndroidModule.java
@@ -541,7 +541,7 @@ public class AndroidModule extends KrollModule
 	public static final int FOREGROUND_SERVICE_TYPE_CAMERA = ServiceInfo.FOREGROUND_SERVICE_TYPE_CAMERA;
 
 	protected RProxy r;
-	private LinkedList<BroadcastReceiverProxy> registeredBroadcastReceiverProxyList = new LinkedList<>();
+	private final LinkedList<BroadcastReceiverProxy> registeredBroadcastReceiverProxyList = new LinkedList<>();
 
 	private static final int REQUEST_CODE = 99;
 
@@ -655,7 +655,7 @@ public class AndroidModule extends KrollModule
 	public boolean hasPermission(Object permissionObject)
 	{
 		if (Build.VERSION.SDK_INT >= 23) {
-			ArrayList<String> permissions = new ArrayList<String>();
+			ArrayList<String> permissions = new ArrayList<>();
 			if (permissionObject instanceof String) {
 				permissions.add((String) permissionObject);
 			} else if (permissionObject instanceof Object[]) {
@@ -705,8 +705,7 @@ public class AndroidModule extends KrollModule
 				if (filteredPermissions.size() > 0) {
 					TiBaseActivity.registerPermissionRequestCallback(REQUEST_CODE, permissionCallback,
 						callbackThisObject, promise);
-					currentActivity.requestPermissions(filteredPermissions.toArray(
-						new String[filteredPermissions.size()]), REQUEST_CODE);
+					currentActivity.requestPermissions(filteredPermissions.toArray(new String[0]), REQUEST_CODE);
 					return;
 				}
 			}

--- a/android/modules/android/src/java/ti/modules/titanium/android/TiJSIntervalService.java
+++ b/android/modules/android/src/java/ti/modules/titanium/android/TiJSIntervalService.java
@@ -65,7 +65,7 @@ public class TiJSIntervalService extends TiJSService
 		}
 
 		if (runners == null) {
-			runners = Collections.synchronizedList(new ArrayList<IntervalServiceRunner>());
+			runners = Collections.synchronizedList(new ArrayList<>());
 		}
 
 		String fullUrl = url;
@@ -139,7 +139,7 @@ public class TiJSIntervalService extends TiJSService
 		runners.remove(runner);
 	}
 
-	private class IntervalServiceRunner
+	private static class IntervalServiceRunner
 	{
 		protected ServiceProxy proxy;
 		private long interval;
@@ -148,7 +148,7 @@ public class TiJSIntervalService extends TiJSService
 		private String serviceSimpleName;
 		private String url;
 		private byte[] source;
-		private AtomicInteger counter = new AtomicInteger();
+		private final AtomicInteger counter = new AtomicInteger();
 
 		IntervalServiceRunner(Service service, ServiceProxy proxy, long interval, String url)
 		{

--- a/android/modules/android/src/java/ti/modules/titanium/android/notificationmanager/NotificationManagerModule.java
+++ b/android/modules/android/src/java/ti/modules/titanium/android/notificationmanager/NotificationManagerModule.java
@@ -137,7 +137,7 @@ public class NotificationManagerModule extends KrollModule
 		Notification notification = notificationProxy.buildNotification();
 
 		// targeting Android O or above? create default channel
-		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && notification.getChannelId() == DEFAULT_CHANNEL_ID) {
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && DEFAULT_CHANNEL_ID.equals(notification.getChannelId())) {
 			useDefaultChannel();
 		}
 

--- a/android/modules/calendar/src/java/ti/modules/titanium/calendar/AlertProxy.java
+++ b/android/modules/calendar/src/java/ti/modules/titanium/calendar/AlertProxy.java
@@ -23,7 +23,6 @@ import android.net.Uri;
 @Kroll.proxy(parentModule = CalendarModule.class)
 public class AlertProxy extends KrollProxy
 {
-
 	public static final int STATE_SCHEDULED = 0;
 	public static final int STATE_FIRED = 1;
 	public static final int STATE_DISMISSED = 2;
@@ -50,7 +49,7 @@ public class AlertProxy extends KrollProxy
 
 	public static ArrayList<AlertProxy> queryAlerts(String query, String[] queryArgs, String orderBy)
 	{
-		ArrayList<AlertProxy> alerts = new ArrayList<AlertProxy>();
+		ArrayList<AlertProxy> alerts = new ArrayList<>();
 		if (!CalendarProxy.hasCalendarPermissions()) {
 			return alerts;
 		}

--- a/android/modules/calendar/src/java/ti/modules/titanium/calendar/CalendarModule.java
+++ b/android/modules/calendar/src/java/ti/modules/titanium/calendar/CalendarModule.java
@@ -153,7 +153,7 @@ public class CalendarModule extends KrollModule
 	public CalendarProxy[] getAllCalendars()
 	{
 		ArrayList<CalendarProxy> calendars = CalendarProxy.queryCalendars(null, null);
-		return calendars.toArray(new CalendarProxy[calendars.size()]);
+		return calendars.toArray(new CalendarProxy[0]);
 	}
 
 	@Kroll.getProperty
@@ -162,7 +162,7 @@ public class CalendarModule extends KrollModule
 		// selectable calendars are "visible"
 		ArrayList<CalendarProxy> calendars;
 		calendars = CalendarProxy.queryCalendars("Calendars.visible = ?", new String[] { "1" });
-		return calendars.toArray(new CalendarProxy[calendars.size()]);
+		return calendars.toArray(new CalendarProxy[0]);
 	}
 
 	@Kroll.method
@@ -182,7 +182,7 @@ public class CalendarModule extends KrollModule
 	public AlertProxy[] getAllAlerts()
 	{
 		ArrayList<AlertProxy> alerts = AlertProxy.queryAlerts(null, null, null);
-		return alerts.toArray(new AlertProxy[alerts.size()]);
+		return alerts.toArray(new AlertProxy[0]);
 	}
 
 	@Override

--- a/android/modules/calendar/src/java/ti/modules/titanium/calendar/CalendarProxy.java
+++ b/android/modules/calendar/src/java/ti/modules/titanium/calendar/CalendarProxy.java
@@ -28,7 +28,6 @@ import android.text.format.DateUtils;
 @Kroll.proxy(parentModule = CalendarModule.class)
 public class CalendarProxy extends KrollProxy
 {
-
 	protected String id, name;
 	private static final String TAG = "Calendar";
 	protected boolean selected, hidden;
@@ -51,27 +50,32 @@ public class CalendarProxy extends KrollProxy
 
 	public static ArrayList<CalendarProxy> queryCalendars(String query, String[] queryArgs)
 	{
-		ArrayList<CalendarProxy> calendars = new ArrayList<CalendarProxy>();
+		ArrayList<CalendarProxy> calendars = new ArrayList<>();
 		if (!hasCalendarPermissions()) {
 			return calendars;
 		}
-		ContentResolver contentResolver = TiApplication.getInstance().getContentResolver();
 
-		Cursor cursor = contentResolver.query(
-			Uri.parse(getBaseCalendarUri() + "/calendars"),
-			new String[] { "_id", "calendar_displayName", "visible" },
-			query,
-			queryArgs,
-			null);
-
-		// calendars can be null
-		if (cursor != null) {
-			while (cursor.moveToNext()) {
-				String id = cursor.getString(0);
-				String name = cursor.getString(1);
-				boolean selected = !cursor.getString(2).equals("0");
-				boolean hidden = false;
-				calendars.add(new CalendarProxy(id, name, selected, hidden));
+		Cursor cursor = null;
+		try {
+			ContentResolver contentResolver = TiApplication.getInstance().getContentResolver();
+			cursor = contentResolver.query(
+				Uri.parse(getBaseCalendarUri() + "/calendars"),
+				new String[] { "_id", "calendar_displayName", "visible" },
+				query,
+				queryArgs,
+				null);
+			if (cursor != null) {
+				while (cursor.moveToNext()) {
+					String id = cursor.getString(0);
+					String name = cursor.getString(1);
+					boolean selected = !cursor.getString(2).equals("0");
+					boolean hidden = false;
+					calendars.add(new CalendarProxy(id, name, selected, hidden));
+				}
+			}
+		} finally {
+			if (cursor != null) {
+				cursor.close();
 			}
 		}
 
@@ -110,7 +114,7 @@ public class CalendarProxy extends KrollProxy
 		long date1 = jan1.getTimeInMillis();
 		long date2 = date1 + DateUtils.YEAR_IN_MILLIS;
 		ArrayList<EventProxy> events = EventProxy.queryEventsBetweenDates(date1, date2, this);
-		return events.toArray(new EventProxy[events.size()]);
+		return events.toArray(new EventProxy[0]);
 	}
 
 	@Kroll.method
@@ -136,7 +140,7 @@ public class CalendarProxy extends KrollProxy
 		long date2 = lastOfTheMonth.getTimeInMillis();
 
 		ArrayList<EventProxy> events = EventProxy.queryEventsBetweenDates(date1, date2, this);
-		return events.toArray(new EventProxy[events.size()]);
+		return events.toArray(new EventProxy[0]);
 	}
 
 	@Kroll.method
@@ -153,7 +157,7 @@ public class CalendarProxy extends KrollProxy
 		long date2 = endOfDay.getTimeInMillis();
 
 		ArrayList<EventProxy> events = EventProxy.queryEventsBetweenDates(date1, date2, this);
-		return events.toArray(new EventProxy[events.size()]);
+		return events.toArray(new EventProxy[0]);
 	}
 
 	@Kroll.method
@@ -161,7 +165,7 @@ public class CalendarProxy extends KrollProxy
 	{
 		long start = date1.getTime();
 		long end = date2.getTime();
-		ArrayList<EventProxy> events = new ArrayList<EventProxy>();
+		ArrayList<EventProxy> events = new ArrayList<>();
 
 		// A workaround for TIMOB-8439
 		while (end - start > MAX_DATE_RANGE) {
@@ -171,7 +175,7 @@ public class CalendarProxy extends KrollProxy
 
 		events.addAll(EventProxy.queryEventsBetweenDates(start, end, this));
 
-		return events.toArray(new EventProxy[events.size()]);
+		return events.toArray(new EventProxy[0]);
 	}
 
 	@Kroll.method

--- a/android/modules/calendar/src/java/ti/modules/titanium/calendar/EventProxy.java
+++ b/android/modules/calendar/src/java/ti/modules/titanium/calendar/EventProxy.java
@@ -30,7 +30,6 @@ import android.provider.CalendarContract.Instances;
 @Kroll.proxy(parentModule = CalendarModule.class, propertyAccessors = { TiC.PROPERTY_RECURRENCE_RULES })
 public class EventProxy extends KrollProxy
 {
-
 	public static final String TAG = "EventProxy";
 
 	public static final int STATUS_TENTATIVE = 0;
@@ -79,7 +78,7 @@ public class EventProxy extends KrollProxy
 	public static ArrayList<EventProxy> queryEventsBetweenDates(long date1, long date2, String query,
 																String[] queryArgs)
 	{
-		ArrayList<EventProxy> events = new ArrayList<EventProxy>();
+		ArrayList<EventProxy> events = new ArrayList<>();
 		if (!CalendarProxy.hasCalendarPermissions()) {
 			return events;
 		}
@@ -155,7 +154,7 @@ public class EventProxy extends KrollProxy
 
 	public static ArrayList<EventProxy> queryEvents(Uri uri, String query, String[] queryArgs, String orderBy)
 	{
-		ArrayList<EventProxy> events = new ArrayList<EventProxy>();
+		ArrayList<EventProxy> events = new ArrayList<>();
 		if (!CalendarProxy.hasCalendarPermissions()) {
 			return events;
 		}
@@ -339,7 +338,7 @@ public class EventProxy extends KrollProxy
 	public ReminderProxy[] getReminders()
 	{
 		ArrayList<ReminderProxy> reminders = ReminderProxy.getRemindersForEvent(this);
-		return reminders.toArray(new ReminderProxy[reminders.size()]);
+		return reminders.toArray(new ReminderProxy[0]);
 	}
 
 	@Kroll.method
@@ -364,7 +363,7 @@ public class EventProxy extends KrollProxy
 	public AlertProxy[] getAlerts()
 	{
 		ArrayList<AlertProxy> alerts = AlertProxy.getAlertsForEvent(this);
-		return alerts.toArray(new AlertProxy[alerts.size()]);
+		return alerts.toArray(new AlertProxy[0]);
 	}
 
 	@Kroll.method

--- a/android/modules/calendar/src/java/ti/modules/titanium/calendar/RecurrenceRuleProxy.java
+++ b/android/modules/calendar/src/java/ti/modules/titanium/calendar/RecurrenceRuleProxy.java
@@ -26,7 +26,6 @@ import java.util.regex.Pattern;
 @Kroll.proxy
 public class RecurrenceRuleProxy extends KrollProxy
 {
-
 	private static final String TAG = "RecurrenceRule";
 
 	// Keys for daysOfTheWeek dictionary.
@@ -58,7 +57,7 @@ public class RecurrenceRuleProxy extends KrollProxy
 	private static final Map<String, Integer> weekdaysMap;
 	static
 	{
-		weekdaysMap = new HashMap<String, Integer>();
+		weekdaysMap = new HashMap<>();
 		weekdaysMap.put("SU", 1);
 		weekdaysMap.put("MO", 2);
 		weekdaysMap.put("TU", 3);
@@ -118,9 +117,6 @@ public class RecurrenceRuleProxy extends KrollProxy
 			finalRRule.append(";");
 			// Handle frequency specific rules in different context.
 			switch (this.frequency) {
-				case DAILY:
-					break;
-				// Case for weekly recurring events.
 				case WEEKLY:
 					StringBuilder weeklyRecurrencesString = new StringBuilder("BYDAY=");
 					int commaIndex = 0;
@@ -133,42 +129,42 @@ public class RecurrenceRuleProxy extends KrollProxy
 					finalRRule.append(weeklyRecurrencesString.toString());
 					finalRRule.append(";");
 					break;
-				// Case for monthly recurring events.
 				case MONTHLY:
 					StringBuilder monthlyReccurencesString = new StringBuilder();
 					// daysOfTheWeek dictionary is with highest priority.
 					if (this.daysOfTheWeek.length > 0) {
 						monthlyReccurencesString.append("BYDAY=");
-						monthlyReccurencesString.append(this.daysOfTheWeek[0].getInt(this.weekNumberKey));
+						int index = this.daysOfTheWeek[0].getInt(this.weekNumberKey);
+						monthlyReccurencesString.append(index);
 						// Potentially add week start (Sunday or Monday) different from the default one.
-						monthlyReccurencesString.append(
-							this.weekdaysMap.keySet().toArray()[this.daysOfTheWeek[0].getInt(this.weekNumberKey)]);
+						monthlyReccurencesString.append(RecurrenceRuleProxy.weekdaysMap.keySet().toArray()[index]);
 					} else {
 						monthlyReccurencesString.append("BYMONTHDAY=");
 						// Case in which we do not have items in daysOfTheWeek array.
-						monthlyReccurencesString.append(String.valueOf(this.daysOfTheMonth[0]));
+						monthlyReccurencesString.append(this.daysOfTheMonth[0]);
 					}
 					finalRRule.append(monthlyReccurencesString);
 					finalRRule.append(";");
 					break;
-				case YEARLY:
-					break;
-			} // end of switch
+			}
 		}
 		// Handle interval.
 		if (this.interval != null) {
-			finalRRule.append("INTERVAL=" + String.valueOf(this.interval));
+			finalRRule.append("INTERVAL=");
+			finalRRule.append(this.interval);
 			finalRRule.append(";");
 		}
 		// Handle end.
 		if (this.endDictionary.containsKey(this.until)) {
 			// Dictionary can contain only one of the keys,
 			// so what's left is a specific date end rule.
-			finalRRule.append("UNTIL=" + String.valueOf(this.endDictionary.get(this.until)));
+			finalRRule.append("UNTIL=");
+			finalRRule.append(this.endDictionary.get(this.until));
 			finalRRule.append(";");
 		} else if (this.endDictionary.containsKey(this.count)) {
 			// End rule is with occurrence count.
-			finalRRule.append("COUNT=" + String.valueOf(this.endDictionary.get(this.count)));
+			finalRRule.append("COUNT=");
+			finalRRule.append(this.endDictionary.get(this.count));
 			finalRRule.append(";");
 		}
 
@@ -219,8 +215,9 @@ public class RecurrenceRuleProxy extends KrollProxy
 					byDay = matchExpression(".*(BYDAY=[,0-9A-Z]*).*", 6);
 					if (byDay != null) {
 						KrollDict daysOfTheWeekDictionary = new KrollDict();
-						daysOfTheWeekDictionary.put(this.dayOfWeekKey,
-													this.weekdaysMap.get(byDay.substring(byDay.length() - 2)));
+						daysOfTheWeekDictionary.put(
+							this.dayOfWeekKey,
+							RecurrenceRuleProxy.weekdaysMap.get(byDay.substring(byDay.length() - 2)));
 						daysOfTheWeekDictionary.put(this.weekNumberKey, byDay.substring(0, byDay.length() - 2));
 						this.daysOfTheWeek = new KrollDict[] { daysOfTheWeekDictionary };
 					}
@@ -234,7 +231,7 @@ public class RecurrenceRuleProxy extends KrollProxy
 						this.daysOfTheWeek = new KrollDict[daysArray.length];
 						for (int i = 0; i < this.daysOfTheWeek.length; i++) {
 							KrollDict daysOfTheWeekDictionary = new KrollDict();
-							daysOfTheWeekDictionary.put(this.dayOfWeekKey, this.weekdaysMap.get(daysArray[i]));
+							daysOfTheWeekDictionary.put(this.dayOfWeekKey, weekdaysMap.get(daysArray[i]));
 							// In the context of a weekly recurrence week number is irrelevant.
 							daysOfTheWeekDictionary.put(this.weekNumberKey, 0);
 							this.daysOfTheWeek[i] = daysOfTheWeekDictionary;

--- a/android/modules/calendar/src/java/ti/modules/titanium/calendar/ReminderProxy.java
+++ b/android/modules/calendar/src/java/ti/modules/titanium/calendar/ReminderProxy.java
@@ -21,7 +21,6 @@ import android.net.Uri;
 @Kroll.proxy(parentModule = CalendarModule.class)
 public class ReminderProxy extends KrollProxy
 {
-
 	public static final int METHOD_DEFAULT = 0;
 	public static final int METHOD_ALERT = 1;
 	public static final int METHOD_EMAIL = 2;
@@ -42,7 +41,7 @@ public class ReminderProxy extends KrollProxy
 
 	public static ArrayList<ReminderProxy> getRemindersForEvent(EventProxy event)
 	{
-		ArrayList<ReminderProxy> reminders = new ArrayList<ReminderProxy>();
+		ArrayList<ReminderProxy> reminders = new ArrayList<>();
 		if (!CalendarProxy.hasCalendarPermissions()) {
 			return reminders;
 		}

--- a/android/modules/contacts/src/java/ti/modules/titanium/contacts/CommonContactsApi.java
+++ b/android/modules/contacts/src/java/ti/modules/titanium/contacts/CommonContactsApi.java
@@ -248,13 +248,13 @@ public abstract class CommonContactsApi
 		String department;
 
 		boolean hasImage = false;
-		Map<String, ArrayList<String>> emails = new HashMap<String, ArrayList<String>>();
-		Map<String, ArrayList<String>> phones = new HashMap<String, ArrayList<String>>();
-		Map<String, ArrayList<String>> addresses = new HashMap<String, ArrayList<String>>();
-		Map<String, ArrayList<String>> instantMessages = new HashMap<String, ArrayList<String>>();
-		Map<String, ArrayList<String>> relatedNames = new HashMap<String, ArrayList<String>>();
-		Map<String, ArrayList<String>> websites = new HashMap<String, ArrayList<String>>();
-		Map<String, ArrayList<String>> dates = new HashMap<String, ArrayList<String>>();
+		Map<String, ArrayList<String>> emails = new HashMap<>();
+		Map<String, ArrayList<String>> phones = new HashMap<>();
+		Map<String, ArrayList<String>> addresses = new HashMap<>();
+		Map<String, ArrayList<String>> instantMessages = new HashMap<>();
+		Map<String, ArrayList<String>> relatedNames = new HashMap<>();
+		Map<String, ArrayList<String>> websites = new HashMap<>();
+		Map<String, ArrayList<String>> dates = new HashMap<>();
 
 		void addPersonInfoFromL5DataRow(Cursor cursor)
 		{
@@ -309,7 +309,7 @@ public abstract class CommonContactsApi
 			if (instantMessages.containsKey(key)) {
 				collection = instantMessages.get(key);
 			} else {
-				collection = new ArrayList<String>();
+				collection = new ArrayList<>();
 				instantMessages.put(key, collection);
 			}
 			collection.add(instantMessage);
@@ -325,7 +325,7 @@ public abstract class CommonContactsApi
 			if (relatedNames.containsKey(key)) {
 				collection = relatedNames.get(key);
 			} else {
-				collection = new ArrayList<String>();
+				collection = new ArrayList<>();
 				relatedNames.put(key, collection);
 			}
 			collection.add(relatedName);
@@ -352,7 +352,7 @@ public abstract class CommonContactsApi
 			if (phones.containsKey(key)) {
 				collection = phones.get(key);
 			} else {
-				collection = new ArrayList<String>();
+				collection = new ArrayList<>();
 				phones.put(key, collection);
 			}
 			collection.add(phoneNumber);
@@ -382,7 +382,7 @@ public abstract class CommonContactsApi
 			if (emails.containsKey(key)) {
 				collection = emails.get(key);
 			} else {
-				collection = new ArrayList<String>();
+				collection = new ArrayList<>();
 				emails.put(key, collection);
 			}
 			collection.add(emailAddress);
@@ -397,7 +397,7 @@ public abstract class CommonContactsApi
 			if (websites.containsKey(key)) {
 				collection = websites.get(key);
 			} else {
-				collection = new ArrayList<String>();
+				collection = new ArrayList<>();
 				websites.put(key, collection);
 			}
 
@@ -413,7 +413,7 @@ public abstract class CommonContactsApi
 			if (dates.containsKey(key)) {
 				collection = dates.get(key);
 			} else {
-				collection = new ArrayList<String>();
+				collection = new ArrayList<>();
 				dates.put(key, collection);
 			}
 			collection.add(date);
@@ -433,7 +433,7 @@ public abstract class CommonContactsApi
 
 		void loadAddressFromL5DataRow(Cursor cursor)
 		{
-			// TODO add structured addresss
+			// TODO add structured address
 			String fullAddress = cursor.getString(ContactsApiLevel5.DATA_COLUMN_ADDRESS_FULL);
 			int type = cursor.getInt(ContactsApiLevel5.DATA_COLUMN_ADDRESS_TYPE);
 			String key = getPostalAddressTextType(type);
@@ -441,7 +441,7 @@ public abstract class CommonContactsApi
 			if (addresses.containsKey(key)) {
 				collection = addresses.get(key);
 			} else {
-				collection = new ArrayList<String>();
+				collection = new ArrayList<>();
 				addresses.put(key, collection);
 			}
 			collection.add(fullAddress);

--- a/android/modules/contacts/src/java/ti/modules/titanium/contacts/ContactsApiLevel5.java
+++ b/android/modules/contacts/src/java/ti/modules/titanium/contacts/ContactsApiLevel5.java
@@ -57,7 +57,7 @@ public class ContactsApiLevel5 extends CommonContactsApi
 	private static Uri ContactsUri;
 	private static Uri DataUri;
 
-	private static String[] DATA_PROJECTION = new String[] {
+	private static final String[] DATA_PROJECTION = new String[] {
 		"contact_id",
 		"mimetype",
 		"photo_id",
@@ -148,15 +148,16 @@ public class ContactsApiLevel5 extends CommonContactsApi
 		TiC.PROPERTY_SISTER
 	};
 
-	private static String[] PEOPLE_PROJECTION = new String[] { "_id", "display_name", "photo_id" };
+	private static final String[] PEOPLE_PROJECTION = new String[] { "_id", "display_name", "photo_id" };
 	protected static int PEOPLE_COL_ID = 0;
 	protected static int PEOPLE_COL_NAME = 1;
 	protected static int PEOPLE_COL_PHOTO_ID = 2;
 
-	private static String INConditionForKinds = "('" + KIND_ADDRESS + "','" + KIND_EMAIL + "','" + KIND_EVENT + "','"
-												+ KIND_NAME + "','" + KIND_NOTE + "','" + KIND_PHONE + "','"
-												+ KIND_NICKNAME + "','" + KIND_ORGANIZE + "','" + KIND_IM + "','"
-												+ KIND_RELATED_NAME + "','" + KIND_WEBSITE + "')";
+	private static final String INConditionForKinds
+		= "('" + KIND_ADDRESS + "','" + KIND_EMAIL + "','" + KIND_EVENT + "','"
+		+ KIND_NAME + "','" + KIND_NOTE + "','" + KIND_PHONE + "','"
+		+ KIND_NICKNAME + "','" + KIND_ORGANIZE + "','" + KIND_IM + "','"
+		+ KIND_RELATED_NAME + "','" + KIND_WEBSITE + "')";
 
 	protected ContactsApiLevel5()
 	{
@@ -172,7 +173,6 @@ public class ContactsApiLevel5 extends CommonContactsApi
 			Log.e(TAG, "Failed to load android.provider.ContactsContract$Contacts " + t.getMessage(), t,
 				  Log.DEBUG_MODE);
 			loadedOk = false;
-			return;
 		}
 	}
 
@@ -200,7 +200,7 @@ public class ContactsApiLevel5 extends CommonContactsApi
 			return null;
 		}
 
-		LinkedHashMap<Long, CommonContactsApi.LightPerson> persons = new LinkedHashMap<Long, LightPerson>();
+		LinkedHashMap<Long, CommonContactsApi.LightPerson> persons = new LinkedHashMap<>();
 
 		String condition = "mimetype IN " + INConditionForKinds;
 
@@ -984,7 +984,7 @@ public class ContactsApiLevel5 extends CommonContactsApi
 
 	protected void modifyContact(PersonProxy person, String id)
 	{
-		ArrayList<ContentProviderOperation> ops = new ArrayList<ContentProviderOperation>();
+		ArrayList<ContentProviderOperation> ops = new ArrayList<>();
 		if (person.isFieldModified(TiC.PROPERTY_NAME)) {
 			modifyName(ops, person, id);
 		}

--- a/android/modules/contacts/src/java/ti/modules/titanium/contacts/ContactsModule.java
+++ b/android/modules/contacts/src/java/ti/modules/titanium/contacts/ContactsModule.java
@@ -171,10 +171,10 @@ public class ContactsModule extends KrollModule implements TiActivityResultHandl
 		int requestCode = requestCodeGen.getAndIncrement();
 
 		if (requests == null) {
-			requests = new HashMap<Integer, Map<String, KrollFunction>>();
+			requests = new HashMap<>();
 		}
-		Map<String, KrollFunction> callbacks = new HashMap<String, KrollFunction>();
-		requests.put(new Integer(requestCode), callbacks);
+		Map<String, KrollFunction> callbacks = new HashMap<>();
+		requests.put(requestCode, callbacks);
 
 		String[] callbacksToConsider = new String[] { "selectedPerson", "cancel" };
 		for (String callbackToConsider : callbacksToConsider) {
@@ -186,7 +186,7 @@ public class ContactsModule extends KrollModule implements TiActivityResultHandl
 			}
 			if (d.containsKey("proxy")) {
 				Object test = d.get("proxy");
-				if (test != null && test instanceof KrollProxy) {
+				if (test instanceof KrollProxy) {
 					launchingActivity = ((KrollProxy) test).getActivity();
 				}
 			}
@@ -206,7 +206,7 @@ public class ContactsModule extends KrollModule implements TiActivityResultHandl
 	@Override
 	public void onResult(Activity activity, int requestCode, int resultCode, Intent data)
 	{
-		Integer rcode = new Integer(requestCode);
+		Integer rcode = requestCode;
 		if (requests.containsKey(rcode)) {
 			Map<String, KrollFunction> request = requests.get(rcode);
 			Log.d(TAG, "Received result from contact picker.  Result code: " + resultCode, Log.DEBUG_MODE);

--- a/android/modules/contacts/src/java/ti/modules/titanium/contacts/PersonProxy.java
+++ b/android/modules/contacts/src/java/ti/modules/titanium/contacts/PersonProxy.java
@@ -54,7 +54,7 @@ public class PersonProxy extends KrollProxy
 	private String fullName = "";
 
 	// Contact Modifications
-	private HashMap<String, Boolean> modified = new HashMap<String, Boolean>();
+	private final HashMap<String, Boolean> modified = new HashMap<>();
 
 	public PersonProxy()
 	{

--- a/android/modules/database/src/java/ti/modules/titanium/database/TiDatabaseProxy.java
+++ b/android/modules/database/src/java/ti/modules/titanium/database/TiDatabaseProxy.java
@@ -41,9 +41,9 @@ public class TiDatabaseProxy extends KrollProxy
 	private static final String TAG = "TiDB";
 
 	private Thread thread;
-	private Lock dbLock = new ReentrantLock(true); // use a "fair" lock
-	private BlockingQueue<Runnable> queue = new LinkedBlockingQueue<>();
-	private AtomicBoolean executingQueue = new AtomicBoolean(false);
+	private final Lock dbLock = new ReentrantLock(true); // use a "fair" lock
+	private final BlockingQueue<Runnable> queue = new LinkedBlockingQueue<>();
+	private final AtomicBoolean executingQueue = new AtomicBoolean(false);
 	private boolean isClosed = false;
 
 	protected SQLiteDatabase db;
@@ -260,7 +260,6 @@ public class TiDatabaseProxy extends KrollProxy
 	 * Asynchronously execute a single SQL query.
 	 * @param query SQL query to execute on database.
 	 * @param parameterObjects Parameters for `query`
-	 * @param callback Result callback for query execution.
 	 */
 	@Kroll.method
 	public KrollPromise<TiResultSetProxy> executeAsync(final String query, final Object... parameterObjects)
@@ -501,7 +500,7 @@ public class TiDatabaseProxy extends KrollProxy
 
 		public HashMap getJSProperties()
 		{
-			HashMap map = new HashMap();
+			HashMap<String, Object> map = new HashMap<>();
 			map.put("index", index);
 			if (partialResults != null) {
 				map.put("results", partialResults.toArray());

--- a/android/modules/database/src/java/ti/modules/titanium/database/TiResultSetProxy.java
+++ b/android/modules/database/src/java/ti/modules/titanium/database/TiResultSetProxy.java
@@ -33,7 +33,7 @@ public class TiResultSetProxy extends KrollProxy
 
 		this.rs = rs;
 		String[] names = rs.getColumnNames();
-		this.columnNames = new HashMap<String, Integer>(names.length);
+		this.columnNames = new HashMap<>(names.length);
 		for (int i = 0; i < names.length; i++) {
 			columnNames.put(names[i].toLowerCase(), i);
 		}

--- a/android/modules/geolocation/src/java/ti/modules/titanium/geolocation/GeolocationModule.java
+++ b/android/modules/geolocation/src/java/ti/modules/titanium/geolocation/GeolocationModule.java
@@ -102,8 +102,7 @@ import android.os.Message;
  * accuracy, frequency properties or even changing modes are respected and kept but don't actually get applied on the OS until
  * the listener count is greater than 0.
  */
-// TODO deprecate the frequency and preferredProvider property
-@Kroll.module(propertyAccessors = { TiC.PROPERTY_ACCURACY, TiC.PROPERTY_FREQUENCY, TiC.PROPERTY_PREFERRED_PROVIDER })
+@Kroll.module(propertyAccessors = { TiC.PROPERTY_ACCURACY })
 public class GeolocationModule extends KrollModule implements Handler.Callback, LocationProviderListener
 {
 	@Kroll.constant
@@ -335,8 +334,6 @@ public class GeolocationModule extends KrollModule implements Handler.Callback, 
 	{
 		if (key.equals(TiC.PROPERTY_ACCURACY)) {
 			propertyChangedAccuracy(newValue);
-		} else if (key.equals(TiC.PROPERTY_FREQUENCY)) {
-			propertyChangedFrequency(newValue);
 		}
 	}
 
@@ -365,16 +362,6 @@ public class GeolocationModule extends KrollModule implements Handler.Callback, 
 				registerLocationProvider(gpsProvider);
 			}
 		}
-	}
-
-	/**
-	 * Handles property change for Ti.Geolocation.frequency
-	 *
-	 * @param newValue					new frequency value
-	 */
-	private void propertyChangedFrequency(Object newValue)
-	{
-		double frequencyProperty = TiConvert.toDouble(newValue) * 1000;
 	}
 
 	/**

--- a/android/modules/geolocation/src/java/ti/modules/titanium/geolocation/GeolocationModule.java
+++ b/android/modules/geolocation/src/java/ti/modules/titanium/geolocation/GeolocationModule.java
@@ -134,14 +134,14 @@ public class GeolocationModule extends KrollModule implements Handler.Callback, 
 	private Context context;
 	private TiCompass tiCompass;
 	private boolean compassListenersRegistered = false;
-	private ArrayList<LocationRuleProxy> simpleLocationRules = new ArrayList<LocationRuleProxy>();
+	private final ArrayList<LocationRuleProxy> simpleLocationRules = new ArrayList<>();
 	private LocationRuleProxy simpleLocationGpsRule;
 	private LocationRuleProxy simpleLocationNetworkRule;
 	private Location currentLocation;
 	//currentLocation is conditionally updated. lastLocation is unconditionally updated
 	//since currentLocation determines when to send out updates, and lastLocation is passive
 	private Location lastLocation;
-	private HashMap<KrollPromise<KrollDict>, KrollFunction> currentPositionCallback = new HashMap<>();
+	private final HashMap<KrollPromise<KrollDict>, KrollFunction> currentPositionCallback = new HashMap<>();
 
 	private FusedLocationProvider fusedLocationProvider;
 	private Geocoder geocoder;
@@ -335,12 +335,8 @@ public class GeolocationModule extends KrollModule implements Handler.Callback, 
 	{
 		if (key.equals(TiC.PROPERTY_ACCURACY)) {
 			propertyChangedAccuracy(newValue);
-
 		} else if (key.equals(TiC.PROPERTY_FREQUENCY)) {
 			propertyChangedFrequency(newValue);
-
-		} else if (key.equals(TiC.PROPERTY_PREFERRED_PROVIDER)) {
-			propertyChangedPreferredProvider(newValue);
 		}
 	}
 
@@ -379,21 +375,6 @@ public class GeolocationModule extends KrollModule implements Handler.Callback, 
 	private void propertyChangedFrequency(Object newValue)
 	{
 		double frequencyProperty = TiConvert.toDouble(newValue) * 1000;
-	}
-
-	/**
-	 * Handles property change for Ti.Geolocation.preferredProvider
-	 *
-	 * @param newValue					new preferredProvider value
-	 */
-	@SuppressLint("MissingPermission")
-	private void propertyChangedPreferredProvider(Object newValue)
-	{
-		String preferredProviderProperty = TiConvert.toString(newValue);
-		if (!(preferredProviderProperty.equals(AndroidModule.PROVIDER_NETWORK))
-			&& (!(preferredProviderProperty.equals(AndroidModule.PROVIDER_GPS)))) {
-			return;
-		}
 	}
 
 	/**
@@ -647,7 +628,7 @@ public class GeolocationModule extends KrollModule implements Handler.Callback, 
 	 * should occur on the runtime thread in order to make sure threading issues are
 	 * avoiding
 	 *
-	 * @param locationProviders
+	 * @param locationProviders Dictionary of providers to use.
 	 */
 	private void doEnableLocationProviders(HashMap<String, LocationProviderProxy> locationProviders)
 	{

--- a/android/modules/geolocation/src/java/ti/modules/titanium/geolocation/TiCompass.java
+++ b/android/modules/geolocation/src/java/ti/modules/titanium/geolocation/TiCompass.java
@@ -37,12 +37,12 @@ public class TiCompass implements SensorEventListener
 
 	private GeolocationModule geolocationModule;
 	private TiLocation tiLocation;
-	private Calendar baseTime = Calendar.getInstance();
-	private long sensorTimerStart = SystemClock.uptimeMillis();
+	private final Calendar baseTime = Calendar.getInstance();
+	private final long sensorTimerStart = SystemClock.uptimeMillis();
 	private long lastEventInUpdate;
 	private float lastHeading = 0.0f;
 	private GeomagneticField geomagneticField;
-	private Criteria locationCriteria = new Criteria();
+	private final Criteria locationCriteria = new Criteria();
 	private Location geomagneticFieldLocation;
 	private long lastDeclinationCheck;
 
@@ -141,11 +141,11 @@ public class TiCompass implements SensorEventListener
 		return data;
 	}
 
-	/*
-     * Check whether a fresher location is available and update the GeomagneticField 
-     * that we use for correcting the magnetic heading. If the location is stale,
-     * use it anyway but log a warning.
-     */
+	/**
+	 * Check whether a fresher location is available and update the GeomagneticField
+	 * that we use for correcting the magnetic heading. If the location is stale,
+	 * use it anyway but log a warning.
+	 */
 	private void updateDeclination()
 	{
 		long currentTime = System.currentTimeMillis();

--- a/android/modules/geolocation/src/java/ti/modules/titanium/geolocation/android/AndroidModule.java
+++ b/android/modules/geolocation/src/java/ti/modules/titanium/geolocation/android/AndroidModule.java
@@ -43,9 +43,8 @@ public class AndroidModule extends KrollModule implements Handler.Callback
 	@Kroll.constant
 	public static final String PROVIDER_GPS = LocationManager.GPS_PROVIDER;
 
-	public HashMap<String, LocationProviderProxy> manualLocationProviders =
-		new HashMap<String, LocationProviderProxy>();
-	public ArrayList<LocationRuleProxy> manualLocationRules = new ArrayList<LocationRuleProxy>();
+	public HashMap<String, LocationProviderProxy> manualLocationProviders = new HashMap<>();
+	public ArrayList<LocationRuleProxy> manualLocationRules = new ArrayList<>();
 	public boolean manualMode = false;
 
 	protected static final int MSG_ADD_LOCATION_PROVIDER = KrollModule.MSG_LAST_ID + 100;
@@ -113,7 +112,6 @@ public class AndroidModule extends KrollModule implements Handler.Callback
 	 * @param manualMode			<code>boolean</code> value to indicate whether
 	 * 								the manual providers should be used
 	 */
-	@SuppressWarnings("deprecation")
 	@Kroll.setProperty
 	public void setManualMode(boolean manualMode)
 	{
@@ -208,18 +206,13 @@ public class AndroidModule extends KrollModule implements Handler.Callback
 
 		// if doesn't exist, add new - otherwise update properties
 		LocationProviderProxy existingLocationProvider = manualLocationProviders.get(providerName);
-		if (existingLocationProvider == null) {
-			manualLocationProviders.put(providerName, locationProvider);
-
-		} else {
+		if (existingLocationProvider != null) {
 			manualLocationProviders.remove(providerName);
-
 			if (manualMode && (geolocationModule.numLocationListeners > 0)) {
 				geolocationModule.unregisterLocationProvider(existingLocationProvider);
 			}
-
-			manualLocationProviders.put(providerName, locationProvider);
 		}
+		manualLocationProviders.put(providerName, locationProvider);
 
 		if (manualMode && (geolocationModule.numLocationListeners > 0)) {
 			geolocationModule.registerLocationProvider(locationProvider);

--- a/android/modules/geolocation/src/java/ti/modules/titanium/geolocation/android/FusedLocationProvider.java
+++ b/android/modules/geolocation/src/java/ti/modules/titanium/geolocation/android/FusedLocationProvider.java
@@ -41,7 +41,6 @@ import java.util.Iterator;
  */
 public class FusedLocationProvider
 {
-
 	private static final String TAG = "FusedLocationProvider";
 
 	public static final String PROVIDER = "fused";
@@ -139,8 +138,8 @@ public class FusedLocationProvider
 		private static GoogleApiClient googleApiClient;
 		private static FusedLocationProviderClient fusedLocationClient;
 
-		private static ArrayList<LocationProviderProxy> fusedLocationQueue = new ArrayList<>();
-		private static ArrayList<LocationProviderProxy> fusedLocationProviders = new ArrayList<>();
+		private static final ArrayList<LocationProviderProxy> fusedLocationQueue = new ArrayList<>();
+		private static final ArrayList<LocationProviderProxy> fusedLocationProviders = new ArrayList<>();
 
 		public static void init(Context context, final GeolocationModule geolocationModule)
 		{

--- a/android/modules/geolocation/src/java/ti/modules/titanium/geolocation/android/LocationProviderProxy.java
+++ b/android/modules/geolocation/src/java/ti/modules/titanium/geolocation/android/LocationProviderProxy.java
@@ -102,7 +102,7 @@ public class LocationProviderProxy extends KrollProxy implements LocationListene
 	}
 
 	/**
-	 * @see FusedLocationProvider.createLocationCallback
+	 * @see FusedLocationProvider#createLocationCallback
 	 */
 	public Object getLocationCallback()
 	{

--- a/android/modules/locale/src/java/ti/modules/titanium/locale/LocaleModule.java
+++ b/android/modules/locale/src/java/ti/modules/titanium/locale/LocaleModule.java
@@ -11,7 +11,6 @@ import java.text.DateFormat;
 import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.Locale;
-import java.text.NumberFormat;
 
 import org.appcelerator.kroll.KrollModule;
 import org.appcelerator.kroll.annotations.Kroll;

--- a/android/modules/media/src/java/android/widget/TiVideoView8.java
+++ b/android/modules/media/src/java/android/widget/TiVideoView8.java
@@ -66,7 +66,6 @@ public class TiVideoView8 extends SurfaceView implements MediaPlayerControl
 	private int mScalingMode = MediaModule.VIDEO_SCALING_RESIZE_ASPECT;
 	// settable by the client
 	private Uri mUri;
-	@SuppressWarnings("unused")
 	private Map<String, String> mHeaders;
 	private int mDuration;
 
@@ -515,7 +514,7 @@ public class TiVideoView8 extends SurfaceView implements MediaPlayerControl
 		}
 	};
 
-	private MediaPlayer.OnCompletionListener mCompletionListener = new MediaPlayer.OnCompletionListener() {
+	private final MediaPlayer.OnCompletionListener mCompletionListener = new MediaPlayer.OnCompletionListener() {
 		public void onCompletion(MediaPlayer mp)
 		{
 			mCurrentState = STATE_PLAYBACK_COMPLETED;
@@ -529,7 +528,7 @@ public class TiVideoView8 extends SurfaceView implements MediaPlayerControl
 		}
 	};
 
-	private MediaPlayer.OnErrorListener mErrorListener = new MediaPlayer.OnErrorListener() {
+	private final MediaPlayer.OnErrorListener mErrorListener = new MediaPlayer.OnErrorListener() {
 		public boolean onError(MediaPlayer mp, int framework_err, int impl_err)
 		{
 			Log.d(TAG, "Error: " + framework_err + "," + impl_err);
@@ -548,7 +547,7 @@ public class TiVideoView8 extends SurfaceView implements MediaPlayerControl
 		}
 	};
 
-	private MediaPlayer.OnBufferingUpdateListener mBufferingUpdateListener =
+	private final MediaPlayer.OnBufferingUpdateListener mBufferingUpdateListener =
 		new MediaPlayer.OnBufferingUpdateListener() {
 			public void onBufferingUpdate(MediaPlayer mp, int percent)
 			{

--- a/android/modules/media/src/java/ti/modules/titanium/media/MediaModule.java
+++ b/android/modules/media/src/java/ti/modules/titanium/media/MediaModule.java
@@ -117,7 +117,7 @@ public class MediaModule extends KrollModule implements Handler.Callback
 	@Kroll.constant
 	public static final int VIDEO_LOAD_STATE_UNKNOWN = 0;
 	@Kroll.constant
-	public static final int VIDEO_LOAD_STATE_PLAYABLE = 1 << 0;
+	public static final int VIDEO_LOAD_STATE_PLAYABLE = 1;
 	@Kroll.constant
 	public static final int VIDEO_LOAD_STATE_PLAYTHROUGH_OK = 1 << 1;
 	@Kroll.constant

--- a/android/modules/media/src/java/ti/modules/titanium/media/SoundProxy.java
+++ b/android/modules/media/src/java/ti/modules/titanium/media/SoundProxy.java
@@ -64,10 +64,6 @@ public class SoundProxy extends KrollProxy implements org.appcelerator.titanium.
 	{
 		super();
 
-		// TODO - we shouldnt need this as this proxy is created only from the runtime - double check
-		// TODO needs to happen post-activity assignment
-		//((TiBaseActivity)getActivity()).addOnLifecycleEventListener(this);
-
 		defaultValues.put(TiC.PROPERTY_VOLUME, 1.0f);
 		defaultValues.put(TiC.PROPERTY_TIME, 0d);
 		defaultValues.put(TiC.PROPERTY_AUDIO_TYPE, AUDIO_TYPE_MEDIA);

--- a/android/modules/media/src/java/ti/modules/titanium/media/TiAudioRecorder.java
+++ b/android/modules/media/src/java/ti/modules/titanium/media/TiAudioRecorder.java
@@ -212,7 +212,7 @@ public class TiAudioRecorder
 		out.write(header, 0, header.length);
 	}
 
-	private AudioRecord.OnRecordPositionUpdateListener onRecordPositionUpdateListener =
+	private final AudioRecord.OnRecordPositionUpdateListener onRecordPositionUpdateListener =
 		new AudioRecord.OnRecordPositionUpdateListener() {
 			@Override
 			public void onMarkerReached(AudioRecord recorder)

--- a/android/modules/media/src/java/ti/modules/titanium/media/TiUIVideoView.java
+++ b/android/modules/media/src/java/ti/modules/titanium/media/TiUIVideoView.java
@@ -45,7 +45,7 @@ public class TiUIVideoView
 	/**
 	 * Used when setting video view to one created by our fullscreen TiVideoActivity, in which
 	 * case we shouldn't create one of our own in this class.
-	 * @param vv instance of TiVideoView8 created by TiVideoActivity
+	 * @param layout The activity's view group this method will attempt to find the VideoView in.
 	 */
 	public void setVideoViewFromActivityLayout(TiCompositeLayout layout)
 	{

--- a/android/modules/media/src/java/ti/modules/titanium/media/VideoPlayerProxy.java
+++ b/android/modules/media/src/java/ti/modules/titanium/media/VideoPlayerProxy.java
@@ -115,10 +115,10 @@ public class VideoPlayerProxy extends TiViewProxy implements TiLifecycle.OnLifec
 		}
 		if (activity instanceof TiBaseActivity) {
 			((TiBaseActivity) activity).addOnLifecycleEventListener(this);
-			activityListeningTo = new WeakReference<Activity>(activity);
+			activityListeningTo = new WeakReference<>(activity);
 		} else if (activity instanceof TiVideoActivity) {
 			((TiVideoActivity) activity).setOnLifecycleEventListener(this);
-			activityListeningTo = new WeakReference<Activity>(activity);
+			activityListeningTo = new WeakReference<>(activity);
 		}
 	}
 
@@ -190,7 +190,7 @@ public class VideoPlayerProxy extends TiViewProxy implements TiLifecycle.OnLifec
 
 	/**
 	 * Create handler used for communication from TiVideoActivity to this proxy.
-	 * @return
+	 * @return Returns the handler used to send commands to the video view.
 	 */
 	private Handler createControlHandler()
 	{

--- a/android/modules/network/src/java/ti/modules/titanium/network/CookieProxy.java
+++ b/android/modules/network/src/java/ti/modules/titanium/network/CookieProxy.java
@@ -32,7 +32,7 @@ import org.appcelerator.titanium.util.TiConvert;
 public class CookieProxy extends KrollProxy
 {
 	private static final String TAG = "CookieProxy";
-	private static TimeZone timezone = TimeZone.getTimeZone("GMT");
+	private static final TimeZone timezone = TimeZone.getTimeZone("GMT");
 	private static final SimpleDateFormat httpExpiryDateFormatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
 	public static final SimpleDateFormat systemExpiryDateFormatter =
 		new SimpleDateFormat("EEE, dd-MMM-yyyy HH:mm:ss 'GMT'");

--- a/android/modules/network/src/java/ti/modules/titanium/network/NetworkModule.java
+++ b/android/modules/network/src/java/ti/modules/titanium/network/NetworkModule.java
@@ -38,7 +38,6 @@ import android.webkit.CookieSyncManager;
 @Kroll.module
 public class NetworkModule extends KrollModule
 {
-
 	private static final String TAG = "TiNetwork";
 	private static java.net.CookieManager cookieManager;
 
@@ -111,7 +110,7 @@ public class NetworkModule extends KrollModule
 	private TiNetworkListener networkListener;
 	private ConnectivityManager connectivityManager;
 
-	private Handler messageHandler = new Handler() {
+	private final Handler messageHandler = new Handler() {
 		public void handleMessage(Message msg)
 		{
 			Bundle b = msg.getData();
@@ -367,7 +366,7 @@ public class NetworkModule extends KrollModule
 		if (path == null || path.length() == 0) {
 			path = "/";
 		}
-		ArrayList<CookieProxy> cookieList = new ArrayList<CookieProxy>();
+		ArrayList<CookieProxy> cookieList = new ArrayList<>();
 		List<HttpCookie> cookies = getCookieManagerInstance().getCookieStore().getCookies();
 		for (HttpCookie cookie : cookies) {
 			String cookieName = cookie.getName();
@@ -379,7 +378,7 @@ public class NetworkModule extends KrollModule
 			}
 		}
 		if (!cookieList.isEmpty()) {
-			return cookieList.toArray(new CookieProxy[cookieList.size()]);
+			return cookieList.toArray(new CookieProxy[0]);
 		}
 		return null;
 	}
@@ -398,7 +397,7 @@ public class NetworkModule extends KrollModule
 			}
 			return null;
 		}
-		ArrayList<CookieProxy> cookieList = new ArrayList<CookieProxy>();
+		ArrayList<CookieProxy> cookieList = new ArrayList<>();
 		List<HttpCookie> cookies = getCookieManagerInstance().getCookieStore().getCookies();
 		for (HttpCookie cookie : cookies) {
 			String cookieDomain = cookie.getDomain();
@@ -407,7 +406,7 @@ public class NetworkModule extends KrollModule
 			}
 		}
 		if (!cookieList.isEmpty()) {
-			return cookieList.toArray(new CookieProxy[cookieList.size()]);
+			return cookieList.toArray(new CookieProxy[0]);
 		}
 		return null;
 	}
@@ -427,7 +426,7 @@ public class NetworkModule extends KrollModule
 			return;
 		}
 		java.net.CookieStore cookieStore = getCookieManagerInstance().getCookieStore();
-		List<HttpCookie> cookies = new ArrayList<HttpCookie>(getCookieManagerInstance().getCookieStore().getCookies());
+		List<HttpCookie> cookies = new ArrayList<>(getCookieManagerInstance().getCookieStore().getCookies());
 		cookieStore.removeAll();
 		for (HttpCookie cookie : cookies) {
 			String cookieName = cookie.getName();
@@ -454,7 +453,7 @@ public class NetworkModule extends KrollModule
 	public void removeHTTPCookiesForDomain(String domain)
 	{
 		java.net.CookieStore cookieStore = getCookieManagerInstance().getCookieStore();
-		List<HttpCookie> cookies = new ArrayList<HttpCookie>(getCookieManagerInstance().getCookieStore().getCookies());
+		List<HttpCookie> cookies = new ArrayList<>(getCookieManagerInstance().getCookieStore().getCookies());
 		cookieStore.removeAll();
 		for (HttpCookie cookie : cookies) {
 			String cookieDomain = cookie.getDomain();
@@ -483,7 +482,7 @@ public class NetworkModule extends KrollModule
 	/**
 	 * Adds a cookie to the system cookie store. Any existing cookie with the same domain, path and name will be replaced with
 	 * the new cookie. The cookie being set must not have expired, otherwise it will be ignored.
-	 * @param cookieProxy the cookie to add
+	 * @param cookieURLConnectionProxy the cookie to add
 	 */
 	@Kroll.method
 	public void addSystemCookie(CookieProxy cookieURLConnectionProxy)
@@ -542,7 +541,7 @@ public class NetworkModule extends KrollModule
 			path = "/";
 		}
 
-		ArrayList<CookieProxy> cookieList = new ArrayList<CookieProxy>();
+		ArrayList<CookieProxy> cookieList = new ArrayList<>();
 		CookieSyncManager.createInstance(TiApplication.getInstance().getRootOrCurrentActivity());
 		CookieManager cookieManager = CookieManager.getInstance();
 		String url = domain.toLowerCase() + path;
@@ -560,7 +559,7 @@ public class NetworkModule extends KrollModule
 			}
 		}
 		if (!cookieList.isEmpty()) {
-			return cookieList.toArray(new CookieProxy[cookieList.size()]);
+			return cookieList.toArray(new CookieProxy[0]);
 		}
 		return null;
 	}

--- a/android/modules/network/src/java/ti/modules/titanium/network/SecurityManagerProtocol.java
+++ b/android/modules/network/src/java/ti/modules/titanium/network/SecurityManagerProtocol.java
@@ -22,14 +22,14 @@ public interface SecurityManagerProtocol {
 
 	/**
 	 * Returns the X509TrustManager array for SSL Context.
-	 * @param uri - The end point of the network connection
+	 * @param proxy The client proxy to fetch trust manager info from.
 	 * @return Return array of X509TrustManager for custom server validation. Null otherwise.
 	 */
 	X509TrustManager[] getTrustManagers(HTTPClientProxy proxy);
 
 	/**
 	 * Returns the X509KeyManager array for the SSL Context.
-	 * @param uri - The end point of the network connection
+	 * @param proxy The client proxy to fetch SSL certificate managers from.
 	 * @return Return array of X509KeyManager for custom client certificate management. Null otherwise.
 	 */
 	X509KeyManager[] getKeyManagers(HTTPClientProxy proxy);

--- a/android/modules/network/src/java/ti/modules/titanium/network/TiHTTPClient.java
+++ b/android/modules/network/src/java/ti/modules/titanium/network/TiHTTPClient.java
@@ -32,6 +32,7 @@ import java.nio.CharBuffer;
 import java.nio.charset.CharacterCodingException;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -126,15 +127,15 @@ public class TiHTTPClient
 	private String url;
 	private URL mURL;
 	private String redirectedLocation;
-	private ArrayList<File> tmpFiles = new ArrayList<File>();
-	private ArrayList<X509TrustManager> trustManagers = new ArrayList<X509TrustManager>();
-	private ArrayList<X509KeyManager> keyManagers = new ArrayList<X509KeyManager>();
+	private final ArrayList<File> tmpFiles = new ArrayList<>();
+	private final ArrayList<X509TrustManager> trustManagers = new ArrayList<>();
+	private final ArrayList<X509KeyManager> keyManagers = new ArrayList<>();
 	protected SecurityManagerProtocol securityManager;
 	private int tlsVersion = NetworkModule.TLS_DEFAULT;
 
-	private static CookieManager cookieManager = NetworkModule.getCookieManagerInstance();
+	private static final CookieManager cookieManager = NetworkModule.getCookieManagerInstance();
 
-	protected HashMap<String, String> requestHeaders = new HashMap<String, String>();
+	protected HashMap<String, String> requestHeaders = new HashMap<>();
 	private ArrayList<NameValuePair> nvPairs;
 	private HashMap<String, ContentBody> parts;
 
@@ -437,8 +438,8 @@ public class TiHTTPClient
 		}
 		readyState = 0;
 		connected = false;
-		this.nvPairs = new ArrayList<NameValuePair>();
-		this.parts = new HashMap<String, ContentBody>();
+		this.nvPairs = new ArrayList<>();
+		this.parts = new HashMap<>();
 		this.maxBufferSize =
 			TiApplication.getInstance().getAppProperties().getInt(PROPERTY_MAX_BUFFER_SIZE, DEFAULT_MAX_BUFFER_SIZE);
 	}
@@ -477,7 +478,7 @@ public class TiHTTPClient
 		Log.d(TAG, "Setting ready state to " + readyState, Log.DEBUG_MODE);
 		this.readyState = readyState;
 		KrollDict data = new KrollDict();
-		data.put("readyState", Integer.valueOf(readyState));
+		data.put("readyState", readyState);
 		dispatchCallback(TiC.PROPERTY_ONREADYSTATECHANGE, data);
 
 		if (readyState == READY_STATE_DONE) {
@@ -782,7 +783,7 @@ public class TiHTTPClient
 			return;
 		}
 
-		List<HttpCookie> cookies = new ArrayList<HttpCookie>(cookieManager.getCookieStore().getCookies());
+		List<HttpCookie> cookies = new ArrayList<>(cookieManager.getCookieStore().getCookies());
 		cookieManager.getCookieStore().removeAll();
 		String lower_url = url.toLowerCase();
 
@@ -810,9 +811,9 @@ public class TiHTTPClient
 				if (requestHeaders.containsKey(header)) {
 					// Appends a value to a header
 					// If it is a cookie, use ';'. If not, use ','.
-					String separator = ("Cookie".equalsIgnoreCase(header)) ? "; " : ", ";
 					StringBuffer val = new StringBuffer(requestHeaders.get(header));
-					val.append(separator + value);
+					val.append("Cookie".equalsIgnoreCase(header) ? "; " : ", ");
+					val.append(value);
 					requestHeaders.put(header, val.toString());
 				} else {
 					// Set header for the first time
@@ -971,7 +972,7 @@ public class TiHTTPClient
 			// harmless for all other cases
 			parts.put(name, new StringBody(value, "", null));
 		} else {
-			nvPairs.add(new NameValuePair(name, value.toString()));
+			nvPairs.add(new NameValuePair(name, value));
 		}
 	}
 
@@ -1291,11 +1292,9 @@ public class TiHTTPClient
 									ByteArrayOutputStream bos =
 										new ByteArrayOutputStream((int) form.getContentLength());
 									form.writeTo(bos);
-									contentLength +=
-										constructFilePart("form", new StringBody(bos.toString(),
-																				 "application/x-www-form-urlencoded",
-																				 Charset.forName("UTF-8")))
-											.length();
+									StringBody stringBody = new StringBody(
+										bos.toString(), "application/x-www-form-urlencoded", StandardCharsets.UTF_8);
+									contentLength += constructFilePart("form", stringBody).length();
 									contentLength += form.getContentLength() + 2;
 								} catch (UnsupportedEncodingException e) {
 									Log.e(TAG, "Unsupported encoding: ", e);
@@ -1349,9 +1348,8 @@ public class TiHTTPClient
 									ByteArrayOutputStream bos =
 										new ByteArrayOutputStream((int) form.getContentLength());
 									form.writeTo(bos);
-									addFilePart("form",
-												new StringBody(bos.toString(), "application/x-www-form-urlencoded",
-															   Charset.forName("UTF-8")));
+									addFilePart("form", new StringBody(
+										bos.toString(), "application/x-www-form-urlencoded", StandardCharsets.UTF_8));
 
 								} catch (UnsupportedEncodingException e) {
 									Log.e(TAG, "Unsupported encoding: ", e);

--- a/android/modules/network/src/java/ti/modules/titanium/network/TiSocketFactory.java
+++ b/android/modules/network/src/java/ti/modules/titanium/network/TiSocketFactory.java
@@ -29,7 +29,6 @@ import android.util.Log;
 
 public class TiSocketFactory extends SSLSocketFactory
 {
-
 	private SSLContext sslContext;
 	private String tlsVersion;
 	private static final String TAG = "TiSocketFactory";
@@ -149,7 +148,7 @@ public class TiSocketFactory extends SSLSocketFactory
 	protected SSLSocket setSupportedAndEnabledProtocolsInSocket(String[] enabledProtocols, SSLSocket sslSocket)
 	{
 		String[] supportedProtocols = sslSocket.getSupportedProtocols();
-		List<String> supportedAndEnabledProtocols = new ArrayList<String>();
+		List<String> supportedAndEnabledProtocols = new ArrayList<>();
 
 		for (String enabledProtocol : enabledProtocols) {
 			for (String supportedProtocol : supportedProtocols) {
@@ -164,7 +163,7 @@ public class TiSocketFactory extends SSLSocketFactory
 		//Default enabled protocols varies depending on API level.
 		if (supportedAndEnabledProtocols.size() > 0) {
 			sslSocket.setEnabledProtocols(
-				supportedAndEnabledProtocols.toArray(new String[supportedAndEnabledProtocols.size()]));
+				supportedAndEnabledProtocols.toArray(new String[0]));
 		}
 
 		return sslSocket;

--- a/android/modules/platform/src/java/ti/modules/titanium/platform/AndroidModule.java
+++ b/android/modules/platform/src/java/ti/modules/titanium/platform/AndroidModule.java
@@ -21,18 +21,18 @@ public class AndroidModule extends PlatformModule
 	@Kroll.constant
 	public static final int PHYSICAL_SIZE_CATEGORY_LARGE = Configuration.SCREENLAYOUT_SIZE_LARGE;
 	@Kroll.constant
-	public static final int PHYSICAL_SIZE_CATEGORY_XLARGE = 4; // Configuration.SCREENLAYOUT_SIZE_XLARGE (API 9)
+	public static final int PHYSICAL_SIZE_CATEGORY_XLARGE = Configuration.SCREENLAYOUT_SIZE_XLARGE;
 
 	@Kroll.getProperty
 	public int getPhysicalSizeCategory()
 	{
-		int size = TiApplication.getInstance().getApplicationContext().getResources().getConfiguration().screenLayout
+		int size = TiApplication.getInstance().getResources().getConfiguration().screenLayout
 				   & Configuration.SCREENLAYOUT_SIZE_MASK;
 		switch (size) {
 			case Configuration.SCREENLAYOUT_SIZE_SMALL:
 			case Configuration.SCREENLAYOUT_SIZE_NORMAL:
 			case Configuration.SCREENLAYOUT_SIZE_LARGE:
-			case 4: // Configuration.SCREENLAYOUT_SIZE_XLARGE (API 9)
+			case Configuration.SCREENLAYOUT_SIZE_XLARGE:
 				return size;
 			case Configuration.SCREENLAYOUT_SIZE_UNDEFINED:
 			default:

--- a/android/modules/platform/src/java/ti/modules/titanium/platform/DisplayCapsProxy.java
+++ b/android/modules/platform/src/java/ti/modules/titanium/platform/DisplayCapsProxy.java
@@ -65,11 +65,11 @@ public class DisplayCapsProxy extends KrollProxy
 		{
 			getDisplay().getMetrics(dm);
 			int dpi = dm.densityDpi;
-			if (dpi >= 560) { // DisplayMetrics.DENSITY_560
+			if (dpi >= DisplayMetrics.DENSITY_560) {
 				return "xxxhigh";
-			} else if (dpi >= 400) { // DisplayMetrics.DENSITY_400
+			} else if (dpi >= DisplayMetrics.DENSITY_400) {
 				return "xxhigh";
-			} else if (dpi >= 280) { // DisplayMetrics.DENSITY_280
+			} else if (dpi >= DisplayMetrics.DENSITY_280) {
 				return "xhigh";
 			} else if (dpi >= DisplayMetrics.DENSITY_HIGH) {
 				return "high";

--- a/android/modules/platform/src/java/ti/modules/titanium/platform/PlatformModule.java
+++ b/android/modules/platform/src/java/ti/modules/titanium/platform/PlatformModule.java
@@ -333,11 +333,11 @@ public class PlatformModule extends KrollModule
 	public String getMacaddress()
 	{
 		String macaddr = null;
-		TiApplication tiApp = TiApplication.getInstance();
+		Context context = TiApplication.getInstance().getApplicationContext();
 
-		if (tiApp.checkCallingOrSelfPermission(Manifest.permission.ACCESS_WIFI_STATE)
+		if (context.checkCallingOrSelfPermission(Manifest.permission.ACCESS_WIFI_STATE)
 			== PackageManager.PERMISSION_GRANTED) {
-			WifiManager wm = (WifiManager) tiApp.getSystemService(Context.WIFI_SERVICE);
+			WifiManager wm = (WifiManager) context.getSystemService(Context.WIFI_SERVICE);
 			if (wm != null) {
 				WifiInfo wi = wm.getConnectionInfo();
 				if (wi != null) {
@@ -439,12 +439,12 @@ public class PlatformModule extends KrollModule
 			return this.processors;
 		}
 		final int processorCount = getProcessorCount();
-		processors = new ArrayList<Processor>(processorCount);
+		processors = new ArrayList<>(processorCount);
 
 		// Now read in their details
 		BufferedReader in = null;
-		List<Map> groups = new ArrayList<Map>();
-		Map<String, String> current = new HashMap<String, String>();
+		List<Map> groups = new ArrayList<>();
+		Map<String, String> current = new HashMap<>();
 		try {
 			String[] args = { "/system/bin/cat", "/proc/cpuinfo" };
 			ProcessBuilder cmd = new ProcessBuilder(args);
@@ -456,7 +456,7 @@ public class PlatformModule extends KrollModule
 				if (line.length() == 0) {
 					// new group!
 					groups.add(current);
-					current = new HashMap<String, String>();
+					current = new HashMap<>();
 				} else {
 					// entry, split by ':'
 					int colonIndex = line.indexOf(':');
@@ -472,7 +472,7 @@ public class PlatformModule extends KrollModule
 
 		} catch (IOException ex) {
 			// somethign went wrong, create "default" set of processors?
-			this.processors = new ArrayList<Processor>(processorCount);
+			this.processors = new ArrayList<>(processorCount);
 			for (int i = 0; i < processorCount; i++) {
 				this.processors.add(Processor.unknown(i));
 			}

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/EmailDialogProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/EmailDialogProxy.java
@@ -97,7 +97,7 @@ public class EmailDialogProxy extends TiViewProxy implements ActivityTransitionL
 	{
 		if (attachment instanceof FileProxy || attachment instanceof TiBlob) {
 			if (attachments == null) {
-				attachments = new ArrayList<Object>();
+				attachments = new ArrayList<>();
 			}
 			attachments.add(attachment);
 		} else {
@@ -325,7 +325,7 @@ public class EmailDialogProxy extends TiViewProxy implements ActivityTransitionL
 		if (attachments == null) {
 			return null;
 		}
-		ArrayList<Uri> uris = new ArrayList<Uri>();
+		ArrayList<Uri> uris = new ArrayList<>();
 		for (Object attachment : attachments) {
 			Uri uri = getAttachmentUri(attachment);
 			if (uri != null) {

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/NavigationWindowProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/NavigationWindowProxy.java
@@ -22,7 +22,7 @@ public class NavigationWindowProxy extends WindowProxy
 {
 	private static final String TAG = "NavigationWindowProxy";
 
-	private List<TiWindowProxy> windows = new ArrayList<>();
+	private final List<TiWindowProxy> windows = new ArrayList<>();
 
 	public NavigationWindowProxy()
 	{

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/PickerColumnProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/PickerColumnProxy.java
@@ -128,7 +128,7 @@ public class PickerColumnProxy extends TiViewProxy implements PickerRowListener
 		if (children == null || children.size() == 0) {
 			return null;
 		}
-		return children.toArray(new PickerRowProxy[children.size()]);
+		return children.toArray(new PickerRowProxy[0]);
 	}
 
 	@Kroll.setProperty

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/PickerProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/PickerProxy.java
@@ -59,7 +59,7 @@ import com.google.android.material.timepicker.TimeFormat;
 public class PickerProxy extends TiViewProxy implements PickerColumnListener
 {
 	private int type = UIModule.PICKER_TYPE_PLAIN;
-	private ArrayList<Integer> preselectedRows = new ArrayList<Integer>();
+	private ArrayList<Integer> preselectedRows = new ArrayList<>();
 	private static final String TAG = "PickerProxy";
 	public static final int DEFAULT_VISIBLE_ITEMS_COUNT = 5;
 	private boolean useSpinner = false;
@@ -286,7 +286,7 @@ public class PickerProxy extends TiViewProxy implements PickerColumnListener
 		if (view == null) {
 			// assign it to be selected after view creation
 			if (preselectedRows == null) {
-				preselectedRows = new ArrayList<Integer>();
+				preselectedRows = new ArrayList<>();
 			}
 			while (preselectedRows.size() < (column + 1)) {
 				preselectedRows.add(null);
@@ -294,8 +294,7 @@ public class PickerProxy extends TiViewProxy implements PickerColumnListener
 			if (preselectedRows.size() >= (column + 1)) {
 				preselectedRows.remove(column);
 			}
-			preselectedRows.add(column, new Integer(row));
-			return;
+			preselectedRows.add(column, row);
 		} else {
 			((TiUIPicker) view).selectRow(column, row, animated);
 			if (TiConvert.toBoolean(getProperty(TiC.PROPERTY_SELECTION_OPENS), false)) {
@@ -334,7 +333,7 @@ public class PickerProxy extends TiViewProxy implements PickerColumnListener
 		if (children == null) {
 			return new PickerColumnProxy[] {};
 		} else {
-			return children.toArray(new PickerColumnProxy[children.size()]);
+			return children.toArray(new PickerColumnProxy[0]);
 		}
 	}
 
@@ -738,7 +737,7 @@ public class PickerProxy extends TiViewProxy implements PickerColumnListener
 		d.put("column", column);
 		d.put("row", row);
 		int columnCount = getColumnCount();
-		ArrayList<String> selectedValues = new ArrayList<String>(columnCount);
+		ArrayList<String> selectedValues = new ArrayList<>(columnCount);
 		for (int i = 0; i < columnCount; i++) {
 			PickerRowProxy rowInColumn = getSelectedRow(i);
 			if (rowInColumn != null) {

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/RefreshControlProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/RefreshControlProxy.java
@@ -37,7 +37,7 @@ public class RefreshControlProxy extends KrollProxy
 	 * "TiSwipeRefreshLayout" view. Instances must be removed when this class' static
 	 * unassignFrom() method has been called.
 	 */
-	private static HashSet<RefreshControlProxy> assignedControls = new HashSet<RefreshControlProxy>();
+	private static final HashSet<RefreshControlProxy> assignedControls = new HashSet<>();
 
 	/** Color integer value to be applied to the refresh layout's progress indicator. */
 	private int tintColor = DEFAULT_TINT_COLOR;

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/ShortcutItemProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/ShortcutItemProxy.java
@@ -34,7 +34,7 @@ public class ShortcutItemProxy extends KrollProxy
 
 	private Context context = null;
 	private static ShortcutManager shortcutManager = null;
-	private static List<ShortcutInfo> shortcuts = new ArrayList<ShortcutInfo>();
+	private static final List<ShortcutInfo> shortcuts = new ArrayList<>();
 
 	private ShortcutInfo shortcut;
 	private ShortcutInfo.Builder shortcutBuilder;
@@ -108,12 +108,12 @@ public class ShortcutItemProxy extends KrollProxy
 		shortcut = shortcutBuilder.build();
 
 		// obtain and update any pre-existing shortcuts
-		for (ShortcutInfo shortcut : new ArrayList<>(this.shortcuts)) {
+		for (ShortcutInfo shortcut : new ArrayList<>(ShortcutItemProxy.shortcuts)) {
 			if (shortcut.getId().equals(this.shortcut.getId())) {
-				this.shortcuts.remove(shortcut);
+				ShortcutItemProxy.shortcuts.remove(shortcut);
 			}
 		}
-		this.shortcuts.add(shortcut);
+		ShortcutItemProxy.shortcuts.add(shortcut);
 
 		super.handleCreationDict(dict);
 	}

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/ShortcutModule.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/ShortcutModule.java
@@ -97,7 +97,7 @@ public class ShortcutModule extends KrollModule
 			items.add(shortcutItemProxy);
 		}
 
-		return items.toArray(new ShortcutItemProxy[items.size()]);
+		return items.toArray(new ShortcutItemProxy[0]);
 	}
 
 	/**

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/SwitchProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/SwitchProxy.java
@@ -10,8 +10,6 @@ import org.appcelerator.kroll.annotations.Kroll;
 import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.proxy.TiViewProxy;
 import org.appcelerator.titanium.view.TiUIView;
-
-import ti.modules.titanium.ui.android.AndroidModule;
 import ti.modules.titanium.ui.widget.TiUISwitch;
 import android.app.Activity;
 
@@ -33,7 +31,7 @@ public class SwitchProxy extends TiViewProxy
 	{
 		super();
 		defaultValues.put(TiC.PROPERTY_VALUE, false);
-		defaultValues.put(TiC.PROPERTY_STYLE, AndroidModule.SWITCH_STYLE_SWITCH);
+		defaultValues.put(TiC.PROPERTY_STYLE, UIModule.SWITCH_STYLE_SLIDER);
 	}
 
 	@Override

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TabGroupProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TabGroupProxy.java
@@ -65,7 +65,7 @@ public class TabGroupProxy extends TiWindowProxy implements TiActivityWindow
 
 	protected static final int MSG_LAST_ID = MSG_FIRST_ID + 999;
 
-	private ArrayList<TabProxy> tabs = new ArrayList<TabProxy>();
+	private ArrayList<TabProxy> tabs = new ArrayList<>();
 	private WeakReference<AppCompatActivity> tabGroupActivity;
 	private TabProxy selectedTab;
 	private String tabGroupTitle = null;
@@ -279,7 +279,7 @@ public class TabGroupProxy extends TiWindowProxy implements TiActivityWindow
 		if (tabs != null) {
 			tabs.clear();
 		} else {
-			tabs = new ArrayList<TabProxy>();
+			tabs = new ArrayList<>();
 		}
 		if (obj instanceof Object[]) {
 			Object[] objArray = (Object[]) obj;
@@ -298,7 +298,7 @@ public class TabGroupProxy extends TiWindowProxy implements TiActivityWindow
 
 		// Support setting orientation modes at creation.
 		Object orientationModes = options.get(TiC.PROPERTY_ORIENTATION_MODES);
-		if (orientationModes != null && orientationModes instanceof Object[]) {
+		if (orientationModes instanceof Object[]) {
 			try {
 				int[] modes = TiConvert.toIntArray((Object[]) orientationModes);
 				setOrientationModes(modes);
@@ -402,7 +402,7 @@ public class TabGroupProxy extends TiWindowProxy implements TiActivityWindow
 	@Override
 	public void windowCreated(TiBaseActivity activity, Bundle savedInstanceState)
 	{
-		tabGroupActivity = new WeakReference<AppCompatActivity>(activity);
+		tabGroupActivity = new WeakReference<>(activity);
 		activity.setWindowProxy(this);
 		activity.setLayoutProxy(this);
 		setActivity(activity);

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TableViewProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TableViewProxy.java
@@ -452,7 +452,7 @@ public class TableViewProxy extends RecyclerViewProxy
 	@Kroll.getProperty
 	public TableViewSectionProxy[] getSections()
 	{
-		return this.sections.toArray(new TableViewSectionProxy[this.sections.size()]);
+		return this.sections.toArray(new TableViewSectionProxy[0]);
 	}
 
 	/**

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TableViewRowProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TableViewRowProxy.java
@@ -60,7 +60,7 @@ public class TableViewRowProxy extends TiViewProxy
 
 	// FIXME: On iOS the same row can be added to a table multiple times.
 	//        Due to constraints, we need to create a new proxy and track changes.
-	private List<WeakReference<TableViewRowProxy>> clones = new ArrayList<>(0);
+	private final List<WeakReference<TableViewRowProxy>> clones = new ArrayList<>(0);
 
 	public TableViewRowProxy()
 	{
@@ -149,7 +149,7 @@ public class TableViewRowProxy extends TiViewProxy
 	 * @param eventName Name of fired event.
 	 * @param data      Data payload of fired event.
 	 * @param bubbles   Specify if event should bubble up to parent.
-	 * @return
+	 * @return Returns true if the event was successfully fired to listener(s)
 	 */
 	@Override
 	public boolean fireEvent(String eventName, Object data, boolean bubbles)

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TableViewSectionProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TableViewSectionProxy.java
@@ -159,7 +159,7 @@ public class TableViewSectionProxy extends TiViewProxy
 	@Kroll.getProperty
 	public TableViewRowProxy[] getRows()
 	{
-		return this.rows.toArray(new TableViewRowProxy[this.rows.size()]);
+		return this.rows.toArray(new TableViewRowProxy[0]);
 	}
 
 	/**

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/WebViewProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/WebViewProxy.java
@@ -57,7 +57,7 @@ public class WebViewProxy extends ViewProxy implements Handler.Callback, OnLifec
 	private static String fusername;
 	private static String fpassword;
 	private static int frequestID = 0;
-	private static Map<Integer, EvalJSRunnable> fevalJSRequests = new HashMap<Integer, EvalJSRunnable>();
+	private static final Map<Integer, EvalJSRunnable> fevalJSRequests = new HashMap<>();
 
 	private Message postCreateMessage;
 
@@ -115,7 +115,7 @@ public class WebViewProxy extends ViewProxy implements Handler.Callback, OnLifec
 		return view.getJSValue(code);
 	}
 
-	private class EvalJSRunnable implements Runnable
+	private static class EvalJSRunnable implements Runnable
 	{
 		private final TiUIWebView view;
 		private final KrollObject krollObject;

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/WindowProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/WindowProxy.java
@@ -217,7 +217,7 @@ public class WindowProxy extends TiWindowProxy implements TiActivityWindow
 	@Override
 	public void windowCreated(TiBaseActivity activity, Bundle savedInstanceState)
 	{
-		windowActivity = new WeakReference<TiBaseActivity>(activity);
+		windowActivity = new WeakReference<>(activity);
 		activity.setWindowProxy(this);
 		setActivity(activity);
 

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/android/TiPreferencesFragment.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/android/TiPreferencesFragment.java
@@ -1,3 +1,9 @@
+/**
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2011-2021 by Axway, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
 package ti.modules.titanium.ui.android;
 
 import org.appcelerator.kroll.common.Log;
@@ -9,7 +15,6 @@ import android.preference.PreferenceFragment;
 
 public class TiPreferencesFragment extends PreferenceFragment
 {
-
 	private static final String TAG = "TiPreferencesFragment";
 	private CharSequence title = null;
 
@@ -31,11 +36,9 @@ public class TiPreferencesFragment extends PreferenceFragment
 				}
 			} else {
 				Log.e(TAG, "xml." + prefsName + " preferences not found.");
-				return;
 			}
 		} catch (TiRHelper.ResourceNotFoundException e) {
 			Log.e(TAG, "Error loading preferences: " + e.getMessage());
-			return;
 		}
 	}
 

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/clipboard/ClipboardModule.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/clipboard/ClipboardModule.java
@@ -19,7 +19,7 @@ import android.text.ClipboardManager;
 @Kroll.module(parentModule = UIModule.class)
 public class ClipboardModule extends KrollModule
 {
-	private String TAG = "Clipboard";
+	private static final String TAG = "Clipboard";
 
 	public ClipboardModule()
 	{

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiImageView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiImageView.java
@@ -156,7 +156,7 @@ public class TiImageView extends ViewGroup implements Handler.Callback, OnClickL
 	public TiImageView(Context context, TiViewProxy proxy)
 	{
 		this(context);
-		this.proxy = new WeakReference<TiViewProxy>(proxy);
+		this.proxy = new WeakReference<>(proxy);
 	}
 
 	public void setEnableScale(boolean enableScale)

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiToolbar.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiToolbar.java
@@ -39,7 +39,6 @@ public class TiToolbar extends TiUIView
 	/**
 	 * Constructs a TiUIView object with the associated proxy.
 	 * @param proxy the associated proxy.
-	 * @module.api
 	 */
 	public TiToolbar(TiViewProxy proxy)
 	{
@@ -195,8 +194,8 @@ public class TiToolbar extends TiUIView
 	 * Changes the LayoutParams type of custom views added to the Toolbar.
 	 * Width and height are preserved.
 	 * They need to be of type Toolbar.LayoutParams.
-	 * @param source
-	 * @return
+	 * @param source The view to be changed.
+	 * @return Returns given TiUIView's native view with layout changes applied to it.
 	 */
 	private View convertLayoutParamsForView(TiUIView source)
 	{
@@ -244,7 +243,7 @@ public class TiToolbar extends TiUIView
 
 	/**
 	 * Return the current logo in the format it was passed
-	 * @return
+	 * @return Returns the currently assigned logo.
 	 */
 	public Object getLogo()
 	{
@@ -264,7 +263,7 @@ public class TiToolbar extends TiUIView
 
 	/**
 	 * Returns the currently set navigation icon in the format it was set.
-	 * @return
+	 * @return Returns the currently assigned icon.
 	 */
 	public Object getNavigationIcon()
 	{
@@ -284,7 +283,7 @@ public class TiToolbar extends TiUIView
 
 	/**
 	 * Returns the overflow menu icon in the format it was set.
-	 * @return
+	 * @return Returns the menu icon to be shown on the right side of the toolbar.
 	 */
 	public Object getOverflowMenuIcon()
 	{
@@ -338,7 +337,7 @@ public class TiToolbar extends TiUIView
 	/**
 	 * Saves the proxy objects of the views passed as custom items.
 	 * Sets them as current custom views.
-	 * @param value
+	 * @param value Array of view proxies to be shown in the toolbar.
 	 */
 	private void setViewProxiesArray(Object[] value)
 	{

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIDrawerLayout.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIDrawerLayout.java
@@ -40,7 +40,6 @@ import java.lang.reflect.Field;
 
 public class TiUIDrawerLayout extends TiUIView
 {
-
 	private DrawerLayout layout = null;
 	private ActionBarDrawerToggle drawerToggle = null;
 
@@ -348,7 +347,7 @@ public class TiUIDrawerLayout extends TiUIView
 	{
 		if (d.containsKey(TiC.PROPERTY_LEFT_VIEW)) {
 			Object leftView = d.get(TiC.PROPERTY_LEFT_VIEW);
-			if (leftView != null && leftView instanceof TiViewProxy) {
+			if (leftView instanceof TiViewProxy) {
 				if (leftView instanceof WindowProxy) {
 					throw new IllegalStateException("cannot add window as a child view of other window");
 				}
@@ -361,7 +360,7 @@ public class TiUIDrawerLayout extends TiUIView
 		}
 		if (d.containsKey(TiC.PROPERTY_RIGHT_VIEW)) {
 			Object rightView = d.get(TiC.PROPERTY_RIGHT_VIEW);
-			if (rightView != null && rightView instanceof TiViewProxy) {
+			if (rightView instanceof TiViewProxy) {
 				if (rightView instanceof WindowProxy) {
 					throw new IllegalStateException("cannot add window as a child view of other window");
 				}
@@ -374,7 +373,7 @@ public class TiUIDrawerLayout extends TiUIView
 		}
 		if (d.containsKey(TiC.PROPERTY_CENTER_VIEW)) {
 			Object centerView = d.get(TiC.PROPERTY_CENTER_VIEW);
-			if (centerView != null && centerView instanceof TiViewProxy) {
+			if (centerView instanceof TiViewProxy) {
 				if (centerView instanceof WindowProxy) {
 					throw new IllegalStateException("cannot use window as a child view of other window");
 				}

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIImageView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIImageView.java
@@ -61,9 +61,9 @@ public class TiUIImageView extends TiUIView implements OnLifecycleEvent, Handler
 	private Animator animator;
 	private Loader loader;
 	private Thread loaderThread;
-	private AtomicBoolean animating = new AtomicBoolean(false);
-	private AtomicBoolean isLoading = new AtomicBoolean(false);
-	private AtomicBoolean isStopping = new AtomicBoolean(false);
+	private final AtomicBoolean animating = new AtomicBoolean(false);
+	private final AtomicBoolean isLoading = new AtomicBoolean(false);
+	private final AtomicBoolean isStopping = new AtomicBoolean(false);
 	private boolean reverse = false;
 	private boolean paused = false;
 	private boolean firedLoad;
@@ -74,7 +74,7 @@ public class TiUIImageView extends TiUIView implements OnLifecycleEvent, Handler
 	private TiDrawableReference defaultImageSource;
 	private TiDownloadListener downloadListener;
 	private TiLoadImageListener loadImageListener;
-	private Object releasedLock = new Object();
+	private final Object releasedLock = new Object();
 
 	private Handler mainHandler = new Handler(Looper.getMainLooper(), this);
 	private static final int SET_IMAGE = 10001;
@@ -83,7 +83,7 @@ public class TiUIImageView extends TiUIView implements OnLifecycleEvent, Handler
 	private static final int SET_TINT = 10004;
 
 	// This handles the memory cache of images.
-	private TiImageLruCache mMemoryCache = TiImageLruCache.getInstance();
+	private final TiImageLruCache mMemoryCache = TiImageLruCache.getInstance();
 
 	public TiUIImageView(final TiViewProxy proxy)
 	{
@@ -269,7 +269,7 @@ public class TiUIImageView extends TiUIView implements OnLifecycleEvent, Handler
 		}
 	}
 
-	private class BitmapWithIndex
+	private static class BitmapWithIndex
 	{
 		public BitmapWithIndex(Bitmap b, int i)
 		{
@@ -673,7 +673,7 @@ public class TiUIImageView extends TiUIView implements OnLifecycleEvent, Handler
 
 	private void setImageSource(Object object)
 	{
-		imageSources = new ArrayList<TiDrawableReference>();
+		imageSources = new ArrayList<>();
 		if (object instanceof Object[]) {
 			for (Object o : (Object[]) object) {
 				imageSources.add(TiDrawableReference.fromObject(getProxy(), o));
@@ -685,7 +685,7 @@ public class TiUIImageView extends TiUIView implements OnLifecycleEvent, Handler
 
 	private void setImageSource(TiDrawableReference source)
 	{
-		imageSources = new ArrayList<TiDrawableReference>();
+		imageSources = new ArrayList<>();
 		imageSources.add(source);
 	}
 
@@ -962,7 +962,7 @@ public class TiUIImageView extends TiUIView implements OnLifecycleEvent, Handler
 			TiImageView view = getView();
 			if (view != null) {
 				Drawable drawable = view.getImageDrawable();
-				if (drawable != null && drawable instanceof BitmapDrawable) {
+				if (drawable instanceof BitmapDrawable) {
 					Bitmap bitmap = ((BitmapDrawable) drawable).getBitmap();
 					if (bitmap == null && imageSources != null && imageSources.size() == 1) {
 						bitmap = imageSources.get(0).getBitmap(true);

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUILabel.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUILabel.java
@@ -220,7 +220,7 @@ public class TiUILabel extends TiUIView
 	/**
 	 * Method used to decrease the fontsize of the text to fit the width
 	 * fontsize should be >= than the property minimumFontSize
-	 * @param textView
+	 * @param textView The text view to be adjusted.
 	 */
 	private void adjustTextFontSize(@NonNull MaterialTextView textView)
 	{

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIMaskedImage.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIMaskedImage.java
@@ -205,7 +205,7 @@ public class TiUIMaskedImage extends TiUIView
 		ImageView.ScaleType scaleType = ImageView.ScaleType.FIT_XY;
 		if ((layoutParams.optionWidth == null) && (layoutParams.optionHeight == null)) {
 			if (!layoutParams.autoFillsWidth && !layoutParams.autoFillsHeight) {
-				if (layoutParams.sizeOrFillWidthEnabled && layoutParams.sizeOrFillWidthEnabled) {
+				if (layoutParams.sizeOrFillWidthEnabled && layoutParams.sizeOrFillHeightEnabled) {
 					scaleType = ImageView.ScaleType.CENTER;
 				}
 			}

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIProgressIndicator.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIProgressIndicator.java
@@ -191,7 +191,7 @@ public class TiUIProgressIndicator
 				if (a instanceof TiBaseActivity) {
 					TiBaseActivity baseActivity = (TiBaseActivity) a;
 					baseActivity.addDialog(new TiBaseActivity.DialogWrapper(
-						progressDialog, true, new WeakReference<TiBaseActivity>(baseActivity)));
+						progressDialog, true, new WeakReference<>(baseActivity)));
 					progressDialog.setOwnerActivity(a);
 				}
 				progressDialog.setOnCancelListener(this);

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIScrollableView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIScrollableView.java
@@ -69,7 +69,7 @@ public class TiUIScrollableView extends TiUIView
 		mContainer = new TiViewPagerLayout(activity);
 
 		// Add ViewPager to container.
-		mViews = new ArrayList<TiViewProxy>();
+		mViews = new ArrayList<>();
 		mAdapter = new ViewPagerAdapter(activity, mViews);
 		mPager = buildViewPager(activity, mAdapter);
 		if (proxy.hasPropertyAndNotNull(TiC.PROPERTY_CLIP_VIEWS)) {

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUISlider.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUISlider.java
@@ -159,7 +159,7 @@ public class TiUISlider extends TiUIView implements SeekBar.OnSeekBarChangeListe
 			String url = proxy.resolveUrl(null, thumbImage);
 			Drawable thumb = tfh.loadDrawable(url, false);
 			if (thumb != null) {
-				thumbDrawable = new SoftReference<Drawable>(thumb);
+				thumbDrawable = new SoftReference<>(thumb);
 				seekBar.setThumb(thumb);
 			} else {
 				Log.e(TAG, "Unable to locate thumb image for progress bar: " + url);

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUITabbedBar.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUITabbedBar.java
@@ -46,7 +46,6 @@ public class TiUITabbedBar extends TiUIView implements MenuItem.OnMenuItemClickL
 	 * Constructs a TiUIView object with the associated proxy.
 	 *
 	 * @param proxy the associated proxy.
-	 * @module.api
 	 */
 	public TiUITabbedBar(TiViewProxy proxy)
 	{

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIText.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIText.java
@@ -1324,7 +1324,7 @@ public class TiUIText extends TiUIView implements TextWatcher, OnEditorActionLis
 	/** Stores a set of unique characters that can be easily turned into an array. */
 	private static class CharacterSet
 	{
-		private StringBuilder stringBuilder = new StringBuilder(32);
+		private final StringBuilder stringBuilder = new StringBuilder(32);
 
 		/**
 		 * Adds the given character if not already contained in the set.

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/picker/CustomDatePicker.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/picker/CustomDatePicker.java
@@ -1,3 +1,9 @@
+/**
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2009-2021 by Axway, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
 package ti.modules.titanium.ui.widget.picker;
 
 import android.content.Context;

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/picker/TextWheelAdapter.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/picker/TextWheelAdapter.java
@@ -24,7 +24,7 @@ public class TextWheelAdapter implements WheelAdapter
 
 	public TextWheelAdapter(Object[] values)
 	{
-		this(new ArrayList<Object>(Arrays.asList(values)));
+		this(new ArrayList<>(Arrays.asList(values)));
 	}
 
 	@Override
@@ -58,7 +58,7 @@ public class TextWheelAdapter implements WheelAdapter
 
 	public void setValues(Object[] newValues)
 	{
-		setValues(new ArrayList<Object>(Arrays.asList(newValues)));
+		setValues(new ArrayList<>(Arrays.asList(newValues)));
 	}
 
 	public void setValues(ArrayList<Object> newValues)

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/picker/TiUIDateSpinner.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/picker/TiUIDateSpinner.java
@@ -45,12 +45,12 @@ public class TiUIDateSpinner extends TiUIView implements WheelView.OnItemSelecte
 	private boolean suppressChangeEvent = false;
 	private boolean ignoreItemSelection = false;
 
-	private Calendar maxDate = Calendar.getInstance(), minDate = Calendar.getInstance();
+	private final Calendar maxDate = Calendar.getInstance();
+	private final Calendar minDate = Calendar.getInstance();
 	private Locale locale = Locale.getDefault();
 	private boolean dayBeforeMonth = false;
 	private boolean numericMonths = false;
-
-	private Calendar calendar = Calendar.getInstance();
+	private final Calendar calendar = Calendar.getInstance();
 
 	public TiUIDateSpinner(TiViewProxy proxy)
 	{

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/picker/TiUINativePicker.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/picker/TiUINativePicker.java
@@ -222,14 +222,14 @@ public class TiUINativePicker extends TiUIPicker
 			if (rowArray == null || rowArray.length == 0) {
 				return;
 			}
-			ArrayList<TiViewProxy> rows = new ArrayList<TiViewProxy>(Arrays.asList(rowArray));
+			ArrayList<TiViewProxy> rows = new ArrayList<>(Arrays.asList(rowArray));
 			// At the moment we're using the simple spinner layouts provided
 			// in android because we're only supporting a piece of text, which
 			// is fetched via PickerRowProxy.toString(). If we allow
 			// anything beyond a string, we'll have to implement our own
 			// layouts (maybe our own Adapter too.)
 			TiSpinnerAdapter<TiViewProxy> adapter =
-				new TiSpinnerAdapter<TiViewProxy>(spinner.getContext(), android.R.layout.simple_spinner_item, rows);
+				new TiSpinnerAdapter<>(spinner.getContext(), android.R.layout.simple_spinner_item, rows);
 			adapter.setFontProperties(proxy.getProperties());
 			adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
 			spinner.setAdapter(adapter);

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/picker/TiUITimeSpinner.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/picker/TiUITimeSpinner.java
@@ -36,7 +36,7 @@ public class TiUITimeSpinner extends TiUIView implements WheelView.OnItemSelecte
 	private boolean ignoreItemSelection = false;
 	private static final String TAG = "TiUITimeSpinner";
 
-	private Calendar calendar = Calendar.getInstance();
+	private final Calendar calendar = Calendar.getInstance();
 
 	public TiUITimeSpinner(TiViewProxy proxy)
 	{
@@ -56,7 +56,7 @@ public class TiUITimeSpinner extends TiUIView implements WheelView.OnItemSelecte
 
 	private WheelView makeAmPmWheel(Context context, int textSize)
 	{
-		ArrayList<Object> amPmRows = new ArrayList<Object>();
+		ArrayList<Object> amPmRows = new ArrayList<>();
 		amPmRows.add(" am ");
 		amPmRows.add(" pm ");
 		WheelView view = new WheelView(context);

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/picker/TiUITimeSpinnerNumberPicker.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/picker/TiUITimeSpinnerNumberPicker.java
@@ -37,7 +37,7 @@ public class TiUITimeSpinnerNumberPicker extends TiUIView implements NumberPicke
 	private boolean suppressChangeEvent = false;
 	private boolean ignoreItemSelection = false;
 	private static final String TAG = "TiUITimeSpinnerNumberPicker";
-	private Calendar calendar = Calendar.getInstance();
+	private final Calendar calendar = Calendar.getInstance();
 
 	public TiUITimeSpinnerNumberPicker(TiViewProxy proxy)
 	{
@@ -116,7 +116,7 @@ public class TiUITimeSpinnerNumberPicker extends TiUIView implements NumberPicke
 									 int stepValue)
 	{
 		int itemCount = ((maxValue - minValue) / stepValue) + 1;
-		List<String> list = new ArrayList<String>();
+		List<String> list = new ArrayList<>();
 		for (int index = 0; index < itemCount; index++) {
 			int actualValue = minValue + index * stepValue;
 			if (formatter != null) {

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIAbstractTabGroup.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIAbstractTabGroup.java
@@ -138,7 +138,7 @@ public abstract class TiUIAbstractTabGroup extends TiUIView
 	 * Returns the value of the Tab's title.
 	 *
 	 * @param index the index of the Tab.
-	 * @return
+	 * @return Returns the tab's title.
 	 */
 	public abstract String getTabTitle(int index);
 
@@ -160,9 +160,9 @@ public abstract class TiUIAbstractTabGroup extends TiUIView
 	private int colorSurfaceInt;
 	private int colorPrimaryInt;
 	private int colorOnSurfaceInt;
-	private AtomicLong fragmentIdGenerator = new AtomicLong();
-	private ArrayList<Long> tabFragmentIDs = new ArrayList<Long>();
-	protected ArrayList<TiUITab> tabs = new ArrayList<TiUITab>();
+	private final AtomicLong fragmentIdGenerator = new AtomicLong();
+	private final ArrayList<Long> tabFragmentIDs = new ArrayList<>();
+	protected ArrayList<TiUITab> tabs = new ArrayList<>();
 	// endregion
 
 	public TiUIAbstractTabGroup(final TabGroupProxy proxy, TiBaseActivity activity)

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIBottomNavigationTabGroup.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIBottomNavigationTabGroup.java
@@ -48,7 +48,7 @@ public class TiUIBottomNavigationTabGroup extends TiUIAbstractTabGroup implement
 	// We track the previously selected item index manually to mimic the behavior in order to keep parity across styles.
 	private int currentlySelectedIndex = -1;
 	private BottomNavigationView mBottomNavigationView;
-	private ArrayList<MenuItem> mMenuItemsArray = new ArrayList<>();
+	private final ArrayList<MenuItem> mMenuItemsArray = new ArrayList<>();
 	// endregion
 
 	public TiUIBottomNavigationTabGroup(TabGroupProxy proxy, TiBaseActivity activity)
@@ -377,8 +377,8 @@ public class TiUIBottomNavigationTabGroup extends TiUIAbstractTabGroup implement
 	/**
 	 * After a menu item is clicked this method sends the proper index to the ViewPager to a select
 	 * a page. Also takes care of sending SELECTED/UNSELECTED events from the proper tabs.
-	 * @param item
-	 * @return
+	 * @param item The menu item that was clicked on.
+	 * @return Returns true if overridden and to prevent tab selection. Returns false to allow tab selection.
 	 */
 	@Override
 	public boolean onMenuItemClick(MenuItem item)

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import javax.crypto.CipherInputStream;
@@ -52,16 +53,14 @@ import ti.modules.titanium.ui.android.AndroidModule;
 @SuppressWarnings("deprecation")
 public class TiUIWebView extends TiUIView
 {
-
 	private static final String TAG = "TiUIWebView";
 	private TiWebViewClient client;
 	private TiWebChromeClient chromeClient;
 	private boolean bindingCodeInjected = false;
 	private boolean isLocalHTML = false;
 	private boolean disableContextMenu = false;
-	private HashMap<String, String> extraHeaders = new HashMap<String, String>();
-	private float zoomLevel =
-		TiApplication.getInstance().getApplicationContext().getResources().getDisplayMetrics().density;
+	private final HashMap<String, String> extraHeaders = new HashMap<>();
+	private float zoomLevel = TiApplication.getInstance().getResources().getDisplayMetrics().density;
 	private float initScale = zoomLevel;
 
 	public static final int PLUGIN_STATE_OFF = 0;
@@ -570,7 +569,7 @@ public class TiUIWebView extends TiUIView
 				InputStream fis = null;
 				try {
 					fis = tiFile.getInputStream();
-					InputStreamReader reader = new InputStreamReader(fis, "utf-8");
+					InputStreamReader reader = new InputStreamReader(fis, StandardCharsets.UTF_8);
 					BufferedReader breader = new BufferedReader(reader);
 					String line = breader.readLine();
 					while (line != null) {

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiWebChromeClient.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiWebChromeClient.java
@@ -306,7 +306,7 @@ public class TiWebChromeClient extends WebChromeClient
 		}
 
 		KrollFunction onCreateWindowFunction = (KrollFunction) onCreateWindow;
-		HashMap<String, Object> args = new HashMap<String, Object>();
+		HashMap<String, Object> args = new HashMap<>();
 		args.put(TiC.EVENT_PROPERTY_IS_DIALOG, isDialog);
 		args.put(TiC.EVENT_PROPERTY_IS_USER_GESTURE, isUserGesture);
 

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiWebViewBinding.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiWebViewBinding.java
@@ -31,7 +31,6 @@ import android.webkit.WebView;
 
 public class TiWebViewBinding
 {
-
 	private static final String TAG = "TiWebViewBinding";
 	// This is based on binding.min.js. If you have to change anything...
 	// - change binding.js
@@ -129,7 +128,8 @@ public class TiWebViewBinding
 			stream = KrollAssetHelper.openAsset("Resources/ti.internal/webview/" + fileName);
 			BufferedReader reader = new BufferedReader(new InputStreamReader(stream));
 			for (String line = reader.readLine(); line != null; line = reader.readLine()) {
-				code.append(line + "\n");
+				code.append(line);
+				code.append('\n');
 			}
 		} catch (Exception e) {
 			Log.e(TAG, "Error reading input stream", e);
@@ -146,7 +146,7 @@ public class TiWebViewBinding
 		return code;
 	}
 
-	private Semaphore returnSemaphore = new Semaphore(0);
+	private final Semaphore returnSemaphore = new Semaphore(0);
 	private String returnValue;
 
 	synchronized public String getJSValue(String expression)
@@ -222,7 +222,7 @@ public class TiWebViewBinding
 	private class AppBinding
 	{
 		private KrollModule module;
-		private HashMap<String, Integer> appListeners = new HashMap<String, Integer>();
+		private final HashMap<String, Integer> appListeners = new HashMap<>();
 		private int counter = 0;
 		private String code = null;
 		public AppBinding()
@@ -298,7 +298,7 @@ public class TiWebViewBinding
 		}
 	}
 
-	private class ApiBinding
+	private static class ApiBinding
 	{
 		private KrollLogging logging;
 

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiWebViewClient.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiWebViewClient.java
@@ -236,7 +236,7 @@ public class TiWebViewClient extends WebViewClientClassicExt
 	/*
 	 * ClientCertRequest wrapper for compatibility with both ClientCertRequest and ClientCertRequestHandler
 	 */
-	private class ClientCertRequestCompat
+	private static class ClientCertRequestCompat
 	{
 		private ClientCertRequest clientCertRequest;
 		private ClientCertRequestHandler clientCertRequestHandler;
@@ -356,7 +356,7 @@ public class TiWebViewClient extends WebViewClientClassicExt
 			Log.e(TAG, TiC.PROPERTY_WEBVIEW_IGNORE_SSL_ERROR + " property does not contain a boolean value, ignoring");
 		}
 
-		if (ignoreSslError == true) {
+		if (ignoreSslError) {
 			Log.w(TAG, "ran into SSL error but ignoring...");
 			handler.proceed();
 

--- a/android/modules/utils/src/java/ti/modules/titanium/utils/UtilsModule.java
+++ b/android/modules/utils/src/java/ti/modules/titanium/utils/UtilsModule.java
@@ -6,11 +6,10 @@
  */
 package ti.modules.titanium.utils;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 
 import org.appcelerator.kroll.KrollModule;
 import org.appcelerator.kroll.annotations.Kroll;
-import org.appcelerator.kroll.common.Log;
 import org.appcelerator.titanium.TiBlob;
 import org.appcelerator.titanium.TiFileProxy;
 import org.appcelerator.titanium.util.TiDigestUtils;
@@ -30,12 +29,7 @@ public class UtilsModule extends KrollModule
 	private byte[] convertToBytes(Object obj)
 	{
 		if (obj instanceof String) {
-			try {
-				return ((String) obj).getBytes("UTF-8");
-			} catch (UnsupportedEncodingException e) {
-				Log.e(TAG, "UTF-8 is not a supported encoding type");
-			}
-			return ((String) obj).getBytes(); // should never fall back here!
+			return ((String) obj).getBytes(StandardCharsets.UTF_8);
 		} else if (obj instanceof TiBlob) {
 			return ((TiBlob) obj).getBytes();
 		} else {
@@ -52,11 +46,7 @@ public class UtilsModule extends KrollModule
 		}
 		byte[] data = convertToBytes(obj);
 		if (data != null) {
-			try {
-				return TiBlob.blobFromString(new String(Base64.encode(data, Base64.NO_WRAP), "UTF-8"));
-			} catch (UnsupportedEncodingException e) {
-				Log.e(TAG, "UTF-8 is not a supported encoding type");
-			}
+			return TiBlob.blobFromString(new String(Base64.encode(data, Base64.NO_WRAP), StandardCharsets.UTF_8));
 		}
 		return null;
 	}

--- a/android/runtime/common/src/java/org/appcelerator/kroll/KrollExceptionHandler.java
+++ b/android/runtime/common/src/java/org/appcelerator/kroll/KrollExceptionHandler.java
@@ -28,11 +28,9 @@ package org.appcelerator.kroll;
  * </pre>
  *
  * To override the default error dialog behavior, simply override the primary handler with a custom handler.
- *
- * @module.api
  */
 public interface KrollExceptionHandler {
-	public class ExceptionMessage
+	class ExceptionMessage
 	{
 		public String title, message, sourceName, lineSource, jsStack, javaStack;
 		public int line, lineOffset;
@@ -56,7 +54,6 @@ public interface KrollExceptionHandler {
 	 * Handles the exception
 	 *
 	 * @param e An exception message containing line number, error title, message, etc
-	 * @module.api
 	 */
 	void handleException(ExceptionMessage e);
 }

--- a/android/runtime/common/src/java/org/appcelerator/kroll/KrollFunction.java
+++ b/android/runtime/common/src/java/org/appcelerator/kroll/KrollFunction.java
@@ -12,7 +12,7 @@ import java.util.HashMap;
  * An interface that exposes a Javascript function to Java.
  */
 public interface KrollFunction {
-	public class FunctionArgs
+	class FunctionArgs
 	{
 		public KrollObject krollObject;
 		public Object[] args;
@@ -29,7 +29,6 @@ public interface KrollFunction {
 	 * @param krollObject The object that represents <code>this</code> in Javascript.
 	 * @param args A single object argument for the function (for convenience)
 	 * @return the result of the executed function.
-	 * @module.api
 	 */
 	Object call(KrollObject krollObject, HashMap args);
 
@@ -38,7 +37,6 @@ public interface KrollFunction {
 	 * @param krollObject The object that represents <code>this</code> in Javascript.
 	 * @param args the function's arguments.
 	 * @return the result of the executed function.
-	 * @module.api
 	 */
 	Object call(KrollObject krollObject, Object[] args);
 
@@ -46,7 +44,6 @@ public interface KrollFunction {
 	 * Executes a function asynchronously.
 	 * @param krollObject The object that represents <code>this</code> in Javascript.
 	 * @param args A single object argument for the function (for convenience)
-	 * @module.api
 	 */
 	void callAsync(KrollObject krollObject, HashMap args);
 
@@ -54,7 +51,6 @@ public interface KrollFunction {
 	 * Executes a function asynchronously.
 	 * @param krollObject The object that represents <code>this</code> in Javascript.
 	 * @param args the function's arguments.
-	 * @module.api
 	 */
 	void callAsync(KrollObject krollObject, Object[] args);
 }

--- a/android/runtime/common/src/java/org/appcelerator/kroll/KrollLogging.java
+++ b/android/runtime/common/src/java/org/appcelerator/kroll/KrollLogging.java
@@ -19,7 +19,7 @@ public class KrollLogging
 	public static final int CRITICAL = 7;
 	public static final int FATAL = 8;
 
-	private static KrollLogging instance = new KrollLogging("TiAPI");
+	private static final KrollLogging instance = new KrollLogging("TiAPI");
 
 	private String tag;
 	private LogListener listener;
@@ -119,15 +119,8 @@ public class KrollLogging
 
 	private String combineLogMessages(String... args)
 	{
-		String msg;
 		int length = (args == null ? 0 : args.length);
-
-		if (length > 0) {
-			msg = args[0];
-		} else {
-			msg = new String();
-		}
-
+		String msg = (length > 0) ? args[0] : "";
 		for (int i = 1; i < length; i++) {
 			msg = msg.concat(String.format(" %s", args[i]));
 		}

--- a/android/runtime/common/src/java/org/appcelerator/kroll/KrollLogging.java
+++ b/android/runtime/common/src/java/org/appcelerator/kroll/KrollLogging.java
@@ -119,12 +119,25 @@ public class KrollLogging
 
 	private String combineLogMessages(String... args)
 	{
-		int length = (args == null ? 0 : args.length);
-		String msg = (length > 0) ? args[0] : "";
-		for (int i = 1; i < length; i++) {
-			msg = msg.concat(String.format(" %s", args[i]));
+		// Do not continue if given a null/empty array.
+		if ((args == null) || (args.length <= 0)) {
+			return "";
 		}
-		return msg;
+
+		// If array only contains 1 element, then we don't need to do below join operation.
+		if (args.length == 1) {
+			return (args[0] != null) ? args[0] : "";
+		}
+
+		// Join array of strings, separated by spaces.
+		StringBuilder stringBuilder = new StringBuilder();
+		for (String nextArg : args) {
+			if (stringBuilder.length() > 0) {
+				stringBuilder.append(' ');
+			}
+			stringBuilder.append(nextArg);
+		}
+		return stringBuilder.toString();
 	}
 
 	private void internalLog(int severity, String msg)

--- a/android/runtime/common/src/java/org/appcelerator/kroll/KrollObject.java
+++ b/android/runtime/common/src/java/org/appcelerator/kroll/KrollObject.java
@@ -20,12 +20,11 @@ import android.os.Message;
  */
 public abstract class KrollObject implements Handler.Callback
 {
-
 	protected static final int MSG_RELEASE = 100;
 	protected static final int MSG_SET_WINDOW = 101;
 	protected static final int MSG_LAST_ID = MSG_SET_WINDOW;
 
-	protected HashMap<String, Boolean> hasListenersForEventType = new HashMap<String, Boolean>();
+	protected HashMap<String, Boolean> hasListenersForEventType = new HashMap<>();
 	protected Handler handler;
 
 	private WeakReference<KrollProxySupport> proxySupport;
@@ -41,7 +40,7 @@ public abstract class KrollObject implements Handler.Callback
 	 */
 	public void setProxySupport(KrollProxySupport proxySupport)
 	{
-		this.proxySupport = new WeakReference<KrollProxySupport>(proxySupport);
+		this.proxySupport = new WeakReference<>(proxySupport);
 	}
 
 	/**
@@ -55,8 +54,7 @@ public abstract class KrollObject implements Handler.Callback
 		if (hasListeners == null) {
 			return false;
 		}
-
-		return hasListeners.booleanValue();
+		return hasListeners;
 	}
 
 	/**
@@ -103,8 +101,7 @@ public abstract class KrollObject implements Handler.Callback
 	 * </p>
 	 *
 	 * <p>
-	 * If the property does not reference a function this method
-	 * will return the {@link KrollRuntime.UNDEFINED} value.
+	 * If the property does not reference a function this method will return null.
 	 * </p>
 	 *
 	 * @param propertyName name of the property that references the function to call
@@ -114,7 +111,7 @@ public abstract class KrollObject implements Handler.Callback
 	public abstract Object callProperty(String propertyName, Object[] args);
 
 	/**
-	 * Releases this KrollObject, that is, removes event listeners and any associated native views or content.	
+	 * Releases this KrollObject, that is, removes event listeners and any associated native views or content.
 	 */
 	protected void release()
 	{

--- a/android/runtime/common/src/java/org/appcelerator/kroll/KrollPromise.java
+++ b/android/runtime/common/src/java/org/appcelerator/kroll/KrollPromise.java
@@ -21,7 +21,7 @@ public interface KrollPromise<V> {
 		return promise;
 	}
 
-	static class NullPromise implements KrollPromise
+	class NullPromise implements KrollPromise
 	{
 		@Override
 		public void resolve(Object value) {}

--- a/android/runtime/common/src/java/org/appcelerator/kroll/KrollRuntime.java
+++ b/android/runtime/common/src/java/org/appcelerator/kroll/KrollRuntime.java
@@ -51,7 +51,7 @@ public abstract class KrollRuntime implements Handler.Callback
 	}
 
 	private static KrollRuntime instance;
-	private static ArrayList<OnDisposingListener> disposingListeners = new ArrayList<>();
+	private static final ArrayList<OnDisposingListener> disposingListeners = new ArrayList<>();
 	private static int activityRefCount = 0;
 	private static int serviceReceiverRefCount = 0;
 
@@ -99,8 +99,8 @@ public abstract class KrollRuntime implements Handler.Callback
 
 		// Set up runtime member variables.
 		Looper looper = Looper.getMainLooper();
-		runtime.krollApplication = new WeakReference<KrollApplication>((KrollApplication) context);
-		runtime.exceptionHandlers = new HashMap<String, KrollExceptionHandler>();
+		runtime.krollApplication = new WeakReference<>((KrollApplication) context);
+		runtime.exceptionHandlers = new HashMap<>();
 		runtime.threadId = looper.getThread().getId();
 		runtime.handler = new Handler(looper, runtime);
 
@@ -486,7 +486,6 @@ public abstract class KrollRuntime implements Handler.Callback
 	 * time.
 	 *
 	 * @param handler The exception handler to set
-	 * @module.api
 	 */
 	public static void setPrimaryExceptionHandler(KrollExceptionHandler handler)
 	{
@@ -501,7 +500,6 @@ public abstract class KrollRuntime implements Handler.Callback
 	 *
 	 * @param handler The exception handler to set
 	 * @param key The key for the exception handler
-	 * @module.api
 	 */
 	public static void addAdditionalExceptionHandler(KrollExceptionHandler handler, String key)
 	{
@@ -513,7 +511,6 @@ public abstract class KrollRuntime implements Handler.Callback
 	/**
 	 * Removes the exception handler from the list of additional handlers. This will not affect the default handler.
 	 * @param key The key for the exception handler
-	 * @module.api
 	 */
 	public static void removeExceptionHandler(String key)
 	{

--- a/android/runtime/common/src/java/org/appcelerator/kroll/common/AsyncResult.java
+++ b/android/runtime/common/src/java/org/appcelerator/kroll/common/AsyncResult.java
@@ -22,7 +22,6 @@ public class AsyncResult extends Semaphore
 
 	/**
 	 * Constructs an AsyncResult with no argument.
-	 * @module.api
 	 */
 	public AsyncResult()
 	{
@@ -32,7 +31,6 @@ public class AsyncResult extends Semaphore
 	/**
 	 * Constructs an AsyncResult with an argument.
 	 * @param arg the general user data for a {@link android.os.Message Message}.
-	 * @module.api
 	 */
 	public AsyncResult(Object arg)
 	{
@@ -42,7 +40,6 @@ public class AsyncResult extends Semaphore
 
 	/**
 	 * @return the arg object that is passed into the constructor.
-	 * @module.api
 	 */
 	public Object getArg()
 	{
@@ -52,7 +49,6 @@ public class AsyncResult extends Semaphore
 	/**
 	 * Sets the result asynchronously, releasing the lock.
 	 * @param result the resulting object.
-	 * @module.api
 	 */
 	public void setResult(Object result)
 	{
@@ -63,7 +59,6 @@ public class AsyncResult extends Semaphore
 	/**
 	 * Sets an exception to be thrown to the code that is blocking on {@link #setResult(Object)}, and releases the lock.
 	 * @param exception a thrown exception. It can be thrown from any place that handles an AsyncResult.
-	 * @module.api
 	 */
 	public void setException(Throwable exception)
 	{
@@ -73,8 +68,7 @@ public class AsyncResult extends Semaphore
 	}
 
 	/**
-	 * @return the result, blocking the current thread until another thread calls {@link #getResult()}
-	 * @module.api
+	 * @return the result, blocking the current thread until another thread calls this method.
 	 */
 	public Object getResult()
 	{

--- a/android/runtime/common/src/java/org/appcelerator/kroll/common/Log.java
+++ b/android/runtime/common/src/java/org/appcelerator/kroll/common/Log.java
@@ -8,7 +8,7 @@ package org.appcelerator.kroll.common;
 
 /**
  * API to send log output. Supported severity-levels include: 'debug', 'warn', 'info' and 'error'.
- * Refer to <a href="http://developer.android.com/reference/android/util/Log.html">Android Log documentation</a> for more information. 
+ * Refer to <a href="http://developer.android.com/reference/android/util/Log.html">Android Log documentation</a> for more information.
  */
 public class Log
 {
@@ -26,13 +26,11 @@ public class Log
 
 	/**
 	 * A constant for the release mode.  In this mode, logs are always processed. This is the default mode if none are specified.
-	 * @module.api
 	 */
 	public static final String RELEASE_MODE = "RELEASE_MODE";
 	/**
 	 * A constant for debug mode. In this mode, logs are only processed when TiConfig.DEBUG is true. (TiConfig.DEBUG
 	 * corresponds to the 'ti.android.debug' property set by the user)
-	 * @module.api
 	 */
 	public static final String DEBUG_MODE = "DEBUG_MODE";
 
@@ -49,9 +47,8 @@ public class Log
 	 * @param tag  used to identify the source of the message.
 	 * @param msg  the message to log.
 	 * @param mode the mode to determine whether the log should be processed
-	 * @return     an integer that is dependent on the content and tag of the log. 
+	 * @return     an integer that is dependent on the content and tag of the log.
 	 *             Two different msgs would have two different return values.
-	 * @module.api
 	 */
 	public static int v(String tag, String msg, String mode)
 	{
@@ -64,9 +61,8 @@ public class Log
 	 * This method is thread safe.
 	 * @param tag  used to identify the source of the message.
 	 * @param msg  the message to log.
-	 * @return     an integer that is dependent on the content and tag of the log. 
+	 * @return     an integer that is dependent on the content and tag of the log.
 	 *             Two different msgs would have two different return values.
-	 * @module.api
 	 */
 	public static int v(String tag, String msg)
 	{
@@ -81,9 +77,8 @@ public class Log
 	 * @param msg  the message to log.
 	 * @param t    the exception to log.
 	 * @param mode the mode to determine whether the log should be processed
-	 * @return     an integer that is dependent on the content and tag of the log. 
+	 * @return     an integer that is dependent on the content and tag of the log.
 	 *             Two different msgs would have two different return values.
-	 * @module.api
 	 */
 	public static int v(String tag, String msg, Throwable t, String mode)
 	{
@@ -97,9 +92,8 @@ public class Log
 	 * @param tag  used to identify the source of the message.
 	 * @param msg  the message to log.
 	 * @param t    the exception to log.
-	 * @return     an integer that is dependent on the content and tag of the log. 
+	 * @return     an integer that is dependent on the content and tag of the log.
 	 *             Two different msgs would have two different return values.
-	 * @module.api
 	 */
 	public static int v(String tag, String msg, Throwable t)
 	{
@@ -113,9 +107,8 @@ public class Log
 	 * @param tag  used to identify the source of the message.
 	 * @param msg  the message to log.
 	 * @param mode the mode to determine whether the log should be processed
-	 * @return     an integer that is dependent on the content and tag of the log. 
+	 * @return     an integer that is dependent on the content and tag of the log.
 	 *             Two different msgs would have two different return values.
-	 * @module.api
 	 */
 	public static int d(String tag, String msg, String mode)
 	{
@@ -128,9 +121,8 @@ public class Log
 	 * This method is thread safe.
 	 * @param tag  used to identify the source of the message.
 	 * @param msg  the message to log.
-	 * @return     an integer that is dependent on the content and tag of the log. 
+	 * @return     an integer that is dependent on the content and tag of the log.
 	 *             Two different msgs would have two different return values.
-	 * @module.api
 	 */
 	public static int d(String tag, String msg)
 	{
@@ -151,9 +143,8 @@ public class Log
 	 * @param msg  the message to log.
 	 * @param t    the exception to log.
 	 * @param mode the mode to determine whether the log should be processed
-	 * @return     an integer that is dependent on the content and tag of the log. 
+	 * @return     an integer that is dependent on the content and tag of the log.
 	 *             Two different msgs would have two different return values.
-	 * @module.api
 	 */
 	public static int d(String tag, String msg, Throwable t, String mode)
 	{
@@ -167,9 +158,8 @@ public class Log
 	 * @param tag  used to identify the source of the message.
 	 * @param msg  the message to log.
 	 * @param t    the exception to log.
-	 * @return     an integer that is dependent on the content and tag of the log. 
+	 * @return     an integer that is dependent on the content and tag of the log.
 	 *             Two different msgs would have two different return values.
-	 * @module.api
 	 */
 	public static int d(String tag, String msg, Throwable t)
 	{
@@ -183,9 +173,8 @@ public class Log
 	 * @param tag  used to identify the source of the message.
 	 * @param msg  the message to log.
 	 * @param mode the mode to determine whether the log should be processed
-	 * @return     an integer that is dependent on the content and tag of the log. 
+	 * @return     an integer that is dependent on the content and tag of the log.
 	 *             Two different msgs would have two different return values.
-	 * @module.api
 	 */
 	public static int i(String tag, String msg, String mode)
 	{
@@ -198,9 +187,8 @@ public class Log
 	 * This method is thread safe.
 	 * @param tag  used to identify the source of the message.
 	 * @param msg  the message to log.
-	 * @return     an integer that is dependent on the content and tag of the log. 
+	 * @return     an integer that is dependent on the content and tag of the log.
 	 *             Two different msgs would have two different return values.
-	 * @module.api
 	 */
 	public static int i(String tag, String msg)
 	{
@@ -208,16 +196,15 @@ public class Log
 	}
 
 	/**
-	 * Sends a 'info' log message, with the thread name and time stamp pre-appended, and log the exception. 
+	 * Sends a 'info' log message, with the thread name and time stamp pre-appended, and log the exception.
 	 * For more information regarding formatting, refer to {@link #w(String, String)}.
 	 * This method is thread safe.
 	 * @param tag  used to idenfity the source of the message.
 	 * @param msg  the message to log.
 	 * @param t    the exception to log.
 	 * @param mode the mode to determine whether the log should be processed
-	 * @return     an integer that is dependent on the content and tag of the log. 
+	 * @return     an integer that is dependent on the content and tag of the log.
 	 *             Two different msgs would have two different return values.
-	 * @module.api
 	 */
 	public static int i(String tag, String msg, Throwable t, String mode)
 	{
@@ -225,15 +212,14 @@ public class Log
 	}
 
 	/**
-	 * Sends a 'info' log message, with the thread name and time stamp pre-appended, and log the exception. 
+	 * Sends a 'info' log message, with the thread name and time stamp pre-appended, and log the exception.
 	 * For more information regarding formatting, refer to {@link #w(String, String)}.
 	 * This method is thread safe.
 	 * @param tag  used to idenfity the source of the message.
 	 * @param msg  the message to log.
 	 * @param t    the exception to log.
-	 * @return     an integer that is dependent on the content and tag of the log. 
+	 * @return     an integer that is dependent on the content and tag of the log.
 	 *             Two different msgs would have two different return values.
-	 * @module.api
 	 */
 	public static int i(String tag, String msg, Throwable t)
 	{
@@ -247,9 +233,8 @@ public class Log
 	 * @param tag  used to identify the source of the message.
 	 * @param msg  the message to log.
 	 * @param mode the mode to determine whether the log should be processed
-	 * @return     an integer that is dependent on the content and tag of the log. 
+	 * @return     an integer that is dependent on the content and tag of the log.
 	 *             Two different msgs would have two different return values.
-	 * @module.api
 	 */
 	public static int w(String tag, String msg, String mode)
 	{
@@ -262,9 +247,8 @@ public class Log
 	 * This method is thread safe.
 	 * @param tag  used to identify the source of the message.
 	 * @param msg  the message to log.
-	 * @return     an integer that is dependent on the content and tag of the log. 
+	 * @return     an integer that is dependent on the content and tag of the log.
 	 *             Two different msgs would have two different return values.
-	 * @module.api
 	 */
 	public static int w(String tag, String msg)
 	{
@@ -279,9 +263,8 @@ public class Log
 	 * @param msg  the message to log.
 	 * @param t    an exception to log.
 	 * @param mode the mode to determine whether the log should be processed
-	 * @return     an integer that is dependent on the content and tag of the log. 
+	 * @return     an integer that is dependent on the content and tag of the log.
 	 *             Two different msgs would have two different return values.
-	 * @module.api
 	 */
 	public static int w(String tag, String msg, Throwable t, String mode)
 	{
@@ -295,9 +278,8 @@ public class Log
 	 * @param tag  used to identify the source of message.
 	 * @param msg  the message to log.
 	 * @param t    an exception to log.
-	 * @return     an integer that is dependent on the content and tag of the log. 
+	 * @return     an integer that is dependent on the content and tag of the log.
 	 *             Two different msgs would have two different return values.
-	 * @module.api
 	 */
 	public static int w(String tag, String msg, Throwable t)
 	{
@@ -311,9 +293,8 @@ public class Log
 	 * @param tag  used to identify the source of message.
 	 * @param msg  the message to log.
 	 * @param mode the mode to determine whether the log should be processed
-	 * @return     an integer that is dependent on the content and tag of the log. 
+	 * @return     an integer that is dependent on the content and tag of the log.
 	 *             Two different msgs would have two different return values.
-	 * @module.api
 	 */
 	public static int e(String tag, String msg, String mode)
 	{
@@ -326,9 +307,8 @@ public class Log
 	 * This method is thread safe.
 	 * @param tag  used to identify the source of message.
 	 * @param msg  the message to log.
-	 * @return     an integer that is dependent on the content and tag of the log. 
+	 * @return     an integer that is dependent on the content and tag of the log.
 	 *             Two different msgs would have two different return values.
-	 * @module.api
 	 */
 	public static int e(String tag, String msg)
 	{
@@ -343,9 +323,8 @@ public class Log
 	 * @param msg  the message to log.
 	 * @param t    the exception to log.
 	 * @param mode the mode to determine whether the log should be processed
-	 * @return     an integer that is dependent on the content and tag of the log. 
+	 * @return     an integer that is dependent on the content and tag of the log.
 	 *             Two different msgs would have two different return values.
-	 * @module.api
 	 */
 	public static int e(String tag, String msg, Throwable t, String mode)
 	{
@@ -359,9 +338,8 @@ public class Log
 	 * @param tag  used to identify the source of message.
 	 * @param msg  the message to log.
 	 * @param t    the exception to log.
-	 * @return     an integer that is dependent on the content and tag of the log. 
+	 * @return     an integer that is dependent on the content and tag of the log.
 	 *             Two different msgs would have two different return values.
-	 * @module.api
 	 */
 	public static int e(String tag, String msg, Throwable t)
 	{

--- a/android/runtime/common/src/java/org/appcelerator/kroll/common/TiConfig.java
+++ b/android/runtime/common/src/java/org/appcelerator/kroll/common/TiConfig.java
@@ -18,12 +18,11 @@ import android.util.Config;
 public class TiConfig
 {
 	/**
-	* Whether or not debug logging has been enabled by the Titanium application. This is normally set in the application's <code>tiapp.xml</code> with the 
+	* Whether or not debug logging has been enabled by the Titanium application. This is normally set in the application's <code>tiapp.xml</code> with the
 	* <code>ti.android.debug</code> property:
 	* <pre>
 	* &lt;property name="ti.android.debug" type="bool"&gt;true&lt;/property&gt;
 	* </pre>
-	* @module.api
 	*/
 	public static boolean LOGD = Config.DEBUG;
 	public static boolean LOGV = Config.DEBUG;

--- a/android/runtime/common/src/java/org/appcelerator/kroll/common/TiMessenger.java
+++ b/android/runtime/common/src/java/org/appcelerator/kroll/common/TiMessenger.java
@@ -68,7 +68,7 @@ public class TiMessenger implements Handler.Callback
 		}
 	};
 
-	protected ArrayBlockingQueue<Message> messageQueue = new ArrayBlockingQueue<Message>(10);
+	protected ArrayBlockingQueue<Message> messageQueue = new ArrayBlockingQueue<>(10);
 	protected CountDownLatch blockingLatch;
 	protected AtomicInteger blockingMessageCount = new AtomicInteger(0);
 	protected Handler.Callback callback;
@@ -90,7 +90,6 @@ public class TiMessenger implements Handler.Callback
 	 * As of Titanium 8.0.0, the JavaScript runtime only supports running on the main thread. This means
 	 * that getMainMessenger() and getRuntimeMessenger() will always return the same TiMessenger instance.
 	 * @return the main UI thread TiMessenger instance.
-	 * @module.api
 	 */
 	public static TiMessenger getMainMessenger()
 	{
@@ -104,7 +103,6 @@ public class TiMessenger implements Handler.Callback
 	 * As of Titanium 8.0.0, the JavaScript runtime only supports running on the main thread. This means
 	 * that getMainMessenger() and getRuntimeMessenger() will always return the same TiMessenger instance.
 	 * @return the KrollRuntime TiMessenger instance.
-	 * @module.api
 	 */
 	public static TiMessenger getRuntimeMessenger()
 	{
@@ -133,7 +131,6 @@ public class TiMessenger implements Handler.Callback
 	 * queue while blocking on the passed in AsyncResult. The blocking is done on the Main thread.
 	 * @param message  the message to send.
 	 * @return  The getResult() value of the AsyncResult put on the message.
-	 * @module.api
 	 */
 	public static Object sendBlockingMainMessage(Message message)
 	{
@@ -147,7 +144,6 @@ public class TiMessenger implements Handler.Callback
 	 * @param message   the message to send.
 	 * @param asyncArg  argument to be added to the AsyncResult.
 	 * @return  The getResult() value of the AsyncResult put on the message.
-	 * @module.api
 	 */
 	public static Object sendBlockingMainMessage(Message message, Object asyncArg)
 	{
@@ -160,7 +156,6 @@ public class TiMessenger implements Handler.Callback
 	 * queue while blocking on the passed in AsyncResult. The blocking is done on the KrollRuntime thread.
 	 * @param message  the message to send.
 	 * @return  The getResult() value of the AsyncResult put on the message.
-	 * @module.api
 	 */
 	public static Object sendBlockingRuntimeMessage(Message message)
 	{
@@ -174,7 +169,6 @@ public class TiMessenger implements Handler.Callback
 	 * @param message   the message to send.
 	 * @param asyncArg  the argument to be added to AsyncResult.
 	 * @return  The getResult() value of the AsyncResult put on the message.
-	 * @module.api
 	 */
 	public static Object sendBlockingRuntimeMessage(Message message, Object asyncArg)
 	{
@@ -190,7 +184,6 @@ public class TiMessenger implements Handler.Callback
 	 * @param asyncArg  the argument to be added to AsyncResult.
 	 * @param maxTimeout the maximum time to wait for a permit from the semaphore, in the unit of milliseconds.
 	 * @return  The getResult() value of the AsyncResult put on the message.
-	 * @module.api
 	 */
 	public static Object sendBlockingRuntimeMessage(Message message, Object asyncArg, long maxTimeout)
 	{
@@ -205,7 +198,6 @@ public class TiMessenger implements Handler.Callback
 
 	/**
 	 * @return the native looper. See {@link android.os.Looper} for more details.
-	 * @module.api
 	 */
 	public Looper getLooper()
 	{

--- a/android/runtime/common/src/java/org/appcelerator/kroll/util/KrollAssetCache.java
+++ b/android/runtime/common/src/java/org/appcelerator/kroll/util/KrollAssetCache.java
@@ -18,7 +18,7 @@ public class KrollAssetCache
 {
 	private static final String TAG = "TiAssetCache";
 
-	private static HashMap<String, byte[]> cache = new HashMap<>();
+	private static final HashMap<String, byte[]> cache = new HashMap<>();
 
 	/**
      * Asynchronous task to load specified assets into cache.

--- a/android/runtime/common/src/java/org/appcelerator/kroll/util/KrollAssetHelper.java
+++ b/android/runtime/common/src/java/org/appcelerator/kroll/util/KrollAssetHelper.java
@@ -33,9 +33,9 @@ public class KrollAssetHelper
 	private static String cacheDir;
 	private static AssetCrypt assetCrypt;
 	private static Collection<String> encryptedAssetFilePaths;
-	private static HashSet<String> apkAssetFilePathSet = new HashSet<>(256);
-	private static DirectoryListingMap apkDirectoryListingMap = new DirectoryListingMap(32);
-	private static DirectoryListingMap encrpytedDirectoryListingMap = new DirectoryListingMap(256);
+	private static final HashSet<String> apkAssetFilePathSet = new HashSet<>(256);
+	private static final DirectoryListingMap apkDirectoryListingMap = new DirectoryListingMap(32);
+	private static final DirectoryListingMap encrpytedDirectoryListingMap = new DirectoryListingMap(256);
 
 	public interface AssetCrypt {
 		InputStream openAsset(String path);
@@ -373,7 +373,7 @@ public class KrollAssetHelper
 			if (path.isEmpty()) {
 				TreeSet<String> fileListing = this.get(path);
 				if (fileListing == null) {
-					this.put(path, new TreeSet<String>());
+					this.put(path, new TreeSet<>());
 				}
 				return;
 			}
@@ -410,7 +410,7 @@ public class KrollAssetHelper
 				// Fetch the parent directory's file listing. Create one if it doesn't exist.
 				TreeSet<String> fileListing = this.get(parentDirectoryPath);
 				if (fileListing == null) {
-					fileListing = new TreeSet<String>();
+					fileListing = new TreeSet<>();
 					this.put(parentDirectoryPath, fileListing);
 				}
 

--- a/android/runtime/v8/src/java/org/appcelerator/kroll/runtime/v8/JSDebugger.java
+++ b/android/runtime/v8/src/java/org/appcelerator/kroll/runtime/v8/JSDebugger.java
@@ -33,16 +33,16 @@ public final class JSDebugger
 	private final Object waitLock;
 
 	// Are we ready to continue? Has the debugger been connected and we've processed the first set of messages?
-	private AtomicBoolean ready = new AtomicBoolean(false);
+	private final AtomicBoolean ready = new AtomicBoolean(false);
 
 	// Holding place for messages received from V8 intended for debugger
-	private LinkedBlockingQueue<String> v8Messages = new LinkedBlockingQueue<String>();
+	private final LinkedBlockingQueue<String> v8Messages = new LinkedBlockingQueue<>();
 
 	// The queue holding messages coming from debugger -> V8
-	private LinkedBlockingQueue<String> inspectorMessages = new LinkedBlockingQueue<String>();
+	private final LinkedBlockingQueue<String> inspectorMessages = new LinkedBlockingQueue<>();
 	// The initial queue of messages received after debugger connected to "initialize" (until we get
 	// Runtime.runIfWaitingForDebugger)
-	private LinkedBlockingQueue<String> initialMessages = new LinkedBlockingQueue<String>();
+	private final LinkedBlockingQueue<String> initialMessages = new LinkedBlockingQueue<>();
 
 	// The thread which acts as the main agent for listening to debugger and V8 messages
 	private InspectorAgent agentThread;
@@ -236,7 +236,7 @@ public final class JSDebugger
 	private class V8MessageHandler implements Runnable
 	{
 		private WebSocket conn;
-		private AtomicBoolean stop = new AtomicBoolean(false);
+		private final AtomicBoolean stop = new AtomicBoolean(false);
 
 		// Dummy message used to stop the sentinel loop if it was waiting on v8Messages.take() while stop() got called.
 		private static final String STOP_MESSAGE = "STOP_MESSAGE";

--- a/android/runtime/v8/src/java/org/appcelerator/kroll/runtime/v8/ReferenceTable.java
+++ b/android/runtime/v8/src/java/org/appcelerator/kroll/runtime/v8/ReferenceTable.java
@@ -17,13 +17,13 @@ import org.appcelerator.kroll.common.Log;
 
 public final class ReferenceTable
 {
-	private static String TAG = "ReferenceTable";
+	private static final String TAG = "ReferenceTable";
 
 	/**
 	 * A simple Map used to hold strong/weak reference to the Java objects we have paired/wrapped in native
 	 * titanium::Proxy/JavaObject instances.
 	 */
-	private static HashMap<Long, Object> references = new HashMap<Long, Object>();
+	private static final HashMap<Long, Object> references = new HashMap<>();
 
 	/**
 	 * Incrementing key, used to generate new keys when a new strong reference is created. FIXME Handle "wrapping" the
@@ -78,7 +78,7 @@ public final class ReferenceTable
 		Log.d(TAG, "Downgrading to weak reference for key: " + key, Log.DEBUG_MODE);
 		Object ref = getReference(key);
 		references.remove(key);
-		references.put(key, new WeakReference<Object>(ref));
+		references.put(key, new WeakReference<>(ref));
 	}
 
 	/**
@@ -91,7 +91,7 @@ public final class ReferenceTable
 		Log.d(TAG, "Downgrading to soft reference for key: " + key, Log.DEBUG_MODE);
 		Object ref = getReference(key);
 		references.remove(key);
-		references.put(key, new SoftReference<Object>(ref));
+		references.put(key, new SoftReference<>(ref));
 	}
 
 	/**

--- a/android/runtime/v8/src/java/org/appcelerator/kroll/runtime/v8/V8Runtime.java
+++ b/android/runtime/v8/src/java/org/appcelerator/kroll/runtime/v8/V8Runtime.java
@@ -37,13 +37,10 @@ public final class V8Runtime extends KrollRuntime implements Handler.Callback
 
 	private boolean libLoaded = false;
 
-	private HashMap<String, Class<? extends KrollExternalModule>> externalModules =
-		new HashMap<String, Class<? extends KrollExternalModule>>();
-	private static HashMap<String, KrollSourceCodeProvider> externalCommonJsModules =
-		new HashMap<String, KrollSourceCodeProvider>();
-
-	private ArrayList<String> loadedLibs = new ArrayList<String>();
-	private AtomicBoolean shouldGC = new AtomicBoolean(false);
+	private final HashMap<String, Class<? extends KrollExternalModule>> externalModules = new HashMap<>();
+	private static final HashMap<String, KrollSourceCodeProvider> externalCommonJsModules = new HashMap<>();
+	private final ArrayList<String> loadedLibs = new ArrayList<>();
+	private final AtomicBoolean shouldGC = new AtomicBoolean(false);
 	private long lastV8Idle;
 
 	/**

--- a/android/titanium/src/java/org/appcelerator/kroll/KrollDict.java
+++ b/android/titanium/src/java/org/appcelerator/kroll/KrollDict.java
@@ -29,7 +29,6 @@ public class KrollDict extends HashMap<String, Object>
 
 	/**
 	 * Constructs a KrollDict with a default capacity.
-	 * @module.api
 	 */
 	public KrollDict()
 	{
@@ -73,7 +72,6 @@ public class KrollDict extends HashMap<String, Object>
 	/**
 	 * Constructs a KrollDict by copying an existing Map
 	 * @param map the existing map to copy
-	 * @module.api
 	 */
 	public KrollDict(Map<? extends String, ? extends Object> map)
 	{
@@ -83,7 +81,6 @@ public class KrollDict extends HashMap<String, Object>
 	/**
 	 * Constructs a KrollDict with the specified capacity.
 	 * @param size the specified capacity.
-	 * @module.api
 	 */
 	public KrollDict(int size)
 	{

--- a/android/titanium/src/java/org/appcelerator/kroll/KrollModule.java
+++ b/android/titanium/src/java/org/appcelerator/kroll/KrollModule.java
@@ -22,8 +22,7 @@ import android.app.Activity;
 @Kroll.module(name = "KrollModule")
 public class KrollModule extends KrollProxy implements KrollProxyListener, OnLifecycleEvent
 {
-
-	protected static ArrayList<KrollModuleInfo> customModuleInfoList = new ArrayList<KrollModuleInfo>();
+	protected static ArrayList<KrollModuleInfo> customModuleInfoList = new ArrayList<>();
 
 	public static void addCustomModuleInfo(KrollModuleInfo customModuleInfo)
 	{
@@ -37,7 +36,6 @@ public class KrollModule extends KrollProxy implements KrollProxyListener, OnLif
 
 	/**
 	 * Constructs a new KrollModule object.
-	 * @module.api
 	 */
 	public KrollModule()
 	{
@@ -48,7 +46,6 @@ public class KrollModule extends KrollProxy implements KrollProxyListener, OnLif
 	/**
 	 * Instantiates and registers module with TiApplication.
 	 * @param name the name of module.
-	 * @module.api
 	 */
 	public KrollModule(String name)
 	{
@@ -76,7 +73,6 @@ public class KrollModule extends KrollProxy implements KrollProxyListener, OnLif
 	/**
 	 * A place holder for subclasses to extend. Its purpose is to receive native Android onResume life cycle events.
 	 * @param activity the activity attached to this module.
-	 * @module.api
 	 */
 	public void onResume(Activity activity)
 	{
@@ -85,7 +81,6 @@ public class KrollModule extends KrollProxy implements KrollProxyListener, OnLif
 	/**
 	 * A place holder for subclasses to extend. Its purpose is to receive native Android onPause life cycle events.
 	 * @param activity the activity attached to this module.
-	 * @module.api
 	 */
 	public void onPause(Activity activity)
 	{
@@ -94,7 +89,6 @@ public class KrollModule extends KrollProxy implements KrollProxyListener, OnLif
 	/**
 	 * A place holder for subclasses to extend. Its purpose is to receive native Android onDestroy life cycle events.
 	 * @param activity the activity attached to this module.
-	 * @module.api
 	 */
 	public void onDestroy(Activity activity)
 	{
@@ -103,7 +97,6 @@ public class KrollModule extends KrollProxy implements KrollProxyListener, OnLif
 	/**
 	 * A place holder for subclasses to extend. Its purpose is to receive native Android onStart life cycle events.
 	 * @param activity the activity attached to this module.
-	 * @module.api
 	 */
 	public void onStart(Activity activity)
 	{
@@ -112,7 +105,6 @@ public class KrollModule extends KrollProxy implements KrollProxyListener, OnLif
 	/**
 	 * A place holder for subclasses to extend. Its purpose is to receive native Android onStop life cycle events.
 	 * @param activity the activity attached to this module.
-	 * @module.api
 	 */
 	public void onStop(Activity activity)
 	{
@@ -125,7 +117,6 @@ public class KrollModule extends KrollProxy implements KrollProxyListener, OnLif
 	 * @param type the event type
 	 * @param count the count of event listeners for the event
 	 * @param proxy the proxy instance that the event listener was added to
-	 * @module.api
 	 */
 	public void listenerAdded(String type, int count, KrollProxy proxy)
 	{
@@ -138,7 +129,6 @@ public class KrollModule extends KrollProxy implements KrollProxyListener, OnLif
 	 * @param type the event type
 	 * @param count the count of event listeners for the event
 	 * @param proxy the proxy instance that the event listener was removed from
-	 * @module.api
 	 */
 	public void listenerRemoved(String type, int count, KrollProxy proxy)
 	{
@@ -147,7 +137,6 @@ public class KrollModule extends KrollProxy implements KrollProxyListener, OnLif
 	/**
 	 * Implementing classes can use this method to examine the properties passed into the proxy when it's first created.
 	 * @param properties  a set of properties to process.
-	 * @module.api
 	 */
 	public void processProperties(KrollDict properties)
 	{
@@ -159,7 +148,6 @@ public class KrollModule extends KrollProxy implements KrollProxyListener, OnLif
 	 * @param oldValue  the property's old value.
 	 * @param newValue  the property's new value.
 	 * @param proxy     the associated proxy.
-	 * @module.api
 	 */
 	public void propertyChanged(String key, Object oldValue, Object newValue, KrollProxy proxy)
 	{

--- a/android/titanium/src/java/org/appcelerator/kroll/KrollProxy.java
+++ b/android/titanium/src/java/org/appcelerator/kroll/KrollProxy.java
@@ -91,7 +91,6 @@ public class KrollProxy implements Handler.Callback, KrollProxySupport, OnLifecy
 
 	/**
 	 * The default KrollProxy constructor. Equivalent to <code>KrollProxy("")</code>
-	 * @module.api
 	 */
 	public KrollProxy()
 	{
@@ -101,13 +100,12 @@ public class KrollProxy implements Handler.Callback, KrollProxySupport, OnLifecy
 	/**
 	 * Constructs a KrollProxy, using the passed in creation URL.
 	 * @param baseCreationUrl the creation URL for this proxy, which can be used to resolve relative paths
-	 * @module.api
 	 */
 	public KrollProxy(String baseCreationUrl)
 	{
 		creationUrl = new TiUrl(baseCreationUrl);
 		this.listenerIdGenerator = new AtomicInteger(0);
-		this.eventListeners = Collections.synchronizedMap(new HashMap<String, HashMap<Integer, KrollEventCallback>>());
+		this.eventListeners = Collections.synchronizedMap(new HashMap<>());
 		this.langConversionTable = getLangConversionTable();
 	}
 
@@ -146,7 +144,7 @@ public class KrollProxy implements Handler.Callback, KrollProxySupport, OnLifecy
 
 	protected void initActivity(Activity activity)
 	{
-		this.activity = new WeakReference<Activity>(activity);
+		this.activity = new WeakReference<>(activity);
 	}
 
 	public void setActivity(Activity activity)
@@ -156,7 +154,7 @@ public class KrollProxy implements Handler.Callback, KrollProxySupport, OnLifecy
 			initActivity(TiApplication.getAppRootOrCurrentActivity());
 			return;
 		}
-		this.activity = new WeakReference<Activity>(activity);
+		this.activity = new WeakReference<>(activity);
 	}
 
 	public void attachActivityLifecycle(Activity activity)
@@ -167,7 +165,6 @@ public class KrollProxy implements Handler.Callback, KrollProxySupport, OnLifecy
 
 	/**
 	 * @return the activity associated with this proxy.
-	 * @module.api
 	 */
 	public Activity getActivity()
 	{
@@ -181,8 +178,7 @@ public class KrollProxy implements Handler.Callback, KrollProxySupport, OnLifecy
 	/**
 	 * Handles the arguments passed into the "create" method for this proxy.
 	 * If your proxy simply needs to handle a KrollDict, see {@link KrollProxy#handleCreationDict(KrollDict)}
-	 * @param args
-	 * @module.api
+	 * @param args Array of arguments passed to the JavaScript create*() method.
 	 */
 	public void handleCreationArgs(KrollModule createdInModule, Object[] args)
 	{
@@ -204,7 +200,6 @@ public class KrollProxy implements Handler.Callback, KrollProxySupport, OnLifecy
 
 	/**
 	 * Handles initialization of the proxy's default property values.
-	 * @module.api
 	 */
 	protected void handleDefaultValues()
 	{
@@ -237,8 +232,6 @@ public class KrollProxy implements Handler.Callback, KrollProxySupport, OnLifecy
 	 *	table.put("text", "textid");
 	 *	return table;
 	 *} </pre> </code>
-	 *
-	 * @module.api
 	 *
 	 */
 	protected KrollDict getLangConversionTable()
@@ -358,8 +351,7 @@ public class KrollProxy implements Handler.Callback, KrollProxySupport, OnLifecy
 	 * This is usually the first (and sometimes only) argument to the proxy's create method.
 	 *
 	 * To set default property values, add them to the {@link KrollProxy#defaultValues map}
-	 * @param dict
-	 * @module.api
+	 * @param dict Dictionary of properties passed to the JavaScript create*() method.
 	 */
 	public void handleCreationDict(KrollDict dict)
 	{
@@ -472,7 +464,6 @@ public class KrollProxy implements Handler.Callback, KrollProxySupport, OnLifecy
 
 	/**
 	 * @return the KrollObject associated with this proxy if it exists. Otherwise create it in the KrollRuntime thread.
-	 * @module.api
 	 */
 	public KrollObject getKrollObject()
 	{
@@ -497,7 +488,6 @@ public class KrollProxy implements Handler.Callback, KrollProxySupport, OnLifecy
 
 	/**
 	 * @return the absolute URL of the location in code where the proxy was created in Javascript.
-	 * @module.api
 	 */
 	public TiUrl getCreationUrl()
 	{
@@ -518,7 +508,7 @@ public class KrollProxy implements Handler.Callback, KrollProxySupport, OnLifecy
 			return;
 		}
 
-		ArrayList<KrollPropertyChange> propertyChanges = new ArrayList<KrollPropertyChange>();
+		ArrayList<KrollPropertyChange> propertyChanges = new ArrayList<>();
 		for (String name : options.keySet()) {
 			Object oldValue = properties.get(name);
 			Object value = options.get(name);
@@ -588,7 +578,6 @@ public class KrollProxy implements Handler.Callback, KrollProxySupport, OnLifecy
 	/**
 	 * @param name  the lookup key.
 	 * @return  true if the proxy contains this property, false otherwise.
-	 * @module.api
 	 */
 	public boolean hasProperty(String name)
 	{
@@ -601,7 +590,6 @@ public class KrollProxy implements Handler.Callback, KrollProxySupport, OnLifecy
 	/**
 	 * @param name  the lookup key.
 	 * @return  true if the proxy contains this property and it is not null, false otherwise.
-	 * @module.api
 	 */
 	public boolean hasPropertyAndNotNull(String name)
 	{
@@ -616,7 +604,6 @@ public class KrollProxy implements Handler.Callback, KrollProxySupport, OnLifecy
 	 * Properties are cached on the Proxy and updated from JS for relevant annotated APIs
 	 * @param name  the lookup key.
 	 * @return the property object or null if a property for the given key does not exist.
-	 * @module.api
 	 */
 	public Object getProperty(String name)
 	{
@@ -628,7 +615,6 @@ public class KrollProxy implements Handler.Callback, KrollProxySupport, OnLifecy
 
 	/**
 	 * This sets the named property as well as updating the actual JS object.
-	 * @module.api
 	 */
 	public void setProperty(String name, Object value)
 	{
@@ -648,7 +634,7 @@ public class KrollProxy implements Handler.Callback, KrollProxySupport, OnLifecy
 		}
 	}
 
-	public class KrollPropertyChangeSet extends KrollPropertyChange
+	public static class KrollPropertyChangeSet extends KrollPropertyChange
 	{
 		public int entryCount;
 		public String[] keys;
@@ -789,7 +775,6 @@ public class KrollProxy implements Handler.Callback, KrollProxySupport, OnLifecy
 	 * @param event the event to be fired.
 	 * @param data  the data to be sent.
 	 * @return whether this proxy has an eventListener for this event.
-	 * @module.api
 	 */
 	public boolean fireEvent(String event, Object data)
 	{
@@ -827,7 +812,6 @@ public class KrollProxy implements Handler.Callback, KrollProxySupport, OnLifecy
 	 * @param event the event to be fired.
 	 * @param data  the data to be sent.
 	 * @return whether this proxy has an eventListener for this event.
-	 * @module.api
 	 */
 	public boolean fireSyncEvent(String event, Object data)
 	{
@@ -848,7 +832,6 @@ public class KrollProxy implements Handler.Callback, KrollProxySupport, OnLifecy
 	 * @param data  the data to be sent.
 	 * @param maxTimeout the maximum time to wait for the result to return, in the unit of milliseconds.
 	 * @return whether this proxy has an eventListener for this event.
-	 * @module.api
 	 */
 	public boolean fireSyncEvent(String event, Object data, long maxTimeout)
 	{
@@ -1025,7 +1008,6 @@ public class KrollProxy implements Handler.Callback, KrollProxySupport, OnLifecy
 	/**
 	 * @param event the event to check
 	 * @return whether the associated KrollObject has an event listener for the passed in event.
-	 * @module.api
 	 */
 	public boolean hasListeners(String event)
 	{
@@ -1071,7 +1053,6 @@ public class KrollProxy implements Handler.Callback, KrollProxySupport, OnLifecy
 	 * {@link KrollProxyListener#propertyChanged(String, Object, Object, KrollProxy)}.
 	 * @param name the property name.
 	 * @param value the property value.
-	 * @module.api
 	 */
 	public void setPropertyAndFire(String name, Object value)
 	{
@@ -1168,7 +1149,6 @@ public class KrollProxy implements Handler.Callback, KrollProxySupport, OnLifecy
 	/**
 	 * Returns a KrollDict object that contains all current properties associated with this proxy.
 	 * @return KrollDict properties object.
-	 * @module.api
 	 */
 	public KrollDict getProperties()
 	{
@@ -1289,7 +1269,6 @@ public class KrollProxy implements Handler.Callback, KrollProxySupport, OnLifecy
 	 * @param count			the number of listeners for this event.  should not be used as this value
 	 * 						is not reported correctly
 	 * @param proxy			the proxy that the event was added to.  otherwise known as "this"
-	 * @return				<code>void</code>
 	 */
 	protected void eventListenerAdded(String event, int count, KrollProxy proxy)
 	{
@@ -1303,7 +1282,6 @@ public class KrollProxy implements Handler.Callback, KrollProxySupport, OnLifecy
 	 * @param count			the number of listeners for this event.  should not be used as this value
 	 * 						is not reported correctly
 	 * @param proxy			the proxy that the event was removed from.  otherwise known as "this"
-	 * @return				<code>void</code>
 	 */
 	protected void eventListenerRemoved(String event, int count, KrollProxy proxy)
 	{
@@ -1313,7 +1291,6 @@ public class KrollProxy implements Handler.Callback, KrollProxySupport, OnLifecy
 	/**
 	 * Associates this proxy with the passed in {@link KrollProxyListener}.
 	 * @param modelListener the passed in KrollProxyListener.
-	 * @module.api
 	 */
 	public void setModelListener(KrollProxyListener modelListener)
 	{
@@ -1351,7 +1328,7 @@ public class KrollProxy implements Handler.Callback, KrollProxySupport, OnLifecy
 
 			HashMap<Integer, KrollEventCallback> listeners = eventListeners.get(eventName);
 			if (listeners == null) {
-				listeners = new HashMap<Integer, KrollEventCallback>();
+				listeners = new HashMap<>();
 				eventListeners.put(eventName, listeners);
 			}
 
@@ -1410,7 +1387,6 @@ public class KrollProxy implements Handler.Callback, KrollProxySupport, OnLifecy
 	 * @param scheme the scheme of Url.
 	 * @param path   the path of Url.
 	 * @return a string representation of URL given its components.
-	 * @module.api
 	 */
 	public String resolveUrl(String scheme, String path)
 	{
@@ -1431,7 +1407,6 @@ public class KrollProxy implements Handler.Callback, KrollProxySupport, OnLifecy
 
 	/**
 	 * Releases the KrollObject, freeing memory.
-	 * @module.api
 	 */
 	public void release()
 	{
@@ -1455,7 +1430,6 @@ public class KrollProxy implements Handler.Callback, KrollProxySupport, OnLifecy
 
 	/**
 	 * Only release kroll, but maintain instance
-	 * @module.api
 	 */
 	public void releaseKroll()
 	{
@@ -1480,7 +1454,6 @@ public class KrollProxy implements Handler.Callback, KrollProxySupport, OnLifecy
 	/**
 	 * A place holder for subclasses to extend. Its purpose is to receive native Android onCreate life cycle events.
 	 * @param activity the activity attached to this module.
-	 * @module.api
 	 */
 	public void onCreate(Activity activity, Bundle savedInstanceState)
 	{
@@ -1489,7 +1462,6 @@ public class KrollProxy implements Handler.Callback, KrollProxySupport, OnLifecy
 	/**
 	 * A place holder for subclasses to extend. Its purpose is to receive native Android onResume life cycle events.
 	 * @param activity the activity attached to this module.
-	 * @module.api
 	 */
 	public void onResume(Activity activity)
 	{
@@ -1498,7 +1470,6 @@ public class KrollProxy implements Handler.Callback, KrollProxySupport, OnLifecy
 	/**
 	 * A place holder for subclasses to extend. Its purpose is to receive native Android onPause life cycle events.
 	 * @param activity the activity attached to this module.
-	 * @module.api
 	 */
 	public void onPause(Activity activity)
 	{
@@ -1507,7 +1478,6 @@ public class KrollProxy implements Handler.Callback, KrollProxySupport, OnLifecy
 	/**
 	 * A place holder for subclasses to extend. Its purpose is to receive native Android onDestroy life cycle events.
 	 * @param activity the activity attached to this module.
-	 * @module.api
 	 */
 	public void onDestroy(Activity activity)
 	{
@@ -1516,7 +1486,6 @@ public class KrollProxy implements Handler.Callback, KrollProxySupport, OnLifecy
 	/**
 	 * A place holder for subclasses to extend. Its purpose is to receive native Android onStart life cycle events.
 	 * @param activity the activity attached to this module.
-	 * @module.api
 	 */
 	public void onStart(Activity activity)
 	{
@@ -1525,7 +1494,6 @@ public class KrollProxy implements Handler.Callback, KrollProxySupport, OnLifecy
 	/**
 	 * A place holder for subclasses to extend. Its purpose is to receive native Android onStop life cycle events.
 	 * @param activity the activity attached to this module.
-	 * @module.api
 	 */
 	public void onStop(Activity activity)
 	{

--- a/android/titanium/src/java/org/appcelerator/kroll/KrollProxyListener.java
+++ b/android/titanium/src/java/org/appcelerator/kroll/KrollProxyListener.java
@@ -19,14 +19,12 @@ public interface KrollProxyListener {
 	 * @param oldValue  the old value.
 	 * @param newValue  the new value.
 	 * @param proxy  the associated proxy.
-	 * @module.api
 	 */
 	void propertyChanged(String key, Object oldValue, Object newValue, KrollProxy proxy);
 
 	/**
 	 * Implementing classes can use this method to examine the properties passed into the proxy.
 	 * @param properties  a set of properties to process.
-	 * @module.api
 	 */
 	void processProperties(KrollDict properties);
 	void propertiesChanged(List<KrollPropertyChange> changes, KrollProxy proxy);
@@ -36,7 +34,6 @@ public interface KrollProxyListener {
 	 * @param type the added event listener
 	 * @param count the count of event listeners.
 	 * @param proxy the proxy that added the listener.
-	 * @module.api
 	 */
 	void listenerAdded(String type, int count, KrollProxy proxy);
 
@@ -45,7 +42,6 @@ public interface KrollProxyListener {
 	 * @param type the removed event listener
 	 * @param count the count of event listeners.
 	 * @param proxy the proxy that removed the listener.
-	 * @module.api
 	 */
 	void listenerRemoved(String type, int count, KrollProxy proxy);
 }

--- a/android/titanium/src/java/org/appcelerator/titanium/TiActivitySupportHelpers.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiActivitySupportHelpers.java
@@ -18,7 +18,7 @@ import android.util.SparseArray;
 public class TiActivitySupportHelpers
 {
 	protected static AtomicInteger supportHelperIdGenerator = new AtomicInteger();
-	protected static SparseArray<TiActivitySupportHelper> supportHelpers = new SparseArray<TiActivitySupportHelper>();
+	protected static SparseArray<TiActivitySupportHelper> supportHelpers = new SparseArray<>();
 
 	public static int addSupportHelper(TiActivitySupportHelper supportHelper)
 	{

--- a/android/titanium/src/java/org/appcelerator/titanium/TiActivityWindows.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiActivityWindows.java
@@ -17,7 +17,7 @@ public final class TiActivityWindows
 	public static final int INVALID_WINDOW_ID = -1;
 
 	private static int nextWindowId = 1;
-	private static HashMap<Integer, TiActivityWindow> windowMap = new HashMap<>(32);
+	private static final HashMap<Integer, TiActivityWindow> windowMap = new HashMap<>(32);
 
 	private TiActivityWindows()
 	{
@@ -34,13 +34,13 @@ public final class TiActivityWindows
 		// Instead, return its already assigned ID.
 		for (HashMap.Entry<Integer, TiActivityWindow> nextEntry : windowMap.entrySet()) {
 			if ((nextEntry != null) && (nextEntry.getValue() == window)) {
-				return nextEntry.getKey().intValue();
+				return nextEntry.getKey();
 			}
 		}
 
 		// Generate a unique ID for the given window.
 		int windowId = nextWindowId;
-		while ((windowId == INVALID_WINDOW_ID) || windowMap.containsKey(Integer.valueOf(windowId))) {
+		while ((windowId == INVALID_WINDOW_ID) || windowMap.containsKey(windowId)) {
 			windowId++;
 		}
 		nextWindowId = windowId + 1;
@@ -52,7 +52,7 @@ public final class TiActivityWindows
 
 	public static void windowCreated(TiBaseActivity activity, int windowId, Bundle savedInstanceState)
 	{
-		TiActivityWindow window = windowMap.get(Integer.valueOf(windowId));
+		TiActivityWindow window = windowMap.get(windowId);
 		if (window != null) {
 			window.windowCreated(activity, savedInstanceState);
 		}
@@ -73,13 +73,13 @@ public final class TiActivityWindows
 	public static void removeWindow(int windowId)
 	{
 		if (windowId != INVALID_WINDOW_ID) {
-			windowMap.remove(Integer.valueOf(windowId));
+			windowMap.remove(windowId);
 		}
 	}
 
 	public static boolean hasWindow(int windowId)
 	{
-		return (windowMap.get(Integer.valueOf(windowId)) != null);
+		return (windowMap.get(windowId) != null);
 	}
 
 	public static int getWindowCount()

--- a/android/titanium/src/java/org/appcelerator/titanium/TiApplication.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiApplication.java
@@ -82,7 +82,7 @@ public abstract class TiApplication extends Application implements KrollApplicat
 	private String baseUrl;
 	private String startUrl;
 	private HashMap<String, SoftReference<KrollProxy>> proxyMap;
-	private TiWeakList<KrollProxy> appEventProxies = new TiWeakList<KrollProxy>();
+	private final TiWeakList<KrollProxy> appEventProxies = new TiWeakList<>();
 	private WeakReference<TiRootActivity> rootActivity;
 	private TiProperties appProperties;
 	private WeakReference<Activity> currentActivity;
@@ -98,9 +98,8 @@ public abstract class TiApplication extends Application implements KrollApplicat
 	protected String[] filteredAnalyticsEvents;
 
 	public static AtomicBoolean isActivityTransition = new AtomicBoolean(false);
-	protected static ArrayList<ActivityTransitionListener> activityTransitionListeners =
-		new ArrayList<ActivityTransitionListener>();
-	protected static TiWeakList<Activity> activityStack = new TiWeakList<Activity>();
+	protected static ArrayList<ActivityTransitionListener> activityTransitionListeners = new ArrayList<>();
+	protected static TiWeakList<Activity> activityStack = new TiWeakList<>();
 
 	public interface ActivityTransitionListener {
 		void onActivityTransition(boolean state);
@@ -137,14 +136,13 @@ public abstract class TiApplication extends Application implements KrollApplicat
 
 		mainThreadId = Looper.getMainLooper().getThread().getId();
 
-		modules = new HashMap<String, WeakReference<KrollModule>>();
+		modules = new HashMap<>();
 		TiMessenger.getMessenger(); // initialize message queue for main thread
 	}
 
 	/**
 	 * Retrieves the instance of TiApplication. There is one instance per Android application.
 	 * @return the instance of TiApplication.
-	 * @module.api
 	 */
 	public static TiApplication getInstance()
 	{
@@ -166,7 +164,7 @@ public abstract class TiApplication extends Application implements KrollApplicat
 	public static void addToActivityStack(Activity activity)
 	{
 		if (activity != null) {
-			activityStack.add(new WeakReference<Activity>(activity));
+			activityStack.add(new WeakReference<>(activity));
 		}
 	}
 
@@ -218,7 +216,6 @@ public abstract class TiApplication extends Application implements KrollApplicat
 	/**
 	 * Check whether the current activity is in foreground or not.
 	 * @return true if the current activity is in foreground; false otherwise.
-	 * @module.api
 	 */
 	public static boolean isCurrentActivityInForeground()
 	{
@@ -233,7 +230,6 @@ public abstract class TiApplication extends Application implements KrollApplicat
 	 * This is a convenience method to avoid having to check TiApplication.getInstance() is not null every
 	 * time we need to grab the current activity.
 	 * @return the current activity
-	 * @module.api
 	 */
 	public static Activity getAppCurrentActivity()
 	{
@@ -244,7 +240,6 @@ public abstract class TiApplication extends Application implements KrollApplicat
 	 * This is a convenience method to avoid having to check TiApplication.getInstance() is not null every
 	 * time we need to grab the root or current activity.
 	 * @return root activity if exists. If root activity doesn't exist, returns current activity if exists. Otherwise returns null.
-	 * @module.api
 	 */
 	public static Activity getAppRootOrCurrentActivity()
 	{
@@ -253,7 +248,6 @@ public abstract class TiApplication extends Application implements KrollApplicat
 
 	/**
 	 * @return the current activity if exists. Otherwise, the thread will wait for a valid activity to be visible.
-	 * @module.api
 	 */
 	@Override
 	public Activity getCurrentActivity()
@@ -345,7 +339,7 @@ public abstract class TiApplication extends Application implements KrollApplicat
 		File fullPath = new File(TiC.URL_ANDROID_ASSET_RESOURCES, "app.js");
 		baseUrl = fullPath.getParent();
 
-		proxyMap = new HashMap<String, SoftReference<KrollProxy>>(5);
+		proxyMap = new HashMap<>(5);
 
 		deployData = new TiDeployData(this);
 
@@ -397,9 +391,8 @@ public abstract class TiApplication extends Application implements KrollApplicat
 		TiImageLruCache.getInstance().evictAll();
 
 		// Perform hard garbage collection to reclaim memory.
-		KrollRuntime instance = KrollRuntime.getInstance();
-		if (instance != null) {
-			instance.hardGC();
+		if (KrollRuntime.getInstance() != null) {
+			KrollRuntime.hardGC();
 		}
 
 		super.onLowMemory();
@@ -415,9 +408,8 @@ public abstract class TiApplication extends Application implements KrollApplicat
 			TiImageLruCache.getInstance().evictAll();
 
 			// Perform soft garbage collection to reclaim memory.
-			KrollRuntime instance = KrollRuntime.getInstance();
-			if (instance != null) {
-				instance.softGC();
+			if (KrollRuntime.getInstance() != null) {
+				KrollRuntime.softGC();
 			}
 		}
 		super.onTrimMemory(level);
@@ -572,7 +564,7 @@ public abstract class TiApplication extends Application implements KrollApplicat
 
 	public void setRootActivity(TiRootActivity rootActivity)
 	{
-		this.rootActivity = new WeakReference<TiRootActivity>(rootActivity);
+		this.rootActivity = new WeakReference<>(rootActivity);
 		if (rootActivity == null) {
 			return;
 		}
@@ -631,7 +623,7 @@ public abstract class TiApplication extends Application implements KrollApplicat
 		{
 			Activity currentActivity = getCurrentActivity();
 			if (currentActivity == null || callingActivity == currentActivity) {
-				this.currentActivity = new WeakReference<Activity>(newValue);
+				this.currentActivity = new WeakReference<>(newValue);
 			}
 		}
 	}
@@ -649,7 +641,7 @@ public abstract class TiApplication extends Application implements KrollApplicat
 	public void addAppEventProxy(KrollProxy appEventProxy)
 	{
 		if (appEventProxy != null && !appEventProxies.contains(appEventProxy)) {
-			appEventProxies.add(new WeakReference<KrollProxy>(appEventProxy));
+			appEventProxies.add(new WeakReference<>(appEventProxy));
 		}
 	}
 
@@ -677,7 +669,6 @@ public abstract class TiApplication extends Application implements KrollApplicat
 	/**
 	 * @return the app's properties, which are listed in tiapp.xml.
 	 * App properties can also be set at runtime by the application in Javascript.
-	 * @module.api
 	 */
 	public TiProperties getAppProperties()
 	{
@@ -710,7 +701,7 @@ public abstract class TiApplication extends Application implements KrollApplicat
 	{
 		String proxyId = proxy.getProxyId();
 		if (!proxyMap.containsKey(proxyId)) {
-			proxyMap.put(proxyId, new SoftReference<KrollProxy>(proxy));
+			proxyMap.put(proxyId, new SoftReference<>(proxy));
 		}
 	}
 
@@ -919,7 +910,6 @@ public abstract class TiApplication extends Application implements KrollApplicat
 
 	/**
 	 * @return true if the current thread is the main thread, false otherwise.
-	 * @module.api
 	 */
 	public static boolean isUIThread()
 	{
@@ -946,7 +936,7 @@ public abstract class TiApplication extends Application implements KrollApplicat
 			Log.w(TAG, "Registering module with name already in use.");
 		}
 
-		modules.put(name, new WeakReference<KrollModule>(module));
+		modules.put(name, new WeakReference<>(module));
 	}
 
 	@Override

--- a/android/titanium/src/java/org/appcelerator/titanium/TiApplicationLifecycle.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiApplicationLifecycle.java
@@ -18,7 +18,7 @@ public class TiApplicationLifecycle implements Application.ActivityLifecycleCall
 {
 	private static final String TAG = "TiApplicationLifecycle";
 
-	private TiApplication tiApp = TiApplication.getInstance();
+	private final TiApplication tiApp = TiApplication.getInstance();
 	private int existingActivityCount;
 	private int visibleActivityCount;
 	private boolean wasPaused;

--- a/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
@@ -86,17 +86,13 @@ public abstract class TiBaseActivity extends AppCompatActivity implements TiActi
 	private boolean onDestroyFired = false;
 	private int originalOrientationMode = -1;
 	private boolean inForeground = false; // Indicates whether this activity is in foreground or not.
-	private TiWeakList<OnLifecycleEvent> lifecycleListeners = new TiWeakList<OnLifecycleEvent>();
-	private TiWeakList<OnWindowFocusChangedEvent> windowFocusChangedListeners =
-		new TiWeakList<OnWindowFocusChangedEvent>();
-	private TiWeakList<interceptOnBackPressedEvent> interceptOnBackPressedListeners =
-		new TiWeakList<interceptOnBackPressedEvent>();
-	private TiWeakList<OnInstanceStateEvent> instanceStateListeners = new TiWeakList<OnInstanceStateEvent>();
-	private TiWeakList<OnActivityResultEvent> onActivityResultListeners = new TiWeakList<OnActivityResultEvent>();
-	private TiWeakList<OnCreateOptionsMenuEvent> onCreateOptionsMenuListeners =
-		new TiWeakList<OnCreateOptionsMenuEvent>();
-	private TiWeakList<OnPrepareOptionsMenuEvent> onPrepareOptionsMenuListeners =
-		new TiWeakList<OnPrepareOptionsMenuEvent>();
+	private final TiWeakList<OnLifecycleEvent> lifecycleListeners = new TiWeakList<>();
+	private final TiWeakList<OnWindowFocusChangedEvent> windowFocusChangedListeners = new TiWeakList<>();
+	private final TiWeakList<interceptOnBackPressedEvent> interceptOnBackPressedListeners = new TiWeakList<>();
+	private final TiWeakList<OnInstanceStateEvent> instanceStateListeners = new TiWeakList<>();
+	private final TiWeakList<OnActivityResultEvent> onActivityResultListeners = new TiWeakList<>();
+	private final TiWeakList<OnCreateOptionsMenuEvent> onCreateOptionsMenuListeners = new TiWeakList<>();
+	private final TiWeakList<OnPrepareOptionsMenuEvent> onPrepareOptionsMenuListeners = new TiWeakList<>();
 	private boolean sustainMode = false;
 	private int lastUIModeFlags = 0;
 	private int lastNightMode = AppCompatDelegate.MODE_NIGHT_UNSPECIFIED;
@@ -115,7 +111,7 @@ public abstract class TiBaseActivity extends AppCompatActivity implements TiActi
 			@NonNull String[] permissions, @NonNull int[] grantResults);
 	}
 
-	private static HashMap<Integer, TiBaseActivity.OnRequestPermissionsResultCallback>
+	private static final HashMap<Integer, TiBaseActivity.OnRequestPermissionsResultCallback>
 		permissionsResultCallbackMap = new HashMap<>();
 
 	protected View layout;
@@ -131,7 +127,7 @@ public abstract class TiBaseActivity extends AppCompatActivity implements TiActi
 	protected int msgActivityCreatedId = -1;
 	protected int msgId = -1;
 	//Storing the activity's dialogs and their persistence
-	private CopyOnWriteArrayList<DialogWrapper> dialogs = new CopyOnWriteArrayList<DialogWrapper>();
+	private final CopyOnWriteArrayList<DialogWrapper> dialogs = new CopyOnWriteArrayList<DialogWrapper>();
 
 	public TiWindowProxy lwWindow;
 	public boolean isResumed = false;
@@ -217,7 +213,7 @@ public abstract class TiBaseActivity extends AppCompatActivity implements TiActi
 
 	/**
 	 * Sets the window proxy.
-	 * @param proxy
+	 * @param proxy The proxy to be assigned to this activity.
 	 */
 	public void setWindowProxy(TiWindowProxy proxy)
 	{
@@ -227,7 +223,7 @@ public abstract class TiBaseActivity extends AppCompatActivity implements TiActi
 	/**
 	 * Sets the proxy for our layout (used for post layout event)
 	 *
-	 * @param proxy
+	 * @param proxy The proxy to be assigned to activity's root view.
 	 */
 	public void setLayoutProxy(TiViewProxy proxy)
 	{
@@ -238,7 +234,7 @@ public abstract class TiBaseActivity extends AppCompatActivity implements TiActi
 
 	/**
 	 * Sets the view proxy.
-	 * @param proxy
+	 * @param proxy Proxy to be used as root decor view.
 	 */
 	public void setViewProxy(TiViewProxy proxy)
 	{
@@ -291,7 +287,7 @@ public abstract class TiBaseActivity extends AppCompatActivity implements TiActi
 
 	public void addConfigurationChangedListener(ConfigurationChangedListener listener)
 	{
-		configChangedListeners.add(new WeakReference<ConfigurationChangedListener>(listener));
+		configChangedListeners.add(new WeakReference<>(listener));
 	}
 
 	public void removeConfigurationChangedListener(ConfigurationChangedListener listener)
@@ -517,7 +513,6 @@ public abstract class TiBaseActivity extends AppCompatActivity implements TiActi
 	}
 
 	// Subclasses can override to handle post-creation (but pre-message fire) logic
-	@SuppressWarnings("deprecation")
 	protected void windowCreated(Bundle savedInstanceState)
 	{
 		boolean fullscreen = getIntentBoolean(TiC.PROPERTY_FULLSCREEN, false);
@@ -1255,37 +1250,37 @@ public abstract class TiBaseActivity extends AppCompatActivity implements TiActi
 
 	public void addOnLifecycleEventListener(OnLifecycleEvent listener)
 	{
-		lifecycleListeners.add(new WeakReference<OnLifecycleEvent>(listener));
+		lifecycleListeners.add(new WeakReference<>(listener));
 	}
 
 	public void addOnInstanceStateEventListener(OnInstanceStateEvent listener)
 	{
-		instanceStateListeners.add(new WeakReference<OnInstanceStateEvent>(listener));
+		instanceStateListeners.add(new WeakReference<>(listener));
 	}
 
 	public void addOnWindowFocusChangedEventListener(OnWindowFocusChangedEvent listener)
 	{
-		windowFocusChangedListeners.add(new WeakReference<OnWindowFocusChangedEvent>(listener));
+		windowFocusChangedListeners.add(new WeakReference<>(listener));
 	}
 
 	public void addInterceptOnBackPressedEventListener(interceptOnBackPressedEvent listener)
 	{
-		interceptOnBackPressedListeners.add(new WeakReference<interceptOnBackPressedEvent>(listener));
+		interceptOnBackPressedListeners.add(new WeakReference<>(listener));
 	}
 
 	public void addOnActivityResultListener(OnActivityResultEvent listener)
 	{
-		onActivityResultListeners.add(new WeakReference<OnActivityResultEvent>(listener));
+		onActivityResultListeners.add(new WeakReference<>(listener));
 	}
 
 	public void addOnCreateOptionsMenuEventListener(OnCreateOptionsMenuEvent listener)
 	{
-		onCreateOptionsMenuListeners.add(new WeakReference<OnCreateOptionsMenuEvent>(listener));
+		onCreateOptionsMenuListeners.add(new WeakReference<>(listener));
 	}
 
 	public void addOnPrepareOptionsMenuEventListener(OnPrepareOptionsMenuEvent listener)
 	{
-		onPrepareOptionsMenuListeners.add(new WeakReference<OnPrepareOptionsMenuEvent>(listener));
+		onPrepareOptionsMenuListeners.add(new WeakReference<>(listener));
 	}
 
 	public void removeOnLifecycleEventListener(OnLifecycleEvent listener)

--- a/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
@@ -120,14 +120,13 @@ public abstract class TiBaseActivity extends AppCompatActivity implements TiActi
 	protected TiWindowProxy window;
 	protected TiViewProxy view;
 	protected ActivityProxy activityProxy;
-	protected TiWeakList<ConfigurationChangedListener> configChangedListeners =
-		new TiWeakList<ConfigurationChangedListener>();
+	protected TiWeakList<ConfigurationChangedListener> configChangedListeners = new TiWeakList<>();
 	protected TiMenuSupport menuHelper;
 	protected Messenger messenger;
 	protected int msgActivityCreatedId = -1;
 	protected int msgId = -1;
 	//Storing the activity's dialogs and their persistence
-	private final CopyOnWriteArrayList<DialogWrapper> dialogs = new CopyOnWriteArrayList<DialogWrapper>();
+	private final CopyOnWriteArrayList<DialogWrapper> dialogs = new CopyOnWriteArrayList<>();
 
 	public TiWindowProxy lwWindow;
 	public boolean isResumed = false;

--- a/android/titanium/src/java/org/appcelerator/titanium/TiBlob.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiBlob.java
@@ -17,8 +17,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
 import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import org.appcelerator.kroll.KrollDict;
 import org.appcelerator.kroll.KrollProxy;
@@ -39,28 +39,16 @@ public class TiBlob extends KrollProxy
 {
 	private static final String TAG = "TiBlob";
 
-	/**
-	 * Represents a Blob that contains image data.
-	 * @module.api
-	 */
+	/** Represents a Blob that contains image data. */
 	public static final int TYPE_IMAGE = 0;
 
-	/**
-	 * Represents a Blob that contains file data.
-	 * @module.api
-	 */
+	/** Represents a Blob that contains file data. */
 	public static final int TYPE_FILE = 1;
 
-	/**
-	 * Represents a Blob that contains data.
-	 * @module.api
-	 */
+	/** Represents a Blob that contains data. */
 	public static final int TYPE_DATA = 2;
 
-	/**
-	 * Represents a Blob that contains String data.
-	 * @module.api
-	 */
+	/** Represents a Blob that contains String data. */
 	public static final int TYPE_STRING = 3;
 
 	private int type;
@@ -73,7 +61,7 @@ public class TiBlob extends KrollProxy
 	private int uprightHeight;
 
 	// This handles the memory cache of images.
-	private TiBlobLruCache mMemoryCache = TiBlobLruCache.getInstance();
+	private final TiBlobLruCache mMemoryCache = TiBlobLruCache.getInstance();
 
 	private TiBlob(int type, Object data, String mimetype)
 	{
@@ -92,7 +80,6 @@ public class TiBlob extends KrollProxy
 	 * Creates a new TiBlob object from String data.
 	 * @param data the data used to create blob.
 	 * @return new instance of TiBlob.
-	 * @module.api
 	 */
 	public static TiBlob blobFromString(String data)
 	{
@@ -103,7 +90,6 @@ public class TiBlob extends KrollProxy
 	 * Creates a blob from a file and sets a mimeType based on the file name.
 	 * @param file the file used to create blob.
 	 * @return new instane of TiBlob.
-	 * @module.api
 	 */
 	public static TiBlob blobFromFile(TiBaseFile file)
 	{
@@ -116,7 +102,6 @@ public class TiBlob extends KrollProxy
 	 * @param file the file used to create blob.
 	 * @param mimeType the mimeType used to create blob.
 	 * @return new instance of TiBlob.
-	 * @module.api
 	 */
 	public static TiBlob blobFromFile(TiBaseFile file, String mimeType)
 	{
@@ -132,7 +117,6 @@ public class TiBlob extends KrollProxy
 	 * Creates a blob from a bitmap.
 	 * @param image the image used to create blob.
 	 * @return new instance of TiBlob.
-	 * @module.api
 	 */
 	public static TiBlob blobFromImage(Bitmap image)
 	{
@@ -165,7 +149,6 @@ public class TiBlob extends KrollProxy
 	 * Creates a blob from binary data, with mimeType as "application/octet-stream".
 	 * @param data data used to create blob.
 	 * @return new instance of TiBlob.
-	 * @module.api
 	 */
 	public static TiBlob blobFromData(byte[] data)
 	{
@@ -178,7 +161,6 @@ public class TiBlob extends KrollProxy
 	 * @param data  binary data used to create blob.
 	 * @param mimetype mimetype used to create blob.
 	 * @return a new instance of TiBlob.
-	 * @module.api
 	 */
 	public static TiBlob blobFromData(byte[] data, String mimetype)
 	{
@@ -306,7 +288,6 @@ public class TiBlob extends KrollProxy
 	 * Returns the content of blob in form of binary data. Exception will be thrown
 	 * if blob's type is unknown.
 	 * @return binary data.
-	 * @module.api
 	 */
 	@Kroll.method(name = "toArrayBuffer")
 	public byte[] getBytes()
@@ -315,11 +296,7 @@ public class TiBlob extends KrollProxy
 
 		switch (type) {
 			case TYPE_STRING:
-				try {
-					bytes = ((String) data).getBytes("utf-8");
-				} catch (UnsupportedEncodingException e) {
-					Log.w(TAG, e.getMessage(), e);
-				}
+				bytes = ((String) data).getBytes(StandardCharsets.UTF_8);
 				break;
 			case TYPE_DATA:
 			case TYPE_IMAGE:
@@ -365,7 +342,6 @@ public class TiBlob extends KrollProxy
 
 	/**
 	 * @return An InputStream for reading the data of this blob.
-	 * @module.api
 	 */
 	public InputStream getInputStream()
 	{
@@ -393,11 +369,7 @@ public class TiBlob extends KrollProxy
 
 		switch (type) {
 			case TYPE_STRING:
-				try {
-					data = new String(newData, "utf-8");
-				} catch (UnsupportedEncodingException e) {
-					Log.w(TAG, e.getMessage(), e);
-				}
+				data = new String(newData, StandardCharsets.UTF_8);
 				break;
 			case TYPE_IMAGE:
 			case TYPE_DATA:
@@ -424,7 +396,7 @@ public class TiBlob extends KrollProxy
 			case TYPE_DATA:
 			case TYPE_FILE:
 				try {
-					result = new String(getBytes(), "utf-8");
+					result = new String(getBytes(), StandardCharsets.UTF_8);
 				} catch (Exception ex) {
 					Log.w(TAG, "Unable to convert to string.");
 				}
@@ -442,7 +414,6 @@ public class TiBlob extends KrollProxy
 
 	/**
 	 * @return the blob's data.
-	 * @module.api
 	 */
 	public Object getData()
 	{
@@ -455,8 +426,6 @@ public class TiBlob extends KrollProxy
 	 * @see TiBlob#TYPE_FILE
 	 * @see TiBlob#TYPE_IMAGE
 	 * @see TiBlob#TYPE_STRING
-	 * @see TiBlob#TYPE_STREAM
-	 * @module.api
 	 */
 	@Kroll.getProperty
 	public int getType()
@@ -696,9 +665,8 @@ public class TiBlob extends KrollProxy
 			Log.e(TAG, "Unable to crop the image. Unknown exception: " + t.getMessage(), t);
 		} finally {
 			// Perform soft garbage collection to reclaim memory.
-			KrollRuntime instance = KrollRuntime.getInstance();
-			if (instance != null) {
-				instance.softGC();
+			if (KrollRuntime.getInstance() != null) {
+				KrollRuntime.softGC();
 			}
 		}
 		return null;
@@ -803,9 +771,8 @@ public class TiBlob extends KrollProxy
 			Log.e(TAG, "Unable to resize the image. Unknown exception: " + t.getMessage(), t);
 		} finally {
 			// Perform soft garbage collection to reclaim memory.
-			KrollRuntime instance = KrollRuntime.getInstance();
-			if (instance != null) {
-				instance.softGC();
+			if (KrollRuntime.getInstance() != null) {
+				KrollRuntime.softGC();
 			}
 		}
 		return null;
@@ -831,11 +798,6 @@ public class TiBlob extends KrollProxy
 			bos = new ByteArrayOutputStream();
 			if (img.compress(CompressFormat.JPEG, (int) (quality * 100), bos)) {
 				byte[] data = bos.toByteArray();
-
-				BitmapFactory.Options bfOptions = new BitmapFactory.Options();
-				bfOptions.inPurgeable = true;
-				bfOptions.inInputShareable = true;
-
 				result = TiBlob.blobFromData(data, "image/jpeg");
 			}
 		} catch (OutOfMemoryError e) {
@@ -854,9 +816,8 @@ public class TiBlob extends KrollProxy
 			bos = null;
 
 			// Perform soft garbage collection to reclaim memory.
-			KrollRuntime instance = KrollRuntime.getInstance();
-			if (instance != null) {
-				instance.softGC();
+			if (KrollRuntime.getInstance() != null) {
+				KrollRuntime.softGC();
 			}
 		}
 
@@ -888,8 +849,7 @@ public class TiBlob extends KrollProxy
 		String nativePath = getNativePath();
 		String key = null;
 		if (nativePath != null) {
-			key = getNativePath() + "_imageAsThumbnail_" + rotation + "_" + thumbnailSize + "_"
-				  + Integer.toString(border) + "_" + Float.toString(radius);
+			key = getNativePath() + "_imageAsThumbnail_" + rotation + "_" + thumbnailSize + "_" + border + "_" + radius;
 			Bitmap bitmap = mMemoryCache.get(key);
 			if (bitmap != null) {
 				if (!bitmap.isRecycled()) {
@@ -944,9 +904,8 @@ public class TiBlob extends KrollProxy
 			Log.e(TAG, "Unable to get the thumbnail image. Unknown exception: " + t.getMessage(), t);
 		} finally {
 			// Perform soft garbage collection to reclaim memory.
-			KrollRuntime instance = KrollRuntime.getInstance();
-			if (instance != null) {
-				instance.softGC();
+			if (KrollRuntime.getInstance() != null) {
+				KrollRuntime.softGC();
 			}
 		}
 		return null;
@@ -998,9 +957,8 @@ public class TiBlob extends KrollProxy
 			Log.e(TAG, "Unable to get the image with alpha. Unknown exception: " + t.getMessage(), t);
 		} finally {
 			// Perform soft garbage collection to reclaim memory.
-			KrollRuntime instance = KrollRuntime.getInstance();
-			if (instance != null) {
-				instance.softGC();
+			if (KrollRuntime.getInstance() != null) {
+				KrollRuntime.softGC();
 			}
 		}
 		return null;
@@ -1025,8 +983,7 @@ public class TiBlob extends KrollProxy
 		String nativePath = getNativePath();
 		String key = null;
 		if (nativePath != null) {
-			key = getNativePath() + "_imageWithRoundedCorner_" + rotation + "_" + Float.toString(border) + "_"
-				  + Float.toString(radius);
+			key = getNativePath() + "_imageWithRoundedCorner_" + rotation + "_" + border + "_" + radius;
 			Bitmap bitmap = mMemoryCache.get(key);
 			if (bitmap != null) {
 				if (!bitmap.isRecycled()) {
@@ -1059,9 +1016,8 @@ public class TiBlob extends KrollProxy
 			Log.e(TAG, "Unable to get the image with rounded corner. Unknown exception: " + t.getMessage(), t);
 		} finally {
 			// Perform soft garbage collection to reclaim memory.
-			KrollRuntime instance = KrollRuntime.getInstance();
-			if (instance != null) {
-				instance.softGC();
+			if (KrollRuntime.getInstance() != null) {
+				KrollRuntime.softGC();
 			}
 		}
 		return null;
@@ -1115,9 +1071,8 @@ public class TiBlob extends KrollProxy
 			Log.e(TAG, "Unable to get the image with transparent border. Unknown exception: " + t.getMessage(), t);
 		} finally {
 			// Perform soft garbage collection to reclaim memory.
-			KrollRuntime instance = KrollRuntime.getInstance();
-			if (instance != null) {
-				instance.softGC();
+			if (KrollRuntime.getInstance() != null) {
+				KrollRuntime.softGC();
 			}
 		}
 		return null;

--- a/android/titanium/src/java/org/appcelerator/titanium/TiC.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiC.java
@@ -1,6 +1,6 @@
 /**
  * Appcelerator Titanium Mobile
- * Copyright (c) 2009-2013 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2009-2021 by Axway, Inc. All Rights Reserved.
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
@@ -11,7 +11,6 @@ package org.appcelerator.titanium;
  * These are sorted alphabetically.
  */
 public class TiC
-
 {
 	public static final int API_LEVEL_HONEYCOMB = 11;
 	public static final int API_LEVEL_ICE_CREAM_SANDWICH = 14;
@@ -45,724 +44,151 @@ public class TiC
 	public static final int ERROR_CODE_UNKNOWN = -1;
 	public static final int ERROR_CODE_NO_ERROR = 0;
 
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_ADDED_TO_TAB = "addedtotab";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_ANDROID_BACK = "androidback";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_ANDROID_CAMERA = "androidcamera";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_ANDROID_FOCUS = "androidfocus";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_ANDROID_SEARCH = "androidsearch";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_ANDROID_VOLDOWN = "androidvoldown";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_ANDROID_VOLUP = "androidvolup";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_BATTERY = "battery";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_BLACKLIST_URL = "blacklisturl";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_BLOCKED_URL = "blockedurl";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_BLUR = "blur";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_CAMERA_READY = "cameraready";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_CANCEL = "cancel";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_COLLAPSE = "collapse";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_CHANGE = "change";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_CLICK = "click";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_CLOSE = "close";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_COMPLETE = "complete";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_DELETE = "delete";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_DESTROY = "destroy";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_DISPOSE_HANDLE = "disposehandle";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_DOUBLE_CLICK = "dblclick";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_DOUBLE_TAP = "doubletap";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_DRAGSTART = "dragstart";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_DRAGEND = "dragend";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_DURATION_AVAILABLE = "durationavailable";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_ERROR = "error";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_EXPAND = "expand";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_FOCUS = "focus";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_FOCUSED = "focused";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_SELECTED = "selected";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_UNSELECTED = "unselected";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_KEY_PRESSED = "keypressed";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_HEADING = "heading";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_ITEM_CLICK = "itemclick";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_LOAD = "load";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_LOADSTATE = "loadstate";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_LOCATION = "location";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_LONGCLICK = "longclick";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_LONGPRESS = "longpress";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_MARKER = "marker";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_NEW_INTENT = "newintent";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_NO_RESULTS = "noresults";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_ON_REQUEST_PERMISSIONS = "onrequestpermissions";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_OPEN = "open";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_PAUSE = "pause";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_PAUSED = "paused";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_PINCH = "pinch";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_PLAYBACK_STATE = "playbackstate";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_PRELOAD = "preload";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_POST_LAYOUT = "postlayout";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_PLAYING = "playing";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_PROPERTY_ACCESSORY_CLICKED = "accessoryClicked";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_PROPERTY_CLICKSOURCE = "clicksource";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_PROPERTY_CURRENT_PLAYBACK_TIME = "currentPlaybackTime";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_PROPERTY_DETAIL = "detail";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_PROPERTY_DIRECTION = "direction";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_PROPERTY_ERROR = "error";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_PROPERTY_INDEX = "index";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_PROPERTY_INTENT = "intent";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_PROPERTY_IS_DIALOG = "isDialog";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_PROPERTY_IS_USER_GESTURE = "isUserGesture";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_PROPERTY_KEYCODE = "keyCode";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_PROPERTY_LAYOUT_NAME = "layoutName";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_PROPERTY_LOADSTATE = "loadState";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_PROPERTY_MENU = "menu";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_PROPERTY_MESSAGE = "message";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_PROPERTY_OBSCURED = "obscured";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_PROPERTY_PLAYBACK_STATE = "playbackState";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_PROPERTY_PREVIOUS_INDEX = "previousIndex";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_PROPERTY_PREVIOUS_TAB = "previousTab";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_PROPERTY_REASON = "reason";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_RECURRENCE_RULES = "recurrenceRules";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_PROPERTY_REQUEST_CODE = "requestCode";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_PROPERTY_RESULT_CODE = "resultCode";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_PROPERTY_ROW = "row";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_PROPERTY_SCALE = "scale";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_PROPERTY_TIME = "time";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_PROPERTY_FOCUS_X = "focusX";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_PROPERTY_FOCUS_Y = "focusY";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_PROPERTY_CURRENT_SPAN = "currentSpan";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_PROPERTY_CURRENT_SPAN_X = "currentSpanX";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_PROPERTY_CURRENT_SPAN_Y = "currentSpanY";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_PROPERTY_PREVIOUS_SPAN = "previousSpan";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_PROPERTY_PREVIOUS_SPAN_X = "previousSpanX";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_PROPERTY_PREVIOUS_SPAN_Y = "previousSpanY";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_PROPERTY_TIME_DELTA = "timeDelta";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_PROPERTY_IN_PROGRESS = "inProgress";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_PROPERTY_SEARCH_MODE = "searchMode";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_PROPERTY_SHORTCUT = "shortcut";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_PROPERTY_SOURCE = "source";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_PROPERTY_STATE = "state";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_PROPERTY_TAB = "tab";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_PROPERTY_THUMB_OFFSET = "thumbOffset";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_PROPERTY_THUMB_SIZE = "thumbSize";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_PROPERTY_TYPE = "type";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_PROPERTY_VELOCITY = "velocity";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_PROPERTY_X = "x";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_PROPERTY_Y = "y";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_PROPERTY_FORCE = "force";
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_PROPERTY_SIZE = "size";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_MOVE = "move";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_REFRESH_END = "refreshend";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_REFRESH_START = "refreshstart";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_REGION_CHANGED = "regionchanged";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_RESUME = "resume";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_RESUMED = "resumed";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_RETURN = "return";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_SCROLL = "scroll";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_SCROLLEND = "scrollend";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_SCROLLING = "scrolling";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_SCROLLSTART = "scrollstart";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_SHORTCUT_ITEM_CLICK = "shortcutitemclick";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_SINGLE_TAP = "singletap";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_SLIDE = "slide";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_START = "start";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_STARTED = "started";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_START_LISTENING = "startlistening";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_STOP = "stop";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_STOP_LISTENING = "stoplistening";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_SUBMIT = "submit";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_SWIPE = "swipe";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_TASK_REMOVED = "taskremoved";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_TILE_ADDED = "tileadded";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_TILE_DIALOG_OPTION_SELECTED = "tiledialogoptionselected";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_TILE_DIALOG_CANCELED = "tiledialogcancelled";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_TILE_DIALOG_POSITIVE = "tiledialogpositive";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_TILE_DIALOG_NEUTRAL = "tiledialogneutral";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_TILE_DIALOG_NEGATIVE = "tiledialognegative";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_TILE_REMOVED = "tileremoved";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_TOUCH_CANCEL = "touchcancel";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_TOUCH_END = "touchend";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_TOUCH_FILTERED = "touchfiltered";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_TOUCH_MOVE = "touchmove";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_TOUCH_START = "touchstart";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_TWOFINGERTAP = "twofingertap";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_PROPERTY_URL = "url";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_USER_INTERACTION = "userinteraction";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_USER_INTERFACE_STYLE = "userinterfacestyle";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_USER_LEAVE_HINT = "userleavehint";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_PROXIMITY = "proximity";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_SSL_ERROR = "sslerror";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_WEBVIEW_ON_LOAD_RESOURCE = "onLoadResource";
-
-	/**
-	 * @module.api
-	 */
 	public static final String EVENT_UNFOCUSED = "unfocused";
+
 	public static final String PROPERTY_ENTER_TRANSITION = "activityEnterTransition";
 	public static final String PROPERTY_EXIT_TRANSITION = "activityExitTransition";
 	public static final String PROPERTY_RETURN_TRANSITION = "activityReturnTransition";
@@ -771,6 +197,7 @@ public class TiC
 	public static final String PROPERTY_SHARED_ELEMENT_EXIT_TRANSITION = "activitySharedElementExitTransition";
 	public static final String PROPERTY_SHARED_ELEMENT_REENTER_TRANSITION = "activitySharedElementReenterTransition";
 	public static final String PROPERTY_SHARED_ELEMENT_RETURN_TRANSITION = "activitySharedElementReturnTransition";
+
 	public static final String INTENT_PROPERTY_FINISH_ROOT = "finishRoot";
 	public static final String INTENT_PROPERTY_IS_TAB = "isTab";
 	public static final String INTENT_PROPERTY_LAYOUT = "layout";
@@ -779,2958 +206,605 @@ public class TiC
 	public static final String INTENT_PROPERTY_MSG_ID = "messageId";
 	public static final String INTENT_PROPERTY_START_MODE = "startMode";
 	public static final String INTENT_PROPERTY_WINDOW_ID = "windowId";
+
 	public static final String LAYOUT_FILL = "fill";
 	public static final String LAYOUT_HORIZONTAL = "horizontal";
 	public static final String LAYOUT_SIZE = "size";
 	public static final String LAYOUT_VERTICAL = "vertical";
+
 	public static final String MSG_PROPERTY_EVENT_NAME = "eventName";
 	public static final String MSG_PROPERTY_FILENAME = "filename";
 	public static final String MSG_PROPERTY_SRC = "src";
 
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ACCURACY = "accuracy";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_SCROLLING_ENABLED = "scrollingEnabled";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ACCESSIBILITY_HIDDEN = "accessibilityHidden";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ACCESSIBILITY_HINT = "accessibilityHint";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ACCESSIBILITY_LABEL = "accessibilityLabel";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ACCESSIBILITY_VALUE = "accessibilityValue";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ACCESSORY_TYPE = "accessoryType";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ACTION = "action";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ACTION_VIEW = "actionView";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ACTIVE_TAB = "activeTab";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ACTIVE_TITLE_COLOR = "activeTitleColor";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ACTIVE_TINT_COLOR = "activeTintColor";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_SWIPEABLE = "swipeable";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_SMOOTH_SCROLL_ON_TAB_CLICK = "smoothScrollOnTabClick";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ACTIVITY = "activity";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ACTIVITY_ENTER_ANIMATION = "activityEnterAnimation";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ACTIVITY_EXIT_ANIMATION = "activityExitAnimation";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ADD = "add";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ADDRESS = "address";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ALLOW_BACKGROUND = "allowBackground";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ALLOW_MULTIPLE = "allowMultiple";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ALTITUDE = "altitude";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ALTITUDE_ACCURACY = "altitudeAccuracy";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ATTRIBUTES = "attributes";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ATTRIBUTED_HINT_TEXT = "attributedHintText";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ATTRIBUTE_RANGE = "range";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ATTRIBUTED_STRING = "attributedString";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ANCHOR_POINT = "anchorPoint";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ANDROID_VIEW = "androidView";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ANIMATE = "animate";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ANIMATED = "animated";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ANNIVERSARY = "anniversary";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ANNOTATION = "annotation";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ANNOTATIONS = "annotations";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ASSISTANT = "assistant";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_AUDIO_STREAM_TYPE = "audioStreamType";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_AUDIO_TYPE = "audioType";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_AUDIO_FOCUS = "audioFocus";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_AUTO_LINK = "autoLink";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_AUTOCAPITALIZATION = "autocapitalization";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_AUTOCORRECT = "autocorrect";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_AUTOFILL_TYPE = "autofillType";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_AUTOPLAY = "autoplay";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_AUTOREVERSE = "autoreverse";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_AUTOROTATE = "autorotate";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_AUTO_REDIRECT = "autoRedirect";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_AUTO_ENCODE_URL = "autoEncodeUrl";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_BACKGROUND_COLOR = "backgroundColor";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_BACKGROUND_DISABLED_COLOR = "backgroundDisabledColor";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_BACKGROUND_DISABLED_IMAGE = "backgroundDisabledImage";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_BACKGROUND_FOCUSED_COLOR = "backgroundFocusedColor";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_BACKGROUND_FOCUSED_IMAGE = "backgroundFocusedImage";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_BACKGROUND_GRADIENT = "backgroundGradient";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_BACKGROUND_IMAGE = "backgroundImage";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_BACKGROUND_PADDING = "backgroundPadding";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_BACKGROUND_PREFIX = "background";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_BACKGROUND_REPEAT = "backgroundRepeat";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_BACKGROUND_SELECTED_COLOR = "backgroundSelectedColor";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_BACKGROUND_SELECTED_IMAGE = "backgroundSelectedImage";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_BADGE = "badge";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_BADGE_COLOR = "badgeColor";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_TOUCH_FEEDBACK = "touchFeedback";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_TOUCH_FEEDBACK_COLOR = "touchFeedbackColor";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_TRANSITION_NAME = "transitionName";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_BAR_COLOR = "barColor";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_BASE_URL = "baseUrl";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_BASE_URL_WEBVIEW = "baseURL";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_BIG_TEXT = "bigText";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_BIG_CONTENT_TITLE = "bigContentTitle";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_BIG_LARGE_ICON = "bigLargeIcon";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_BIG_PICTURE = "bigPicture";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_BIND_ID = "bindId";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_BIRTHDAY = "birthday";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_BLACKLISTED_URLS = "blacklistedURLs";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_BLOCKED_URLS = "blockedURLs";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_BORDER_COLOR = "borderColor";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_BORDER_PREFIX = "border";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_BORDER_RADIUS = "borderRadius";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_BORDER_STYLE = "borderStyle";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_BORDER_WIDTH = "borderWidth";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_BOTTOM = "bottom";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_BROTHER = "brother";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_BUTTON = "button";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_BUBBLE_PARENT = "bubbleParent";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_BUBBLES = "bubbles";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_BUTTON_NAMES = "buttonNames";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_BUTTON_CLICK_REQUIRED = "buttonClickRequired";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_BYTE_ORDER = "byteOrder";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_BYPASS_DND = "bypassDnd";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_CACHE_MODE = "cacheMode";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_CACHE_SIZE = "cacheSize";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_CALLBACK = "callback";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_CALENDAR_DAYS_OF_THE_MONTH = "daysOfTheMonth";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_CALENDAR_DAYS_OF_THE_WEEK = "daysOfTheWeek";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_CALENDAR_DAYS_OF_THE_YEAR = "daysOfTheYear";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_CALENDAR_ID = "calendarID";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_CALENDAR_MONTHS_OF_THE_YEAR = "monthsOfTheYear";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_CALENDAR_VIEW_SHOWN = "calendarViewShown";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_CALENDAR_WEEKS_OF_THE_YEAR = "weeksOfTheYear";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_CAMERA_FLASH_MODE = "cameraFlashMode";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_CAN_CANCEL_EVENTS = "canCancelEvents";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_CANCEL = "cancel";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_CANCELABLE = "cancelable";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_CANCELED_ON_TOUCH_OUTSIDE = "canceledOnTouchOutside";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_CAN_EDIT = "canEdit";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_CAN_MOVE = "canMove";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_CAN_SCROLL = "canScroll";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_CASE_INSENSITIVE_SEARCH = "caseInsensitiveSearch";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_CENTER = "center";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_CHARSET = "charset";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_CHANNEL_ID = "channelId";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_CHECKABLE = "checkable";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_CHECKED = "checked";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_CHILD = "child";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_CHILD_TEMPLATES = "childTemplates";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_CITY = "city";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_CLASS_NAME = "className";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_CLASS_NAMES = "classNames";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_CLEAR_ON_EDIT = "clearOnEdit";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_CLIP_VIEWS = "clipViews";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_CODE = "code";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_COLOR = "color";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_COMMENT = "comment";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_CONTENT_HEIGHT = "contentHeight";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_CONTENT_SIZE = "contentSize";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_CONTENT_INSET_END_WITH_ACTIONS = "contentInsetEndWithActions";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_CONTENT_INSET_START_WITH_NAVIGATION = "contentInsetStartWithNavigation";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_CONTENT_INTENT = "contentIntent";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_CONTENT_OFFSET = "contentOffset";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_PADDING = "padding";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_PADDING_BOTTOM = "paddingBottom";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_PADDING_LEFT = "paddingLeft";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_PADDING_RIGHT = "paddingRight";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_PADDING_TOP = "paddingTop";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_CENTER_VIEW = "centerView";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_CONTENT_TEXT = "contentText";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_CONTENT_TITLE = "contentTitle";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_CONTENT_VIEW = "contentView";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_CONTENT_WIDTH = "contentWidth";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_COORDS = "coords";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_COUNT = "count";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_COUNTRY = "country";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_COUNTRY_CODE = "countryCode";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_CROP_RECT = "cropRect";
-
-	/**
-	 * @module.api
-	 */ // TIMOB-4478
 	public static final String PROPERTY_CURRENT_PAGE = "currentPage";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_CURVE = "curve";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_DATA = "data";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_DATE = "date";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_DAY_BEFORE_MONTH = "dayBeforeMonth";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_DECODE_RETRIES = "decodeRetries";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_DESCRIPTION = "description";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_DEFAULT_IMAGE = "defaultImage";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_DEFAULT_ITEM_TEMPLATE = "defaultItemTemplate";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_DEFAULTS = "defaults";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_DELAY = "delay";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_DELETE_INTENT = "deleteIntent";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_DEST = "dest";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_DEST_POSITION = "destPosition";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_DIRECTION = "direction";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_DISABLE_CONTEXT_MENU = "disableContextMenu";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_DISPLAY_ADDRESS = "displayAddress";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_DOMAIN = "domain";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_DOMESTIC_PARTNER = "domesticPartner";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_DRAG_MARGIN = "dragMargin";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_DRAWER_INDICATOR_ENABLED = "drawerIndicatorEnabled";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_DRAWER_LOCK_MODE = "drawerLockMode";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_DURATION = "duration";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_EDITABLE = "editable";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_EDITING = "editing";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ELEVATION = "elevation";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ELLIPSIZE = "ellipsize";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_EMAIL = "email";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ENABLE_ZOOM_CONTROLS = "enableZoomControls";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ENABLED = "enabled";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ENABLE_JAVASCRIPT_INTERFACE = "enableJavascriptInterface";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ENABLE_LIGHTS = "enableLights";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ENABLE_RETURN_KEY = "enableReturnKey";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ENABLE_VIBRATION = "enableVibration";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_END = "end";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_END_PLAYBACK_TIME = "endPlaybackTime";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_EVENT = "event";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_EVENTS = "events";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_EXIT_ON_CLOSE = "exitOnClose";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_EXPIRY_DATE = "expiryDate";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_EXTEND_BACKGROUND = "extendBackground";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_FAST_SCROLL = "fastScroll";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_EXTEND_SAFE_AREA = "extendSafeArea";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_FATHER = "father";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_FILE = "file";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_FILTER_ATTRIBUTE = "filterAttribute";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_FILTER_ANCHORED = "filterAnchored";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_FILTER_CASE_INSENSITIVE = "filterCaseInsensitive";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_FILTER_TOUCHES_WHEN_OBSCURED = "filterTouchesWhenObscured";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_FIRSTNAME = "firstName";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_FIRST_VISIBLE_ITEM = "firstVisibleItem";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_FIRST_VISIBLE_ITEM_INDEX = "firstVisibleItemIndex";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_FIRST_VISIBLE_SECTION = "firstVisibleSection";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_FIRST_VISIBLE_SECTION_INDEX = "firstVisibleSectionIndex";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_FLAG_SECURE = "flagSecure";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_FLAGS = "flags";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_FOCUSABLE = "focusable";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_FONT = "font";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_FONTFAMILY = "fontFamily";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_FONTWEIGHT = "fontWeight";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_FONTSIZE = "fontSize";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_FONTSTYLE = "fontStyle";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_FONT_FAMILY = "font-family";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_FONT_WEIGHT = "font-weight";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_FONT_SIZE = "font-size";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_FOOTER_DIVIDERS_ENABLED = "footerDividersEnabled";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_FOOTER = "footer";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_FOOTER_TITLE = "footerTitle";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_FOOTER_VIEW = "footerView";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_FORMAT_24 = "format24";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_FORWARD = "forward";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_FRAGMENT_ONLY = "fragmentOnly";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_HIDDEN_BEHAVIOR = "hiddenBehavior";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_HIDES_BACK_BUTTON = "hidesBackButton";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_FREQUENCY = "frequency";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_FRIEND = "friend";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_FROM = "from";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_FULLNAME = "fullname";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_FULLSCREEN = "fullscreen";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_GROUP_ID = "groupId";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_GROUP_KEY = "groupKey";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_GROUP_ALERT_BEHAVIOR = "groupAlertBehavior";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_GROUP_SUMMARY = "groupSummary";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_HAS_CHECK = "hasCheck";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_HAS_CHILD = "hasChild";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_HAS_DETAIL = "hasDetail";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_HAS_LINK = "hasLink";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_HEADER = "header";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_HEADER_DIVIDERS_ENABLED = "headerDividersEnabled";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_HEADER_TITLE = "headerTitle";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_HEADER_VIEW = "headerView";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_HEADING = "heading";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_HEADING_FILTER = "headingFilter";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_HEIGHT = "height";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_HIDE_ANNOTATION_WHEN_TOUCH_MAP = "hideAnnotationWhenTouchMap";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_HIGHLIGHTED_COLOR = "highlightedColor";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_HINT_TEXT = "hintText";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_HINT_TEXT_ID = "hinttextid";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_HINT_TEXT_COLOR = "hintTextColor";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_HINT_TYPE = "hintType";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_HOME = "home";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_HOMEPAGE = "homepage";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_HTML = "html";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_HTTP_ONLY = "httponly";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ICON = "icon";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ICON_LEVEL = "iconLevel";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ICONIFIED = "iconified";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ICONIFIED_BY_DEFAULT = "iconifiedByDefault";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ID = "id";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_IMAGE = "image";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_IMAGES = "images";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_IMPORTANCE = "importance";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_INDICATOR_COLOR = "indicatorColor";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_INDEX = "index";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_INCLUDE_FONT_PADDING = "includeFontPadding";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_INITIAL_PLAYBACK_TIME = "initialPlaybackTime";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_INPUT_TYPE = "inputType";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_INSTANTMSG = "instantMessage";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_INTENT = "intent";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_INTERVAL = "interval";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ITEM = "item";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ITEM_ID = "itemId";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ITEM_INDEX = "itemIndex";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ITEMS = "items";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_KEEP_SCREEN_ON = "keepScreenOn";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_KEYBOARD_TYPE = "keyboardType";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_KIND = "kind";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_LABELS = "labels";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_LABEL = "label";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_LARGE_ICON = "largeIcon";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_LASTNAME = "lastName";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_LATITUDE = "latitude";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_LATITUDE_DELTA = "latitudeDelta";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_LAYOUT = "layout";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_LAYOUT_ID = "layoutId";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_LEFT_DRAWER_LOCK_MODE = "leftDrawerLockMode";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_LINES = "lines";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_LINE_SPACING = "lineSpacing";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_LIFECYCLE_CONTAINER = "lifecycleContainer";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_LIGHT_COLOR = "lightColor";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_LOAD_URL = "loadUrl";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_LOOPING = "looping";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_LED_ARGB = "ledARGB";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_LED_OFF_MS = "ledOffMS";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_LED_ON_MS = "ledOnMS";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_LEFT = "left";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_LEFT_BUTTON = "leftButton";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_LEFT_IMAGE = "leftImage";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_LEFT_VIEW = "leftView";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_LEFT_WIDTH = "leftWidth";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_LENGTH = "length";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_LEVEL = "level";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_LOCALE = "locale";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_LOCATION = "location";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_LOGO = "logo";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_LOCKSCREEN_VISIBILITY = "lockscreenVisibility";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_LONGITUDE = "longitude";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_LONGITUDE_DELTA = "longitudeDelta";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_MAGNETIC_HEADING = "magneticHeading";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_MANAGER = "manager";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_MAP_TYPE = "mapType";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_MASK = "mask";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_MAX = "max";
-
-	/**
-     * @module.api
-     */
 	public static final String PROPERTY_MAX_AGE = "maxAge";
-
-	/**
-     * @module.api
-     */
 	public static final String PROPERTY_MAX_CLASSNAME = "maxClassname";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_MAX_ELEVATION = "maxElevation";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_MAX_LENGTH = "maxLength";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_MAX_LINES = "maxLines";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_MAX_ROW_HEIGHT = "maxRowHeight";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_MEDIA = "media";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_MEDIA_CONTROL_STYLE = "mediaControlStyle";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_MEDIA_TYPES = "mediaTypes";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_MENU = EVENT_PROPERTY_MENU;
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_MESSAGE = "message";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_MESSAGEID = "messageid";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_MESSENGER = "messenger";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_MESSENGER_RECEIVER = "messengerReceiver";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_MIDDLENAME = "middleName";
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_MIMETYPE = "mimeType";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_MIN = "min";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_MIN_AGE = "minAge";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_MIN_UPDATE_DISTANCE = "minUpdateDistance";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_MIN_UPDATE_TIME = "minUpdateTime";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_MIN_ROW_HEIGHT = "minRowHeight";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_MINIMUM_FONT_SIZE = "minimumFontSize";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_MINUTE_INTERVAL = "minuteInterval";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_MIXED_CONTENT_MODE = "mixedContentMode";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_MOBILE = "mobile";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_MODAL = "modal";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_MODE = "mode";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_MOTHER = "mother";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_MOVABLE = "movable";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_MOVING = "moving";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_MULTIPLY = "multiply";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_NAME = "name";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_NATIVE_SPINNER = "nativeSpinner";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_NAVIGATION_ICON = "navigationIcon";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_NICKNAME = "nickname";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_NOTE = "note";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_NUMBER = "number";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_NUMBERING_SYSTEM = "numberingSystem";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_NUMERIC_MONTHS = "numericMonths";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_OK = "ok";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_OKID = "okid";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_OPEN = "open";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ON_BACK = "onBack";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ON_CREATE_OPTIONS_MENU = "onCreateOptionsMenu";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ON_INTENT = "onIntent";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ON_CREATE = "onCreate";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ON_START = "onStart";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ON_RESUME = "onResume";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ON_RESTART = "onRestart";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ON_PAUSE = "onPause";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ON_STOP = "onStop";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_TLS_VERSION = "tlsVersion";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ON_DESTROY = "onDestroy";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ON_CREATE_WINDOW = "onCreateWindow";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ONDATASTREAM = "ondatastream";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ONERROR = "onerror";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ON_HOME_ICON_ITEM_SELECTED = "onHomeIconItemSelected";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ONLOAD = "onload";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ON_LINK = "onlink";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ON_PREPARE_OPTIONS_MENU = "onPrepareOptionsMenu";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ONREADYSTATECHANGE = "onreadystatechange";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ON_RECEIVED = "onReceived";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ONSENDSTREAM = "onsendstream";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_OPACITY = "opacity";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_OPTIONS = "options";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_OPTED_OUT = "optedOut";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ORDER = "order";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ORGANIZATION = "organization";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ORIENTATION_MODES = "orientationModes";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_OTHER = "other";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_OVER_SCROLL_MODE = "overScrollMode";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_OVERFLOW_ICON = "overflowIcon";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_OVERRIDE_CURRENT_ANIMATION = "overrideCurrentAnimation";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_PACKAGE_NAME = "packageName";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_PAGING_CONTROL_TIMEOUT = "pagingControlTimeout";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_PARENT = "parent";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_PARTNER = "partner";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_PASSWORD = "password";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_PASSWORD_MASK = "passwordMask";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_PATH = "path";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_PERSISTENT = "persistent";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_PHONE = "phone";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_PIN_IMAGE = "pinImage";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_PINCOLOR = "pincolor";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_PLACES = "places";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_PLAY = "play";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_PLUGIN_STATE = "pluginState";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_POSITION = "position";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_POSTAL_CODE = "postalCode";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_POWER = "power";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_PREFERRED_PROVIDER = "preferredProvider";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_PREVENT_CORNER_OVERLAP = "preventCornerOverlap";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_PROMPT = "prompt";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_PROMPT_ID = "promptid";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_PROPERTIES = "properties";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_PLAYABLE_DURATION = "playableDuration";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_PROVIDER = "provider";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_REFERRED_BY = "referredBy";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_REFRESH_CONTROL = "refreshControl";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_REGION = "region";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_REGION1 = "region1";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_REGION2 = "region2";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_REGION_FIT = "regionFit";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_RELATED_NAMES = "relatedNames";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_RELATIONSHIP = "relationship";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_REPEAT = "repeat";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_REPEAT_COUNT = "repeatCount";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_REPEAT_MODE = "repeatMode";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_REQUEST_HEADERS = "requestHeaders";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_RETURN_KEY_TYPE = "returnKeyType";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_REVERSE = "reverse";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_RIGHT = "right";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_RIGHT_BUTTON = "rightButton";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_RIGHT_DRAWER_LOCK_MODE = "rightDrawerLockMode";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_RIGHT_IMAGE = "rightImage";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_RIGHT_VIEW = "rightView";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_RIGHT_WIDTH = "rightWidth";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ROTATE = "rotate";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ROTATION = "rotation";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ROTATION_X = "rotationX";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ROTATION_Y = "rotationY";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ROW_DATA = "rowData";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ROW_HEIGHT = "rowHeight";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_SCALE = "scale";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_SCALE_X = "scaleX";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_SCALE_Y = "scaleY";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_SCALING_MODE = "scalingMode";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_SCALES_PAGE_TO_FIT = "scalesPageToFit";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_SCROLL_ENABLED = "scrollEnabled";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_SCROLL_TYPE = "scrollType";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_SCROLLABLE = "scrollable";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_SEARCH = "search";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_SEARCH_AS_CHILD = "searchAsChild";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_SEARCH_TEXT = "searchText";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_SEARCH_VIEW = "searchView";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_SEARCHABLE_TEXT = "searchableText";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_SECTION = "section";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_SECTION_INDEX = "sectionIndex";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_SECTIONS = "sections";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_SECURE = "secure";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_SELECTED_BACKGROUND_COLOR = "selectedBackgroundColor";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_SELECTED_BACKGROUND_IMAGE = "selectedBackgroundImage";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_SELECTED_INDEX = "selectedIndex";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_SELECTION_INDICATOR = "selectionIndicator";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_SELECTION_OPENS = "selectionOpens";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_SEPARATOR_COLOR = "separatorColor";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_SEPARATOR_HEIGHT = "separatorHeight";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_SEPARATOR_STYLE = "separatorStyle";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_SHADOW_COLOR = "shadowColor";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_SHADOW_OFFSET = "shadowOffset";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_SHADOW_RADIUS = "shadowRadius";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_SHIFT_MODE = "shiftMode";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_SHOW_AS_ACTION = "showAsAction";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_SHOW_BADGE = "showBadge";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_SHOW_CANCEL = "showCancel";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_SHOWS_CONTROLS = "showsControls";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_SHOW_HORIZONTAL_SCROLL_INDICATOR = "showHorizontalScrollIndicator";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_SHOW_VERTICAL_SCROLL_INDICATOR = "showVerticalScrollIndicator";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_SHOW_PAGING_CONTROL = "showPagingControl";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_SHOW_PROGRESS = "showProgress";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_SISTER = "sister";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_SIZE = "size";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_SOFT_KEYBOARD_ON_FOCUS = "softKeyboardOnFocus";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_SOUND = "sound";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_SPEED = "speed";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_SOURCE = EVENT_PROPERTY_SOURCE;
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_SOURCE_LENGTH = "sourceLength";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_SOURCE_POSITION = "sourcePosition";
-
-	/**
-	* @module.api
-	*/
 	public static final String PROPERTY_SPLIT_ACTIONBAR = "splitActionBar";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_SPLIT_TRACK = "splitTrack";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_SPOUSE = "spouse";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_START = "start";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_STATE = "state";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_STATUS = "status";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_STOP = "stop";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_STREET = "street";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_STREET1 = "street1";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_STYLE = "style";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_SUBMIT_ENABLED = "submitEnabled";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_SUBTITLE = "subtitle";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_SUBTITLE_TEXT_COLOR = "subtitleTextColor";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_SUBTITLEID = "subtitleid";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_SUCCESS = "success";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_SUMMARY_TEXT = "summaryText";
-
-	/**
-	 @module.api
-	 */
 	public static final String PROPERTY_SUSTAINED_PERFORMANCE_MODE = "sustainedPerformanceMode";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_SUPPORT_TOOLBAR = "supportToolbar";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_TABS = "tabs";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_TAB_OPEN = "tabOpen";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_TABS_BACKGROUND_COLOR = "tabsBackgroundColor";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_TABS_BACKGROUND_SELECTED_COLOR = "tabsBackgroundSelectedColor";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_TAG = "tag";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_TEMPLATE = "template";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_TEMPLATES = "templates";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_TEXT = "text";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_TEXTID = "textid";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_THEME = "theme";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_TEXT_ALIGN = "textAlign";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_TI_PROXY = "tiProxy";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_TICKER_TEXT = "tickerText";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_TIME = "time";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_TIMEOUT = "timeout";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_TIMESTAMP = "timestamp";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_TINT = "tint";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_TINT_COLOR = "tintColor";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_TITLE = "title";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_TITLE_COLOR = "titleColor";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_TITLE_CONDENSED = "titleCondensed";
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_TITLEID = "titleid";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_TITLE_ON = "titleOn";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_TITLE_OFF = "titleOff";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_TITLE_PROMPT = "titlePrompt";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_TITLE_PROMPTID = "titlepromptid";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_TITLE_TEXT_COLOR = "titleTextColor";
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_TO = "to";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_TOP = "top";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_TOTAL_ITEM_COUNT = "totalItemCount";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_TOUCH_ENABLED = "touchEnabled";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_TOOLBAR = "toolbar";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_TOOLBAR_ENABLED = "toolbarEnabled";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_SOUND_EFFECTS_ENABLED = "soundEffectsEnabled";
-
-	/**
-	 * module.api
-	 */
 	public static final String PROPERTY_TRACK_TINT_COLOR = "trackTintColor";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_TRANSFORM = "transform";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_TRANSLATION_X = "translationX";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_TRANSLATION_Y = "translationY";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_TRANSLATION_Z = "translationZ";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_TRANSLUCENT = "translucent";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_TRUE_HEADING = "trueHeading";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_TYPE = "type";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_UPDATE_CURRENT_INTENT = "updateCurrentIntent";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_URI = "uri";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_URL = "url";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_USE_COMPAT_PADDING = "useCompatPadding";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_USE_SPINNER = "useSpinner";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_USER_AGENT = "userAgent";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_USERNAME = "username";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_USER_LOCATION = "userLocation";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_VALUE = "value";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_VERSION = "version";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_VERTICAL_ALIGN = "verticalAlign";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_VIBRATE_PATTERN = "vibratePattern";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_VIDEO_MAX_DURATION = "videoMaximumDuration";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_VIDEO_QUALITY = "videoQuality";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_VISIBLE = "visible";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_VISIBILITY = "visibility";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_VISIBLE_ITEM_COUNT = "visibleItemCount";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_VISIBLE_ITEMS = "visibleItems";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_VIEW = "view";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_VIEWS = "views";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_VOLUME = "volume";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_WAKE_LOCK = "wakeLock";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_WEBVIEW_IGNORE_SSL_ERROR = "ignoreSslError";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_WHEN = "when";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_WHICH_CAMERA = "whichCamera";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_WIDTH = "width";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_WINDOW = "window";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_WINDOW_FLAGS = "windowFlags";
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_WINDOW_PIXEL_FORMAT = "windowPixelFormat";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_WINDOW_SOFT_INPUT_MODE = "windowSoftInputMode";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_WORD_WRAP = "wordWrap";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_WORK = "work";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_HORIZONTAL_WRAP = "horizontalWrap";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_X = "x";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_X_ABSOLUTE = "absoluteX";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_Y = "y";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_Y_ABSOLUTE = "absoluteY";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_Z = "z";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ZINDEX = "zIndex";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ZOOM_LEVEL = "zoomLevel";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_ZOOM_ENABLED = "zoomEnabled";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_LIGHT_TOUCH_ENABLED = "lightTouchEnabled";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_CATEGORY = "category";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_CUSTOM = "custom";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_CUSTOM_VIEW = "customView";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_MIN_DATE = "minDate";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_MAX_DATE = "maxDate";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_PREFIX = "prefix";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_PRIORITY = "priority";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_SUFFIX = "suffix";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_FIRSTPHONETIC = "firstPhonetic";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_MIDDLEPHONETIC = "middlePhonetic";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_LASTPHONETIC = "lastPhonetic";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_JOBTITLE = "jobTitle";
-
-	/**
-	 * @module.api
-	 */
 	public static final String PROPERTY_DEPARTMENT = "department";
 
 	public static final String SIZE_AUTO = "auto";

--- a/android/titanium/src/java/org/appcelerator/titanium/TiExceptionHandler.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiExceptionHandler.java
@@ -41,7 +41,7 @@ public class TiExceptionHandler implements Handler.Callback, KrollExceptionHandl
 {
 	private static final String TAG = "TiExceptionHandler";
 	private static final int MSG_OPEN_ERROR_DIALOG = 10011;
-	private static LinkedList<ExceptionMessage> errorMessages = new LinkedList<ExceptionMessage>();
+	private static final LinkedList<ExceptionMessage> errorMessages = new LinkedList<>();
 	private static boolean dialogShowing = false;
 	private static Handler mainHandler;
 
@@ -87,7 +87,7 @@ public class TiExceptionHandler implements Handler.Callback, KrollExceptionHandl
 
 	public static String getError(KrollDict error)
 	{
-		String output = new String();
+		String output = "";
 
 		final String sourceName = error.getString(ERROR_SOURCENAME);
 		final String message = error.getString(ERROR_MESSAGE);
@@ -290,7 +290,6 @@ public class TiExceptionHandler implements Handler.Callback, KrollExceptionHandl
 	/**
 	 * Handles the exception by opening an error dialog with an error message
 	 * @param error An error message containing line number, error title, message, etc
-	 * @module.api
 	 */
 	public void handleException(ExceptionMessage error)
 	{

--- a/android/titanium/src/java/org/appcelerator/titanium/TiFileProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiFileProxy.java
@@ -48,7 +48,7 @@ public class TiFileProxy extends KrollProxy
 		Uri uri = Uri.parse(parts[0]);
 		if (uri.getScheme() != null) {
 			scheme = uri.getScheme() + ":";
-			ArrayList<String> pb = new ArrayList<String>();
+			ArrayList<String> pb = new ArrayList<>();
 
 			int schemeLength = scheme.length();
 			if (parts[0].charAt(schemeLength + 1) == '/') {
@@ -64,7 +64,7 @@ public class TiFileProxy extends KrollProxy
 			for (int i = 1; i < parts.length; i++) {
 				pb.add(parts[i]);
 			}
-			String[] newParts = pb.toArray(new String[pb.size()]);
+			String[] newParts = pb.toArray(new String[0]);
 			path = TiFileHelper2.joinSegments(newParts);
 			if (!path.startsWith("..") || !path.startsWith("/")) {
 				path = "/" + path;

--- a/android/titanium/src/java/org/appcelerator/titanium/TiLaunchActivity.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiLaunchActivity.java
@@ -30,7 +30,7 @@ public abstract class TiLaunchActivity extends TiBaseActivity
 	 * The key is the Java package name and class name of the TiJSActivity derived class.
 	 * The value is the JavaScript file URL assigned to it.
 	 */
-	private static HashMap<String, String> jsActivityClassScriptMap = new HashMap<>();
+	private static final HashMap<String, String> jsActivityClassScriptMap = new HashMap<>();
 
 	/** JavaScript file URL to be loaded by loadScript() method. This URL is assigned in onCreate() method. */
 	private TiUrl url;

--- a/android/titanium/src/java/org/appcelerator/titanium/TiLifecycle.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiLifecycle.java
@@ -72,13 +72,13 @@ public class TiLifecycle
 
 		/**
 		 * Implementing classes should use this to receive native Android onSaveInstanceState events.
-		 * @param activity the attached activity.
+		 * @param bundle The bundle to save activity/view states to.
 		 */
 		void onSaveInstanceState(Bundle bundle);
 
 		/**
 		 * Implementing classes should use this to receive native Android onRestoreInstanceState events.
-		 * @param activity the attached activity.
+		 * @param bundle The bundle to restore activity/view states from.
 		 */
 		void onRestoreInstanceState(Bundle bundle);
 	}

--- a/android/titanium/src/java/org/appcelerator/titanium/TiProperties.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiProperties.java
@@ -47,7 +47,6 @@ public class TiProperties
 	 * @param key the lookup key.
 	 * @param def the default value.
 	 * @return mapping of key, or default value.
-	 * @module.api
 	 */
 	public String getString(String key, String def)
 	{
@@ -84,7 +83,6 @@ public class TiProperties
 	 * Otherwise, its value will be overwritten.
 	 * @param key the key to set.
 	 * @param value the value to set.
-	 * @module.api
 	 */
 	public void setString(String key, String value)
 	{
@@ -113,7 +111,6 @@ public class TiProperties
 	 * @param key the lookup key.
 	 * @param def the default value.
 	 * @return mapping of key, or default value.
-	 * @module.api
 	 */
 	public int getInt(String key, int def)
 	{
@@ -147,7 +144,6 @@ public class TiProperties
 	 * Maps the specified key with an int value. If key exists, its value will be overwritten.
 	 * @param key the key to set.
 	 * @param value the value to set.
-	 * @module.api
 	 */
 	public void setInt(String key, int value)
 	{
@@ -172,7 +168,6 @@ public class TiProperties
 	 * @param key the lookup key.
 	 * @param def the default value.
 	 * @return mapping of key, or default value.
-	 * @module.api
 	 */
 	public double getDouble(String key, double def)
 	{
@@ -197,7 +192,6 @@ public class TiProperties
 	 * overwritten.
 	 * @param key the key to set.
 	 * @param value the value to set.
-	 * @module.api
 	 */
 	public void setDouble(String key, double value)
 	{
@@ -222,7 +216,6 @@ public class TiProperties
 	 * @param key the lookup key.
 	 * @param def the default value.
 	 * @return mapping of key, or default value.
-	 * @module.api
 	 */
 	public boolean getBool(String key, boolean def)
 	{
@@ -257,7 +250,6 @@ public class TiProperties
 	 * overwritten.
 	 * @param key the key to set.
 	 * @param value the value to set.
-	 * @module.api
 	 */
 	public void setBool(String key, boolean value)
 	{
@@ -282,7 +274,6 @@ public class TiProperties
 	 * @param key the lookup key.
 	 * @param def the default value.
 	 * @return mapping of key, or default value.
-	 * @module.api
 	 */
 	public String[] getList(String key, String[] def)
 	{
@@ -307,7 +298,6 @@ public class TiProperties
 	 * If key exists, its value will be overwritten.
 	 * @param key the key to set.
 	 * @param value the value to set.
-	 * @module.api
 	 */
 	public void setList(String key, String[] value)
 	{
@@ -327,7 +317,6 @@ public class TiProperties
 	/**
 	 * @param key the lookup list key.
 	 * @return true if the list property exists in preferences
-	 * @module.api
 	 */
 	public boolean hasListProperty(String key)
 	{
@@ -338,7 +327,6 @@ public class TiProperties
 	 * Returns whether key exists in preferences.
 	 * @param key the lookup key.
 	 * @return true if key exists in preferences.
-	 * @module.api
 	 */
 	public boolean hasProperty(String key)
 	{
@@ -349,7 +337,6 @@ public class TiProperties
 	/**
 	 * Returns an array of keys whose values are lists.
 	 * @return an array of keys.
-	 * @module.api
 	 */
 	public String[] listProperties()
 	{
@@ -371,13 +358,12 @@ public class TiProperties
 			}
 		}
 
-		return properties.toArray(new String[properties.size()]);
+		return properties.toArray(new String[0]);
 	}
 
 	/**
 	 * Removes the key from preferences if it exists.
 	 * @param key the key to remove.
-	 * @module.api
 	 */
 	public void removeProperty(String key)
 	{
@@ -397,7 +383,6 @@ public class TiProperties
 
 	/**
 	 * Removes all keys from preferences.
-	 * @module.api
 	 */
 	public void removeAllProperties()
 	{

--- a/android/titanium/src/java/org/appcelerator/titanium/TiRootActivity.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiRootActivity.java
@@ -54,9 +54,9 @@ public class TiRootActivity extends TiLaunchActivity implements TiActivitySuppor
 	 */
 	private static boolean isScriptRunning;
 
-	private ArrayList<OnNewIntentListener> newIntentListeners = new ArrayList<>(16);
-	private LinkedList<Runnable> pendingRuntimeRunnables = new LinkedList<>();
-	private Drawable[] backgroundLayers = { null, null };
+	private final ArrayList<OnNewIntentListener> newIntentListeners = new ArrayList<>(16);
+	private final LinkedList<Runnable> pendingRuntimeRunnables = new LinkedList<>();
+	private final Drawable[] backgroundLayers = { null, null };
 	private int runtimeStartedListenerId = KrollProxy.INVALID_EVENT_LISTENER_ID;
 	private boolean wasRuntimeStarted;
 	private boolean isDuplicateInstance;

--- a/android/titanium/src/java/org/appcelerator/titanium/TiStylesheet.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiStylesheet.java
@@ -24,10 +24,10 @@ public abstract class TiStylesheet
 	// The concrete implementation fills these
 	public TiStylesheet()
 	{
-		classesMap = new HashMap<String, HashMap<String, KrollDict>>();
-		idsMap = new HashMap<String, HashMap<String, KrollDict>>();
-		classesDensityMap = new HashMap<String, HashMap<String, HashMap<String, KrollDict>>>();
-		idsDensityMap = new HashMap<String, HashMap<String, HashMap<String, KrollDict>>>();
+		classesMap = new HashMap<>();
+		idsMap = new HashMap<>();
+		classesDensityMap = new HashMap<>();
+		idsDensityMap = new HashMap<>();
 	}
 
 	protected void addAll(KrollDict result, HashMap<String, KrollDict> map, String key)

--- a/android/titanium/src/java/org/appcelerator/titanium/io/TiBaseFile.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/io/TiBaseFile.java
@@ -78,7 +78,6 @@ public abstract class TiBaseFile
 
 	/**
 	 * @return true if the file is a File, false otherwise. See {@link java.io.File#isFile()} for more details.
-	 * @module.api
 	 */
 	public boolean isFile()
 	{
@@ -87,7 +86,6 @@ public abstract class TiBaseFile
 
 	/**
 	 * @return true if the file is a directory, false otherwise. See {@link java.io.File#isDirectory()} for more details.
-	 * @module.api
 	 */
 	public boolean isDirectory()
 	{
@@ -96,7 +94,6 @@ public abstract class TiBaseFile
 
 	/**
 	 * @return  true if the file is executable, false otherwise.
-	 * @module.api
 	 */
 	public boolean isExecutable()
 	{
@@ -105,7 +102,6 @@ public abstract class TiBaseFile
 
 	/**
 	 * @return  true if the file is read-only, false otherwise.
-	 * @module.api
 	 */
 	public boolean isReadonly()
 	{
@@ -114,7 +110,6 @@ public abstract class TiBaseFile
 
 	/**
 	 * @return  true if the file is writable, false otherwise.
-	 * @module.api
 	 */
 	public boolean isWriteable()
 	{
@@ -123,7 +118,6 @@ public abstract class TiBaseFile
 
 	/**
 	 * @return true if the file is hidden, false otherwise.
-	 * @module.api
 	 */
 	public boolean isHidden()
 	{
@@ -132,7 +126,6 @@ public abstract class TiBaseFile
 
 	/**
 	 * @return true if the file is a symbolic link, false otherwise.
-	 * @module.api
 	 */
 	public boolean isSymbolicLink()
 	{
@@ -241,7 +234,6 @@ public abstract class TiBaseFile
 
 	/**
 	 * @return Whether or not this file exists.
-	 * @module.api
 	 */
 	public boolean exists()
 	{
@@ -257,7 +249,6 @@ public abstract class TiBaseFile
 
 	/**
 	 * @return a list of all files and directories in this directory.
-	 * @module.api
 	 */
 	public List<String> getDirectoryListing()
 	{
@@ -267,7 +258,6 @@ public abstract class TiBaseFile
 
 	/**
 	 * @return The parent directory of this file
-	 * @module.api
 	 */
 	public TiBaseFile getParent()
 	{
@@ -331,7 +321,6 @@ public abstract class TiBaseFile
 
 	/**
 	 * @return the file's name.
-	 * @module.api
 	 */
 	public String name()
 	{
@@ -341,7 +330,6 @@ public abstract class TiBaseFile
 
 	/**
 	 * @return the file's path.
-	 * @module.api
 	 */
 	public String nativePath()
 	{
@@ -541,7 +529,6 @@ public abstract class TiBaseFile
 	 * the contents of the file.
 	 * @return  the InputStream of the file.
 	 * @throws IOException the thrown exception.
-	 * @module.api
 	 */
 	public abstract InputStream getInputStream() throws IOException;
 
@@ -549,14 +536,12 @@ public abstract class TiBaseFile
 	 * Implementing subclasses should return an OutputStream for writing to the file.
 	 * @return  the OutputStream of the file.
 	 * @throws IOException the thrown exception.
-	 * @module.api
 	 */
 	public abstract OutputStream getOutputStream() throws IOException;
 
 	/**
 	 * Implementing subclasses should return the file object.
 	 * @return  the file object.
-	 * @module.api
 	 */
 	public abstract File getNativeFile();
 }

--- a/android/titanium/src/java/org/appcelerator/titanium/io/TiContentFile.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/io/TiContentFile.java
@@ -46,7 +46,7 @@ public class TiContentFile extends TiBaseFile
 	/** The file's creation time in milliseconds since 1970. Will be negative if unknown. */
 	private long createdTime = -1L;
 
-	/** The file's modfication time in milliseconds since 1970. Will be negative if unknown. */
+	/** The file's modification time in milliseconds since 1970. Will be negative if unknown. */
 	private long modifiedTime = -1L;
 
 	/**

--- a/android/titanium/src/java/org/appcelerator/titanium/io/TiFile.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/io/TiFile.java
@@ -20,6 +20,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
@@ -253,7 +254,6 @@ public class TiFile extends TiBaseFile
 		return file.length();
 	}
 
-	@SuppressWarnings("deprecation")
 	@Override
 	public long spaceAvailable()
 	{
@@ -309,7 +309,7 @@ public class TiFile extends TiBaseFile
 	public List<String> getDirectoryListing()
 	{
 		File dir = getNativeFile();
-		List<String> listing = new ArrayList<String>();
+		List<String> listing = new ArrayList<>();
 
 		String[] names = dir.list();
 		if (names != null) {
@@ -358,7 +358,7 @@ public class TiFile extends TiBaseFile
 			if (binary) {
 				instream = new BufferedInputStream(getInputStream());
 			} else {
-				inreader = new BufferedReader(new InputStreamReader(new FileInputStream(file), "utf-8"));
+				inreader = new BufferedReader(new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8));
 			}
 		} else {
 			OutputStream os = getOutputStream(mode);
@@ -416,7 +416,7 @@ public class TiFile extends TiBaseFile
 				if (binary) {
 					copyStream(blob.getInputStream(), outstream);
 				} else {
-					outwriter.write(new String(blob.getBytes(), "UTF-8"));
+					outwriter.write(new String(blob.getBytes(), StandardCharsets.UTF_8));
 				}
 			}
 		}
@@ -462,7 +462,7 @@ public class TiFile extends TiBaseFile
 				} else {
 					BufferedReader ir = null;
 					try {
-						ir = new BufferedReader(new InputStreamReader(f.getInputStream(), "utf-8"));
+						ir = new BufferedReader(new InputStreamReader(f.getInputStream(), StandardCharsets.UTF_8));
 						copyStream(ir, outwriter);
 					} finally {
 						if (ir != null) {

--- a/android/titanium/src/java/org/appcelerator/titanium/io/TiFileFactory.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/io/TiFileFactory.java
@@ -55,7 +55,6 @@ public class TiFileFactory
 	 * @param path the path of the file
 	 * @param stream this is not being used
 	 * @return a TiBaseFile instance
-	 * @module.api
 	 */
 	public static TiBaseFile createTitaniumFile(String path, boolean stream)
 	{
@@ -70,7 +69,6 @@ public class TiFileFactory
 	 * @param parts A String Array containing parts of a file path.
 	 * @param stream this is not being used.
 	 * @return a TiBaseFile instance.
-	 * @module.api
 	 */
 	public static TiBaseFile createTitaniumFile(String[] parts, boolean stream)
 	{
@@ -209,11 +207,9 @@ public class TiFileFactory
 
 	/**
 	 * Retrieves/creates a data directory in which the application can place its own custom data files.
-	 * Refer to {@link TiFileFactory#getDataDirectory(boolean)} for more details.
 	 * @param privateStorage  determines the location of the data directory. If this is true, the location is internal(app-data://),
 	 * and external (SD) otherwise.
 	 * @return  the data directory.
-	 * @module.api
 	 */
 	public static File getDataDirectory(boolean privateStorage)
 	{

--- a/android/titanium/src/java/org/appcelerator/titanium/io/TiInputStreamWrapper.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/io/TiInputStreamWrapper.java
@@ -81,7 +81,7 @@ public class TiInputStreamWrapper extends InputStream
 	 * reposition the stream back to the given marked position.
 	 * <p>
 	 * This method does nothing if the stream's markSupported() method returns false.
-	 * @param The maximum number of bytes that can be read before the mark position becomes invalid.
+	 * @param readLimit The maximum number of bytes that can be read before the mark position becomes invalid.
 	 */
 	@Override
 	public void mark(int readLimit)

--- a/android/titanium/src/java/org/appcelerator/titanium/io/TiResourceFile.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/io/TiResourceFile.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import javax.crypto.CipherInputStream;
 import org.appcelerator.kroll.common.Log;
@@ -96,7 +97,7 @@ public class TiResourceFile extends TiBaseFile
 				if (binary) {
 					instream = new BufferedInputStream(in);
 				} else {
-					inreader = new BufferedReader(new InputStreamReader(in, "utf-8"));
+					inreader = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8));
 				}
 				opened = true;
 			} else {

--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/ActivityProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/ActivityProxy.java
@@ -280,7 +280,7 @@ public class ActivityProxy extends KrollProxy implements TiActivityResultHandler
 	public void invalidateOptionsMenu()
 	{
 		Activity activity = getWrappedActivity();
-		if (activity != null && activity instanceof AppCompatActivity) {
+		if (activity instanceof AppCompatActivity) {
 			((AppCompatActivity) activity).supportInvalidateOptionsMenu();
 		}
 	}
@@ -361,7 +361,7 @@ public class ActivityProxy extends KrollProxy implements TiActivityResultHandler
 	 */
 	private static class ProxyModelListener implements KrollProxyListener
 	{
-		private static ProxyModelListener instance = new ProxyModelListener();
+		private static final ProxyModelListener instance = new ProxyModelListener();
 
 		public static ProxyModelListener getInstance()
 		{

--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/IntentProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/IntentProxy.java
@@ -143,7 +143,7 @@ public class IntentProxy extends KrollProxy
 
 		if (dict.containsKey(TiC.PROPERTY_FLAGS)) {
 			flags = TiConvert.toInt(dict, TiC.PROPERTY_FLAGS);
-			Log.d(TAG, "Setting flags: " + Integer.toString(flags), Log.DEBUG_MODE);
+			Log.d(TAG, "Setting flags: " + flags, Log.DEBUG_MODE);
 			intent.setFlags(flags);
 		} else {
 			setProperty(TiC.PROPERTY_FLAGS, intent.getFlags());
@@ -285,7 +285,7 @@ public class IntentProxy extends KrollProxy
 			try {
 				Object[] objVal = (Object[]) value;
 				String[] stringArray = Arrays.copyOf(objVal, objVal.length, String[].class);
-				ArrayList<Uri> imageUris = new ArrayList<Uri>();
+				ArrayList<Uri> imageUris = new ArrayList<>();
 				ClipData clipData = null;
 				for (String s : stringArray) {
 					if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && s.startsWith("file://")) {

--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/MenuProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/MenuProxy.java
@@ -35,7 +35,7 @@ public class MenuProxy extends KrollProxy
 	public MenuProxy(Menu menu)
 	{
 		this.menu = menu;
-		menuMap = new HashMap<MenuItem, MenuItemProxy>();
+		menuMap = new HashMap<>();
 	}
 
 	@Kroll.method
@@ -184,7 +184,7 @@ public class MenuProxy extends KrollProxy
 	{
 		//TODO will get to get items in the group and remove them from our map
 		menu.removeGroup(groupId);
-		HashMap<MenuItem, MenuItemProxy> mm = new HashMap<MenuItem, MenuItemProxy>(menu.size());
+		HashMap<MenuItem, MenuItemProxy> mm = new HashMap<>(menu.size());
 		int len = menu.size();
 		for (int i = 0; i < len; i++) {
 			MenuItem mi = menu.getItem(i);

--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/RProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/RProxy.java
@@ -34,7 +34,7 @@ public class RProxy extends KrollProxy
 
 	protected String name;
 	protected int resourceType;
-	protected HashMap<String, Object> subResources = new HashMap<String, Object>();
+	protected HashMap<String, Object> subResources = new HashMap<>();
 
 	public RProxy(int resourceType)
 	{

--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/TiViewProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/TiViewProxy.java
@@ -119,7 +119,6 @@ public abstract class TiViewProxy extends KrollProxy
 
 	/**
 	 * Constructs a new TiViewProxy instance.
-	 * @module.api
 	 */
 	public TiViewProxy()
 	{
@@ -151,7 +150,7 @@ public abstract class TiViewProxy extends KrollProxy
 		return overrideCurrentAnimation;
 	}
 
-	private static HashMap<TiUrl, String> styleSheetUrlCache = new HashMap<TiUrl, String>(5);
+	private static final HashMap<TiUrl, String> styleSheetUrlCache = new HashMap<>(5);
 	protected String getBaseUrlForStylesheet()
 	{
 		TiUrl creationUrl = getCreationUrl();
@@ -388,7 +387,6 @@ public abstract class TiViewProxy extends KrollProxy
 
 	/**
 	 * @return the TiUIView associated with this proxy.
-	 * @module.api
 	 */
 	public TiUIView peekView()
 	{
@@ -427,7 +425,6 @@ public abstract class TiViewProxy extends KrollProxy
 	/**
 	 * Creates or retrieves the view associated with this proxy.
 	 * @return a TiUIView instance.
-	 * @module.api
 	 */
 	public TiUIView getOrCreateView()
 	{
@@ -543,7 +540,6 @@ public abstract class TiViewProxy extends KrollProxy
 	 * Implementing classes should use this method to create and return the appropriate view.
 	 * @param activity the context activity.
 	 * @return a TiUIView instance.
-	 * @module.api
 	 */
 	public abstract TiUIView createView(Activity activity);
 
@@ -572,7 +568,6 @@ public abstract class TiViewProxy extends KrollProxy
 	/**
 	 * Adds a child to this view proxy.
 	 * @param args The child view proxy/proxies to add.
-	 * @module.api
 	 */
 	@Kroll.method
 	public void add(Object args)
@@ -592,7 +587,7 @@ public abstract class TiViewProxy extends KrollProxy
 		} else if (args instanceof TiViewProxy) {
 			TiViewProxy child = (TiViewProxy) args;
 			children.add(child);
-			child.parent = new WeakReference<TiViewProxy>(this);
+			child.parent = new WeakReference<>(this);
 			if ((peekView() != null) && (view != null)) {
 				child.setActivity(getActivity());
 				if (this instanceof DecorViewProxy) {
@@ -630,7 +625,6 @@ public abstract class TiViewProxy extends KrollProxy
 	 * Adds a child to this view proxy in the specified position. This is useful for "vertical" and
 	 * "horizontal" layouts.
 	 * @param params A Dictionary containing a TiViewProxy for the view and an int for the position
-	 * @module.api
 	 */
 	@Kroll.method
 	public void insertAt(Object params)
@@ -674,7 +668,6 @@ public abstract class TiViewProxy extends KrollProxy
 	/**
 	 * Removes a view from this view proxy, releasing the underlying native view if it exists.
 	 * @param child The child to remove.
-	 * @module.api
 	 */
 	@Kroll.method
 	public void remove(TiViewProxy child)
@@ -698,7 +691,6 @@ public abstract class TiViewProxy extends KrollProxy
 
 	/**
 	 * Removes all children views.
-	 * @module.api
 	 */
 	@Kroll.method
 	public void removeAllChildren()
@@ -716,7 +708,6 @@ public abstract class TiViewProxy extends KrollProxy
 
 	/**
 	* Returns the view by the given ID.
-	* @module.api
 	*/
 	@Kroll.method
 	public TiViewProxy getViewById(String id)
@@ -866,7 +857,6 @@ public abstract class TiViewProxy extends KrollProxy
 			View view = tiv.getNativeView();
 			if (view == null || (view.getWidth() == 0 && view.getHeight() == 0) || tiv.isLayoutPending()) {
 				getMainHandler().sendEmptyMessage(MSG_QUEUED_ANIMATE);
-				return;
 			} else {
 				tiv.animate();
 			}
@@ -1007,7 +997,6 @@ public abstract class TiViewProxy extends KrollProxy
 
 	/**
 	 * @return The parent view proxy of this view proxy.
-	 * @module.api
 	 */
 	@Kroll.getProperty
 	public TiViewProxy getParent()
@@ -1145,7 +1134,6 @@ public abstract class TiViewProxy extends KrollProxy
 
 	/**
 	 * @return An array of the children view proxies of this view.
-	 * @module.api
 	 */
 	@Kroll.getProperty
 	public TiViewProxy[] getChildren()
@@ -1153,7 +1141,7 @@ public abstract class TiViewProxy extends KrollProxy
 		if (children == null) {
 			return new TiViewProxy[0];
 		}
-		return children.toArray(new TiViewProxy[children.size()]);
+		return children.toArray(new TiViewProxy[0]);
 	}
 
 	@Override
@@ -1199,7 +1187,7 @@ public abstract class TiViewProxy extends KrollProxy
 		// This is a pretty naive implementation right now,
 		// but it will work for our current needs
 		String baseUrl = getBaseUrlForStylesheet();
-		ArrayList<String> classes = new ArrayList<String>();
+		ArrayList<String> classes = new ArrayList<>();
 		for (Object c : classNames) {
 			classes.add(TiConvert.toString(c));
 		}

--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/TiWindowProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/TiWindowProxy.java
@@ -61,7 +61,7 @@ public abstract class TiWindowProxy extends TiViewProxy
 	protected static final int MSG_LAST_ID = MSG_FIRST_ID + 999;
 
 	private static WeakReference<TiWindowProxy> waitingForOpen;
-	private TiWeakList<KrollProxy> proxiesWaitingForActivity = new TiWeakList<KrollProxy>();
+	private final TiWeakList<KrollProxy> proxiesWaitingForActivity = new TiWeakList<>();
 
 	protected boolean opened, opening;
 	protected boolean isFocused;
@@ -82,15 +82,16 @@ public abstract class TiWindowProxy extends TiViewProxy
 
 	public static TiWindowProxy getWaitingForOpen()
 	{
-		if (waitingForOpen == null)
+		if (waitingForOpen == null) {
 			return null;
+		}
 		return waitingForOpen.get();
 	}
 
 	public TiWindowProxy()
 	{
 		inTab = false;
-		sharedElementPairs = new ArrayList<Pair<View, String>>();
+		sharedElementPairs = new ArrayList<>();
 	}
 
 	@Override
@@ -109,7 +110,7 @@ public abstract class TiWindowProxy extends TiViewProxy
 			});
 		}
 		opening = true;
-		waitingForOpen = new WeakReference<TiWindowProxy>(this);
+		waitingForOpen = new WeakReference<>(this);
 
 		openPromise = KrollPromise.create((promise) -> {
 			KrollDict options = null;
@@ -214,7 +215,7 @@ public abstract class TiWindowProxy extends TiViewProxy
 
 	public void addProxyWaitingForActivity(KrollProxy waitingProxy)
 	{
-		proxiesWaitingForActivity.add(new WeakReference<KrollProxy>(waitingProxy));
+		proxiesWaitingForActivity.add(new WeakReference<>(waitingProxy));
 	}
 
 	protected void releaseViewsForActivityForcedToDestroy()
@@ -602,7 +603,7 @@ public abstract class TiWindowProxy extends TiViewProxy
 	{
 		TiUIView v = view.peekView();
 		if (v != null) {
-			Pair<View, String> p = new Pair<View, String>(v.getNativeView(), transitionName);
+			Pair<View, String> p = new Pair<>(v.getNativeView(), transitionName);
 			sharedElementPairs.add(p);
 		}
 	}
@@ -639,7 +640,7 @@ public abstract class TiWindowProxy extends TiViewProxy
 		if (hasActivityTransitions() && !(activity instanceof TiLaunchActivity)) {
 			if (!sharedElementPairs.isEmpty()) {
 				options = ActivityOptionsCompat.makeSceneTransitionAnimation(
-					activity, sharedElementPairs.toArray(new Pair[sharedElementPairs.size()]));
+					activity, sharedElementPairs.toArray(new Pair[0]));
 			} else {
 				options = ActivityOptionsCompat.makeSceneTransitionAnimation(activity);
 			}

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiActivityResultHandler.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiActivityResultHandler.java
@@ -22,7 +22,6 @@ public interface TiActivityResultHandler {
 	 * @param requestCode the returned request code.
 	 * @param resultCode the returned result code.
 	 * @param data the intent.
-	 * @module.api
 	 */
 	void onResult(Activity activity, int requestCode, int resultCode, Intent data);
 
@@ -32,7 +31,6 @@ public interface TiActivityResultHandler {
 	 * @param activity the launched activity.
 	 * @param requestCode the returned request code.
 	 * @param e the returned exception
-	 * @module.api
 	 */
 	void onError(Activity activity, int requestCode, Exception e);
 }

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiActivitySupport.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiActivitySupport.java
@@ -24,7 +24,6 @@ public interface TiActivitySupport {
 	 * @param code  the request code, a code that represents the launched activity. This code will be returned in
 	 * {@link TiActivityResultHandler#onResult(android.app.Activity, int, int, Intent)} when the activity exits.
 	 * @param handler the callback handler.
-	 * @module.api
 	 */
 	void launchActivityForResult(Intent intent, int code, TiActivityResultHandler handler);
 
@@ -40,8 +39,7 @@ public interface TiActivitySupport {
 	 * @param extraFlags always set to 0.
 	 * @param options additional options for how the Activity should be started. See Context.startActivity(Intent, Bundle) for more details.
 	 * If options have also been supplied by the IntentSender, options given here will override any that conflict with those given by the IntentSender.
-	 * @param handler the callback handler.
-	 * @module.api
+	 * @param resultHandler the callback handler.
 	 */
 	void launchIntentSenderForResult(IntentSender intent, int requestCode, Intent fillInIntent, int flagsMask,
 									 int flagsValues, int extraFlags, Bundle options,
@@ -50,7 +48,6 @@ public interface TiActivitySupport {
 	/**
 	 * @return a code that represents the launched activity. This must be unique to differentiate launched activities that
 	 * use the same callback handler.
-	 * @module.api
 	 */
 	int getUniqueResultCode();
 }

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiActivitySupportHelper.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiActivitySupportHelper.java
@@ -32,7 +32,7 @@ public class TiActivitySupportHelper implements TiActivitySupport
 	public TiActivitySupportHelper(Activity activity)
 	{
 		this.activity = activity;
-		resultHandlers = new HashMap<Integer, TiActivityResultHandler>();
+		resultHandlers = new HashMap<>();
 		uniqueResultCodeAllocator = new AtomicInteger(1); // start with non-zero
 	}
 

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiAnimationBuilder.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiAnimationBuilder.java
@@ -99,7 +99,7 @@ public class TiAnimationBuilder
 	private static final String TAG = "TiAnimationBuilder";
 
 	// Views on which animations are currently running.
-	private static ArrayList<WeakReference<View>> sRunningViews = new ArrayList<WeakReference<View>>();
+	private static final ArrayList<WeakReference<View>> sRunningViews = new ArrayList<>();
 	private static final TiAnimationCurve DEFAULT_CURVE = TiAnimationCurve.EASE_IN_OUT;
 
 	protected float anchorX;
@@ -291,7 +291,7 @@ public class TiAnimationBuilder
 	 */
 	private AnimatorSet buildPropertyAnimators(int x, int y, int w, int h, int parentWidth, int parentHeight)
 	{
-		List<Animator> animators = new ArrayList<Animator>();
+		List<Animator> animators = new ArrayList<>();
 		boolean includesRotation = false;
 
 		if (toOpacity != null) {
@@ -1086,7 +1086,7 @@ public class TiAnimationBuilder
 	{
 		if (running) {
 			if (!isAnimationRunningFor(v)) {
-				sRunningViews.add(new WeakReference<View>(v));
+				sRunningViews.add(new WeakReference<>(v));
 			}
 
 		} else {

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiColorHelper.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiColorHelper.java
@@ -43,8 +43,8 @@ public class TiColorHelper
 
 	private static final String TAG = "TiColorHelper";
 	private static HashMap<String, Integer> colorTable;
-	private static List<String> alphaMissingColors = Arrays.asList(
-		new String[] { "aqua", "fuchsia", "lime", "maroon", "navy", "olive", "purple", "silver", "teal" });
+	private static final List<String> alphaMissingColors = Arrays.asList(
+		"aqua", "fuchsia", "lime", "maroon", "navy", "olive", "purple", "silver", "teal");
 
 	/**
 	 * Convert string representations of colors, like "red" into the corresponding RGB/RGBA representation.
@@ -229,7 +229,7 @@ public class TiColorHelper
 	{
 		synchronized (TiColorHelper.class)
 		{
-			colorTable = new HashMap<String, Integer>(20);
+			colorTable = new HashMap<>(20);
 
 			colorTable.put("black", Color.BLACK);
 			colorTable.put("red", Color.RED);

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiConvert.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiConvert.java
@@ -67,14 +67,14 @@ public class TiConvert
 					Log.w(TAG, "First member of array is null", Log.DEBUG_MODE);
 				}
 
-				if (v != null && v instanceof String) {
+				if (v instanceof String) {
 					String[] sa = new String[len];
 					for (int i = 0; i < len; i++) {
 						sa[i] = (String) a[i];
 					}
 					d.put(key, sa);
 
-				} else if (v != null && v instanceof Double) {
+				} else if (v instanceof Double) {
 					double[] da = new double[len];
 					for (int i = 0; i < len; i++) {
 						da[i] = (Double) a[i];
@@ -133,7 +133,6 @@ public class TiConvert
 	 * Refer to {@link TiColorHelper#parseColor(String)} for more details.
 	 * @param value  color value to convert.
 	 * @return an int representation of the color.
-	 * @module.api
 	 */
 	public static int toColor(String value)
 	{
@@ -146,7 +145,6 @@ public class TiConvert
 	 * @param hashMap the HashMap contains the String representation of the color.
 	 * @param key the color lookup key.
 	 * @return an int representation of the color.
-	 * @module.api
 	 */
 	public static int toColor(HashMap<String, Object> hashMap, String key)
 	{
@@ -326,7 +324,6 @@ public class TiConvert
 	 * @param value the value to convert.
 	 * @param def  the default value.
 	 * @return a boolean value.
-	 * @module.api
 	 */
 	public static boolean toBoolean(Object value, boolean def)
 	{
@@ -345,7 +342,6 @@ public class TiConvert
 	 * an exception is thrown.
 	 * @param value the value to convert.
 	 * @return a boolean value.
-	 * @module.api
 	 */
 	public static boolean toBoolean(Object value)
 	{
@@ -371,7 +367,6 @@ public class TiConvert
 	 * @param key the lookup key.
 	 * @param def the default value.
 	 * @return a boolean value.
-	 * @module.api
 	 */
 	public static boolean toBoolean(HashMap<String, Object> hashMap, String key, boolean def)
 	{
@@ -387,7 +382,6 @@ public class TiConvert
 	 * @param hashMap the hash map to search.
 	 * @param key the lookup key.
 	 * @return a boolean value.
-	 * @module.api
 	 */
 	public static boolean toBoolean(HashMap<String, Object> hashMap, String key)
 	{
@@ -399,7 +393,6 @@ public class TiConvert
 	 * an exception is thrown.
 	 * @param value the value to convert.
 	 * @return an int value.
-	 * @module.api
 	 */
 	public static int toInt(Object value)
 	{
@@ -429,7 +422,6 @@ public class TiConvert
 	 * @param value the value to convert.
 	 * @param def the default value to return
 	 * @return an int value.
-	 * @module.api
 	 */
 	public static int toInt(Object value, int def)
 	{
@@ -448,7 +440,6 @@ public class TiConvert
 	 * @param hashMap the hash map to search.
 	 * @param key the lookup key.
 	 * @return an int value.
-	 * @module.api
 	 */
 	public static int toInt(HashMap<String, Object> hashMap, String key)
 	{
@@ -460,7 +451,6 @@ public class TiConvert
 	 * an exception is thrown.
 	 * @param value the value to convert.
 	 * @return a float value.
-	 * @module.api
 	 */
 	public static float toFloat(Object value)
 	{
@@ -487,7 +477,6 @@ public class TiConvert
 	 * @param value the value to convert.
 	 * @param def the default value to return
 	 * @return an float value.
-	 * @module.api
 	 */
 	public static float toFloat(Object value, float def)
 	{
@@ -506,7 +495,6 @@ public class TiConvert
 	 * @param hashMap the hash map to search.
 	 * @param key the lookup key.
 	 * @return a float value.
-	 * @module.api
 	 */
 	public static float toFloat(HashMap<String, Object> hashMap, String key)
 	{
@@ -519,7 +507,6 @@ public class TiConvert
 	 * @param key the lookup key.
 	 * @param def the default value to return.
 	 * @return a float value.
-	 * @module.api
 	 */
 	public static float toFloat(HashMap<String, Object> hashMap, String key, float def)
 	{
@@ -531,7 +518,6 @@ public class TiConvert
 	 * an exception is thrown.
 	 * @param value the value to convert.
 	 * @return a double value.
-	 * @module.api
 	 */
 	public static double toDouble(Object value)
 	{
@@ -555,7 +541,6 @@ public class TiConvert
 	 * @param hashMap the hash map to search.
 	 * @param key the lookup key.
 	 * @return a double.
-	 * @module.api
 	 */
 	public static double toDouble(HashMap<String, Object> hashMap, String key)
 	{
@@ -567,7 +552,6 @@ public class TiConvert
 	 * @param value the value to convert.
 	 * @param defaultString the default value.
 	 * @return a String.
-	 * @module.api
 	 */
 	public static String toString(Object value, String defaultString)
 	{
@@ -583,7 +567,6 @@ public class TiConvert
 	 * Converts a value into a String. If value is null, returns null.
 	 * @param value the value to convert.
 	 * @return String or null.
-	 * @module.api
 	 */
 	public static String toString(Object value)
 	{
@@ -595,7 +578,6 @@ public class TiConvert
 	 * @param hashMap the hash map to search.
 	 * @param key the lookup key.
 	 * @return String or null.
-	 * @module.api
 	 */
 	public static String toString(HashMap<String, Object> hashMap, String key)
 	{
@@ -606,7 +588,6 @@ public class TiConvert
 	 * Converts an Object array into a String array.
 	 * @param parts the object array to convert
 	 * @return a String array.
-	 * @module.api
 	 */
 	public static String[] toStringArray(Object[] parts)
 	{
@@ -706,7 +687,6 @@ public class TiConvert
 	 * Casts and returns value as TiBlob.
 	 * @param value must be of type TiBlob.
 	 * @return a TiBlob instance.
-	 * @module.api
 	 */
 	public static TiBlob toBlob(Object value)
 	{
@@ -719,7 +699,6 @@ public class TiConvert
 	 * @param object the hashmap.
 	 * @param property the lookup key.
 	 * @return a TiBlob instance.
-	 * @module.api
 	 */
 	public static TiBlob toBlob(HashMap<String, Object> object, String property)
 	{
@@ -823,7 +802,6 @@ public class TiConvert
 	 * return a String representation of value.
 	 * @param value the value to convert.
 	 * @return a String.
-	 * @module.api
 	 */
 	public static String toJSONString(Object value)
 	{
@@ -842,7 +820,6 @@ public class TiConvert
 	 * Converts value into Date object and returns it.
 	 * @param value the value to convert.
 	 * @return a Date instance.
-	 * @module.api
 	 */
 	public static Date toDate(Object value)
 	{
@@ -864,7 +841,6 @@ public class TiConvert
 	 * @param hashMap the hash map to search.
 	 * @param key the lookup key
 	 * @return a Date instance.
-	 * @module.api
 	 */
 	public static Date toDate(HashMap<String, Object> hashMap, String key)
 	{

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiDownloadManager.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiDownloadManager.java
@@ -42,9 +42,8 @@ public class TiDownloadManager implements Handler.Callback
 	protected static TiDownloadManager _instance;
 	public static final int THREAD_POOL_SIZE = 2;
 
-	protected HashMap<String, ArrayList<SoftReference<TiDownloadListener>>> listeners =
-		new HashMap<String, ArrayList<SoftReference<TiDownloadListener>>>();
-	protected ArrayList<String> downloadingURIs = new ArrayList<String>();
+	protected HashMap<String, ArrayList<SoftReference<TiDownloadListener>>> listeners = new HashMap<>();
+	protected ArrayList<String> downloadingURIs = new ArrayList<>();
 	protected ExecutorService threadPool;
 	protected Handler handler;
 

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiEventHelper.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiEventHelper.java
@@ -37,7 +37,7 @@ public class TiEventHelper
 			fireViewEvent(view, type, (Map<String, Object>) null);
 		}
 
-		Map<String, Object> extraProperties = new HashMap<String, Object>();
+		Map<String, Object> extraProperties = new HashMap<>();
 		for (int i = 0; i < properties.length; i++) {
 			if (i + 1 < properties.length) {
 				extraProperties.put(properties[i], properties[++i]);

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiFileHelper.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiFileHelper.java
@@ -62,24 +62,24 @@ public class TiFileHelper
 
 	public TiFileHelper(Context context)
 	{
-		softContext = new SoftReference<Context>(context);
+		softContext = new SoftReference<>(context);
 		this.nph = new TiNinePatchHelper();
 		if (resourcePathCache == null) {
-			resourcePathCache = new HashSet<String>();
-			foundResourcePathCache = new HashSet<String>();
-			notFoundResourcePathCache = new HashSet<String>();
+			resourcePathCache = new HashSet<>();
+			foundResourcePathCache = new HashSet<>();
+			notFoundResourcePathCache = new HashSet<>();
 		}
 
 		if (resourcePathCache == null) {
-			resourcePathCache = new HashSet<String>();
-			foundResourcePathCache = new HashSet<String>();
-			notFoundResourcePathCache = new HashSet<String>();
+			resourcePathCache = new HashSet<>();
+			foundResourcePathCache = new HashSet<>();
+			notFoundResourcePathCache = new HashSet<>();
 		}
 
 		synchronized (TI_DIR)
 		{
 			if (systemIcons == null) {
-				systemIcons = new HashMap<String, Integer>();
+				systemIcons = new HashMap<>();
 				systemIcons.put("ic_menu_camera", android.R.drawable.ic_menu_camera);
 				//systemIcons.put("ic_menu_compose", android.R.drawable.ic_menu_compose);
 				systemIcons.put("ic_menu_search", android.R.drawable.ic_menu_search);
@@ -402,7 +402,7 @@ public class TiFileHelper
 	{
 		Context ctx = softContext.get();
 		if (ctx != null) {
-			ArrayList<String> paths = new ArrayList<String>();
+			ArrayList<String> paths = new ArrayList<>();
 			AssetManager am = ctx.getAssets();
 			walkAssets(am, "", paths);
 
@@ -696,9 +696,7 @@ public class TiFileHelper
 			String name = ze.getName();
 			zis.closeEntry();
 
-			if (name.startsWith(MACOSX_PREFIX)) {
-				continue;
-			} else {
+			if (!name.startsWith(MACOSX_PREFIX)) {
 				if (name.indexOf("tiapp.xml") > -1) {
 					String[] segments = name.split("\\/");
 					if (segments.length == 2) {

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiLoadImageManager.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiLoadImageManager.java
@@ -31,9 +31,8 @@ public class TiLoadImageManager implements Handler.Callback
 	protected static TiLoadImageManager _instance;
 	public static final int THREAD_POOL_SIZE = 2;
 
-	protected SparseArray<ArrayList<SoftReference<TiLoadImageListener>>> listeners =
-		new SparseArray<ArrayList<SoftReference<TiLoadImageListener>>>();
-	protected ArrayList<Integer> loadingImageRefs = new ArrayList<Integer>();
+	protected SparseArray<ArrayList<SoftReference<TiLoadImageListener>>> listeners = new SparseArray<>();
+	protected ArrayList<Integer> loadingImageRefs = new ArrayList<>();
 	protected ExecutorService threadPool;
 	protected Handler handler;
 

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiLocationHelper.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiLocationHelper.java
@@ -33,7 +33,7 @@ public class TiLocationHelper
 
 	private static final String TAG = "TiLocationHelper";
 
-	private static AtomicInteger listenerCount = new AtomicInteger();
+	private static final AtomicInteger listenerCount = new AtomicInteger();
 	private static LocationManager locationManager;
 
 	public static LocationManager getLocationManager()

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiMimeTypeHelper.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiMimeTypeHelper.java
@@ -27,7 +27,7 @@ public class TiMimeTypeHelper
 	public static final String MIME_TYPE_OCTET_STREAM = DEFAULT_MIME_TYPE;
 	public static final String MIME_TYPE_JAVASCRIPT = "text/javascript";
 	public static final String MIME_TYPE_HTML = "text/html";
-	public static final HashMap<String, String> EXTRA_MIMETYPES = new HashMap<String, String>();
+	public static final HashMap<String, String> EXTRA_MIMETYPES = new HashMap<>();
 	static
 	{
 		EXTRA_MIMETYPES.put("js", MIME_TYPE_JAVASCRIPT);

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiNinePatchHelper.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiNinePatchHelper.java
@@ -18,7 +18,7 @@ import android.graphics.drawable.NinePatchDrawable;
 @SuppressWarnings("deprecation")
 public class TiNinePatchHelper
 {
-	class SegmentColor
+	private static class SegmentColor
 	{
 		int index;
 		int color;
@@ -145,7 +145,7 @@ public class TiNinePatchHelper
 
 		int last = b.getPixel(0, 0);
 
-		ArrayList<SegmentColor> xdivs = new ArrayList<SegmentColor>();
+		ArrayList<SegmentColor> xdivs = new ArrayList<>();
 		// Walk Top
 		for (int x = 1; x < b.getWidth(); x++) {
 			int p = b.getPixel(x, 0);
@@ -162,7 +162,7 @@ public class TiNinePatchHelper
 		last = b.getPixel(0, 0);
 
 		// Walk left
-		ArrayList<SegmentColor> ydivs = new ArrayList<SegmentColor>();
+		ArrayList<SegmentColor> ydivs = new ArrayList<>();
 		for (int y = 1; y < b.getHeight(); y++) {
 			int p = b.getPixel(0, y);
 			if (p != last) {
@@ -176,7 +176,7 @@ public class TiNinePatchHelper
 		}
 
 		// Calculate Region Colors
-		ArrayList<Integer> colors = new ArrayList<Integer>();
+		ArrayList<Integer> colors = new ArrayList<>();
 		for (int y = 0; y < ydivs.size(); y++) {
 			int yc = ydivs.get(y).color;
 			for (int x = 0; x < xdivs.size(); x++) {

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiPlatformHelper.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiPlatformHelper.java
@@ -28,20 +28,20 @@ public class TiPlatformHelper
 {
 	public static final String TAG = "TiPlatformHelper";
 	private static final Map<String, Locale> locales =
-		java.util.Collections.synchronizedMap(new HashMap<String, Locale>());
+		java.util.Collections.synchronizedMap(new HashMap<>());
 	private static final Map<Locale, String> currencyCodes =
-		java.util.Collections.synchronizedMap(new HashMap<Locale, String>());
+		java.util.Collections.synchronizedMap(new HashMap<>());
 	private static final Map<Locale, String> currencySymbols =
-		java.util.Collections.synchronizedMap(new HashMap<Locale, String>());
+		java.util.Collections.synchronizedMap(new HashMap<>());
 	private static final Map<String, String> currencySymbolsByCode =
-		java.util.Collections.synchronizedMap(new HashMap<String, String>());
+		java.util.Collections.synchronizedMap(new HashMap<>());
 
 	private static class InstanceHolder
 	{
 		private static final TiPlatformHelper INSTANCE = new TiPlatformHelper();
 	}
 
-	public static final TiPlatformHelper getInstance()
+	public static TiPlatformHelper getInstance()
 	{
 		return InstanceHolder.INSTANCE;
 	}
@@ -147,11 +147,11 @@ public class TiPlatformHelper
 	public String getIpAddress()
 	{
 		String ipAddress = null;
-		TiApplication tiApp = TiApplication.getInstance();
+		Context context = TiApplication.getInstance().getApplicationContext();
 
-		if (tiApp.getRootActivity().checkCallingOrSelfPermission(Manifest.permission.ACCESS_WIFI_STATE)
+		if (context.checkCallingOrSelfPermission(Manifest.permission.ACCESS_WIFI_STATE)
 			== PackageManager.PERMISSION_GRANTED) {
-			WifiManager wifiManager = (WifiManager) tiApp.getRootActivity().getSystemService(Context.WIFI_SERVICE);
+			WifiManager wifiManager = (WifiManager) context.getSystemService(Context.WIFI_SERVICE);
 			if (wifiManager != null) {
 				WifiInfo wifiInfo = wifiManager.getConnectionInfo();
 				if (wifiInfo != null) {
@@ -173,11 +173,11 @@ public class TiPlatformHelper
 	public String getNetmask()
 	{
 		String netmask = null;
-		TiApplication tiApp = TiApplication.getInstance();
+		Context context = TiApplication.getInstance().getApplicationContext();
 
-		if (tiApp.getRootActivity().checkCallingOrSelfPermission(Manifest.permission.ACCESS_WIFI_STATE)
+		if (context.checkCallingOrSelfPermission(Manifest.permission.ACCESS_WIFI_STATE)
 			== PackageManager.PERMISSION_GRANTED) {
-			WifiManager wifiManager = (WifiManager) tiApp.getRootActivity().getSystemService(Context.WIFI_SERVICE);
+			WifiManager wifiManager = (WifiManager) context.getSystemService(Context.WIFI_SERVICE);
 			if (wifiManager != null) {
 				DhcpInfo dhcpInfo = wifiManager.getDhcpInfo();
 				if (dhcpInfo != null) {

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiRHelper.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiRHelper.java
@@ -22,15 +22,14 @@ public class TiRHelper
 {
 	private static final String TAG = "TiRHelper";
 
-	private static Map<String, Class<?>> clsCache = Collections.synchronizedMap(new HashMap<String, Class<?>>());
-	private static Map<String, Integer> valCache = Collections.synchronizedMap(new HashMap<String, Integer>());
+	private static final Map<String, Class<?>> clsCache = Collections.synchronizedMap(new HashMap<>());
+	private static final Map<String, Integer> valCache = Collections.synchronizedMap(new HashMap<>());
 
-	private static String clsPrefixAndroid = "android.R$";
+	private static final String clsPrefixAndroid = "android.R$";
 	private static String clsPrefixApplication = null;
 
 	/**
 	 * The exception thrown by TiRHelper when a particular resource is not found.
-	 * @module.api
 	 */
 	public static final class ResourceNotFoundException extends ClassNotFoundException
 	{
@@ -105,11 +104,10 @@ public class TiRHelper
 	 * Searches for an Android compiled resource given its path. These resources are traditionally accessed via a resource ID
 	 * (either from the application's resource bundle, or Android's internal resource bundle)
 	 * @param path the resource's path.
-	 * @param includeSystemResources indicates whether or not {@link #getResource(String, boolean)} will look in the system's (Android)
+	 * @param includeSystemResources Set true to lookup Android system resources.
 	 * resource bundle, if the resource is not found in the application's resource bundle.
 	 * @return the resource, if found.
 	 * @throws ResourceNotFoundException the exception thrown when the resource is not found in either location listed above.
-	 * @module.api
 	 */
 	public static int getResource(String path, boolean includeSystemResources) throws ResourceNotFoundException
 	{
@@ -136,7 +134,6 @@ public class TiRHelper
 	 * @return the resource, if found.
 	 * @throws ResourceNotFoundException the exception thrown when the resource is not found in either
 	 * the application's resource bundle, or Android's internal resource bundle.
-	 * @module.api
 	 */
 	public static int getResource(String path) throws ResourceNotFoundException
 	{
@@ -147,7 +144,6 @@ public class TiRHelper
 	 * Checks if the given resource path exists. Refer to {@link #getResource(String)} for more details.
 	 * @param path the resource's path
 	 * @return whether or not the resource exists in the application's resource bundle.
-	 * @module.api
 	 */
 	public static boolean hasResource(String path)
 	{
@@ -162,7 +158,7 @@ public class TiRHelper
 	/**
 	 * @param path path of the resource.
 	 * @return the application resource given its path.
-	 * @throws ResourceNotFoundException
+	 * @throws ResourceNotFoundException Thrown if given resource name was not found.
 	 */
 	public static int getApplicationResource(String path) throws ResourceNotFoundException
 	{

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiResponseCache.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiResponseCache.java
@@ -47,12 +47,11 @@ public class TiResponseCache extends ResponseCache
 	private static final int DEFAULT_CACHE_SIZE = 25 * 1024 * 1024; // 25MB
 	private static final int INITIAL_DELAY = 10000;
 	private static final int CLEANUP_DELAY = 60000;
-	private static HashMap<String, ArrayList<CompleteListener>> completeListeners = new HashMap<>();
+	private static final HashMap<String, ArrayList<CompleteListener>> completeListeners = new HashMap<>();
 	private static long maxCacheSize = 0;
 
 	// List of Video Media Formats from http://developer.android.com/guide/appendix/media-formats.html
-	private static final List<String> videoFormats =
-		new ArrayList<String>(Arrays.asList("mkv", "webm", "3gp", "mp4", "ts"));
+	private static final List<String> videoFormats = new ArrayList<>(Arrays.asList("mkv", "webm", "3gp", "mp4", "ts"));
 
 	private static ScheduledExecutorService cleanupExecutor = null;
 
@@ -74,13 +73,13 @@ public class TiResponseCache extends ResponseCache
 		public void run()
 		{
 			// Build up a list of access times
-			HashMap<Long, File> lastTime = new HashMap<Long, File>();
+			HashMap<Long, File> lastTime = new HashMap<>();
 			for (File hdrFile : cacheDir.listFiles((dir, name) -> name.endsWith(HEADER_SUFFIX))) {
 				lastTime.put(hdrFile.lastModified(), hdrFile);
 			}
 
 			// Ensure that the cache is under the required size
-			List<Long> sz = new ArrayList<Long>(lastTime.keySet());
+			List<Long> sz = new ArrayList<>(lastTime.keySet());
 			Collections.sort(sz);
 			Collections.reverse(sz);
 			long cacheSize = 0;
@@ -182,7 +181,7 @@ public class TiResponseCache extends ResponseCache
 	 * Check whether the content from uri has been cached. This method is optimized for
 	 * TiResponseCache. For other kinds of ResponseCache, eg. HttpResponseCache, it only
 	 * checks whether the system's default response cache is set.
-	 * @param uri
+	 * @param uri The uri to check if cached content exists for.
 	 * @return true if the content from uri is cached; false otherwise.
 	 */
 	public static boolean peek(URI uri)
@@ -248,7 +247,7 @@ public class TiResponseCache extends ResponseCache
 		// Check if the given URI is cached. If it is, follow its cached redirects if applicable.
 		try {
 			URI nextUri = uri;
-			HashMap<String, List<String>> requestHeaders = new HashMap<String, List<String>>();
+			HashMap<String, List<String>> requestHeaders = new HashMap<>();
 			while (TiResponseCache.peek(nextUri)) {
 				// Fetch the URI's cached response.
 				CacheResponse response = TiResponseCache.getDefault().get(nextUri, "GET", requestHeaders);
@@ -315,7 +314,7 @@ public class TiResponseCache extends ResponseCache
 
 	/**
 	 * Get the cached content for uri. It works for all kinds of ResponseCache.
-	 * @param uri
+	 * @param uri The URI to fetch cached content from.
 	 * @return an InputStream of the cached content
 	 */
 	public static InputStream openCachedStream(URI uri)
@@ -378,7 +377,7 @@ public class TiResponseCache extends ResponseCache
 		{
 			String key = uri.toString();
 			if (!completeListeners.containsKey(key)) {
-				completeListeners.put(key, new ArrayList<CompleteListener>());
+				completeListeners.put(key, new ArrayList<>());
 			}
 			completeListeners.get(key).add(listener);
 		}
@@ -389,7 +388,7 @@ public class TiResponseCache extends ResponseCache
 	public TiResponseCache(File cachedir, TiApplication tiApp)
 	{
 		super();
-		assert cachedir.isDirectory() : "cachedir MUST be a directory";
+
 		this.cacheDir = cachedir;
 
 		maxCacheSize = tiApp.getAppProperties().getInt(CACHE_SIZE_KEY, DEFAULT_CACHE_SIZE) * 1024;
@@ -446,7 +445,7 @@ public class TiResponseCache extends ResponseCache
 	private static Map<String, List<String>> readHeaders(File hFile) throws IOException
 	{
 		// Read in the headers
-		Map<String, List<String>> headers = new HashMap<String, List<String>>();
+		Map<String, List<String>> headers = new HashMap<>();
 		BufferedReader rdr = new BufferedReader(new FileReader(hFile), 1024);
 		for (String line = rdr.readLine(); line != null; line = rdr.readLine()) {
 			String[] keyval = line.split("=", 2);
@@ -459,7 +458,7 @@ public class TiResponseCache extends ResponseCache
 			}
 
 			if (!headers.containsKey(keyval[0])) {
-				headers.put(keyval[0], new ArrayList<String>());
+				headers.put(keyval[0], new ArrayList<>());
 			}
 
 			headers.get(keyval[0]).add(keyval[1]);
@@ -492,7 +491,7 @@ public class TiResponseCache extends ResponseCache
 
 	private Map<String, List<String>> makeLowerCaseHeaders(Map<String, List<String>> origHeaders)
 	{
-		Map<String, List<String>> headers = new HashMap<String, List<String>>(origHeaders.size());
+		Map<String, List<String>> headers = new HashMap<>(origHeaders.size());
 		for (String key : origHeaders.keySet()) {
 			if (key != null) {
 				headers.put(key.toLowerCase(), origHeaders.get(key));

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiStreamHelper.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiStreamHelper.java
@@ -22,7 +22,6 @@ import ti.modules.titanium.BufferProxy;
 
 public class TiStreamHelper
 {
-
 	/**
 	 * Common code for handling JS calls for #read() on a Ti.IOStream.
 	 * @param  TAG         logging tag

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiUIHelper.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiUIHelper.java
@@ -98,9 +98,8 @@ public class TiUIHelper
 	public static final String MIME_TYPE_PNG = "image/png";
 
 	private static Method overridePendingTransition;
-	private static Map<String, String> resourceImageKeys = Collections.synchronizedMap(new HashMap<String, String>());
-	private static Map<String, Typeface> mCustomTypeFaces =
-		Collections.synchronizedMap(new HashMap<String, Typeface>());
+	private static final Map<String, String> resourceImageKeys = Collections.synchronizedMap(new HashMap<>());
+	private static final Map<String, Typeface> mCustomTypeFaces = Collections.synchronizedMap(new HashMap<>());
 
 	public static OnClickListener createDoNothingListener()
 	{
@@ -218,7 +217,7 @@ public class TiUIHelper
 		}
 		final OnClickListener fListener = listener;
 		waitForCurrentActivity(new CurrentActivityListener() {
-			// TODO @Override
+			@Override
 			public void onCurrentActivityReady(Activity activity)
 			{
 				//add dialog to activity for cleaning up purposes
@@ -232,7 +231,7 @@ public class TiUIHelper
 					if (activity instanceof TiBaseActivity) {
 						TiBaseActivity baseActivity = (TiBaseActivity) activity;
 						baseActivity.addDialog(new TiBaseActivity.DialogWrapper(
-							dialog, true, new WeakReference<TiBaseActivity>(baseActivity)));
+							dialog, true, new WeakReference<>(baseActivity)));
 						dialog.setOwnerActivity(activity);
 					}
 					dialog.show();
@@ -622,7 +621,7 @@ public class TiUIHelper
 		// Create an array of the layers that will compose this background.
 		// Note that the order in which the layers is important to get the
 		// correct rendering behavior.
-		ArrayList<Drawable> layers = new ArrayList<Drawable>(3);
+		ArrayList<Drawable> layers = new ArrayList<>(3);
 
 		if (color != null) {
 			Drawable colorDrawable = new ColorDrawable(TiColorHelper.parseColor(color));
@@ -646,7 +645,7 @@ public class TiUIHelper
 			layers.add(imageDrawable);
 		}
 
-		return new LayerDrawable(layers.toArray(new Drawable[layers.size()]));
+		return new LayerDrawable(layers.toArray(new Drawable[0]));
 	}
 
 	public static final int[] BACKGROUND_DEFAULT_STATE_1 = {
@@ -682,7 +681,7 @@ public class TiUIHelper
 			/** Creates a new image drawable loader. */
 			public ImageDrawableLoader()
 			{
-				this.imagePathDrawableMap = new HashMap<String, Drawable>(4);
+				this.imagePathDrawableMap = new HashMap<>(4);
 			}
 
 			/**
@@ -851,7 +850,6 @@ public class TiUIHelper
 	 * Creates and returns a Bitmap from an InputStream.
 	 * @param stream an InputStream to read bitmap data.
 	 * @return a new bitmap instance.
-	 * @module.api
 	 */
 	public static Bitmap createBitmap(InputStream stream)
 	{
@@ -976,7 +974,6 @@ public class TiUIHelper
 	 * Creates and returns a bitmap from its url.
 	 * @param url the bitmap url.
 	 * @return a new bitmap instance
-	 * @module.api
 	 */
 	public static Bitmap getResourceBitmap(String url)
 	{
@@ -992,7 +989,6 @@ public class TiUIHelper
 	 * Creates and returns a bitmap for the specified resource ID.
 	 * @param res_id the bitmap id.
 	 * @return a new bitmap instance.
-	 * @module.api
 	 */
 	public static Bitmap getResourceBitmap(int res_id)
 	{

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiUrl.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiUrl.java
@@ -102,7 +102,7 @@ public class TiUrl
 		return bUrl;
 	}
 
-	private static HashMap<String, TiUrl> proxyUrlCache = new HashMap<String, TiUrl>(5);
+	private static final HashMap<String, TiUrl> proxyUrlCache = new HashMap<>(5);
 	public static TiUrl createProxyUrl(String url)
 	{
 		if (proxyUrlCache.containsKey(url)) {

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiWeakList.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiWeakList.java
@@ -16,7 +16,6 @@ import java.util.NoSuchElementException;
 @SuppressWarnings({ "serial" })
 public class TiWeakList<T> extends ArrayList<WeakReference<T>>
 {
-
 	protected List<WeakReference<T>> synchronizedList;
 
 	public TiWeakList()
@@ -134,7 +133,7 @@ public class TiWeakList<T> extends ArrayList<WeakReference<T>>
 			return -1;
 		}
 
-		// TODO @Override
+		@Override
 		public boolean hasNext()
 		{
 			if (synchronizedList != null) {
@@ -147,7 +146,7 @@ public class TiWeakList<T> extends ArrayList<WeakReference<T>>
 			}
 		}
 
-		// TODO @Override
+		@Override
 		public T next()
 		{
 			if (synchronizedList != null) {
@@ -168,7 +167,7 @@ public class TiWeakList<T> extends ArrayList<WeakReference<T>>
 			}
 		}
 
-		// TODO @Override
+		@Override
 		public void remove()
 		{
 			if (synchronizedList != null) {

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiWeakMap.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiWeakMap.java
@@ -12,7 +12,6 @@ import java.util.HashMap;
 @SuppressWarnings("serial")
 public class TiWeakMap<K, V> extends HashMap<WeakReference<K>, V>
 {
-
 	@Override
 	public boolean containsKey(Object object)
 	{

--- a/android/titanium/src/java/org/appcelerator/titanium/view/Ti2DMatrix.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/Ti2DMatrix.java
@@ -221,7 +221,7 @@ public class Ti2DMatrix extends KrollProxy
 	public Matrix interpolate(float interpolatedTime, int childWidth, int childHeight, float anchorX, float anchorY)
 	{
 		Ti2DMatrix first = this;
-		ArrayList<Ti2DMatrix> preMatrixList = new ArrayList<Ti2DMatrix>();
+		ArrayList<Ti2DMatrix> preMatrixList = new ArrayList<>();
 
 		while (first.prev != null) {
 			first = first.prev;
@@ -274,8 +274,8 @@ public class Ti2DMatrix extends KrollProxy
 	 * Checks all of the scale operations in the sequence and sets the appropriate
 	 * scale "from" values for them all (in case they aren't specified), then gives
 	 * back the final scale values that will be in effect when the animation has completed.
-	 * @param view
-	 * @param autoreverse
+	 * @param view The view to be checked.
+	 * @param autoreverse Set true if animation is to be reversed when the end is reached.
 	 * @return Final scale values after the animation has finished.
 	 */
 	public Pair<Float, Float> verifyScaleValues(TiUIView view, boolean autoreverse)
@@ -292,7 +292,7 @@ public class Ti2DMatrix extends KrollProxy
 		}
 
 		Pair<Float, Float> viewCurrentScale =
-			(view == null ? Pair.create(Float.valueOf(1f), Float.valueOf(1f)) : view.getAnimatedScaleValues());
+			(view == null ? Pair.create(1.0f, 1.0f) : view.getAnimatedScaleValues());
 
 		if (scaleOps.size() == 0) {
 			return viewCurrentScale;
@@ -326,13 +326,13 @@ public class Ti2DMatrix extends KrollProxy
 	 * Checks all of the rotate operations in the sequence and sets the appropriate
 	 * "from" value for them all (in case they aren't specified), then gives
 	 * back the final value that will be in effect when the animation has completed.
-	 * @param view
-	 * @param autoreverse
+	 * @param view The view to be checked.
+	 * @param autoreverse Set true to reverse the animation when it reaches the end.
 	 * @return Final rotation value after the animation has finished.
 	 */
 	public float verifyRotationValues(TiUIView view, boolean autoreverse)
 	{
-		ArrayList<Operation> rotationOps = new ArrayList<Operation>();
+		ArrayList<Operation> rotationOps = new ArrayList<>();
 
 		Ti2DMatrix check = this;
 		while (check != null) {
@@ -448,7 +448,7 @@ public class Ti2DMatrix extends KrollProxy
 	 */
 	public List<Operation> getAllOperations()
 	{
-		List<Operation> ops = new ArrayList<Operation>();
+		List<Operation> ops = new ArrayList<>();
 		Ti2DMatrix toCheck = this;
 
 		while (toCheck != null) {

--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiBackgroundColorWrapper.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiBackgroundColorWrapper.java
@@ -162,7 +162,6 @@ public class TiBackgroundColorWrapper
 		} catch (Exception e) {
 			Log.e(TAG, "Reflection failed while trying to determine background color of view.", e);
 			cdBackgroundStateColorField = null;
-			return;
 		}
 	}
 

--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiBackgroundDrawable.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiBackgroundDrawable.java
@@ -26,7 +26,6 @@ import android.util.AttributeSet;
 
 public class TiBackgroundDrawable extends StateListDrawable
 {
-
 	private Drawable background;
 	private RectF innerRect;
 	private static final int NOT_SET = -1;

--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiBorderWrapperView.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiBorderWrapperView.java
@@ -35,7 +35,7 @@ public class TiBorderWrapperView extends FrameLayout
 
 	private int color = Color.TRANSPARENT;
 	private int backgroundColor = Color.TRANSPARENT;
-	private float[] radius = { 0, 0, 0, 0, 0, 0, 0, 0 };
+	private final float[] radius = { 0, 0, 0, 0, 0, 0, 0, 0 };
 	private float borderWidth = 0;
 	private int alpha = -1;
 	private Paint paint;

--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiCompositeLayout.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiCompositeLayout.java
@@ -34,8 +34,6 @@ public class TiCompositeLayout extends ViewGroup implements OnHierarchyChangeLis
 {
 	/**
 	 * Supported layout arrangements
-	 *
-	 * @module.api
 	 */
 	public enum LayoutArrangement {
 		/**
@@ -109,7 +107,6 @@ public class TiCompositeLayout extends ViewGroup implements OnHierarchyChangeLis
 	 * Constructs a new TiCompositeLayout object.
 	 *
 	 * @param context the associated context.
-	 * @module.api
 	 */
 	public TiCompositeLayout(Context context)
 	{
@@ -121,7 +118,6 @@ public class TiCompositeLayout extends ViewGroup implements OnHierarchyChangeLis
 	 *
 	 * @param context the associated context.
 	 * @param arrangement the associated LayoutArrangement
-	 * @module.api
 	 */
 	public TiCompositeLayout(Context context, LayoutArrangement arrangement)
 	{
@@ -169,7 +165,7 @@ public class TiCompositeLayout extends ViewGroup implements OnHierarchyChangeLis
 		super(context, set);
 
 		this.arrangement = arrangement;
-		this.viewSorter = new TreeSet<View>(new Comparator<View>() {
+		this.viewSorter = new TreeSet<>(new Comparator<View>() {
 			public int compare(View o1, View o2)
 			{
 				// TIMOB-20206 and
@@ -227,7 +223,7 @@ public class TiCompositeLayout extends ViewGroup implements OnHierarchyChangeLis
 
 		setNeedsSort(true);
 		setOnHierarchyChangeListener(this);
-		this.proxy = new WeakReference<TiViewProxy>(proxy);
+		this.proxy = new WeakReference<>(proxy);
 	}
 
 	private String viewToString(View view)
@@ -1132,8 +1128,6 @@ public class TiCompositeLayout extends ViewGroup implements OnHierarchyChangeLis
 		 * {@link #sizeOrFillWidthEnabled} is true, then we use the size
 		 * behavior, which constrains the view width to fit the width of its
 		 * contents.
-		 *
-		 * @module.api
 		 */
 		public boolean autoFillsWidth = false;
 
@@ -1144,8 +1138,6 @@ public class TiCompositeLayout extends ViewGroup implements OnHierarchyChangeLis
 		 * {@link #sizeOrFillHeightEnabled} is true, then we use the size
 		 * behavior, which constrains the view height to fit the height of its
 		 * contents.
-		 *
-		 * @module.api
 		 */
 		public boolean autoFillsHeight = false;
 
@@ -1254,7 +1246,7 @@ public class TiCompositeLayout extends ViewGroup implements OnHierarchyChangeLis
 
 	public void setProxy(TiViewProxy proxy)
 	{
-		this.proxy = new WeakReference<TiViewProxy>(proxy);
+		this.proxy = new WeakReference<>(proxy);
 	}
 
 	private void setNeedsSort(boolean value)

--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiDrawableReference.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiDrawableReference.java
@@ -89,7 +89,7 @@ public class TiDrawableReference
 	public TiDrawableReference(Activity activity, DrawableReferenceType type)
 	{
 		this.type = type;
-		softActivity = new SoftReference<Activity>(activity);
+		softActivity = new SoftReference<>(activity);
 		ApplicationInfo appInfo;
 
 		if (activity != null) {
@@ -140,7 +140,6 @@ public class TiDrawableReference
 	 * @param activity the referenced activity.
 	 * @param blob the referenced blob.
 	 * @return A ready instance of TiDrawableReference.
-	 * @module.api
 	 */
 	public static TiDrawableReference fromBlob(Activity activity, TiBlob blob)
 	{
@@ -154,7 +153,6 @@ public class TiDrawableReference
 	 * @param proxy the activity proxy.
 	 * @param url the url to resolve.
 	 * @return A ready instance of TiDrawableReference.
-	 * @module.api
 	 */
 	public static TiDrawableReference fromUrl(KrollProxy proxy, String url)
 	{
@@ -176,7 +174,6 @@ public class TiDrawableReference
 	 * @param activity the referenced activity.
 	 * @param url the resource's url.
 	 * @return A ready instance of TiDrawableReference.
-	 * @module.api
 	 */
 	public static TiDrawableReference fromUrl(Activity activity, String url)
 	{
@@ -228,7 +225,6 @@ public class TiDrawableReference
 	 * @param proxy Used to acquire an activty and resolve relative paths if given object is a string path.
 	 * @param object Reference to the image to be loaded such as a file, path, blob, etc.
 	 * @return Returns an instance of TiDrawableReference wrapping the given object.
-	 * @module.api
 	 */
 	public static TiDrawableReference fromObject(KrollProxy proxy, Object object)
 	{
@@ -254,7 +250,6 @@ public class TiDrawableReference
 	 * @param activity the referenced activity.
 	 * @param object the referenced object.
 	 * @return A ready instance of TiDrawableReference.
-	 * @module.api
 	 */
 	public static TiDrawableReference fromObject(Activity activity, Object object)
 	{
@@ -313,7 +308,6 @@ public class TiDrawableReference
 	/**
 	 * Gets the bitmap from the resource without respect to sampling/scaling.
 	 * @return Bitmap, or null if errors occurred while trying to load or fetch it.
-	 * @module.api
 	 */
 	public Bitmap getBitmap()
 	{
@@ -329,7 +323,6 @@ public class TiDrawableReference
 	 * the thread if it needs to retry several times.
 	 * @param needRetry If true, it will retry loading when decode fails.
 	 * @return Bitmap, or null if errors occurred while trying to load or fetch it.
-	 * @module.api
 	 */
 	public Bitmap getBitmap(boolean needRetry)
 	{

--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiUIFragment.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiUIFragment.java
@@ -56,7 +56,7 @@ public abstract class TiUIFragment extends TiUIView implements Handler.Callback
 		}
 	}
 
-	private Runnable onCommitRunnable = new Runnable() {
+	private final Runnable onCommitRunnable = new Runnable() {
 		@Override
 		public void run()
 		{

--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiUIView.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiUIView.java
@@ -106,7 +106,7 @@ public abstract class TiUIView implements KrollProxyListener, OnFocusChangeListe
 
 	protected TiViewProxy proxy;
 	protected TiViewProxy parent;
-	protected ArrayList<TiUIView> children = new ArrayList<TiUIView>();
+	protected ArrayList<TiUIView> children = new ArrayList<>();
 
 	protected LayoutParams layoutParams;
 	protected TiAnimationBuilder animBuilder;
@@ -149,13 +149,12 @@ public abstract class TiUIView implements KrollProxyListener, OnFocusChangeListe
 
 	protected GestureDetector detector = null;
 
-	private AtomicBoolean bLayoutPending = new AtomicBoolean();
-	private AtomicBoolean bTransformPending = new AtomicBoolean();
+	private final AtomicBoolean bLayoutPending = new AtomicBoolean();
+	private final AtomicBoolean bTransformPending = new AtomicBoolean();
 
 	/**
 	 * Constructs a TiUIView object with the associated proxy.
 	 * @param proxy the associated proxy.
-	 * @module.api
 	 */
 	public TiUIView(TiViewProxy proxy)
 	{
@@ -264,7 +263,6 @@ public abstract class TiUIView implements KrollProxyListener, OnFocusChangeListe
 
 	/**
 	 * @return the view proxy.
-	 * @module.api
 	 */
 	public TiViewProxy getProxy()
 	{
@@ -274,7 +272,6 @@ public abstract class TiUIView implements KrollProxyListener, OnFocusChangeListe
 	/**
 	 * Sets the view proxy.
 	 * @param proxy the proxy to set.
-	 * @module.api
 	 */
 	public void setProxy(TiViewProxy proxy)
 	{
@@ -293,7 +290,6 @@ public abstract class TiUIView implements KrollProxyListener, OnFocusChangeListe
 
 	/**
 	 * @return the view's layout params.
-	 * @module.api
 	 */
 	public LayoutParams getLayoutParams()
 	{
@@ -302,7 +298,6 @@ public abstract class TiUIView implements KrollProxyListener, OnFocusChangeListe
 
 	/**
 	 * @return the Android native view.
-	 * @module.api
 	 */
 	public View getNativeView()
 	{
@@ -312,7 +307,6 @@ public abstract class TiUIView implements KrollProxyListener, OnFocusChangeListe
 	/**
 	 * Sets the nativeView to view.
 	 * @param view the view to set
-	 * @module.api
 	 */
 	protected void setNativeView(View view)
 	{
@@ -472,7 +466,7 @@ public abstract class TiUIView implements KrollProxyListener, OnFocusChangeListe
 				(new Ti2DMatrix()).rotate(new Object[] { 0d }).translate(0d, 0d).scale(new Object[] { 1d, 1d });
 		}
 
-		HashMap<String, Object> options = new HashMap<String, Object>(2);
+		HashMap<String, Object> options = new HashMap<>(2);
 		options.put(TiC.PROPERTY_TRANSFORM, matrixApply);
 		options.put(TiC.PROPERTY_DURATION, 1);
 
@@ -572,7 +566,7 @@ public abstract class TiUIView implements KrollProxyListener, OnFocusChangeListe
 	{
 		if (nativeView != null) {
 			Animation a = nativeView.getAnimation();
-			if (a != null && a instanceof TiMatrixAnimation) {
+			if (a instanceof TiMatrixAnimation) {
 				TiMatrixAnimation matrixAnimation = (TiMatrixAnimation) a;
 				matrixAnimation.invalidateWithMatrix(nativeView);
 			}
@@ -1532,7 +1526,7 @@ public abstract class TiUIView implements KrollProxyListener, OnFocusChangeListe
 		borderView.postInvalidate();
 	}
 
-	private static SparseArray<String> motionEvents = new SparseArray<String>();
+	private static final SparseArray<String> motionEvents = new SparseArray<>();
 	static
 	{
 		motionEvents.put(MotionEvent.ACTION_DOWN, TiC.EVENT_TOUCH_START);
@@ -1620,9 +1614,6 @@ public abstract class TiUIView implements KrollProxyListener, OnFocusChangeListe
 		return true;
 	}
 
-	/**
-	 * @module.api
-	 */
 	protected boolean allowRegisterForKeyPress()
 	{
 		return true;
@@ -1642,14 +1633,13 @@ public abstract class TiUIView implements KrollProxyListener, OnFocusChangeListe
 
 	protected void registerTouchEvents(final View touchable)
 	{
-
-		touchView = new WeakReference<View>(touchable);
+		touchView = new WeakReference<>(touchable);
 
 		final ScaleGestureDetector scaleDetector =
 			new ScaleGestureDetector(touchable.getContext(), new SimpleOnScaleGestureListener() {
 				// protect from divide by zero errors
-				long minTimeDelta = 1;
-				float minStartSpan = 1.0f;
+				final long minTimeDelta = 1;
+				final float minStartSpan = 1.0f;
 				float startSpan;
 
 				@Override
@@ -1759,6 +1749,7 @@ public abstract class TiUIView implements KrollProxyListener, OnFocusChangeListe
 		touchable.setOnTouchListener(new OnTouchListener() {
 			int pointersDown = 0;
 
+			@Override
 			public boolean onTouch(View view, MotionEvent event)
 			{
 				if (event.getAction() == MotionEvent.ACTION_UP) {

--- a/android/titanium/src/java/ti/modules/titanium/BufferProxy.java
+++ b/android/titanium/src/java/ti/modules/titanium/BufferProxy.java
@@ -125,7 +125,6 @@ public class BufferProxy extends KrollProxy
 
 	/**
 	 * @return The native buffer for this proxy
-	 * @module.api
 	 */
 	public byte[] getBuffer()
 	{
@@ -182,7 +181,6 @@ public class BufferProxy extends KrollProxy
 	 * @param sourceOffset the offset position of the sourceBuffer.
 	 * @param sourceLength the length of the sourceBuffer.
 	 * @return number of bytes written, -1 if no data is available.
-	 * @module.api
 	 */
 	public int write(int position, byte[] sourceBuffer, int sourceOffset, int sourceLength)
 	{
@@ -364,7 +362,6 @@ public class BufferProxy extends KrollProxy
 
 	/**
 	 * @return The length of this buffer in bytes
-	 * @module.api
 	 */
 	@Kroll.getProperty
 	public int getLength()
@@ -376,7 +373,6 @@ public class BufferProxy extends KrollProxy
 	 * Sets the length of this buffer proxy by either growing or shrinking
 	 * the allocated buffer space
 	 * @param length The new length of this buffer proxy in bytes
-	 * @module.api
 	 */
 	@Kroll.setProperty
 	public void setLength(int length)

--- a/android/titanium/src/java/ti/modules/titanium/TitaniumModule.java
+++ b/android/titanium/src/java/ti/modules/titanium/TitaniumModule.java
@@ -40,15 +40,13 @@ public class TitaniumModule extends KrollModule
 	private static final int MSG_ALERT = KrollProxy.MSG_LAST_ID + 100;
 
 	private Stack<String> basePath;
-	private Map<String, NumberFormat> numberFormats =
-		java.util.Collections.synchronizedMap(new HashMap<String, NumberFormat>());
-
-	private static final SparseArray<Timer> activeTimers = new SparseArray<TitaniumModule.Timer>();
+	private final Map<String, NumberFormat> numberFormats = java.util.Collections.synchronizedMap(new HashMap<>());
+	private static final SparseArray<Timer> activeTimers = new SparseArray<>();
 	private static int lastTimerId = 1;
 
 	public TitaniumModule()
 	{
-		basePath = new Stack<String>();
+		basePath = new Stack<>();
 	}
 
 	@Override

--- a/apidoc/Titanium/Geolocation/Geolocation.yml
+++ b/apidoc/Titanium/Geolocation/Geolocation.yml
@@ -771,6 +771,7 @@ properties:
   - name: frequency
     deprecated:
         since: "2.0.0"
+        removed: "8.0.0"
         notes: |
             Android legacy mode operation is deprecated. For new development, use
             either simple mode or manual mode. See "Configurating Location Updates on Android"
@@ -822,6 +823,7 @@ properties:
   - name: preferredProvider
     deprecated:
         since: "2.0.0"
+        removed: "8.0.0"
         notes: |
             Android legacy mode operation is deprecated. For new development, use
             either simple mode or manual mode. See "Configurating Location Updates on Android"

--- a/apidoc/Titanium/Geolocation/Geolocation.yml
+++ b/apidoc/Titanium/Geolocation/Geolocation.yml
@@ -785,6 +785,7 @@ properties:
          A lower frequency value generally increases power consumption.
         A value of 0 means that updates should be generated as quickly as possible.
     type: Number
+    platforms: [android]
 
   - name: hasCompass
     summary: Indicates whether the current device supports a compass.


### PR DESCRIPTION
**Summary:**
Fixes most (but not all) Java lint warnings reported by Android Studio.
- Removed all `@module.api` javadoc tags.
- Made member variables `final` if assigned upon declaration.
- Made inner classes static if possible.
- Leveraged Java 7 diamond operator. Ex: `ArrayList<String> list = new ArrayList<>();`
- Initialized `toArray()` calls with zero length array. (Slight optimization.)
