### PR TITLE
fix(android): logged theme error in "ti.map" module

### DIFF
--- a/support/module/packaged/modules.json
+++ b/support/module/packaged/modules.json
@@ -39,8 +39,8 @@
 			"integrity": "sha512-z5Zx2OpSKDl3MCgP2Bf8uSQ58Op60FaUWFddWpyix3XAFNRlO3o3TqAmOUJAZvgDymRh71iWDOwghe50kznkZw=="
 		},
 		"ti.map": {
-			"url": "https://github.com/appcelerator-modules/ti.map/releases/download/v5.0.1-android/ti.map-android-5.0.1.zip",
-			"integrity": "sha512-W8Fq4DV3E8kcWqcZdjvoEbKHgqBumZS9jzi4gTiZf1OeeNoEsnXI4ZrjOZsO0VguuG9kra82EcXU6HMM/Jur0Q=="
+			"url": "https://github.com/appcelerator-modules/ti.map/releases/download/v5.3.2-android/ti.map-android-5.3.2.zip",
+			"integrity": "sha512-SdpHB56dv5UTtZ1NaXPxlf/7VuU6KEYE3pqRmsYjOuYLg/ihSaqyMPeJnQhlWFicIbKihAxfnvQLMNGEDjthmQ=="
 		},
 		"ti.webdialog": {
 			"url": "https://github.com/appcelerator-modules/titanium-web-dialog/releases/download/v2.0.0-android/ti.webdialog-android-2.0.0.zip",
@@ -63,8 +63,8 @@
 	},
 	"hyperloop": {
 		"hyperloop": {
-			"url":"https://github.com/appcelerator/hyperloop.next/releases/download/v7.0.1/hyperloop-7.0.1.zip",
-			"integrity":"sha512-k1ZPCglcdr8KPskvPwaQE0e8ohtdB4aYuOtFNKLOmOFu+JD6Ft7MPmXnZNPJe2IXOHt6UXb0pkAEzwHo/8JFVg=="
+			"url": "https://github.com/appcelerator/hyperloop.next/releases/download/v7.0.1/hyperloop-7.0.1.zip",
+			"integrity": "sha512-k1ZPCglcdr8KPskvPwaQE0e8ohtdB4aYuOtFNKLOmOFu+JD6Ft7MPmXnZNPJe2IXOHt6UXb0pkAEzwHo/8JFVg=="
 		}
 	}
 }


### PR DESCRIPTION
**JIRA:**
https://jira.appcelerator.org/browse/TIMOB-28358

**Summary:**
- Updated "ti.map" module to 5.3.2.
- Updated map library dependencies.
- Fixed error that gets logged the first time a map is shown. (Error is harmless though.)

**Test:**
1. Set up a Titanium project to use "ti.map" module version 5.3.2 included with this PR.
2. Build and run the below code on Android.
3. Verify the map is displayed fine.
4. Verify the following error does **NOT** get logged. _(This is the fix.)_
`[ERROR] ThemeUtils: View class com.google.maps.android.ui.SquareTextView is an AppCompat widget that can only be used with a Theme.AppCompat theme (or descendant).`

app.js
```javascript
const map = require("ti.map");
const window = Ti.UI.createWindow();
window.add(map.createView({
	width: Ti.UI.FILL,
	height: Ti.UI.FILL,
}));
window.open();
```
