### PR TITLE
feat(android): ignoreLog config

### DIFF
--- a/android/cli/hooks/run.js
+++ b/android/cli/hooks/run.js
@@ -18,6 +18,7 @@ exports.cliVersion = '>=3.2';
 
 exports.init = function (logger, config, cli) {
 	let deviceInfo = [];
+	const ignoreLog = config.cli.ignoreLog || [];
 
 	cli.on('build.pre.compile', {
 		priority: 8000,
@@ -264,6 +265,13 @@ exports.init = function (logger, config, cli) {
 						// if it begins with something like "E/SQLiteLog( 1659):" it's not a contination, don't log it.
 						} else if (nonTiLogRegexp.test(line)) {
 							return;
+						}
+
+						// ignore some Android logs in info log level
+						for (let i = 0, len = ignoreLog.length; i < len; ++i) {
+							if (line.includes(ignoreLog[i])) {
+								return;
+							}
 						}
 
 						switch (logLevel) {


### PR DESCRIPTION
Adds a quick way to filter out lines in the android log using `ti config`

New key: `cli.ignoreLog = []`
if one of the lines is in the log line it will be ignored.

Example:

```js
"cli": {
  "ignoreLog": [
    "Too many Flogger logs received before configuration",
    "Counters: exceeded sample count in FrameTime",
    "OpenGLRenderer: Davey!"
  ]
}
```
will filter out those nasty map logs.

**TODO:**
we don't have a page with the CLI config parameters. Should be somewhere in the `titanium` repo I guess