### PR TITLE
docs(all): update Android transition example

### DIFF
--- a/apidoc/Titanium/UI/Window.yml
+++ b/apidoc/Titanium/UI/Window.yml
@@ -394,29 +394,65 @@ description: |
     since the system needs the source element and connects the destination element from the shared transition name once window B is created
     and shown.
 
-    For example to transition a title label in window A to a title label in window B.
+    For example to transition a preview ImageView in window A to a full-width ImageView in window B.
 
     ``` js
-    // Create label in window A with a unique transitionName.
-    var titleInWinA = new Ti.UI.createLabel({
-        text:'Top 10 pics from Mars!',
-        left:70, top: 6,
-        width:200, height: 30,
-        transitionName: 'title'
-    });
-    windowA.add(titleInWinA);
-
-    // Creating label in window B, note that the same transitionName is used.
-    var titleInWinB = new Ti.UI.createLabel({
-        text:'Top 10 pics from Mars!',
-        left:50, top: 10,
-        width:200, height: 30,
-        transitionName: 'title'
+    const windowA = Ti.UI.createWindow({
+      title: "overview"
     });
 
-    // Before opening window B specify the common UI elements.
-    windowB.addSharedElement(titleInWinA, "title");
-    windowB.open();
+    // Create an item in window A with a unique transitionName.
+    const viewA = Ti.UI.createImageView({
+      top: 10,
+      left: 10,
+      scalingMode: Titanium.Media.IMAGE_SCALING_ASPECT_FILL,
+      image: "https://api.lorem.space/image/shoes?w=500&h=500",
+      height: 100,
+      width: 100,
+      transitionName: 'title'
+    });
+
+    const btn = Ti.UI.createButton({
+      bottom: 10,
+      title: "open new window"
+    })
+
+    btn.addEventListener("click", function() {
+      // Before opening window B specify the common UI elements.
+      windowB.addSharedElement(viewA, "title");
+      windowB.open();
+
+      windowB.activity.onCreate = () => {
+        const actionBar = windowB.activity.actionBar;
+        if (actionBar) {
+          actionBar.displayHomeAsUp = true;
+          actionBar.title = "New Title";
+          actionBar.onHomeIconItemSelected = () => {
+            windowB.close();
+          };
+        }
+      };
+    })
+    windowA.add([viewA, btn]);
+    windowA.open();
+
+    // Creating an item in window B, note that the same transitionName is used.
+    const windowB = Ti.UI.createWindow({});
+    const viewB = Ti.UI.createImageView({
+      scalingMode: Titanium.Media.IMAGE_SCALING_ASPECT_FILL,
+      top: 0,
+      left: 0,
+      image: "https://api.lorem.space/image/shoes?w=500&h=500",
+      height: 200,
+      width: Ti.UI.FILL,
+      transitionName: 'title'
+    });
+    const labelB = Ti.UI.createLabel({
+      top: 210,
+      left: 10,
+      text: "Detail window"
+    })
+    windowB.add([viewB, labelB]);
     ```
 
     Further you can use `activityEnterTransition`, `activityExitTransition`, `activityReenterTransition`


### PR DESCRIPTION
Update the shared element transition example for Android in the Window docs


https://user-images.githubusercontent.com/4334997/189544592-42991237-4995-4bed-b361-92ea1b0fc0a1.mp4

