### PR TITLE
feat(android): parity for optionbar index

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIOptionBar.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIOptionBar.java
@@ -115,6 +115,9 @@ public class TiUIOptionBar extends TiUIView
 					((Checkable) view).setChecked(true);
 					this.isIgnoringCheckEvent = oldValue;
 				}
+			} else if (index == -1) {
+				// unselect all
+				getButtonGroup().clearChecked();
 			}
 		}
 	}
@@ -231,7 +234,6 @@ public class TiUIOptionBar extends TiUIView
 				if (((Checkable) childView).isChecked()) {
 					// Update the proxy's "index" property.
 					this.proxy.setProperty(TiC.PROPERTY_INDEX, index);
-
 					// Fire a "click" event for selected option.
 					if (!this.isIgnoringCheckEvent) {
 						KrollDict data = new KrollDict();

--- a/apidoc/Titanium/UI/OptionBar.yml
+++ b/apidoc/Titanium/UI/OptionBar.yml
@@ -31,6 +31,8 @@ events:
 properties:
   - name: index
     summary: Index of the currently selected option.
+    description: |
+      Index of the currently selected option. Setting this to `-1` will deselect all options.
     type: Number
 
   - name: labels
@@ -64,10 +66,17 @@ examples:
         const optionBar = Ti.UI.createOptionBar({
           labels: [ 'Option 1', 'Option 2', 'Option 3' ]
         });
+        const btn = Ti.UI.createButton({
+          title:"reset", bottom: 10
+        })
         optionBar.addEventListener('click', (e) => {
           Ti.API.info(`Option ${e.index} was selected.`);
         });
-        win.add(optionBar);
+        btn.addEventListener('click', (e) => {
+          optionBar.index = -1;
+        });
+        win.add([optionBar,btn]);
+
         win.open();
         ```
 


### PR DESCRIPTION
fixes https://github.com/tidev/titanium_mobile/issues/13323

Adds parity for setting the optionBar.index to -1 to deselect everything.

example
```js
const win = Ti.UI.createWindow();
const optionBar = Ti.UI.createOptionBar({
  labels: [ 'Option 1', 'Option 2', 'Option 3' ]
});
const btn = Ti.UI.createButton({
  title:"reset", bottom: 10
})
optionBar.addEventListener('click', (e) => {
  Ti.API.info(`Option ${e.index} was selected.`);
});
btn.addEventListener('click', (e) => {
  optionBar.index = -1;
});
win.add([optionBar,btn]);

win.open();
```