### PR TITLE
[Backport 10_0_X] chore: deprecate TableViewRow header and footer properties

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TableViewRowProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TableViewRowProxy.java
@@ -318,8 +318,7 @@ public class TableViewRowProxy extends TiViewProxy
 	 */
 	private void headerDeprecationLog()
 	{
-		// TODO: Display deprecation warning in SDK 10.0
-		// Log.w(TAG, "Usage of 'TableViewRow.header' has been deprecated, use 'TableViewRow.headerTitle' instead.");
+		Log.w(TAG, "Usage of 'TableViewRow.header' has been deprecated, use 'TableViewRow.headerTitle' instead.");
 	}
 
 	/**
@@ -327,8 +326,7 @@ public class TableViewRowProxy extends TiViewProxy
 	 */
 	private void footerDeprecationLog()
 	{
-		// TODO: Display deprecation warning in SDK 10.0
-		// Log.w(TAG, "Usage of 'TableViewRow.footer' has been deprecated, use 'TableViewRow.footerTitle' instead.");
+		Log.w(TAG, "Usage of 'TableViewRow.footer' has been deprecated, use 'TableViewRow.footerTitle' instead.");
 	}
 
 	/**

--- a/apidoc/Titanium/UI/TableViewRow.yml
+++ b/apidoc/Titanium/UI/TableViewRow.yml
@@ -238,6 +238,18 @@ properties:
         the `footerTitle` property of a <Titanium.UI.TableViewSection>.
     type: String
     platforms: [iphone, ipad, android, macos]
+    deprecated:
+      since: "10.0.0"
+      notes: Use the <Titanium.UI.TableViewRow.footerTitle> property instead.
+
+  - name: footerTitle
+    summary: The footer title of the row.
+    description: |
+        The `footerTitle` property is used to assign a footer title to a row. It has the same effect as setting
+        the `footerTitle` property of a <Titanium.UI.TableViewSection>.
+    type: String
+    platforms: [iphone, ipad, android, macos]
+    since: {android: "10.0.0", iphone: "10.0.0", ipad: "10.0.0", macos: "10.0.0"}
 
   - name: hasCheck
     summary: |
@@ -285,6 +297,18 @@ properties:
         the `headerTitle` property of a <Titanium.UI.TableViewSection>.
     type: String
     platforms: [iphone, ipad, android, macos]
+    deprecated:
+      since: "10.0.0"
+      notes: Use the <Titanium.UI.TableViewRow.headerTitle> property instead.
+
+  - name: headerTitle
+    summary: The header title of the row.
+    description: |
+        The `headerTitle` property is used to assign a header title to a row. It has the same effect as setting
+        the `headerTitle` property of a <Titanium.UI.TableViewSection>.
+    type: String
+    platforms: [iphone, ipad, android, macos]
+    since: {android: "10.0.0", iphone: "10.0.0", ipad: "10.0.0", macos: "10.0.0"}
 
   - name: indentionLevel
     summary: Indention level for the row.

--- a/iphone/Classes/TiUITableViewProxy.m
+++ b/iphone/Classes/TiUITableViewProxy.m
@@ -529,9 +529,9 @@ USE_VIEW_FOR_CONTENT_HEIGHT
 
   TiUITableViewRowProxy *newrow = [self tableRowFromArg:data];
   TiUITableViewActionType actionType = TiUITableViewActionInsertRowBefore;
-  id header = [newrow valueForKey:@"header"];
-  if (header != nil) {
-    TiUITableViewSectionProxy *newSection = [self sectionWithHeader:header table:table];
+  id headerTitle = [self getRowHeaderTitle:newrow];
+  if (headerTitle != nil) {
+    TiUITableViewSectionProxy *newSection = [self sectionWithHeader:headerTitle table:table];
 
     // Insert the new section into the array - but, exactly WHERE we insert depends.
     NSInteger sectionIndex = [sections indexOfObject:section];
@@ -600,9 +600,9 @@ USE_VIEW_FOR_CONTENT_HEIGHT
 
   TiUITableViewRowProxy *newrow = [self tableRowFromArg:data];
   TiUITableViewActionType actionType = TiUITableViewActionInsertRowAfter;
-  id header = [newrow valueForKey:@"header"];
-  if (header != nil) {
-    TiUITableViewSectionProxy *newSection = [self sectionWithHeader:header table:table];
+  id headerTitle = [self getRowHeaderTitle:newrow];
+  if (headerTitle != nil) {
+    TiUITableViewSectionProxy *newSection = [self sectionWithHeader:headerTitle table:table];
 
     // Set up the new section
     newSection.section = section.section + 1;
@@ -668,12 +668,12 @@ USE_VIEW_FOR_CONTENT_HEIGHT
     [self setData:[NSArray arrayWithObject:data] withObject:anim immediate:YES];
     return;
   } else {
-    id header = [row valueForKey:@"header"];
     TiUITableViewActionType actionType = TiUITableViewActionAppendRow;
     TiUITableViewSectionProxy *section = [sections lastObject];
-    if (header != nil) {
+    id headerTitle = [self getRowHeaderTitle:row];
+    if (headerTitle != nil) {
       NSInteger newSectionIndex = section.section + 1;
-      section = [self sectionWithHeader:header table:table];
+      section = [self sectionWithHeader:headerTitle table:table];
       section.section = newSectionIndex;
       actionType = TiUITableViewActionAppendRowWithSection;
     }
@@ -710,16 +710,16 @@ USE_VIEW_FOR_CONTENT_HEIGHT
     if ([row isKindOfClass:dictionaryClass]) {
       NSDictionary *dict = (NSDictionary *)row;
       TiUITableViewRowProxy *rowProxy = [self makeTableViewRowFromDict:dict];
-      NSString *header = [dict objectForKey:@"header"];
-      if (section == nil || header != nil) {
+      id headerTitle = [self getRowHeaderTitle:dict];
+      if (section == nil || headerTitle != nil) {
         // if we don't yet have a section, that means we need to create one
         // if we have a header property, that means start a new section
-        section = [self sectionWithHeader:header table:nil];
+        section = [self sectionWithHeader:headerTitle table:nil];
         [data addObject:section];
       }
-      NSString *footer = [dict objectForKey:@"footer"];
-      if (footer != nil) {
-        [section replaceValue:footer forKey:@"footerTitle" notification:NO];
+      id footerTitle = [self getRowFooterTitle:dict];
+      if (footerTitle != nil) {
+        [section replaceValue:footerTitle forKey:@"footerTitle" notification:NO];
       }
       [section add:rowProxy];
     } else if ([row isKindOfClass:sectionClass]) {
@@ -727,15 +727,15 @@ USE_VIEW_FOR_CONTENT_HEIGHT
       [self rememberProxy:row];
       [data addObject:section];
     } else if ([row isKindOfClass:rowClass]) {
-      id rowHeader = [row valueForKey:@"header"];
-      id rowFooter = [row valueForKey:@"footer"];
-      if (section == nil || rowHeader != nil) {
-        section = [self sectionWithHeader:rowHeader table:[self tableView]];
+      id headerTitle = [self getRowHeaderTitle:row];
+      id footerTitle = [self getRowFooterTitle:row];
+      if (section == nil || headerTitle != nil) {
+        section = [self sectionWithHeader:headerTitle table:[self tableView]];
         section.section = [data count];
         [data addObject:section];
       }
-      if (rowFooter != nil) {
-        [section replaceValue:rowFooter forKey:@"footerTitle" notification:NO];
+      if (footerTitle != nil) {
+        [section replaceValue:footerTitle forKey:@"footerTitle" notification:NO];
       }
       [section add:row];
     }
@@ -1160,6 +1160,32 @@ DEFINE_DEF_PROP(scrollsToTop, [NSNumber numberWithBool:YES]);
 - (void)add:(id)arg
 {
   NSLog(@"[ERROR] Cannot add sub-views to table views. Use \"appendRow\" or \"appendSection\" instead.");
+}
+
+- (NSString *)getRowHeaderTitle:(id)row
+{
+  id headerTitle = [row valueForKey:@"headerTitle"];
+  if (headerTitle == nil) {
+    headerTitle = [row valueForKey:@"header"];
+
+    if (headerTitle != nil) {
+      DEPRECATED_REPLACED(@"header", @"10.0.0", @"headerTitle");
+    }
+  }
+  return headerTitle;
+}
+
+- (NSString *)getRowFooterTitle:(id)row
+{
+  id footerTitle = [row valueForKey:@"footerTitle"];
+  if (footerTitle == nil) {
+    footerTitle = [row valueForKey:@"footer"];
+
+    if (footerTitle != nil) {
+      DEPRECATED_REPLACED(@"footer", @"10.0.0", @"footerTitle");
+    }
+  }
+  return footerTitle;
 }
 
 #pragma mark Accessibility Overrides

--- a/iphone/Classes/TiUITableViewRowProxy.m
+++ b/iphone/Classes/TiUITableViewRowProxy.m
@@ -314,18 +314,35 @@ TiProxy *DeepScanForProxyOfViewContainingPoint(UIView *targetView, CGPoint point
   modifyingRow = YES;
   [super _initWithProperties:data];
 
-  // check to see if we have a section header change, too...
-  if ([data objectForKey:@"header"]) {
-    [section setValue:[data objectForKey:@"header"] forUndefinedKey:@"headerTitle"];
-    // we can return since we're reloading the section, will cause the
-    // row to be repainted at the same time
+  id headerTitle = [data objectForKey:@"headerTitle"];
+  if (headerTitle == nil) {
+    headerTitle = [data objectForKey:@"header"];
+
+    if (headerTitle != nil)
+      DEPRECATED_REPLACED(@"header", @"10.0.0", @"headerTitle");
   }
-  if ([data objectForKey:@"footer"]) {
-    [section setValue:[data objectForKey:@"footer"] forUndefinedKey:@"footerTitle"];
-    // we can return since we're reloading the section, will cause the
-    // row to be repainted at the same time
-  }
-  modifyingRow = NO;
+}
+if (headerTitle != nil) {
+
+  // Update section header with new headerTitle.
+  [section setValue:headerTitle forUndefinedKey:@"headerTitle"];
+}
+
+id footerTitle = [data objectForKey:@"footerTitle"];
+if (footerTitle == nil) {
+  footerTitle = [data objectForKey:@"footer"];
+
+  if (footerTitle != nil)
+    DEPRECATED_REPLACED(@"footer", @"10.0.0", @"footerTitle");
+}
+}
+if (footerTitle != nil) {
+
+  // Update section footer with new footerTitle.
+  [section setValue:footerTitle forUndefinedKey:@"footerTitle"];
+}
+
+modifyingRow = NO;
 }
 
 - (void)configureTitle:(UITableViewCell *)cell

--- a/iphone/Classes/TiUITableViewRowProxy.m
+++ b/iphone/Classes/TiUITableViewRowProxy.m
@@ -318,31 +318,31 @@ TiProxy *DeepScanForProxyOfViewContainingPoint(UIView *targetView, CGPoint point
   if (headerTitle == nil) {
     headerTitle = [data objectForKey:@"header"];
 
-    if (headerTitle != nil)
+    if (headerTitle != nil) {
       DEPRECATED_REPLACED(@"header", @"10.0.0", @"headerTitle");
+    }
   }
-}
-if (headerTitle != nil) {
+  if (headerTitle != nil) {
 
-  // Update section header with new headerTitle.
-  [section setValue:headerTitle forUndefinedKey:@"headerTitle"];
-}
+    // Update section header with new headerTitle.
+    [section setValue:headerTitle forUndefinedKey:@"headerTitle"];
+  }
 
-id footerTitle = [data objectForKey:@"footerTitle"];
-if (footerTitle == nil) {
-  footerTitle = [data objectForKey:@"footer"];
+  id footerTitle = [data objectForKey:@"footerTitle"];
+  if (footerTitle == nil) {
+    footerTitle = [data objectForKey:@"footer"];
 
-  if (footerTitle != nil)
-    DEPRECATED_REPLACED(@"footer", @"10.0.0", @"footerTitle");
-}
-}
-if (footerTitle != nil) {
+    if (footerTitle != nil) {
+      DEPRECATED_REPLACED(@"footer", @"10.0.0", @"footerTitle");
+    }
+  }
+  if (footerTitle != nil) {
 
-  // Update section footer with new footerTitle.
-  [section setValue:footerTitle forUndefinedKey:@"footerTitle"];
-}
+    // Update section footer with new footerTitle.
+    [section setValue:footerTitle forUndefinedKey:@"footerTitle"];
+  }
 
-modifyingRow = NO;
+  modifyingRow = NO;
 }
 
 - (void)configureTitle:(UITableViewCell *)cell


### PR DESCRIPTION
Backport of #12689.
See that PR for full details.