### PR TITLE
fix: WebView example

### DIFF
--- a/apidoc/Titanium/UI/WebView.yml
+++ b/apidoc/Titanium/UI/WebView.yml
@@ -182,7 +182,7 @@ description: |
 
     ``` js
     var win = Ti.UI.createWindow({
-      backgroundColor: 'white';
+      backgroundColor: 'white'
     });
 
     var verticalView = Ti.UI.createView({layout: 'vertical', width: "100%", height: "100%"});


### PR DESCRIPTION
I've removed a semicolon in the `createWebView` example as it breaks the app on build with it