### PR TITLE
build: add engines.node entry to platform package.json files

### DIFF
--- a/android/package.json
+++ b/android/package.json
@@ -33,6 +33,9 @@
 		"android ndk": ">=r21 <=r22b",
 		"java": ">=1.8.x"
 	},
+	"engines": {
+		"node": ">=12.13.0"
+	},
 	"repository": {
 		"type": "git",
 		"url": "git://github.com/appcelerator/titanium_mobile.git"

--- a/iphone/package.json
+++ b/iphone/package.json
@@ -22,6 +22,9 @@
 		"xcode": ">=11.0 <=12.x",
 		"ios sdk": ">=13.0 <=14.x"
 	},
+	"engines": {
+		"node": ">=12.13.0"
+	},
 	"repository": {
 		"type": "git",
 		"url": "git://github.com/appcelerator/titanium_mobile_ios.git"


### PR DESCRIPTION
eslint-plugin-node will walk up the file tree to look for the nearest package.json and use that to
determine the minimum node version, as these package.json files didnt have an engines.node property
it was defaulting to >=8.0.0. So, although it's duplication, just set it here to avoid issues
