### PR TITLE
refactor(android): add "homeAsUpIndicator" and "res/drawable" icon support to ActionBar

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/ActionBarProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/ActionBarProxy.java
@@ -50,6 +50,23 @@ public class ActionBarProxy extends KrollProxy
 	}
 
 	@Kroll.setProperty
+	public void setHomeAsUpIndicator(Object icon)
+	{
+		if (this.actionBar == null) {
+			Log.w(TAG, ACTION_BAR_NOT_AVAILABLE_MESSAGE);
+			return;
+		}
+
+		if (icon instanceof Number) {
+			this.actionBar.setHomeAsUpIndicator(TiConvert.toInt(icon));
+		} else if (icon != null) {
+			this.actionBar.setHomeAsUpIndicator(TiUIHelper.getResourceDrawable(icon));
+		} else {
+			this.actionBar.setHomeAsUpIndicator(null);
+		}
+	}
+
+	@Kroll.setProperty
 	public void setHomeButtonEnabled(boolean homeButtonEnabled)
 	{
 		if (actionBar != null) {

--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/ActionBarProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/ActionBarProxy.java
@@ -6,24 +6,22 @@
  */
 package org.appcelerator.titanium.proxy;
 
+import android.graphics.drawable.Drawable;
+import androidx.appcompat.app.ActionBar;
+import androidx.appcompat.app.AppCompatActivity;
 import org.appcelerator.kroll.KrollProxy;
 import org.appcelerator.kroll.annotations.Kroll;
 import org.appcelerator.kroll.common.Log;
-import org.appcelerator.titanium.TiApplication;
 import org.appcelerator.titanium.TiC;
-import org.appcelerator.titanium.util.TiFileHelper;
-import org.appcelerator.titanium.util.TiUrl;
-
-import android.graphics.drawable.Drawable;
-
-import androidx.appcompat.app.ActionBar;
-import androidx.appcompat.app.AppCompatActivity;
+import org.appcelerator.titanium.util.TiConvert;
+import org.appcelerator.titanium.util.TiUIHelper;
 
 @SuppressWarnings("deprecation")
 @Kroll.proxy(propertyAccessors = { TiC.PROPERTY_ON_HOME_ICON_ITEM_SELECTED, TiC.PROPERTY_CUSTOM_VIEW })
 public class ActionBarProxy extends KrollProxy
 {
 	private static final String TAG = "ActionBarProxy";
+	private static final String ACTION_BAR_NOT_AVAILABLE_MESSAGE = "ActionBar is not enabled";
 
 	private ActionBar actionBar;
 	private boolean showTitleEnabled = true;
@@ -47,7 +45,7 @@ public class ActionBarProxy extends KrollProxy
 		if (actionBar != null) {
 			actionBar.setDisplayHomeAsUpEnabled(showHomeAsUp);
 		} else {
-			Log.w(TAG, "ActionBar is not enabled");
+			Log.w(TAG, ACTION_BAR_NOT_AVAILABLE_MESSAGE);
 		}
 	}
 
@@ -57,29 +55,35 @@ public class ActionBarProxy extends KrollProxy
 		if (actionBar != null) {
 			actionBar.setHomeButtonEnabled(homeButtonEnabled);
 		} else {
-			Log.w(TAG, "ActionBar is not enabled");
+			Log.w(TAG, ACTION_BAR_NOT_AVAILABLE_MESSAGE);
 		}
 	}
 
 	@Kroll.setProperty
 	public void setNavigationMode(int navigationMode)
 	{
-		actionBar.setNavigationMode(navigationMode);
+		if (actionBar != null) {
+			actionBar.setNavigationMode(navigationMode);
+		} else {
+			Log.w(TAG, ACTION_BAR_NOT_AVAILABLE_MESSAGE);
+		}
 	}
 
 	@Kroll.setProperty
 	public void setBackgroundImage(String url)
 	{
 		if (actionBar == null) {
-			Log.w(TAG, "ActionBar is not enabled");
+			Log.w(TAG, ACTION_BAR_NOT_AVAILABLE_MESSAGE);
 			return;
 		}
 
-		Drawable backgroundImage = getDrawableFromUrl(url);
-		//This is a workaround due to https://code.google.com/p/styled-action-bar/issues/detail?id=3. [TIMOB-12148]
+		Drawable backgroundImage = TiUIHelper.getResourceDrawable(url);
 		if (backgroundImage != null) {
+			// Work-around Android OS bug where you can't change background image unless you update title.
+			// See: https://code.google.com/p/styled-action-bar/issues/detail?id=3
 			actionBar.setDisplayShowTitleEnabled(!showTitleEnabled);
 			actionBar.setDisplayShowTitleEnabled(showTitleEnabled);
+
 			actionBar.setBackgroundDrawable(backgroundImage);
 		}
 	}
@@ -90,7 +94,7 @@ public class ActionBarProxy extends KrollProxy
 		if (actionBar != null) {
 			actionBar.setTitle(title);
 		} else {
-			Log.w(TAG, "ActionBar is not enabled");
+			Log.w(TAG, ACTION_BAR_NOT_AVAILABLE_MESSAGE);
 		}
 	}
 
