### PR TITLE
Android: fix Ti.UI.overrideUserInterfaceStyle

### DIFF
--- a/android/modules/android/src/java/ti/modules/titanium/android/notificationmanager/NotificationProxy.java
+++ b/android/modules/android/src/java/ti/modules/titanium/android/notificationmanager/NotificationProxy.java
@@ -198,7 +198,7 @@ public class NotificationProxy extends KrollProxy
 	@Kroll.setProperty
 	public void setColor(String color)
 	{
-		notificationBuilder.setColor(TiColorHelper.parseColor(color));
+		notificationBuilder.setColor(TiColorHelper.parseColor(color, getActivity()));
 		setProperty(TiC.PROPERTY_COLOR, color);
 	}
 

--- a/android/modules/media/src/java/ti/modules/titanium/media/VideoPlayerProxy.java
+++ b/android/modules/media/src/java/ti/modules/titanium/media/VideoPlayerProxy.java
@@ -178,14 +178,16 @@ public class VideoPlayerProxy extends TiViewProxy implements TiLifecycle.OnLifec
 
 	private void launchVideoActivity(KrollDict options)
 	{
-		final Intent intent = new Intent(getActivity(), TiVideoActivity.class);
+		final Activity activity = getActivity();
+		final Intent intent = new Intent(activity, TiVideoActivity.class);
 
 		if (options.containsKey(TiC.PROPERTY_BACKGROUND_COLOR)) {
-			intent.putExtra(TiC.PROPERTY_BACKGROUND_COLOR, TiConvert.toColor(options, TiC.PROPERTY_BACKGROUND_COLOR));
+			int color = TiConvert.toColor(options, TiC.PROPERTY_BACKGROUND_COLOR, activity);
+			intent.putExtra(TiC.PROPERTY_BACKGROUND_COLOR, color);
 		}
 		videoActivityHandler = createControlHandler();
 		intent.putExtra(TiC.PROPERTY_MESSENGER, new Messenger(videoActivityHandler));
-		getActivity().startActivity(intent);
+		activity.startActivity(intent);
 	}
 
 	/**

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/AttributedStringProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/AttributedStringProxy.java
@@ -249,12 +249,12 @@ public class AttributedStringProxy extends KrollProxy
 										break;
 									case UIModule.ATTRIBUTE_BACKGROUND_COLOR:
 										spannableText.setSpan(
-											new BackgroundColorSpan(TiConvert.toColor(TiConvert.toString(attrValue))),
+											new BackgroundColorSpan(TiConvert.toColor(attrValue, activity)),
 											range[0], range[0] + range[1], Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
 										break;
 									case UIModule.ATTRIBUTE_FOREGROUND_COLOR:
 										spannableText.setSpan(
-											new ForegroundColorSpan(TiConvert.toColor(TiConvert.toString(attrValue))),
+											new ForegroundColorSpan(TiConvert.toColor(attrValue, activity)),
 											range[0], range[0] + range[1], Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
 										break;
 									case UIModule.ATTRIBUTE_STRIKETHROUGH_STYLE:
@@ -263,7 +263,7 @@ public class AttributedStringProxy extends KrollProxy
 										break;
 									case UIModule.ATTRIBUTE_UNDERLINE_COLOR:
 										final UnderlineColorSpan underlineColorSpan = new UnderlineColorSpan(
-											TiConvert.toColor(TiConvert.toString(attrValue)));
+											TiConvert.toColor(attrValue, activity));
 
 										spannableText.setSpan(underlineColorSpan, range[0], range[0] + range[1],
 											Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/RefreshControlProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/RefreshControlProxy.java
@@ -126,7 +126,7 @@ public class RefreshControlProxy extends KrollProxy
 		if (colorName == null) {
 			this.tintColor = RefreshControlProxy.DEFAULT_TINT_COLOR;
 		} else if (colorName instanceof String) {
-			this.tintColor = TiColorHelper.parseColor((String) colorName);
+			this.tintColor = TiColorHelper.parseColor((String) colorName, getActivity());
 		} else {
 			Log.e(TAG, "Property '" + TiC.PROPERTY_TINT_COLOR + "' must be of type string.");
 			return;

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/UIModule.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/UIModule.java
@@ -471,7 +471,7 @@ public class UIModule extends KrollModule
 	{
 		TiRootActivity root = TiApplication.getInstance().getRootActivity();
 		if (root != null) {
-			root.setBackgroundColor(color != null ? TiColorHelper.parseColor(color) : Color.TRANSPARENT);
+			root.setBackgroundColor(color != null ? TiColorHelper.parseColor(color, root) : Color.TRANSPARENT);
 		}
 	}
 

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/WindowProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/WindowProxy.java
@@ -305,7 +305,7 @@ public class WindowProxy extends TiWindowProxy implements TiActivityWindow
 
 		// Handle barColor property.
 		if (hasProperty(TiC.PROPERTY_BAR_COLOR)) {
-			int colorInt = TiColorHelper.parseColor(TiConvert.toString(getProperty(TiC.PROPERTY_BAR_COLOR)));
+			int colorInt = TiColorHelper.parseColor(TiConvert.toString(getProperty(TiC.PROPERTY_BAR_COLOR)), activity);
 			ActionBar actionBar = activity.getSupportActionBar();
 			// Guard for using a theme with actionBar disabled.
 			if (actionBar != null) {
@@ -354,7 +354,7 @@ public class WindowProxy extends TiWindowProxy implements TiActivityWindow
 		if (!modal && hasProperty(TiC.PROPERTY_OPACITY)) {
 			intent.setClass(activity, TiTranslucentActivity.class);
 		} else if (hasProperty(TiC.PROPERTY_BACKGROUND_COLOR)) {
-			int bgColor = TiConvert.toColor(properties, TiC.PROPERTY_BACKGROUND_COLOR);
+			int bgColor = TiConvert.toColor(properties, TiC.PROPERTY_BACKGROUND_COLOR, getActivity());
 			if (Color.alpha(bgColor) < 0xFF) {
 				intent.setClass(activity, TiTranslucentActivity.class);
 			}
@@ -396,12 +396,13 @@ public class WindowProxy extends TiWindowProxy implements TiActivityWindow
 			// Guard for activity being destroyed
 			if (windowActivity != null && windowActivity.get() != null) {
 				// Get a reference to the ActionBar.
-				ActionBar actionBar = ((AppCompatActivity) windowActivity.get()).getSupportActionBar();
+				AppCompatActivity activity = windowActivity.get();
+				ActionBar actionBar = activity.getSupportActionBar();
 				// Check if it is available ( app is using a theme with one or a Toolbar is used as one ).
 				if (actionBar != null) {
 					// Change to background to the new color.
 					actionBar.setBackgroundDrawable(
-						new ColorDrawable(TiColorHelper.parseColor(TiConvert.toString(value))));
+						new ColorDrawable(TiColorHelper.parseColor(TiConvert.toString(value), activity)));
 				} else {
 					// Log a warning if there is no ActionBar available.
 					Log.w(TAG, "There is no ActionBar available for this Window.");

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/android/AndroidModule.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/android/AndroidModule.java
@@ -21,6 +21,7 @@ import ti.modules.titanium.ui.widget.TiUIProgressIndicator;
 import ti.modules.titanium.ui.widget.webview.TiUIWebView;
 
 import android.app.Activity;
+import android.content.Context;
 import android.content.Intent;
 import android.graphics.PixelFormat;
 import android.view.Gravity;
@@ -277,7 +278,11 @@ public class AndroidModule extends KrollModule
 			// Color by resource id
 			if (idOrName instanceof Number) {
 				int colorResId = ((Number) idOrName).intValue();
-				@ColorInt int packedColorInt = ContextCompat.getColor(TiApplication.getInstance(), colorResId);
+				Context context = TiApplication.getAppRootOrCurrentActivity();
+				if (context == null) {
+					context = TiApplication.getInstance();
+				}
+				@ColorInt int packedColorInt = ContextCompat.getColor(context, colorResId);
 				return new ColorProxy(packedColorInt);
 			}
 			// Color by name

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiImageView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiImageView.java
@@ -6,6 +6,7 @@
  */
 package ti.modules.titanium.ui.widget;
 
+import android.app.Activity;
 import android.content.Context;
 import android.content.res.ColorStateList;
 import android.graphics.Bitmap;
@@ -400,8 +401,15 @@ public class TiImageView extends ViewGroup
 			imageView.clearColorFilter();
 			return;
 		}
+		Activity activity = null;
+		if (proxy != null) {
+			TiViewProxy p = proxy.get();
+			if (p != null) {
+				activity = p.getActivity();
+			}
+		}
 
