### PR TITLE
Fix module example application build parameters : target & deviceId

### DIFF
--- a/android/cli/commands/_buildModule.js
+++ b/android/cli/commands/_buildModule.js
@@ -194,6 +194,8 @@ AndroidModuleBuilder.prototype.validate = function validate(logger, config, cli)
 	return function (finished) {
 		this.projectDir = cli.argv['project-dir'];
 		this.buildOnly = cli.argv['build-only'];
+		this.target = cli.argv['target'];
+		this.deviceId = cli.argv['device-id'];
 
 		this.cli = cli;
 		this.logger = logger;
@@ -889,7 +891,15 @@ AndroidModuleBuilder.prototype.runModule = async function (cli) {
 
 	// Run the temp app.
 	this.logger.debug(__('Running example project...', tmpDir.cyan));
-	const buildArgs = [ process.argv[1], 'build', '-p', 'android', '-d', tmpProjectDir ];
+	let buildArgs = [ process.argv[1], 'build', '-p', 'android', '-d', tmpProjectDir ];
+	if (this.target) {
+		buildArgs.push('-T');
+		buildArgs.push(this.target);
+	}
+	if (this.deviceId) {
+		buildArgs.push('-C');
+		buildArgs.push(this.deviceId);
+	}
 	await runTiCommand(process.execPath, buildArgs, this.logger);
 };
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "android": "node ./build/scons cleanbuild android",
     "build": "node ./build/scons build",
-    "build:local": "node ./build/scons build && node ./build/scons package --skip-zip && ./build/scons install",
+    "build:local": "node ./build/scons build && node ./build/scons package --skip-zip && node ./build/scons install",
     "build:android": "npm run build -- android",
     "build:changelog": "conventional-changelog -n changelog/config.js -i CHANGELOG.md -s -p angular",
     "build:docs": "docgen apidoc -o ./dist",


### PR DESCRIPTION
**GitHub discussions:** https://github.com/tidev/vscode-titanium/issues/993

When building a module, this apply the command line parameters target & device Id to the build of the module application.

Building a module with 
`ti build --target device --device-id AAAB`
will result in building the module example application with the same parameters
`ti build --target device --device-id AAAB`

Before, the module application was built without those two parameters regardless if they have been used in the module build comand line

NB: also fix package.json build:local command
