### PR TITLE
fix(android): retain isWhatever query methods on MenuItem/Sound, mark deprecated

### DIFF
--- a/android/modules/media/src/java/ti/modules/titanium/media/SoundProxy.java
+++ b/android/modules/media/src/java/ti/modules/titanium/media/SoundProxy.java
@@ -141,6 +141,7 @@ public class SoundProxy extends KrollProxy implements org.appcelerator.titanium.
 	}
 
 	@Kroll.getProperty
+	@Kroll.method
 	public boolean isPlaying()
 	{
 		TiSound s = getSound();
@@ -151,6 +152,7 @@ public class SoundProxy extends KrollProxy implements org.appcelerator.titanium.
 	}
 
 	@Kroll.getProperty
+	@Kroll.method
 	public boolean isPaused()
 	{
 		TiSound s = getSound();
@@ -161,6 +163,7 @@ public class SoundProxy extends KrollProxy implements org.appcelerator.titanium.
 	}
 
 	@Kroll.getProperty
+	@Kroll.method
 	public boolean isLooping()
 	{
 		TiSound s = getSound();

--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/MenuItemProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/MenuItemProxy.java
@@ -92,24 +92,28 @@ public class MenuItemProxy extends KrollProxy
 	}
 
 	@Kroll.getProperty
+	@Kroll.method
 	public boolean isChecked()
 	{
 		return item.isChecked();
 	}
 
 	@Kroll.getProperty
+	@Kroll.method
 	public boolean isCheckable()
 	{
 		return item.isCheckable();
 	}
 
 	@Kroll.getProperty
+	@Kroll.method
 	public boolean isEnabled()
 	{
 		return item.isEnabled();
 	}
 
 	@Kroll.getProperty
+	@Kroll.method
 	public boolean isVisible()
 	{
 		return item.isVisible();
@@ -313,6 +317,7 @@ public class MenuItemProxy extends KrollProxy
 	}
 
 	@Kroll.getProperty
+	@Kroll.method
 	public boolean isActionViewExpanded()
 	{
 		return item.isActionViewExpanded();

--- a/apidoc/Titanium/Android/MenuItem.yml
+++ b/apidoc/Titanium/Android/MenuItem.yml
@@ -62,9 +62,7 @@ methods:
         type: Boolean
     deprecated:
       since: "10.0.0"
-      removed: "10.0.0"
       notes: Use the <Titanium.Android.MenuItem.actionViewExpanded> property instead.
-
 
   - name: isCheckable
     summary: |
@@ -73,7 +71,6 @@ methods:
         type: Boolean
     deprecated:
       since: "10.0.0"
-      removed: "10.0.0"
       notes: Use the <Titanium.Android.MenuItem.checkable> property instead.
 
   - name: isChecked
@@ -82,7 +79,6 @@ methods:
         type: Boolean
     deprecated:
       since: "10.0.0"
-      removed: "10.0.0"
       notes: Use the <Titanium.Android.MenuItem.checked> property instead.
 
   - name: isEnabled
@@ -91,7 +87,6 @@ methods:
         type: Boolean
     deprecated:
       since: "10.0.0"
-      removed: "10.0.0"
       notes: Use the <Titanium.Android.MenuItem.enabled> property instead.
 
   - name: isVisible
@@ -100,7 +95,6 @@ methods:
         type: Boolean
     deprecated:
       since: "10.0.0"
-      removed: "10.0.0"
       notes: Use the <Titanium.Android.MenuItem.visible> property instead.
 
   - name: setCheckable

--- a/apidoc/Titanium/Media/Sound.yml
+++ b/apidoc/Titanium/Media/Sound.yml
@@ -22,16 +22,25 @@ methods:
     summary: Returns the value of the [looping](Titanium.Media.Sound.looping) property.
     returns:
         type: Boolean
+    deprecated:
+      since: "10.0.0"
+      notes: Use the <Titanium.Media.Sound.looping> property instead.
 
   - name: isPaused
     summary: Returns the value of the [paused](Titanium.Media.Sound.paused) property.
     returns:
         type: Boolean
+    deprecated:
+      since: "10.0.0"
+      notes: Use the <Titanium.Media.Sound.paused> property instead.
 
   - name: isPlaying
     summary: Returns the value of the [playing](Titanium.Media.Sound.playing) property.
     returns:
         type: Boolean
+    deprecated:
+      since: "10.0.0"
+      notes: Use the <Titanium.Media.Sound.playing> property instead.
 
   - name: pause
     summary: Pauses the audio.

--- a/apidoc/Titanium/UI/Tab.yml
+++ b/apidoc/Titanium/UI/Tab.yml
@@ -125,6 +125,9 @@ methods:
       - name: window
         summary: Root window of the tab.
         type: Titanium.UI.Window
+    deprecated:
+      since: "10.0.0"
+      notes: Set the value of the [window](Titanium.UI.Tab.window) property directly.
 
   - name: popToRootWindow
     # FIXME: I don't think this exists on Android!

--- a/common/Resources/ti.internal/extensions/ti/ui/tab.js
+++ b/common/Resources/ti.internal/extensions/ti/ui/tab.js
@@ -4,7 +4,7 @@
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
-/* globals OS_ANDROID */
+/* globals OS_ANDROID, OS_IOS */
 if (OS_ANDROID) {
 	const Tab = Titanium.UI.Tab;
 
@@ -48,6 +48,7 @@ if (OS_ANDROID) {
 		_setWindow.call(this, window);
 	};
 
+	// TODO: Remove! This is an undocumented accessor method
 	Tab.prototype.getWindow = function () {
 		return this._window;
 	};
@@ -57,4 +58,10 @@ if (OS_ANDROID) {
 		set: Tab.prototype.setWindow,
 		get: Tab.prototype.getWindow
 	});
+} else if (OS_IOS) {
+	const tab = Titanium.UI.createTab();
+	const TabPrototype = Object.getPrototypeOf(tab);
+	TabPrototype.setWindow = function (window) {
+		this.window = window; // forward to setting property
+	};
 }

