### PR TITLE
fix(android): amend ShapeDrawable workaround

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/TiRecyclerViewHolder.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/TiRecyclerViewHolder.java
@@ -206,9 +206,9 @@ public abstract class TiRecyclerViewHolder extends RecyclerView.ViewHolder
 			stateDrawable.addState(new int[] { android.R.attr.state_activated }, new ColorDrawable(COLOR_SELECTED));
 		}
 
-		// NOTE: Android 6.0 and below require ShapeDrawable to have non-null Shape.
-		// This bug is fixed on Android 7.0 and above.
-		if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
+		// NOTE: Android 7.1 and below require ShapeDrawable to have non-null Shape.
+		// This bug is fixed on Android 8.0 and above.
+		if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
 			Drawable currentDrawable = drawable;
 
 			if (currentDrawable instanceof RippleDrawable) {


### PR DESCRIPTION
- Amend `ShaepDrawable` condition to include Android 7.1 (25)

##### TEST CASE
```JS
const win = Ti.UI.createWindow();
const table = Ti.UI.createTableView({
    data: [ { title: 'row 1' } ]
});
 
win.add(table);
win.open();
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-28572)