### PR TITLE
[Backport 10_0_X] fix(ios): use weak instead of assign in properties for Objects

### DIFF
--- a/iphone/Classes/TiUITableViewRowProxy.h
+++ b/iphone/Classes/TiUITableViewRowProxy.h
@@ -16,8 +16,8 @@
 @interface TiUITableViewRowProxy : TiViewProxy <TiProxyDelegate> {
   @private
   NSString *tableClass;
-  TiUITableView *table;
-  TiUITableViewSectionProxy *section;
+  __weak TiUITableView *table;
+  __weak TiUITableViewSectionProxy *section;
   TiDimension height;
   TiDimension leftCap;
   TiDimension topCap;
@@ -31,7 +31,7 @@
   BOOL modifyingRow;
   BOOL attaching;
   NSInteger row;
-  TiUITableViewCell *callbackCell;
+  __weak TiUITableViewCell *callbackCell;
 }
 
 #pragma mark Public APIs
@@ -41,10 +41,10 @@
 
 #pragma mark Framework
 
-@property (nonatomic, readwrite, assign) TiUITableView *table;
-@property (nonatomic, readwrite, assign) TiUITableViewSectionProxy *section;
+@property (nonatomic, readwrite, weak) TiUITableView *table;
+@property (nonatomic, readwrite, weak) TiUITableViewSectionProxy *section;
 @property (nonatomic, readwrite, assign) NSInteger row;
-@property (nonatomic, readwrite, assign) TiUITableViewCell *callbackCell;
+@property (nonatomic, readwrite, weak) TiUITableViewCell *callbackCell;
 
 - (void)prepareTableRowForReuse;
 - (void)initializeTableViewCell:(UITableViewCell *)cell;

--- a/tests/Resources/ti.ui.tableview.test.js
+++ b/tests/Resources/ti.ui.tableview.test.js
@@ -1783,8 +1783,7 @@ describe('Titanium.UI.TableView', function () {
 		should(view).matchImage('snapshots/tableView_tableViewSection_header_footer.png', options);
 	});
 
-	// FIXME: This is supposed to be iOS-only, but causes crashes: https://jira.appcelerator.org/browse/TIMOB-28413
-	it.allBroken('All text should show if TableView.style is .INSET_GROUPED ', () => {
+	it.ios('All text should show if TableView.style is .INSET_GROUPED ', () => {
 		// FIXME: Does not honour scale correctly on macOS: https://jira.appcelerator.org/browse/TIMOB-28261
 		if (isCI && utilities.isMacOS() && OS_VERSION_MAJOR < 11) {
 			return;


### PR DESCRIPTION
Backport of #12706.
See that PR for full details.