### PR TITLE
[Backport 10_0_X] fix(ios): ScrollView setZoomScale()/setContentOffset() methods crash as of 10.0.0

### DIFF
--- a/iphone/Classes/TiUIScrollViewProxy.m
+++ b/iphone/Classes/TiUIScrollViewProxy.m
@@ -349,6 +349,17 @@ static NSArray *scrollViewKeySequence;
       YES);
 }
 
+- (void)setContentOffset:(id)args
+{
+  id arg1 = args;
+  id arg2 = nil;
+  if ([args isKindOfClass:[NSArray class]]) {
+    arg1 = VALUE_AT_INDEX_OR_NIL(args, 0);
+    arg2 = VALUE_AT_INDEX_OR_NIL(args, 1);
+  }
+  [self setContentOffset:arg1 withObject:arg2];
+}
+
 - (void)setContentOffset:(id)value withObject:(id)animated
 {
   TiThreadPerformOnMainThread(
@@ -356,6 +367,17 @@ static NSArray *scrollViewKeySequence;
         [(TiUIScrollView *)[self view] setContentOffset_:value withObject:animated];
       },
       YES);
+}
+
+- (void)setZoomScale:(id)args
+{
+  id arg1 = args;
+  id arg2 = nil;
+  if ([args isKindOfClass:[NSArray class]]) {
+    arg1 = VALUE_AT_INDEX_OR_NIL(args, 0);
+    arg2 = VALUE_AT_INDEX_OR_NIL(args, 1);
+  }
+  [self setZoomScale:arg1 withObject:arg2];
 }
 
 - (void)setZoomScale:(id)value withObject:(id)animated

--- a/tests/Resources/ti.ui.scrollview.test.js
+++ b/tests/Resources/ti.ui.scrollview.test.js
@@ -52,6 +52,22 @@ describe('Titanium.UI.ScrollView', function () {
 		should(bar.contentOffset.y).be.a.Number();
 	});
 
+	it.ios('#setContentOffset', function (finish) {
+		win = Ti.UI.createWindow();
+		const bar = Ti.UI.createScrollView({});
+		win.add(bar);
+		win.addEventListener('postlayout', function listener(e) {
+			win.removeEventListener(e.type, listener);
+			try {
+				bar.setContentOffset({ x: 0, y: 0 }, { animated: true });
+			} catch (err) {
+				return finish(err);
+			}
+			finish();
+		});
+		win.open();
+	});
+
 	it.androidAndIosBroken('contentWidth', function () {
 		const bar = Ti.UI.createScrollView({});
 		should(bar.contentWidth).be.a.String(); // defaults to undefined on Android and iOS
@@ -151,6 +167,22 @@ describe('Titanium.UI.ScrollView', function () {
 	it.androidMissing('zoomScale', function () {
 		const bar = Ti.UI.createScrollView({});
 		should(bar.zoomScale).be.a.Number();
+	});
+
+	it.androidMissing('#setZoomScale', function (finish) {
+		win = Ti.UI.createWindow();
+		const bar = Ti.UI.createScrollView({});
+		win.add(bar);
+		win.addEventListener('postlayout', function listener(e) {
+			win.removeEventListener(e.type, listener);
+			try {
+				bar.setZoomScale(2, { animated: true });
+			} catch (err) {
+				return finish(err);
+			}
+			finish();
+		});
+		win.open();
 	});
 
 	it('#scrollTo()', function () {


### PR DESCRIPTION
Backport of #12788.
See that PR for full details.