### PR TITLE
fix(ios): fix rare crash in Ti.UI.TableView

### DIFF
--- a/iphone/Classes/TiUITableView.m
+++ b/iphone/Classes/TiUITableView.m
@@ -55,7 +55,9 @@
 
 - (void)dealloc
 {
-  [proxy setCallbackCell:nil];
+  if ([proxy callbackCell] == self) {
+    [proxy setCallbackCell:nil];
+  }
 
   RELEASE_TO_NIL(proxy);
   RELEASE_TO_NIL(gradientLayer);

--- a/iphone/Classes/TiUITableView.m
+++ b/iphone/Classes/TiUITableView.m
@@ -55,7 +55,7 @@
 
 - (void)dealloc
 {
-  if ([proxy callbackCell] == self) {
+  if (proxy != nil && [proxy callbackCell] == self) {
     [proxy setCallbackCell:nil];
   }
 


### PR DESCRIPTION
Very rarely reproducible (I wasn't) when opening an closing a window containing a table-view fast. Crash:
```js
Crashed: com.apple.main-thread
0  libobjc.A.dylib                0x20c20 objc_class::isInitialized() + 36
1  libobjc.A.dylib                0x69b0 lookUpImpOrForward + 60
2  libobjc.A.dylib                0x23e4 _objc_msgSend_uncached + 68
3  MyApp                          0x34e9c -[TiUITableView dealloc] + 347 (TiUITableView.m:347)
4  libobjc.A.dylib                0x7b14 AutoreleasePoolPage::releaseUntil(objc_object**) + 196
5  libobjc.A.dylib                0x3e54 objc_autoreleasePoolPop + 212
6  CoreFoundation                 0x13dd4 _CFAutoreleasePoolPop + 32
7  CoreFoundation                 0xcaf4 __CFRunLoopPerCalloutARPEnd + 48
8  CoreFoundation                 0xb748 __CFRunLoopRun + 2600
9  CoreFoundation                 0x1ebc8 CFRunLoopRunSpecific + 600
10 GraphicsServices               0x1374 GSEventRunModal + 164
11 UIKitCore                      0x514648 -[UIApplication _run] + 1100
12 UIKitCore                      0x295d90 UIApplicationMain + 364
13 MyApp                          0xa090 main + 77 (main.m:77)
14 ???                            0x1069f1ce4 (Missing)
```

The fix is a simple guard thats used earlier in the code base as well, therefore considered to add an extra layer of checks. Please excuse that I don't have a proper test case, as I wasn't able to reproduce it myself, yet.