### PR TITLE
fix(android): amend TabGroup selected tab

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TabGroupProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TabGroupProxy.java
@@ -156,8 +156,9 @@ public class TabGroupProxy extends TiWindowProxy implements TiActivityWindow
 			// Once the change is completed onTabSelected() will be
 			// called to fire events and update the active tab.
 			tabGroup.selectTab(tab);
+		} else {
+			selectedTab = tab;
 		}
-		selectedTab = tab;
 	}
 
 	@Kroll.getProperty(name = "activity")


### PR DESCRIPTION
- Fix failing unit test for `TabGroup`
- Do not update selected tab when `disableTabNavigation()` is `false`

##### TEST CASE
- Should not see fail states
```JS
const winA = Ti.UI.createWindow();
const tabA = Ti.UI.createTab({
	title: 'Tab A',
	window: winA
});
const winB = Ti.UI.createWindow();
const tabB = Ti.UI.createTab({
	title: 'Tab B',
	window: winB
});
const tabGroup = Ti.UI.createTabGroup();

// Pre-select tab index 1 before tabs are added and TabGroup is open.
tabGroup.activeTab = 1;

tabGroup.addEventListener('open', () => {
	try {
		if (tabGroup.activeTab.title !== 'Tab B') {
			alert(`FAIL #1: ${tabGroup.activeTab.title} != Tab B`);
		}

		tabGroup.disableTabNavigation(true);
		tabGroup.activeTab = tabA;

		if (tabGroup.activeTab.title !== 'Tab B') {
			alert(`FAIL #2: ${tabGroup.activeTab.title} != Tab B`);
		}

		tabGroup.disableTabNavigation(false);
		tabGroup.activeTab = tabA;

		if (tabGroup.activeTab.title !== 'Tab A') {
			alert(`FAIL #3: ${tabGroup.activeTab.title} != Tab A`);
		}
	} catch (e) {
	} finally {
		tabGroup.removeTab(tabA);
		tabGroup.removeTab(tabB);
	}
});

tabGroup.addTab(tabA);
tabGroup.addTab(tabB);
tabGroup.open();
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-28404)