@@ -101,7 +105,7 @@ public class ActionBarProxy extends KrollProxy
 			actionBar.setDisplayShowTitleEnabled(true);
 			actionBar.setSubtitle(subTitle);
 		} else {
-			Log.w(TAG, "ActionBar is not enabled");
+			Log.w(TAG, ACTION_BAR_NOT_AVAILABLE_MESSAGE);
 		}
 	}
 
@@ -155,7 +159,7 @@ public class ActionBarProxy extends KrollProxy
 		if (actionBar != null) {
 			actionBar.show();
 		} else {
-			Log.w(TAG, "ActionBar is not enabled");
+			Log.w(TAG, ACTION_BAR_NOT_AVAILABLE_MESSAGE);
 		}
 	}
 
@@ -165,43 +169,61 @@ public class ActionBarProxy extends KrollProxy
 		if (actionBar != null) {
 			actionBar.hide();
 		} else {
-			Log.w(TAG, "ActionBar is not enabled");
+			Log.w(TAG, ACTION_BAR_NOT_AVAILABLE_MESSAGE);
+		}
+	}
+
+	@Kroll.getProperty
+	public boolean getVisible()
+	{
+		if (this.actionBar == null) {
+			return false;
+		}
+		return this.actionBar.isShowing();
+	}
+
+	@Kroll.setProperty
+	public void setVisible(boolean value)
+	{
+		if (value) {
+			show();
+		} else {
+			hide();
 		}
 	}
 
 	@Kroll.setProperty
