### PR TITLE
chore(android): update gradle tools and dependencies

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -14,7 +14,7 @@ buildscript {
 	}
 	dependencies {
 		classpath 'com.android.tools.build:gradle:4.2.1'
-		classpath 'com.google.gms:google-services:4.3.5'
+		classpath 'com.google.gms:google-services:4.3.8'
 		classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 	}
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 
 	repositories {
 		google()
-		jcenter()
+		mavenCentral()
 	}
 	dependencies {
 		classpath 'com.android.tools.build:gradle:4.2.1'
@@ -22,7 +22,7 @@ buildscript {
 allprojects {
 	repositories {
 		google()
-		jcenter()
+		mavenCentral()
 	}
 
 	// Load plugin used to enforce our Java coding style guidelines.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,7 +6,7 @@
  */
 
 buildscript {
-	ext.kotlin_version = '1.4.30'
+	ext.kotlin_version = '1.5.0'
 
 	repositories {
 		google()

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 		jcenter()
 	}
 	dependencies {
-		classpath 'com.android.tools.build:gradle:4.1.2'
+		classpath 'com.android.tools.build:gradle:4.2.1'
 		classpath 'com.google.gms:google-services:4.3.5'
 		classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 	}

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/android/package.json
+++ b/android/package.json
@@ -27,7 +27,7 @@
 	"compileSDKVersion": "30",
 	"vendorDependencies": {
 		"android sdk": ">=23.x <=30.x",
-		"android build tools": ">=29.0.2 <=30.x",
+		"android build tools": ">=30.0.2 <=31.x",
 		"android platform tools": "30.x",
 		"android tools": "<=26.x",
 		"android ndk": ">=r11c <=r21d",	

--- a/android/templates/build/root.build.gradle
+++ b/android/templates/build/root.build.gradle
@@ -4,7 +4,7 @@ buildscript {
 
 	repositories {
 		google()
-		jcenter()
+		mavenCentral()
 	}
 	dependencies {
 		classpath 'com.android.tools.build:gradle:4.2.1'
@@ -16,7 +16,7 @@ buildscript {
 allprojects {
 	repositories {
 		google()
-		jcenter()
+		mavenCentral()
 	}
 	project.apply from: "${rootDir}/ti.constants.gradle"
 }

--- a/android/templates/build/root.build.gradle
+++ b/android/templates/build/root.build.gradle
@@ -7,7 +7,7 @@ buildscript {
 		jcenter()
 	}
 	dependencies {
-		classpath 'com.android.tools.build:gradle:4.1.2'
+		classpath 'com.android.tools.build:gradle:4.2.1'
 		classpath 'com.google.gms:google-services:4.3.5'
 		classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 	}

--- a/android/templates/build/root.build.gradle
+++ b/android/templates/build/root.build.gradle
@@ -8,7 +8,7 @@ buildscript {
 	}
 	dependencies {
 		classpath 'com.android.tools.build:gradle:4.2.1'
-		classpath 'com.google.gms:google-services:4.3.5'
+		classpath 'com.google.gms:google-services:4.3.8'
 		classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 	}
 }

--- a/android/templates/build/root.build.gradle
+++ b/android/templates/build/root.build.gradle
@@ -1,6 +1,6 @@
 
 buildscript {
-	ext.kotlin_version = '1.4.30'
+	ext.kotlin_version = '1.5.0'
 
 	repositories {
 		google()

--- a/android/templates/build/ti.constants.gradle
+++ b/android/templates/build/ti.constants.gradle
@@ -6,9 +6,9 @@
  */
 
 project.ext {
-	tiAndroidXAppCompatLibVersion = '1.2.0'
-	tiAndroidXCoreLibVersion = '1.3.2'
-	tiAndroidXFragmentLibVersion = '1.3.0'
+	tiAndroidXAppCompatLibVersion = '1.3.0'
+	tiAndroidXCoreLibVersion = '1.5.0'
+	tiAndroidXFragmentLibVersion = '1.3.4'
 	tiMaterialLibVersion = '1.3.0'
 	tiPlayServicesBaseLibVersion = '17.6.0'
 	tiManifestPlaceholders = [

--- a/android/titanium/build.gradle
+++ b/android/titanium/build.gradle
@@ -248,15 +248,15 @@ dependencies {
 	implementation 'androidx.drawerlayout:drawerlayout:1.1.1'
 	implementation 'androidx.exifinterface:exifinterface:1.3.2'
 	implementation "androidx.fragment:fragment:${project.ext.tiAndroidXFragmentLibVersion}"
-	implementation 'androidx.media:media:1.2.1'
-	implementation 'androidx.recyclerview:recyclerview:1.1.0'
+	implementation 'androidx.media:media:1.3.1'
+	implementation 'androidx.recyclerview:recyclerview:1.2.0'
 	implementation 'androidx.recyclerview:recyclerview-selection:1.1.0'
 	implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
-	implementation 'androidx.transition:transition:1.4.0'
+	implementation 'androidx.transition:transition:1.4.1'
 	implementation 'androidx.vectordrawable:vectordrawable:1.1.0'
 	implementation 'androidx.vectordrawable:vectordrawable-animated:1.1.0'
 	implementation 'androidx.viewpager:viewpager:1.0.0'
-	compileOnly 'androidx.annotation:annotation:1.1.0'
+	compileOnly 'androidx.annotation:annotation:1.2.0'
 
 	// Google's "Material Components" themed UI library.
 	implementation "com.google.android.material:material:${project.ext.tiMaterialLibVersion}"
@@ -264,7 +264,7 @@ dependencies {
 	// The Google Play Services libraries are only used by Titanium's geolocation feature.
 	// We link to them dynamically at runtime. So, they can be safely excluded when in the app project.
 	implementation "com.google.android.gms:play-services-base:${project.ext.tiPlayServicesBaseLibVersion}"
-	implementation 'com.google.android.gms:play-services-location:17.1.0'
+	implementation 'com.google.android.gms:play-services-location:18.0.0'
 
 	// XML library providing XPath support to our Ti.XML APIs.
 	implementation 'jaxen:jaxen:1.2.0'


### PR DESCRIPTION
**JIRA:**
- https://jira.appcelerator.org/browse/TIMOB-28455
- https://jira.appcelerator.org/browse/TIMOB-28456
- https://jira.appcelerator.org/browse/TIMOB-28457

**Summary:**
- [TIMOB-28455](https://jira.appcelerator.org/browse/TIMOB-28455) Updated Android gradle tool to version `4.2.1`.
- [TIMOB-28457](https://jira.appcelerator.org/browse/TIMOB-28457) Updated Kotlin language version to `1.5.0` for module builds.
- [TIMOB-28456](https://jira.appcelerator.org/browse/TIMOB-28456) Replaced deprecated usage of `jcenter()` repo with `mavenCentral()`.
  * See: https://developer.android.com/studio/build/jcenter-migration
  * Might be a breaking-change for hyperloop/module builds whose dependencies don't exist on Maven Central, but we have to do it since JCenter will be shutdown by February 2022. _(You can re-add JCenter via "build.gradle".)_
- Updated all of the Titanium SDK's library dependencies to the newest versions.

---
**Hyperloop Test:**
1. Build and run [hyperloop-examples](https://github.com/appcelerator/hyperloop-examples) for Android.
2. Verify each window successfully displays its contents. Particularly the 3rd party libraries section.

---
**Kotlin Test:**
1. `appc ti sdk select 10.1.0`
2. `appc new`
3. Select "Titanium Module".
4. Select "Kotlin" language for the Android question.
5. `CD` to the module's "android" folder.
6. `appc run -p android`
7. Verify it builds and runs successfully.
