### PR TITLE
feat(android): tabbedbar color properties

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUITabbedBar.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUITabbedBar.java
@@ -8,10 +8,12 @@ package ti.modules.titanium.ui.widget;
 
 import android.app.Activity;
 import android.content.Context;
+import android.content.res.Configuration;
 import android.graphics.Color;
 import android.graphics.drawable.Drawable;
 import android.view.MenuItem;
 import androidx.annotation.ColorInt;
+
 import com.google.android.material.bottomnavigation.BottomNavigationView;
 import com.google.android.material.color.MaterialColors;
 import com.google.android.material.tabs.TabLayout;
@@ -21,6 +23,7 @@ import org.appcelerator.kroll.KrollDict;
 import org.appcelerator.kroll.KrollProxy;
 import org.appcelerator.kroll.common.Log;
 import org.appcelerator.titanium.R;
+import org.appcelerator.titanium.TiApplication;
 import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.proxy.TiViewProxy;
 import org.appcelerator.titanium.util.TiColorHelper;
@@ -102,7 +105,34 @@ public class TiUITabbedBar extends TiUIView implements MenuItem.OnMenuItemClickL
 		// Note: By default it uses a gray ripple for unselected tabs which doesn't match Google's own apps.
 		int colorPrimary = getTabRippleColorFrom(this.tabLayout.getContext());
 		this.tabLayout.setTabRippleColor(TiUIAbstractTabGroup.createRippleColorStateListFrom(colorPrimary));
+		if (getProxy().hasPropertyAndNotNull(TiC.PROPERTY_SELECTED_TEXT_COLOR)
+			|| getProxy().hasPropertyAndNotNull(TiC.PROPERTY_TEXT_COLOR)) {
+			// get default colors
+			int selectedTextColor = activity.getResources().getColor(R.color.ti_light_primary);
+			int textColor = tabLayout.getTabTextColors().getDefaultColor();
+			Configuration config;
 
+			// if night mode get dark default color
+			if (activity != null) {
+				config = activity.getResources().getConfiguration();
+			} else {
+				config = TiApplication.getInstance().getResources().getConfiguration();
+			}
+			if ((config.uiMode & Configuration.UI_MODE_NIGHT_YES) != 0) {
+				selectedTextColor = activity.getResources().getColor(R.color.ti_dark_primary);
+			}
+
+			// assign new colors
+			if (getProxy().hasPropertyAndNotNull(TiC.PROPERTY_TEXT_COLOR)) {
+				textColor = TiConvert.toColor(getProxy().getProperties().getString(TiC.PROPERTY_TEXT_COLOR), activity);
+			}
+			if (getProxy().hasPropertyAndNotNull(TiC.PROPERTY_SELECTED_TEXT_COLOR)) {
+				selectedTextColor =
+					TiConvert.toColor(getProxy().getProperties().getString(TiC.PROPERTY_SELECTED_TEXT_COLOR), activity);
+			}
+
+			this.tabLayout.setTabTextColors(textColor, selectedTextColor);
+		}
 		setNativeView(this.tabLayout);
 	}
 

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUITabbedBar.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUITabbedBar.java
@@ -129,6 +129,9 @@ public class TiUITabbedBar extends TiUIView implements MenuItem.OnMenuItemClickL
 			if (getProxy().hasPropertyAndNotNull(TiC.PROPERTY_SELECTED_TEXT_COLOR)) {
 				selectedTextColor =
 					TiConvert.toColor(getProxy().getProperties().getString(TiC.PROPERTY_SELECTED_TEXT_COLOR), activity);
+			} else if (getProxy().hasPropertyAndNotNull(TiC.PROPERTY_TEXT_COLOR)) {
+				// no selected color specified but a text color -> use that
+				selectedTextColor = textColor;
 			}
 
 			this.tabLayout.setTabTextColors(textColor, selectedTextColor);

--- a/android/titanium/src/java/org/appcelerator/titanium/TiC.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiC.java
@@ -694,6 +694,7 @@ public class TiC
 	public static final String PROPERTY_SELECTION_INDICATOR = "selectionIndicator";
 	public static final String PROPERTY_SELECTION_OPENS = "selectionOpens";
 	public static final String PROPERTY_SELECTED_ROWS = "selectedRows";
+	public static final String PROPERTY_SELECTED_TEXT_COLOR = "selectedTextColor";
 	public static final String PROPERTY_SELECTION_STYLE = "selectionStyle";
 	public static final String PROPERTY_SEPARATOR_COLOR = "separatorColor";
 	public static final String PROPERTY_SEPARATOR_HEIGHT = "separatorHeight";
@@ -747,6 +748,7 @@ public class TiC
 	public static final String PROPERTY_TEMPLATE = "template";
 	public static final String PROPERTY_TEMPLATES = "templates";
 	public static final String PROPERTY_TEXT = "text";
+	public static final String PROPERTY_TEXT_COLOR = "textColor";
 	public static final String PROPERTY_TEXTID = "textid";
 	public static final String PROPERTY_THEME = "theme";
 	public static final String PROPERTY_TEXT_ALIGN = "textAlign";

--- a/apidoc/Titanium/UI/TabbedBar.yml
+++ b/apidoc/Titanium/UI/TabbedBar.yml
@@ -5,10 +5,10 @@ summary: A button bar that maintains a selected state.
 description: |
     A tabbed bar is a button bar that
     maintains a state (visually distinguished as a pressed or selected look).
