### PR TITLE
fix(ios): re-add KrollBridge "modules" method some 3rd party modules depend on

### DIFF
--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/KrollBridge.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/KrollBridge.m
@@ -34,6 +34,24 @@ CFMutableSetRef krollBridgeRegistry = nil;
 
 @implementation KrollBridge
 
+- (NSDictionary<NSString *, id> *)modules
+{
+  // Some 3rd party modules built before Titanium 10.0.0 depend on this method.
+  // Returns a dictionary of all external modules, using module ID as the key and module instance as the value.
+  NSDictionary<NSString *, id> *orig = [self.host valueForKey:@"modules"];
+  NSMutableDictionary<NSString *, id> *copy = [[orig mutableCopy] autorelease];
+  for (NSString *key in orig) {
+    id module = [orig objectForKey:key];
+    if ([module respondsToSelector:@selector(moduleId)]) {
+      NSString *moduleId = [module moduleId];
+      if (moduleId) {
+        copy[moduleId] = module;
+      }
+    }
+  }
+  return copy;
+}
+
 + (void)initialize
 {
   if (krollBridgeRegistry == nil) {


### PR DESCRIPTION
**JIRA:**
https://jira.appcelerator.org/browse/TIMOB-28415

**Summary:**
- This is for backward compatibility with 3rd modules that call this native method directly, such as the [drag-and-drop](https://github.com/hansemannn/titanium-drag-and-drop) module.
- Method was removed in Titanium 10.0.0. Re-added in 10.2.0.
