### PR TITLE
fix(ios): properly map user activity for cold starts

### DIFF
--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiApp.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiApp.m
@@ -350,6 +350,36 @@ TI_INLINE void waitForMemoryPanicCleared(void); //WARNING: This must never be ru
   UILocalNotification *_localNotification = [launchOptions objectForKey:UIApplicationLaunchOptionsLocalNotificationKey];
   NSNumber *launchedLocation = [launchOptions objectForKey:UIApplicationLaunchOptionsLocationKey];
   UIApplicationShortcutItem *shortcut = [launchOptions objectForKey:UIApplicationLaunchOptionsShortcutItemKey];
+  NSDictionary *userActivityDictionary = launchOptions[UIApplicationLaunchOptionsUserActivityDictionaryKey];
+
+  // Map user activity if exists
+  if (userActivityDictionary != nil) {
+    NSUserActivity *userActivity = userActivityDictionary[@"UIApplicationLaunchOptionsUserActivityKey"];
+
+    NSMutableDictionary *dict = [NSMutableDictionary dictionaryWithDictionary:@{ @"activityType" : [userActivity activityType] }];
+
+    if ([TiUtils isIOSVersionOrGreater:@"9.0"] && [[userActivity activityType] isEqualToString:CSSearchableItemActionType]) {
+      if ([userActivity userInfo] != nil) {
+        [dict setObject:[[userActivity userInfo] objectForKey:CSSearchableItemActivityIdentifier] forKey:@"searchableItemActivityIdentifier"];
+      }
+    }
+
+    if ([userActivity title] != nil) {
+      [dict setObject:[userActivity title] forKey:@"title"];
+    }
+
+    if ([userActivity webpageURL] != nil) {
+      [dict setObject:[[userActivity webpageURL] absoluteString] forKey:@"webpageURL"];
+    }
+
+    if ([userActivity userInfo] != nil) {
+      [dict setObject:[userActivity userInfo] forKey:@"userInfo"];
+    }
+
+    // Update launchOptions so that we send only expected values rather than NSUserActivity
+    [launchOptions setObject:@{ @"UIApplicationLaunchOptionsUserActivityKey": dict }
+                      forKey:UIApplicationLaunchOptionsUserActivityDictionaryKey];
+  }
 
   // Map background location key
   if (launchedLocation != nil) {

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiApp.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiApp.m
@@ -377,7 +377,7 @@ TI_INLINE void waitForMemoryPanicCleared(void); //WARNING: This must never be ru
     }
 
     // Update launchOptions so that we send only expected values rather than NSUserActivity
-    [launchOptions setObject:@{ @"UIApplicationLaunchOptionsUserActivityKey": dict }
+    [launchOptions setObject:@{ @"UIApplicationLaunchOptionsUserActivityKey" : dict }
                       forKey:UIApplicationLaunchOptionsUserActivityDictionaryKey];
   }
 


### PR DESCRIPTION
**JIRA:**
- https://jira.appcelerator.org/browse/TIMOB-28513
- https://jira.appcelerator.org/browse/TIMOB-28514

**Note:**
Also fixes https://github.com/appcelerator/titanium_mobile/issues/12944

**Summary:**
The reason is that on a cold start, the user activity contains some native values that cannot be bridged into an `NSDictionary` by default. Just like for other instances (like `CLLocation` or `UIShortcutItem`), we should bridge it to JS-accessible types.