### PR TITLE
[Backport 10_0_X] fix(android): crash with MapView in TabGroup as of 10.0.1

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUITab.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUITab.java
@@ -44,6 +44,7 @@ public class TiUITab extends TiUIView
 		// In order for the 'activity' property to work correctly
 		// we need to set the content view's activity to that of the group.
 		Activity tabGroupActivity = ((TabProxy) proxy).getTabGroup().getActivity();
+		proxy.setActivity(tabGroupActivity);
 		windowProxy.setActivity(tabGroupActivity);
 
 		// Assign parent so events bubble up correctly.

--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/TiViewProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/TiViewProxy.java
@@ -441,11 +441,8 @@ public abstract class TiViewProxy extends KrollProxy
 				Log.d(TAG, "getView: " + getClass().getSimpleName(), Log.DEBUG_MODE);
 			}
 
-			TiViewProxy parentProxy = getParent();
-			Activity parentActivity = (parentProxy != null) ? parentProxy.getActivity() : null;
-
 			Activity lastActivity = getActivity();
-			Activity activity = (parentActivity != null) ? parentActivity : lastActivity;
+			Activity activity = lastActivity;
 			TiBaseActivity baseActivity = null;
 
 			if (activity instanceof TiBaseActivity) {
@@ -460,9 +457,13 @@ public abstract class TiViewProxy extends KrollProxy
 				activity = baseActivity;
 
 			} else if (activity == null) {
-				if (parentActivity != null) {
-					activity = parentActivity;
-				} else {
+				for (TiViewProxy parent = getParent(); parent != null; parent = parent.getParent()) {
+					activity = parent.getActivity();
+					if (activity != null) {
+						break;
+					}
+				}
+				if (activity == null) {
 					activity = TiApplication.getAppRootOrCurrentActivity();
 				}
 			}


### PR DESCRIPTION
Backport of #12932.
See that PR for full details.