### PR TITLE
fix(ios): navigation bar jumps at end of open animation on iOS15

### DIFF
--- a/iphone/Classes/TiUINavigationWindowProxy.m
+++ b/iphone/Classes/TiUINavigationWindowProxy.m
@@ -391,7 +391,10 @@
 #pragma mark - TiWindowProtocol
 - (void)viewWillAppear:(BOOL)animated
 {
-  if ([self viewAttached]) {
+  if (navController && [self viewAttached]) {
+    UIViewController *parentController = [self windowHoldingController];
+    [parentController addChildViewController:navController];
+    [navController didMoveToParentViewController:parentController];
     [navController viewWillAppear:animated];
   }
   [super viewWillAppear:animated];
@@ -525,18 +528,6 @@
   [nview setFrame:[[self view] bounds]];
   [[self view] addSubview:nview];
   [super windowWillOpen];
-}
-
-- (void)windowDidOpen
-{
-  // Set parent for navigation controller
-  if (navController) {
-    UIViewController *parentController = [self windowHoldingController];
-    [parentController addChildViewController:navController];
-    [navController didMoveToParentViewController:parentController];
-  }
-
-  [super windowDidOpen];
 }
 
 - (void)windowDidClose

--- a/iphone/Classes/TiUITabGroupProxy.m
+++ b/iphone/Classes/TiUITabGroupProxy.m
@@ -150,19 +150,6 @@ static NSArray *tabGroupKeySequence;
   [super windowWillOpen];
 }
 
-- (void)windowDidOpen
-{
-  // Set parent view controller for UITabBarController
-  TiUITabGroup *tabGroup = (TiUITabGroup *)self.view;
-  if (tabGroup) {
-    UITabBarController *tabController = [tabGroup tabController];
-    UIViewController *parentController = [self windowHoldingController];
-    [parentController addChildViewController:tabController];
-    [tabController didMoveToParentViewController:parentController];
-  }
-  [super windowDidOpen];
-}
-
 - (void)windowWillClose
 {
   TiUITabGroup *tabGroup = (TiUITabGroup *)self.view;
@@ -230,6 +217,9 @@ static NSArray *tabGroupKeySequence;
 {
   if ([self viewAttached]) {
     UITabBarController *tabController = [(TiUITabGroup *)[self view] tabController];
+    UIViewController *parentController = [self windowHoldingController];
+    [parentController addChildViewController:tabController];
+    [tabController didMoveToParentViewController:parentController];
     [tabController viewWillAppear:animated];
   }
   [super viewWillAppear:animated];


### PR DESCRIPTION
**JIRA:**
https://jira.appcelerator.org/browse/TIMOB-28488

**Summary:**
- On iOS 15, the top navigation bar will wrongly apply the top notch's safe area inset when opening a "modal" window and then remove the inset when the open animation ends. This only happens when using the `MODAL_PRESENTATION_PAGESHEET` style, which is the default.
- Fixed it by configuring the navigation controller before the window's open animation has started.
- The same needs to be applied to `TabGroup` which was opened by `NavigationWindow`.
- Thanks goes to @hansemannn for isolating this issue.

---
**Modal Navigation Bar Test:**
1. Build and run the below on iOS 15.
2. Tap on the "Open Window" button.
3. Verify the title bar height does not change at the end of the open window animation.

```javascript
const rootWindow = Ti.UI.createWindow({
	backgroundColor: 'white',
});
const openButton = Ti.UI.createButton({ title: "Open Window" });
openButton.addEventListener('click', () => {
	let navigationWindow;
	const modalWindow = Ti.UI.createWindow({
		title: 'Modal Window',
		backgroundColor: 'white',
	});
	const closeButton = Ti.UI.createButton({
		title: "Close",
	});
	closeButton.addEventListener("click", () => {
		navigationWindow.close();
	});
	modalWindow.add(closeButton);
	navigationWindow = Ti.UI.createNavigationWindow({
		window: modalWindow,
	});
	navigationWindow.open({ modal: true });
});
rootWindow.add(openButton);
rootWindow.open();
```

---
**TabGroup Navigation Bar Test:**
1. Create a Classic app project from template. _(Below needs its "tab1.png".)_
2. Build and run on iPhone X, 11, or 12. _(Devices have a bottom "home indicator" line.)_
3. Tap on the "Open TabGroup" button.
4. Verify the bottom tabs are not overlapped by the bottom "home indicator".

```javascript
let navigationWindow = null;
function createTab(title) {
	const window = Ti.UI.createWindow({ title: title });
	window.add(Ti.UI.createLabel({
		text: title + " View",
		top: "25%",
	}));
	const openButton = Ti.UI.createButton({
		title: "Open Child Window",
		top: "50%",
	});
	openButton.addEventListener("click", function() {
		var childWindow = Ti.UI.createWindow({
			title: title + " Child Window",
			backgroundColor: "white",
		});
		var closeButton = Ti.UI.createButton({
			title: "Close Window",
		});
		closeButton.addEventListener("click", function() {
			navigationWindow.closeWindow(childWindow, { animated: true });
		});
		childWindow.add(closeButton);
		navigationWindow.openWindow(childWindow, { animated: true });
	});
	window.add(openButton);
	const tab = Ti.UI.createTab({
		title: title,
		icon: "/assets/images/tab1.png",
		window: window,
	});
	return tab;
}
const rootWindow = Ti.UI.createWindow({
	title: "Root Window",
	backgroundColor: "white",
});
const openButton = Ti.UI.createButton({
	title: "Open TabGroup",
});
openButton.addEventListener("click", () => {
	const tabGroup = Ti.UI.createTabGroup({
		title: "TabGroup",
		backgroundColor: "white",
		tabs: [createTab("Tab 1"), createTab("Tab 2"), createTab("Tab 3")],
	});
	navigationWindow.openWindow(tabGroup, { animated: true });
});
rootWindow.add(openButton);
navigationWindow = Ti.UI.createNavigationWindow({
	window: rootWindow,
});
navigationWindow.open();
```
