### PR TITLE
fix(ios): optimize ListView continuousUpdate

### DIFF
--- a/iphone/Classes/TiUIListView.m
+++ b/iphone/Classes/TiUIListView.m
@@ -79,6 +79,8 @@ static TiViewProxy *FindViewProxyWithBindIdContainingPoint(UIView *view, CGPoint
   BOOL isSearched;
   UIView *dimmingView;
   BOOL isSearchBarInNavigation;
+  int lastVisibleItem;
+  int lastVisibleSection;
 }
 
 #ifdef TI_USE_AUTOLAYOUT
@@ -1969,6 +1971,14 @@ static TiViewProxy *FindViewProxyWithBindIdContainingPoint(UIView *view, CGPoint
           [eventArgs setValue:NUMINTEGER([indexPath section]) forKey:@"firstVisibleSectionIndex"];
           [eventArgs setValue:section forKey:@"firstVisibleSection"];
           [eventArgs setValue:[section itemAtIndex:[indexPath row]] forKey:@"firstVisibleItem"];
+
+          if (lastVisibleItem == [indexPath row] && lastVisibleSection == [indexPath section]) {
+            // skip event - still the same item at the top
+          } else {
+            [self.proxy fireEvent:@"scrolling" withObject:eventArgs propagate:NO];
+            lastVisibleItem = [indexPath row];
+            lastVisibleSection = [indexPath section];
+          }
         } else {
           section = [[self listViewProxy] sectionForIndex:0];
 
@@ -1978,8 +1988,6 @@ static TiViewProxy *FindViewProxyWithBindIdContainingPoint(UIView *view, CGPoint
           [eventArgs setValue:section forKey:@"firstVisibleSection"];
           [eventArgs setValue:NUMINTEGER(-1) forKey:@"firstVisibleItem"];
         }
-
-        [self.proxy fireEvent:@"scrolling" withObject:eventArgs propagate:NO];
       });
     }
   }

--- a/iphone/Classes/TiUIListView.m
+++ b/iphone/Classes/TiUIListView.m
@@ -1972,9 +1972,8 @@ static TiViewProxy *FindViewProxyWithBindIdContainingPoint(UIView *view, CGPoint
           [eventArgs setValue:section forKey:@"firstVisibleSection"];
           [eventArgs setValue:[section itemAtIndex:[indexPath row]] forKey:@"firstVisibleItem"];
 
-          if (lastVisibleItem == [indexPath row] && lastVisibleSection == [indexPath section]) {
-            // skip event - still the same item at the top
-          } else {
+          if (lastVisibleItem != [indexPath row] || lastVisibleSection != [indexPath section]) {
+            // only log if the item changes
             [self.proxy fireEvent:@"scrolling" withObject:eventArgs propagate:NO];
             lastVisibleItem = [indexPath row];
             lastVisibleSection = [indexPath section];


### PR DESCRIPTION
Fixes https://github.com/tidev/titanium_mobile/issues/13537

Optimization for the old PR: https://github.com/tidev/titanium_mobile/pull/13095
It will fire less events, only when the item really changes. Android works like this already. Currently iOS will fire `scrolling` even if the same item is still the top item when you scroll. 

**Workaround** is very simple inside JS but not sending the same event multiple times would be better

```js
var toggle = true;
var sections = [];
const win = Ti.UI.createWindow();
const btn = Ti.UI.createButton({
	title: "change",
	bottom: 20
});
const lbl = Ti.UI.createLabel({
	top: 10,
	right: 10,
	width: Ti.UI.SIZE,
	height: Ti.UI.SIZE
})
const listView = Ti.UI.createListView({
	height: Ti.UI.FILL,
	width: Ti.UI.FILL,
	continuousUpdate: true
});

btn.addEventListener("click", function() {
	toggle = !toggle;
	listView.continuousUpdate = toggle
	console.log(listView.continuousUpdate);
})

for (var s = 0; s < 5; s++) {
	var section = Ti.UI.createListSection({
		headerTitle: 'Section ' + s
	});
	var set = [];
	for (var i = 0; i < 20; ++i) {
		set.push({
			properties: {
				title: 'Item 0 ' + i
			}
		})
	}
	section.setItems(set);
	sections.push(section);
}

listView.sections = sections;
win.add([listView, btn, lbl]);

listView.addEventListener("scrolling", function(e) {
	lbl.text = "Item: " + e.firstVisibleItemIndex + " section:" + e.firstVisibleSectionIndex;
	console.log("Item", e.firstVisibleItemIndex, e.firstVisibleSectionIndex);
})
win.open();
```