### PR TITLE
[Backport 10_0_X] fix(ios): videoplayer crash when setting showsControls earlier than url property

### DIFF
--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiProxy.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiProxy.m
@@ -936,10 +936,11 @@ void TiClassSelectorFunction(TiBindingRunLoop runloop, void *payload)
       NSThread.isMainThread);
 }
 
-- (void)setValuesForKeysWithDictionary:(NSDictionary *)keyedValues
+- (void)setValuesForKeysWithDictionary:(NSDictionary *)dictionary
 {
   //It's possible that the 'setvalueforkey' has its own plans of what should be in the JS object,
   //so we should do this first as to not overwrite the subclass's setter.
+  NSDictionary *keyedValues = [dictionary copy];
   if ((bridgeCount == 1) && (pageKrollObject != nil)) {
     for (NSString *currentKey in keyedValues) {
       id currentValue = [keyedValues objectForKey:currentKey];
@@ -991,6 +992,7 @@ void TiClassSelectorFunction(TiBindingRunLoop runloop, void *payload)
     }
     [self setValue:thisValue forKey:thisKey];
   }
+  RELEASE_TO_NIL(keyedValues);
 }
 
 DEFINE_EXCEPTIONS

--- a/tests/Resources/ti.media.videoplayer.test.js
+++ b/tests/Resources/ti.media.videoplayer.test.js
@@ -495,10 +495,10 @@ describe.androidARM64Broken('Titanium.Media.VideoPlayer', () => {
 		});
 		player.url = '/movie.mp4';
 		win.add(player);
-		win.open();
-
 		win.addEventListener('open', () => {
 			finish();
 		});
+
+		win.open();
 	});
 });

--- a/tests/Resources/ti.media.videoplayer.test.js
+++ b/tests/Resources/ti.media.videoplayer.test.js
@@ -478,4 +478,27 @@ describe.androidARM64Broken('Titanium.Media.VideoPlayer', () => {
 		player.addEventListener('playing', () => finish());
 		win.open();
 	});
+
+	it.ios('App should not crash when setting url after video player creation (TIMOB-28217)', function (finish) {
+		this.timeout(10000);
+
+		win = Ti.UI.createWindow();
+		player = Ti.Media.createVideoPlayer({
+			top: 120,
+			autoplay: false,
+			backgroundColor: 'blue',
+			height: 300,
+			width: 300,
+			mediaControlStyle: Titanium.Media.VIDEO_CONTROL_DEFAULT,
+			scalingMode: Titanium.Media.VIDEO_SCALING_ASPECT_FIT,
+			showsControls: true,
+		});
+		player.url = '/movie.mp4';
+		win.add(player);
+		win.open();
+
+		win.addEventListener('open', () => {
+			finish();
+		});
+	});
 });


### PR DESCRIPTION
Backport of #12508.
See that PR for full details.