### PR TITLE
Update Ti.UI.WebView to restore previous default setting

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
@@ -298,6 +298,7 @@ public class TiUIWebView extends TiUIView
 		settings.setJavaScriptCanOpenWindowsAutomatically(true);
 		settings.setLoadsImagesAutomatically(true);
 		settings.setDomStorageEnabled(true); // Required by some sites such as Twitter. This is in our iOS WebView too.
+		settings.setAllowFileAccess(true);
 		File path = TiApplication.getInstance().getFilesDir();
 		if (path != null) {
 			settings.setDatabasePath(path.getAbsolutePath());


### PR DESCRIPTION
In Android targetSDKVersion=30+ the setAllowFileAcess property now defaults to false.

This is a breaking change for the Appcelerator SDK as it now prevents access to local file assets through the file:// path.

This overrides the new default and restores the expected behaviour within the Appcelerator SDK.

Fixes #13188 

**JIRA:** https://jira.appcelerator.org/browse/[TICKET]

Provide a clear PR title prefixed with `[TICKET]`

**Optional Description:**
