### PR TITLE
fix(ios): do not create invalid swift compiler flags from symbol usage

### DIFF
--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -6641,7 +6641,12 @@ iOSBuilder.prototype.processTiSymbols = function processTiSymbols() {
 		if (parts.length) {
 			namespaces[parts[0].toLowerCase()] = 1;
 			while (parts.length) {
-				symbols[parts.join('.').replace(/\.create/gi, '').replace(/\./g, '').replace(/-/g, '_').toUpperCase()] = 1;
+				const value = parts.join('.').replace(/\.create/gi, '').replace(/\./g, '').replace(/-/g, '_').toUpperCase();
+				// Ignore any value that is not a single uppercased word, this is most likely an
+				// invalid detection by the babel plugin that collects the symbols used
+				if (/^\w+$/.test(value)) {
+					symbols[value] = 1;
+				}
 				parts.pop();
 			}
 		}

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "markdown": "0.5.0",
         "moment": "^2.29.1",
         "node-appc": "^1.1.2",
-        "node-titanium-sdk": "^5.1.3",
+        "node-titanium-sdk": "^5.1.4",
         "node-uuid": "1.4.8",
         "nodeify": "^1.0.1",
         "p-limit": "^3.1.0",
@@ -12383,9 +12383,9 @@
       "integrity": "sha512-ZQmnWS7adi61A9JsllJ2gdj2PauElcjnOwTp2O011iGzoakTxUsDGSe+6vD7wXbKdqhSFymC0OSx35aAMhrSdw=="
     },
     "node_modules/node-titanium-sdk": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/node-titanium-sdk/-/node-titanium-sdk-5.1.3.tgz",
-      "integrity": "sha512-17eniim+u8xSsay/tD/E6Ue5A+Vdx7GIh5VztxkyJqpH5tbBfOyExRCUACKIrVPMWMHq/Rv6nwv2BZdECXae3A==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/node-titanium-sdk/-/node-titanium-sdk-5.1.4.tgz",
+      "integrity": "sha512-NJpEY1e122reIocZHDPpxlZ4bIYJRt8FEw8W+AeE7WjJz2kZjLbWvvhYbkb6QfAyEL1aU9dMRutspVFYyqycaw==",
       "dependencies": {
         "@babel/core": "^7.8.0",
         "@babel/parser": "^7.8.3",
@@ -26606,9 +26606,9 @@
       "integrity": "sha512-ZQmnWS7adi61A9JsllJ2gdj2PauElcjnOwTp2O011iGzoakTxUsDGSe+6vD7wXbKdqhSFymC0OSx35aAMhrSdw=="
     },
     "node-titanium-sdk": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/node-titanium-sdk/-/node-titanium-sdk-5.1.3.tgz",
-      "integrity": "sha512-17eniim+u8xSsay/tD/E6Ue5A+Vdx7GIh5VztxkyJqpH5tbBfOyExRCUACKIrVPMWMHq/Rv6nwv2BZdECXae3A==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/node-titanium-sdk/-/node-titanium-sdk-5.1.4.tgz",
+      "integrity": "sha512-NJpEY1e122reIocZHDPpxlZ4bIYJRt8FEw8W+AeE7WjJz2kZjLbWvvhYbkb6QfAyEL1aU9dMRutspVFYyqycaw==",
       "requires": {
         "@babel/core": "^7.8.0",
         "@babel/parser": "^7.8.3",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "markdown": "0.5.0",
     "moment": "^2.29.1",
     "node-appc": "^1.1.2",
-    "node-titanium-sdk": "^5.1.3",
+    "node-titanium-sdk": "^5.1.4",
     "node-uuid": "1.4.8",
     "nodeify": "^1.0.1",
     "p-limit": "^3.1.0",


### PR DESCRIPTION
**JIRA:**
- https://jira.appcelerator.org/browse/TIMOB-28510
- https://jira.appcelerator.org/browse/TIMOB-28496

**Summary:**
* Update node-titanium-sdk to improve detection of Ti API usage
* Add a check into the iOS build where we transform those values to ignore any values that are not just an uppercased string
* Fix build failure on 64-bit Linux