### PR TITLE
chore: remove appc CLI from commands in templates

### DIFF
--- a/iphone/templates/module/objc/template/ios/README.md.ejs
+++ b/iphone/templates/module/objc/template/ios/README.md.ejs
@@ -1,4 +1,4 @@
-# Axway Titanium iOS Project
+# Titanium iOS Project
 
 This is a skeleton Titanium iOS module project. Modules can be used to extend 
 the functionality of Titanium by providing additional native code that is compiled 
@@ -73,7 +73,7 @@ used for testing and providing an example of usage to the users of your module.
 
 ## Install
 
-1. Run `appc run -p ios --build-only` which creates your distribution package
+1. Run `ti build -p ios --build-only` which creates your distribution package
 2. Switch to `~/Library/Application Support/Titanium`
 3. Copy this zip file into the folder of your Titanium SDK or copy it to your local project
 
@@ -124,11 +124,11 @@ can leave it as-is and build.
 
 ## Testing
 
-Run the `appc` CLI to test your module or test from within Xcode.
+Run the `ti` CLI to test your module or test from within Xcode.
 To test with the script, execute:
 
 ```
-appc run --project-dir <your-module-directory>
+ti build --project-dir <your-module-directory>
 ```
 
 This will execute the app.js in the example folder as a Titanium application.

--- a/iphone/templates/module/objc/template/ios/{{ModuleName}}.xcodeproj/project.pbxproj.ejs
+++ b/iphone/templates/module/objc/template/ios/{{ModuleName}}.xcodeproj/project.pbxproj.ejs
@@ -188,7 +188,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# shell script goes here\n\nappc run --project-dir \"${PROJECT_DIR}\"\nexit $?\n";
+			shellScript = "# shell script goes here\n\nti build --project-dir \"${PROJECT_DIR}\"\nexit $?\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/iphone/templates/module/swift/template/ios/README.md.ejs
+++ b/iphone/templates/module/swift/template/ios/README.md.ejs
@@ -1,4 +1,4 @@
-# Axway Titanium iOS Project
+# Titanium iOS Project
 
 This is a skeleton Titanium iOS module project. Modules can be used to extend 
 the functionality of Titanium by providing additional native code that is compiled 
@@ -71,7 +71,7 @@ used for testing and providing an example of usage to the users of your module.
 
 ## Install
 
-1. Run `appc run -p ios --build-only` which creates your distribution package
+1. Run `ti build -p ios --build-only` which creates your distribution package
 2. Switch to `~/Library/Application Support/Titanium`
 3. Copy this zip file into the folder of your Titanium SDK or copy it to your local project
 
@@ -122,11 +122,11 @@ can leave it as-is and build.
 
 ## Testing
 
-Run the `appc` CLI to test your module or test from within Xcode.
+Run the `ti` CLI to test your module or test from within Xcode.
 To test with the script, execute:
 
 ```
-appc run --project-dir <your-module-directory>
+ti build --project-dir <your-module-directory>
 ```
 
 This will execute the app.js in the example folder as a Titanium application.

--- a/templates/app/angular-default/template/.vscode/extensions.json
+++ b/templates/app/angular-default/template/.vscode/extensions.json
@@ -1,5 +1,5 @@
 {
 	"recommendations": [
-		"axway.vscode-titanium"
+		"tidev.titanium-sdk"
 	]
 }

--- a/templates/app/default/template/.vscode/extensions.json
+++ b/templates/app/default/template/.vscode/extensions.json
@@ -1,5 +1,5 @@
 {
 	"recommendations": [
-		"axway.vscode-titanium"
+		"tidev.titanium-sdk"
 	]
 }

--- a/templates/app/webpack-default/template/.vscode/extensions.json
+++ b/templates/app/webpack-default/template/.vscode/extensions.json
@@ -1,5 +1,5 @@
 {
 	"recommendations": [
-		"axway.vscode-titanium"
+		"tidev.titanium-sdk"
 	]
 }

--- a/templates/module/default/template/README.ejs
+++ b/templates/module/default/template/README.ejs
@@ -32,7 +32,7 @@ used for testing and providing an example of usage to the users of your module.
 
 ## Building
 
-Simply run `appc run -p [ios|android] --build-only` which will compile and package your module.
+Simply run `ti build -p [ios|android] --build-only` which will compile and package your module.
 
 ## Linting
 
@@ -93,7 +93,7 @@ MyModule.foo();
 To test your module with the example, use:
 
 ```js
-appc run -p [ios|android]
+ti build -p [ios|android]
 ```
 
 This will execute the app.js in the example/ folder as a Titanium application.


### PR DESCRIPTION
This removes the `appc run` command in the README in modules and also replaces the Axway VS Code extension in favour of the TiDev one