### PR TITLE
docs: remote bindings in webview, fix two example errors

### DIFF
--- a/apidoc/Titanium/UI/OptionBar.yml
+++ b/apidoc/Titanium/UI/OptionBar.yml
@@ -21,10 +21,10 @@ excludes:
     properties: [children]
     methods: [add, remove, removeAllChildren, replaceAt]
 
-events: 
+events:
   - name: click
     summary: Fired when an option has been selected.
-    properties: 
+    properties:
       - name: index
         summary: Index of the option clicked on.
         type: Number
@@ -62,7 +62,7 @@ examples:
         ``` js
         const win = Ti.UI.createWindow();
         const optionBar = Ti.UI.createOptionBar({
-          labels: [ 'Option 1', 'Option 2', Option 3 ]
+          labels: [ 'Option 1', 'Option 2', 'Option 3' ]
         });
         optionBar.addEventListener('click', (e) => {
           Ti.API.info(`Option ${e.index} was selected.`);

--- a/apidoc/Titanium/UI/OptionDialog.yml
+++ b/apidoc/Titanium/UI/OptionDialog.yml
@@ -242,7 +242,7 @@ examples:
   - title: Dialog with 3 Options
     example: |
         ``` js
-        Ti.UI.setBackgroundColor('white');
+        Ti.UI.backgroundColor = 'white';
         var win = Ti.UI.createWindow({
           title: 'Click window to test',
           backgroundColor: 'white'

--- a/apidoc/Titanium/UI/WebView.yml
+++ b/apidoc/Titanium/UI/WebView.yml
@@ -35,6 +35,22 @@ description: |
     [evalJS](Titanium.UI.WebView.evalJS) method to execute a JavaScript expression
     inside the web view and retrieve the value of an expression.
 
+    You can inject the local `Ti.App.fireEvent` bindings yourself by adding a script element using
+    evalJS.
+
+    ```js
+    webview.evalJS(
+      'javascript=(function addBinding(){' +
+        'var s=document.createElement("script");' +
+        's.setAttribute("type","text/javascript");' +
+        's.innerHTML="' + require('/binding.js') + '";'
+        +
+        'document.getElementsByTagName("body")[0].appendChild(s);' +
+      '})()'
+    );
+    ```
+    The `binding.min.js` is available in the [repository](https://github.com/tidev/titanium_mobile/tree/master/android/modules/ui/assets/Resources/ti.internal/webview).
+
     #### Local JavaScript Files
 
     During the build process for creating a package, all JavaScript files, that is, any file with a


### PR DESCRIPTION
Apidoc update:

* webview: add example to inject bindigs.js into a remote webpage
* fix error in OptionBar example (missing quotes)
* fix error in OptionDialog example (setter)