### PR TITLE
Improve reporting of failed test runs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -94,7 +94,7 @@ def androidUnitTests(testName, nodeVersion, npmVersion, deviceId) {
 							timeout(30) {
 								// Forcibly remove value for specific build tools version to use (set by module builds)
 								sh returnStatus: true, script: 'ti config android.buildTools.selectedVersion --remove'
-								sh label: 'Run Test Suite on emulator', script: "npm run test:integration -- android -T emulator -D test -C ${deviceId}"
+								sh label: 'Run Test Suite on emulator', script: "npm run test:integration -- android -T emulator -D test -C ${deviceId} -J ${testName}"
 							} // timeout
 						}
 					} catch (e) {

--- a/build/lib/test/index.js
+++ b/build/lib/test/index.js
@@ -25,7 +25,7 @@ async function runTests(platforms, program) {
 		fs.emptyDir(path.join(snapshotDir, '..', 'generated')),
 		fs.emptyDir(path.join(snapshotDir, '..', 'diffs'))
 	]);
-	return test(platforms, program.target, program.deviceId, program.deployType, program.deviceFamily, snapshotDir);
+	return test(platforms, program.target, program.deviceId, program.deployType, program.deviceFamily, program.junitPrefix, snapshotDir);
 }
 
 /**

--- a/build/lib/test/test.js
+++ b/build/lib/test/test.js
@@ -50,12 +50,13 @@ const isCI = !!(process.env.BUILD_NUMBER || process.env.CI || false);
  * @param {String} [deviceId] Titanium device id target to run the tests on
  * @param {string} [deployType] 'development' || 'test'
  * @param {string} [deviceFamily] 'ipad' || 'iphone'
+ * @param {string} [junitPrefix] A prefix for the junit filename
  * @param {string} [snapshotDir='../../../tests/Resources'] directory to place generated snapshot images
  * @returns {Promise<object>}
  */
