### PR TITLE
build(deps): update to node-titanium-sdk@5.1.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "markdown": "0.5.0",
         "moment": "^2.29.1",
         "node-appc": "^1.1.2",
-        "node-titanium-sdk": "^5.1.4",
+        "node-titanium-sdk": "^5.1.5",
         "node-uuid": "1.4.8",
         "nodeify": "^1.0.1",
         "p-limit": "^3.1.0",
@@ -14587,9 +14587,9 @@
       "integrity": "sha512-ZQmnWS7adi61A9JsllJ2gdj2PauElcjnOwTp2O011iGzoakTxUsDGSe+6vD7wXbKdqhSFymC0OSx35aAMhrSdw=="
     },
     "node_modules/node-titanium-sdk": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/node-titanium-sdk/-/node-titanium-sdk-5.1.4.tgz",
-      "integrity": "sha512-NJpEY1e122reIocZHDPpxlZ4bIYJRt8FEw8W+AeE7WjJz2kZjLbWvvhYbkb6QfAyEL1aU9dMRutspVFYyqycaw==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/node-titanium-sdk/-/node-titanium-sdk-5.1.5.tgz",
+      "integrity": "sha512-1clvLX9k5m76EGZRmtLsMkGMDX5gOdF7wHwYPndSumznfEoCYE+PK/vfhZNJYyyTCNGdGRYpyqFuvpZAb/NQWA==",
       "dependencies": {
         "@babel/core": "^7.8.0",
         "@babel/parser": "^7.8.3",
@@ -30706,9 +30706,9 @@
       "integrity": "sha512-ZQmnWS7adi61A9JsllJ2gdj2PauElcjnOwTp2O011iGzoakTxUsDGSe+6vD7wXbKdqhSFymC0OSx35aAMhrSdw=="
     },
     "node-titanium-sdk": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/node-titanium-sdk/-/node-titanium-sdk-5.1.4.tgz",
-      "integrity": "sha512-NJpEY1e122reIocZHDPpxlZ4bIYJRt8FEw8W+AeE7WjJz2kZjLbWvvhYbkb6QfAyEL1aU9dMRutspVFYyqycaw==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/node-titanium-sdk/-/node-titanium-sdk-5.1.5.tgz",
+      "integrity": "sha512-1clvLX9k5m76EGZRmtLsMkGMDX5gOdF7wHwYPndSumznfEoCYE+PK/vfhZNJYyyTCNGdGRYpyqFuvpZAb/NQWA==",
       "requires": {
         "@babel/core": "^7.8.0",
         "@babel/parser": "^7.8.3",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "markdown": "0.5.0",
     "moment": "^2.29.1",
     "node-appc": "^1.1.2",
-    "node-titanium-sdk": "^5.1.4",
+    "node-titanium-sdk": "^5.1.5",
     "node-uuid": "1.4.8",
     "nodeify": "^1.0.1",
     "p-limit": "^3.1.0",


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-28519

Updates to node-titanium-sdk@5.1.5 to remove the required check for `dx` which is removed in the latest Android tooling.

Test steps in jira