### PR TITLE
fix(ios): drag-and-drop text in TextArea can crash on iOS 15

### DIFF
--- a/iphone/Classes/TiUITextArea.h
+++ b/iphone/Classes/TiUITextArea.h
@@ -18,6 +18,7 @@
 @property (nonatomic, readwrite, assign) BOOL enableCopy;
 
 - (void)setTouchHandler:(TiUIView *)handler;
+- (NSComparisonResult)comparePosition:(UITextPosition *)position toPosition:(UITextPosition *)other;
 
 @end
 

--- a/iphone/Classes/TiUITextArea.m
+++ b/iphone/Classes/TiUITextArea.m
@@ -38,6 +38,18 @@
   touchHandler = handler;
 }
 
+- (NSComparisonResult)comparePosition:(UITextPosition *)position toPosition:(UITextPosition *)other
+{
+  NSComparisonResult result = NSOrderedAscending;
+  @try {
+    result = [super comparePosition:position toPosition:other];
+  }
+  @catch (NSException *ex) {
+    // Ignore exception that can occur on iOS 15 if "maxLength" trims text that was dragged-and-dropped.
+  }
+  return result;
+}
+
 - (BOOL)touchesShouldBegin:(NSSet *)touches withEvent:(UIEvent *)event inContentView:(UIView *)view
 {
   //If the content view is of type TiUIView touch events will automatically propagate
@@ -376,7 +388,7 @@
     }
   }
 
-  return TRUE;
+  return YES;
 }
 
 - (void)setHandleLinks_:(id)args


### PR DESCRIPTION
**JIRA:**
https://jira.appcelerator.org/browse/TIMOB-28556

**Summary:**
- Drag-and-dropping text into a `TextArea` that exceeds the "maxLength" property will crash the app on iOS 15.
- This looks like a bug on Apple's end where they don't check the final string length before updating the cursor/selection position. Probably because they don't expect us to manipulate the string that's been pasted.

**Test:**
1. Build and run the below on iOS 15.
2. Tap and hold the top TextArea's text.
3. Tap on "Select All" in the context menu.
4. Tap and hold selected text until it becomes draggable.
5. Drag text into bottom TextArea.
6. Verify dragged text is copied into TextArea, but trimmed based on maxLength of 20.

```javascript
const window = Ti.UI.createWindow({
	layout: "vertical",
	backgroundColor: "white",
});
window.add(Ti.UI.createTextArea({
	value: "Hello World! This is a test.",
	borderWidth: 1,
	top: 100,
	width: "80%",
	height: 80,
}));
window.add(Ti.UI.createTextArea({
	value: "Paste text here.",
	maxLength: 20,
	borderWidth: 1,
	top: 20,
	width: "80%",
	height: 80,
}));
window.open();
```
