### PR TITLE
fix(android): crash with MapView in TabGroup as of 10.0.1

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUITab.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUITab.java
@@ -44,6 +44,7 @@ public class TiUITab extends TiUIView
 		// In order for the 'activity' property to work correctly
 		// we need to set the content view's activity to that of the group.
 		Activity tabGroupActivity = ((TabProxy) proxy).getTabGroup().getActivity();
+		proxy.setActivity(tabGroupActivity);
 		windowProxy.setActivity(tabGroupActivity);
 
 		// Assign parent so events bubble up correctly.

--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/TiViewProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/TiViewProxy.java
@@ -441,11 +441,8 @@ public abstract class TiViewProxy extends KrollProxy
 				Log.d(TAG, "getView: " + getClass().getSimpleName(), Log.DEBUG_MODE);
 			}
 
-			TiViewProxy parentProxy = getParent();
-			Activity parentActivity = (parentProxy != null) ? parentProxy.getActivity() : null;
-
 			Activity lastActivity = getActivity();
-			Activity activity = (parentActivity != null) ? parentActivity : lastActivity;
+			Activity activity = lastActivity;
 			TiBaseActivity baseActivity = null;
 
 			if (activity instanceof TiBaseActivity) {
@@ -460,9 +457,13 @@ public abstract class TiViewProxy extends KrollProxy
 				activity = baseActivity;
 
 			} else if (activity == null) {
-				if (parentActivity != null) {
-					activity = parentActivity;
-				} else {
+				for (TiViewProxy parent = getParent(); parent != null; parent = parent.getParent()) {
+					activity = parent.getActivity();
+					if (activity != null) {
+						break;
+					}
+				}
+				if (activity == null) {
 					activity = TiApplication.getAppRootOrCurrentActivity();
 				}
 			}


### PR DESCRIPTION
**JIRA:**
https://jira.appcelerator.org/browse/TIMOB-28501

**Summary:**
- Regression caused by PR #12909 in Titanium 10.0.1 and was caught before release.
- Crash occurs because map's activity is wrongly changed to previous window's activity (or splash).
  * Issue was with parent tab proxy whose activity was never updated to use TabGroup's activity.

**Test:**
1. Set up a project with the "ti.map" module.
2. Build and run the below on Android.
3. Verify a map is displayed within tab 1.
4. Verify you can select tab 2 and 3.

```javascript
const map = require("ti.map");
const tabWindow1 = Ti.UI.createWindow();
tabWindow1.add(map.createView({
	width: Ti.UI.FILL,
	height: Ti.UI.FILL,
}));
const tabWindow2 = Ti.UI.createWindow();
tabWindow2.add(Ti.UI.createLabel({ text: "Tab 2" }));
const tabWindow3 = Ti.UI.createWindow();
tabWindow3.add(Ti.UI.createLabel({ text: "Tab 3" }));
const tabGroup = Ti.UI.createTabGroup({
	tabs: [
		Ti.UI.createTab({ title: "Tab 1", window: tabWindow1 }),
		Ti.UI.createTab({ title: "Tab 2", window: tabWindow2 }),
		Ti.UI.createTab({ title: "Tab 3", window: tabWindow3 }),
	],
});
tabGroup.open();
```
