### PR TITLE
test: remove axway and appcelerator domains in tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -74,7 +74,7 @@ def androidUnitTests(testName, nodeVersion, npmVersion, deviceId) {
 		def labels = 'git && osx && android-emulator && android-sdk' // FIXME get working on windows/linux!
 		
 		if (!deviceId) {
-			deviceId = 'android-30-playstore-x86';
+			deviceId = 'android-31-playstore-x86_64';
 		}
 
 		node(labels) {

--- a/tests/Resources/ti.android.test.js
+++ b/tests/Resources/ti.android.test.js
@@ -1514,7 +1514,7 @@ describe.android('Titanium.Android', () => {
 		const launchIntent = Ti.App.Android.launchIntent;
 		const newIntent = Ti.Android.createIntent({
 			action: Ti.Android.ACTION_VIEW,
-			data: 'https://www.appcelerator.com',
+			data: 'https://www.example.com',
 			packageName: launchIntent.packageName,
 			className: launchIntent.className
 		});

--- a/tests/Resources/ti.network.httpclient.test.js
+++ b/tests/Resources/ti.network.httpclient.test.js
@@ -96,7 +96,7 @@ describe('Titanium.Network.HTTPClient', function () {
 		xhr.onload = () => finish();
 
 		xhr.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
-		xhr.open('POST', 'https://www.google.com/');
+		xhr.open('POST', 'https://httpbin.org/post');
 		xhr.send('TIMOB-23127');
 	});
 

--- a/tests/Resources/ti.network.httpclient.test.js
+++ b/tests/Resources/ti.network.httpclient.test.js
@@ -96,7 +96,7 @@ describe('Titanium.Network.HTTPClient', function () {
 		xhr.onload = () => finish();
 
 		xhr.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
-		xhr.open('POST', 'http://www.appcelerator.com/');
+		xhr.open('POST', 'http://www.example.com/');
 		xhr.send('TIMOB-23127');
 	});
 
@@ -107,7 +107,7 @@ describe('Titanium.Network.HTTPClient', function () {
 		xhr.onload = () => finish();
 
 		xhr.setRequestHeader('Content-Type', 'application/json');
-		xhr.open('GET', 'http://www.appcelerator.com/');
+		xhr.open('GET', 'http://www.example.com/');
 		xhr.send();
 	});
 
@@ -206,7 +206,7 @@ describe('Titanium.Network.HTTPClient', function () {
 				finish(new Error('failed to retrieve headers: ' + e));
 			}
 		};
-		xhr.open('GET', 'https://www.axway.com');
+		xhr.open('GET', 'https://www.example.com');
 		xhr.send();
 	});
 
@@ -242,7 +242,7 @@ describe('Titanium.Network.HTTPClient', function () {
 				finish(new Error('failed to retrieve headers: ' + e)); // Failing on Windows here, likely need to update test!
 			}
 		};
-		xhr.open('GET', 'http://www.appcelerator.com'); // FIXME Update URL!
+		xhr.open('GET', 'http://www.example.com');
 		xhr.send();
 	});
 
@@ -821,7 +821,7 @@ describe('Titanium.Network.HTTPClient', function () {
 			finish();
 		};
 
-		xhr.open('GET', 'https://www.axway.com');
+		xhr.open('GET', 'https://www.example.com');
 		xhr.send();
 	});
 });