-async function test(platforms, target, deviceId, deployType, deviceFamily, snapshotDir = path.join(__dirname, '../../../tests/Resources')) {
+async function test(platforms, target, deviceId, deployType, deviceFamily, junitPrefix, snapshotDir = path.join(__dirname, '../../../tests/Resources')) {
 	const snapshotPromises = []; // place to stick commands we've fired off to pull snapshot images
-
+	console.log(platforms);
 	// delete old test app (if does not exist, this will no-op)
 	await fs.remove(PROJECT_DIR);
 
@@ -70,7 +71,7 @@ async function test(platforms, target, deviceId, deployType, deviceFamily, snaps
 		const results = {};
 		for (const platform of platforms) {
 			const result = await runBuild(platform, target, deviceId, deployType, deviceFamily, snapshotDir, snapshotPromises);
-			const prefix = generateJUnitPrefix(platform, target, deviceFamily);
+			const prefix = generateJUnitPrefix(platform, target, junitPrefix || deviceFamily);
 			results[prefix] = result;
 			await outputJUnitXML(result, prefix);
 		}
@@ -902,16 +903,16 @@ function massageJSONString(testResults) {
 /**
  * @param {string} platform 'ios' || 'android'
  * @param {string} [target] 'emulator' || 'simulator' || 'device'
- * @param {string} [deviceFamily] 'iphone' || 'ipad'
+ * @param {string} [customPrefix] A custom prefix to help differentiate junit results
  * @returns {string}
  */
-function generateJUnitPrefix(platform, target, deviceFamily) {
+function generateJUnitPrefix(platform, target, customPrefix) {
 	let prefix = platform;
 	if (target) {
 		prefix += '.' + target;
 	}
-	if (deviceFamily) {
-		prefix += '.' + deviceFamily;
+	if (customPrefix) {
+		prefix += '.' + customPrefix;
 	}
 	return prefix;
 }

--- a/build/scons-test.js
+++ b/build/scons-test.js
@@ -9,6 +9,7 @@ program
 	.option('-v, --sdk-version [version]', 'Override the SDK version we report', process.env.PRODUCT_VERSION || version)
 	.option('-D, --deploy-type <type>', 'Override the deploy type used to build the project', /^(development|test)$/)
 	.option('-F, --device-family <value>', 'Override the device family used to build the project', /^(iphone|ipad)$/)
+	.option('-J --junit-prefix <value>', 'A prefix to add to junit tests to help distinguish them. Useful if targeting same platform and target', '')
 	.parse(process.argv);
 
 async function main(program) {

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -97,7 +97,7 @@ async function checkCommitMessages() {
 // Check that we have a JIRA Link in the body
 async function checkJIRA() {
 	// Don't require dependabot dependency updates require a JIRA ticket
-	if (github.pr.user.login === 'dependabot-preview[bot]') {
+	if (github.pr.user.type === 'Bot') {
 		return;
 	}
 
@@ -169,7 +169,7 @@ async function checkMergeable() {
 // Check PR author to see if it's community, etc
 async function checkCommunity() {
 	// Don't give special thanks to bot accounts
-	if (github.pr.user.login === 'dependabot-preview[bot]') {
+	if (github.pr.user.type === 'Bot') {
 		return;
 	}
 

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -337,7 +337,7 @@ async function main() {
 		checkJIRA(),
 		linkToSDK(),
 		checkForIOSCrash(),
-		junit({ pathToReport: './junit.*.xml' }),
+		junit({ pathToReport: './junit.*.xml', onlyWarn: true }),
 		checkChangedFileLocations(),
 		checkCommunity(),
 		checkMergeable(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
         "@seadub/clang-format-lint": "0.0.2",
         "@seadub/danger-plugin-dependencies": "1.0.0",
         "@seadub/danger-plugin-eslint": "^2.0.0",
-        "@seadub/danger-plugin-junit": "0.2.0",
+        "@seadub/danger-plugin-junit": "^0.3.0",
         "babel-plugin-transform-titanium": "^0.1.1",
         "chai": "^4.3.4",
         "clang-format": "1.5.0",
@@ -4309,14 +4309,14 @@
       }
     },
     "node_modules/@seadub/danger-plugin-junit": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@seadub/danger-plugin-junit/-/danger-plugin-junit-0.2.0.tgz",
-      "integrity": "sha512-SmiIdgA+86PdG59n+fHE2iuil/PVhOFv7QD+Cd6ItPJSWvqb41cUxGMsELAe0/33s+CKcsfMS9nMCTzGYkjCgg==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@seadub/danger-plugin-junit/-/danger-plugin-junit-0.3.0.tgz",
+      "integrity": "sha512-x2PkV5Q7cR9UAhS2jsEgyqs4JP7yXGk2psQKdZFq4zuwRrzsMT0e4JpipSzb05zMaGLqtdwV6oW8XJwS3FpHIQ==",
       "dev": true,
       "dependencies": {
+        "@xmldom/xmldom": "^0.7.3",
         "fs-extra": "^9.0.1",
-        "glob": "^7.1.6",
-        "xmldom": "^0.3.0"
+        "glob": "^7.1.6"
       },
       "engines": {
         "node": ">=4.0.0"
@@ -4356,16 +4356,6 @@
       "dev": true,
       "engines": {
         "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@seadub/danger-plugin-junit/node_modules/xmldom": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.3.0.tgz",
-      "integrity": "sha512-z9s6k3wxE+aZHgXYxSTpGDo7BYOUfJsIRyoZiX6HTjwpwfS2wpQBQKa2fD+ShLyPkqDYo5ud7KitmLZ2Cd6r0g==",
-      "deprecated": "Deprecated due to CVE-2021-21366 resolved in 0.5.0",
-      "dev": true,
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/@tootallnate/once": {
@@ -4431,6 +4421,15 @@
       "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
       "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
       "dev": true
+    },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.4.tgz",
+      "integrity": "sha512-wdxC79cvO7PjSM34jATd/RYZuYWQ8y/R7MidZl1NYYlbpFn1+spfjkiR3ZsJfcaTs2IyslBN7VwBBJwrYKM+zw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/@yarnpkg/lockfile": {
       "version": "1.1.0",
@@ -22745,14 +22744,14 @@
       "requires": {}
     },
     "@seadub/danger-plugin-junit": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@seadub/danger-plugin-junit/-/danger-plugin-junit-0.2.0.tgz",
-      "integrity": "sha512-SmiIdgA+86PdG59n+fHE2iuil/PVhOFv7QD+Cd6ItPJSWvqb41cUxGMsELAe0/33s+CKcsfMS9nMCTzGYkjCgg==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@seadub/danger-plugin-junit/-/danger-plugin-junit-0.3.0.tgz",
+      "integrity": "sha512-x2PkV5Q7cR9UAhS2jsEgyqs4JP7yXGk2psQKdZFq4zuwRrzsMT0e4JpipSzb05zMaGLqtdwV6oW8XJwS3FpHIQ==",
       "dev": true,
       "requires": {
+        "@xmldom/xmldom": "^0.7.3",
         "fs-extra": "^9.0.1",
-        "glob": "^7.1.6",
-        "xmldom": "^0.3.0"
+        "glob": "^7.1.6"
       },
       "dependencies": {
         "fs-extra": {
@@ -22781,12 +22780,6 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
           "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-          "dev": true
-        },
-        "xmldom": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.3.0.tgz",
-          "integrity": "sha512-z9s6k3wxE+aZHgXYxSTpGDo7BYOUfJsIRyoZiX6HTjwpwfS2wpQBQKa2fD+ShLyPkqDYo5ud7KitmLZ2Cd6r0g==",
           "dev": true
         }
       }
@@ -22850,6 +22843,12 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
       "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
+      "dev": true
+    },
+    "@xmldom/xmldom": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.4.tgz",
+      "integrity": "sha512-wdxC79cvO7PjSM34jATd/RYZuYWQ8y/R7MidZl1NYYlbpFn1+spfjkiR3ZsJfcaTs2IyslBN7VwBBJwrYKM+zw==",
       "dev": true
     },
     "@yarnpkg/lockfile": {

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "@seadub/clang-format-lint": "0.0.2",
     "@seadub/danger-plugin-dependencies": "1.0.0",
     "@seadub/danger-plugin-eslint": "^2.0.0",
-    "@seadub/danger-plugin-junit": "0.2.0",
+    "@seadub/danger-plugin-junit": "^0.3.0",
     "babel-plugin-transform-titanium": "^0.1.1",
     "chai": "^4.3.4",
     "clang-format": "1.5.0",


### PR DESCRIPTION
* Adds a danger check for all of the test reports and fails the build if any are missing (this does mean if we remove or rename one we have to update the check)
* Adds a flag to allow us to distinguish between Android main and Android 5.0 test reports
* Moves the junit danger check to only _warn_ about failed tests

This means that we can make danger the only required check, and remove required status on the Jenkins check. So:

* All builds pass and we have test failures, anyone with merge access can merge
* Build(s) fail (either the app build, or the SDK build), danger will block the merge