### PR TITLE
[Backport 10_0_X] fix(ios): removing eventListener in location event will freeze app

### DIFF
--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/ObjcProxy.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/ObjcProxy.m
@@ -251,9 +251,12 @@
   pthread_rwlock_rdlock(&_listenerLock);
   @try {
     if (_listeners == nil) {
+      pthread_rwlock_unlock(&_listenerLock);
       return;
     }
-    NSArray *listenersForType = [_listeners objectForKey:name];
+    NSArray *listenersForType = [[_listeners objectForKey:name] copy];
+    pthread_rwlock_unlock(&_listenerLock);
+
     if (listenersForType == nil) {
       return;
     }
@@ -261,9 +264,9 @@
     for (JSValue *storedCallback in listenersForType) {
       [self _fireEventToListener:name withObject:dict listener:storedCallback];
     }
+    [listenersForType autorelease];
   }
   @finally {
-    pthread_rwlock_unlock(&_listenerLock);
   }
 }
 


### PR DESCRIPTION
Backport of #12542.
See that PR for full details.