### PR TITLE
fix(android): correctly process bootstrap paths

### DIFF
--- a/cli/lib/tasks/process-js-task.js
+++ b/cli/lib/tasks/process-js-task.js
@@ -257,7 +257,7 @@ class ProcessJsTask extends IncrementalFileTask {
 			throw new Error(`Unable to resolve relative path for ${filePathAndName}.`);
 		}
 
-		const bootstrapPath = file.substr(0, file.length - 3);  // Remove the ".js" extension.
+		const bootstrapPath = file.substr(0, file.length - 3).replace(/\\/g, '/');  // Remove the ".js" extension.
 		if (bootstrapPath.endsWith('.bootstrap') && !this.jsBootstrapFiles.includes(bootstrapPath)) {
 			this.jsBootstrapFiles.push(bootstrapPath);
 		}
@@ -366,7 +366,7 @@ class ProcessJsTask extends IncrementalFileTask {
 	 */
 	async handleDeletedFile(filePathAndName) {
 		let file = this.resolveRelativePath(filePathAndName, this.data.jsFiles);
-		const bootstrapPath = file.substr(0, file.length - 3);  // Remove the ".js" extension.
+		const bootstrapPath = file.substr(0, file.length - 3).replace(/\\/g, '/');  // Remove the ".js" extension.
 		if (bootstrapPath.endsWith('.bootstrap')) {
 			const index = this.jsBootstrapFiles.indexOf(bootstrapPath);
 			if (index !== -1) {


### PR DESCRIPTION
- Correctly handle `bootstrap.json` paths on Windows

##### TESTCASE
- Create a Titanium application on Windows
- Build and run application
- Application should launch successfully without
```
Error: Requested module not found: ti.playservices\ti.playservices.bootstrap
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-28463)