### PR TITLE
fix(ios): do not hard-crash on invalid string URLs

### DIFF
--- a/iphone/Classes/TiUIImageView.m
+++ b/iphone/Classes/TiUIImageView.m
@@ -702,10 +702,13 @@ DEFINE_EXCEPTIONS
 
   if (image == nil) {
     NSURL *imageURL = [[self proxy] sanitizeURL:arg];
+    // Try to fix the URL, e.g. if the encoding was missed
+    if ([imageURL isKindOfClass:[NSString class]]) {
+      imageURL = [[self proxy] sanitizeURL:[TiUtils encodeURIParameters:arg]];
+    }
     if (![imageURL isKindOfClass:[NSURL class]]) {
-      [self throwException:@"invalid image type"
-                 subreason:[NSString stringWithFormat:@"expected TiBlob, String, TiFile, was: %@", [arg class]]
-                  location:CODELOCATION];
+      NSLog(@"[ERROR] Invalid image type: Expected TiBlob, String (qualified URL) or TiFile, was: %@", [arg class]);
+      return;
     }
 
     [self loadUrl:imageURL];


### PR DESCRIPTION
Fixes https://github.com/tidev/titanium_mobile/issues/13517. See the linked issue for a test case and more context.