### PR TITLE
fix(ios16): fix navigation items in tab group layout

### DIFF
--- a/iphone/Classes/TiUITabGroup.m
+++ b/iphone/Classes/TiUITabGroup.m
@@ -635,7 +635,11 @@ DEFINE_EXCEPTIONS
 {
   if (controller != nil) {
     controller.viewControllers = nil;
+    [controller willMoveToParentViewController:nil];
+    [controller.view removeFromSuperview];
+    [controller removeFromParentViewController];
   }
+
   RELEASE_TO_NIL(controller);
 }
 

--- a/iphone/Classes/TiUITabGroup.m
+++ b/iphone/Classes/TiUITabGroup.m
@@ -9,6 +9,7 @@
 #import "TiUITabGroup.h"
 #import "TiUITabGroupProxy.h"
 #import "TiUITabProxy.h"
+#import <TitaniumKit/TiApp.h>
 #import <TitaniumKit/TiColor.h>
 #import <TitaniumKit/TiUtils.h>
 
@@ -620,9 +621,12 @@ DEFINE_EXCEPTIONS
 {
   TiThreadPerformOnMainThread(
       ^{
-        UIView *view = [self tabController].view;
-        [view setFrame:[self bounds]];
-        [self addSubview:view];
+        [self.tabController willMoveToParentViewController:TiApp.controller.topPresentedController];
+
+        self.tabController.view.frame = self.bounds;
+        [self addSubview:self.tabController.view];
+
+        [TiApp.controller.topPresentedController addChildViewController:self.tabController];
       },
       NO);
 }


### PR DESCRIPTION
Fixes #13529

After some weeks of discussion with Apple, this solution will solve the outstanding layout issues on iOS and improve the general tab group layout behavior (for older iOS versions as well).

Test Case:
```js
const rootWindow = Ti.UI.createWindow({ backgroundColor: 'green' });
const btn = Ti.UI.createButton({ title: 'Open Tab Group' });

btn.addEventListener('click', () => {
	let tabGroup;

	const window = Ti.UI.createWindow({
		title: 'Window 1',
		backgroundColor: 'white',
		leftNavButton: Ti.UI.createButton({ title: 'Left Button' })
	});

	const btn2 = Ti.UI.createButton({ title: 'Close Tab Group' });

	btn2.addEventListener('click', () => {
		tabGroup.close();
	});

	window.add(btn2);

	const tab = Ti.UI.createTab({
		window,
		title: 'Tab 1'
	});

	tabGroup = Ti.UI.createTabGroup({
		tabs: [ tab ]
	});

	tabGroup.open();
});

rootWindow.add(btn);
rootWindow.open();
```