### PR TITLE
fix(ios): remove falsy error log

### DIFF
--- a/iphone/Classes/TiWindowProxy+Addons.m
+++ b/iphone/Classes/TiWindowProxy+Addons.m
@@ -16,7 +16,6 @@
     return (TiUINavigationWindowProxy *)parentController;
   }
 
-  NSLog(@"[ERROR] Trying to receive a Ti.UI.NavigationWindow instance that does not exist in this context!");
   return nil;
 }
 #endif


### PR DESCRIPTION
The error was thrown when checking for `window.navigationWindow`, which is the wrong place because the property can be used to check if it's available or not.