### PR TITLE
ci: restrict the regen actions to the tidev org

### DIFF
--- a/.github/workflows/regen-builds.yml
+++ b/.github/workflows/regen-builds.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   on-success:
+    if: github.repository_owner == 'tidev'
     runs-on: ubuntu-latest
     name: Regenerate build
     steps:

--- a/.github/workflows/regen-docs.yml
+++ b/.github/workflows/regen-docs.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   regen:
-    if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
+    if: github.repository_owner == 'tidev' && (github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     name: Trigger Regen
 


### PR DESCRIPTION
This is so that forks don't get failures for these actions
