### PR TITLE
fix(ios): cleanup search controller on close

### DIFF
--- a/iphone/Classes/TiUITableView.m
+++ b/iphone/Classes/TiUITableView.m
@@ -318,6 +318,15 @@
   return self;
 }
 
+- (void)cleanup:(id)unused
+{
+  if (searchController.isActive) {
+    searchController.active = NO;
+  }
+
+  [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(dismissSearchController) object:nil];
+}
+
 - (void)dealloc
 {
   if ([searchController isActive]) {

--- a/iphone/Classes/TiUITableViewProxy.m
+++ b/iphone/Classes/TiUITableViewProxy.m
@@ -88,6 +88,14 @@ USE_VIEW_FOR_CONTENT_HEIGHT
   }
 }
 
+- (void)windowWillClose
+{
+  if ([self viewInitialized]) {
+    [self makeViewPerformSelector:@selector(cleanup:) withObject:nil createIfNeeded:NO waitUntilDone:YES];
+  }
+  [super windowWillClose];
+}
+
 - (void)gainFocus
 {
   [[self tableView] viewGetFocus];


### PR DESCRIPTION
- Cleanup search controller state upon window close
  - Preventing search controller from maintaining focus after close

##### TEST CASE
```JS
const win_a = Ti.UI.createWindow({ title: 'Window A' });
const row = Ti.UI.createTableViewRow({ title: 'Open Window B' });
const table_a = Ti.UI.createTableView({ data: [ row ] });
const nav = Ti.UI.createNavigationWindow({ window: win_a });

row.addEventListener('click', e => {
    const win_b = Ti.UI.createWindow({ title: 'Window B' });
    const table_b = Ti.UI.createTableView({
        search: Ti.UI.createSearchBar(),
        data: [ Ti.UI.createTableViewRow({ title: 'Focus search then navigate back' }) ]
    });

    win_b.add(table_b);
    nav.openWindow(win_b);
});

win_a.add(table_a);
nav.open();
```
- Tap 'Open Window B'
- Tap search box
- Navigate to Window A
- Tap 'Open Window B'
  - Window B should display

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-28536)
Issue #13070
