### PR TITLE
fix(android): drop-down picker to never accept keyboard input

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/PickerProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/PickerProxy.java
@@ -34,8 +34,13 @@ import ti.modules.titanium.ui.widget.picker.TiUITimePicker;
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.graphics.Color;
+import android.text.Editable;
+import android.text.InputType;
+import android.text.method.BaseKeyListener;
 import android.util.Log;
 import android.view.Gravity;
+import android.view.KeyEvent;
+import android.view.View;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
@@ -182,7 +187,24 @@ public class PickerProxy extends TiViewProxy implements PickerColumnProxy.OnChan
 		editText.setSingleLine();
 		editText.setMaxLines(1);
 		editText.setGravity(Gravity.CENTER_VERTICAL | Gravity.START);
-		editText.setInputType(0);
+		editText.setKeyListener(new BaseKeyListener() {
+			@Override
+			public int getInputType()
+			{
+				return InputType.TYPE_NULL;
+			}
+			@Override
+			public boolean backspace(View view, Editable content, int keyCode, KeyEvent event)
+			{
+				return false;
+			}
+			@Override
+			public boolean forwardDelete(View view, Editable content, int keyCode, KeyEvent event)
+			{
+				return false;
+			}
+		});
+		editText.setRawInputType(InputType.TYPE_NULL);
 		if (textInputLayout.isHintEnabled() == false) {
 			// Remove extra padding from top since hint text is disabled.
 			editText.setPadding(


### PR DESCRIPTION
**JIRA:**
https://jira.appcelerator.org/browse/TIMOB-28581

**Summary:**
- Regression as of Titanium 10.0.1.
- `Ti.UI.Picker` set up as a drop-down picker will wrongly accept keyboard input when it should be read-only.
- Can happen in the Android emulator when tapping on the picker and typing on the physical keyboard.
- Can happen when there is a TextField before the picker and you tap on the "Next" button on the virtual keyboard.

**Test:**
1. Build and run the below on Android.
2. Tap on the text field.
3. Tap on the Next/Enter button in the virtual keyboard.
4. Drop-down picker now has the focus.
5. Type in the virtual keyboard and verify that the picker does **NOT** change.

```javascript
const window = Ti.UI.createWindow({ layout: "vertical" });
window.add(Ti.UI.createTextField({
	top: "30dp",
	width: "80%",
}));
const picker = Ti.UI.createPicker({
	top: "20dp",
	width: "80%",
});
picker.add([
	Ti.UI.createPickerRow({ title: "Item 1" }),
	Ti.UI.createPickerRow({ title: "Item 2" }),
	Ti.UI.createPickerRow({ title: "Item 3" }),
	Ti.UI.createPickerRow({ title: "Item 4" }),
	Ti.UI.createPickerRow({ title: "Item 5" }),
]);
picker.addEventListener("change", (e) => {
	Ti.API.info("@@@ change: " + e.rowIndex);
});
window.add(picker);
window.open();
```
