### PR TITLE
[Backport 10_0_X] fix(android): setting tab properties before open event crashes as of 10.0.0

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TabGroupProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TabGroupProxy.java
@@ -141,6 +141,12 @@ public class TabGroupProxy extends TiWindowProxy implements TiActivityWindow
 		}
 	}
 
+	private TabProxy getActiveTabProxy()
+	{
+		Object activeTab = getActiveTab();
+		return (activeTab != null) ? parseTab(activeTab) : null;
+	}
+
 	@Kroll.setProperty
 	public void setActiveTab(Object tabOrIndex)
 	{
@@ -395,15 +401,12 @@ public class TabGroupProxy extends TiWindowProxy implements TiActivityWindow
 			}
 		}
 
-		Object activeTab = getActiveTab();
-		if (activeTab != null) {
-			// If tabHost's selected tab is same as the active tab, we need
-			// to invoke onTabSelected so focus/blur event fire appropriately
-			TabProxy tab = parseTab(activeTab);
-			if (tab != null) {
-				tg.selectTab(tab);
-				selectedTab = tab;
-			}
+		// If TabGroup's selected tab is same as the active tab,
+		// then we need to invoke onTabSelected so focus/blur event fire appropriately
+		TabProxy tab = getActiveTabProxy();
+		if (tab != null) {
+			tg.selectTab(tab);
+			selectedTab = tab;
 		}
 
 		// Selected tab should have been focused by now.
@@ -462,9 +465,11 @@ public class TabGroupProxy extends TiWindowProxy implements TiActivityWindow
 		}
 		isFocused = focused;
 
-		TabProxy tab = parseTab(selectedTab);
+		// Fetch a proxy to the active tab. (Skip this if no tabs exists in group yet to avoid warnings in the log.)
+		TabProxy tab = (tabs.size() > 0) ? getActiveTabProxy() : null;
+
+		// If no tab is selected fall back to the default behavior.
 		if (tab == null) {
-			// If no tab is selected fall back to the default behavior.
 			super.onWindowFocusChange(focused);
 			return;
 		}
@@ -488,7 +493,7 @@ public class TabGroupProxy extends TiWindowProxy implements TiActivityWindow
 	 */
 	public void onTabSelected(TabProxy tabProxy)
 	{
-		TabProxy previousSelectedTab = parseTab(selectedTab);
+		TabProxy previousSelectedTab = getActiveTabProxy();
 		selectedTab = tabProxy;
 
 		// Focus event data which will be dispatched to the selected tab.

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TabProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TabProxy.java
@@ -139,16 +139,6 @@ public class TabProxy extends TiViewProxy
 		}
 	}
 
-	/*@Kroll.getProperty
-	public String getTitle()
-	{
-		// Validate tabGroup proxy.
-		if (tabGroupProxy == null ) {
-			return null;
-		}
-		return ((TiUIAbstractTabGroup) tabGroupProxy.getOrCreateView()).getTabTitle(tabGroupProxy.getTabIndex(this));
-	}*/
-
 	public void setWindowId(int id)
 	{
 		windowId = id;
@@ -236,29 +226,27 @@ public class TabProxy extends TiViewProxy
 	public void onPropertyChanged(String name, Object value)
 	{
 		super.onPropertyChanged(name, value);
-		// Check if the Tab Group proxy has been released.
-		if (tabGroupProxy == null) {
+
+		// Fetch the TabGroup's view. If currently null, then we have to wait for TabGroup activity to be created.
+		TiUIView view = (this.tabGroupProxy != null) ? this.tabGroupProxy.peekView() : null;
+		if (!(view instanceof TiUIAbstractTabGroup)) {
 			return;
 		}
+		TiUIAbstractTabGroup tabGroupView = (TiUIAbstractTabGroup) view;
+
+		// Update tab.
 		if (name.equals(TiC.PROPERTY_BACKGROUND_COLOR) || name.equals(TiC.PROPERTY_BACKGROUND_FOCUSED_COLOR)) {
-			((TiUIAbstractTabGroup) tabGroupProxy.getOrCreateView())
-				.updateTabBackgroundDrawable(tabGroupProxy.getTabIndex(this));
-		}
-		if (name.equals(TiC.PROPERTY_TITLE)) {
-			((TiUIAbstractTabGroup) tabGroupProxy.getOrCreateView()).updateTabTitle(tabGroupProxy.getTabIndex(this));
-		}
-		if (name.equals(TiC.PROPERTY_TITLE_COLOR) || name.equals(TiC.PROPERTY_ACTIVE_TITLE_COLOR)) {
-			((TiUIAbstractTabGroup) tabGroupProxy.getOrCreateView())
-				.updateTabTitleColor(tabGroupProxy.getTabIndex(this));
-		}
-		if (name.equals(TiC.PROPERTY_ICON)) {
-			((TiUIAbstractTabGroup) tabGroupProxy.getOrCreateView()).updateTabIcon(tabGroupProxy.getTabIndex(this));
-		}
-		if (name.equals(TiC.PROPERTY_BADGE)) {
-			((TiUIAbstractTabGroup) tabGroupProxy.getOrCreateView()).updateBadge(tabGroupProxy.getTabIndex(this));
-		}
-		if (name.equals(TiC.PROPERTY_BADGE_COLOR)) {
-			((TiUIAbstractTabGroup) tabGroupProxy.getOrCreateView()).updateBadgeColor(tabGroupProxy.getTabIndex(this));
+			tabGroupView.updateTabBackgroundDrawable(this.tabGroupProxy.getTabIndex(this));
+		} else if (name.equals(TiC.PROPERTY_TITLE)) {
+			tabGroupView.updateTabTitle(this.tabGroupProxy.getTabIndex(this));
+		} else if (name.equals(TiC.PROPERTY_TITLE_COLOR) || name.equals(TiC.PROPERTY_ACTIVE_TITLE_COLOR)) {
+			tabGroupView.updateTabTitleColor(this.tabGroupProxy.getTabIndex(this));
+		} else if (name.equals(TiC.PROPERTY_ICON)) {
+			tabGroupView.updateTabIcon(this.tabGroupProxy.getTabIndex(this));
+		} else if (name.equals(TiC.PROPERTY_BADGE)) {
+			tabGroupView.updateBadge(this.tabGroupProxy.getTabIndex(this));
+		} else if (name.equals(TiC.PROPERTY_BADGE_COLOR)) {
+			tabGroupView.updateBadgeColor(this.tabGroupProxy.getTabIndex(this));
 		}
 	}
 

--- a/tests/Resources/ti.ui.tabgroup.test.js
+++ b/tests/Resources/ti.ui.tabgroup.test.js
@@ -231,7 +231,18 @@ describe('Titanium.UI.TabGroup', function () {
 				should(tabGroup.tabs).eql([ tabA, tabB ]);
 			});
 
-			it.androidBroken('has no accessors', () => { // Windows are created during open
+			it('set properties before open event', () => {
+				const tab = Ti.UI.createTab({ window: Ti.UI.createWindow() });
+				tabGroup.tabs = [ tab ];
+				tabGroup.tabs[0].title = 'Tab 1';
+				tabGroup.tabs[0].badge = '5';
+				tabGroup.tabs[0].icon = '/SmallLogo.png';
+				should(tab.title).eql('Tab 1');
+				should(tab.badge).eql('5');
+				should(tab.icon.endsWith('/SmallLogo.png')).be.true();
+			});
+
+			it('has no accessors', () => {
 				should(tabGroup).not.have.accessors('barColor');
 			});
 


### PR DESCRIPTION
Backport of #12717.
See that PR for full details.