--- a/tests/Resources/ti.network.httpclient.test.js
+++ b/tests/Resources/ti.network.httpclient.test.js
@@ -186,11 +186,11 @@ describe('Titanium.Network.HTTPClient', function () {
 		xhr.onload = e => {
 			try {
 				const responseHeaders = e.source.responseHeaders;
-
-				if (responseHeaders['Content-Type']
-					&& responseHeaders['Content-Type'].startsWith('text/html')) {
-					finish();
+				if (responseHeaders['freeform']
+					&& responseHeaders['freeform'] === 'titanium=awesome') {
+					return finish();
 				}
+				return finish(new Error('Expected header was not present'));
 			} catch (err) {
 				return finish(err);
 			}
@@ -206,7 +206,7 @@ describe('Titanium.Network.HTTPClient', function () {
 				finish(new Error('failed to retrieve headers: ' + e));
 			}
 		};
-		xhr.open('GET', 'https://www.google.com');
+		xhr.open('GET', 'https://httpbin.org/response-headers?freeform=titanium%3Dawesome');
 		xhr.send();
 	});
 

--- a/tests/Resources/ti.network.httpclient.test.js
+++ b/tests/Resources/ti.network.httpclient.test.js
@@ -96,7 +96,7 @@ describe('Titanium.Network.HTTPClient', function () {
 		xhr.onload = () => finish();
 
 		xhr.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
-		xhr.open('POST', 'http://www.example.com/');
+		xhr.open('POST', 'https://www.google.com/');
 		xhr.send('TIMOB-23127');
 	});
 
@@ -107,7 +107,7 @@ describe('Titanium.Network.HTTPClient', function () {
 		xhr.onload = () => finish();
 
 		xhr.setRequestHeader('Content-Type', 'application/json');
-		xhr.open('GET', 'http://www.example.com/');
+		xhr.open('GET', 'https://www.google.com/');
 		xhr.send();
 	});
 
@@ -206,7 +206,7 @@ describe('Titanium.Network.HTTPClient', function () {
 				finish(new Error('failed to retrieve headers: ' + e));
 			}
 		};
-		xhr.open('GET', 'https://www.example.com');
+		xhr.open('GET', 'https://www.google.com');
 		xhr.send();
 	});
 
@@ -242,7 +242,7 @@ describe('Titanium.Network.HTTPClient', function () {
 				finish(new Error('failed to retrieve headers: ' + e)); // Failing on Windows here, likely need to update test!
 			}
 		};
-		xhr.open('GET', 'http://www.example.com');
+		xhr.open('GET', 'http://www.google.com');
 		xhr.send();
 	});
 
@@ -821,7 +821,7 @@ describe('Titanium.Network.HTTPClient', function () {
 			finish();
 		};
 
-		xhr.open('GET', 'https://www.example.com');
+		xhr.open('GET', 'https://www.google.com');
 		xhr.send();
 	});
 });

