### PR TITLE
refactor(android): remove warning about sigalg compatability for older android versions

### DIFF
--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -266,10 +266,6 @@ AndroidBuilder.prototype.config = function config(logger, config, cli) {
 								if (!alias) {
 									return callback(new Error(__('Invalid "--alias" value "%s"', value)));
 								}
-								if (alias.sigalg && alias.sigalg.toLowerCase() === 'sha256withrsa') {
-									logger.warn(__('The selected alias %s uses the %s signature algorithm which will likely have issues with Android 4.3 and older.', ('"' + value + '"').cyan, ('"' + alias.sigalg + '"').cyan));
-									logger.warn(__('Certificates that use the %s or %s signature algorithm will provide better compatibility.', '"SHA1withRSA"'.cyan, '"MD5withRSA"'.cyan));
-								}
 							}
 							callback(null, value);
 						}

--- a/android/cli/locales/en.js
+++ b/android/cli/locales/en.js
@@ -9,7 +9,6 @@
 	"What is the name of the keystore's certificate alias?": "What is the name of the keystore's certificate alias?",
 	"Select a certificate alias by number or name": "Select a certificate alias by number or name",
 	"Invalid \"--alias\" value \"%s\"": "Invalid \"--alias\" value \"%s\"",
-	"The selected alias %s uses the %s signature algorithm which will likely have issues with Android 4.3 and older.": "The selected alias %s uses the %s signature algorithm which will likely have issues with Android 4.3 and older.",
 	"Certificates that use the %s or %s signature algorithm will provide better compatibility.": "Certificates that use the %s or %s signature algorithm will provide better compatibility.",
 	"the path to the Android SDK": "the path to the Android SDK",
 	"path": "path",


### PR DESCRIPTION
Given that the min SDK is now Android 5 this warning is no longer needed

To test create a keystore using `keytool -genkey -alias testing1234 -keyalg RSA -dname "CN=test,OU=test,O=test,L=test,ST=test,C=TE" -validity 9125 -keypass testing -storepass testing -keystore keystore.jks` and then build using it. The warning should no longer be there