### PR TITLE
fix(ios): window.setToolbar() background color alway transparent on iOS 15

### DIFF
--- a/iphone/TitaniumKit/TitaniumKit/Sources/Modules/TiUIWindowProxy.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/Modules/TiUIWindowProxy.m
@@ -968,7 +968,14 @@
           UIColor *tintColor = [[TiUtils colorValue:@"tintColor" properties:properties] color];
           [ourNC.toolbar setBarTintColor:barColor];
           [ourNC.toolbar setTintColor:tintColor];
-
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 150000
+          if ([TiUtils isIOSVersionOrGreater:@"15.0"]) {
+            UIToolbarAppearance *appearance = ourNC.toolbar.standardAppearance;
+            [appearance configureWithDefaultBackground];
+            appearance.backgroundColor = barColor;
+            ourNC.toolbar.scrollEdgeAppearance = appearance;
+          }
+#endif
           [array release];
         }
       },


### PR DESCRIPTION
**JIRA:**
https://jira.appcelerator.org/browse/TIMOB-28574

**Summary:**
- On iOS 15, the `Window.setToolbar()` background color is always wrongly transparent on iOS 15.
  * "barColor" property is always ignored.
  * Default background color should be gray (like nav bar) if "barColor" is not set.
- Causes by iOS 15 breaking-change which requires us to also set the `scrollEdgeAppearance` to make this work.

**Test:**
1. Build and run the below code on iOS 15.
2. Verify bottom toolbar has a gray background like top nav bar.
3. Uncomment the below "barColor" and "backgroundColor" lines.
4. Re-build and run on iOS 15.
5. Verify bottom toolbar has an orange background.

```javascript
const rootWindow = Ti.UI.createWindow({
//	barColor: "orange",
//	backgroundColor: "yellow",
	title: "Test App",
});
const button1 = Ti.UI.createButton({
	title: "Button 1",
	color: "red",
});
button1.addEventListener("click", () => { alert("Clicked: Button 1"); });
const button2 = Ti.UI.createButton({
	title: "Button 2",
});
button2.addEventListener("click", () => { alert("Clicked: Button 2"); });
rootWindow.setToolbar([button1, button2], {
	animated: true,
//	barColor: "orange",
	tintColor: "purple",
});
rootWindow.add(Ti.UI.createLabel({ text: "iOS setToolBar() Test" }));
const navigationWindow = Ti.UI.createNavigationWindow({
	window: rootWindow,
});
navigationWindow.open();
```
