### PR TITLE
fix(ios): textarea contentHeight fix with new return property textareaHeight in "change" event  #13413

### DIFF
--- a/iphone/Classes/TiUITextArea.m
+++ b/iphone/Classes/TiUITextArea.m
@@ -337,6 +337,14 @@
 
 - (void)textViewDidChange:(UITextView *)tv
 {
+  CGFloat height = tv.contentSize.height;
+  NSNumber *textareaHeight = [NSNumber numberWithFloat:tv.contentSize.height];
+  NSMutableDictionary *event = [NSMutableDictionary dictionary];
+  [event setValue:textareaHeight forKey:@"textareaHeight"];
+  if ([self.proxy _hasListeners:@"contentChange"]) {
+    [self.proxy fireEvent:@"contentChange" withObject:event];
+  }
+
   [(TiUITextAreaProxy *)[self proxy] noteValueChange:[(UITextView *)textWidgetView text]];
 }
 


### PR DESCRIPTION
added new event for contentHeight of textarea