### PR TITLE
[Backport 10_0_X] Revert "perf(ios): use new API for rendering view to image"

### DIFF
--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiViewProxy.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiViewProxy.m
@@ -700,7 +700,6 @@ LAYOUTFLAGS_SETTER(setHorizontalWrap, horizontalWrap, horizontalWrap, [self will
         }
         TiUIView *myview = [self view];
         CGSize size = myview.bounds.size;
-        CGRect bounds = myview.bounds;
         if (CGSizeEqualToSize(size, CGSizeZero) || size.width == 0 || size.height == 0) {
 #ifndef TI_USE_AUTOLAYOUT
           CGFloat width = [self autoWidthForSize:CGSizeMake(1000, 1000)];
@@ -719,14 +718,12 @@ LAYOUTFLAGS_SETTER(setHorizontalWrap, horizontalWrap, horizontalWrap, [self will
           }
           CGRect rect = CGRectMake(0, 0, size.width, size.height);
           [TiUtils setView:myview positionRect:rect];
-          bounds = rect;
         }
         if (!viewIsAttached) {
           [self layoutChildren:NO];
         }
-
         UIGraphicsBeginImageContextWithOptions(size, [myview.layer isOpaque], (honorScale ? 0.0 : 1.0));
-        [myview drawViewHierarchyInRect:bounds afterScreenUpdates:YES];
+        [myview.layer renderInContext:UIGraphicsGetCurrentContext()];
         UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
         blob = [[[TiBlob alloc] initWithImage:image] autorelease];
         [blob setMimeType:@"image/png" type:TiBlobTypeImage];

--- a/tests/Resources/ti.ui.textfield.test.js
+++ b/tests/Resources/ti.ui.textfield.test.js
@@ -412,7 +412,7 @@ describe('Titanium.UI.TextField', () => {
 			win.addEventListener('postlayout', function listener () {
 				win.removeEventListener('postlayout', listener);
 				textField.setSelection(0, 5);
-				setTimeout(function (e) {
+				setTimeout(function () {
 					try {
 						should(textField.selection.length).eql(5);
 						should(textField.selection.location).eql(0);


### PR DESCRIPTION
Backport of #12687.
See that PR for full details.