### PR TITLE
fix(ios): TabGroup icon/title tinting issues

### DIFF
--- a/iphone/Classes/TiUITabProxy.m
+++ b/iphone/Classes/TiUITabProxy.m
@@ -592,16 +592,12 @@
     }
 
     if (image != nil) {
-      if ([image respondsToSelector:@selector(imageWithRenderingMode:)]) {
-        NSInteger theMode = iconOriginal ? UIImageRenderingModeAlwaysOriginal : UIImageRenderingModeAlwaysTemplate;
-        image = [image imageWithRenderingMode:theMode];
-      }
+      NSInteger theMode = iconOriginal ? UIImageRenderingModeAlwaysOriginal : UIImageRenderingModeAlwaysTemplate;
+      image = [image imageWithRenderingMode:theMode];
     }
     if (activeImage != nil) {
-      if ([activeImage respondsToSelector:@selector(imageWithRenderingMode:)]) {
-        NSInteger theMode = activeIconOriginal ? UIImageRenderingModeAlwaysOriginal : UIImageRenderingModeAlwaysTemplate;
-        activeImage = [activeImage imageWithRenderingMode:theMode];
-      }
+      NSInteger theMode = activeIconOriginal ? UIImageRenderingModeAlwaysOriginal : UIImageRenderingModeAlwaysTemplate;
+      activeImage = [activeImage imageWithRenderingMode:theMode];
     }
 
     TiColor *tintColor = [TiUtils colorValue:[self valueForKey:@"tintColor"]];
@@ -646,15 +642,35 @@
   if (titleColor == nil) {
     titleColor = [TiUtils colorValue:[tabGroup valueForKey:@"titleColor"]];
   }
-  if (titleColor != nil) {
-    [ourItem setTitleTextAttributes:[NSDictionary dictionaryWithObjectsAndKeys:[titleColor color], NSForegroundColorAttributeName, nil] forState:UIControlStateNormal];
-  }
   TiColor *activeTitleColor = [TiUtils colorValue:[self valueForKey:@"activeTitleColor"]];
   if (activeTitleColor == nil) {
     activeTitleColor = [TiUtils colorValue:[tabGroup valueForKey:@"activeTitleColor"]];
   }
-  if (activeTitleColor != nil) {
-    [ourItem setTitleTextAttributes:[NSDictionary dictionaryWithObjectsAndKeys:[activeTitleColor color], NSForegroundColorAttributeName, nil] forState:UIControlStateSelected];
+  if ((titleColor != nil) || (activeTitleColor != nil)) {
+#if IS_SDK_IOS_15
+    if ([TiUtils isIOSVersionOrGreater:@"15.0"]) {
+      UITabBarAppearance *appearance = UITabBarAppearance.new;
+      if (titleColor != nil) {
+        UITabBarItemStateAppearance *normalAppearance = appearance.stackedLayoutAppearance.normal;
+        normalAppearance.titleTextAttributes = @{ NSForegroundColorAttributeName : [titleColor color] };
+      }
+      if (activeTitleColor != nil) {
+        UITabBarItemStateAppearance *selectedAppearance = appearance.stackedLayoutAppearance.selected;
+        selectedAppearance.titleTextAttributes = @{ NSForegroundColorAttributeName : [activeTitleColor color] };
+      }
+      ourItem.standardAppearance = appearance;
+      ourItem.scrollEdgeAppearance = appearance;
+    } else {
+#endif
+      if (titleColor != nil) {
+        [ourItem setTitleTextAttributes:[NSDictionary dictionaryWithObjectsAndKeys:[titleColor color], NSForegroundColorAttributeName, nil] forState:UIControlStateNormal];
+      }
+      if (activeTitleColor != nil) {
+        [ourItem setTitleTextAttributes:[NSDictionary dictionaryWithObjectsAndKeys:[activeTitleColor color], NSForegroundColorAttributeName, nil] forState:UIControlStateSelected];
+      }
+#if IS_SDK_IOS_15
+    }
+#endif
   }
 
   if (iconInsets != nil) {

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiUtils.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiUtils.m
@@ -809,7 +809,7 @@ static NSDictionary *sizeMap = nil;
   UIImage *tintedImage = UIGraphicsGetImageFromCurrentImageContext();
   UIGraphicsEndImageContext();
 
-  return tintedImage;
+  return [tintedImage imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal];
 }
 
 + (NSURL *)checkFor2XImage:(NSURL *)url


### PR DESCRIPTION
**JIRA:**
- https://jira.appcelerator.org/browse/TIMOB-28550
- https://jira.appcelerator.org/browse/TIMOB-28551

**Summary:**
- [TIMOB-28550](https://jira.appcelerator.org/browse/TIMOB-28550) `TabGroup` property "titleColor" does not work correctly on iOS 15.
  * Fails to tint inactive tab titles and will show default gray instead.
  * Wrongly tints active tab's title and ignores "activeTitleColor".
- [TIMOB-28551](https://jira.appcelerator.org/browse/TIMOB-28551) `TabGroup` property "tintColor" does not work correctly on iOS 12 and older.
  * Fails to tint inactive tab icons and wrongly tints active tab icon instead.

**Test:**
1. Create a Classic Titanium project from template. _(Will provide tab icons needed.)_
2. Use the below code as the "app.js".
3. Build and run on iOS 15.
4. Verify selected tab shows a red icon and red title.
5. Verify unselected tabs show purple icons and purple titles.
6. Repeat steps 4-5 on iOS 14.
7. Repeat steps 4-5 on iOS 12.

```javascript
function createTab(title, icon) {
	const window = Ti.UI.createWindow({ title: title });
	window.add(Ti.UI.createLabel({ text: title + " View" }));
	const tab = Ti.UI.createTab({
		title: title,
		icon: icon,
		window: window,
	});
	return tab;
}

const tabGroup = Ti.UI.createTabGroup({
	tabs: [
		createTab("Tab 1", "/assets/images/tab1.png"),
		createTab("Tab 2", "/assets/images/tab2.png"),
		createTab("Tab 3", "/assets/images/tab1.png")
	],
	activeTintColor: "red",
	activeTitleColor: "red",
	tintColor: "purple",
	titleColor: "purple",
	tabsBackgroundColor: "#F7F7F7",
});
tabGroup.open();
```
