### PR TITLE
fix(android): restore "res/drawable" support to Ti.UI.Button images

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIButton.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIButton.java
@@ -17,7 +17,6 @@ import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.proxy.TiViewProxy;
 import org.appcelerator.titanium.util.TiConvert;
 import org.appcelerator.titanium.util.TiUIHelper;
-import org.appcelerator.titanium.view.TiDrawableReference;
 import org.appcelerator.titanium.view.TiUIView;
 
 import ti.modules.titanium.ui.AttributedStringProxy;
@@ -311,18 +310,17 @@ public class TiUIButton extends TiUIView
 		}
 
 		// Fetch the image.
-		TiDrawableReference drawableRef = null;
+		Drawable drawable = null;
 		Object imageObject = this.proxy.getProperty(TiC.PROPERTY_IMAGE);
 		if (imageObject != null) {
-			drawableRef = TiDrawableReference.fromObject(this.proxy.getActivity(), imageObject);
+			drawable = TiUIHelper.getResourceDrawable(imageObject);
 		}
 
 		// Update button's image/icon.
-		if (drawableRef != null) {
+		if (drawable != null) {
 			boolean imageIsMask = TiConvert.toBoolean(this.proxy.getProperty(TiC.PROPERTY_IMAGE_IS_MASK), true);
 			String colorString = TiConvert.toString(this.proxy.getProperty(TiC.PROPERTY_TINT_COLOR));
 			int colorValue = (colorString != null) ? TiConvert.toColor(colorString) : this.defaultColor;
-			Drawable drawable = drawableRef.getDensityScaledDrawable();
 			if (button instanceof MaterialButton) {
 				MaterialButton materialButton = (MaterialButton) button;
 				materialButton.setIcon(drawable);


### PR DESCRIPTION
**JIRA:**
https://jira.appcelerator.org/browse/TIMOB-28558

**Summary:**
- The changes I made in PR #13125 caused a regression where `Ti.UI.Button` image won't load from "res/drawable" DPI scaled images anymore. We need to restore this behavior.
- This issue was caught before release.

**Test:**
1. Download kitchensink-v2 app: https://github.com/appcelerator/kitchensink-v2/pull/59
2. Tap on the "Button" list item.
3. Verify the "Image Button" icon is the same size as shown in the PR's screenshot, except the icon should be "white" when using the Light theme.
