### PR TITLE
fix(android): normalize encrypted asset paths

### DIFF
--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -556,7 +556,7 @@ AndroidBuilder.prototype.config = function config(logger, config, cli) {
 										}
 									}
 
-								} else if (cli.argv['device-id'] === undefined && results.length && config.get('android.autoSelectDevice', true)) {
+								} else if (cli.argv['device-id'] === undefined && results && results.length && config.get('android.autoSelectDevice', true)) {
 									// we set the device-id to an array of devices so that later in validate()
 									// after the tiapp.xml has been parsed, we can auto select the best device
 									_t.devicesToAutoSelectFrom = results.sort(function (a, b) {
@@ -2849,7 +2849,7 @@ AndroidBuilder.prototype.encryptJSFiles = async function encryptJSFiles() {
 					await fs.readFile(path.join(this.templatesDir, 'AssetCryptImpl.java'), 'utf8'),
 					{
 						appid: this.appid,
-						assets: this.jsFilesToEncrypt,
+						assets: this.jsFilesToEncrypt.map(f => f.replace(/\\/g, '/')),
 						salt: cloak.salt
 					}
 				)


### PR DESCRIPTION
- Normalize encrypted asset paths
- Prevent `length on undefined object` error when no devices are found

###### NOTES
- `cache.json` already normalizes paths
- `index.json` used for `require` also normalizes paths

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-28423)