### PR TITLE
docs(all): add Slider style example

### DIFF
--- a/apidoc/Titanium/UI/Slider.yml
+++ b/apidoc/Titanium/UI/Slider.yml
@@ -402,6 +402,7 @@ properties:
   - name: tintColor
     summary: The color shown for the portion of the progress bar that is filled.
     type: [String, Titanium.UI.Color]
+    platforms: [iphone, ipad, android, macos]
     since: {iphone: "3.1.3", ipad: "3.1.3", android: "8.3.0"}
     osver: {android: {min: "5.0"}}
 

--- a/apidoc/Titanium/UI/Slider.yml
+++ b/apidoc/Titanium/UI/Slider.yml
@@ -22,6 +22,14 @@ description: |
     [rightTrackImage](Titanium.UI.Slider.rightTrackImage) properties be specified before the properties would be honored. Beginning with
     Titanium SDK 4.0.0 this limitation has been removed. However it is recommended that either both or neither be specified.
 
+    If you want to style different parts of the Slider you can set those properties in a custom Android theme:
+    ``` xml
+      <item name="android:progressBackgroundTint">#f4511e</item>
+      <item name="android:progressTint">#388e3c</item>
+      <item name="android:thumbTint">#c51162</item>
+    ```
+    You can also use `@android:color/transparent` to remove the tint.
+
 extends: Titanium.UI.View
 excludes:
     events: [pinch]

--- a/apidoc/Titanium/UI/Slider.yml
+++ b/apidoc/Titanium/UI/Slider.yml
@@ -22,7 +22,7 @@ description: |
     [rightTrackImage](Titanium.UI.Slider.rightTrackImage) properties be specified before the properties would be honored. Beginning with
     Titanium SDK 4.0.0 this limitation has been removed. However it is recommended that either both or neither be specified.
 
-    If you want to style different parts of the Slider you can set those properties in a custom Android theme:
+    To style different parts of the Slider you can set these properties in a custom Android theme:
     ``` xml
       <item name="android:progressBackgroundTint">#f4511e</item>
       <item name="android:progressTint">#388e3c</item>


### PR DESCRIPTION
* Adding some info how to style a Slider with Android themes
* added the missing platforms line to `tintColor`. Was implemented 3 years (8.3.0) ago for Android but doesn't show up in the docs

fixes https://github.com/tidev/titanium_mobile/issues/13520