### PR TITLE
fix(android): ScrollableView "views" property wrongly empty before window open as of 10.0.1

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/ScrollableViewProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/ScrollableViewProxy.java
@@ -63,6 +63,16 @@ public class ScrollableViewProxy extends TiViewProxy
 	}
 
 	@Override
+	public void handleCreationDict(KrollDict properties)
+	{
+		super.handleCreationDict(properties);
+
+		if (properties.containsKey(TiC.PROPERTY_VIEWS)) {
+			setViews(properties.get(TiC.PROPERTY_VIEWS));
+		}
+	}
+
+	@Override
 	public TiUIView createView(Activity activity)
 	{
 		this.scrollableView = new TiUIScrollableView(this);

--- a/tests/Resources/ti.ui.scrollableview.test.js
+++ b/tests/Resources/ti.ui.scrollableview.test.js
@@ -105,11 +105,10 @@ describe('Titanium.UI.ScrollableView', () => {
 				should(scrollableView.currentPage).eql(0);
 			});
 
-			// FIXME explicitly setting currentPage doesn't seem to update value on Android
-			it.androidBroken('can be assigned an Integer value', () => {
+			it('can be assigned an Integer value', () => {
 				scrollableView.views = [ Ti.UI.createView(), Ti.UI.createView() ];
 				scrollableView.currentPage = 1;
-				should(scrollableView.currentPage).eql(1); // Android gives 0
+				should(scrollableView.currentPage).eql(1);
 			});
 
 			it('has no accessors', () => {
@@ -207,24 +206,39 @@ describe('Titanium.UI.ScrollableView', () => {
 		});
 
 		describe('.views', () => {
-			beforeEach(() => {
-				scrollableView = Ti.UI.createScrollableView();
-			});
-
 			it('is an Array', () => {
+				scrollableView = Ti.UI.createScrollableView();
 				should(scrollableView).have.property('views').which.is.an.Array();
 			});
 
 			it('defaults to empty Array', () => {
+				scrollableView = Ti.UI.createScrollableView();
 				should(scrollableView.views).be.empty();
 			});
 
-			it('can be assigned an Array of Ti.UI.Views', () => {
+			it('assigned during creation', () => {
+				scrollableView = Ti.UI.createScrollableView({
+					views: [ Ti.UI.createView(), Ti.UI.createView(), Ti.UI.createView() ]
+				});
+				should(scrollableView.views.length).eql(3);
+			});
+
+			it('assigned after creation', () => {
+				scrollableView = Ti.UI.createScrollableView();
 				scrollableView.views = [ Ti.UI.createView(), Ti.UI.createView() ];
 				should(scrollableView.views.length).eql(2);
 			});
 
+			it('update after creation', () => {
+				scrollableView = Ti.UI.createScrollableView({
+					views: [ Ti.UI.createView(), Ti.UI.createView() ]
+				});
+				scrollableView.views = scrollableView.views.concat(Ti.UI.createView(), Ti.UI.createView());
+				should(scrollableView.views.length).eql(4);
+			});
+
 			it('has no accessors', () => {
+				scrollableView = Ti.UI.createScrollableView();
 				should(scrollableView).not.have.accessors('views');
 			});
 		});


### PR DESCRIPTION
**JIRA:**
https://jira.appcelerator.org/browse/TIMOB-28504

**Summary:**
- Regression as of Titanium 10.0.1. Caught before release.
- "views" property does not return same array assigned upon creation before window open, but works after window opens.

**Test:**
Covered by this PR's unit tests.
