### PR TITLE
fix(android): amend actionBarStyle for MaterialComponents

### DIFF
--- a/android/titanium/res/values/values.xml
+++ b/android/titanium/res/values/values.xml
@@ -59,7 +59,7 @@
 	<!-- Titanium's light material theme with an action bar. -->
 	<style name="Theme.Titanium.Light" parent="Theme.MaterialComponents.Light.DarkActionBar">
 		<item name="actionBarSize">@dimen/ti_action_bar_height</item>
-		<item name="actionBarStyle">@style/Widget.AppCompat.Light.ActionBar.Solid</item>
+		<item name="actionBarStyle">@style/Widget.MaterialComponents.Light.ActionBar.Solid</item>
 		<item name="colorPrimary">@color/ti_light_primary</item>
 		<item name="colorPrimaryDark">@color/ti_light_primary_dark</item>
 		<item name="colorAccent">@color/ti_light_accent</item>


### PR DESCRIPTION
- Amend `actionBarStyle` to use `MaterialComponents` instead of `AppCompat`

##### TEST CASE
```JS
const window = Ti.UI.createWindow();

window.addEventListener('open', _ => {
	const actionBar = window.activity.actionBar;

	if (actionBar) {
		actionBar.title = 'ActionBar';
		actionBar.homeButtonEnabled = true;
		actionBar.displayHomeAsUp = true;
		actionBar.onHomeIconItemSelected = _ => {
			alert('Home');
		};
	}
});

window.open();
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-28493)