### PR TITLE
feat: add default semantic.colors.json

### DIFF
--- a/templates/app/default/template/Resources/semantic.colors.json
+++ b/templates/app/default/template/Resources/semantic.colors.json
@@ -1,0 +1,6 @@
+{
+  "textColor": {
+    "dark": "#ffffff",
+    "light": "#000000"
+  }
+}


### PR DESCRIPTION
Fixes: https://github.com/tidev/titanium_mobile/issues/13241

Adds a default `semantic.colors.json` file with an example.

Needs: https://github.com/tidev/alloy/pull/1322 to be in the correct folder when going from classic -> alloy