### PR TITLE
feat(android): ActionBar menu text should not be all-caps by default

### DIFF
--- a/android/titanium/res/values/values.xml
+++ b/android/titanium/res/values/values.xml
@@ -29,14 +29,6 @@
 		<attr name="titaniumSplashIcon" format="reference"/>
 	</declare-styleable>
 
-	<!-- Titanium's button text style is not all-caps just like Google's apps. -->
-	<style name="TextAppearance.Titanium.Button" parent="TextAppearance.MaterialComponents.Button">
-		<item name="android:textAllCaps">false</item>
-	</style>
-	<style name="Widget.Titanium.Button" parent="Widget.AppCompat.Button">
-		<item name="android:textAllCaps">false</item>
-	</style>
-
 	<!-- Titanium's dark material theme with an action bar. -->
 	<style name="Theme.Titanium.Dark" parent="Theme.MaterialComponents">
 		<item name="actionBarSize">@dimen/ti_action_bar_height</item>
@@ -47,10 +39,9 @@
 		<item name="colorSurface">@color/ti_dark_surface</item>
 		<item name="android:colorBackground">@color/ti_dark_background</item>
 		<item name="android:navigationBarColor">?attr/colorPrimaryDark</item>
-		<item name="android:buttonStyle">@style/Widget.Titanium.Button</item>
 		<item name="android:statusBarColor">?attr/colorPrimaryDark</item>
-		<item name="buttonStyle">@style/Widget.Titanium.Button</item>
-		<item name="textAppearanceButton">@style/TextAppearance.Titanium.Button</item>
+		<item name="android:textAllCaps">false</item>
+		<item name="textAllCaps">false</item>
 	</style>
 
 	<!-- Titanium's dark material theme without an action bar. -->
@@ -103,10 +94,9 @@
 		<item name="colorSurface">@color/ti_light_surface</item>
 		<item name="android:colorBackground">@color/ti_light_background</item>
 		<item name="android:navigationBarColor">?attr/colorPrimaryDark</item>
-		<item name="android:buttonStyle">@style/Widget.Titanium.Button</item>
 		<item name="android:statusBarColor">?attr/colorPrimaryDark</item>
-		<item name="buttonStyle">@style/Widget.Titanium.Button</item>
-		<item name="textAppearanceButton">@style/TextAppearance.Titanium.Button</item>
+		<item name="android:textAllCaps">false</item>
+		<item name="textAllCaps">false</item>
 	</style>
 
 	<!-- Titanium's light material theme without an action bar. -->


### PR DESCRIPTION
**JIRA:**
https://jira.appcelerator.org/browse/TIMOB-28575

**Summary:**
- As of Titanium 10.0.0, default theme was changed to not use all-caps for button text. We should do the same for menu text for consistency.
- Simplified theme to apply `textAllCaps` attribute globally for the theme instead of individual widget styles.

**Test:**
1. Build and run the below on Android.
2. Verify the action bar displays "Menu Item" in not all-caps.
3. Verify button "My Button" is not all-caps.
4. Tap on the action bar "..." overflow menu icon in the top-right corner.
5. Verify "Drop-Down Menu Item" is not all-caps.
6. Repeat steps 2-5 on Android 5.0. _(This OS version ignores attribute "android:textAllCaps".)_

```javascript
function showAlertForEvent(e) {
	alert(`Clicked on: ${e.source.title}`);
}

const window = Ti.UI.createWindow();
window.activity.onCreateOptionsMenu = (e) => {
	const menuItem1 = e.menu.add({
		title: "Menu Item",
		showAsAction: Ti.Android.SHOW_AS_ACTION_IF_ROOM,
	});
	menuItem1.addEventListener("click", showAlertForEvent);
	const menuItem2 = e.menu.add({
		title: "Drop-Down Menu Item",
		showAsAction: Ti.Android.SHOW_AS_ACTION_NEVER,
	});
	menuItem2.addEventListener("click", showAlertForEvent);
};
const button = Ti.UI.createButton({ title: "My Button" });
button.addEventListener("click", showAlertForEvent);
window.add(button);
window.open();
```
