### PR TITLE
[Backport 10_0_X] docs: mark accessors that were autogenerated but documented as removed in 10

### DIFF
--- a/apidoc/Titanium/Android/Intent.yml
+++ b/apidoc/Titanium/Android/Intent.yml
@@ -152,6 +152,10 @@ methods:
     summary: Get the Data URI from this `Intent`.
     returns:
         type: String
+    deprecated:
+      since: "10.0.0"
+      removed: "10.0.0"
+      notes: Use the <Titanium.Android.Intent.data> property instead.
 
   - name: getDoubleExtra
     summary: Get a double property from this `Intent`.

--- a/apidoc/Titanium/Android/MenuItem.yml
+++ b/apidoc/Titanium/Android/MenuItem.yml
@@ -101,7 +101,7 @@ methods:
     deprecated:
       since: "10.0.0"
       removed: "10.0.0"
-      notes: Use the <Titanium.Android.MenuItem.checkable> property instead.
+      notes: Use the <Titanium.Android.MenuItem.visible> property instead.
 
   - name: setCheckable
     summary: Sets the [checkable](Titanium.Android.MenuItem.checkable) state of the menu item.

--- a/apidoc/Titanium/Android/MenuItem.yml
+++ b/apidoc/Titanium/Android/MenuItem.yml
@@ -60,27 +60,48 @@ methods:
         on devices running Android 4.0 (API level 14) and greater.
     returns:
         type: Boolean
+    deprecated:
+      since: "10.0.0"
+      removed: "10.0.0"
+      notes: Use the <Titanium.Android.MenuItem.actionViewExpanded> property instead.
+
 
   - name: isCheckable
     summary: |
         Returns the [checkable](Titanium.Android.MenuItem.checkable) state of the menu item.
     returns:
         type: Boolean
+    deprecated:
+      since: "10.0.0"
+      removed: "10.0.0"
+      notes: Use the <Titanium.Android.MenuItem.checkable> property instead.
 
   - name: isChecked
     summary: Returns the [checked](Titanium.Android.MenuItem.checked) state of the menu item.
     returns:
         type: Boolean
+    deprecated:
+      since: "10.0.0"
+      removed: "10.0.0"
+      notes: Use the <Titanium.Android.MenuItem.checked> property instead.
 
   - name: isEnabled
     summary: Returns the [enabled](Titanium.Android.MenuItem.enabled) state of the menu item.
     returns:
         type: Boolean
+    deprecated:
+      since: "10.0.0"
+      removed: "10.0.0"
+      notes: Use the <Titanium.Android.MenuItem.enabled> property instead.
 
   - name: isVisible
     summary: Returns the [visible](Titanium.Android.MenuItem.visible) state of the menu item.
     returns:
         type: Boolean
+    deprecated:
+      since: "10.0.0"
+      removed: "10.0.0"
+      notes: Use the <Titanium.Android.MenuItem.checkable> property instead.
 
   - name: setCheckable
     summary: Sets the [checkable](Titanium.Android.MenuItem.checkable) state of the menu item.
@@ -88,6 +109,10 @@ methods:
       - name: checkable
         summary: True enable checking and unchecking this item, false to disable it.
         type: Boolean
+    deprecated:
+      since: "10.0.0"
+      removed: "10.0.0"
+      notes: Use the <Titanium.Android.MenuItem.checkable> property instead.
 
   - name: setChecked
     summary: Sets the [checked](Titanium.Android.MenuItem.checked) state of the menu item.
@@ -95,6 +120,10 @@ methods:
       - name: enabled
         summary: True to check the item, false to uncheck it.
         type: Boolean
+    deprecated:
+      since: "10.0.0"
+      removed: "10.0.0"
+      notes: Use the <Titanium.Android.MenuItem.checked> property instead.
 
   - name: setEnabled
     summary: Sets the [enabled](Titanium.Android.MenuItem.enabled) state of the menu item.
@@ -102,6 +131,10 @@ methods:
       - name: enabled
         summary: True to enable item, false to disable it.
         type: Boolean
+    deprecated:
+      since: "10.0.0"
+      removed: "10.0.0"
+      notes: Use the <Titanium.Android.MenuItem.enabled> property instead.
 
   - name: setVisible
     summary: Sets the [visible](Titanium.Android.MenuItem.visible) state of the menu item.
@@ -109,6 +142,10 @@ methods:
       - name: visible
         summary: True to show the item, false to hide it.
         type: Boolean
+    deprecated:
+      since: "10.0.0"
+      removed: "10.0.0"
+      notes: Use the <Titanium.Android.MenuItem.visible> property instead.
 
 events:
   - name: click

--- a/apidoc/Titanium/Network/HTTPClient.yml
+++ b/apidoc/Titanium/Network/HTTPClient.yml
@@ -327,6 +327,11 @@ methods:
       - name: timeout
         summary: Timeout in milliseconds.
         type: Number
+    deprecated:
+      since: "10.0.0"
+      removed: "10.0.0"
+      notes: Use the <Titanium.Network.HTTPClient.timeout> property instead.
+
 
 properties:
   - name: DONE

--- a/apidoc/Titanium/UI/TableView.yml
+++ b/apidoc/Titanium/UI/TableView.yml
@@ -1014,6 +1014,11 @@ methods:
         type: Titanium.UI.View
     platforms: [iphone, ipad, macos]
     since: "2.1.0"
+    deprecated:
+      since: "10.0.0"
+      removed: "10.0.0"
+      notes: Use the <Titanium.UI.TableView.headerPullView> property instead.
+
 
   - name: updateRow
     summary: Updates an existing row, optionally with animation.


### PR DESCRIPTION
Backport of #12677.
See that PR for full details.