-	public void setLogo(String url)
+	public void setLogo(Object image)
 	{
-		if (actionBar == null) {
-			Log.w(TAG, "ActionBar is not enabled");
+		if (this.actionBar == null) {
+			Log.w(TAG, ACTION_BAR_NOT_AVAILABLE_MESSAGE);
 			return;
 		}
 
-		Drawable logo = getDrawableFromUrl(url);
-		if (logo != null) {
-			actionBar.setLogo(logo);
+		if (image instanceof Number) {
+			this.actionBar.setLogo(TiConvert.toInt(image));
+		} else if (image != null) {
+			this.actionBar.setLogo(TiUIHelper.getResourceDrawable(image));
+		} else {
+			this.actionBar.setLogo(null);
 		}
 	}
 
 	@Kroll.setProperty
-	public void setIcon(String url)
+	public void setIcon(Object image)
 	{
-		if (actionBar == null) {
-			Log.w(TAG, "ActionBar is not enabled");
+		if (this.actionBar == null) {
+			Log.w(TAG, ACTION_BAR_NOT_AVAILABLE_MESSAGE);
 			return;
 		}
 
-		Drawable icon = getDrawableFromUrl(url);
-		if (icon != null) {
-			actionBar.setIcon(icon);
+		if (image instanceof Number) {
+			this.actionBar.setIcon(TiConvert.toInt(image));
+		} else if (image != null) {
+			this.actionBar.setIcon(TiUIHelper.getResourceDrawable(image));
+		} else {
+			this.actionBar.setIcon(null);
 		}
-	}
-
-	private Drawable getDrawableFromUrl(String url)
-	{
-		TiUrl imageUrl = new TiUrl((String) url);
-		TiFileHelper tfh = new TiFileHelper(TiApplication.getInstance());
-		return tfh.loadDrawable(imageUrl.resolve(), false);
 	}
 
 	@Override

--- a/apidoc/Titanium/Android/ActionBar.yml
+++ b/apidoc/Titanium/Android/ActionBar.yml
@@ -4,16 +4,14 @@ summary: |
     An action bar is a window feature that identifies the application and user location,
     and provides user actions and navigation modes.
 description: |
-    Starting with Release 3.3.0, the Titanium SDK uses the appcompat library to provide support for
-    the action bar, including devices running Android 2.3.x and prior. If you are using a release earlier
-    than 3.3.0, refer to the _Applicaton Note_ below for additional information.
-
     You can add action items to the action bar by defining an Android menu and setting the
     menu items to display as action items. See [Menu](Titanium.Android.Menu) and
     [MenuItem](Titanium.Android.MenuItem) for details.
 
-    In JavaScript, wait for the window or tab group's `open` event before accessing
-    the action bar from the window or tab group's [activity](Titanium.Android.Activity).
+    You cannot change the action bar's settings until the window's [activity](Titanium.UI.Window.activity)
+    or tab group's [activity](Titanium.UI.TabGroup.activity) has been created.
+    You can detect this by assigning a callback to the activity's [onCreate](Titanium.Android.Activity.onCreate)
+    property.
 
     Note that setting the [Window.navBarHidden](Titanium.UI.Window.navBarHidden) property
     to true disables the Action Bar since it is part of the navigation title bar.
@@ -36,26 +34,6 @@ description: |
     Set MenuItem attributes in either the XML or TSS file.
 
     For an example of using the Action Bar with Alloy, see "Action Bar using Alloy XML Markup" below.
-
-    #### Action Bar Icon
-
-    Starting with Release 4.0, due to the requirement that the target SDK must be set to Android 5.0
-    (API level 21) or higher, the action bar icon may not display. Google is discouraging
-    the use of icons in toolbars:
-
-    > In modern Android UIs developers should lean more on a visually distinct color scheme for toolbars
-    > than on their application icon. The use of application icon plus title as a standard layout is
-    > discouraged on API 21 devices and newer.
-
-    Source: [Android Developer: Toolbar API reference](https://developer.android.com/reference/android/support/v7/widget/Toolbar.html)
-
-    #### Application Note for Release 3.2.x and earlier
-
-    If you are using Release 3.2.x or earlier, this feature is only available in Android 3.0
-    (API level 11) and above.
-
-    To access the action bar, you must first open a heavyweight window or tab group that
-    uses one of the action bar themes (such as the Android Holo theme).
 
 examples:
 
@@ -99,34 +77,28 @@ examples:
         The following example sets several properties on a window's action bar.
 
         ``` js
-        var win = Ti.UI.createWindow({
+        const win = Ti.UI.createWindow({
             title: "Old Title",
             navBarHidden: false
         });
-        var actionBar;
-
-        win.addEventListener("open", function() {
-            if (Ti.Platform.osname === "android") {
-                if (! win.activity) {
-                    Ti.API.error("Can't access action bar on a lightweight window.");
-                } else {
-                    actionBar = win.activity.actionBar;
-                    if (actionBar) {
-                        actionBar.backgroundImage = "/bg.png";
-                        actionBar.title = "New Title";
-                        actionBar.onHomeIconItemSelected = function() {
-                            Ti.API.info("Home icon clicked!");
-                        };
-                    }
+        if (OS_ANDROID) {
+            win.activity.onCreate = () => {
+                const actionBar = win.activity.actionBar;
+                if (actionBar) {
+                    actionBar.backgroundImage = "/bg.png";
+                    actionBar.title = "New Title";
+                    actionBar.onHomeIconItemSelected = () => {
+                        Ti.API.info("Home icon clicked!");
+                    };
                 }
-            }
-        });
-
+            };
+        }
         win.open();
         ```
 
-        Nearly identical code can be used for a tab group, but in Release 3.0, the tab group's
-        activity must be accessed using the [getActivity](Titanium.UI.TabGroup.getActivity) method.
+        The above can be done for a tab group via its [activity](Titanium.UI.TabGroup.activity) property.
+        Note that individual tab windows do not have an activity. Only the root tab group (which hosts the tabs)
+        provides an activity property.
 
 extends: Titanium.Proxy
 platforms: [android]
@@ -195,24 +167,25 @@ properties:
     permission: write-only
 
   - name: icon
-    summary: Sets the application icon displayed in the "home" area of the action bar, specified as a local file path or URL.
+    summary: Sets the application icon displayed in the "home" area of the action bar.
     description: |
-        Starting with Release 4.0, the action bar icon may not display. Google is discouraging the
-        use of icons in toolbars.
+        Before Titanium 10.2.0, this property only supports a `String` and it must be assigned a local file path
+        or URL to an image.
 
-        Prior to Release 3.3.0, this method only works on devices with Android 4.0 (API 14) and above. See also:
-        [setIcon](https://developer.android.com/reference/android/app/ActionBar.html#setIcon(android.graphics.drawable.Drawable))
-        in the Android Developer Reference.
-    type: String
+        As of Titanium 10.2.0, this property can also be assigned an image blob or a native drawable resource ID
+        from `Ti.App.Android.R.drawable.*` or `Ti.Android.R.drawable.*`.
+    type: [String, Number, Titanium.Blob]
     permission: write-only
 
   - name: logo
-    summary: Sets the application logo displayed in the "home" area of the action bar, specified as a local file path or URL.
+    summary: Sets the application logo displayed in the "home" area of the action bar.
     description: |
-        Prior to Release 3.3.0, this method only works on devices with Android 4.0 (API 14) and above. See also:
-        [setLogo](https://developer.android.com/reference/android/app/ActionBar.html#setLogo(android.graphics.drawable.Drawable))
-        in the Android Developer Reference.
-    type: String
+        Before Titanium 10.2.0, this property only supports a `String` and it must be assigned a local file path
+        or URL to an image.
+
+        As of Titanium 10.2.0, this property can also be assigned an image blob or a native drawable resource ID
+        from `Ti.App.Android.R.drawable.*` or `Ti.Android.R.drawable.*`.
+    type: [String, Number, Titanium.Blob]
     permission: write-only
 
   - name: navigationMode
@@ -246,3 +219,11 @@ properties:
         between the application's home button and menu actions.
         The custom view is trimmed to fit the space available.
     since: "7.1.0"
+
+  - name: visible
+    summary: Gets or sets the action bar visibility state.
+    type: Boolean
+    description: |
+        Setting this property to `true` or `false` is the equivalent of calling the
+        [show()](Titanium.Android.ActionBar.show) or [hide()](Titanium.Android.ActionBar.hide) methods.
+    since: "10.2.0"

--- a/apidoc/Titanium/Android/ActionBar.yml
+++ b/apidoc/Titanium/Android/ActionBar.yml
@@ -157,6 +157,16 @@ properties:
     type: Boolean
     permission: write-only
 
+  - name: homeAsUpIndicator
+    summary: Sets a custom icon for the "home" button in the corner of the action bar.
+    description: |
+        Can be set to a `String` file path or URL to an image, to an image blob, or to a resource ID
+        from `Ti.App.Android.R.drawable.*` or `Ti.Android.R.drawable.*`. It's highly recommended to set this
+        to a vector drawable resource ID.
+    type: [String, Number, Titanium.Blob]
+    since: "10.2.0"
+    permission: write-only
+
   - name: homeButtonEnabled
     summary: Enable or disable the "home" button in the corner of the action bar.
     description: |

--- a/tests/Resources/app.js
+++ b/tests/Resources/app.js
@@ -84,6 +84,7 @@ function loadTests() {
 	require('./ti.analytics.test');
 	if (OS_ANDROID) {
 		require('./ti.android.test');
+		require('./ti.android.actionbar.test');
 		require('./ti.android.notificationmanager.test');
 		require('./ti.android.r.test');
 		require('./ti.android.service.test');

--- a/tests/Resources/ti.android.actionbar.test.js
+++ b/tests/Resources/ti.android.actionbar.test.js
@@ -47,6 +47,40 @@ describe.android('Titanium.Android.ActionBar', function () {
 		win.open();
 	});
 
+	it('.homeAsUpIndicator (Image)', (finish) => {
+		win = Ti.UI.createWindow();
+		win.activity.onCreate = () => {
+			try {
+				const actionBar = win.activity.actionBar;
+				actionBar.displayHomeAsUp = true;
+				actionBar.homeButtonEnabled = true;
+				actionBar.homeAsUpIndicator = 'SmallLogo.png';
+				actionBar.onHomeIconItemSelected = () => {};
+				finish();
+			} catch (err) {
+				finish(err);
+			}
+		};
+		win.open();
+	});
+
+	it('.homeAsUpIndicator (Resource ID)', (finish) => {
+		win = Ti.UI.createWindow();
+		win.activity.onCreate = () => {
+			try {
+				const actionBar = win.activity.actionBar;
+				actionBar.displayHomeAsUp = true;
+				actionBar.homeButtonEnabled = true;
+				actionBar.homeAsUpIndicator = Ti.App.Android.R.drawable.ic_baseline_close_24;
+				actionBar.onHomeIconItemSelected = () => {};
+				finish();
+			} catch (err) {
+				finish(err);
+			}
+		};
+		win.open();
+	});
+
 	it('.icon (Image)', (finish) => {
 		win = Ti.UI.createWindow();
 		win.activity.onCreate = () => {

--- a/tests/Resources/ti.android.actionbar.test.js
+++ b/tests/Resources/ti.android.actionbar.test.js
@@ -1,0 +1,178 @@
+/*
+ * Axway Appcelerator Titanium Mobile
+ * Copyright (c) 2011-2021 by Axway Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+/* eslint-env mocha */
+/* eslint no-unused-expressions: "off" */
+'use strict';
+const should = require('./utilities/assertions');
+
+describe.android('Titanium.Android.ActionBar', function () {
+	let win;
+	this.timeout(5000);
+
+	beforeEach(() => {
+		win = Ti.UI.createWindow();
+	});
+
+	afterEach(done => { // fires after every test in sub-suites too...
+		if (win && !win.closed) {
+			win.addEventListener('close', function listener () {
+				win.removeEventListener('close', listener);
+				win = null;
+				done();
+			});
+			win.close();
+		} else {
+			win = null;
+			done();
+		}
+	});
+
+	it('.displayHomeAsUp', (finish) => {
+		win = Ti.UI.createWindow();
+		win.activity.onCreate = () => {
+			try {
+				const actionBar = win.activity.actionBar;
+				actionBar.displayHomeAsUp = true;
+				actionBar.homeButtonEnabled = true;
+				actionBar.onHomeIconItemSelected = () => {};
+				finish();
+			} catch (err) {
+				finish(err);
+			}
+		};
+		win.open();
+	});
+
+	it('.icon (Image)', (finish) => {
+		win = Ti.UI.createWindow();
+		win.activity.onCreate = () => {
+			try {
+				win.activity.actionBar.icon = 'SmallLogo.png';
+				finish();
+			} catch (err) {
+				finish(err);
+			}
+		};
+		win.open();
+	});
+
+	it('.icon (Resource ID)', (finish) => {
+		win = Ti.UI.createWindow();
+		win.activity.onCreate = () => {
+			try {
+				win.activity.actionBar.icon = Ti.App.Android.R.drawable.ic_baseline_close_24;
+				finish();
+			} catch (err) {
+				finish(err);
+			}
+		};
+		win.open();
+	});
+
+	it('.logo (Image)', (finish) => {
+		win = Ti.UI.createWindow();
+		win.activity.onCreate = () => {
+			try {
+				win.activity.actionBar.logo = 'SmallLogo.png';
+				finish();
+			} catch (err) {
+				finish(err);
+			}
+		};
+		win.open();
+	});
+
+	it('.logo (Resource ID)', (finish) => {
+		win = Ti.UI.createWindow();
+		win.activity.onCreate = () => {
+			try {
+				win.activity.actionBar.logo = Ti.App.Android.R.drawable.ic_baseline_close_24;
+				finish();
+			} catch (err) {
+				finish(err);
+			}
+		};
+		win.open();
+	});
+
+	it('.visible', (finish) => {
+		win = Ti.UI.createWindow();
+		win.activity.onCreate = () => {
+			try {
+				should(win.activity.actionBar.visible).be.true();
+				win.activity.actionBar.visible = false;
+				should(win.activity.actionBar.visible).be.false();
+				win.activity.actionBar.visible = true;
+				should(win.activity.actionBar.visible).be.true();
+				finish();
+			} catch (err) {
+				finish(err);
+			}
+		};
+		win.open();
+	});
+
+	it('#show()/hide()', (finish) => {
+		win = Ti.UI.createWindow();
+		win.activity.onCreate = () => {
+			try {
+				should(win.activity.actionBar.visible).be.true();
+				win.activity.actionBar.hide();
+				should(win.activity.actionBar.visible).be.false();
+				win.activity.actionBar.show();
+				should(win.activity.actionBar.visible).be.true();
+				finish();
+			} catch (err) {
+				finish(err);
+			}
+		};
+		win.open();
+	});
+
+	it('.subtitle', (finish) => {
+		win = Ti.UI.createWindow();
+		win.activity.onCreate = () => {
+			try {
+				win.activity.actionBar.subtitle = 'My Subtitle';
+				should(win.activity.actionBar.subtitle).be.eql('My Subtitle');
+				finish();
+			} catch (err) {
+				finish(err);
+			}
+		};
+		win.open();
+	});
+
+	it('.title', (finish) => {
+		win = Ti.UI.createWindow();
+		win.activity.onCreate = () => {
+			try {
+				win.activity.actionBar.title = 'My Title';
+				should(win.activity.actionBar.title).be.eql('My Title');
+				finish();
+			} catch (err) {
+				finish(err);
+			}
+		};
+		win.open();
+	});
+
+	it('Theme.AppDerived.NoTitleBar', (finish) => {
+		win = Ti.UI.createWindow({
+			theme: 'Theme.AppDerived.NoTitleBar'
+		});
+		win.activity.onCreate = () => {
+			try {
+				should(win.activity.actionBar.visible).be.false();
+				finish();
+			} catch (err) {
+				finish(err);
+			}
+		};
+		win.open();
+	});
+});


### PR DESCRIPTION
**JIRA:**
- https://jira.appcelerator.org/browse/TIMOB-28570
- https://jira.appcelerator.org/browse/TIMOB-28571

**Summary:**
- [TIMOB-28570](https://jira.appcelerator.org/browse/TIMOB-28570) Add property "homeAsUpIndicator" to `ActionBar`.
  * Allows you to set a custom icon for the home button (such as a close button).
- [TIMOB-28571](https://jira.appcelerator.org/browse/TIMOB-28571) Add `R.drawable` ID support to `ActionBar` properties "homeAsUpIndicator", "icon", and "logo".
  * Allows you to use native vector drawables for icons.
- Added boolean "visible" property to `ActionBar`.
  * Helps detect if `ActionBar` is shown or not.
  * Will return `false` if using a `*.NoTitleBar` theme.
  * Setting it to `true` or `false` is equivalent to calling `show()` or `hide()`.

**Home Icon Test:**
Follow the test procedure attached to ticket [TIMOB-28570](https://jira.appcelerator.org/browse/TIMOB-28570).

**Icon Test:**
Run the "Icon Example" test code attached to [TIMOB-28571](https://jira.appcelerator.org/browse/TIMOB-28571) and verify you see a checked checkbox to the left of the title.

**Logo Test:**
Run the "Logo Example" test code attached to [TIMOB-28571](https://jira.appcelerator.org/browse/TIMOB-28571) and verify you see a checked checkbox to the left of the title.
