### PR TITLE
build: add back linux when packaging on any os with --all

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -430,7 +430,7 @@ timestamps {
 					sh 'rm -rf dist/'
 					unarchive mapping: ['dist/': '.']
 					// Have to use Java-style loop for now: https://issues.jenkins-ci.org/browse/JENKINS-26481
-					def oses = ['osx', 'win32']
+					def oses = ['osx', 'linux', 'win32']
 					for (int i = 0; i < oses.size(); i++) {
 						def os = oses[i]
 						def sha1 = sh(returnStdout: true, script: "shasum ${basename}-${os}.zip").trim().split()[0]

--- a/build/lib/builder.js
+++ b/build/lib/builder.js
@@ -17,8 +17,6 @@ const DIST_DIR = path.join(ROOT_DIR, 'dist');
 const TMP_DIR = path.join(DIST_DIR, 'tmp');
 
 // Platforms/OS mappings
-// NOTE: 'linux' could be added, but is not officially supported.
-// Specifying --all will only produce a linux output on a linux host.
 const ALL_OSES = [ 'win32', 'osx', 'linux' ];
 const ALL_PLATFORMS = [ 'ios', 'android' ];
 const OS_TO_PLATFORMS = {

--- a/build/lib/builder.js
+++ b/build/lib/builder.js
@@ -19,7 +19,7 @@ const TMP_DIR = path.join(DIST_DIR, 'tmp');
 // Platforms/OS mappings
 // NOTE: 'linux' could be added, but is not officially supported.
 // Specifying --all will only produce a linux output on a linux host.
-const ALL_OSES = Array.from(new Set([ 'win32', 'osx', thisOS() ]));
+const ALL_OSES = [ 'win32', 'osx', 'linux' ];
 const ALL_PLATFORMS = [ 'ios', 'android' ];
 const OS_TO_PLATFORMS = {
 	win32: [ 'android' ],


### PR DESCRIPTION
Removing linux caused the builds.appc site to break for newer builds as it has an expectation that
there will be 3 platforms for every build released for master/10_0_X branches