### PR TITLE
fix: move “movestart” event call to a better place

### DIFF
--- a/iphone/Classes/TiUIListView.m
+++ b/iphone/Classes/TiUIListView.m
@@ -1102,12 +1102,9 @@ static TiViewProxy *FindViewProxyWithBindIdContainingPoint(UIView *view, CGPoint
   UIDragItem *dragItem = [[UIDragItem alloc] initWithItemProvider:itemProvider];
   dragItem.localObject = identifier;
 
-  return @[ dragItem ];
-}
-
-- (void)tableView:(UITableView *)tableView dropSessionDidEnter:(id<UIDropSession>)session
-{
   [[self proxy] fireEvent:@"movestart"];
+
+  return @[ dragItem ];
 }
 
 - (void)tableView:(UITableView *)tableView dropSessionDidEnd:(id<UIDropSession>)session


### PR DESCRIPTION
This improves the trigger time of the event by ~ 500ms which helps a lot to further improve the UI updates that consume this event.

Test case:
```js
const myTemplate = {
	childTemplates: [
		{
			type: 'Ti.UI.Label',
			bindId: 'title',
			properties: {
				left: 15,
				color: 'black'
			}
		}
	]
};

const win = Ti.UI.createWindow({
	backgroundColor: '#fff'
});

const listView = Ti.UI.createListView({
	templates: { template: myTemplate },
	requiresEditingToMove: false,
	defaultItemTemplate: 'template',
	sections: [
		Ti.UI.createListSection({
			headerTitle: 'Section 1',
			items: [
				{ properties: { canMove: true, height: 43 }, title: { text: 'Title 1' } },
				{ properties: { canMove: true, height: 43 }, title: { text: 'Title 2' } },
				{ properties: { canMove: true, height: 43 }, title: { text: 'Title 3' } },
				{ properties: { canMove: true, height: 43 }, title: { text: 'Title 4' } }
			]
		}),
		Ti.UI.createListSection({
			headerTitle: 'Section 1',
			items: [
				{ properties: { canMove: true, height: 43 }, title: { text: 'Title 1' } },
				{ properties: { canMove: true, height: 43 }, title: { text: 'Title 2' } },
				{ properties: { canMove: true, height: 43 }, title: { text: 'Title 3' } },
				{ properties: { canMove: true, height: 43 }, title: { text: 'Title 4' } }
			]
		})
	]
});

listView.addEventListener('movestart', () => {
	console.warn('STARTED MOVING GESTURE');
});

listView.addEventListener('moveend', () => {
	console.warn('STOPPED MOVING GESTURE');
});

listView.addEventListener('move', () => {
	console.warn('MOVED TO A DIFFERENT INDEX');
});

win.add(listView);
win.open();
```