### PR TITLE
[Backport 10_0_X] fix(ios): hierarchy error when using SplitWindow and NavigationWindow

### DIFF
--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiWindowProxy.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiWindowProxy.m
@@ -505,11 +505,20 @@
 
 - (UIViewController *)windowHoldingController
 {
+  // Use assigned controller if set.
   if (controller != nil) {
     return controller;
-  } else {
-    return [[TiApp app] controller];
   }
+
+  // Walk up the view hierarchy for the 1st controller available.
+  for (UIResponder *responder = [self view].nextResponder; responder != nil; responder = responder.nextResponder) {
+    if ([responder isKindOfClass:[UIViewController class]]) {
+      return (UIViewController *)responder;
+    }
+  }
+
+  // Fallback to the app's root view controller.
+  return [[TiApp app] controller];
 }
 
 #pragma mark - Private Methods

--- a/tests/Resources/ti.ui.ios.splitwindow.test.js
+++ b/tests/Resources/ti.ui.ios.splitwindow.test.js
@@ -25,6 +25,28 @@ describe.ios('Titanium.UI.iOS', function () {
 		should(splitWindow.masterView).be.an.Object();
 		should(splitWindow.detailView).be.an.Object();
 	});
+
+	// Verify view controller hierarchy is set up correctly. (Used to crash in 10.0.0. See: TIMOB-28497)
+	it('view controller hierarchy', function (finish) {
+		this.slow(2000);
+		this.timeout(5000);
+		const splitWindow = Ti.UI.iOS.createSplitWindow({
+			detailView: Ti.UI.createNavigationWindow({
+				window: Ti.UI.createWindow({ title: 'Detail View' }),
+			}),
+			masterView: Ti.UI.createNavigationWindow({
+				window: Ti.UI.createWindow({ title: 'Master View' }),
+			}),
+			showMasterInPortrait: true,
+		});
+		const navWindow = Ti.UI.createNavigationWindow({ window: splitWindow });
+		navWindow.addEventListener('postlayout', function listener() {
+			navWindow.removeEventListener('postlayout', listener);
+			navWindow.close();
+			finish();
+		});
+		navWindow.open();
+	});
 });
 
 // describe.ios('Titanium.UI.iOS.SplitWindow', function () {


### PR DESCRIPTION
Backport of #12930.
See that PR for full details.