### PR TITLE
fix(android): Ti.UI.Android.ProgressIndicator dialog not using theme's "colorPrimary"

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIProgressIndicator.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIProgressIndicator.java
@@ -22,9 +22,15 @@ import org.appcelerator.titanium.view.TiUIView;
 import android.app.Activity;
 import android.app.ProgressDialog;
 import android.content.DialogInterface;
+import android.graphics.Color;
+import android.graphics.PorterDuff;
+import android.graphics.PorterDuffColorFilter;
+import android.os.Build;
+import android.widget.ProgressBar;
+import com.google.android.material.color.MaterialColors;
 
-public class TiUIProgressIndicator
-	extends TiUIView implements DialogInterface.OnCancelListener, DialogInterface.OnDismissListener
+public class TiUIProgressIndicator extends TiUIView implements
+	DialogInterface.OnShowListener, DialogInterface.OnCancelListener, DialogInterface.OnDismissListener
 {
 	private static final String TAG = "TiUIProgressDialog";
 
@@ -194,6 +200,7 @@ public class TiUIProgressIndicator
 						progressDialog, true, new WeakReference<>(baseActivity)));
 					progressDialog.setOwnerActivity(a);
 				}
+				progressDialog.setOnShowListener(this);
 				progressDialog.setOnCancelListener(this);
 				progressDialog.setOnDismissListener(this);
 			}
@@ -274,6 +281,24 @@ public class TiUIProgressIndicator
 		}
 
 		this.visible = false;
+	}
+
+	@Override
+	public void onShow(DialogInterface dialog)
+	{
+		// Work-around Android 5.x and older issue where it ignores "indeterminateTint" color in theme.
+		// Only happens to the indeterminate type. The determinate type is okay.
+		if ((Build.VERSION.SDK_INT < 23) && (type == INDETERMINANT)) {
+			var view = progressDialog.findViewById(android.R.id.progress);
+			if (view instanceof ProgressBar) {
+				int colorValue = MaterialColors.getColor(
+					progressDialog.getContext(), android.R.attr.indeterminateTint, Color.TRANSPARENT);
+				var drawable = ((ProgressBar) view).getIndeterminateDrawable();
+				if ((colorValue != Color.TRANSPARENT) && (drawable != null)) {
+					drawable.setColorFilter(new PorterDuffColorFilter(colorValue, PorterDuff.Mode.SRC_IN));
+				}
+			}
+		}
 	}
 
 	@Override

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIProgressIndicator.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIProgressIndicator.java
@@ -286,9 +286,16 @@ public class TiUIProgressIndicator extends TiUIView implements
 	@Override
 	public void onShow(DialogInterface dialog)
 	{
+		// Fetch progress dialog reference.
+		// Note: Argument won't match "progressDialog" member variable if hide() was called before dialog was shown.
+		if ((dialog instanceof ProgressDialog) == false) {
+			return;
+		}
+		ProgressDialog progressDialog = (ProgressDialog) dialog;
+
 		// Work-around Android 5.x and older issue where it ignores "indeterminateTint" color in theme.
 		// Only happens to the indeterminate type. The determinate type is okay.
-		if ((Build.VERSION.SDK_INT < 23) && (type == INDETERMINANT)) {
+		if ((Build.VERSION.SDK_INT < 23) && progressDialog.isIndeterminate()) {
 			var view = progressDialog.findViewById(android.R.id.progress);
 			if (view instanceof ProgressBar) {
 				int colorValue = MaterialColors.getColor(

--- a/android/titanium/res/values/values.xml
+++ b/android/titanium/res/values/values.xml
@@ -46,7 +46,9 @@
 		<item name="colorAccent">@color/ti_dark_accent</item>
 		<item name="colorSurface">@color/ti_dark_surface</item>
 		<item name="android:colorBackground">@color/ti_dark_background</item>
+		<item name="android:indeterminateTint">?attr/colorPrimary</item>
 		<item name="android:navigationBarColor">?attr/colorPrimaryDark</item>
+		<item name="android:progressTint">?attr/colorPrimary</item>
 		<item name="android:buttonStyle">@style/Widget.Titanium.Button</item>
 		<item name="android:statusBarColor">?attr/colorPrimaryDark</item>
 		<item name="buttonStyle">@style/Widget.Titanium.Button</item>
@@ -102,7 +104,9 @@
 		<item name="colorAccent">@color/ti_light_accent</item>
 		<item name="colorSurface">@color/ti_light_surface</item>
 		<item name="android:colorBackground">@color/ti_light_background</item>
+		<item name="android:indeterminateTint">?attr/colorPrimary</item>
 		<item name="android:navigationBarColor">?attr/colorPrimaryDark</item>
+		<item name="android:progressTint">?attr/colorPrimary</item>
 		<item name="android:buttonStyle">@style/Widget.Titanium.Button</item>
 		<item name="android:statusBarColor">?attr/colorPrimaryDark</item>
 		<item name="buttonStyle">@style/Widget.Titanium.Button</item>


### PR DESCRIPTION
**JIRA:**
https://jira.appcelerator.org/browse/TIMOB-28576

**Summary:**
- `Ti.UI.Android.ProgressIndicator` dialog is still using Holo Dark theme's green color by default.
- Should use material theme's "colorPrimary" style since Titanium 10.0.0 switched to material widgets/themes.
- This is not an issue with `Ti.UI.ProgressBar`.

**Test:**
1. Build and run the below code on Android.
2. Tap on the "Show Determinate Progress" button.
3. Verify progress bar is blue. _(Was green.)_
4. Tap on the "Show Indeterminate Progress" button.
5. Verify progress circle is blue. _(Was green.)_
6. Repeat steps 2-5 on Android 5.0.

```javascript
const window = Ti.UI.createWindow({ layout: "vertical" });
const button1 = Ti.UI.createButton({
	title: "Show Determinant Progress",
	top: 40,
});
button1.addEventListener("click", () => {
	const dialog = Ti.UI.Android.createProgressIndicator({
		message: "Loading...",
		value: 0,
		min: 0,
		max: 100,
		location: Ti.UI.Android.PROGRESS_INDICATOR_DIALOG,
		type: Ti.UI.Android.PROGRESS_INDICATOR_DETERMINANT,
	});
	dialog.show();
	const timerId = setInterval(() => {
		if (dialog.value < dialog.max) {
			dialog.value++;
		} else {
			dialog.hide();
			clearInterval(timerId);
		}
	}, 50);
});
window.add(button1);
const button2 = Ti.UI.createButton({
	title: "Show Indeterminant Progress",
	top: 40,
});
button2.addEventListener("click", () => {
	const dialog = Ti.UI.Android.createProgressIndicator({
		message: "Loading...",
		location: Ti.UI.Android.PROGRESS_INDICATOR_DIALOG,
		type: Ti.UI.Android.PROGRESS_INDICATOR_INDETERMINANT,
	});
	dialog.show();
	setTimeout(() => {
		dialog.hide();
	}, 2000);
});
window.add(button2);
window.open();
```
