### PR TITLE
fix: issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1.bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1.bug_report.yml
@@ -2,64 +2,64 @@ name: Bug Report
 description: Create a bug report for the Titanium SDK
 labels: [bug, needs triage]
 body:
-  - type: markdown
-    attributes:
-      value: Thank you for the time you have taken to file a bug report! Please make sure to ensure you have filled this form out as best you can.
-  - type: markdown
-    attributes:
-      value: Leaving sections incomplete might mean that your issue is closed or moved to GitHub discussions
-  - type: checkboxes
-    attributes:
-      label: I have searched and made sure there are no existing issues for the issue I am filing
-      options:
-        - label: I have searched the existing issues
-          required: true
-  - type: textarea
-    attributes:
-      label: Description
-      description: A description of the issue
-    validations:
-      required: true
-  - type: textarea
-    attributes:
-      label: Expected Behavior
-      description: What is the expected behavior of what you are trying to do?
-    validations:
-      required: true
-  - type: textarea
-    attributes:
-      label: Actual behavior
-      description: What is the actual behavior of what you are trying to do?
-    validations:
-      required: true
-  - type: textarea
-    attributes:
-      label: Reproducible sample
-      description: A code sample that reproduces the issue. This could be a standalone block of code, or a link to a git repository, but it must be simple enough to paste/clone, build an app, and reproduce the issue
-    validations:
-      required: true
-  - type: textarea
-    attributes:
-      label: Steps to reproduce
-      description: Steps that are required to be taken to reproduce the issue
-    validations:
-      required: true
-  - type: dropdown
-    attributes:
-      label: Platform
-      description: What is the platform that this issue is seen on?
-      multiple: true
-      options:
-        - Android
-        - iOS
-        - Android & iOS
-        - CLI
-  - type: input
-    attributes:
-      label: SDK version you are using
-    validations:
-      required: true
-  - type: input
+- type: markdown
+  attributes:
+    value: Thank you for the time you have taken to file a bug report! Please make sure to ensure you have filled this form out as best you can.
+- type: markdown
+  attributes:
+    value: Leaving sections incomplete might mean that your issue is closed or moved to GitHub discussions
+- type: checkboxes
+  attributes:
+    label: I have searched and made sure there are no existing issues for the issue I am filing
+    options:
+      - label: I have searched the existing issues
+        required: true
+- type: textarea
+  attributes:
+    label: Description
+    description: A description of the issue
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Expected Behavior
+    description: What is the expected behavior of what you are trying to do?
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Actual behavior
+    description: What is the actual behavior of what you are trying to do?
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Reproducible sample
+    description: A code sample that reproduces the issue. This could be a standalone block of code, or a link to a git repository, but it must be simple enough to paste/clone, build an app, and reproduce the issue
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Steps to reproduce
+    description: Steps that are required to be taken to reproduce the issue
+  validations:
+    required: true
+- type: dropdown
+  attributes:
+    label: Platform
+    description: What is the platform that this issue is seen on?
+    multiple: true
+    options:
+      - Android
+      - iOS
+      - Android & iOS
+      - CLI
+- type: input
+  attributes:
+    label: SDK version you are using
+  validations:
+    required: true
+- type: input
   attributes:
       label: Alloy version you are using
   validations:

--- a/.github/ISSUE_TEMPLATE/2.docs_issue.yml
+++ b/.github/ISSUE_TEMPLATE/2.docs_issue.yml
@@ -2,33 +2,33 @@ name: Docs Issue
 description: Noticed an issue with the docs, let us know!
 labels: [bug, docs, needs triage]
 body:
-  - type: markdown
-    attributes:
-      value: Thank you for the time you have taken to file this issue! Please make sure to ensure you have filled this form out as best you can.
-  - type: markdown
-    attributes:
-      value: If you have the time and are interested, why not make a PR that fixes the issue.
-  - type: checkboxes
-    attributes:
-      label: I have searched and made sure there are no existing issues for the issue I am filing
-      options:
-        - label: I have searched the existing issues
-          required: true
-  - type: input
-    attributes:
-      label: URL
-      description: What is the URL for the docs page?
-    validations:
-      required: true
-  - type: textarea
-    attributes:
-      label: Description
-      description: A description of the issue
-    validations:
-      required: true
-  - type: textarea
-    attributes:
-      label: Suggestion
-      description: How do you suggest this could be improved? If the issue is with a code sample please provide the suggested replacement.
-    validations:
-      required: true
+- type: markdown
+  attributes:
+    value: Thank you for the time you have taken to file this issue! Please make sure to ensure you have filled this form out as best you can.
+- type: markdown
+  attributes:
+    value: If you have the time and are interested, why not make a PR that fixes the issue.
+- type: checkboxes
+  attributes:
+    label: I have searched and made sure there are no existing issues for the issue I am filing
+    options:
+      - label: I have searched the existing issues
+        required: true
+- type: input
+  attributes:
+    label: URL
+    description: What is the URL for the docs page?
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Description
+    description: A description of the issue
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Suggestion
+    description: How do you suggest this could be improved? If the issue is with a code sample please provide the suggested replacement.
+  validations:
+    required: true

--- a/.github/ISSUE_TEMPLATE/3.feature_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/3.feature_proposal.yml
@@ -2,40 +2,40 @@ name: Feature Proposal
 description: Propose a new feature or an improvement for Titanium SDK
 labels: [feature, needs triage]
 body:
-  - type: markdown
-    attributes:
-      value: Thank you for the time you have taken to file a feature proposal! Please make sure to ensure you have filled this form out as best you can.
-  - type: checkboxes
-    attributes:
-      label: I have searched and made sure there are no existing issues for the issue I am filing
-      options:
-        - label: I have searched the existing issues
-          required: true
-  - type: textarea
-    attributes:
-      label: Description
-      description: A concise description of the proposal you are making and the use case for it
-    validations:
-      required: true
-  - type: textarea
-    attributes:
-      label: Solution
-      description: Describe the solution you are proposing to solve the feature proposal, this could include code snippets
-    validations:
-      required: true
-  - type: textarea
-    attributes:
-      label: Alternatives
-      description: Describe any alternatives solutions you have considered
-    validations:
-      required: false
-  - type: dropdown
-    attributes:
-      label: Platforms
-      description: What is the platform associated with this proposal?
-      multiple: true
-      options:
-        - Android
-        - iOS
-        - Android & iOS
-        - CLI
+- type: markdown
+  attributes:
+    value: Thank you for the time you have taken to file a feature proposal! Please make sure to ensure you have filled this form out as best you can.
+- type: checkboxes
+  attributes:
+    label: I have searched and made sure there are no existing issues for the issue I am filing
+    options:
+      - label: I have searched the existing issues
+        required: true
+- type: textarea
+  attributes:
+    label: Description
+    description: A concise description of the proposal you are making and the use case for it
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Solution
+    description: Describe the solution you are proposing to solve the feature proposal, this could include code snippets
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Alternatives
+    description: Describe any alternatives solutions you have considered
+  validations:
+    required: false
+- type: dropdown
+  attributes:
+    label: Platforms
+    description: What is the platform associated with this proposal?
+    multiple: true
+    options:
+      - Android
+      - iOS
+      - Android & iOS
+      - CLI


### PR DESCRIPTION
Fixes https://github.com/tidev/titanium_mobile/issues/13331

Text is the same, just moved it to the right level.

You can view the files now without an error and I've tested it in my fork master branch and can open a bug issue there again.
![Screenshot_20220326_213712](https://user-images.githubusercontent.com/4334997/160256237-ed4e75ef-913a-40ca-8db7-001215c55b30.png)

