### PR TITLE
fix(android): date dialog picker not showing initial selection in range of min/max

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/PickerProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/PickerProxy.java
@@ -487,7 +487,6 @@ public class PickerProxy extends TiViewProxy implements PickerColumnListener
 
 		// Configure main picker settings.
 		MaterialDatePicker.Builder<Long> pickerBuilder = MaterialDatePicker.Builder.datePicker();
-		pickerBuilder.setSelection(calendar.getTimeInMillis());
 		pickerBuilder.setInputMode(MaterialDatePicker.INPUT_MODE_CALENDAR);
 		if (settings.containsKey(TiC.PROPERTY_TITLE)) {
 			pickerBuilder.setTitleText(TiConvert.toString(settings, TiC.PROPERTY_TITLE));
@@ -516,15 +515,26 @@ public class PickerProxy extends TiViewProxy implements PickerColumnListener
 				long unixTime = createDateWithoutTime(minDate).getTime();
 				constraintsBuilder.setStart(unixTime);
 				validatorList.add(DateValidatorPointForward.from(unixTime));
+				if (calendar.getTimeInMillis() < unixTime) {
+					calendar.setTimeInMillis(unixTime);
+				}
 			}
 			if (maxDate != null) {
 				long unixTime = createDateWithoutTime(maxDate).getTime();
 				constraintsBuilder.setEnd(unixTime);
 				validatorList.add(DateValidatorPointBackward.before(unixTime));
+				if (calendar.getTimeInMillis() > unixTime) {
+					calendar.setTimeInMillis(unixTime);
+				}
 			}
 			constraintsBuilder.setValidator(CompositeDateValidator.allOf(validatorList));
+			constraintsBuilder.setOpenAt(calendar.getTimeInMillis());
 			pickerBuilder.setCalendarConstraints(constraintsBuilder.build());
 		}
+
+		// Select date from "value" property or current time.
+		// We must do this after applying min/max above (if applicable) to ensure selection is within range.
+		pickerBuilder.setSelection(calendar.getTimeInMillis());
 
 		// Create the dialog with above settings and assign it listeners.
 		MaterialDatePicker<Long> picker = pickerBuilder.build();


### PR DESCRIPTION
**JIRA:**
https://jira.appcelerator.org/browse/TIMOB-28442

**Summary:**
- Fixes regression introduced by Titanium 10.0.0's new material date picker dialog.
- The assigned "value" property should be forced in range of "minDate" and "maxDate" if applied.

**Test:**
1. Build and run code attached to [TIMOB-28442](https://jira.appcelerator.org/browse/TIMOB-28442) on Android.
2. Verify picker shows 2015/12/31 selected.
3. Tap on the OK button.
4. In the log, verify 2015/12/31 was printed.
