### PR TITLE
fix(android): drop-down picker text color for dark/light theme change

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/picker/TiUINativePicker.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/picker/TiUINativePicker.java
@@ -39,12 +39,12 @@ public class TiUINativePicker extends TiUIPicker
 {
 	private static final String TAG = "TiUINativePicker";
 	private boolean nativeViewDrawn = false;
-	private static int defaultTextColor;
-	private static boolean setDefaultTextColor = false;
 
 	public static class TiSpinnerAdapter<T> extends ArrayAdapter<T>
 	{
 		String[] fontProperties;
+		private int defaultTextColor;
+		private boolean hasLoadedDefaultTextColor;
 
 		public TiSpinnerAdapter(Context context, int textViewResourceId, List<T> objects)
 		{
@@ -74,21 +74,25 @@ public class TiUINativePicker extends TiUIPicker
 
 		private void styleTextView(int position, TextView tv)
 		{
-			TiViewProxy rowProxy = (TiViewProxy) this.getItem(position);
+			// Fetch text view's default text color if not done already.
+			if (!this.hasLoadedDefaultTextColor) {
+				this.defaultTextColor = tv.getCurrentTextColor();
+				this.hasLoadedDefaultTextColor = true;
+			}
+
+			// Update text view's font if configured.
 			if (fontProperties != null) {
 				TiUIHelper.styleText(
 					tv, fontProperties[TiUIHelper.FONT_FAMILY_POSITION], fontProperties[TiUIHelper.FONT_SIZE_POSITION],
 					fontProperties[TiUIHelper.FONT_WEIGHT_POSITION], fontProperties[TiUIHelper.FONT_STYLE_POSITION]);
 			}
-			if (!setDefaultTextColor) {
-				defaultTextColor = tv.getCurrentTextColor();
-				setDefaultTextColor = true;
-			}
+
+			// Update text color if configured.
+			TiViewProxy rowProxy = (TiViewProxy) this.getItem(position);
 			if (rowProxy.hasProperty(TiC.PROPERTY_COLOR)) {
-				final int color = TiConvert.toColor((String) rowProxy.getProperty(TiC.PROPERTY_COLOR));
+				String colorString = TiConvert.toString(rowProxy.getProperty(TiC.PROPERTY_COLOR));
+				int color = (colorString != null) ? TiConvert.toColor(colorString) : this.defaultTextColor;
 				tv.setTextColor(color);
-			} else {
-				tv.setTextColor(defaultTextColor);
 			}
 		}
 	}


### PR DESCRIPTION
**JIRA:**
https://jira.appcelerator.org/browse/TIMOB-28424

**Summary:**
- Default text color not changing after switching dark/light theme.
- Caused by storing default text color to a "static" variable. Changed to store to an instance member variable.

---
**Dark/Light Theme Test:**
1. Build the below on Android 10 or higher.
2. Verify you can see the text in the picker. _(Dark text with light theme or light text with dark theme.)_
3. Go to `System Settings` -> `Display`.
4. Toggle the Dark/Light theme switch.
5. Go back to the Titanium app.
6. Verify that the picker's text color has changed. _(Used to use previous theme's text color.)_

```javascript
const window = Ti.UI.createWindow();
const rows = [];
for (let index = 1; index <= 5; index++) {
	rows.push(Ti.UI.createPickerRow({ title: `Item ${index}` }));
}
const picker = Ti.UI.createPicker({
	columns: [Ti.UI.createPickerColumn({ rows: rows })],
	width: "50%",
});
picker.addEventListener("change", (e) => {
	Ti.API.info(`@@@ Selected rowIndex: ${e.rowIndex}, rowTitle: "${e.row.title}"`);
});
window.add(picker);
window.open();
```

---
**Custom Color Test:**
1. Build and run the below on Android.
2. Tap on the picker.
3. Verify rows 1, 3, and 5 are green.
4. Verify rows 2 and 4 are red.

```javascript
const window = Ti.UI.createWindow();
const rows = [];
for (let index = 1; index <= 5; index++) {
	rows.push(Ti.UI.createPickerRow({ title: `Item ${index}`, color: (index % 2) ? "green" : "orange" }));
}
const picker = Ti.UI.createPicker({
	columns: [Ti.UI.createPickerColumn({ rows: rows })],
	width: "50%",
});
picker.addEventListener("change", (e) => {
	Ti.API.info(`@@@ Selected rowIndex: ${e.rowIndex}, rowTitle: "${e.row.title}"`);
});
window.add(picker);
window.open();
```
