### PR TITLE
[Backport 10_0_X] fix(android): Ti.UI.Picker "change" event not returning row titles from "selectedValue" as of 10.0.1

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/PickerProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/PickerProxy.java
@@ -756,7 +756,7 @@ public class PickerProxy extends TiViewProxy implements PickerColumnProxy.OnChan
 		for (int i = 0; i < columnCount; i++) {
 			PickerRowProxy rowInColumn = getSelectedRow(i);
 			if (rowInColumn != null) {
-				selectedValues.add(rowInColumn.toString());
+				selectedValues.add(rowInColumn.getTitle());
 			} else {
 				selectedValues.add(null);
 			}


### PR DESCRIPTION
Backport of #12833.
See that PR for full details.