### PR TITLE
Fix usage of variables before definition

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,6 +4,7 @@
     "sourceType": "script"
   },
   "rules": {
+    "no-use-before-define": ["error", { "functions": false, "classes": false, "variables": true }],
     "promise/catch-or-return": [ "warn", { "terminationMethod": [ "catch", "finally" ]} ]
   },
   "overrides": [

--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -5776,6 +5776,8 @@ iOSBuilder.prototype.createAppIconSetAndiTunesArtwork = async function createApp
 	let defaultIconChanged = false;
 	let defaultIconHasAlpha = false;
 	const defaultIcon = this.defaultIcons.find(icon => fs.existsSync(icon));
+	const flattenedDefaultIconDest = path.join(this.buildDir, 'DefaultIcon.png');
+
 	if (defaultIcon) {
 		const defaultIconPrev = this.previousBuildManifest.files && this.previousBuildManifest.files['DefaultIcon.png'],
 			defaultIconContents = fs.readFileSync(defaultIcon),
@@ -5942,7 +5944,6 @@ iOSBuilder.prototype.createAppIconSetAndiTunesArtwork = async function createApp
 	missingIcons = missingIcons.concat(await this.processLaunchLogos(launchLogos, resourcesToCopy, defaultIcon, defaultIconChanged));
 
 	// Do we need to flatten the default icon?
-	const flattenedDefaultIconDest = path.join(this.buildDir, 'DefaultIcon.png');
 	if (missingIcons.length !== 0 && defaultIcon && defaultIconChanged && defaultIconHasAlpha) {
 		this.defaultIcons = [ flattenedDefaultIconDest ];
 		flattenIcons.push({

--- a/tests/Resources/ti.ui.listview.test.js
+++ b/tests/Resources/ti.ui.listview.test.js
@@ -1016,6 +1016,8 @@ describe('Titanium.UI.ListView', function () {
 			extendEdges: [ Ti.UI.EXTEND_EDGE_ALL ]
 		});
 
+		const control = Ti.UI.createRefreshControl();
+
 		window.addEventListener('open', function () {
 			control.beginRefreshing();
 		});
@@ -1023,8 +1025,6 @@ describe('Titanium.UI.ListView', function () {
 		const nav = Ti.UI.createNavigationWindow({
 			window: window
 		});
-
-		const control = Ti.UI.createRefreshControl();
 
 		const listView = Ti.UI.createListView({
 			refreshControl: control


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-28401

This PR is 2 parts:

* Add the [no-use-before-define](https://eslint.org/docs/rules/no-use-before-define) rule to the eslint config for variables only
* Fix the errors that arise from that. Whilst not all of them would cause the same issue due to being used in event handlers, it's better to be safe imo

This fixes the issue in the linked ticket (originally from https://github.com/appcelerator/titanium_mobile/discussions/12600)