### PR TITLE
[Backport 10_0_X] fix(ios): properly dismiss search controller after editing

### DIFF
--- a/iphone/Classes/TiUIListView.m
+++ b/iphone/Classes/TiUIListView.m
@@ -2082,8 +2082,11 @@ static TiViewProxy *FindViewProxyWithBindIdContainingPoint(UIView *view, CGPoint
   if ([searchBar.text length] == 0) {
     self.searchString = @"";
     [self buildResultsForSearchText];
-    [self performSelector:@selector(dismissSearchController) withObject:nil afterDelay:.2];
   }
+
+  // Finished editing, always dismiss search controller.
+  // Only one search controller can be active at a time.
+  [self performSelector:@selector(dismissSearchController) withObject:nil afterDelay:.2];
 }
 
 - (void)searchBar:(UISearchBar *)searchBar textDidChange:(NSString *)searchText

--- a/iphone/Classes/TiUITableView.m
+++ b/iphone/Classes/TiUITableView.m
@@ -1570,6 +1570,13 @@
   // Also if a previous search string exists this reload results in blank cells.
 }
 
+- (void)searchBarTextDidEndEditing:(UISearchBar *)searchBar
+{
+  // Finished editing, always dismiss search controller.
+  // Only one search controller can be active at a time.
+  [self performSelector:@selector(dismissSearchController) withObject:nil afterDelay:.2];
+}
+
 - (void)searchBarSearchButtonClicked:(UISearchBar *)searchBar
 {
   // called when keyboard search button pressed
@@ -2446,7 +2453,9 @@
 
 - (void)dismissSearchController
 {
-  [searchController setActive:NO];
+  if (searchController.isActive) {
+    [searchController setActive:NO];
+  }
 }
 
 - (void)keyboardWillChangeFrame:(NSNotification *)notification


### PR DESCRIPTION
Backport of #12906.
See that PR for full details.