### PR TITLE
[Backport 10_1_X] fix(ios): window.setToolbar() background color alway transparent on iOS 15

### DIFF
--- a/iphone/TitaniumKit/TitaniumKit/Sources/Modules/TiUIWindowProxy.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/Modules/TiUIWindowProxy.m
@@ -968,7 +968,14 @@
           UIColor *tintColor = [[TiUtils colorValue:@"tintColor" properties:properties] color];
           [ourNC.toolbar setBarTintColor:barColor];
           [ourNC.toolbar setTintColor:tintColor];
-
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 150000
+          if ([TiUtils isIOSVersionOrGreater:@"15.0"]) {
+            UIToolbarAppearance *appearance = ourNC.toolbar.standardAppearance;
+            [appearance configureWithDefaultBackground];
+            appearance.backgroundColor = barColor;
+            ourNC.toolbar.scrollEdgeAppearance = appearance;
+          }
+#endif
           [array release];
         }
       },


### PR DESCRIPTION
Backport of #13165.
See that PR for full details.