### PR TITLE
fix: always use PHPickerViewController on iOS 14+, cleanup outdated version guards 

### DIFF
--- a/iphone/Classes/MediaModule.m
+++ b/iphone/Classes/MediaModule.m
@@ -1073,7 +1073,7 @@ MAKE_SYSTEM_PROP(VIDEO_REPEAT_MODE_ONE, VideoRepeatModeOne);
 
   NSArray *types = (NSArray *)[args objectForKey:@"mediaTypes"];
 #if IS_SDK_IOS_14
-  if ([TiUtils isIOSVersionOrGreater:@"14.0"] && [TiUtils boolValue:[args objectForKey:@"allowMultiple"] def:NO]) {
+  if ([TiUtils isIOSVersionOrGreater:@"14.0"]) {
     [self showPHPicker:args];
   } else {
 #endif


### PR DESCRIPTION
Currently, the `PHPickerViewController` is only used if the target is iOS 14 *and* `allowMultiple` is set to `true`. To benefit from the improved user experience of the picker, it should always be used if the target is iOS 14+, even if `allowMultiple` is set to `false`.

The relevant commit for this change is https://github.com/appcelerator/titanium_mobile/pull/13178/commits/85c9801e7635693fa85752f1392c4a6c41a0a8ef. I also migrated some outdated version guards for iOS 9.x that are not necessary anymore and will make the code more readable.

**JIRA:** https://jira.appcelerator.org/browse/TIMOB-28579