### PR TITLE
build: wired up regen build registry

### DIFF
--- a/.github/workflows/regen-builds.yml
+++ b/.github/workflows/regen-builds.yml
@@ -5,6 +5,9 @@ on:
   workflow_run:
     workflows: [Build]
     types: [completed]
+    branches:
+    - master
+    - "[0-9]+_[0-9]+_X"
 
 jobs:
   on-success:

--- a/.github/workflows/regen-builds.yml
+++ b/.github/workflows/regen-builds.yml
@@ -1,0 +1,20 @@
+name: Regen Builds
+on:
+  release:
+    types: [published, released]
+  workflow_run:
+    workflows: [Build]
+    types: [completed]
+
+jobs:
+  on-success:
+    runs-on: ubuntu-latest
+    name: Regenerate build
+    steps:
+    - name: Repository Dispatch
+      if: github.event.workflow_run.conclusion == 'success'
+      uses: peter-evans/repository-dispatch@v2
+      with:
+        event-type: regen-builds
+        repository: tidev/downloads-www
+        token: ${{ secrets.REGEN_BUILDS_DOCS_GITHUB_TOKEN }}


### PR DESCRIPTION
This GitHub action should notify the regen-builds action in the downloads-www repo to fetch and update the static build registry JSON files.