### PR TITLE
fix(android): null check in getVibrationPattern

### DIFF
--- a/android/modules/android/src/java/ti/modules/titanium/android/notificationmanager/NotificationChannelProxy.java
+++ b/android/modules/android/src/java/ti/modules/titanium/android/notificationmanager/NotificationChannelProxy.java
@@ -221,7 +221,13 @@ public class NotificationChannelProxy extends KrollProxy
 	@Kroll.getProperty
 	public Object getVibrationPattern()
 	{
+		if (channel == null) {
+			return null;
+		}
 		long[] pattern = channel.getVibrationPattern();
+		if (pattern == null) {
+			return null;
+		}
 		Object[] patternArray = new Object[pattern.length];
 		for (int i = 0; i < pattern.length; i++) {
 			patternArray[i] = Long.valueOf(pattern[i]);


### PR DESCRIPTION
Just fixing a possible `null` exception in `getVibrationPattern()`. It stopped me from logging the whole object in the `didReceiveMessage` event of FCM

https://github.com/hansemannn/titanium-firebase-cloud-messaging/blob/main/example/app.js#L13-L22

If you log `Ti.API.info('Message', e);` it just showed an error saying `pattern` is null. With the fix it will return `null` for that field and shows the whole output again:

```js
{
	"type": "didReceiveMessage",
	"source": {
		"fcmToken": "",
		"notificationChannel": {
			"enableLights": true,
			"id": "my_channel",
			"name": "default",
			"bypassDnd": false,
			"vibrationPattern": null,
			"showBadge": true,
			"lightColor": 0,
			"description": null,
			"sound": "file:///android_asset/Resources/notification",
			"groupId": null,
			"importance": 4,
			"enableVibration": true,
			"lockscreenVisibility": -1000,
			"apiName": "Ti.Android.NotificationChannel",
			"bubbleParent": true
		},
		"forceShowInForeground": true,
		"lastData": {
			"inBackground": true,
			"fullscreen": "false"
		},
		"apiName": "Ti.Module",
		"bubbleParent": true,
		"invocationAPIs": [],
		"_events": {
			"success": {},
			"error": {},
			"didRefreshRegistrationToken": {},
			"tokenRemoved": {},
			"didReceiveMessage": {},
			"subscribe": {},
			"unsubscribe": {}
		}
	},
	"message": {
		"messageType": null,
		"data": {},
		"messageId": "0:123%ac3e80e412340e4",
		"from": "47582391234",
		"to": null,
		"title": "title",
		"body": "Topic test",
		"ttl": 2419200,
		"sendTime": 1662471795576
	},
	"bubbles": false,
	"cancelBubble": false
}
```