### PR TITLE
[Backport 10_0_X] fix(android): always clone when row has parent

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TableViewSectionProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TableViewSectionProxy.java
@@ -49,7 +49,7 @@ public class TableViewSectionProxy extends TiViewProxy
 		if (row != null) {
 
 			final TiViewProxy parent = row.getParent();
-			if (parent != null && parent.getParent() != null) {
+			if (parent != null) {
 
 				// Row already exists, clone.
 				row = row.clone();
@@ -81,7 +81,7 @@ public class TableViewSectionProxy extends TiViewProxy
 		if (row != null) {
 
 			final TiViewProxy parent = row.getParent();
-			if (parent != null && parent.getParent() != null) {
+			if (parent != null) {
 
 				// Row already exists, clone.
 				row = row.clone();


### PR DESCRIPTION
Backport of #12778.
See that PR for full details.