### PR TITLE
Fix changelog generation

### DIFF
--- a/changelog/config.js
+++ b/changelog/config.js
@@ -360,10 +360,9 @@ module.exports = {
 				}
 				eosDate.setMonth(eosDate.getMonth() + 6);
 			}
-			const yyyy = eosDate.getUTCFullYear();
-			const mm = (eosDate.getUTCMonth() + 1).toString().padStart(2, '0');
-			const dd = eosDate.getUTCDate().toString().padStart(2, '0');
-			context.eosDate = `${yyyy}-${mm}-${dd}}`;
+
+			// yyyy-mm-dd
+			context.eosDate = eosDate.toISOString().split('T')[0];
 
 			// Gather up the modules shipped with this version and toss into a variable we can put into the changelog
 			const modules = gatherModules();

--- a/changelog/config.js
+++ b/changelog/config.js
@@ -2,7 +2,6 @@
 
 const path = require('path');
 const semver = require('semver');
-const dateFormat = require('dateformat');
 const fs = require('fs-extra');
 // eslint-disable-next-line security/detect-child-process
 const execSync = require('child_process').execSync;
@@ -361,7 +360,10 @@ module.exports = {
 				}
 				eosDate.setMonth(eosDate.getMonth() + 6);
 			}
-			context.eosDate = dateFormat(eosDate, 'yyyy-mm-dd', true);
+			const yyyy = eosDate.getUTCFullYear();
+			const mm = (eosDate.getUTCMonth() + 1).toString().padStart(2, '0');
+			const dd = eosDate.getUTCDate().toString().padStart(2, '0');
+			context.eosDate = `${yyyy}-${mm}-${dd}}`;
 
 			// Gather up the modules shipped with this version and toss into a variable we can put into the changelog
 			const modules = gatherModules();

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,6 @@
         "core-js": "^3.18.3",
         "cz-conventional-changelog": "^3.3.0",
         "danger": "^10.6.6",
-        "dateformat": "^5.0.3",
         "eslint": "^8.13.0",
         "eslint-config-axway": "^7.0.0",
         "eslint-plugin-mocha": "^10.0.0",
@@ -7058,15 +7057,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/date-fns"
-      }
-    },
-    "node_modules/dateformat": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-5.0.3.tgz",
-      "integrity": "sha512-Kvr6HmPXUMerlLcLF+Pwq3K7apHpYmGDVqrxcDasBg86UcKeTSNWbEzU8bwdXnxnR44FtMhJAxI4Bov6Y/KUfA==",
-      "dev": true,
-      "engines": {
-        "node": ">=12.20"
       }
     },
     "node_modules/debug": {
@@ -24060,12 +24050,6 @@
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.16.1.tgz",
       "integrity": "sha512-sAJVKx/FqrLYHAQeN7VpJrPhagZc9R4ImZIWYRFZaaohR3KzmuK88touwsSwSVT8Qcbd4zoDsnGfX4GFB4imyQ==",
-      "dev": true
-    },
-    "dateformat": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-5.0.3.tgz",
-      "integrity": "sha512-Kvr6HmPXUMerlLcLF+Pwq3K7apHpYmGDVqrxcDasBg86UcKeTSNWbEzU8bwdXnxnR44FtMhJAxI4Bov6Y/KUfA==",
       "dev": true
     },
     "debug": {

--- a/package.json
+++ b/package.json
@@ -135,7 +135,6 @@
     "core-js": "^3.18.3",
     "cz-conventional-changelog": "^3.3.0",
     "danger": "^10.6.6",
-    "dateformat": "^5.0.3",
     "eslint": "^8.13.0",
     "eslint-config-axway": "^7.0.0",
     "eslint-plugin-mocha": "^10.0.0",


### PR DESCRIPTION
fix `npm run build:changelog`

The `dateformat` package is now a esm module, but we require it from `changelog/config.js` (a commonjs module).
But we can't convert `config.js` to esm, because it is required from `conventional-changelog` which is also a commonjs module.

