### PR TITLE
Clean up Android's HTTPClient proxy

### DIFF
--- a/android/modules/network/src/java/ti/modules/titanium/network/HTTPClientProxy.java
+++ b/android/modules/network/src/java/ti/modules/titanium/network/HTTPClientProxy.java
@@ -1,15 +1,12 @@
 /**
  * Appcelerator Titanium Mobile
- * Copyright (c) 2009-2016 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2009-2021 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
 package ti.modules.titanium.network;
 
 import java.io.UnsupportedEncodingException;
-
-import javax.net.ssl.X509KeyManager;
-import javax.net.ssl.X509TrustManager;
 
 import org.appcelerator.kroll.KrollDict;
 import org.appcelerator.kroll.KrollProxy;
@@ -287,36 +284,6 @@ public class HTTPClientProxy extends KrollProxy
 			return TiConvert.toString(this.getProperty(TiC.PROPERTY_DOMAIN));
 		}
 		return null;
-	}
-
-	// This uses Apache
-	/*
-	@Kroll.method
-	public void addAuthFactory(String scheme, Object factory)
-	{
-		//Sanity Checks
-		if ( (scheme == null) || (scheme.length() == 0) || (! (factory instanceof AuthSchemeFactory) )) {
-			return;
-		}
-
-		client.addAuthFactory(scheme, (AuthSchemeFactory)factory);
-	}
-	*/
-
-	@Kroll.method
-	public void addTrustManager(Object manager)
-	{
-		if (manager instanceof X509TrustManager) {
-			client.addTrustManager((X509TrustManager) manager);
-		}
-	}
-
-	@Kroll.method
-	public void addKeyManager(Object manager)
-	{
-		if (manager instanceof X509KeyManager) {
-			client.addKeyManager((X509KeyManager) manager);
-		}
 	}
 
 	@Kroll.setProperty

--- a/android/modules/network/src/java/ti/modules/titanium/network/TiHTTPClient.java
+++ b/android/modules/network/src/java/ti/modules/titanium/network/TiHTTPClient.java
@@ -47,8 +47,6 @@ import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.TrustManager;
-import javax.net.ssl.X509KeyManager;
-import javax.net.ssl.X509TrustManager;
 
 import android.util.Base64;
 import org.appcelerator.kroll.KrollDict;
@@ -128,8 +126,6 @@ public class TiHTTPClient
 	private URL mURL;
 	private String redirectedLocation;
 	private final ArrayList<File> tmpFiles = new ArrayList<>();
-	private final ArrayList<X509TrustManager> trustManagers = new ArrayList<>();
-	private final ArrayList<X509KeyManager> keyManagers = new ArrayList<>();
 	protected SecurityManagerProtocol securityManager;
 	private int tlsVersion = NetworkModule.TLS_DEFAULT;
 
