### PR TITLE
fix(android): lower SDK level for borderFix

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiBorderWrapperView.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiBorderWrapperView.java
@@ -105,12 +105,12 @@ public class TiBorderWrapperView extends FrameLayout
 			canvas.drawPath(outerPath, paint);
 
 			// TIMOB-16909: hack to fix anti-aliasing
-			if (Build.VERSION.SDK_INT < 31 && backgroundColor != Color.TRANSPARENT) {
+			if (Build.VERSION.SDK_INT < 30 && backgroundColor != Color.TRANSPARENT) {
 				paint.setColor(backgroundColor);
 				canvas.drawPath(innerPath, paint);
 			}
 			canvas.clipPath(innerPath);
-			if (Build.VERSION.SDK_INT < 31 && backgroundColor != Color.TRANSPARENT) {
+			if (Build.VERSION.SDK_INT < 30 && backgroundColor != Color.TRANSPARENT) {
 				canvas.drawColor(0, PorterDuff.Mode.CLEAR);
 			}
 		} else {

--- a/apidoc/Titanium/UI/View.yml
+++ b/apidoc/Titanium/UI/View.yml
@@ -1456,9 +1456,13 @@ properties:
 
   - name: borderRadius
     summary: Radius for the rounded corners of the view's border.
-    description: Each corner is rounded using an arc of a circle.
+    description: |
+        Each corner is rounded using an arc of a circle.
         Values for each corner can be specified. For example, '20px 20px' will set both left and right corners to `20px`.
         Specifying '20px 20px 20px 20px' will set top-left, top-right, bottom-right and bottom-left corners in that order.
+
+        If you have issues with dark artifacts on Android you can try to disable Hardware acceleration by setting a
+        `backgroundColor` with a small amount of transparency: `backgroundColor:"rgba(255,255,255,254)"`.
     type: [Number, String, Array<Number>, Array<String>]
     default: 0
     osver: {android: {min: "5.0"}}


### PR DESCRIPTION
In my old PR https://github.com/tidev/titanium_mobile/pull/13283 ` fix(android): roundBorder fix for Android 12+` I've added a check so the fix will only be used for Android 12+ since in my tests only those were affected by the issue.

In Slack a user pointed out that a Samsung device with Android 11 is having those issues with 11.0.0.RC:
![android-11---11 0 0 RC](https://user-images.githubusercontent.com/4334997/170476124-9d89bbc5-a6e8-47d4-878d-3995f3b0996b.jpg)

This PR will lower the SDK version for the patch to Android 11. 

I've tested it in my simulator:
![Screenshot_1653485697](https://user-images.githubusercontent.com/4334997/170476226-0069fe10-4daa-46a1-a122-d9ecc117dc9e.png)
and it didn't make a difference for me (which is great) but the Samsung device looks fine now :+1: 
