### PR TITLE
fix(ios): fix asset catalog regression

### DIFF
--- a/cli/lib/gather.js
+++ b/cli/lib/gather.js
@@ -278,9 +278,6 @@ class Categorizer {
 							results.imageAssets.set(relPath, info);
 							return;
 						}
-					} else {
-						results.imageAssets.set(relPath, info);
-						return;
 					}
 				}
 				// fall through to lump with JPG...


### PR DESCRIPTION
Fixes a regression caused by https://github.com/tidev/titanium_mobile/pull/13484. The else-case did not exist before. Removing it again fixes the crash.