### PR TITLE
fix(android): menu and toolbar icons to use ActionBar style colors

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiToolbar.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiToolbar.java
@@ -17,6 +17,7 @@ import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.TiDimension;
 import org.appcelerator.titanium.proxy.TiViewProxy;
 import org.appcelerator.titanium.util.TiColorHelper;
+import org.appcelerator.titanium.util.TiConvert;
 import org.appcelerator.titanium.view.TiCompositeLayout;
 import org.appcelerator.titanium.view.TiDrawableReference;
 import org.appcelerator.titanium.view.TiToolbarStyleHandler;
@@ -256,9 +257,15 @@ public class TiToolbar extends TiUIView
 	 */
 	public void setNavigationIcon(Object object)
 	{
-		navigationIcon = object;
-		TiDrawableReference tiDrawableReference = TiDrawableReference.fromObject(proxy, object);
-		((MaterialToolbar) getNativeView()).setNavigationIcon(tiDrawableReference.getDrawable());
+		this.navigationIcon = object;
+		if (object instanceof Number) {
+			this.toolbar.setNavigationIcon(TiConvert.toInt(object));
+		} else if (object != null) {
+			TiDrawableReference tiDrawableReference = TiDrawableReference.fromObject(proxy, object);
+			this.toolbar.setNavigationIcon(tiDrawableReference.getDrawable());
+		} else {
+			this.toolbar.setNavigationIcon(null);
+		}
 	}
 
 	/**
@@ -276,9 +283,13 @@ public class TiToolbar extends TiUIView
 	 */
 	public void setOverflowMenuIcon(Object object)
 	{
-		overflowMenuIcon = object;
-		TiDrawableReference tiDrawableReference = TiDrawableReference.fromObject(proxy, object);
-		((MaterialToolbar) getNativeView()).setOverflowIcon(tiDrawableReference.getDrawable());
+		this.overflowMenuIcon = object;
+		if (object != null) {
+			TiDrawableReference tiDrawableReference = TiDrawableReference.fromObject(proxy, object);
+			this.toolbar.setOverflowIcon(tiDrawableReference.getDrawable());
+		} else {
+			this.toolbar.setOverflowIcon(null);
+		}
 	}
 
 	/**

--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/MenuItemProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/MenuItemProxy.java
@@ -15,7 +15,6 @@ import org.appcelerator.titanium.TiApplication;
 import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.util.TiConvert;
 import org.appcelerator.titanium.util.TiFileHelper;
-import org.appcelerator.titanium.util.TiUIHelper;
 import org.appcelerator.titanium.util.TiUrl;
 import org.appcelerator.titanium.view.TiUIView;
 
@@ -233,10 +232,7 @@ public class MenuItemProxy extends KrollProxy
 					}
 				}
 			} else if (icon instanceof Number) {
-				Drawable d = TiUIHelper.getResourceDrawable(TiConvert.toInt(icon));
-				if (d != null) {
-					item.setIcon(d);
-				}
+				item.setIcon(TiConvert.toInt(icon));
 			}
 		}
 		return this;


### PR DESCRIPTION
**JIRA:**
https://jira.appcelerator.org/browse/TIMOB-28547

**Summary:**
When setting menu/toolbar icons to a resource ID (ie: a vector drawable), the icon should use the theme/style assigned to the ActionBar or Toolbar. Currently, it uses the style colors assigned to the activity window, which won't be the same as the ActionBar if using a DarkActionBar theme.

**Test:**
1. Download https://github.com/appcelerator/kitchensink-v2/pull/59
2. Build and run on Android.
3. Make sure device is using the Light theme.
3. Go to: Views -> ListView (Multi-Select)
4. Verify all top toolbar icons are white. (They used to be gray.)
