### PR TITLE
fix(docs): remove deprecated parameter from example

### DIFF
--- a/apidoc/Titanium/UI/TableView.yml
+++ b/apidoc/Titanium/UI/TableView.yml
@@ -1711,50 +1711,50 @@ examples:
 
         for (var i=1; i<=20; i++){
           var row = Ti.UI.createTableViewRow({
-            className:'forumEvent', // used to improve table performance
-            selectedBackgroundColor:'white',
-            rowIndex:i, // custom property, useful for determining the row during events
-            height:110
+            className: 'forumEvent', // used to improve table performance
+            backgroundSelectedColor: 'white',
+            rowIndex: i, // custom property, useful for determining the row during events
+            height: 110
           });
 
           var imageAvatar = Ti.UI.createImageView({
             image: IMG_BASE + 'custom_tableview/user.png',
-            left:10, top:5,
-            width:50, height:50
+            left: 10, top: 5,
+            width: 50, height: 50
           });
           row.add(imageAvatar);
 
           var labelUserName = Ti.UI.createLabel({
-            color:'#576996',
-            font:{fontFamily:'Arial', fontSize:defaultFontSize+6, fontWeight:'bold'},
-            text:'Fred Smith ' + i,
-            left:70, top: 6,
-            width:200, height: 30
+            color: '#576996',
+            font: {fontFamily:'Arial', fontSize: defaultFontSize+6, fontWeight: 'bold'},
+            text: 'Fred Smith ' + i,
+            left: 70, top: 6,
+            width: 200, height: 30
           });
           row.add(labelUserName);
 
           var labelDetails = Ti.UI.createLabel({
-            color:'#222',
-            font:{fontFamily:'Arial', fontSize:defaultFontSize+2, fontWeight:'normal'},
-            text:'Replied to post with id ' + randomInt(1000) + '.',
-            left:70, top:44,
-            width:360
+            color: '#222',
+            font: {fontFamily:'Arial', fontSize: defaultFontSize+2, fontWeight: 'normal'},
+            text: 'Replied to post with id ' + randomInt(1000) + '.',
+            left: 70, top: 44,
+            width: 360
           });
           row.add(labelDetails);
 
           var imageCalendar = Ti.UI.createImageView({
-            image:IMG_BASE + 'custom_tableview/eventsButton.png',
-            left:70, bottom: 2,
-            width:32, height: 32
+            image: IMG_BASE + 'custom_tableview/eventsButton.png',
+            left: 70, bottom: 2,
+            width: 32, height: 32
           });
           row.add(imageCalendar);
 
           var labelDate = Ti.UI.createLabel({
-            color:'#999',
-            font:{fontFamily:'Arial', fontSize:defaultFontSize, fontWeight:'normal'},
-            text:'on ' + randomInt(30) + ' Nov 2012',
-            left:105, bottom:10,
-            width:200, height:20
+            color: '#999',
+            font: {fontFamily:'Arial', fontSize: defaultFontSize, fontWeight: 'normal'},
+            text: 'on ' + randomInt(30) + ' Nov 2012',
+            left: 105, bottom: 10,
+            width: 200, height: 20
           });
           row.add(labelDate);
 
@@ -1762,8 +1762,8 @@ examples:
         }
 
         var tableView = Ti.UI.createTableView({
-          backgroundColor:'white',
-          data:tableData
+          backgroundColor: 'white',
+          data: tableData
         });
 
         win.add(tableView);


### PR DESCRIPTION
In the TableView example it still uses `selectedBackgroundColor` and will show a deprecation warning. Change it to`backgroundSelectedColor` and added spaces after the `:` signs.