### PR TITLE
fix(android): fix build deps

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,7 +6,7 @@
  */
 
 buildscript {
-	ext.kotlin_version = '1.5.21'
+	ext.kotlin_version = '1.6.10'
 
 	repositories {
 		google()

--- a/android/templates/build/root.build.gradle
+++ b/android/templates/build/root.build.gradle
@@ -1,6 +1,6 @@
 
 buildscript {
-	ext.kotlin_version = '1.5.21'
+	ext.kotlin_version = '1.6.10'
 
 	repositories {
 		google()

--- a/android/titanium/libv8-services.js
+++ b/android/titanium/libv8-services.js
@@ -174,7 +174,7 @@ async function createSnapshot() {
 			// Post rolled-up "ti.main" script to server and obtain a snapshot ID as a response.
 			// We will send an HTTP request for the snapshot code later.
 			console.log('Attempting to request snapshot...');
-			const snapshotUrl = 'https://v8-snapshot.appcelerator.com';
+			const snapshotUrl = 'http://v8-snapshot.appcelerator.com'; // TODO: Migrate to Github Artifacts once ready
 			const packageJsonData = await loadPackageJson();
 			const requestOptions = {
 				body: {


### PR DESCRIPTION
The local build was failing because of two reasons:
1) If no cached V8 artifact was found, a new one could not be fetched because the https:// cert expired and we don't have any other server for it, yet
2) The build failed on newer versions of Android Studio because of the outdated Kotlin version