@@ -1059,27 +1055,7 @@ public class TiHTTPClient
 			}
 		}
 		if (sslSocketFactory == null) {
-			if (trustManagers.size() > 0 || keyManagers.size() > 0) {
-				TrustManager[] trustManagerArray = null;
-				KeyManager[] keyManagerArray = null;
-
-				if (trustManagers.size() > 0) {
-					trustManagerArray = new X509TrustManager[trustManagers.size()];
-					trustManagerArray = trustManagers.toArray(trustManagerArray);
-				}
-
-				if (keyManagers.size() > 0) {
-					keyManagerArray = new X509KeyManager[keyManagers.size()];
-					keyManagerArray = keyManagers.toArray(keyManagerArray);
-				}
-
-				try {
-					sslSocketFactory = new TiSocketFactory(keyManagerArray, trustManagerArray, tlsVersion);
-				} catch (Exception e) {
-					Log.e(TAG, "Error creating SSLSocketFactory: " + e.getMessage());
-					sslSocketFactory = null;
-				}
-			} else if (!validating) {
+			if (!validating) {
 				TrustManager[] trustManagerArray = new TrustManager[] { new NonValidatingTrustManager() };
 				try {
 					sslSocketFactory = new TiSocketFactory(null, trustManagerArray, tlsVersion);
@@ -1625,28 +1601,6 @@ public class TiHTTPClient
 	protected boolean getAutoRedirect()
 	{
 		return autoRedirect;
-	}
-
-	protected void addKeyManager(X509KeyManager manager)
-	{
-		if (Log.isDebugModeEnabled()) {
-			String message
-				= "addKeyManager() method is deprecated. "
-				+ "Use the securityManager property on the HttpClient to define custom SSL Contexts.";
-			Log.d(TAG, message, Log.DEBUG_MODE);
-		}
-		keyManagers.add(manager);
-	}
-
-	protected void addTrustManager(X509TrustManager manager)
-	{
-		if (Log.isDebugModeEnabled()) {
-			String message
-				= "addTrustManager() method is deprecated. "
-				+ "Use the securityManager property on the HttpClient to define custom SSL Contexts.";
-			Log.d(TAG, message, Log.DEBUG_MODE);
-		}
-		trustManagers.add(manager);
 	}
 
 	protected void setTlsVersion(int value)

--- a/apidoc/Titanium/Network/HTTPClient.yml
+++ b/apidoc/Titanium/Network/HTTPClient.yml
@@ -173,58 +173,6 @@ methods:
   - name: abort
     summary: Cancels a pending request.
 
-  - name: addAuthFactory
-    summary: Registers a new AuthSchemeFactory for a given scheme.
-    description: |
-        This has been deprecated.
-        Use this method to add support for authorization schemes not natively supported by Android.
-    parameters:
-      - name: scheme
-        summary: The authentication scheme.
-        type: String
-      - name: factory
-        summary: The authentication factory. This factory must implement the [AuthSchemeFactory](https://developer.android.com/reference/org/apache/http/auth/AuthSchemeFactory.html) interface.
-        type: Object
-    platforms: [android]
-    since: {android: "3.0.0"}
-    deprecated:
-        since: "5.0.0"
-        removed: "5.0.0"
-
-  - name: addKeyManager
-    summary: Adds a custom key manager.
-    description: |
-        Use this method to add support for X.509 certifcate-base keypairs.
-
-        If this method is used to create a custom SSLContext, the `validatesSecureCertificate`
-        property is ignored.
-    parameters:
-      - name: X509KeyManager
-        summary: X.509 key manager. This key manager must implement the [X509KeyManager](https://developer.android.com/reference/javax/net/ssl/X509KeyManager.html) inteface.
-        type: Object
-    platforms: [android]
-    since: {android: "3.1.0"}
-    deprecated:
-        since: "3.3.0"
-        removed: "3.4.0"
-
-  - name: addTrustManager
-    summary: Adds a custom trust manager.
-    description: |
-        Use this method to add support for X.509 certifcates.
-
-        If this method is used to create a custom SSLContext, the `validatesSecureCertificate`
-        property is ignored.
-    parameters:
-      - name: X509TrustManager
-        summary: X.509 trust manager. This trust manager must implement the [X509TrustManager](https://developer.android.com/reference/javax/net/ssl/X509TrustManager.html) inteface.
-        type: Object
-    platforms: [android]
-    since: {android: "3.1.0"}
-    deprecated:
-        since: "3.3.0"
-        removed: "3.4.0"
-
   - name: clearCookies
     summary: Clears any cookies stored for the host.
     parameters:
@@ -620,8 +568,7 @@ properties:
   - name: validatesSecureCertificate
     summary: Determines how SSL certification validation is performed on connection.
     description: |
-        On Android, this property is ignored if the `addKeyManager` or `addTrustManager` methods
-        are used to create a custom SSL context.
+        On Android, this property is ignored if the `securityManager` property is used to create a custom SSL context and will handle the given URI.
     type: Boolean
     default: |
         False when running in the simulator or on device in testing mode, and true if built for


### PR DESCRIPTION
**Description:**
`Ti.network.HTTPClient` had some methods documented as removed in 3.4.0 but whose implementation as never removed. This yanks them from the apidocs as well as removes the actual implementations.