### PR TITLE
fix(ios): mediaModule undeclared identifier

### DIFF
--- a/iphone/Classes/MediaModule.m
+++ b/iphone/Classes/MediaModule.m
@@ -2175,7 +2175,7 @@ MAKE_SYSTEM_PROP(VIDEO_REPEAT_MODE_ONE, VideoRepeatModeOne);
 - (void)mediaPicker:(MPMediaPickerController *)mediaPicker_ didPickMediaItems:(MPMediaItemCollection *)collection
 {
   if (autoHidePicker) {
-    [self closeModalPicker:musicPicker];
+    [self closeModalPicker:mediaPicker_];
   }
 
   TiMediaItem *representative = [[[TiMediaItem alloc] _initWithPageContext:[self pageContext] item:[collection representativeItem]] autorelease];
@@ -2197,7 +2197,7 @@ MAKE_SYSTEM_PROP(VIDEO_REPEAT_MODE_ONE, VideoRepeatModeOne);
 
 - (void)mediaPickerDidCancel:(MPMediaPickerController *)mediaPicker_
 {
-  [self closeModalPicker:musicPicker];
+  [self closeModalPicker:mediaPicker_];
   [self sendPickerCancel];
 }
 #endif


### PR DESCRIPTION
fixes https://github.com/tidev/titanium_mobile/issues/13396

**Error log**
```
[TRACE] app/build/iphone/Classes/MediaModule.m:2180:28: error: use of undeclared identifier 'musicPicker'; did you mean 'mediaPicker_'?
[TRACE]     [self closeModalPicker:musicPicker];
[TRACE]                            ^~~~~~~~~~~
[TRACE]                            mediaPicker_
[TRACE] app/build/iphone/Classes/MediaModule.m:2177:48: note: 'mediaPicker_' declared here
[TRACE] - (void)mediaPicker:(MPMediaPickerController *)mediaPicker_ didPickMediaItems:(MPMediaItemCollection *)collection
[TRACE]                                                ^
[TRACE] app/build/iphone/Classes/MediaModule.m:2202:26: error: use of undeclared identifier 'musicPicker'; did you mean 'mediaPicker_'?
[TRACE]   [self closeModalPicker:musicPicker];
[TRACE]                          ^~~~~~~~~~~
[TRACE]                          mediaPicker_
[TRACE] app/build/iphone/Classes/MediaModule.m:2200:57: note: 'mediaPicker_' declared here
[TRACE] - (void)mediaPickerDidCancel:(MPMediaPickerController *)mediaPicker_
[TRACE]                                                         ^
[TRACE] 2 errors generated.
[TRACE]  
```

**Test**
* create an empty app
* just add 
```js
 Ti.Media.queryMusicLibrary({
 	mediaType: {
 		value: Ti.Media.MUSIC_MEDIA_TYPE_MUSIC
 	}
 });
```
* make a store build

in case needed but I think its not needed to compile it:
```xml
<key>NSAppleMusicUsageDescription</key>
<string>Text</string>
```