### PR TITLE
fix(android): card view "touchFeedbackColor" property is ignored

### DIFF
--- a/tests/Resources/app.js
+++ b/tests/Resources/app.js
@@ -144,6 +144,7 @@ function loadTests() {
 	require('./ti.ui.alertdialog.test');
 	if (OS_ANDROID) {
 		require('./ti.ui.android.test');
+		require('./ti.ui.android.cardview.test');
 		require('./ti.ui.android.drawerlayout.test');
 		require('./ti.ui.android.progressindicator.test');
 	}

--- a/tests/Resources/ti.ui.android.cardview.test.js
+++ b/tests/Resources/ti.ui.android.cardview.test.js
@@ -1,0 +1,94 @@
+/*
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2021 by Axway, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+/* eslint-env mocha */
+/* eslint no-unused-expressions: "off" */
+'use strict';
+const should = require('./utilities/assertions');
+
+describe.android('Titanium.UI.Android.CardView', function () {
+	this.timeout(5000);
+
+	let win;
+	afterEach(done => { // fires after every test in sub-suites too...
+		if (win && !win.closed) {
+			win.addEventListener('close', function listener () {
+				win.removeEventListener('close', listener);
+				win = null;
+				done();
+			});
+			win.close();
+		} else {
+			win = null;
+			done();
+		}
+	});
+
+	it.iosBroken('Ti.UI.Android.CardView', () => {
+		should(Ti.UI.Android.CardView).not.be.undefined();
+	});
+
+	it('.apiName', () => {
+		const cardView = Ti.UI.Android.createCardView();
+		should(cardView).have.readOnlyProperty('apiName').which.is.a.String();
+		should(cardView.apiName).be.eql('Ti.UI.Android.CardView');
+	});
+
+	it('createCardView', (finish) => {
+		should(Ti.UI.Android.createCardView).not.be.undefined();
+		should(Ti.UI.Android.createCardView).be.a.Function();
+
+		win = Ti.UI.createWindow();
+		win.add(Ti.UI.Android.createCardView());
+		win.addEventListener('postlayout', function listener() {
+			win.removeEventListener('postlayout', listener);
+			finish();
+		});
+		win.open();
+	});
+
+	it('.backgroundColor', (finish) => {
+		win = Ti.UI.createWindow();
+		const cardView = Ti.UI.Android.createCardView({
+			backgroundColor: 'orange'
+		});
+		should(cardView.backgroundColor).be.eql('orange');
+		win.add(cardView);
+		win.addEventListener('postlayout', function listener() {
+			win.removeEventListener('postlayout', listener);
+			finish();
+		});
+		win.open();
+	});
+
+	it('.touchFeedback', (finish) => {
+		win = Ti.UI.createWindow();
+		const cardView = Ti.UI.Android.createCardView({
+			touchFeedback: false
+		});
+		should(cardView.touchFeedback).be.false();
+		win.add(cardView);
+		win.addEventListener('postlayout', function listener() {
+			win.removeEventListener('postlayout', listener);
+			finish();
+		});
+		win.open();
+	});
+
+	it('.touchFeedbackColor', (finish) => {
+		win = Ti.UI.createWindow();
+		const cardView = Ti.UI.Android.createCardView({
+			touchFeedbackColor: 'yellow'
+		});
+		should(cardView.touchFeedbackColor).be.eql('yellow');
+		win.add(cardView);
+		win.addEventListener('postlayout', function listener() {
+			win.removeEventListener('postlayout', listener);
+			finish();
+		});
+		win.open();
+	});
+});


### PR DESCRIPTION
**JIRA:**
https://jira.appcelerator.org/browse/TIMOB-28517

**Summary:**
- Added support for "touchFeedbackColor" to `Ti.UI.Android.CardView`.
  * Before Titanium 10.0.0, card view did not support touch feedback at all.
  * As of Titanium 10.0.0, "touchFeedback" is supported, but ripple color was alway gray and could not be changed via this property.
- Optimized native view creation.
  * It was wrongly being created twice since `processProperties()` method was called twice.
  * Native view is now created once via constructor and `processProperties()` is only called once.

**Test:**
1. Build and run the below on Android.
2. Tap on the card view.
3. Verify the touch ripple effect is "yellow".
4. Uncomment the following line:  `// touchFeedback: false,`
5. Build and run on Android.
6. Tap on the card view.
7. Verify a touch ripple effect does **NOT** happen.
8. Verify the following log message does **NOT** appear.
`MaterialCardView: Setting a custom background is not supported.`

```javascript
const window = Ti.UI.createWindow();
const cardView = Ti.UI.Android.createCardView({
	elevation: 20,
//	touchFeedback: false,
	touchFeedbackColor: "yellow",
	top: "20dp",
	left: "20dp",
	bottom: "20dp",
	right: "20dp",
});
cardView.add(Ti.UI.createLabel({
	text: 'Tap Me',
	touchEnabled: false,
}));
window.add(cardView);
window.open();
```
