### PR TITLE
docs: mark accessors that were autogenerated but documented as removed in 10

### DIFF
--- a/apidoc/Titanium/Android/Intent.yml
+++ b/apidoc/Titanium/Android/Intent.yml
@@ -152,6 +152,10 @@ methods:
     summary: Get the Data URI from this `Intent`.
     returns:
         type: String
+    deprecated:
+      since: "10.0.0"
+      removed: "10.0.0"
+      notes: Use the <Titanium.Android.Intent.data> property instead.
 
   - name: getDoubleExtra
     summary: Get a double property from this `Intent`.

--- a/apidoc/Titanium/Android/MenuItem.yml
+++ b/apidoc/Titanium/Android/MenuItem.yml
@@ -101,7 +101,7 @@ methods:
     deprecated:
       since: "10.0.0"
       removed: "10.0.0"
-      notes: Use the <Titanium.Android.MenuItem.checkable> property instead.
+      notes: Use the <Titanium.Android.MenuItem.visible> property instead.
 
   - name: setCheckable
     summary: Sets the [checkable](Titanium.Android.MenuItem.checkable) state of the menu item.

--- a/apidoc/Titanium/Android/MenuItem.yml
+++ b/apidoc/Titanium/Android/MenuItem.yml
@@ -60,27 +60,48 @@ methods:
         on devices running Android 4.0 (API level 14) and greater.
     returns:
         type: Boolean
+    deprecated:
+      since: "10.0.0"
+      removed: "10.0.0"
+      notes: Use the <Titanium.Android.MenuItem.actionViewExpanded> property instead.
+
 
   - name: isCheckable
     summary: |
         Returns the [checkable](Titanium.Android.MenuItem.checkable) state of the menu item.
     returns:
         type: Boolean
+    deprecated:
+      since: "10.0.0"
+      removed: "10.0.0"
+      notes: Use the <Titanium.Android.MenuItem.checkable> property instead.
 
   - name: isChecked
     summary: Returns the [checked](Titanium.Android.MenuItem.checked) state of the menu item.
     returns:
         type: Boolean
+    deprecated:
+      since: "10.0.0"
+      removed: "10.0.0"
+      notes: Use the <Titanium.Android.MenuItem.checked> property instead.
 
   - name: isEnabled
     summary: Returns the [enabled](Titanium.Android.MenuItem.enabled) state of the menu item.
     returns:
         type: Boolean
+    deprecated:
+      since: "10.0.0"
+      removed: "10.0.0"
+      notes: Use the <Titanium.Android.MenuItem.enabled> property instead.
 
   - name: isVisible
     summary: Returns the [visible](Titanium.Android.MenuItem.visible) state of the menu item.
     returns:
         type: Boolean
+    deprecated:
+      since: "10.0.0"
+      removed: "10.0.0"
+      notes: Use the <Titanium.Android.MenuItem.checkable> property instead.
 
   - name: setCheckable
     summary: Sets the [checkable](Titanium.Android.MenuItem.checkable) state of the menu item.
@@ -88,6 +109,10 @@ methods:
       - name: checkable
         summary: True enable checking and unchecking this item, false to disable it.
         type: Boolean
+    deprecated:
+      since: "10.0.0"
+      removed: "10.0.0"
+      notes: Use the <Titanium.Android.MenuItem.checkable> property instead.
 
   - name: setChecked
     summary: Sets the [checked](Titanium.Android.MenuItem.checked) state of the menu item.
@@ -95,6 +120,10 @@ methods:
       - name: enabled
         summary: True to check the item, false to uncheck it.
         type: Boolean
+    deprecated:
+      since: "10.0.0"
+      removed: "10.0.0"
+      notes: Use the <Titanium.Android.MenuItem.checked> property instead.
 
   - name: setEnabled
     summary: Sets the [enabled](Titanium.Android.MenuItem.enabled) state of the menu item.
@@ -102,6 +131,10 @@ methods:
       - name: enabled
         summary: True to enable item, false to disable it.
         type: Boolean
+    deprecated:
+      since: "10.0.0"
+      removed: "10.0.0"
+      notes: Use the <Titanium.Android.MenuItem.enabled> property instead.
 
   - name: setVisible
     summary: Sets the [visible](Titanium.Android.MenuItem.visible) state of the menu item.
@@ -109,6 +142,10 @@ methods:
       - name: visible
         summary: True to show the item, false to hide it.
         type: Boolean
+    deprecated:
+      since: "10.0.0"
+      removed: "10.0.0"
+      notes: Use the <Titanium.Android.MenuItem.visible> property instead.
 
 events:
   - name: click

--- a/apidoc/Titanium/Network/HTTPClient.yml
+++ b/apidoc/Titanium/Network/HTTPClient.yml
@@ -327,6 +327,11 @@ methods:
       - name: timeout
         summary: Timeout in milliseconds.
         type: Number
+    deprecated:
+      since: "10.0.0"
+      removed: "10.0.0"
+      notes: Use the <Titanium.Network.HTTPClient.timeout> property instead.
+
 
 properties:
   - name: DONE

--- a/apidoc/Titanium/UI/TableView.yml
+++ b/apidoc/Titanium/UI/TableView.yml
@@ -1014,6 +1014,11 @@ methods:
         type: Titanium.UI.View
     platforms: [iphone, ipad, macos]
     since: "2.1.0"
+    deprecated:
+      since: "10.0.0"
+      removed: "10.0.0"
+      notes: Use the <Titanium.UI.TableView.headerPullView> property instead.
+
 
   - name: updateRow
     summary: Updates an existing row, optionally with animation.


### PR DESCRIPTION
This PR is related to #12661 and #12654 and removes some accessor functions that were documented properly (i.e existed in the yml docs and were not autogenerated by the docs scripts) but were actually backed by the auto-generation of accessors. Namely:

* Ti.Android.Intent.getData
* Ti.Android.MenuItem.setCheckable
* Ti.Android.MenuItem.setChecked
* Ti.Android.MenuItem.setEnabled
* Ti.Android.MenuItem.setVisible
* Ti.Android.MenuItem.isActionViewExpanded
* Ti.Android.MenuItem.isCheckable
* Ti.Android.MenuItem.isChecked
* Ti.Android.MenuItem.isEnabled
* Ti.Android.MenuItem.isVisible
* Ti.Network.HTTPClient.setTimeout (this is fine to remove as it is not part of the spec)
* Ti.UI.TableView.setHeaderPullView (iOS only)

It does not (yet) deal with the following APIs:

* Ti.UI.Tab.setWindow - This exists on Android but not iOS
* Sound.isLooping - This exists on iOS but not Android
* Sound.isPlaying - This exists on iOS but not Android
* Sound.isPaused - This exists on iOS but not Android

Personally, I think we should just remove the above APIs rather than have a difference between iOS and Android. But, that's like just my opinion so I'm open to suggestions


[JIRA](https://jira.appcelerator.org/browse/TIMOB-28407)