### PR TITLE
[Backport 10_0_X] fix(android): views added to ScrollableView can be lost upon window open

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIScrollableView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIScrollableView.java
@@ -382,10 +382,6 @@ public class TiUIScrollableView extends TiUIView
 	@Override
 	public void processProperties(KrollDict d)
 	{
-		if (d.containsKey(TiC.PROPERTY_VIEWS)) {
-			getScrollableViewProxy().setViews(d.get(TiC.PROPERTY_VIEWS));
-		}
-
 		if (d.containsKey(TiC.PROPERTY_CURRENT_PAGE)) {
 			int page = TiConvert.toInt(d, TiC.PROPERTY_CURRENT_PAGE);
 			if (page > 0) {


### PR DESCRIPTION
Backport of #12989.
See that PR for full details.