-		this.tintColor = TiColorHelper.parseColor(color);
+		this.tintColor = TiColorHelper.parseColor(color, activity);
 		imageView.setColorFilter(this.tintColor, Mode.SRC_IN);
 	}
 

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiToolbar.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiToolbar.java
@@ -128,7 +128,7 @@ public class TiToolbar extends TiUIView
 	 */
 	public void setToolbarColor(String color)
 	{
-		toolbar.setBackgroundColor((TiColorHelper.parseColor(color)));
+		toolbar.setBackgroundColor((TiColorHelper.parseColor(color, proxy.getActivity())));
 		if (proxy.hasProperty(TiC.PROPERTY_TRANSLUCENT)) {
 			if ((Boolean) proxy.getProperty(TiC.PROPERTY_TRANSLUCENT)) {
 				toolbar.getBackground().setAlpha(BACKGROUND_TRANSLUCENT_VALUE);
@@ -324,7 +324,7 @@ public class TiToolbar extends TiUIView
 	 */
 	private void setTitleTextColor(String value)
 	{
-		toolbar.setTitleTextColor(TiColorHelper.parseColor(value));
+		toolbar.setTitleTextColor(TiColorHelper.parseColor(value, proxy.getActivity()));
 	}
 
 	/**
@@ -342,7 +342,7 @@ public class TiToolbar extends TiUIView
 	 */
 	private void setSubtitleTextColor(String value)
 	{
-		toolbar.setSubtitleTextColor(TiColorHelper.parseColor(value));
+		toolbar.setSubtitleTextColor(TiColorHelper.parseColor(value, proxy.getActivity()));
 	}
 
 	/**

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIActivityIndicator.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIActivityIndicator.java
@@ -39,6 +39,7 @@ public class TiUIActivityIndicator extends TiUIView
 	private boolean visible;
 	private MaterialTextView label;
 	private CircularProgressIndicator progress;
+	private final int defaultTextColor;
 
 	public TiUIActivityIndicator(TiViewProxy proxy)
 	{
@@ -62,6 +63,7 @@ public class TiUIActivityIndicator extends TiUIView
 		view.addView(this.label);
 
 		setNativeView(view);
+		this.defaultTextColor = this.label.getCurrentTextColor();
 	}
 
 	@Override
@@ -81,7 +83,7 @@ public class TiUIActivityIndicator extends TiUIView
 			label.setText(TiConvert.toString(d, TiC.PROPERTY_MESSAGE));
 		}
 		if (d.containsKey(TiC.PROPERTY_COLOR)) {
-			label.setTextColor(TiConvert.toColor(d, TiC.PROPERTY_COLOR));
+			label.setTextColor(TiConvert.toColor(d, TiC.PROPERTY_COLOR, proxy.getActivity()));
 		}
 		updateIndicator();
 
@@ -102,7 +104,11 @@ public class TiUIActivityIndicator extends TiUIView
 			label.setText(TiConvert.toString(newValue));
 			label.requestLayout();
 		} else if (key.equals(TiC.PROPERTY_COLOR)) {
-			label.setTextColor(TiConvert.toColor((String) newValue));
+			if (newValue == null) {
+				label.setTextColor(defaultTextColor);
+			} else {
+				label.setTextColor(TiConvert.toColor(newValue, proxy.getActivity()));
+			}
 		} else if (key.equals(TiC.PROPERTY_INDICATOR_COLOR)) {
 			updateIndicator();
 		} else {
@@ -164,7 +170,7 @@ public class TiUIActivityIndicator extends TiUIView
 
 		// Update indicator's color.
 		if (this.proxy.hasPropertyAndNotNull(TiC.PROPERTY_INDICATOR_COLOR)) {
-			int color = TiConvert.toColor(TiConvert.toString(this.proxy.getProperty(TiC.PROPERTY_INDICATOR_COLOR)));
+			int color = TiConvert.toColor(proxy.getProperty(TiC.PROPERTY_INDICATOR_COLOR), proxy.getActivity());
 			this.progress.getIndeterminateDrawable().setColorFilter(
 				new PorterDuffColorFilter(color, PorterDuff.Mode.SRC_IN));
 		} else if ((styleId == DARK) || (styleId == BIG_DARK)) {

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIButton.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIButton.java
@@ -6,7 +6,20 @@
  */
 package ti.modules.titanium.ui.widget;
 
-import java.util.HashMap;
+import android.app.Activity;
+import android.content.res.ColorStateList;
+import android.graphics.Color;
+import android.graphics.PorterDuff.Mode;
+import android.graphics.drawable.Drawable;
+import android.text.TextUtils;
+import android.view.Gravity;
+import android.view.MotionEvent;
+import android.view.View;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.widget.AppCompatButton;
+
+import com.google.android.material.button.MaterialButton;
 
 import org.appcelerator.kroll.KrollDict;
 import org.appcelerator.kroll.KrollProxy;
@@ -19,21 +32,10 @@ import org.appcelerator.titanium.util.TiConvert;
 import org.appcelerator.titanium.util.TiUIHelper;
 import org.appcelerator.titanium.view.TiUIView;
 
+import java.util.HashMap;
+
 import ti.modules.titanium.ui.AttributedStringProxy;
 import ti.modules.titanium.ui.UIModule;
-
-import android.content.res.ColorStateList;
-import android.graphics.Color;
-import android.graphics.PorterDuff.Mode;
-import android.graphics.drawable.Drawable;
-import android.text.TextUtils;
-import android.view.Gravity;
-import android.view.MotionEvent;
-import android.view.View;
-import androidx.annotation.NonNull;
-import androidx.appcompat.widget.AppCompatButton;
-
-import com.google.android.material.button.MaterialButton;
 
 public class TiUIButton extends TiUIView
 {
@@ -80,7 +82,7 @@ public class TiUIButton extends TiUIView
 
 		// Determine if a background drawable will be applied to the button.
 		boolean hasCustomBackground
-			=  hasImage(proxy.getProperties())
+			= hasImage(proxy.getProperties())
 			|| hasColorState(proxy.getProperties())
 			|| hasBorder(proxy.getProperties())
 			|| hasGradient(proxy.getProperties());
@@ -89,7 +91,8 @@ public class TiUIButton extends TiUIView
 		// Note: MaterialButton does not support replacing its background drawable. Will log a nasty warning.
 		AppCompatButton btn;
 		if (hasCustomBackground) {
-			btn = new AppCompatButton(proxy.getActivity()) {
+			btn = new AppCompatButton(proxy.getActivity())
+			{
 				@Override
 				public boolean onFilterTouchEventForSecurity(MotionEvent event)
 				{
@@ -101,7 +104,8 @@ public class TiUIButton extends TiUIView
 				}
 			};
 		} else {
-			btn = new MaterialButton(proxy.getActivity(), null, styleId) {
+			btn = new MaterialButton(proxy.getActivity(), null, styleId)
+			{
 				@Override
 				public boolean onFilterTouchEventForSecurity(MotionEvent event)
 				{
@@ -114,7 +118,8 @@ public class TiUIButton extends TiUIView
 			};
 			this.defaultRippleColor = ((MaterialButton) btn).getRippleColor();
 		}
-		btn.addOnLayoutChangeListener(new View.OnLayoutChangeListener() {
+		btn.addOnLayoutChangeListener(new View.OnLayoutChangeListener()
+		{
 			@Override
 			public void onLayoutChange(
 				View v, int left, int top, int right, int bottom,
@@ -137,6 +142,7 @@ public class TiUIButton extends TiUIView
 
 		boolean needShadow = false;
 
+		Activity activity = proxy.getActivity();
 		AppCompatButton btn = (AppCompatButton) getNativeView();
 		if (!d.containsKey(TiC.PROPERTY_IMAGE) && d.containsKey(TiC.PROPERTY_BACKGROUND_COLOR)) {
 			// Reset the padding here if the background color is set. By default the padding will be calculated
@@ -148,7 +154,8 @@ public class TiUIButton extends TiUIView
 			ColorStateList colorStateList = null;
 			if (TiConvert.toBoolean(d, TiC.PROPERTY_TOUCH_FEEDBACK, false)) {
 				if (d.containsKeyAndNotNull(TiC.PROPERTY_TOUCH_FEEDBACK_COLOR)) {
-					colorStateList = ColorStateList.valueOf(TiConvert.toColor(d, TiC.PROPERTY_TOUCH_FEEDBACK_COLOR));
+					colorStateList = ColorStateList.valueOf(
+						TiConvert.toColor(d, TiC.PROPERTY_TOUCH_FEEDBACK_COLOR, activity));
 				} else {
 					colorStateList = this.defaultRippleColor;
 				}
@@ -169,7 +176,7 @@ public class TiUIButton extends TiUIView
 			if (colorString == null) {
 				colorString = TiConvert.toString(d.get(TiC.PROPERTY_TINT_COLOR));
 			}
-			btn.setTextColor((colorString != null) ? TiConvert.toColor(colorString) : this.defaultColor);
+			btn.setTextColor((colorString != null) ? TiConvert.toColor(colorString, activity) : this.defaultColor);
 		}
 		if (d.containsKey(TiC.PROPERTY_FONT)) {
 			TiUIHelper.styleText(btn, d.getKrollDict(TiC.PROPERTY_FONT));
@@ -197,7 +204,7 @@ public class TiUIButton extends TiUIView
 		}
 		if (d.containsKey(TiC.PROPERTY_SHADOW_COLOR)) {
 			needShadow = true;
-			shadowColor = TiConvert.toColor(d, TiC.PROPERTY_SHADOW_COLOR);
+			shadowColor = TiConvert.toColor(d, TiC.PROPERTY_SHADOW_COLOR, activity);
 		}
 		if (needShadow) {
 			btn.setShadowLayer(shadowRadius, shadowX, shadowY, shadowColor);
@@ -212,6 +219,7 @@ public class TiUIButton extends TiUIView
 		if (Log.isDebugModeEnabled()) {
 			Log.d(TAG, "Property: " + key + " old: " + oldValue + " new: " + newValue, Log.DEBUG_MODE);
 		}
+		Activity activity = proxy.getActivity();
 
 		AppCompatButton btn = (AppCompatButton) getNativeView();
 		if (key.equals(TiC.PROPERTY_TITLE)) {
@@ -220,7 +228,7 @@ public class TiUIButton extends TiUIView
 			setAttributedStringText((AttributedStringProxy) newValue);
 		} else if (key.equals(TiC.PROPERTY_COLOR)) {
 			String colorString = TiConvert.toString(newValue);
-			btn.setTextColor((colorString != null) ? TiConvert.toColor(colorString) : this.defaultColor);
+			btn.setTextColor((colorString != null) ? TiConvert.toColor(colorString, activity) : this.defaultColor);
 		} else if (key.equals(TiC.PROPERTY_FONT)) {
 			TiUIHelper.styleText(btn, (HashMap) newValue);
 		} else if (key.equals(TiC.PROPERTY_TEXT_ALIGN)) {
@@ -234,7 +242,8 @@ public class TiUIButton extends TiUIView
 			|| key.equals(TiC.PROPERTY_TINT_COLOR)) {
 			if (!proxy.hasProperty(TiC.PROPERTY_COLOR) && key.equals(TiC.PROPERTY_TINT_COLOR)) {
 				String colorString = TiConvert.toString(newValue);
-				btn.setTextColor((colorString != null) ? TiConvert.toColor(colorString) : this.defaultColor);
+				int color = (colorString != null) ? TiConvert.toColor(colorString, activity) : this.defaultColor;
+				btn.setTextColor(color);
 			}
 			updateButtonImage();
 		} else if ((btn instanceof MaterialButton)
@@ -245,7 +254,7 @@ public class TiUIButton extends TiUIView
 				if (TiConvert.toBoolean(proxy.getProperty(TiC.PROPERTY_TOUCH_FEEDBACK), false)) {
 					if (proxy.hasPropertyAndNotNull(TiC.PROPERTY_TOUCH_FEEDBACK_COLOR)) {
 						String colorString = TiConvert.toString(proxy.getProperty(TiC.PROPERTY_TOUCH_FEEDBACK_COLOR));
-						colorStateList = ColorStateList.valueOf(TiConvert.toColor(colorString));
+						colorStateList = ColorStateList.valueOf(TiConvert.toColor(colorString, activity));
 					} else {
 						colorStateList = this.defaultRippleColor;
 					}
@@ -263,7 +272,7 @@ public class TiUIButton extends TiUIView
 			shadowRadius = TiConvert.toFloat(newValue, DEFAULT_SHADOW_RADIUS);
 			btn.setShadowLayer(shadowRadius, shadowX, shadowY, shadowColor);
 		} else if (key.equals(TiC.PROPERTY_SHADOW_COLOR)) {
-			shadowColor = TiConvert.toColor(TiConvert.toString(newValue));
+			shadowColor = TiConvert.toColor(TiConvert.toString(newValue), activity);
 			btn.setShadowLayer(shadowRadius, shadowX, shadowY, shadowColor);
 		} else {
 			super.propertyChanged(key, oldValue, newValue, proxy);
@@ -320,7 +329,10 @@ public class TiUIButton extends TiUIView
 		if (drawable != null) {
 			boolean imageIsMask = TiConvert.toBoolean(this.proxy.getProperty(TiC.PROPERTY_IMAGE_IS_MASK), true);
 			String colorString = TiConvert.toString(this.proxy.getProperty(TiC.PROPERTY_TINT_COLOR));
-			int colorValue = (colorString != null) ? TiConvert.toColor(colorString) : this.defaultColor;
+			int colorValue = this.defaultColor;
+			if (proxy.hasPropertyAndNotNull(TiC.PROPERTY_TINT_COLOR)) {
+				colorValue = TiConvert.toColor(proxy.getProperty(TiC.PROPERTY_TINT_COLOR), proxy.getActivity());
+			}
 			if (button instanceof MaterialButton) {
 				MaterialButton materialButton = (MaterialButton) button;
 				materialButton.setIcon(drawable);

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUICardView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUICardView.java
@@ -161,7 +161,7 @@ public class TiUICardView extends TiUIView
 		}
 
 		if (d.containsKey(TiC.PROPERTY_BORDER_COLOR)) {
-			cardview.setStrokeColor(TiConvert.toColor(d, TiC.PROPERTY_BORDER_COLOR));
+			cardview.setStrokeColor(TiConvert.toColor(d, TiC.PROPERTY_BORDER_COLOR, proxy.getActivity()));
 		}
 
 		if (d.containsKey(TiC.PROPERTY_BORDER_RADIUS)) {
@@ -198,8 +198,9 @@ public class TiUICardView extends TiUIView
 		if (!d.optBoolean(TiC.PROPERTY_TOUCH_FEEDBACK, true)) {
 			cardview.setRippleColor(ColorStateList.valueOf(Color.TRANSPARENT));
 		} else if (d.containsKey(TiC.PROPERTY_TOUCH_FEEDBACK_COLOR)) {
+			// TODO: reset to default value when property is null
 			String colorString = TiConvert.toString(d.get(TiC.PROPERTY_TOUCH_FEEDBACK_COLOR));
-			cardview.setRippleColor(ColorStateList.valueOf(TiConvert.toColor(colorString)));
+			cardview.setRippleColor(ColorStateList.valueOf(TiConvert.toColor(colorString, proxy.getActivity())));
 		} else if (this.defaultRippleColorSateList != null) {
 			cardview.setRippleColor(this.defaultRippleColorSateList);
 		}
@@ -291,10 +292,10 @@ public class TiUICardView extends TiUIView
 		TiCardView cardview = ((TiCardView) getNativeView());
 
 		if (key.equals(TiC.PROPERTY_BACKGROUND_COLOR)) {
-			cardview.setCardBackgroundColor(TiConvert.toColor(TiConvert.toString(newValue)));
+			cardview.setCardBackgroundColor(TiConvert.toColor(newValue, proxy.getActivity()));
 			cardview.requestLayout();
 		} else if (key.equals(TiC.PROPERTY_BORDER_COLOR)) {
-			cardview.setStrokeColor(TiConvert.toColor(TiConvert.toString(newValue)));
+			cardview.setStrokeColor(TiConvert.toColor(newValue, proxy.getActivity()));
 		} else if (key.equals(TiC.PROPERTY_BORDER_RADIUS)) {
 			float radius = 0;
 			TiDimension radiusDim = TiConvert.toTiDimension(newValue, TiDimension.TYPE_WIDTH);
@@ -390,7 +391,7 @@ public class TiUICardView extends TiUIView
 				cardview.setRippleColor(ColorStateList.valueOf(Color.TRANSPARENT));
 			} else if (this.proxy.hasProperty(TiC.PROPERTY_TOUCH_FEEDBACK_COLOR)) {
 				String colorString = TiConvert.toString(this.proxy.getProperty(TiC.PROPERTY_TOUCH_FEEDBACK_COLOR));
-				cardview.setRippleColor(ColorStateList.valueOf(TiConvert.toColor(colorString)));
+				cardview.setRippleColor(ColorStateList.valueOf(TiConvert.toColor(colorString, proxy.getActivity())));
 			} else if (this.defaultRippleColorSateList != null) {
 				cardview.setRippleColor(this.defaultRippleColorSateList);
 			}

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIImageView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIImageView.java
@@ -738,9 +738,12 @@ public class TiUIImageView extends TiUIView implements OnLifecycleEvent, Handler
 			setDefaultImageSource(d.get(TiC.PROPERTY_DEFAULT_IMAGE));
 		}
 		if (d.containsKey(TiC.PROPERTY_IMAGE_TOUCH_FEEDBACK_COLOR)) {
-			String colorString = TiConvert.toString(d.get(TiC.PROPERTY_IMAGE_TOUCH_FEEDBACK_COLOR));
-			view.setImageRippleColor(
-				(colorString != null) ? TiConvert.toColor(colorString) : view.getDefaultRippleColor());
+			Object colorObject = d.get(TiC.PROPERTY_IMAGE_TOUCH_FEEDBACK_COLOR);
+			if (colorObject == null) {
+				view.setImageRippleColor(view.getDefaultRippleColor());
+			} else {
+				view.setImageRippleColor(TiConvert.toColor(colorObject, proxy.getActivity()));
+			}
 		}
 		if (d.containsKey(TiC.PROPERTY_IMAGE_TOUCH_FEEDBACK)) {
 			view.setIsImageRippleEnabled(TiConvert.toBoolean(d.get(TiC.PROPERTY_IMAGE_TOUCH_FEEDBACK), false));
@@ -794,9 +797,11 @@ public class TiUIImageView extends TiUIView implements OnLifecycleEvent, Handler
 		} else if (key.equals(TiC.PROPERTY_IMAGE_TOUCH_FEEDBACK)) {
 			view.setIsImageRippleEnabled(TiConvert.toBoolean(newValue, false));
 		} else if (key.equals(TiC.PROPERTY_IMAGE_TOUCH_FEEDBACK_COLOR)) {
-			String colorString = TiConvert.toString(newValue);
-			view.setImageRippleColor(
-				(colorString != null) ? TiConvert.toColor(colorString) : view.getDefaultRippleColor());
+			if (newValue == null) {
+				view.setImageRippleColor(view.getDefaultRippleColor());
+			} else {
+				view.setImageRippleColor(TiConvert.toColor(newValue, proxy.getActivity()));
+			}
 		} else if (key.equals(TiC.PROPERTY_IMAGE)) {
 			if ((oldValue == null && newValue != null) || (oldValue != null && !oldValue.equals(newValue))) {
 				TiDrawableReference source = TiDrawableReference.fromObject(getProxy(), newValue);

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUILabel.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUILabel.java
@@ -397,11 +397,11 @@ public class TiUILabel extends TiUIView
 			if (color == null) {
 				tv.setTextColor(defaultColor);
 			} else {
-				tv.setTextColor(TiConvert.toColor(d, TiC.PROPERTY_COLOR));
+				tv.setTextColor(TiConvert.toColor(d, TiC.PROPERTY_COLOR, proxy.getActivity()));
 			}
 		}
 		if (d.containsKey(TiC.PROPERTY_HIGHLIGHTED_COLOR)) {
-			tv.setHighlightColor(TiConvert.toColor(d, TiC.PROPERTY_HIGHLIGHTED_COLOR));
+			tv.setHighlightColor(TiConvert.toColor(d, TiC.PROPERTY_HIGHLIGHTED_COLOR, proxy.getActivity()));
 		}
 		if (d.containsKey(TiC.PROPERTY_FONT)) {
 			TiUIHelper.styleText(tv, d.getKrollDict(TiC.PROPERTY_FONT));
@@ -454,7 +454,7 @@ public class TiUILabel extends TiUIView
 		}
 		if (d.containsKey(TiC.PROPERTY_SHADOW_COLOR)) {
 			needShadow = true;
-			shadowColor = TiConvert.toColor(d, TiC.PROPERTY_SHADOW_COLOR);
+			shadowColor = TiConvert.toColor(d, TiC.PROPERTY_SHADOW_COLOR, proxy.getActivity());
 		}
 		if (needShadow) {
 			tv.setShadowLayer(shadowRadius, shadowX, shadowY, shadowColor);
@@ -496,10 +496,11 @@ public class TiUILabel extends TiUIView
 			if (newValue == null) {
 				tv.setTextColor(defaultColor);
 			} else {
-				tv.setTextColor(TiConvert.toColor((String) newValue));
+				tv.setTextColor(TiConvert.toColor(newValue, proxy.getActivity()));
 			}
 		} else if (key.equals(TiC.PROPERTY_HIGHLIGHTED_COLOR)) {
-			tv.setHighlightColor(TiConvert.toColor((String) newValue));
+			// TODO: reset to default value when property is null
+			tv.setHighlightColor(TiConvert.toColor(newValue, proxy.getActivity()));
 		} else if (key.equals(TiC.PROPERTY_TEXT_ALIGN)) {
 			TiUIHelper.setAlignment(tv, TiConvert.toString(newValue), null);
 			tv.requestLayout();
@@ -548,7 +549,7 @@ public class TiUILabel extends TiUIView
 			shadowRadius = TiConvert.toFloat(newValue, DEFAULT_SHADOW_RADIUS);
 			tv.setShadowLayer(shadowRadius, shadowX, shadowY, shadowColor);
 		} else if (key.equals(TiC.PROPERTY_SHADOW_COLOR)) {
-			shadowColor = TiConvert.toColor(TiConvert.toString(newValue));
+			shadowColor = TiConvert.toColor(newValue, proxy.getActivity());
 			tv.setShadowLayer(shadowRadius, shadowX, shadowY, shadowColor);
 		} else if (key.equals(TiC.PROPERTY_LINES)) {
 			this.viewHeightInLines = TiConvert.toInt(newValue, 0);

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIListView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIListView.java
@@ -215,15 +215,17 @@ public class TiUIListView extends TiUIView
 				? TiConvert.toTiDimension(heightString, TiDimension.TYPE_HEIGHT)
 				.getAsPixels((View) getNativeView().getParent()) : 0;
 
+			boolean hasColor = name.equals(TiC.PROPERTY_SEPARATOR_COLOR) && value != null;
 			if (height == 0) {
 				this.listView.setSeparator(0, height);
-			} else if (name.equals(TiC.PROPERTY_SEPARATOR_COLOR)
-				|| properties.containsKey(TiC.PROPERTY_SEPARATOR_COLOR)) {
-				String colorString = properties.getString(TiC.PROPERTY_SEPARATOR_COLOR);
+			} else if (hasColor || properties.containsKeyAndNotNull(TiC.PROPERTY_SEPARATOR_COLOR)) {
+				String colorString;
 				if (name.equals(TiC.PROPERTY_SEPARATOR_COLOR)) {
 					colorString = TiConvert.toString(value);
+				} else {
+					colorString = properties.getString(TiC.PROPERTY_SEPARATOR_COLOR);
 				}
-				final int color = TiConvert.toColor(colorString);
+				final int color = TiConvert.toColor(colorString, proxy.getActivity());
 
 				// Set separator with specified color.
 				this.listView.setSeparator(color, height);

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIMaskedImage.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIMaskedImage.java
@@ -399,14 +399,14 @@ public class TiUIMaskedImage extends TiUIView
 	private void updateMaskTintWith(Object value)
 	{
 		if (this.maskedDrawable != null) {
-			if (value instanceof String) {
-				int color = TiConvert.toColor((String) value);
+			if (value == null) {
+				this.maskedDrawable.setTintingEnabled(false);
+			} else if (value instanceof String) {
+				int color = TiConvert.toColor(value, proxy.getActivity());
 				this.maskedDrawable.setTintColor(color);
 				this.maskedDrawable.setTintingEnabled(true);
-			} else if (value != null) {
-				Log.w(TAG, "MaskedImage 'tint' property must be set to a string.");
 			} else {
-				this.maskedDrawable.setTintingEnabled(false);
+				Log.w(TAG, "MaskedImage 'tint' property must be set to a string.");
 			}
 		}
 	}
@@ -418,13 +418,13 @@ public class TiUIMaskedImage extends TiUIView
 	private void updateTintColorFilterWith(Object value)
 	{
 		if (this.maskedDrawable != null) {
-			if (value instanceof String) {
-				int color = TiConvert.toColor((String) value);
+			if (value == null) {
+				this.maskedDrawable.clearColorFilter();
+			} else if (value instanceof String) {
+				int color = TiConvert.toColor(value, proxy.getActivity());
 				this.maskedDrawable.setColorFilter(color, PorterDuff.Mode.MULTIPLY);
 			} else if (value != null) {
 				Log.w(TAG, "MaskedImage 'tintColor' property must be set to a string.");
-			} else {
-				this.maskedDrawable.clearColorFilter();
 			}
 		}
 	}

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIProgressBar.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIProgressBar.java
@@ -6,6 +6,7 @@
  */
 package ti.modules.titanium.ui.widget;
 
+import android.app.Activity;
 import android.view.Gravity;
 import android.widget.LinearLayout;
 import com.google.android.material.progressindicator.LinearProgressIndicator;
@@ -57,18 +58,19 @@ public class TiUIProgressBar extends TiUIView
 	{
 		super.processProperties(d);
 
+		Activity activity = proxy.getActivity();
 		if (d.containsKey(TiC.PROPERTY_MESSAGE)) {
 			handleSetMessage(TiConvert.toString(d, TiC.PROPERTY_MESSAGE));
 		}
 		if (d.containsKey(TiC.PROPERTY_COLOR)) {
-			final int color = TiConvert.toColor(d, TiC.PROPERTY_COLOR);
+			final int color = TiConvert.toColor(d, TiC.PROPERTY_COLOR, activity);
 			handleSetMessageColor(color);
 		}
 		if (d.containsKey(TiC.PROPERTY_TINT_COLOR)) {
-			this.progress.setIndicatorColor(TiConvert.toColor(d, TiC.PROPERTY_TINT_COLOR));
+			this.progress.setIndicatorColor(TiConvert.toColor(d, TiC.PROPERTY_TINT_COLOR, activity));
 		}
 		if (d.containsKey(TiC.PROPERTY_TRACK_TINT_COLOR)) {
-			this.progress.setTrackColor(TiConvert.toColor(d, TiC.PROPERTY_TRACK_TINT_COLOR));
+			this.progress.setTrackColor(TiConvert.toColor(d, TiC.PROPERTY_TRACK_TINT_COLOR, activity));
 		}
 		updateProgress();
 	}
@@ -86,12 +88,16 @@ public class TiUIProgressBar extends TiUIView
 				handleSetMessage(message);
 			}
 		} else if (key.equals(TiC.PROPERTY_COLOR)) {
-			final int color = TiConvert.toColor(TiConvert.toString(newValue));
-			handleSetMessageColor(color);
+			// TODO: reset to default value when property is null
+			if (newValue != null) {
+				handleSetMessageColor(TiConvert.toColor(newValue, proxy.getActivity()));
+			}
 		} else if (key.equals(TiC.PROPERTY_TINT_COLOR)) {
-			this.progress.setIndicatorColor(TiConvert.toColor(TiConvert.toString(newValue)));
+			// TODO: reset to default value when property is null
+			this.progress.setIndicatorColor(TiConvert.toColor(newValue, proxy.getActivity()));
 		} else if (key.equals(TiC.PROPERTY_TRACK_TINT_COLOR)) {
-			this.progress.setTrackColor(TiConvert.toColor(TiConvert.toString(newValue)));
+			// TODO: reset to default value when property is null
+			this.progress.setTrackColor(TiConvert.toColor(newValue, proxy.getActivity()));
 		}
 	}
 

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUISlider.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUISlider.java
@@ -18,6 +18,7 @@ import org.appcelerator.titanium.util.TiFileHelper;
 import org.appcelerator.titanium.util.TiUIHelper;
 import org.appcelerator.titanium.view.TiUIView;
 
+import android.app.Activity;
 import android.content.res.ColorStateList;
 import android.graphics.Rect;
 import android.graphics.drawable.ClipDrawable;
@@ -70,6 +71,7 @@ public class TiUISlider extends TiUIView implements SeekBar.OnSeekBarChangeListe
 		super.processProperties(d);
 
 		SeekBar seekBar = (SeekBar) getNativeView();
+		Activity activity = proxy.getActivity();
 
 		if (d.containsKey(TiC.PROPERTY_VALUE)) {
 			pos = TiConvert.toFloat(d, TiC.PROPERTY_VALUE, 0);
@@ -100,10 +102,10 @@ public class TiUISlider extends TiUIView implements SeekBar.OnSeekBarChangeListe
 			updateTrackingImages(seekBar, d);
 		}
 		if (d.containsKeyAndNotNull(TiC.PROPERTY_TINT_COLOR)) {
-			handleSetTintColor(TiConvert.toColor(d, TiC.PROPERTY_TINT_COLOR));
+			handleSetTintColor(TiConvert.toColor(d, TiC.PROPERTY_TINT_COLOR, activity));
 		}
 		if (d.containsKeyAndNotNull(TiC.PROPERTY_TRACK_TINT_COLOR)) {
-			handleSetTrackTintColor(TiConvert.toColor(d, TiC.PROPERTY_TRACK_TINT_COLOR));
+			handleSetTrackTintColor(TiConvert.toColor(d, TiC.PROPERTY_TRACK_TINT_COLOR, activity));
 		}
 		updateRange();
 		updateControl();
@@ -280,14 +282,14 @@ public class TiUISlider extends TiUIView implements SeekBar.OnSeekBarChangeListe
 			int curPos = (int) Math.floor(scaleFactor * (pos + offset));
 			onProgressChanged(seekBar, curPos, false);
 		} else if (key.equals(TiC.PROPERTY_TINT_COLOR)) {
-			String stringValue = TiConvert.toString(newValue);
-			if (stringValue != null) {
-				handleSetTintColor(TiConvert.toColor(stringValue));
+			// TODO: reset to default value when property is null
+			if (newValue != null) {
+				handleSetTintColor(TiConvert.toColor(newValue, proxy.getActivity()));
 			}
 		} else if (key.equals(TiC.PROPERTY_TRACK_TINT_COLOR)) {
-			String stringValue = TiConvert.toString(newValue);
-			if (stringValue != null) {
-				handleSetTrackTintColor(TiConvert.toColor(stringValue));
+			// TODO: reset to default value when property is null
+			if (newValue != null) {
+				handleSetTrackTintColor(TiConvert.toColor(newValue, proxy.getActivity()));
 			}
 		} else if (key.equals("thumbImage")) {
 			//updateThumb(seekBar, proxy.getDynamicProperties());

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUISwitch.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUISwitch.java
@@ -93,7 +93,7 @@ public class TiUISwitch extends TiUIView implements OnCheckedChangeListener
 			cb.setChecked(TiConvert.toBoolean(d, TiC.PROPERTY_VALUE));
 		}
 		if (d.containsKey(TiC.PROPERTY_COLOR)) {
-			cb.setTextColor(TiConvert.toColor(d, TiC.PROPERTY_COLOR));
+			cb.setTextColor(TiConvert.toColor(d, TiC.PROPERTY_COLOR, proxy.getActivity()));
 		}
 		if (d.containsKey(TiC.PROPERTY_FONT)) {
 			TiUIHelper.styleText(cb, d.getKrollDict(TiC.PROPERTY_FONT));
@@ -138,7 +138,8 @@ public class TiUISwitch extends TiUIView implements OnCheckedChangeListener
 		} else if (key.equals(TiC.PROPERTY_VALUE)) {
 			cb.setChecked(TiConvert.toBoolean(newValue));
 		} else if (key.equals(TiC.PROPERTY_COLOR)) {
-			cb.setTextColor(TiConvert.toColor(TiConvert.toString(newValue)));
+			// TODO: reset to default value when property is null
+			cb.setTextColor(TiConvert.toColor(newValue, proxy.getActivity()));
 		} else if (key.equals(TiC.PROPERTY_FONT)) {
 			TiUIHelper.styleText(cb, (KrollDict) newValue);
 		} else if (key.equals(TiC.PROPERTY_TEXT_ALIGN)) {

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUITabbedBar.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUITabbedBar.java
@@ -6,6 +6,7 @@
  */
 package ti.modules.titanium.ui.widget;
 
+import android.app.Activity;
 import android.content.Context;
 import android.graphics.Color;
 import android.graphics.drawable.Drawable;
@@ -79,7 +80,8 @@ public class TiUITabbedBar extends TiUIView implements MenuItem.OnMenuItemClickL
 
 	private void createTabLayout()
 	{
-		this.tabLayout = new TabLayout(getProxy().getActivity()) {
+		Activity activity = getProxy().getActivity();
+		this.tabLayout = new TabLayout(activity) {
 			@Override
 			protected void onLayout(boolean changed, int l, int t, int r, int b)
 			{
@@ -92,7 +94,8 @@ public class TiUITabbedBar extends TiUIView implements MenuItem.OnMenuItemClickL
 		// For now use the proxy's selectedBackgroundColor for selected indicator
 		if (getProxy().hasPropertyAndNotNull(TiC.PROPERTY_SELECTED_BACKGROUND_COLOR)) {
 			this.tabLayout.setSelectedTabIndicatorColor(
-				TiColorHelper.parseColor(getProxy().getProperty(TiC.PROPERTY_SELECTED_BACKGROUND_COLOR).toString()));
+				TiColorHelper.parseColor(
+					getProxy().getProperty(TiC.PROPERTY_SELECTED_BACKGROUND_COLOR).toString(), activity));
 		}
 
 		// Set up the touch ripple effect to show primary color for both selected and unselected tabs.

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUITableView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUITableView.java
@@ -223,13 +223,15 @@ public class TiUITableView extends TiUIView
 				? TiConvert.toTiDimension(heightString, TiDimension.TYPE_HEIGHT)
 					.getAsPixels((View) getNativeView().getParent()) : 0;
 
-			if (name.equals(TiC.PROPERTY_SEPARATOR_COLOR)
-				|| properties.containsKey(TiC.PROPERTY_SEPARATOR_COLOR)) {
-				String colorString = properties.getString(TiC.PROPERTY_SEPARATOR_COLOR);
+			boolean hasColor = name.equals(TiC.PROPERTY_SEPARATOR_COLOR) && value != null;
+			if (hasColor || properties.containsKey(TiC.PROPERTY_SEPARATOR_COLOR)) {
+				String colorString;
 				if (name.equals(TiC.PROPERTY_SEPARATOR_COLOR)) {
 					colorString = TiConvert.toString(value);
+				} else {
+					colorString = properties.getString(TiC.PROPERTY_SEPARATOR_COLOR);
 				}
-				final int color = TiConvert.toColor(colorString);
+				final int color = TiConvert.toColor(colorString, proxy.getActivity());
 
 				// Set separator with specified color.
 				this.tableView.setSeparator(color, height);

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIText.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIText.java
@@ -171,11 +171,12 @@ public class TiUIText extends TiUIView implements TextWatcher, OnEditorActionLis
 		tv.setText(TiConvert.toString(d.get(TiC.PROPERTY_VALUE), ""));
 
 		if (d.containsKey(TiC.PROPERTY_BACKGROUND_COLOR)) {
+			// Why transparent?
 			tv.setBackgroundColor(Color.TRANSPARENT);
 		}
 
 		if (d.containsKey(TiC.PROPERTY_COLOR)) {
-			tv.setTextColor(TiConvert.toColor(d, TiC.PROPERTY_COLOR));
+			tv.setTextColor(TiConvert.toColor(d, TiC.PROPERTY_COLOR, proxy.getActivity()));
 		}
 
 		if (d.containsKey(TiC.PROPERTY_HINT_TEXT) || d.containsKey(TiC.PROPERTY_HINT_TYPE)) {
@@ -187,7 +188,7 @@ public class TiUIText extends TiUIView implements TextWatcher, OnEditorActionLis
 		}
 
 		if (d.containsKey(TiC.PROPERTY_HINT_TEXT_COLOR)) {
-			tv.setHintTextColor(TiConvert.toColor(d, TiC.PROPERTY_HINT_TEXT_COLOR));
+			tv.setHintTextColor(TiConvert.toColor(d, TiC.PROPERTY_HINT_TEXT_COLOR, proxy.getActivity()));
 		}
 
 		if (d.containsKey(TiC.PROPERTY_ELLIPSIZE)) {
@@ -355,7 +356,8 @@ public class TiUIText extends TiUIView implements TextWatcher, OnEditorActionLis
 			tv.setBackgroundColor(Color.TRANSPARENT);
 			super.propertyChanged(key, oldValue, newValue, proxy);
 		} else if (key.equals(TiC.PROPERTY_COLOR)) {
-			tv.setTextColor(TiConvert.toColor((String) newValue));
+			// TODO: reset to default value when property is null
+			tv.setTextColor(TiConvert.toColor(newValue, proxy.getActivity()));
 		} else if (key.equals(TiC.PROPERTY_HINT_TEXT)) {
 			int type = UIModule.HINT_TYPE_STATIC;
 			if (proxy.getProperties() != null) {
@@ -363,7 +365,8 @@ public class TiUIText extends TiUIView implements TextWatcher, OnEditorActionLis
 			}
 			setHintText(type, TiConvert.toString(newValue));
 		} else if (key.equals(TiC.PROPERTY_HINT_TEXT_COLOR)) {
-			tv.setHintTextColor(TiConvert.toColor((String) newValue));
+			// TODO: reset to default value when property is null
+			tv.setHintTextColor(TiConvert.toColor(newValue, proxy.getActivity()));
 		} else if (key.equals(TiC.PROPERTY_HINT_TYPE)) {
 			Object attributedHintText = proxy.getProperty(TiC.PROPERTY_ATTRIBUTED_HINT_TEXT);
 			if (attributedHintText instanceof AttributedStringProxy) {

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/TiRecyclerViewHolder.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/TiRecyclerViewHolder.java
@@ -169,7 +169,7 @@ public abstract class TiRecyclerViewHolder<V extends TiViewProxy> extends Recycl
 			final TypedArray colorControlHighlight = activity.obtainStyledAttributes(
 				typedValue.data, new int[] { android.R.attr.colorControlHighlight });
 			final int colorControlHighlightInt = color != null && !color.isEmpty()
-				? TiConvert.toColor(color) : colorControlHighlight.getColor(0, 0);
+				? TiConvert.toColor(color, getProxy().getActivity()) : colorControlHighlight.getColor(0, 0);
 			final int[] rippleColors = new int[] { colorControlHighlightInt };
 			final ColorStateList colorStateList = new ColorStateList(rippleStates, rippleColors);
 			final ShapeDrawable maskDrawable = drawable == null ? new ShapeDrawable() : null;
@@ -194,11 +194,13 @@ public abstract class TiRecyclerViewHolder<V extends TiViewProxy> extends Recycl
 		if (properties.containsKeyAndNotNull(TiC.PROPERTY_BACKGROUND_SELECTED_COLOR)
 			|| properties.containsKeyAndNotNull(TiC.PROPERTY_BACKGROUND_SELECTED_IMAGE)) {
 
+			V proxy = getProxy();
+			Activity activity = proxy != null ? proxy.getActivity() : null;
 			final Drawable selectedBackgroundDrawable = TiUIHelper.buildBackgroundDrawable(
 				properties.getString(TiC.PROPERTY_BACKGROUND_SELECTED_COLOR),
 				properties.getString(TiC.PROPERTY_BACKGROUND_SELECTED_IMAGE),
 				TiConvert.toBoolean(properties.get(TiC.PROPERTY_BACKGROUND_REPEAT), false),
-				null
+				null, activity
 			);
 
 			stateDrawable.addState(new int[] { android.R.attr.state_activated }, selectedBackgroundDrawable);

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/picker/TiUIPlainDropDownPicker.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/picker/TiUIPlainDropDownPicker.java
@@ -322,9 +322,12 @@ public class TiUIPlainDropDownPicker extends TiUIPlainPicker
 			// Update text color if configured.
 			PickerRowProxy rowProxy = this.getItem(position).getRowProxy();
 			if ((rowProxy != null) && rowProxy.hasProperty(TiC.PROPERTY_COLOR)) {
-				String colorString = TiConvert.toString(rowProxy.getProperty(TiC.PROPERTY_COLOR));
-				int color = (colorString != null) ? TiConvert.toColor(colorString) : this.defaultTextColor;
-				textView.setTextColor(color);
+				Object color = rowProxy.getProperty(TiC.PROPERTY_COLOR);
+				if (color == null) {
+					textView.setTextColor(this.defaultTextColor);
+				} else {
+					textView.setTextColor(TiConvert.toColor(rowProxy.getColor(), rowProxy.getActivity()));
+				}
 			}
 		}
 	}

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/searchbar/TiUISearchBar.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/searchbar/TiUISearchBar.java
@@ -6,6 +6,7 @@
  */
 package ti.modules.titanium.ui.widget.searchbar;
 
+import android.app.Activity;
 import android.content.Context;
 import android.graphics.drawable.Drawable;
 import android.text.InputType;
@@ -123,14 +124,16 @@ public class TiUISearchBar extends TiUIView
 			return;
 		}
 
+		final Activity activity = proxy.getActivity();
+
 		// Apply given properties to view.
 		if (properties.containsKey(TiC.PROPERTY_BAR_COLOR)) {
-			searchView.setBackgroundColor(TiConvert.toColor(properties, TiC.PROPERTY_BAR_COLOR));
+			searchView.setBackgroundColor(TiConvert.toColor(properties, TiC.PROPERTY_BAR_COLOR, activity));
 		}
 		if (properties.containsKey(TiC.PROPERTY_COLOR)) {
 			EditText editText = getEditText();
 			if (editText != null) {
-				editText.setTextColor(TiConvert.toColor(properties, TiC.PROPERTY_COLOR));
+				editText.setTextColor(TiConvert.toColor(properties, TiC.PROPERTY_COLOR, activity));
 			}
 		}
 		if (properties.containsKey(TiC.PROPERTY_VALUE)) {
@@ -145,7 +148,7 @@ public class TiUISearchBar extends TiUIView
 		if (properties.containsKey(TiC.PROPERTY_HINT_TEXT_COLOR)) {
 			EditText editText = getEditText();
 			if (editText != null) {
-				editText.setHintTextColor(TiConvert.toColor(properties, TiC.PROPERTY_HINT_TEXT_COLOR));
+				editText.setHintTextColor(TiConvert.toColor(properties, TiC.PROPERTY_HINT_TEXT_COLOR, activity));
 			}
 		}
 		if (properties.containsKey(TiC.PROPERTY_ICONIFIED)) {
@@ -179,11 +182,11 @@ public class TiUISearchBar extends TiUIView
 		if (key.equals(TiC.PROPERTY_SHOW_CANCEL)) {
 			updateCloseButton();
 		} else if (key.equals(TiC.PROPERTY_BAR_COLOR)) {
-			searchView.setBackgroundColor(TiConvert.toColor(TiConvert.toString(newValue)));
+			searchView.setBackgroundColor(TiConvert.toColor(newValue, proxy.getActivity()));
 		} else if (key.equals(TiC.PROPERTY_COLOR)) {
 			EditText editText = getEditText();
 			if (editText != null) {
-				editText.setTextColor(TiConvert.toColor(TiConvert.toString(newValue)));
+				editText.setTextColor(TiConvert.toColor(newValue, proxy.getActivity()));
 			}
 		} else if (key.equals(TiC.PROPERTY_VALUE)) {
 			boolean wasIgnored = this.isIgnoringChangeEvent;
@@ -195,7 +198,7 @@ public class TiUISearchBar extends TiUIView
 		} else if (key.equals(TiC.PROPERTY_HINT_TEXT_COLOR)) {
 			EditText editText = getEditText();
 			if (editText != null) {
-				editText.setHintTextColor(TiConvert.toColor(TiConvert.toString(newValue)));
+				editText.setHintTextColor(TiConvert.toColor(newValue, proxy.getActivity()));
 			}
 		} else if (key.equals(TiC.PROPERTY_ICONIFIED)) {
 			searchView.setIconified(TiConvert.toBoolean(newValue, false));

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/searchview/TiUISearchView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/searchview/TiUISearchView.java
@@ -20,6 +20,8 @@ import org.appcelerator.titanium.view.TiUIView;
 
 import ti.modules.titanium.ui.widget.searchbar.TiUISearchBar.OnSearchChangeListener;
 import androidx.appcompat.widget.SearchView;
+
+import android.app.Activity;
 import android.widget.EditText;
 
 public class TiUISearchView extends TiUIView implements SearchView.OnQueryTextListener, SearchView.OnCloseListener
@@ -49,6 +51,8 @@ public class TiUISearchView extends TiUIView implements SearchView.OnQueryTextLi
 	{
 		super.processProperties(props);
 
+		final Activity activity = proxy.getActivity();
+
 		// Check if the hint text is specified when the view is created.
 		if (props.containsKey(TiC.PROPERTY_HINT_TEXT)) {
 			searchView.setQueryHint(props.getString(TiC.PROPERTY_HINT_TEXT));
@@ -58,7 +62,7 @@ public class TiUISearchView extends TiUIView implements SearchView.OnQueryTextLi
 				int id = TiRHelper.getResource("id.search_src_text");
 				EditText text = (EditText) searchView.findViewById(id);
 				if (text != null) {
-					text.setHintTextColor(TiConvert.toColor(props, TiC.PROPERTY_HINT_TEXT_COLOR));
+					text.setHintTextColor(TiConvert.toColor(props, TiC.PROPERTY_HINT_TEXT_COLOR, activity));
 				}
 			} catch (ResourceNotFoundException e) {
 				Log.e(TAG, "Could not find SearchView EditText");
@@ -83,7 +87,7 @@ public class TiUISearchView extends TiUIView implements SearchView.OnQueryTextLi
 				int id = TiRHelper.getResource("id.search_src_text");
 				EditText text = (EditText) searchView.findViewById(id);
 				if (text != null) {
-					text.setTextColor(TiConvert.toColor(props, TiC.PROPERTY_COLOR));
+					text.setTextColor(TiConvert.toColor(props, TiC.PROPERTY_COLOR, activity));
 				}
 			} catch (ResourceNotFoundException e) {
 				Log.e(TAG, "Could not find SearchView EditText");
@@ -100,7 +104,8 @@ public class TiUISearchView extends TiUIView implements SearchView.OnQueryTextLi
 				int id = TiRHelper.getResource("id.search_src_text");
 				EditText text = (EditText) searchView.findViewById(id);
 				if (text != null) {
-					text.setTextColor(TiConvert.toColor((String) newValue));
+					// TODO: reset to default value when property is null
+					text.setTextColor(TiConvert.toColor(newValue, proxy.getActivity()));
 				}
 			} catch (ResourceNotFoundException e) {
 				Log.e(TAG, "Could not find SearchView EditText");
@@ -112,7 +117,8 @@ public class TiUISearchView extends TiUIView implements SearchView.OnQueryTextLi
 				int id = TiRHelper.getResource("id.search_src_text");
 				EditText text = (EditText) searchView.findViewById(id);
 				if (text != null) {
-					text.setHintTextColor(TiConvert.toColor((String) newValue));
+					// TODO: reset to default value when property is null
+					text.setHintTextColor(TiConvert.toColor(newValue, proxy.getActivity()));
 				}
 			} catch (ResourceNotFoundException e) {
 				Log.e(TAG, "Could not find SearchView EditText");

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIAbstractTabGroup.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIAbstractTabGroup.java
@@ -6,6 +6,7 @@
  */
 package ti.modules.titanium.ui.widget.tabgroup;
 
+import android.app.Activity;
 import android.content.res.ColorStateList;
 import android.content.res.TypedArray;
 import android.graphics.Color;
@@ -317,18 +318,19 @@ public abstract class TiUIAbstractTabGroup extends TiUIView
 
 		final KrollDict tabProperties = tabProxy.getProperties();
 		final KrollDict properties = getProxy().getProperties();
+		final Activity activity = getProxy().getActivity();
 
 		if (tabProperties.containsKeyAndNotNull(TiC.PROPERTY_TITLE_COLOR)
 			|| properties.containsKeyAndNotNull(TiC.PROPERTY_TITLE_COLOR)) {
 			final String colorString = tabProperties.optString(TiC.PROPERTY_TITLE_COLOR,
 				properties.getString(TiC.PROPERTY_TITLE_COLOR));
-			textColors[0] = TiColorHelper.parseColor(colorString);
+			textColors[0] = TiColorHelper.parseColor(colorString, activity);
 		}
 		if (tabProperties.containsKeyAndNotNull(TiC.PROPERTY_ACTIVE_TITLE_COLOR)
 			|| properties.containsKeyAndNotNull(TiC.PROPERTY_ACTIVE_TITLE_COLOR)) {
 			final String colorString = tabProperties.optString(TiC.PROPERTY_ACTIVE_TITLE_COLOR,
 				properties.getString(TiC.PROPERTY_ACTIVE_TITLE_COLOR));
-			textColors[1] = TiColorHelper.parseColor(colorString);
+			textColors[1] = TiColorHelper.parseColor(colorString, activity);
 		}
 		return new ColorStateList(textColorStates, textColors);
 	}
@@ -365,28 +367,32 @@ public abstract class TiUIAbstractTabGroup extends TiUIView
 	 */
 	protected Drawable createBackgroundDrawableForState(TiViewProxy tabProxy, int stateToUse)
 	{
+		if (proxy == null || tabProxy == null) {
+			return null;
+		}
+		final KrollDict tabProperties = tabProxy.getProperties();
+		final KrollDict properties = proxy.getProperties();
+		final Activity activity = proxy.getActivity();
 		StateListDrawable stateListDrawable = new StateListDrawable();
 		int colorInt;
 
 		// If the TabGroup has backgroundColor property, use it. If not - use the primaryColor of the theme.
-		colorInt = proxy.hasPropertyAndNotNull(TiC.PROPERTY_TABS_BACKGROUND_COLOR)
-					   ? TiColorHelper.parseColor(proxy.getProperty(TiC.PROPERTY_TABS_BACKGROUND_COLOR).toString())
+		colorInt = properties.containsKeyAndNotNull(TiC.PROPERTY_TABS_BACKGROUND_COLOR)
+					   ? TiColorHelper.parseColor(properties.getString(TiC.PROPERTY_TABS_BACKGROUND_COLOR), activity)
 					   : this.colorSurfaceInt;
 		// If the Tab has its own backgroundColor property, use it instead.
-		colorInt = tabProxy.hasPropertyAndNotNull(TiC.PROPERTY_BACKGROUND_COLOR)
-					   ? TiColorHelper.parseColor(tabProxy.getProperty(TiC.PROPERTY_BACKGROUND_COLOR).toString())
+		colorInt = tabProperties.containsKeyAndNotNull(TiC.PROPERTY_BACKGROUND_COLOR)
+					   ? TiColorHelper.parseColor(tabProperties.getString(TiC.PROPERTY_BACKGROUND_COLOR), activity)
 					   : colorInt;
 		stateListDrawable.addState(new int[] { -stateToUse }, new ColorDrawable(colorInt));
 
 		// Take the TabGroup tabsBackgroundSelectedProperty.
-		colorInt =
-			proxy.hasPropertyAndNotNull(TiC.PROPERTY_TABS_BACKGROUND_SELECTED_COLOR)
-				? TiColorHelper.parseColor(proxy.getProperty(TiC.PROPERTY_TABS_BACKGROUND_SELECTED_COLOR).toString())
+		colorInt = properties.containsKeyAndNotNull(TiC.PROPERTY_TABS_BACKGROUND_SELECTED_COLOR)
+				? TiColorHelper.parseColor(properties.getString(TiC.PROPERTY_TABS_BACKGROUND_SELECTED_COLOR), activity)
 				: colorInt;
 		// If a tab specific background color is defined for selected state, use it instead.
-		colorInt =
-			tabProxy.hasPropertyAndNotNull(TiC.PROPERTY_BACKGROUND_FOCUSED_COLOR)
-				? TiColorHelper.parseColor(tabProxy.getProperty(TiC.PROPERTY_BACKGROUND_FOCUSED_COLOR).toString())
+		colorInt = tabProperties.containsKeyAndNotNull(TiC.PROPERTY_BACKGROUND_FOCUSED_COLOR)
+				? TiColorHelper.parseColor(tabProperties.getString(TiC.PROPERTY_BACKGROUND_FOCUSED_COLOR), activity)
 				: colorInt;
 		stateListDrawable.addState(new int[] { stateToUse }, new ColorDrawable(colorInt));
 		return stateListDrawable;
@@ -449,7 +455,7 @@ public abstract class TiUIAbstractTabGroup extends TiUIView
 					|| windowProperties.containsKeyAndNotNull(TiC.PROPERTY_BAR_COLOR)) {
 					final String colorString = properties.optString(TiC.PROPERTY_BAR_COLOR,
 						windowProperties.getString(TiC.PROPERTY_BAR_COLOR));
-					final int color = TiColorHelper.parseColor(colorString);
+					final int color = TiColorHelper.parseColor(colorString, proxy.getActivity());
 					actionBar.setBackgroundDrawable(new ColorDrawable(color));
 				}
 			}
@@ -474,7 +480,7 @@ public abstract class TiUIAbstractTabGroup extends TiUIView
 			this.smoothScrollOnTabClick = d.getBoolean(TiC.PROPERTY_SMOOTH_SCROLL_ON_TAB_CLICK);
 		}
 		if (d.containsKeyAndNotNull(TiC.PROPERTY_TABS_BACKGROUND_COLOR)) {
-			setBackgroundColor(TiColorHelper.parseColor(d.get(TiC.PROPERTY_TABS_BACKGROUND_COLOR).toString()));
+			setBackgroundColor(TiConvert.toColor(d, TiC.PROPERTY_TABS_BACKGROUND_COLOR, proxy.getActivity()));
 		} else {
 			setBackgroundColor(getDefaultBackgroundColor());
 		}
@@ -492,7 +498,7 @@ public abstract class TiUIAbstractTabGroup extends TiUIView
 			for (TiUITab tabView : tabs) {
 				updateTabBackgroundDrawable(tabs.indexOf(tabView));
 			}
-			setBackgroundColor(TiColorHelper.parseColor(newValue.toString()));
+			setBackgroundColor(TiColorHelper.parseColor(newValue.toString(), proxy.getActivity()));
 		} else if (key.equals(TiC.PROPERTY_TABS_BACKGROUND_SELECTED_COLOR)) {
 			for (TiUITab tabView : tabs) {
 				updateTabBackgroundDrawable(tabs.indexOf(tabView));
@@ -537,6 +543,7 @@ public abstract class TiUIAbstractTabGroup extends TiUIView
 
 		final KrollDict tabProperties = tabProxy.getProperties();
 		final KrollDict properties = getProxy().getProperties();
+		final Activity activity = getProxy().getActivity();
 
 		int color = this.colorPrimaryInt;
 		if (selected) {
@@ -544,7 +551,7 @@ public abstract class TiUIAbstractTabGroup extends TiUIView
 				|| properties.containsKeyAndNotNull(TiC.PROPERTY_ACTIVE_TINT_COLOR)) {
 				final String colorString = tabProperties.optString(TiC.PROPERTY_ACTIVE_TINT_COLOR,
 					properties.getString(TiC.PROPERTY_ACTIVE_TINT_COLOR));
-				color = TiColorHelper.parseColor(colorString);
+				color = TiColorHelper.parseColor(colorString, activity);
 			}
 			drawable.setColorFilter(color, PorterDuff.Mode.SRC_IN);
 		} else {
@@ -553,7 +560,7 @@ public abstract class TiUIAbstractTabGroup extends TiUIView
 				|| properties.containsKeyAndNotNull(TiC.PROPERTY_TINT_COLOR)) {
 				final String colorString = tabProperties.optString(TiC.PROPERTY_TINT_COLOR,
 					properties.getString(TiC.PROPERTY_TINT_COLOR));
-				color = TiColorHelper.parseColor(colorString);
+				color = TiColorHelper.parseColor(colorString, activity);
 			}
 			drawable.setColorFilter(color, PorterDuff.Mode.SRC_IN);
 		}
@@ -587,13 +594,14 @@ public abstract class TiUIAbstractTabGroup extends TiUIView
 	@ColorInt
 	protected int getActiveColor(TiViewProxy tabProxy)
 	{
-		Object colorObject = null;
+		String colorString = null;
 		if ((tabProxy != null) && tabProxy.hasPropertyAndNotNull(TiC.PROPERTY_ACTIVE_TINT_COLOR)) {
-			colorObject = tabProxy.getProperty(TiC.PROPERTY_ACTIVE_TINT_COLOR);
+			colorString = tabProxy.getProperty(TiC.PROPERTY_ACTIVE_TINT_COLOR).toString();
 		} else if ((this.proxy != null) && this.proxy.hasPropertyAndNotNull(TiC.PROPERTY_ACTIVE_TINT_COLOR)) {
-			colorObject = this.proxy.getProperty(TiC.PROPERTY_ACTIVE_TINT_COLOR);
+			colorString = this.proxy.getProperty(TiC.PROPERTY_ACTIVE_TINT_COLOR).toString();
 		}
-		return (colorObject != null) ? TiColorHelper.parseColor(colorObject.toString()) : this.colorPrimaryInt;
+		Activity activity = getProxy().getActivity();
+		return (colorString != null) ? TiColorHelper.parseColor(colorString, activity) : this.colorPrimaryInt;
 	}
 
 	public static ColorStateList createRippleColorStateListFrom(@ColorInt int colorInt)

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIBottomNavigationTabGroup.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIBottomNavigationTabGroup.java
@@ -403,11 +403,12 @@ public class TiUIBottomNavigationTabGroup extends TiUIAbstractTabGroup implement
 			return;
 		}
 
-		if (tabProxy.getProperty(TiC.PROPERTY_BADGE_COLOR) != null) {
+		// TODO: reset to default value when property is null
+		if (tabProxy.hasPropertyAndNotNull(TiC.PROPERTY_BADGE_COLOR)) {
 			int menuItemId = this.mBottomNavigationView.getMenu().getItem(index).getItemId();
 			BadgeDrawable badgeDrawable = this.mBottomNavigationView.getOrCreateBadge(menuItemId);
 			badgeDrawable.setBackgroundColor(
-				TiConvert.toColor((String) tabProxy.getProperty(TiC.PROPERTY_BADGE_COLOR)));
+				TiConvert.toColor(tabProxy.getProperty(TiC.PROPERTY_BADGE_COLOR), tabProxy.getActivity()));
 		}
 	}
 

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUITabLayoutTabGroup.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUITabLayoutTabGroup.java
@@ -327,10 +327,11 @@ public class TiUITabLayoutTabGroup extends TiUIAbstractTabGroup implements TabLa
 			return;
 		}
 
-		if (tabProxy.getProperty(TiC.PROPERTY_BADGE_COLOR) != null) {
+		// TODO: reset to default value when property is null
+		if (tabProxy.hasPropertyAndNotNull(TiC.PROPERTY_BADGE_COLOR)) {
 			BadgeDrawable badgeDrawable = this.mTabLayout.getTabAt(index).getOrCreateBadge();
 			badgeDrawable.setBackgroundColor(
-				TiConvert.toColor((String) tabProxy.getProperty(TiC.PROPERTY_BADGE_COLOR)));
+				TiConvert.toColor(tabProxy.getProperty(TiC.PROPERTY_BADGE_COLOR), tabProxy.getActivity()));
 		}
 	}
 

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TableViewHolder.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TableViewHolder.java
@@ -160,6 +160,7 @@ public class TableViewHolder extends TiRecyclerViewHolder<TableViewRowProxy>
 			proxy.releaseViews();
 			proxy.setActivity((Activity) context);
 		}
+		final Activity activity = proxy.getActivity();
 
 		// Obtain row view.
 		final TableViewRowProxy.RowView rowView = (TableViewRowProxy.RowView) proxy.getOrCreateView();
@@ -198,7 +199,7 @@ public class TableViewHolder extends TiRecyclerViewHolder<TableViewRowProxy>
 			// Set title color.
 			int titleColor = 0;
 			if (properties.containsKeyAndNotNull(TiC.PROPERTY_COLOR)) {
-				final int color = TiConvert.toColor(properties.getString(TiC.PROPERTY_COLOR));
+				final int color = TiConvert.toColor(properties, TiC.PROPERTY_COLOR, proxy.getActivity());
 
 				if (color != Color.TRANSPARENT) {
 
@@ -210,8 +211,8 @@ public class TableViewHolder extends TiRecyclerViewHolder<TableViewRowProxy>
 
 				// Determine title color based on background.
 				final int tableBackgroundColor =
-					TiConvert.toColor(tableViewProxy.getProperties(), TiC.PROPERTY_BACKGROUND_COLOR);
-				final int rowBackgroundColor = TiConvert.toColor(properties, TiC.PROPERTY_BACKGROUND_COLOR);
+					TiConvert.toColor(tableViewProxy.getProperties(), TiC.PROPERTY_BACKGROUND_COLOR, activity);
+				final int rowBackgroundColor = TiConvert.toColor(properties, TiC.PROPERTY_BACKGROUND_COLOR, activity);
 				final int backgroundColor = rowBackgroundColor != Color.TRANSPARENT
 					? rowBackgroundColor : tableBackgroundColor;
 				final int defaultTitleColor = backgroundColor < (Color.BLACK / 2) ? Color.WHITE : Color.BLACK;

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiColorHelper.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiColorHelper.java
@@ -53,6 +53,10 @@ public class TiColorHelper
 	 */
 	public static int parseColor(String value)
 	{
+		return parseColor(value, null);
+	}
+	public static int parseColor(String value, Context context)
+	{
 		if (value == null) {
 			return Color.TRANSPARENT;
 		}
@@ -100,14 +104,19 @@ public class TiColorHelper
 		final String TI_SEMANTIC_COLOR_PREFIX = "ti.semantic.color:";
 		if (value.startsWith(TI_SEMANTIC_COLOR_PREFIX)) {
 			String themePrefix = "light=";
-			Configuration config = TiApplication.getInstance().getResources().getConfiguration();
+			Configuration config;
+			if (context != null) {
+				config = context.getResources().getConfiguration();
+			} else {
+				config = TiApplication.getInstance().getResources().getConfiguration();
+			}
 			if ((config.uiMode & Configuration.UI_MODE_NIGHT_YES) != 0) {
 				themePrefix = "dark=";
 			}
 			String[] stringArray = value.substring(TI_SEMANTIC_COLOR_PREFIX.length()).split(";");
 			for (String nextString : stringArray) {
 				if (nextString.startsWith(themePrefix)) {
-					return TiColorHelper.parseColor(nextString.substring(themePrefix.length()));
+					return TiColorHelper.parseColor(nextString.substring(themePrefix.length()), context);
 				}
 			}
 			Log.e(TAG, "Cannot find named color: " + value);
@@ -115,9 +124,9 @@ public class TiColorHelper
 		}
 
 		// Ti.Android.R.color or Ti.App.Android.R.color resource (by name)
-		if (TiColorHelper.hasColorResource(value)) {
+		if (TiColorHelper.hasColorResource(value, context)) {
 			try {
-				return TiColorHelper.getColorResource(value);
+				return TiColorHelper.getColorResource(value, context);
 			} catch (Exception e) {
 				Log.e(TAG, "Cannot find named color: " + value, e);
 			}
@@ -148,16 +157,25 @@ public class TiColorHelper
 
 	public static boolean hasColorResource(String colorName)
 	{
+		return hasColorResource(colorName, null);
+	}
+	public static boolean hasColorResource(String colorName, Context context)
+	{
 		try {
-			TypedValue typedValue = TiColorHelper.getColorResourceTypedValue(colorName);
+			TypedValue typedValue = TiColorHelper.getColorResourceTypedValue(colorName, context);
 			return TiColorHelper.isColor(typedValue);
 		} catch (Exception ex) {
 		}
 		return false;
 	}
-
 	@NonNull
 	public static TypedValue getColorResourceTypedValue(String colorName) throws Resources.NotFoundException
+	{
+		return getColorResourceTypedValue(colorName, null);
+	}
+	@NonNull
+	public static TypedValue getColorResourceTypedValue(String colorName, Context context)
+		throws Resources.NotFoundException
 	{
 		TypedValue typedValue = new TypedValue();
 
@@ -169,13 +187,12 @@ public class TiColorHelper
 		// Resource ID starting with '?' (instead of '@') should favor current activity theme.
 		// Note: Resources.getIdentifier() won't accept leading '?'. We must replace it.
 		TiApplication app = TiApplication.getInstance();
-		Context context = app;
+		if (context == null) {
+			Context activity = app.getCurrentActivity();
+			context = activity != null ? activity : app;
+		}
 		if (colorName.startsWith("?")) {
 			colorName = "@" + colorName.substring(1);
-			Context activity = app.getCurrentActivity();
-			if (activity != null) {
-				context = activity;
-			}
 		}
 
 		// First check if resource name is defined in app or its libraries.
@@ -207,7 +224,11 @@ public class TiColorHelper
 
 	public static @ColorInt int getColorResource(String colorName) throws Resources.NotFoundException
 	{
-		TypedValue typedValue = TiColorHelper.getColorResourceTypedValue(colorName);
+		return getColorResource(colorName, null);
+	}
+	public static @ColorInt int getColorResource(String colorName, Context context) throws Resources.NotFoundException
+	{
+		TypedValue typedValue = TiColorHelper.getColorResourceTypedValue(colorName, context);
 		if (TiColorHelper.isColor(typedValue)) {
 			return typedValue.data;
 		}

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiConvert.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiConvert.java
@@ -27,6 +27,7 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import android.content.Context;
 import android.graphics.drawable.ColorDrawable;
 import android.net.Uri;
 
@@ -136,7 +137,18 @@ public class TiConvert
 	 */
 	public static int toColor(String value)
 	{
-		return TiColorHelper.parseColor(value);
+		Log.w(TAG, "Calling .toColor() without Context parameter is deprecated");
+		return TiColorHelper.parseColor(value, null);
+	}
+
+	public static int toColor(String value, Context context)
+	{
+		return TiColorHelper.parseColor(value, context);
+	}
+
+	public static int toColor(Object value, Context context)
+	{
+		return TiColorHelper.parseColor(toString(value), context);
 	}
 
 	/**
@@ -148,12 +160,24 @@ public class TiConvert
 	 */
 	public static int toColor(HashMap<String, Object> hashMap, String key)
 	{
-		return toColor(TiConvert.toString(hashMap.get(key)));
+		Log.w(TAG, "Calling .toColor() without Context parameter is deprecated");
+		return toColor(hashMap, key, null);
+	}
+
+	public static int toColor(HashMap<String, Object> hashMap, String key, Context context)
+	{
+		return toColor(TiConvert.toString(hashMap.get(key)), context);
 	}
 
 	public static ColorDrawable toColorDrawable(String value)
 	{
-		return new ColorDrawable(toColor(value));
+		Log.w(TAG, "Calling .toColorDrawable() without Context parameter is deprecated");
+		return toColorDrawable(value, null);
+	}
+
+	public static ColorDrawable toColorDrawable(String value, Context context)
+	{
+		return new ColorDrawable(toColor(value, context));
 	}
 
 	public static ColorDrawable toColorDrawable(HashMap<String, Object> hashMap, String key)

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiUIHelper.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiUIHelper.java
@@ -608,16 +608,30 @@ public class TiUIHelper
 	public static Drawable buildBackgroundDrawable(String color, String image, boolean tileImage,
 												   Drawable gradientDrawable)
 	{
+		Log.w(TAG, "Calling .buildBackgroundDrawable() without Context parameter is deprecated");
+		return buildBackgroundDrawable(color, image, tileImage, gradientDrawable, null);
+	}
+
+	public static Drawable buildBackgroundDrawable(String color, String image, boolean tileImage,
+												   Drawable gradientDrawable, Context context)
+	{
 		Drawable imageDrawable = null;
 		if (image != null) {
 			TiFileHelper tfh = TiFileHelper.getInstance();
 			imageDrawable = tfh.loadDrawable(image, false, true, false);
 		}
-		return buildBackgroundDrawable(color, imageDrawable, tileImage, gradientDrawable);
+		return buildBackgroundDrawable(color, imageDrawable, tileImage, gradientDrawable, context);
 	}
 
 	public static Drawable buildBackgroundDrawable(String color, Drawable imageDrawable, boolean tileImage,
 												   Drawable gradientDrawable)
+	{
+		Log.w(TAG, "Calling .buildBackgroundDrawable() without Context parameter is deprecated");
+		return buildBackgroundDrawable(color, imageDrawable, tileImage, gradientDrawable, null);
+	}
+
+	public static Drawable buildBackgroundDrawable(String color, Drawable imageDrawable, boolean tileImage,
+												   Drawable gradientDrawable, Context context)
 	{
 		// Create an array of the layers that will compose this background.
 		// Note that the order in which the layers is important to get the
@@ -625,7 +639,7 @@ public class TiUIHelper
 		ArrayList<Drawable> layers = new ArrayList<>(3);
 
 		if (color != null) {
-			Drawable colorDrawable = new ColorDrawable(TiColorHelper.parseColor(color));
+			Drawable colorDrawable = new ColorDrawable(TiColorHelper.parseColor(color, context));
 			layers.add(colorDrawable);
 		}
 
@@ -671,6 +685,17 @@ public class TiUIHelper
 															String disabledImage, String disabledColor,
 															String focusedImage, String focusedColor,
 															Drawable gradientDrawable)
+	{
+		Log.w(TAG, "Calling .buildBackgroundDrawable() without Context parameter is deprecated");
+		return buildBackgroundDrawable(image, tileImage, color, selectedImage, selectedColor, disabledImage,
+			disabledColor, focusedImage, focusedColor, gradientDrawable, null);
+	}
+
+	public static StateListDrawable buildBackgroundDrawable(String image, boolean tileImage, String color,
+															String selectedImage, String selectedColor,
+															String disabledImage, String disabledColor,
+															String focusedImage, String focusedColor,
+															Drawable gradientDrawable, Context context)
 	{
 		// Anonymous class used by this method to load image drawables.
 		// Supports drawable caching to prevent the same image file from being decoded twice.
@@ -731,21 +756,21 @@ public class TiUIHelper
 		// Create the layered drawable objects for the the UI object's different states.
 		StateListDrawable sld = new StateListDrawable();
 		Drawable bgSelectedDrawable =
-			buildBackgroundDrawable(selectedColor, selectedImageDrawable, tileImage, gradientDrawable);
+			buildBackgroundDrawable(selectedColor, selectedImageDrawable, tileImage, gradientDrawable, context);
 		if (bgSelectedDrawable != null) {
 			sld.addState(BACKGROUND_SELECTED_STATE, bgSelectedDrawable);
 		}
 		Drawable bgFocusedDrawable =
-			buildBackgroundDrawable(focusedColor, focusedImageDrawable, tileImage, gradientDrawable);
+			buildBackgroundDrawable(focusedColor, focusedImageDrawable, tileImage, gradientDrawable, context);
 		if (bgFocusedDrawable != null) {
 			sld.addState(BACKGROUND_FOCUSED_STATE, bgFocusedDrawable);
 		}
 		Drawable bgDisabledDrawable =
-			buildBackgroundDrawable(disabledColor, disabledImageDrawable, tileImage, gradientDrawable);
+			buildBackgroundDrawable(disabledColor, disabledImageDrawable, tileImage, gradientDrawable, context);
 		if (bgDisabledDrawable != null) {
 			sld.addState(BACKGROUND_DISABLED_STATE, bgDisabledDrawable);
 		}
-		Drawable bgDrawable = buildBackgroundDrawable(color, mainImageDrawable, tileImage, gradientDrawable);
+		Drawable bgDrawable = buildBackgroundDrawable(color, mainImageDrawable, tileImage, gradientDrawable, context);
 		if (bgDrawable != null) {
 			sld.addState(BACKGROUND_DEFAULT_STATE_1, bgDrawable);
 			sld.addState(BACKGROUND_DEFAULT_STATE_2, bgDrawable);

--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiUIView.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiUIView.java
@@ -812,7 +812,8 @@ public abstract class TiUIView implements KrollProxyListener, OnFocusChangeListe
 
 				if (this.nativeView != null) {
 					if (d.containsKeyAndNotNull(TiC.PROPERTY_BACKGROUND_COLOR)) {
-						this.nativeView.setBackgroundColor(TiConvert.toColor(d, TiC.PROPERTY_BACKGROUND_COLOR));
+						this.nativeView.setBackgroundColor(
+							TiConvert.toColor(d, TiC.PROPERTY_BACKGROUND_COLOR, proxy.getActivity()));
 					} else {
 						this.nativeView.setBackground(null);
 					}
@@ -827,7 +828,7 @@ public abstract class TiUIView implements KrollProxyListener, OnFocusChangeListe
 
 				if (!hasColorState && !hasGradient) {
 					if (d.get(TiC.PROPERTY_BACKGROUND_COLOR) != null) {
-						bgColor = TiConvert.toColor(d, TiC.PROPERTY_BACKGROUND_COLOR);
+						bgColor = TiConvert.toColor(d, TiC.PROPERTY_BACKGROUND_COLOR, proxy.getActivity());
 						if (newBackground
 							|| (key.equals(TiC.PROPERTY_OPACITY) || key.equals(TiC.PROPERTY_BACKGROUND_COLOR))) {
 							background.setBackgroundColor(bgColor);
@@ -873,7 +874,7 @@ public abstract class TiUIView implements KrollProxyListener, OnFocusChangeListe
 			}
 			if (canApplyTouchFeedback(d)) {
 				String colorString = TiConvert.toString(d.get(TiC.PROPERTY_TOUCH_FEEDBACK_COLOR));
-				applyTouchFeedback((colorString != null) ? TiConvert.toColor(colorString) : null);
+				applyTouchFeedback((colorString != null) ? TiConvert.toColor(colorString, proxy.getActivity()) : null);
 			}
 			if (key.equals(TiC.PROPERTY_OPACITY)) {
 				setOpacity(TiConvert.toFloat(newValue, 1f));
@@ -993,7 +994,7 @@ public abstract class TiUIView implements KrollProxyListener, OnFocusChangeListe
 		} else if (d.containsKey(TiC.PROPERTY_BACKGROUND_COLOR) && !nativeViewNull) {
 			// Set the background color on the view directly only if there is no border.
 			// If border is present, then we must use the TiBackgroundDrawable.
-			bgColor = TiConvert.toColor(d, TiC.PROPERTY_BACKGROUND_COLOR);
+			bgColor = TiConvert.toColor(d, TiC.PROPERTY_BACKGROUND_COLOR, proxy.getActivity());
 			if (hasBorder(d)) {
 				if (background == null) {
 					applyCustomBackground(false);
@@ -1005,7 +1006,7 @@ public abstract class TiUIView implements KrollProxyListener, OnFocusChangeListe
 		}
 		if (canApplyTouchFeedback(d)) {
 			String colorString = TiConvert.toString(d.get(TiC.PROPERTY_TOUCH_FEEDBACK_COLOR));
-			applyTouchFeedback((colorString != null) ? TiConvert.toColor(colorString) : null);
+			applyTouchFeedback((colorString != null) ? TiConvert.toColor(colorString, proxy.getActivity()) : null);
 		}
 
 		if (d.containsKey(TiC.PROPERTY_FILTER_TOUCHES_WHEN_OBSCURED) && !nativeViewNull) {
@@ -1445,7 +1446,8 @@ public abstract class TiUIView implements KrollProxyListener, OnFocusChangeListe
 			if (background != null) {
 				Drawable bgDrawable = TiUIHelper.buildBackgroundDrawable(
 					bg, TiConvert.toBoolean(d, TiC.PROPERTY_BACKGROUND_REPEAT, false), bgColor, bgSelected,
-					bgSelectedColor, bgDisabled, bgDisabledColor, bgFocused, bgFocusedColor, gradientDrawable);
+					bgSelectedColor, bgDisabled, bgDisabledColor, bgFocused, bgFocusedColor, gradientDrawable,
+					proxy.getActivity());
 
 				background.setBackgroundDrawable(bgDrawable);
 			}
@@ -1500,7 +1502,7 @@ public abstract class TiUIView implements KrollProxyListener, OnFocusChangeListe
 					borderView.setColor(bgColor);
 				}
 				if (d.containsKey(TiC.PROPERTY_BORDER_COLOR)) {
-					borderView.setColor(TiConvert.toColor(d, TiC.PROPERTY_BORDER_COLOR));
+					borderView.setColor(TiConvert.toColor(d, TiC.PROPERTY_BORDER_COLOR, proxy.getActivity()));
 				}
 
 				//Have a default border width of 1 if the border has defined color.
@@ -1532,7 +1534,8 @@ public abstract class TiUIView implements KrollProxyListener, OnFocusChangeListe
 	private void handleBorderProperty(String property, Object value)
 	{
 		if (TiC.PROPERTY_BORDER_COLOR.equals(property)) {
-			borderView.setColor(value != null ? TiConvert.toColor(value.toString()) : Color.TRANSPARENT);
+			int color = value != null ? TiConvert.toColor(value.toString(), proxy.getActivity()) : Color.TRANSPARENT;
+			borderView.setColor(color);
 			if (!proxy.hasProperty(TiC.PROPERTY_BORDER_WIDTH)) {
 				borderView.setBorderWidth(1);
 			}


### PR DESCRIPTION
**JIRA:** https://jira.appcelerator.org/browse/TIMOB-28563
fix #13266

Known issues:
- `TiGradientDrawable`: doesn't have a `proxy` reference
- `TiAnimationBuilder`: `proxy` is assinged in `start()` methond, i.e. after parameters calculation.

In both cases classes could be refactored, but I'm not going to do it now.
As simple workaround it is possible to use `tiApp.getRootOrCurrentActivity()` instead of `TiApplication.getInstance()`. In most cases this will give the desired result, but is not really correct, since it's possible that a `proxy` will have different `Activity` from current.

If someone will be thinking about merging this, please consider refactoring classes mentioned above or at least creating issues, so this don't get lost.