### PR TITLE
feat(android): add position to TableView scrollToIndex

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TableViewProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TableViewProxy.java
@@ -12,6 +12,7 @@ import java.util.List;
 
 import org.appcelerator.kroll.KrollDict;
 import org.appcelerator.kroll.annotations.Kroll;
+import org.appcelerator.titanium.TiApplication;
 import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.TiDimension;
 import org.appcelerator.titanium.proxy.TiViewProxy;
@@ -21,6 +22,8 @@ import android.app.Activity;
 import android.view.View;
 
 import androidx.recyclerview.selection.SelectionTracker;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.LinearSmoothScroller;
 import androidx.recyclerview.widget.RecyclerView;
 
 import ti.modules.titanium.ui.widget.TiUITableView;
@@ -797,6 +800,14 @@ public class TableViewProxy extends RecyclerViewProxy
 	{
 		final TiTableView tableView = getTableView();
 		final boolean animated = animation == null || animation.optBoolean(TiC.PROPERTY_ANIMATED, true);
+		final int position = animation != null ? animation.optInt(TiC.PROPERTY_POSITION, 0) : 0;
+		final RecyclerView.SmoothScroller smoothScrollerToTop =
+			new LinearSmoothScroller(TiApplication.getAppCurrentActivity())
+			{
+				@Override
+				protected int getVerticalSnapPreference()
+				{ return LinearSmoothScroller.SNAP_TO_START; }
+			};
 
 		if (tableView != null) {
 			final RecyclerView recyclerView = tableView.getRecyclerView();
@@ -808,9 +819,19 @@ public class TableViewProxy extends RecyclerViewProxy
 					final int rowAdapterIndex = tableView.getAdapterIndex(index);
 					final Runnable action = () -> {
 						if (animated) {
-							recyclerView.smoothScrollToPosition(rowAdapterIndex);
+							if (position == ListViewScrollPositionModule.TOP) {
+								smoothScrollerToTop.setTargetPosition(rowAdapterIndex);
+								recyclerView.getLayoutManager().startSmoothScroll(smoothScrollerToTop);
+							} else {
+								recyclerView.smoothScrollToPosition(rowAdapterIndex);
+							}
 						} else {
-							recyclerView.scrollToPosition(rowAdapterIndex);
+							if (position == ListViewScrollPositionModule.TOP) {
+								((LinearLayoutManager) recyclerView.getLayoutManager())
+									.scrollToPositionWithOffset(rowAdapterIndex, 0);
+							} else {
+								recyclerView.scrollToPosition(rowAdapterIndex);
+							}
 						}
 					};
 

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TableViewScrollPositionModule.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TableViewScrollPositionModule.java
@@ -1,0 +1,31 @@
+/**
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2009-2020 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+package ti.modules.titanium.ui;
+
+import org.appcelerator.kroll.KrollModule;
+import org.appcelerator.kroll.annotations.Kroll;
+
+import ti.modules.titanium.ui.UIModule;
+
+@Kroll.module(parentModule = UIModule.class)
+public class TableViewScrollPositionModule extends KrollModule
+{
+	@Kroll.constant
+	public static final int TOP = 1;
+	@Kroll.constant
+	public static final int BOTTOM = 2;
+	@Kroll.constant
+	public static final int MIDDLE = 3;
+	@Kroll.constant
+	public static final int NONE = 0;
+
+	@Override
+	public String getApiName()
+	{
+		return "Ti.UI.TableViewScrollPositionModule";
+	}
+}

--- a/apidoc/Titanium/UI/ListViewScrollPosition.yml
+++ b/apidoc/Titanium/UI/ListViewScrollPosition.yml
@@ -6,7 +6,7 @@ summary: |
     `deleteSectionAt`, `insertSectionAt` and `replaceSectionAt` methods.
 extends: Titanium.Proxy
 platforms: [android, iphone, ipad, macos]
-since: {android: "10.2.0", iphone: "5.4.0", ipad: "5.4.0", macos: "9.2.0"}
+since: 11.1.0
 excludes:
     properties: [bubbleParent]
     methods: [addEventListener, applyProperties, fireEvent, removeEventListener]

--- a/apidoc/Titanium/UI/TableView.yml
+++ b/apidoc/Titanium/UI/TableView.yml
@@ -1823,8 +1823,8 @@ properties:
   - name: position
     summary: Specifies what position to scroll the selected row to.
     type: Number
-    constants: Titanium.UI.iOS.TableViewScrollPosition.*
-    default: <Titanium.UI.iOS.TableViewScrollPosition.NONE>
+    constants: Titanium.UI.TableViewScrollPosition.*
+    default: <Titanium.UI.TableViewScrollPosition.NONE>
 
 ---
 name: TableViewIndexEntry

--- a/apidoc/Titanium/UI/TableViewScrollPosition.yml
+++ b/apidoc/Titanium/UI/TableViewScrollPosition.yml
@@ -1,14 +1,11 @@
 ---
-name: Titanium.UI.iOS.TableViewScrollPosition
-deprecated:
-    since: 11.1.0
-    notes: Use [Titanium.UI.ListViewScrollPosition](Titanium.UI.ListViewScrollPosition) instead.
+name: Titanium.UI.TableViewScrollPosition
 summary: |
     A set of constants for the position value that can be used for the `position` property of
     <Titanium.UI.TableView> when invoking `scrollToIndex`.
 extends: Titanium.Proxy
-platforms: [iphone, ipad, macos]
-since: {iphone: "5.4.0", ipad: "5.4.0", macos: "9.2.0"}
+platforms: [android, iphone, ipad, macos]
+since: 11.1.0
 createable: false
 properties:
   - name: BOTTOM

--- a/apidoc/Titanium/UI/iOS/ListViewScrollPosition.yml
+++ b/apidoc/Titanium/UI/iOS/ListViewScrollPosition.yml
@@ -1,7 +1,10 @@
 ---
 name: Titanium.UI.iOS.ListViewScrollPosition
+deprecated:
+    since: 11.1.0
+    notes: Use [Titanium.UI.ListViewScrollPosition](Titanium.UI.ListViewScrollPosition) instead.
 summary: |
-    A set of constants for the position value that can be used for the `position` property of 
+    A set of constants for the position value that can be used for the `position` property of
     <ListViewAnimationProperties> when invoking the ListView's `scrollToItem`, `appendSection`,
     `deleteSectionAt`, `insertSectionAt` and `replaceSectionAt` methods.
 extends: Titanium.Proxy
@@ -16,12 +19,12 @@ properties:
     summary: The list view scrolls the row of interest to the bottom of the visible list view.
     type: Number
     permission: read-only
-    
+
   - name: MIDDLE
     summary: The list view scrolls the row of interest to the middle of the list table view.
     type: Number
     permission: read-only
-    
+
   - name: NONE
     summary: |
         The table view scrolls the row of interest to be fully visible with a minimal movement.
@@ -29,7 +32,7 @@ properties:
         visible area, the behavior is identical to that specified by `TOP`. This is the default.
     type: Number
     permission: read-only
-    
+
   - name: TOP
     summary: The list view scrolls the row of interest to the top of the visible list view.
     type: Number


### PR DESCRIPTION
Adds the position (top, bottom) to `scrollToIndex` for Androids TableView

```js
var win = Ti.UI.createWindow();
var btn = Ti.UI.createButton({
	title: "scroll"
});
btn.addEventListener("click", function() {
	table.scrollToIndex(50, {
		animated: true,
		position: Ti.UI.TableViewScrollPosition.TOP // Ti.UI.TableViewScrollPosition.BOTTOM
	});
})
var tableData = [];
for (var i = 0; i < 1000; i++) {
	tableData.push({
		title: "Row " + i
	});
}

var table = Ti.UI.createTableView({
	data: tableData
});
win.add([table, btn]);
win.open();
```

ListView was added in https://github.com/tidev/titanium_mobile/pull/13251 already and iOS TableView. Androids TableView was missing!

* added deprecation note for `.iOS.` namespace