### PR TITLE
fix(ios): handle authenticationMethod in webview

### DIFF
--- a/iphone/Classes/TiUIWebView.m
+++ b/iphone/Classes/TiUIWebView.m
@@ -880,10 +880,13 @@ static NSString *const baseInjectScript = @"Ti._hexish=function(a){var r='';var 
       completionHandler(NSURLSessionAuthChallengeCancelAuthenticationChallenge, nil);
     }
     // HTTPS in general
-  } else if ([authenticationMethod isEqualToString:NSURLAuthenticationMethodServerTrust]) {
+  } else if ([authenticationMethod isEqualToString:NSURLAuthenticationMethodServerTrust]
+      || [authenticationMethod isEqualToString:NSURLAuthenticationMethodClientCertificate]) {
     completionHandler(NSURLSessionAuthChallengePerformDefaultHandling, nil);
     // Default: Reject authentication challenge
   } else {
+    // Not sure why not let the DefaultHandling handle this but at least warn in the log because of canceled challenge
+    NSLog(@"[WARN] Ti.UI.WebView canceled unknown authentication challenge with method %@", authenticationMethod);
     completionHandler(NSURLSessionAuthChallengeCancelAuthenticationChallenge, nil);
   }
 }

--- a/tests/Resources/ti.ui.webview.test.js
+++ b/tests/Resources/ti.ui.webview.test.js
@@ -950,4 +950,24 @@ describe('Titanium.UI.WebView', function () {
 			win.open();
 		});
 	});
+
+	it('url with clientCertChallenge', function (finish) {
+		const url = 'https://device.login.microsoftonline.com';
+
+		win = Ti.UI.createWindow();
+		const webView = Ti.UI.createWebView({
+			url: url
+		});
+
+		webView.addEventListener('error', function () {
+			finish(new Error('clientCertChallenge must be handled correctly.'));
+		});
+
+		webView.addEventListener('load', function () {
+			finish();
+		});
+
+		win.add(webView);
+		win.open();
+	});
 });


### PR DESCRIPTION
Fixes https://github.com/tidev/titanium_mobile/issues/13351

Test:
```js
$.webview.addEventListener('error', function (e) {
    Ti.API.error('error: ' + e.error + '  Code: ' + e.code + ' BaseUrl' + e.url);
});
$.webview.url = "https://device.login.microsoftonline.com";
```