### PR TITLE
fix(android): tabgroup/scrollview null pointer

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIScrollView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIScrollView.java
@@ -70,14 +70,14 @@ public class TiUIScrollView extends TiUIView
 				@Override
 				public void onLongPress(MotionEvent e)
 				{
-					if (proxy.hierarchyHasListener(TiC.EVENT_LONGPRESS)) {
+					if (proxy != null && proxy.hierarchyHasListener(TiC.EVENT_LONGPRESS)) {
 						fireEvent(TiC.EVENT_LONGPRESS, dictFromEvent(e));
 					}
 				}
 				@Override
 				public boolean onSingleTapConfirmed(MotionEvent e)
 				{
-					if (proxy.hierarchyHasListener(TiC.EVENT_SINGLE_TAP)) {
+					if (proxy != null && proxy.hierarchyHasListener(TiC.EVENT_SINGLE_TAP)) {
 						fireEvent(TiC.EVENT_SINGLE_TAP, dictFromEvent(e));
 					}
 					return true;
@@ -85,7 +85,7 @@ public class TiUIScrollView extends TiUIView
 				@Override
 				public boolean onDoubleTap(MotionEvent e)
 				{
-					if (proxy.hierarchyHasListener(TiC.EVENT_DOUBLE_TAP)) {
+					if (proxy != null && proxy.hierarchyHasListener(TiC.EVENT_DOUBLE_TAP)) {
 						fireEvent(TiC.EVENT_DOUBLE_TAP, dictFromEvent(e));
 					}
 					return true;

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIAbstractTabGroup.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIAbstractTabGroup.java
@@ -438,18 +438,20 @@ public abstract class TiUIAbstractTabGroup extends TiUIView
 		});
 
 		// Set action bar color.
-		final ActionBar actionBar = ((AppCompatActivity) proxy.getActivity()).getSupportActionBar();
-		if (actionBar != null) {
-			final TiWindowProxy windowProxy = ((TabProxy) this.tabs.get(tabIndex).getProxy()).getWindow();
-			final KrollDict windowProperties = windowProxy.getProperties();
-			final KrollDict properties = getProxy().getProperties();
+		if (proxy != null) {
+			final ActionBar actionBar = ((AppCompatActivity) proxy.getActivity()).getSupportActionBar();
+			if (actionBar != null) {
+				final TiWindowProxy windowProxy = ((TabProxy) this.tabs.get(tabIndex).getProxy()).getWindow();
+				final KrollDict windowProperties = windowProxy.getProperties();
+				final KrollDict properties = getProxy().getProperties();
 
-			if (properties.containsKeyAndNotNull(TiC.PROPERTY_BAR_COLOR)
-				|| windowProperties.containsKeyAndNotNull(TiC.PROPERTY_BAR_COLOR)) {
-				final String colorString = properties.optString(TiC.PROPERTY_BAR_COLOR,
-					windowProperties.getString(TiC.PROPERTY_BAR_COLOR));
-				final int color = TiColorHelper.parseColor(colorString);
-				actionBar.setBackgroundDrawable(new ColorDrawable(color));
+				if (properties.containsKeyAndNotNull(TiC.PROPERTY_BAR_COLOR)
+					|| windowProperties.containsKeyAndNotNull(TiC.PROPERTY_BAR_COLOR)) {
+					final String colorString = properties.optString(TiC.PROPERTY_BAR_COLOR,
+						windowProperties.getString(TiC.PROPERTY_BAR_COLOR));
+					final int color = TiColorHelper.parseColor(colorString);
+					actionBar.setBackgroundDrawable(new ColorDrawable(color));
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Resolves https://github.com/appcelerator/titanium_mobile/issues/13196
Resolves https://github.com/appcelerator/titanium_mobile/issues/13195

Adding proxy null checks in TabGroup and ScrollView
