### PR TITLE
chore: add „movestart“ and "moveend" events to drag and drop

### DIFF
--- a/android/app/src/main/assets/Resources/app.js
+++ b/android/app/src/main/assets/Resources/app.js
@@ -1,55 +1,57 @@
-'use strict';
+const myTemplate = {
+	childTemplates: [
+		{
+			type: 'Ti.UI.Label',
+			bindId: 'title',
+			properties: {
+				left: 15,
+				color: 'black'
+			}
+		}
+	]
+};
 
-// create tab group
-const tabGroup = Titanium.UI.createTabGroup({
-	style: Ti.UI.Android.TABS_STYLE_BOTTOM_NAVIGATION,
+const win = Ti.UI.createWindow({
+	backgroundColor: '#fff'
 });
 
-//
-// create base UI tab and root window
-//
-const win1 = Titanium.UI.createWindow({
-	title: 'Tab 1',
-});
-const tab1 = Titanium.UI.createTab({
-	icon: 'KS_nav_views.png',
-	title: 'Tab 1',
-	window: win1
+const listView = Ti.UI.createListView({
+	templates: { template: myTemplate },
+	requiresEditingToMove: false,
+	defaultItemTemplate: 'template',
+	sections: [
+		Ti.UI.createListSection({
+			headerTitle: 'Section 1',
+			items: [
+				{ properties: { canMove: true, height: 43 }, title: { text: 'Title 1' } },
+				{ properties: { canMove: true, height: 43 }, title: { text: 'Title 2' } },
+				{ properties: { canMove: true, height: 43 }, title: { text: 'Title 3' } },
+				{ properties: { canMove: true, height: 43 }, title: { text: 'Title 4' } }
+			]
+		}),
+		Ti.UI.createListSection({
+			headerTitle: 'Section 1',
+			items: [
+				{ properties: { canMove: true, height: 43 }, title: { text: 'Title 1' } },
+				{ properties: { canMove: true, height: 43 }, title: { text: 'Title 2' } },
+				{ properties: { canMove: true, height: 43 }, title: { text: 'Title 3' } },
+				{ properties: { canMove: true, height: 43 }, title: { text: 'Title 4' } }
+			]
+		})
+	]
 });
 
-const label1 = Titanium.UI.createLabel({
-	text: 'I am Window 1',
-	font: { fontSize: 20, fontFamily: 'Helvetica Neue' },
-	textAlign: 'center',
-	width: 'auto'
+listView.addEventListener('movestart', () => {
+	console.warn('STARTED MOVING');
 });
 
-win1.add(label1);
-
-//
-// create controls tab and root window
-//
-const win2 = Titanium.UI.createWindow({
-	title: 'Tab 2',
+listView.addEventListener('moveend', () => {
+	console.warn('STOPPED MOVING');
 });
-const tab2 = Titanium.UI.createTab({
-	icon: 'KS_nav_ui.png',
-	title: 'Tab 2',
-	window: win2
-});
-var label2 = Titanium.UI.createLabel({
-	text: 'I am Window 2',
-	font: { fontSize: 20, fontFamily: 'Helvetica Neue' },
-	textAlign: 'center',
-	width: 'auto'
-});
-win2.add(label2);
 
-//
-//  add tabs
-//
-tabGroup.addTab(tab1);
-tabGroup.addTab(tab2);
+listView.addEventListener('move', () => {
+	console.warn('FINISHED MOVING');
+});
 
-// open tab group
-tabGroup.open();
+win.add(listView);
+win.open();

--- a/android/app/src/main/assets/Resources/app.js
+++ b/android/app/src/main/assets/Resources/app.js
@@ -1,57 +1,55 @@
-const myTemplate = {
-	childTemplates: [
-		{
-			type: 'Ti.UI.Label',
-			bindId: 'title',
-			properties: {
-				left: 15,
-				color: 'black'
-			}
-		}
-	]
-};
+'use strict';
 
-const win = Ti.UI.createWindow({
-	backgroundColor: '#fff'
+// create tab group
+const tabGroup = Titanium.UI.createTabGroup({
+	style: Ti.UI.Android.TABS_STYLE_BOTTOM_NAVIGATION,
 });
 
-const listView = Ti.UI.createListView({
-	templates: { template: myTemplate },
-	requiresEditingToMove: false,
-	defaultItemTemplate: 'template',
-	sections: [
-		Ti.UI.createListSection({
-			headerTitle: 'Section 1',
-			items: [
-				{ properties: { canMove: true, height: 43 }, title: { text: 'Title 1' } },
-				{ properties: { canMove: true, height: 43 }, title: { text: 'Title 2' } },
-				{ properties: { canMove: true, height: 43 }, title: { text: 'Title 3' } },
-				{ properties: { canMove: true, height: 43 }, title: { text: 'Title 4' } }
-			]
-		}),
-		Ti.UI.createListSection({
-			headerTitle: 'Section 1',
-			items: [
-				{ properties: { canMove: true, height: 43 }, title: { text: 'Title 1' } },
-				{ properties: { canMove: true, height: 43 }, title: { text: 'Title 2' } },
-				{ properties: { canMove: true, height: 43 }, title: { text: 'Title 3' } },
-				{ properties: { canMove: true, height: 43 }, title: { text: 'Title 4' } }
-			]
-		})
-	]
+//
+// create base UI tab and root window
+//
+const win1 = Titanium.UI.createWindow({
+	title: 'Tab 1',
+});
+const tab1 = Titanium.UI.createTab({
+	icon: 'KS_nav_views.png',
+	title: 'Tab 1',
+	window: win1
 });
 
-listView.addEventListener('movestart', () => {
-	console.warn('STARTED MOVING');
+const label1 = Titanium.UI.createLabel({
+	text: 'I am Window 1',
+	font: { fontSize: 20, fontFamily: 'Helvetica Neue' },
+	textAlign: 'center',
+	width: 'auto'
 });
 
-listView.addEventListener('moveend', () => {
-	console.warn('STOPPED MOVING');
-});
+win1.add(label1);
 
-listView.addEventListener('move', () => {
-	console.warn('FINISHED MOVING');
+//
+// create controls tab and root window
+//
+const win2 = Titanium.UI.createWindow({
+	title: 'Tab 2',
 });
+const tab2 = Titanium.UI.createTab({
+	icon: 'KS_nav_ui.png',
+	title: 'Tab 2',
+	window: win2
+});
+var label2 = Titanium.UI.createLabel({
+	text: 'I am Window 2',
+	font: { fontSize: 20, fontFamily: 'Helvetica Neue' },
+	textAlign: 'center',
+	width: 'auto'
+});
+win2.add(label2);
 
-win.add(listView);
-win.open();
+//
+//  add tabs
+//
+tabGroup.addTab(tab1);
+tabGroup.addTab(tab2);
+
+// open tab group
+tabGroup.open();

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TableViewProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TableViewProxy.java
@@ -310,6 +310,14 @@ public class TableViewProxy extends RecyclerViewProxy
 	}
 
 	/**
+	 * Called when item drag-and-drop movement has started.
+	 */
+	public void onMoveItemStarted()
+	{
+		fireEvent(TiC.EVENT_MOVE_START, new KrollDict());
+	}
+
+	/**
 	 * Called when row drag-and-drop movement has ended.
 	 *
 	 * @param adapterIndex Index of position the row was dragged in adapter list.

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TableViewProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TableViewProxy.java
@@ -310,14 +310,6 @@ public class TableViewProxy extends RecyclerViewProxy
 	}
 
 	/**
-	 * Called when item drag-and-drop movement has started.
-	 */
-	public void onMoveItemStarted()
-	{
-		fireEvent(TiC.EVENT_MOVE_START, new KrollDict());
-	}
-
-	/**
 	 * Called when row drag-and-drop movement has ended.
 	 *
 	 * @param adapterIndex Index of position the row was dragged in adapter list.
@@ -332,6 +324,21 @@ public class TableViewProxy extends RecyclerViewProxy
 				rowProxy.fireEvent(TiC.EVENT_MOVE, null);
 			}
 		}
+	}
+	/**
+	 * Called when starting a drag-and-drop gesture (touch start)
+	 */
+	public void onMoveGestureStarted()
+	{
+		fireEvent(TiC.EVENT_MOVE_START, null);
+	}
+
+	/**
+	 * Called when starting a drag-and-drop gesture (touch end)
+	 */
+	public void onMoveGestureEnded()
+	{
+		fireEvent(TiC.EVENT_MOVE_END, null);
 	}
 
 	/**

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/ItemTouchHandler.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/ItemTouchHandler.java
@@ -39,6 +39,7 @@ public class ItemTouchHandler extends ItemTouchHelper.SimpleCallback
 	private int moveEndIndex = -1;
 	private Drawable icon;
 	private final ColorDrawable background;
+	private boolean hasTouchStarted = false;
 
 	@SuppressLint("ClickableViewAccessibility")
 	public ItemTouchHandler(@NonNull TiRecyclerViewAdapter adapter,
@@ -56,7 +57,11 @@ public class ItemTouchHandler extends ItemTouchHelper.SimpleCallback
 			@Override
 			public boolean onTouch(View v, MotionEvent event)
 			{
-				if (event.getAction() == MotionEvent.ACTION_UP) {
+				if (event.getAction() == MotionEvent.ACTION_MOVE && !hasTouchStarted) {
+					recyclerViewProxy.onMoveItemStarted();
+					hasTouchStarted = true;
+				} else if (event.getAction() == MotionEvent.ACTION_UP) {
+					hasTouchStarted = false;
 					if (moveEndIndex >= 0) {
 						// Notify owner that item movement has ended. Will fire a "move" event.
 						recyclerViewProxy.onMoveItemEnded(moveEndIndex);

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/ItemTouchHandler.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/ItemTouchHandler.java
@@ -39,7 +39,7 @@ public class ItemTouchHandler extends ItemTouchHelper.SimpleCallback
 	private int moveEndIndex = -1;
 	private Drawable icon;
 	private final ColorDrawable background;
-	private boolean hasTouchStarted = false;
+	private boolean hasMoveStarted = false;
 
 	@SuppressLint("ClickableViewAccessibility")
 	public ItemTouchHandler(@NonNull TiRecyclerViewAdapter adapter,
@@ -57,12 +57,12 @@ public class ItemTouchHandler extends ItemTouchHelper.SimpleCallback
 			@Override
 			public boolean onTouch(View v, MotionEvent event)
 			{
-				if (event.getAction() == MotionEvent.ACTION_MOVE && !hasTouchStarted) {
+				if (event.getAction() == MotionEvent.ACTION_MOVE && !hasMoveStarted) {
 					recyclerViewProxy.onMoveGestureStarted();
-					hasTouchStarted = true;
+					hasMoveStarted = true;
 				} else if (event.getAction() == MotionEvent.ACTION_UP) {
 					recyclerViewProxy.onMoveGestureEnded();
-					hasTouchStarted = false;
+					hasMoveStarted = false;
 
 					if (moveEndIndex >= 0) {
 						// Notify owner that item movement has ended. Will fire a "move" event.

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/ItemTouchHandler.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/ItemTouchHandler.java
@@ -58,10 +58,12 @@ public class ItemTouchHandler extends ItemTouchHelper.SimpleCallback
 			public boolean onTouch(View v, MotionEvent event)
 			{
 				if (event.getAction() == MotionEvent.ACTION_MOVE && !hasTouchStarted) {
-					recyclerViewProxy.onMoveItemStarted();
+					recyclerViewProxy.onMoveGestureStarted();
 					hasTouchStarted = true;
 				} else if (event.getAction() == MotionEvent.ACTION_UP) {
+					recyclerViewProxy.onMoveGestureEnded();
 					hasTouchStarted = false;
+
 					if (moveEndIndex >= 0) {
 						// Notify owner that item movement has ended. Will fire a "move" event.
 						recyclerViewProxy.onMoveItemEnded(moveEndIndex);

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/ListViewProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/ListViewProxy.java
@@ -244,6 +244,14 @@ public class ListViewProxy extends RecyclerViewProxy
 	}
 
 	/**
+	 * Called when item drag-and-drop movement has started.
+	 */
+	public void onMoveItemStarted()
+	{
+		fireEvent(TiC.EVENT_MOVE_START, new KrollDict());
+	}
+
+	/**
 	 * Called when item drag-and-drop movement has ended.
 	 *
 	 * @param adapterIndex Index of position the item was dragged in adapter list.

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/ListViewProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/ListViewProxy.java
@@ -244,14 +244,6 @@ public class ListViewProxy extends RecyclerViewProxy
 	}
 
 	/**
-	 * Called when item drag-and-drop movement has started.
-	 */
-	public void onMoveItemStarted()
-	{
-		fireEvent(TiC.EVENT_MOVE_START, new KrollDict());
-	}
-
-	/**
 	 * Called when item drag-and-drop movement has ended.
 	 *
 	 * @param adapterIndex Index of position the item was dragged in adapter list.
@@ -280,6 +272,22 @@ public class ListViewProxy extends RecyclerViewProxy
 
 		// Clear last "move" event info.
 		this.moveEventInfo.clear();
+	}
+
+	/**
+	 * Called when starting a drag-and-drop gesture (touch start)
+	 */
+	public void onMoveGestureStarted()
+	{
+		fireEvent(TiC.EVENT_MOVE_START, null);
+	}
+
+	/**
+	 * Called when starting a drag-and-drop gesture (touch end)
+	 */
+	public void onMoveGestureEnded()
+	{
+		fireEvent(TiC.EVENT_MOVE_END, null);
 	}
 
 	/**

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/RecyclerViewProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/RecyclerViewProxy.java
@@ -18,7 +18,9 @@ public abstract class RecyclerViewProxy extends TiViewProxy
 
 	public abstract boolean onMoveItemStarting(int index);
 
-	public abstract  void onMoveItemStarted();
-
 	public abstract void onMoveItemEnded(int index);
+
+	public abstract  void onMoveGestureStarted();
+
+	public abstract  void onMoveGestureEnded();
 }

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/RecyclerViewProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/RecyclerViewProxy.java
@@ -18,5 +18,7 @@ public abstract class RecyclerViewProxy extends TiViewProxy
 
 	public abstract boolean onMoveItemStarting(int index);
 
+	public abstract  void onMoveItemStarted();
+
 	public abstract void onMoveItemEnded(int index);
 }

--- a/android/titanium/src/java/org/appcelerator/titanium/TiC.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiC.java
@@ -147,6 +147,7 @@ public class TiC
 	public static final String EVENT_PROPERTY_FORCE = "force";
 	public static final String EVENT_PROPERTY_SIZE = "size";
 	public static final String EVENT_MOVE = "move";
+	public static final String EVENT_MOVE_START = "movestart";
 	public static final String EVENT_REFRESH_END = "refreshend";
 	public static final String EVENT_REFRESH_START = "refreshstart";
 	public static final String EVENT_REGION_CHANGED = "regionchanged";

--- a/android/titanium/src/java/org/appcelerator/titanium/TiC.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiC.java
@@ -148,6 +148,7 @@ public class TiC
 	public static final String EVENT_PROPERTY_SIZE = "size";
 	public static final String EVENT_MOVE = "move";
 	public static final String EVENT_MOVE_START = "movestart";
+	public static final String EVENT_MOVE_END = "moveend";
 	public static final String EVENT_REFRESH_END = "refreshend";
 	public static final String EVENT_REFRESH_START = "refreshstart";
 	public static final String EVENT_REGION_CHANGED = "regionchanged";

--- a/apidoc/Titanium/UI/ListView.yml
+++ b/apidoc/Titanium/UI/ListView.yml
@@ -387,8 +387,14 @@ events:
   - name: movestart
     summary: Fired when a list row has started moving.
     description: |
-      This property can be used to change the UI once a new drag-and-drop interaction occurs. There is no additional "dragend" event, since
-      that case if covered by the existing `move` event.
+      This property can be used to change the UI once a new drag-and-drop interaction starts.
+    since: "11.1.0"
+    platforms: [android, iphone, ipad, macos]
+
+  - name: moveend
+    summary: Fired when a list row has ended moving.
+    description: |
+      This property can be used to change the UI once a drag-and-drop interaction ends.
     since: "11.1.0"
     platforms: [android, iphone, ipad, macos]
 

--- a/apidoc/Titanium/UI/ListView.yml
+++ b/apidoc/Titanium/UI/ListView.yml
@@ -384,6 +384,14 @@ events:
         summary: section item index of the reference item.
         type: Number
 
+  - name: movestart
+    summary: Fired when a list row has started moving.
+    description: |
+      This property can be used to change the UI once a new drag-and-drop interaction occurs. There is no additional "dragend" event, since
+      that case if covered by the existing `move` event.
+    since: "11.1.0"
+    platforms: [android, iphone, ipad, macos]
+
   - name: move
     summary: Fired when a list row is moved to a different location by the user.
     description: |

--- a/iphone/Classes/TiUIListView.m
+++ b/iphone/Classes/TiUIListView.m
@@ -1102,9 +1102,17 @@ static TiViewProxy *FindViewProxyWithBindIdContainingPoint(UIView *view, CGPoint
   UIDragItem *dragItem = [[UIDragItem alloc] initWithItemProvider:itemProvider];
   dragItem.localObject = identifier;
 
-  [[self proxy] fireEvent:@"movestart"];
-
   return @[ dragItem ];
+}
+
+- (void)tableView:(UITableView *)tableView dropSessionDidEnter:(id<UIDropSession>)session
+{
+  [[self proxy] fireEvent:@"movestart"];
+}
+
+- (void)tableView:(UITableView *)tableView dropSessionDidEnd:(id<UIDropSession>)session
+{
+  [[self proxy] fireEvent:@"moveend"];
 }
 
 - (void)tableView:(UITableView *)tableView performDropWithCoordinator:(id<UITableViewDropCoordinator>)coordinator

--- a/iphone/Classes/TiUIListView.m
+++ b/iphone/Classes/TiUIListView.m
@@ -1079,15 +1079,42 @@ static TiViewProxy *FindViewProxyWithBindIdContainingPoint(UIView *view, CGPoint
 - (BOOL)canInsertRowAtIndexPath:(NSIndexPath *)indexPath
 {
   id insertValue = [self valueWithKey:@"canInsert" atIndexPath:indexPath];
-  //canInsert if undefined is false
   return [TiUtils boolValue:insertValue def:NO];
 }
 
 - (BOOL)canMoveRowAtIndexPath:(NSIndexPath *)indexPath
 {
   id moveValue = [self valueWithKey:@"canMove" atIndexPath:indexPath];
-  //canMove if undefined is false
   return [TiUtils boolValue:moveValue def:NO];
+}
+
+- (nonnull NSArray<UIDragItem *> *)tableView:(nonnull UITableView *)tableView itemsForBeginningDragSession:(nonnull id<UIDragSession>)session atIndexPath:(nonnull NSIndexPath *)indexPath
+{
+  NSItemProvider *itemProvider = [NSItemProvider new];
+  NSString *identifier = [NSString stringWithFormat:@"%lu_%lu", indexPath.section, indexPath.row];
+
+  [itemProvider registerDataRepresentationForTypeIdentifier:(NSString *)kUTTypePlainText
+                                                 visibility:NSItemProviderRepresentationVisibilityAll
+                                                loadHandler:^NSProgress *_Nullable(void (^_Nonnull completionHandler)(NSData *_Nullable, NSError *_Nullable)) {
+                                                  return nil;
+                                                }];
+
+  UIDragItem *dragItem = [[UIDragItem alloc] initWithItemProvider:itemProvider];
+  dragItem.localObject = identifier;
+
+  [[self proxy] fireEvent:@"movestart"];
+
+  return @[ dragItem ];
+}
+
+- (void)tableView:(UITableView *)tableView performDropWithCoordinator:(id<UITableViewDropCoordinator>)coordinator
+{
+  // NO-OP right now
+}
+
+- (BOOL)tableView:(UITableView *)tableView canHandleDropSession:(id<UIDropSession>)session
+{
+  return [session canLoadObjectsOfClass:[NSString class]];
 }
 
 - (NSArray *)editActionsFromValue:(id)value
@@ -2559,33 +2586,6 @@ static TiViewProxy *FindViewProxyWithBindIdContainingPoint(UIView *view, CGPoint
   }
   BOOL animate = [TiUtils boolValue:@"animated" properties:properties def:NO];
   return animate ? UITableViewRowAnimationFade : UITableViewRowAnimationNone;
-}
-
-- (nonnull NSArray<UIDragItem *> *)tableView:(nonnull UITableView *)tableView itemsForBeginningDragSession:(nonnull id<UIDragSession>)session atIndexPath:(nonnull NSIndexPath *)indexPath
-{
-  NSItemProvider *itemProvider = [NSItemProvider new];
-  NSString *identifier = [NSString stringWithFormat:@"%lu_%lu", indexPath.section, indexPath.row];
-
-  [itemProvider registerDataRepresentationForTypeIdentifier:(NSString *)kUTTypePlainText
-                                                 visibility:NSItemProviderRepresentationVisibilityAll
-                                                loadHandler:^NSProgress *_Nullable(void (^_Nonnull completionHandler)(NSData *_Nullable, NSError *_Nullable)) {
-                                                  return nil;
-                                                }];
-
-  UIDragItem *dragItem = [[UIDragItem alloc] initWithItemProvider:itemProvider];
-  dragItem.localObject = identifier;
-
-  return @[ dragItem ];
-}
-
-- (void)tableView:(UITableView *)tableView performDropWithCoordinator:(id<UITableViewDropCoordinator>)coordinator
-{
-  // NO-OP right now
-}
-
-- (BOOL)tableView:(UITableView *)tableView canHandleDropSession:(id<UIDropSession>)session
-{
-  return [session canLoadObjectsOfClass:[NSString class]];
 }
 
 @end


### PR DESCRIPTION
This piece was missing - now available!

Test case (should fire the `movestart` and `moveend` event):
```js
const myTemplate = {
	childTemplates: [
		{
			type: 'Ti.UI.Label',
			bindId: 'title',
			properties: {
				left: 15,
				color: 'black'
			}
		}
	]
};

const win = Ti.UI.createWindow({
	backgroundColor: '#fff'
});

const listView = Ti.UI.createListView({
	templates: { template: myTemplate },
	requiresEditingToMove: false,
	defaultItemTemplate: 'template',
	sections: [
		Ti.UI.createListSection({
			headerTitle: 'Section 1',
			items: [
				{ properties: { canMove: true, height: 43 }, title: { text: 'Title 1' } },
				{ properties: { canMove: true, height: 43 }, title: { text: 'Title 2' } },
				{ properties: { canMove: true, height: 43 }, title: { text: 'Title 3' } },
				{ properties: { canMove: true, height: 43 }, title: { text: 'Title 4' } }
			]
		}),
		Ti.UI.createListSection({
			headerTitle: 'Section 1',
			items: [
				{ properties: { canMove: true, height: 43 }, title: { text: 'Title 1' } },
				{ properties: { canMove: true, height: 43 }, title: { text: 'Title 2' } },
				{ properties: { canMove: true, height: 43 }, title: { text: 'Title 3' } },
				{ properties: { canMove: true, height: 43 }, title: { text: 'Title 4' } }
			]
		})
	]
});

listView.addEventListener('movestart', () => {
	console.warn('STARTED MOVING GESTURE');
});

listView.addEventListener('moveend', () => {
	console.warn('STOPPED MOVING GESTURE');
});

listView.addEventListener('move', () => {
	console.warn('MOVED TO A DIFFERENT INDEX');
});

win.add(listView);
win.open();
```
