### PR TITLE
test(macos): disable animate width/height unit test

### DIFF
--- a/tests/Resources/ti.ui.view.test.js
+++ b/tests/Resources/ti.ui.view.test.js
@@ -701,6 +701,12 @@ describe('Titanium.UI.View', function () {
 
 	// On iOS, the animation's 'complete' event used to never fire. See: TIMOB-27236
 	it('animate width/height from zero', function (finish) {
+		// This fails for Mac on Jenkins.
+		// Maybe because the animation's "complete" event won't fire if there is no monitor connected?
+		if (isCI && utilities.isMacOS()) {
+			return finish();
+		}
+
 		win = Ti.UI.createWindow({ backgroundColor: 'white' });
 		const view = Ti.UI.createView({
 			backgroundColor: 'orange',


### PR DESCRIPTION
**Note:**
Unit test only fails for Jenkins node. I think the animation "complete" event won't fire if there is no monitor connected to the Mac... or really the animation doesn't happen because it can't be seen.
