### PR TITLE
fix(android): update log4j version

### DIFF
--- a/android/kroll-apt/build.gradle
+++ b/android/kroll-apt/build.gradle
@@ -74,5 +74,5 @@ jar {
 dependencies {
 	implementation 'com.googlecode.json-simple:json-simple:1.1'
 	implementation 'org.freemarker:freemarker:2.3.30'
-	implementation 'log4j:log4j:1.2.17'
+	implementation 'org.apache.logging.log4j:log4j-core:2.16.0'
 }

--- a/android/kroll-apt/src/main/java/org/appcelerator/kroll/annotations/generator/KrollBindingGenerator.java
+++ b/android/kroll-apt/src/main/java/org/appcelerator/kroll/annotations/generator/KrollBindingGenerator.java
@@ -20,9 +20,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.log4j.BasicConfigurator;
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.core.config.Configurator;
+import org.apache.logging.log4j.core.config.DefaultConfiguration;
+import org.apache.logging.log4j.Level;
+
 import org.json.simple.JSONArray;
 import org.json.simple.JSONValue;
 import org.json.simple.parser.ParseException;
@@ -62,8 +63,8 @@ public class KrollBindingGenerator
 
 	protected void initTemplates()
 	{
-		BasicConfigurator.configure();
-		Logger.getRootLogger().setLevel(Level.ERROR);
+		Configurator.initialize(new DefaultConfiguration());
+		Configurator.setRootLevel(Level.ERROR);
 
 		fmConfig = new Configuration();
 		fmConfig.setObjectWrapper(new DefaultObjectWrapper());


### PR DESCRIPTION
As discussed in https://github.com/appcelerator/titanium_mobile/discussions/13206 

* Updated the log4j library to the latest 2.16.0
* Build SDK -> works fine
* setting the default SDK to 10.2.0
* rebuilding the SDK -> works fine
* build a module -> works fine