-    It is closely related to the `ButtonBar` control. See the description of 
+    It is closely related to the `ButtonBar` control. See the description of
     [ButtonBar](Titanium.UI.ButtonBar) for information on styling tabbed bars and buttons
     bars.
-    
+
     Use the <Titanium.UI.createTabbedBar> method to create a Tabbed Bar.
 extends: Titanium.UI.View
 platforms: [iphone, ipad, android, macos]
@@ -19,38 +19,50 @@ excludes:
     properties: [children]
     methods: [add, remove, removeAllChildren, replaceAt]
 
-events: 
+events:
   - name: click
     summary: Fired when a button is clicked.
-    properties: 
+    properties:
       - name: index
-        summary: Index of the clicked button. 
+        summary: Index of the clicked button.
         type: Number
 properties:
   - name: index
     summary: Index of the currently selected button.
     type: Number
   - name: labels
-    summary: Array of labels for the tabbed bar. 
+    summary: Array of labels for the tabbed bar.
     description: |
         The labels can be specified either using an array of strings, in which case
         each string defines the title for a button, or using an array of simple
-        dictionary objects, <BarItemType>, which can specify title, image, width and 
+        dictionary objects, <BarItemType>, which can specify title, image, width and
         enabled state for each button.
     type: [Array<String>, Array<BarItemType>]
+  - name: textColor
+    summary: Color of the unselected item
+    type: [ String, Titanium.UI.Color ]
+    availability: creation
+    platforms: [android]
+    since: { android: "12.0.0" }
+  - name: selectedTextColor
+    summary: Color of the selected item
+    type: [ String, Titanium.UI.Color ]
+    availability: creation
+    platforms: [android]
+    since: { android: "12.0.0" }
   - name: style
     summary: Style of the tabbed bar.
     description: |
         Specify one of the constants:
-        For iOS: 
+        For iOS:
         [Titanium.UI.iOS.SystemButtonStyle](Titanium.UI.iOS.SystemButtonStyle),
         either `PLAIN`, `BORDERED`, or `BAR`.
-        
+
         The `BAR` style specifies a more compact style and allows the bar's background
         color or gradient to show through.
         For Android:
         [Titanium.UI.TABS_STYLE_*]
-        In Android [style](Titanium.UI.TabbedBar.style) is only supported in the creation dictionary 
+        In Android [style](Titanium.UI.TabbedBar.style) is only supported in the creation dictionary
         of the proxy.
     type: Number
     default: Titanium.UI.iOS.SystemButtonStyle.PLAIN for iOS, Ti.UI.TABS_STYLE_DEFAULT for Android

--- a/apidoc/Titanium/UI/TabbedBar.yml
+++ b/apidoc/Titanium/UI/TabbedBar.yml
@@ -39,17 +39,17 @@ properties:
         enabled state for each button.
     type: [Array<String>, Array<BarItemType>]
   - name: textColor
-    summary: Color of the unselected item
+    summary: Color of the text
     type: [ String, Titanium.UI.Color ]
     availability: creation
-    platforms: [android]
-    since: { android: "12.0.0" }
+    platforms: [iphone, ipad, android, macos]
+    since: {iphone: "9.0.0", ipad: "9.0.0", android: "12.0.0"}
   - name: selectedTextColor
-    summary: Color of the selected item
+    summary: Color of the selected text
     type: [ String, Titanium.UI.Color ]
     availability: creation
-    platforms: [android]
-    since: { android: "12.0.0" }
+    platforms: [iphone, ipad, android, macos]
+    since: {iphone: "9.0.0", ipad: "9.0.0", android: "12.0.0"}
   - name: style
     summary: Style of the tabbed bar.
     description: |


### PR DESCRIPTION
Adding `textColor` and `selectedTextColor` to the Android tabbedBar so you can style it in code and don't need to use a Theme.

```js
const window = Ti.UI.createWindow({
	layout: "vertical"
});

const bb = Ti.UI.createTabbedBar({
	labels: ['Default', 'Tabbed', 'Bar'],
	backgroundColor: '#336699',
	top: 10,
	width: 300,
});

const bb1 = Ti.UI.createTabbedBar({
	labels: ['Selected', 'is', 'different'],
	backgroundColor: '#336699',
	top: 10,
	width: 300,
	selectedTextColor: "yellow"
});

const bb2 = Ti.UI.createTabbedBar({
	labels: ['Text', 'is', 'different'],
	backgroundColor: '#336699',
	top: 10,
	width: 300,
	textColor: "red",
});

const bb3 = Ti.UI.createTabbedBar({
	labels: ['All', 'are', 'different'],
	backgroundColor: '#336699',
	top: 10,
	width: 300,
	textColor: "red",
	selectedTextColor: "yellow"
});
window.add([bb, bb1, bb2, bb3]);
window.open();
```
_check images below_

**Test**
* run the code
* first bar is the reference color
* 2nd row: only the selected color should be different
* 3rd row: only the normal text color should be different
* 4th row: both colors are different
* check in dark and light mode

**iOS node**
I have to check it on iOS. The docs say:
> See the description of [Titanium.UI.ButtonBar](https://titaniumsdk.com/api/titanium/ui/buttonbar.html) for information on styling tabbed bars and buttons bars.

and there are `textColor` and `selectedTextColor` for iOS already. So if that is correct I can add `ios` in the docs too and we have full partiy already