--- a/tests/Resources/ti.network.socket.tcp.test.js
+++ b/tests/Resources/ti.network.socket.tcp.test.js
@@ -22,7 +22,7 @@ describe('Titanium.Network.Socket.TCP', function () {
 
 	it('#connect()', function (finish) {
 		socket = Ti.Network.Socket.createTCP({
-			host: 'www.appcelerator.com', port: 80,
+			host: 'www.example.com', port: 80,
 			connected: function () {
 				finish();
 			},
@@ -56,11 +56,11 @@ describe('Titanium.Network.Socket.TCP', function () {
 	// FIXME: Android chokes with : android.os.NetworkOnMainThreadException
 	it('#connect() and send data', function (finish) {
 		socket = Ti.Network.Socket.createTCP({
-			host: 'www.appcelerator.com', port: 80,
+			host: 'www.example.com', port: 80,
 			connected: function () {
 				should(socket.write).not.be.null();
 				should(socket.write).be.a.Function();
-				socket.write(Ti.createBuffer({ value: 'GET / HTTP/1.1\r\nHost: www.appcelerator.com\r\nConnection: close\r\n\r\n' }));
+				socket.write(Ti.createBuffer({ value: 'GET / HTTP/1.1\r\nHost: www.example.com\r\nConnection: close\r\n\r\n' }));
 				finish();
 			},
 			error: function (e) {
@@ -114,15 +114,15 @@ describe('Titanium.Network.Socket.TCP', function () {
 
 	it('#connect() and #write() async', function (finish) {
 		socket = Ti.Network.Socket.createTCP({
-			host: 'www.appcelerator.com',
+			host: 'www.example.com',
 			port: 80,
 			connected: function () {
 				should(socket.write).not.be.null();
 				should(socket.write).be.a.Function();
-				socket.write(Ti.createBuffer({ value: 'GET / HTTP/1.1\r\nHost: www.appcelerator.com\r\nConnection: close\r\n\r\n' }), function (evt) {
+				socket.write(Ti.createBuffer({ value: 'GET / HTTP/1.1\r\nHost: www.example.com\r\nConnection: close\r\n\r\n' }), function (evt) {
 					try {
 						evt.success.should.be.true();
-						evt.bytesProcessed.should.eql(65);
+						evt.bytesProcessed.should.eql(60);
 						finish();
 					} catch (err) {
 						finish(err);

--- a/tests/Resources/ti.network.socket.tcp.test.js
+++ b/tests/Resources/ti.network.socket.tcp.test.js
@@ -22,7 +22,7 @@ describe('Titanium.Network.Socket.TCP', function () {
 
 	it('#connect()', function (finish) {
 		socket = Ti.Network.Socket.createTCP({
-			host: 'www.example.com', port: 80,
+			host: 'www.google.com', port: 80,
 			connected: function () {
 				finish();
 			},
@@ -56,11 +56,11 @@ describe('Titanium.Network.Socket.TCP', function () {
 	// FIXME: Android chokes with : android.os.NetworkOnMainThreadException
 	it('#connect() and send data', function (finish) {
 		socket = Ti.Network.Socket.createTCP({
-			host: 'www.example.com', port: 80,
+			host: 'www.google.com', port: 80,
 			connected: function () {
 				should(socket.write).not.be.null();
 				should(socket.write).be.a.Function();
-				socket.write(Ti.createBuffer({ value: 'GET / HTTP/1.1\r\nHost: www.example.com\r\nConnection: close\r\n\r\n' }));
+				socket.write(Ti.createBuffer({ value: 'GET / HTTP/1.1\r\nHost: www.google.com\r\nConnection: close\r\n\r\n' }));
 				finish();
 			},
 			error: function (e) {
@@ -114,15 +114,15 @@ describe('Titanium.Network.Socket.TCP', function () {
 
 	it('#connect() and #write() async', function (finish) {
 		socket = Ti.Network.Socket.createTCP({
-			host: 'www.example.com',
+			host: 'www.google.com',
 			port: 80,
 			connected: function () {
 				should(socket.write).not.be.null();
 				should(socket.write).be.a.Function();
-				socket.write(Ti.createBuffer({ value: 'GET / HTTP/1.1\r\nHost: www.example.com\r\nConnection: close\r\n\r\n' }), function (evt) {
+				socket.write(Ti.createBuffer({ value: 'GET / HTTP/1.1\r\nHost: www.google.com\r\nConnection: close\r\n\r\n' }), function (evt) {
 					try {
 						evt.success.should.be.true();
-						evt.bytesProcessed.should.eql(60);
+						evt.bytesProcessed.should.eql(59);
 						finish();
 					} catch (err) {
 						finish(err);

--- a/tests/Resources/ti.platform.test.js
+++ b/tests/Resources/ti.platform.test.js
@@ -309,7 +309,7 @@ describe('Titanium.Platform', () => {
 			});
 
 			it('returns true for typical http URL', () => {
-				should(Ti.Platform.canOpenURL('http://www.appcelerator.com/')).be.true();
+				should(Ti.Platform.canOpenURL('http://www.example.com/')).be.true();
 			});
 
 			it('returns true for app-sepcific URI scheme', () => {

--- a/tests/Resources/ti.platform.test.js
+++ b/tests/Resources/ti.platform.test.js
@@ -309,7 +309,7 @@ describe('Titanium.Platform', () => {
 			});
 
 			it('returns true for typical http URL', () => {
-				should(Ti.Platform.canOpenURL('http://www.example.com/')).be.true();
+				should(Ti.Platform.canOpenURL('http://www.google.com/')).be.true();
 			});
 
 			it('returns true for app-sepcific URI scheme', () => {

--- a/tests/Resources/ti.ui.webview.test.js
+++ b/tests/Resources/ti.ui.webview.test.js
@@ -522,7 +522,7 @@ describe('Titanium.UI.WebView', function () {
 	it('blacklistedURLs', (finish) => {
 		win = Ti.UI.createWindow();
 		const webView = Ti.UI.createWebView({
-			url: 'https://www.example.com',
+			url: 'https://www.github.com',
 			blacklistedURLs: [ 'www.apple.com', 'www.google.com' ]
 		});
 		webView.addEventListener('load', () => {
@@ -535,7 +535,7 @@ describe('Titanium.UI.WebView', function () {
 	it('blockedURLs', (finish) => {
 		win = Ti.UI.createWindow();
 		const webView = Ti.UI.createWebView({
-			url: 'https://www.example.com',
+			url: 'https://www.github.com',
 			blockedURLs: [ 'www.apple.com', 'www.google.com' ]
 		});
 		webView.addEventListener('load', () => {
@@ -614,7 +614,7 @@ describe('Titanium.UI.WebView', function () {
 	});
 
 	it.ios('beforeload should provide the URL that is about to be loaded and handle redirects', (finish) => {
-		const url = 'https://mockbin.org/redirect/301?to=https%3A%2F%2Fexample.com';
+		const url = 'https://mockbin.org/redirect/301?to=https%3A%2F%2Fgoogle.com';
 		win = Ti.UI.createWindow();
 		const webView = Ti.UI.createWebView({
 			url: url
@@ -678,7 +678,7 @@ describe('Titanium.UI.WebView', function () {
 	it('requestHeaders with redirecting url should work properly', function (finish) {
 		win = Ti.UI.createWindow();
 		const webView = Ti.UI.createWebView({
-			url: 'https://mockbin.org/redirect/301?to=https%3A%2F%2Fexample.com',
+			url: 'https://mockbin.org/redirect/301?to=https%3A%2F%2Fgoogle.com',
 			requestHeaders: { 'Custom-field1': 'value1' }
 		});
 
@@ -897,7 +897,7 @@ describe('Titanium.UI.WebView', function () {
 				return;
 			}
 			const webView = Ti.UI.createWebView({
-				url: 'https://www.example.com'
+				url: 'https://www.google.com'
 			});
 			should(webView.findString).be.a.Function();
 		});
@@ -909,11 +909,11 @@ describe('Titanium.UI.WebView', function () {
 			}
 			win = Ti.UI.createWindow();
 			const webView = Ti.UI.createWebView({
-				url: 'https://www.example.com'
+				url: 'https://www.google.com'
 			});
 
 			webView.addEventListener('load', function () {
-				webView.findString('EXAMPLE', function (e) {
+				webView.findString('GOOGLE', function (e) {
 					if (e.success) {
 						finish();
 					} else {
@@ -932,12 +932,12 @@ describe('Titanium.UI.WebView', function () {
 			}
 			win = Ti.UI.createWindow();
 			const webView = Ti.UI.createWebView({
-				url: 'https://www.example.com'
+				url: 'https://www.google.com'
 			});
 
 			webView.addEventListener('load', function () {
 				// It should fail.
-				webView.findString('EXAMPLE', { caseSensitive: true, backwards: false, wraps: true }, function (e) {
+				webView.findString('GOOGLE', { caseSensitive: true, backwards: false, wraps: true }, function (e) {
 					if (e.success) {
 						finish(new Error('Search should fail'));
 					} else {

--- a/tests/Resources/ti.ui.webview.test.js
+++ b/tests/Resources/ti.ui.webview.test.js
@@ -11,7 +11,7 @@
 const should = require('./utilities/assertions');
 const utilities = require('./utilities/utilities');
 
-describe.androidARM64Broken('Titanium.UI.WebView', function () {
+describe('Titanium.UI.WebView', function () {
 	this.slow(3000);
 	this.timeout(30000);
 
@@ -522,7 +522,7 @@ describe.androidARM64Broken('Titanium.UI.WebView', function () {
 	it('blacklistedURLs', (finish) => {
 		win = Ti.UI.createWindow();
 		const webView = Ti.UI.createWebView({
-			url: 'https://www.axway.com',
+			url: 'https://www.example.com',
 			blacklistedURLs: [ 'www.apple.com', 'www.google.com' ]
 		});
 		webView.addEventListener('load', () => {
@@ -535,7 +535,7 @@ describe.androidARM64Broken('Titanium.UI.WebView', function () {
 	it('blockedURLs', (finish) => {
 		win = Ti.UI.createWindow();
 		const webView = Ti.UI.createWebView({
-			url: 'https://www.axway.com',
+			url: 'https://www.example.com',
 			blockedURLs: [ 'www.apple.com', 'www.google.com' ]
 		});
 		webView.addEventListener('load', () => {
@@ -613,8 +613,8 @@ describe.androidARM64Broken('Titanium.UI.WebView', function () {
 		win.open();
 	});
 
-	it.ios('beforeload', (finish) => {
-		const url = 'https://www.appcelerator.com/';
+	it.ios('beforeload should provide the URL that is about to be loaded and handle redirects', (finish) => {
+		const url = 'https://mockbin.org/redirect/301?to=https%3A%2F%2Fexample.com';
 		win = Ti.UI.createWindow();
 		const webView = Ti.UI.createWebView({
 			url: url
@@ -678,7 +678,7 @@ describe.androidARM64Broken('Titanium.UI.WebView', function () {
 	it('requestHeaders with redirecting url should work properly', function (finish) {
 		win = Ti.UI.createWindow();
 		const webView = Ti.UI.createWebView({
-			url: 'https://jira.appcelerator.org/',
+			url: 'https://mockbin.org/redirect/301?to=https%3A%2F%2Fexample.com',
 			requestHeaders: { 'Custom-field1': 'value1' }
 		});
 
@@ -897,7 +897,7 @@ describe.androidARM64Broken('Titanium.UI.WebView', function () {
 				return;
 			}
 			const webView = Ti.UI.createWebView({
-				url: 'https://www.appcelerator.com'
+				url: 'https://www.example.com'
 			});
 			should(webView.findString).be.a.Function();
 		});
@@ -909,11 +909,11 @@ describe.androidARM64Broken('Titanium.UI.WebView', function () {
 			}
 			win = Ti.UI.createWindow();
 			const webView = Ti.UI.createWebView({
-				url: 'https://www.appcelerator.com'
+				url: 'https://www.example.com'
 			});
 
 			webView.addEventListener('load', function () {
-				webView.findString('APPCELERATOR', function (e) {
+				webView.findString('EXAMPLE', function (e) {
 					if (e.success) {
 						finish();
 					} else {
@@ -932,12 +932,12 @@ describe.androidARM64Broken('Titanium.UI.WebView', function () {
 			}
 			win = Ti.UI.createWindow();
 			const webView = Ti.UI.createWebView({
-				url: 'https://www.appcelerator.com'
+				url: 'https://www.example.com'
 			});
 
 			webView.addEventListener('load', function () {
 				// It should fail.
-				webView.findString('APPCELERATOR', { caseSensitive: true, backwards: false, wraps: true }, function (e) {
+				webView.findString('EXAMPLE', { caseSensitive: true, backwards: false, wraps: true }, function (e) {
 					if (e.success) {
 						finish(new Error('Search should fail'));
 					} else {


### PR DESCRIPTION
It seems like axway.com and appcelerator.com domains are taking a while to resolve on the Jenkins nodes, so lets just tear any reference to them out. Works locally, 🤞 for Jenkins