### PR TITLE
chore(android): remove "log4j" library

### DIFF
--- a/android/kroll-apt/build.gradle
+++ b/android/kroll-apt/build.gradle
@@ -74,5 +74,4 @@ jar {
 dependencies {
 	implementation 'com.googlecode.json-simple:json-simple:1.1'
 	implementation 'org.freemarker:freemarker:2.3.30'
-	implementation 'log4j:log4j:1.2.17'
 }

--- a/android/kroll-apt/src/main/java/org/appcelerator/kroll/annotations/generator/KrollBindingGenerator.java
+++ b/android/kroll-apt/src/main/java/org/appcelerator/kroll/annotations/generator/KrollBindingGenerator.java
@@ -20,9 +20,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.log4j.BasicConfigurator;
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONValue;
 import org.json.simple.parser.ParseException;
@@ -62,9 +59,6 @@ public class KrollBindingGenerator
 
 	protected void initTemplates()
 	{
-		BasicConfigurator.configure();
-		Logger.getRootLogger().setLevel(Level.ERROR);
-
 		fmConfig = new Configuration();
 		fmConfig.setObjectWrapper(new DefaultObjectWrapper());
 		fmConfig.setClassForTemplateLoading(getClass(), "");


### PR DESCRIPTION
**JIRA:**
https://jira.appcelerator.org/browse/TIMOB-28582

**Summary:**
- Removed since "log4j" library has security issues.
- Was only used by our `@Kroll` Java annotation processor for:
  * Titanium SDK builds.
  * Native Android module builds.
- Note that "log4j" is not included in Titanium built Android apps or modules. So, app developers are okay... unless you use a 3rd party module which uses this library.
- This PR addresses discussion #13206 .

---
**Titanium SDK Build Test:**
Already covered by Jenkins.

---
**Module Build Test:**
1. Download [ti.imagefactory](https://github.com/appcelerator-modules/ti.imagefactory)
2. Build and run this module for Android.
