### PR TITLE
fix(build): fix windows build of Titanium SDK - titanium_mobile

### DIFF
--- a/build/lib/packager.js
+++ b/build/lib/packager.js
@@ -31,7 +31,7 @@ const TITANIUM_PREP_LOCATIONS = [
  */
 async function zip(cwd, filename) {
 	const command = os.platform() === 'win32' ? path.join(ROOT_DIR, 'build/win32/zip') : 'zip';
-	await exec(`${command} -9 -q -r -y "${path.join('..', path.basename(filename))}" *`, { cwd });
+	await exec(`${command} -9 -q -r "${path.join('..', path.basename(filename))}" *`, { cwd });
 
 	const outputFolder = path.resolve(cwd, '..');
 	const outputFile = path.join(outputFolder, path.basename(filename));

--- a/build/lib/packager.js
+++ b/build/lib/packager.js
@@ -31,7 +31,8 @@ const TITANIUM_PREP_LOCATIONS = [
  */
 async function zip(cwd, filename) {
 	const command = os.platform() === 'win32' ? path.join(ROOT_DIR, 'build/win32/zip') : 'zip';
-	await exec(`${command} -9 -q -r "${path.join('..', path.basename(filename))}" *`, { cwd });
+	const params = os.platform() === 'win32' ? '-9 -q -r' : '-9 -q -r -y';
+	await exec(`${command} ${params} "${path.join('..', path.basename(filename))}" *`, { cwd });
 
 	const outputFolder = path.resolve(cwd, '..');
 	const outputFile = path.join(outputFolder, path.basename(filename));

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "android": "node ./build/scons cleanbuild android",
     "build": "node ./build/scons build",
-    "build:local": "node ./build/scons build && node ./build/scons package --skip-zip && ./build/scons install",
+    "build:local": "node ./build/scons build && node ./build/scons package --skip-zip && node ./build/scons install",
     "build:android": "npm run build -- android",
     "build:changelog": "conventional-changelog -n changelog/config.js -i CHANGELOG.md -s -p angular",
     "build:docs": "docgen apidoc -o ./dist",


### PR DESCRIPTION
Thoses are two small changes required to build titanium_mobile project on windows : 
1 - **node** command is missing in **package.json** for **build:local** (in the last part of the command line)
2 - **packager.js** use an unknow flag (-y) for zip tool on windows
