### PR TITLE
fix(ios): apply “overrideUserInterfaceStyle” to main app window

### DIFF
--- a/iphone/Classes/UIModule.m
+++ b/iphone/Classes/UIModule.m
@@ -451,7 +451,7 @@ MAKE_SYSTEM_PROP(EXTEND_EDGE_ALL, 15); //UIEdgeRectAll
             notification:NO];
   if ([TiUtils isIOSVersionOrGreater:@"13.0"] || [TiUtils isMacOS]) {
     int style = [TiUtils intValue:args def:UIUserInterfaceStyleUnspecified];
-    TiApp.controller.overrideUserInterfaceStyle = style;
+    TiApp.app.window.overrideUserInterfaceStyle = style;
   }
 }
 


### PR DESCRIPTION
Fixes #13328

```js
Ti.UI.overrideUserInterfaceStyle = Ti.UI.USER_INTERFACE_STYLE_DARK;

const win = Ti.UI.createWindow({
	backgroundColor: 'blue',
	title: 'Main Window'
});
win.add(Ti.UI.createLabel({ top: 100, text: 'Window-Title should be white!' }));

const btn = Ti.UI.createButton({
	title: 'Open Sub-Window'
});

btn.addEventListener('click', () => {
	const window = Ti.UI.createWindow({ title: 'Sub-Window', backgroundColor: 'red' });
	window.add(Ti.UI.createLabel({ top: 100, text: 'Window-Title should be white!' }));
	const nav = Ti.UI.createNavigationWindow({ window });
	nav.open({ modal: true });
});

win.add(btn);

const nav = Ti.UI.createNavigationWindow({ window: win });
nav.open();
```