### PR TITLE
[Backport 10_0_X] fix(ios): update layout after assigning label property

### DIFF
--- a/iphone/Classes/TiUIButtonBar.m
+++ b/iphone/Classes/TiUIButtonBar.m
@@ -236,6 +236,7 @@
     }
     [segmentedControl setSelectedSegmentIndex:selectedIndex];
   }
+  [(TiViewProxy *)[self proxy] contentsWillChange];
 }
 
 - (IBAction)onSegmentChange:(id)sender


### PR DESCRIPTION
Backport of #12526.
See that PR for full details.