### PR TITLE
fix(android): ProgressBar tintColor/trackTintColor ignored as of 10.0.0

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIProgressBar.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIProgressBar.java
@@ -6,7 +6,6 @@
  */
 package ti.modules.titanium.ui.widget;
 
-import android.content.res.ColorStateList;
 import android.view.Gravity;
 import android.widget.LinearLayout;
 import com.google.android.material.progressindicator.LinearProgressIndicator;
@@ -66,10 +65,10 @@ public class TiUIProgressBar extends TiUIView
 			handleSetMessageColor(color);
 		}
 		if (d.containsKey(TiC.PROPERTY_TINT_COLOR)) {
-			handleSetTintColor(TiConvert.toColor(d, TiC.PROPERTY_TINT_COLOR));
+			this.progress.setIndicatorColor(TiConvert.toColor(d, TiC.PROPERTY_TINT_COLOR));
 		}
 		if (d.containsKey(TiC.PROPERTY_TRACK_TINT_COLOR)) {
-			handleSetTrackTintColor(TiConvert.toColor(d, TiC.PROPERTY_TRACK_TINT_COLOR));
+			this.progress.setTrackColor(TiConvert.toColor(d, TiC.PROPERTY_TRACK_TINT_COLOR));
 		}
 		updateProgress();
 	}
@@ -90,11 +89,9 @@ public class TiUIProgressBar extends TiUIView
 			final int color = TiConvert.toColor(TiConvert.toString(newValue));
 			handleSetMessageColor(color);
 		} else if (key.equals(TiC.PROPERTY_TINT_COLOR)) {
-			int tintColor = TiConvert.toColor(TiConvert.toString(newValue));
-			handleSetTintColor(tintColor);
+			this.progress.setIndicatorColor(TiConvert.toColor(TiConvert.toString(newValue)));
 		} else if (key.equals(TiC.PROPERTY_TRACK_TINT_COLOR)) {
-			int trackTintColor = TiConvert.toColor(TiConvert.toString(newValue));
-			handleSetTrackTintColor(trackTintColor);
+			this.progress.setTrackColor(TiConvert.toColor(TiConvert.toString(newValue)));
 		}
 	}
 
@@ -148,17 +145,5 @@ public class TiUIProgressBar extends TiUIView
 	protected void handleSetMessageColor(int color)
 	{
 		label.setTextColor(color);
-	}
-
-	protected void handleSetTintColor(int color)
-	{
-		ColorStateList singleColorStateList = ColorStateList.valueOf(color);
-		progress.setProgressTintList(singleColorStateList);
-	}
-
-	protected void handleSetTrackTintColor(int color)
-	{
-		ColorStateList singleColorStateList = ColorStateList.valueOf(color);
-		progress.setProgressBackgroundTintList(singleColorStateList);
 	}
 }


### PR DESCRIPTION
**JIRA:**
https://jira.appcelerator.org/browse/TIMOB-28485

**Test:**
1. Build and run the below on Android.
2. Verify you see a "green" progress bar filling a "red" background bar.

```javascript
let timerId = null;
const window = Ti.UI.createWindow();
const progressBar = Ti.UI.createProgressBar({
	tintColor: "green",
	trackTintColor: "red",
	animated: false,
	min: 0,
	max: 100,
	value: 0,
	width: "80%",
});
window.add(progressBar);
window.addEventListener("open", () => {
	timerId = setInterval(() => {
		const value = progressBar.value + 1;
		progressBar.value = (value <= 100) ? value : 0;
		progressBar.message = `Progress at ${progressBar.value}%`;
	}, 50);
});
window.addEventListener("close", () => {
	if (timerId) {
		clearInterval(timerId);
		timerId = null;
	}
});
window.open();
```
