### PR TITLE
chore(android): remove unneeded warnings

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/TiExceptionHandler.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiExceptionHandler.java
@@ -54,7 +54,7 @@ public class TiExceptionHandler implements Handler.Callback, KrollExceptionHandl
 	public static final String ERROR_STACK = "stack";
 	public static final String ERROR_NATIVESTACK = "nativeStack";
 
-	// DEPRECATED in 9.0.0, REMOVE 10.0.0
+	// DEPRECATED in 9.0.0, REMOVE 11.0.0
 	public static final String ERROR_LINEOFFSET = "lineOffset";
 	public static final String ERROR_JS_STACK = "javascriptStack";
 	public static final String ERROR_JAVA_STACK = "javaStack";
@@ -78,7 +78,7 @@ public class TiExceptionHandler implements Handler.Callback, KrollExceptionHandl
 		dict.put(ERROR_STACK, error.jsStack);
 		dict.put(ERROR_NATIVESTACK, error.javaStack);
 
-		// DEPRECATED in 9.0.0, REMOVE 10.0.0
+		// DEPRECATED in 9.0.0, REMOVE 11.0.0
 		dict.put(ERROR_LINEOFFSET, error.lineOffset);
 		dict.put(ERROR_JS_STACK, error.jsStack);
 		dict.put(ERROR_JAVA_STACK, error.javaStack);

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiStreamHelper.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiStreamHelper.java
@@ -1,6 +1,6 @@
 /**
  * Appcelerator Titanium Mobile
- * Copyright (c) 2009-2018 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2009-2021 by Axway, Inc. All Rights Reserved.
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
@@ -10,14 +10,11 @@ package org.appcelerator.titanium.util;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-
 import org.appcelerator.kroll.KrollDict;
 import org.appcelerator.kroll.KrollFunction;
 import org.appcelerator.kroll.KrollObject;
-import org.appcelerator.kroll.common.Log;
 import org.appcelerator.titanium.TiApplication;
 import org.appcelerator.titanium.io.TiStream;
-
 import ti.modules.titanium.BufferProxy;
 
 public class TiStreamHelper
@@ -81,11 +78,6 @@ public class TiStreamHelper
 			return 0;
 		}
 
-		String warningMessage
-			= "Synchronous invocation of read will cause performance issues under the main thread."
-			+ " This will no longer be supported in SDK 10.0.0."
-			+ " Please invoke with a final callback function to receive the result.";
-		Log.w(TAG, warningMessage);
 		final BufferProxy finalBufferProxy = bufferProxy;
 		final int finalOffset = offset;
 		final int finalLength = length;
@@ -182,11 +174,6 @@ public class TiStreamHelper
 			return 0;
 		}
 
-		String warningMessage
-			= "Synchronous invocation of write will cause performance issues under the main thread."
-			+ " This will no longer be supported in SDK 10.0.0."
-			+ " Please invoke with a final callback function to receive the result.";
-		Log.w(TAG, warningMessage);
 		final BufferProxy finalBufferProxy = bufferProxy;
 		final int finalOffset = offset;
 		final int finalLength = length;

--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiDrawableReference.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiDrawableReference.java
@@ -405,7 +405,6 @@ public class TiDrawableReference
 				}
 			} else {
 				if (is == null) {
-					Log.w(TAG, "Could not open stream to get bitmap");
 					return null;
 				}
 				try {
@@ -418,7 +417,6 @@ public class TiDrawableReference
 			}
 		} finally {
 			if (is == null) {
-				Log.w(TAG, "Could not open stream to get bitmap");
 				return null;
 			}
 			try {
@@ -673,7 +671,6 @@ public class TiDrawableReference
 
 		InputStream is = getInputStream();
 		if (is == null) {
-			Log.w(TAG, "Could not open stream to get bitmap");
 			return null;
 		}
 

--- a/apidoc/Titanium/App/App.yml
+++ b/apidoc/Titanium/App/App.yml
@@ -309,14 +309,14 @@ events:
         type: String
         platforms: [android]
       - name: lineOffset
-        summary: The offset on the line where the error occurred.
+        summary: The offset on the line where the error occurred. (Deprecated since 9.0.0. Use `column` instead.)
         type: Number
         deprecated: 
           since: "9.0.0"
           notes: Use `column` property for cross-platform parity.
         platforms: [android]
-      - name: jsStack
-        summary: The javascript stack trace of the exception.
+      - name: javascriptStack
+        summary: The javascript stack trace of the exception. (Deprecated since 9.0.0. Use `stack` instead.)
         type: String
         since: "8.0.0"
         deprecated: 
@@ -324,7 +324,7 @@ events:
           notes: Use `stack` property for cross-platform parity.
         platforms: [android]
       - name: javaStack
-        summary: The java stack trace of the exception.
+        summary: The java stack trace of the exception. (Deprecated since 9.0.0. Use `nativeStack` instead.)
         type: String
         since: "8.0.0"
         deprecated: 


### PR DESCRIPTION
**JIRA:**
https://jira.appcelerator.org/browse/TIMOB-28441

**Summary:**
- Remove below warning when calling blocking streaming API. We do not plan on removing this API in the future.
`Synchronous invocation of write will cause performance issues under the main thread. This will no longer be supported in SDK 10.0.0. Please invoke with a final callback function to receive the result.`
- Removed below image loading warning that needless spams the log. Calling code typically falls-back to the correct image path for cases where it has to guess the correct path. It's up to the caller to log an error or fire an error event.
`Could not open stream to get bitmap`
