### PR TITLE
fix(android): use maxMemory as property

### DIFF
--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -879,11 +879,17 @@ AndroidBuilder.prototype.validate = function validate(logger, config, cli) {
 	cli.tiapp.properties['ti.deploytype'] = { type: 'string', value: this.deployType };
 
 	// Fetch Java max heap size setting.
+	this.javacMaxMemory = config.get('android.javac.maxMemory', '3072M');
+
+	// TODO remove in the next SDK
 	if (cli.tiapp.properties['android.javac.maxmemory'] && cli.tiapp.properties['android.javac.maxmemory'].value) {
-		logger.error(__('android.javac.maxmemory is deprecated. Please use android.javac.maxMemory') + '\n');
-		process.exit(1);
+		logger.error(__('android.javac.maxmemory is deprecated and will be removed in the next version. Please use android.javac.maxMemory') + '\n');
+		this.javacMaxMemory = cli.tiapp.properties['android.javac.maxmemory'].value;
 	}
-	this.javacMaxMemory = cli.tiapp.properties['android.javac.maxMemory'] && cli.tiapp.properties['android.javac.maxMemory'].value || config.get('android.javac.maxMemory', '3072M');
+
+	if (cli.tiapp.properties['android.javac.maxMemory'] && cli.tiapp.properties['android.javac.maxMemory'].value) {
+		this.javacMaxMemory = cli.tiapp.properties['android.javac.maxMemory'].value;
+	}
 
 	// Transpilation details
 	this.transpile = cli.tiapp['transpile'] !== false; // Transpiling is an opt-out process now

--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -879,7 +879,11 @@ AndroidBuilder.prototype.validate = function validate(logger, config, cli) {
 	cli.tiapp.properties['ti.deploytype'] = { type: 'string', value: this.deployType };
 
 	// Fetch Java max heap size setting.
-	this.javacMaxMemory = cli.tiapp.properties['android.javac.maxmemory'] && cli.tiapp.properties['android.javac.maxmemory'].value || config.get('android.javac.maxMemory', '3072M');
+	if (cli.tiapp.properties['android.javac.maxmemory'] && cli.tiapp.properties['android.javac.maxmemory'].value) {
+		logger.error(__('android.javac.maxmemory is deprecated. Please use android.javac.maxMemory') + '\n');
+		process.exit(1);
+	}
+	this.javacMaxMemory = cli.tiapp.properties['android.javac.maxMemory'] && cli.tiapp.properties['android.javac.maxMemory'].value || config.get('android.javac.maxMemory', '3072M');
 
 	// Transpilation details
 	this.transpile = cli.tiapp['transpile'] !== false; // Transpiling is an opt-out process now

--- a/android/cli/commands/_buildModule.js
+++ b/android/cli/commands/_buildModule.js
@@ -252,7 +252,11 @@ AndroidModuleBuilder.prototype.validate = function validate(logger, config, cli)
 			}
 
 			// get javac params
-			this.javacMaxMemory = cli.timodule.properties['android.javac.maxmemory'] && cli.timodule.properties['android.javac.maxmemory'].value || config.get('android.javac.maxMemory', '3072M');
+			if (cli.timodule.properties['android.javac.maxmemory'] && cli.timodule.properties['android.javac.maxmemory'].value) {
+				logger.error(__('android.javac.maxmemory is deprecated. Please use android.javac.maxMemory') + '\n');
+				process.exit(1);
+			}
+			this.javacMaxMemory = cli.timodule.properties['android.javac.maxMemory'] && cli.timodule.properties['android.javac.maxMemory'].value || config.get('android.javac.maxMemory', '3072M');
 
 			// detect java development kit
 			appc.jdk.detect(config, null, function (jdkInfo) {

--- a/android/cli/commands/_buildModule.js
+++ b/android/cli/commands/_buildModule.js
@@ -252,11 +252,17 @@ AndroidModuleBuilder.prototype.validate = function validate(logger, config, cli)
 			}
 
 			// get javac params
+			this.javacMaxMemory = config.get('android.javac.maxMemory', '3072M');
+
+			// TODO remove in the next SDK
 			if (cli.timodule.properties['android.javac.maxmemory'] && cli.timodule.properties['android.javac.maxmemory'].value) {
-				logger.error(__('android.javac.maxmemory is deprecated. Please use android.javac.maxMemory') + '\n');
-				process.exit(1);
+				logger.error(__('android.javac.maxmemory is deprecated and will be removed in the next version. Please use android.javac.maxMemory') + '\n');
+				this.javacMaxMemory = cli.timodule.properties['android.javac.maxmemory'].value;
 			}
-			this.javacMaxMemory = cli.timodule.properties['android.javac.maxMemory'] && cli.timodule.properties['android.javac.maxMemory'].value || config.get('android.javac.maxMemory', '3072M');
+
+			if (cli.timodule.properties['android.javac.maxMemory'] && cli.timodule.properties['android.javac.maxMemory'].value) {
+				this.javacMaxMemory = cli.timodule.properties['android.javac.maxMemory'].value;
+			}
 
 			// detect java development kit
 			appc.jdk.detect(config, null, function (jdkInfo) {


### PR DESCRIPTION
resolves https://github.com/tidev/titanium_mobile/issues/11068

Using camel-case for `maxMemory` CLI + tiapp.xml property. 

**Before**
tiapp.xml uses `android.javac.maxmemory` and CLI used `android.javac.maxMemory`

**After**
both use `android.javac.maxMemory`

**Test**
* add `<property name="android.javac.maxmemory" type="string">1G</property>` to your tiapp.xml
* it will stop and showing an error that you should use maxMemory
* use `<property name="android.javac.maxMemory" type="string">1G</property>` and it will build fine

Since many users won't use this at all I've used `process.exit(1);` and stopped the build. This way I don't have to support both values. 