### PR TITLE
fix: pin to colors 1.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "boxen": "^5.1.2",
         "buffer-equal": "1.0.0",
         "clean-css": "5.2.1",
-        "colors": "^1.4.0",
+        "colors": "1.4.0",
         "ejs": "^3.1.6",
         "fields": "0.1.24",
         "fs-extra": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "boxen": "^5.1.2",
     "buffer-equal": "1.0.0",
     "clean-css": "5.2.1",
-    "colors": "^1.4.0",
+    "colors": "1.4.0",
     "ejs": "^3.1.6",
     "fields": "0.1.24",
     "fs-extra": "^10.0.0",


### PR DESCRIPTION
Pins to colors 1.4.0 to avoid the DoS issue.

Note: this does not impact any released version of Titanium 