### PR TITLE
fix(ios): fix tabgroup layout on iOS 16+

### DIFF
--- a/iphone/Classes/TiUITabGroup.m
+++ b/iphone/Classes/TiUITabGroup.m
@@ -618,11 +618,13 @@ DEFINE_EXCEPTIONS
 
 - (void)open:(id)args
 {
-  TiThreadPerformOnMainThread(^{
-    UIView *view = [self tabController].view;
-    [view setFrame:[self bounds]];
-    [self addSubview:view];
-  }, NO);
+  TiThreadPerformOnMainThread(
+      ^{
+        UIView *view = [self tabController].view;
+        [view setFrame:[self bounds]];
+        [self addSubview:view];
+      },
+      NO);
 }
 
 - (void)close:(id)args

--- a/iphone/Classes/TiUITabGroup.m
+++ b/iphone/Classes/TiUITabGroup.m
@@ -618,9 +618,11 @@ DEFINE_EXCEPTIONS
 
 - (void)open:(id)args
 {
-  UIView *view = [self tabController].view;
-  [view setFrame:[self bounds]];
-  [self addSubview:view];
+  TiThreadPerformOnMainThread(^{
+    UIView *view = [self tabController].view;
+    [view setFrame:[self bounds]];
+    [self addSubview:view];
+  }, NO);
 }
 
 - (void)close:(id)args


### PR DESCRIPTION
Wow, that one was heavy to find out. Yet a simple and reasonable fix!

> ~~*NOTE*: Do not merge, yet. There is still a (maybe related) issue regarding x-spacing of the navigation bar.~~
> It's unrelated, filing a new issue for this soon.

**Test case**:
```js
const window1 = Ti.UI.createWindow({ title: 'Window 1', backgroundColor: 'blue' });
const window2 = Ti.UI.createWindow({ title: 'Window 2', backgroundColor: 'red' });
const window3 = Ti.UI.createWindow({ title: 'Window 3', backgroundColor: 'green' });

const tabGroup = Ti.UI.createTabGroup({
	tabs: [
		Ti.UI.createTab({ window: window1, title: 'Tab 1' }),
		Ti.UI.createTab({ window: window2, title: 'Tab 2' }),
		Ti.UI.createTab({ window: window3, title: 'Tab 3' })
	]
});

tabGroup.open();
```

**Example**:

| Before | After |
|-|-|
| <img src="https://user-images.githubusercontent.com/10667698/182031005-7db89e31-3908-4a6b-a409-1564b51b84a5.png" width="300" /> | <img src="https://user-images.githubusercontent.com/10667698/182031075-798042a4-ede5-4618-92b9-73170aae504d.png" width="300" /> |


Fixes #13479 