### PR TITLE
fix(ios): tab background color on iOS 15 when setting title color

### DIFF
--- a/iphone/Classes/TiUITabGroup.m
+++ b/iphone/Classes/TiUITabGroup.m
@@ -375,8 +375,17 @@ DEFINE_EXCEPTIONS
   [tabBar setBarTintColor:[color color]];
 #if IS_SDK_IOS_15
   if ([TiUtils isIOSVersionOrGreater:@"15.0"]) {
+    // Update main tab bar's appearance.
     tabBar.standardAppearance.backgroundColor = [color color];
     tabBar.scrollEdgeAppearance.backgroundColor = [color color];
+
+    // We must also update each tab in case they override main tab bar's appearance.
+    id tabs = [[self proxy] valueForKey:@"tabs"];
+    if ([tabs isKindOfClass:[NSArray class]]) {
+      for (TiUITabProxy *tabProxy in (NSArray *)tabs) {
+        [tabProxy updateTabBarItem];
+      }
+    }
   }
 #endif
 }

--- a/iphone/Classes/TiUITabProxy.h
+++ b/iphone/Classes/TiUITabProxy.h
@@ -51,6 +51,7 @@
 - (void)handleDidFocus:(NSDictionary *)event;
 - (void)handleWillShowViewController:(UIViewController *)viewController animated:(BOOL)animated;
 - (void)handleDidShowViewController:(UIViewController *)viewController animated:(BOOL)animated;
+- (void)updateTabBarItem;
 
 @end
 

--- a/iphone/Classes/TiUITabProxy.m
+++ b/iphone/Classes/TiUITabProxy.m
@@ -658,6 +658,10 @@
         UITabBarItemStateAppearance *selectedAppearance = appearance.stackedLayoutAppearance.selected;
         selectedAppearance.titleTextAttributes = @{ NSForegroundColorAttributeName : [activeTitleColor color] };
       }
+      TiColor *backgroundColor = [TiUtils colorValue:[tabGroup valueForKey:@"tabsBackgroundColor"]];
+      if (backgroundColor != nil) {
+        appearance.backgroundColor = [backgroundColor color];
+      }
       ourItem.standardAppearance = appearance;
       ourItem.scrollEdgeAppearance = appearance;
     } else {


### PR DESCRIPTION
**JIRA:**
https://jira.appcelerator.org/browse/TIMOB-28551

**Summary:**
- Fixes regression caused by PR #13110 where "tabsBackgroundColor" property is ignored on iOS 15 if you also set property "activeTitleColor" or "titleColor".
- This issue was caught before release.

**Test:**
1. Create a Classic Titanium project from template. _(Will provide tab icons needed.)_
2. Use the below code as the "app.js".
3. Build and run on iOS 15.
4. Verify selected tab shows a red icon and red title.
5. Verify unselected tabs show purple icons and purple titles.
6. Verify tabs background color is green. _(This is the fix.)_
7. Remove the `tabsBackgroundColor` property assignment below and re-run on iOS 15.
8. Verify tab background colors are now light gray.
9. Verify selected tab titles are still red and unselected tab titles are still purple.

```javascript
function createTab(title, icon) {
	const window = Ti.UI.createWindow({ title: title });
	window.add(Ti.UI.createLabel({ text: title + " View" }));
	const tab = Ti.UI.createTab({
		title: title,
		icon: icon,
		window: window,
	});
	return tab;
}

const tabGroup = Ti.UI.createTabGroup({
	tabs: [
		createTab("Tab 1", "/assets/images/tab1.png"),
		createTab("Tab 2", "/assets/images/tab2.png"),
		createTab("Tab 3", "/assets/images/tab1.png")
	],
	activeTintColor: "red",
	activeTitleColor: "red",
	tintColor: "purple",
	titleColor: "purple",
	tabsBackgroundColor: "#DDFFDD",
});
tabGroup.open();
```
