### PR TITLE
fix(ios): linter fix

### DIFF
--- a/cli/lib/gather.js
+++ b/cli/lib/gather.js
@@ -273,7 +273,7 @@ class Categorizer {
 					}
 					if (this.excludeAssestsDir !== null) {
 						let testPath = this.excludeAssestsDir;
-						const checkRegEx = new RegExp(`${testPath}`);
+						const checkRegEx = new RegExp(testPath);
 						if (!relPath.match(checkRegEx)) {
 							results.imageAssets.set(relPath, info);
 							return;
@@ -312,7 +312,7 @@ class Categorizer {
 					if (this.useAppThinning && !relPath.match(BUNDLE_FILE_REGEXP)) {
 						if (this.excludeAssestsDir !== null) {
 							let testPath = this.excludeAssestsDir;
-							const checkRegEx = new RegExp(`${testPath}`);
+							const checkRegEx = new RegExp(testPath);
 							if (!relPath.match(checkRegEx)) {
 								results.imageAssets.set(relPath, info);
 								return;


### PR DESCRIPTION
@hansemannn @mbender74 can you test this (introduced in https://github.com/tidev/titanium_mobile/pull/13484)? It should fix the warning `Unchanged files with check annotations` that is below every PR now (e.g. https://github.com/tidev/titanium_mobile/pull/13514/files)

If I run
```js
var testPath = "test";
var checkRegEx = new RegExp(`${testPath}`);
console.log("test".match(checkRegEx));


var testPath = "test";
var checkRegEx = new RegExp(testPath);
console.log("test".match(checkRegEx));
```
in nodejs the result is the same