### PR TITLE
fix(ios): expose KrollBridge modules dictionary

### DIFF
--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/KrollBridge.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/KrollBridge.m
@@ -34,6 +34,26 @@ CFMutableSetRef krollBridgeRegistry = nil;
 
 @implementation KrollBridge
 
+- (NSDictionary<NSString *, id> *)modules
+{
+  // This is for backwards compatibility with native modules relying on a modules property that
+  // cached module ids -> module instances
+  // Note that this one will only return external native modules and relies on their moduleId
+  // method returning the correct valiue
+  NSDictionary<NSString *, id> *orig = [self.host valueForKey:@"modules"];
+  NSMutableDictionary<NSString *, id> *copy = [orig mutableCopy];
+  for (NSString *key in orig) {
+    id module = [orig objectForKey:key];
+    if ([module respondsToSelector:@selector(moduleId)]) {
+      NSString *moduleId = [module moduleId];
+      if (moduleId) {
+        copy[moduleId] = module;
+      }
+    }
+  }
+  return copy;
+}
+
 + (void)initialize
 {
   if (krollBridgeRegistry == nil) {

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiExceptionHandler.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiExceptionHandler.m
@@ -156,8 +156,19 @@ static NSUncaughtExceptionHandler *prevUncaughtExceptionHandler = NULL;
     if (_backtrace == nil) {
       _backtrace = [[[dictionary objectForKey:@"stack"] description] copy];
     }
-    _nativeStack = [[dictionary objectForKey:@"nativeStack"] copy];
     _dictionaryValue = [dictionary copy];
+
+    id nativeStackObject = [dictionary objectForKey:@"nativeStack"];
+    if (nativeStackObject) {
+      if ([nativeStackObject isKindOfClass:[NSArray class]]) {
+        nativeStackObject = [nativeStackObject copy];
+      } else if ([nativeStackObject isKindOfClass:[NSString class]]) {
+        nativeStackObject = [[nativeStackObject componentsSeparatedByString:@"\n"] retain];
+      } else {
+        nativeStackObject = nil;
+      }
+    }
+    _nativeStack = nativeStackObject;
   }
   return self;
 }


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-28415

**Description:**
This is purely for native module backwards compatibility. Hans had a drag and drop module that relied in accessing this dictionary to get it's own singleton instance. This patch "fixes" this to still work. That said, I'm not sure if we want to expose this to module developers.

Also note that I cherry-picked Josh's fix from #12721 so that I could se the true underlying errors.