--- a/iphone/Classes/TiUIClipboardProxy.h
+++ b/iphone/Classes/TiUIClipboardProxy.h
@@ -29,7 +29,7 @@ READONLY_PROPERTY(bool, unique, Unique);
 JSExportAs(setData,
            -(void)setData
            : (NSString *)type withData
-           : (id)data);
+           : (JSValue *)data);
 - (void)setText:(NSString *)text;
 - (void)setItems:(NSDictionary<NSString *, id> *)items;
 - (void)remove;

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/KrollBridge.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/KrollBridge.m
@@ -348,47 +348,74 @@ CFMutableSetRef krollBridgeRegistry = nil;
   // Load ti.kernel.js (kroll.js equivalent)
   NSURL *bootstrapURL = [TiHost resourceBasedURL:@"ti.kernel.js" baseURL:NULL];
   NSString *source = [AssetsModule readURL:bootstrapURL];
-
-  JSValue *bootstrapFunc = [objcJSContext evaluateScript:source withSourceURL:bootstrapURL];
-  if (objcJSContext.exception != nil) {
+  if (source == nil || source.length == 0) {
+    NSLog(@"[ERROR] Error reading ti.kernel.js, source is nil/empty. Most likely due to failure to decrypt via remote policy and device offline.");
     evaluationError = YES;
-    [TiExceptionHandler.defaultExceptionHandler reportScriptError:objcJSContext.exception inJSContext:objcJSContext];
-  }
-  [bootstrapFunc callWithArguments:@[ global, [[KrollModule alloc] init] ]];
-  if (objcJSContext.exception != nil) {
-    evaluationError = YES;
-    [TiExceptionHandler.defaultExceptionHandler reportScriptError:objcJSContext.exception inJSContext:objcJSContext];
-  }
-
-  JSValue *titanium = global[@"Ti"];
-  TopTiModule *module = [titanium toObject];
-  if ([[TiSharedConfig defaultConfig] isAnalyticsEnabled]) {
-    APSAnalytics *sharedAnalytics = [APSAnalytics sharedInstance];
-    NSString *buildType = [[TiSharedConfig defaultConfig] applicationBuildType];
-    NSString *deployType = [[TiSharedConfig defaultConfig] applicationDeployType];
-    NSString *guid = [[TiSharedConfig defaultConfig] applicationGUID];
-    if (buildType != nil || buildType.length > 0) {
-      [sharedAnalytics performSelector:@selector(setBuildType:) withObject:buildType];
+    // Don't put up a dialog, as the most likely cause here is remote policy encryption/decryption failing to decrypt due to being offline.
+    // And if we have a dialog up, the security violation dialog won't appear
+  } else {
+    JSValue *bootstrapFunc = [objcJSContext evaluateScript:source withSourceURL:bootstrapURL];
+    if (objcJSContext.exception != nil) {
+      NSLog(@"[ERROR] Error eval'ing ti.kernel.js bootstrap script. Please contact Titanium developers and file a bug report.");
+      evaluationError = YES;
+      [TiExceptionHandler.defaultExceptionHandler reportScriptError:objcJSContext.exception inJSContext:objcJSContext];
+    } else if (bootstrapFunc == nil || [bootstrapFunc isUndefined]) {
+      // it didn't export a bootstrap function! Most likely reason is we hosed the file
+      NSLog(@"[ERROR] Error eval'ing ti.kernel.js, bootstrap function is undefined/nil. Please contact Titanium developers and file a bug report.");
+      evaluationError = YES;
+      [TiExceptionHandler.defaultExceptionHandler reportScriptError:objcJSContext.exception inJSContext:objcJSContext];
+    } else {
+      // ti.kernel.js eval'd OK, so now let's run the exported bootstrap function
+      [bootstrapFunc callWithArguments:@[ global, [[KrollModule alloc] init] ]];
+      if (objcJSContext.exception != nil) {
+        NSLog(@"[ERROR] Error calling ti.kernel.js' exported bootstrap function. Please contact Titanium developers and file a bug report.");
+        evaluationError = YES;
+        [TiExceptionHandler.defaultExceptionHandler reportScriptError:objcJSContext.exception inJSContext:objcJSContext];
+      }
     }
-    [sharedAnalytics performSelector:@selector(setSDKVersion:) withObject:[module performSelector:@selector(version)]];
+  }
+
+  JSValue *titanium = global[@"Ti"]; // This may be nil/undefined it we couldn't load ti.kernel.js or the bootstrapping failed
+  if (TiSharedConfig.defaultConfig.isAnalyticsEnabled) {
+    APSAnalytics *sharedAnalytics = APSAnalytics.sharedInstance;
+    NSString *buildType = TiSharedConfig.defaultConfig.applicationBuildType;
+    if (buildType != nil || buildType.length > 0) {
+      [sharedAnalytics setBuildType:buildType];
+    }
+    TopTiModule *module;
+    if (titanium != nil && ![titanium isUndefined]) {
+      module = [titanium toObject];
+    } else {
+      // Uh-oh, something went really wrong! For analytics sake, let's just create the module
+      module = [[TopTiModule alloc] init];
+      global[@"Ti"] = module;
+      global[@"Titanium"] = module;
+    }
+    [sharedAnalytics setSDKVersion:module.version];
+    NSString *deployType = TiSharedConfig.defaultConfig.applicationDeployType;
+    NSString *guid = TiSharedConfig.defaultConfig.applicationGUID;
     [sharedAnalytics enableWithAppKey:guid andDeployType:deployType];
   }
 
   NSURL *startURL = nil;
   //if we have a preload dictionary, register those static key/values into our namespace
   if (preload != nil) {
-    for (NSString *name in preload) {
-      JSValue *moduleJSObject = titanium[name];
-      KrollObject *ti = (KrollObject *)JSObjectGetPrivate(JSValueToObject(jsContext, moduleJSObject.JSValueRef, NULL));
-      NSDictionary *values = preload[name];
-      for (id key in values) {
-        id target = values[key];
-        KrollObject *ko = [self krollObjectForProxy:target];
-        if (ko == nil) {
-          ko = [self registerProxy:target];
+    // Guard for top level Titanium object being unassigned. likley means we had issues
+    // setting up ti.kernel.js, so we likely need to skip most everything here.
+    if (titanium != nil && ![titanium isUndefined]) {
+      for (NSString *name in preload) {
+        JSValue *moduleJSObject = titanium[name];
+        KrollObject *ti = (KrollObject *)JSObjectGetPrivate(JSValueToObject(jsContext, moduleJSObject.JSValueRef, NULL));
+        NSDictionary *values = preload[name];
+        for (id key in values) {
+          id target = values[key];
+          KrollObject *ko = [self krollObjectForProxy:target];
+          if (ko == nil) {
+            ko = [self registerProxy:target];
+          }
+          [ti noteKrollObject:ko forKey:key];
+          [ti setStaticValue:ko forKey:key purgable:NO];
         }
-        [ti noteKrollObject:ko forKey:key];
-        [ti setStaticValue:ko forKey:key purgable:NO];
       }
     }
     startURL = [url copy]; // should be the entry point of the background service js file
@@ -398,7 +425,14 @@ CFMutableSetRef krollBridgeRegistry = nil;
 
   // We need to run this before the entry js file, which means it has to be here.
   TiBindingRunLoopAnnounceStart(kroll);
-  [self evalFile:[startURL absoluteString] callback:self selector:@selector(booted)];
+  if (!evaluationError) {
+    [self evalFile:[startURL absoluteString] callback:self selector:@selector(booted)];
+  } else {
+    NSLog(@"[ERROR] Error loading/executing ti.kernel.js bootstrap code, refusing to launch app main file.");
+    // DO NOT POP AN ERROR DIALOG! The most likley scenario here is that the app is remotely encrypted
+    // and the decryption failed because the device is offline
+    // If we pop a dialog here, it will block the "Security Violation" error dialog that would show in that case
+  }
 
   if (TiUtils.isHyperloopAvailable) {
     Class cls = NSClassFromString(@"Hyperloop");

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiProxy.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiProxy.m
@@ -936,10 +936,11 @@ void TiClassSelectorFunction(TiBindingRunLoop runloop, void *payload)
       NSThread.isMainThread);
 }
 
-- (void)setValuesForKeysWithDictionary:(NSDictionary *)keyedValues
+- (void)setValuesForKeysWithDictionary:(NSDictionary *)dictionary
 {
   //It's possible that the 'setvalueforkey' has its own plans of what should be in the JS object,
   //so we should do this first as to not overwrite the subclass's setter.
+  NSDictionary *keyedValues = [dictionary copy];
   if ((bridgeCount == 1) && (pageKrollObject != nil)) {
     for (NSString *currentKey in keyedValues) {
       id currentValue = [keyedValues objectForKey:currentKey];
@@ -991,6 +992,7 @@ void TiClassSelectorFunction(TiBindingRunLoop runloop, void *payload)
     }
     [self setValue:thisValue forKey:thisKey];
   }
+  RELEASE_TO_NIL(keyedValues);
 }
 
 DEFINE_EXCEPTIONS

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
         "commander": "^7.2.0",
         "commitizen": "^4.2.3",
         "conventional-changelog-cli": "^2.1.1",
-        "core-js": "^3.10.0",
+        "core-js": "^3.10.1",
         "cz-conventional-changelog": "^3.3.0",
         "danger": "^10.6.4",
         "dateformat": "^4.5.1",
@@ -5701,9 +5701,9 @@
       }
     },
     "node_modules/core-js": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.10.0.tgz",
-      "integrity": "sha512-MQx/7TLgmmDVamSyfE+O+5BHvG1aUGj/gHhLn1wVtm2B5u1eVIPvh7vkfjwWKNCjrTJB8+He99IntSQ1qP+vYQ==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.10.1.tgz",
+      "integrity": "sha512-pwCxEXnj27XG47mu7SXAwhLP3L5CrlvCB91ANUkIz40P27kUcvNfSdvyZJ9CLHiVoKSp+TTChMQMSKQEH/IQxA==",
       "dev": true,
       "hasInstallScript": true,
       "funding": {
@@ -21125,9 +21125,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.10.0.tgz",
-      "integrity": "sha512-MQx/7TLgmmDVamSyfE+O+5BHvG1aUGj/gHhLn1wVtm2B5u1eVIPvh7vkfjwWKNCjrTJB8+He99IntSQ1qP+vYQ==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.10.1.tgz",
+      "integrity": "sha512-pwCxEXnj27XG47mu7SXAwhLP3L5CrlvCB91ANUkIz40P27kUcvNfSdvyZJ9CLHiVoKSp+TTChMQMSKQEH/IQxA==",
       "dev": true
     },
     "core-js-compat": {

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "commander": "^7.2.0",
     "commitizen": "^4.2.3",
     "conventional-changelog-cli": "^2.1.1",
-    "core-js": "^3.10.0",
+    "core-js": "^3.10.1",
     "cz-conventional-changelog": "^3.3.0",
     "danger": "^10.6.4",
     "dateformat": "^4.5.1",

--- a/tests/Resources/ti.media.videoplayer.test.js
+++ b/tests/Resources/ti.media.videoplayer.test.js
@@ -478,4 +478,27 @@ describe.androidARM64Broken('Titanium.Media.VideoPlayer', () => {
 		player.addEventListener('playing', () => finish());
 		win.open();
 	});
+
+	it.ios('App should not crash when setting url after video player creation (TIMOB-28217)', function (finish) {
+		this.timeout(10000);
+
+		win = Ti.UI.createWindow();
+		player = Ti.Media.createVideoPlayer({
+			top: 120,
+			autoplay: false,
+			backgroundColor: 'blue',
+			height: 300,
+			width: 300,
+			mediaControlStyle: Titanium.Media.VIDEO_CONTROL_DEFAULT,
+			scalingMode: Titanium.Media.VIDEO_SCALING_ASPECT_FIT,
+			showsControls: true,
+		});
+		player.url = '/movie.mp4';
+		win.add(player);
+		win.addEventListener('open', () => {
+			finish();
+		});
+
+		win.open();
+	});
 });


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-28407

**Optional Description:**
Follow-on to #12677

- Add back, but deprecate:
  - `Ti.Android.MenuItem.isActionViewExpanded`
  - `Ti.Android.MenuItem.isCheckable`
  - `Ti.Android.MenuItem.isChecked`
  - `Ti.Android.MenuItem.isEnabled` 
  - `Ti.Android.MenuItem.isVisible`
  - `Ti.Media.Sound.isLooping` (added back to Android, it's cross-platform now)
  - `Ti.Media.Sound.isPlaying` (added back to Android, it's cross-platform now)
  - `Ti.Media.Sound.isPaused` (added back to Android, it's cross-platform now)

- Deprecate:
  - `Ti.UI.Tab.setWindow`