### PR TITLE
build: specify sha length when calling rev-parse

### DIFF
--- a/build/lib/git.js
+++ b/build/lib/git.js
@@ -4,13 +4,13 @@ const promisify = require('util').promisify;
 const exec = promisify(require('child_process').exec); // eslint-disable-line security/detect-child-process
 
 /**
- * Get the short (7-character) SHA hash of HEAD in the supplied workig directory.
+ * Get the short (10-character) SHA hash of HEAD in the supplied working directory.
  * @param {string} cwd current working directory path
  * @returns {Promise<string>} sha of current git commit for HEAD
  */
 async function getHash(cwd) {
-	const { stdout } = await exec('git rev-parse --short --no-color HEAD', { cwd });
-	return stdout.trim(); // drop leading 'commit ', just take 7-character sha
+	const { stdout } = await exec('git rev-parse --short=10 --no-color HEAD', { cwd });
+	return stdout.trim(); // drop leading 'commit ', just take 10-character sha
 }
 
 /**

--- a/support/iphone/build_titaniumkit.sh
+++ b/support/iphone/build_titaniumkit.sh
@@ -33,7 +33,7 @@ fi
 
 if [ -z "$GIT_HASH" ]
 then
-      GIT_HASH=`git rev-parse --short --no-color HEAD`
+      GIT_HASH=`git rev-parse --short=10 --no-color HEAD`
 fi
 
 # Inject the values into the source


### PR DESCRIPTION
In actions this only returns a 7 character string, but the tests expect a 10 character string. It
probably doesn't matter, but best be safe.

This is totally inconsequential (although the tests assert a length of 10), but I figured it's best to maintain the behaviour _just in case_