### PR TITLE
feat(android): expose Picker text color

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/PickerProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/PickerProxy.java
@@ -225,6 +225,10 @@ public class PickerProxy extends TiViewProxy implements PickerColumnProxy.OnChan
 		textInputLayout.addView(editText, new TextInputLayout.LayoutParams(
 			TextInputLayout.LayoutParams.MATCH_PARENT, TextInputLayout.LayoutParams.MATCH_PARENT));
 
+		if (hasPropertyAndNotNull(TiC.PROPERTY_COLOR)) {
+			editText.setTextColor(TiConvert.toColor(getProperty(TiC.PROPERTY_COLOR).toString()));
+		}
+
 		return textInputLayout;
 	}
 

--- a/apidoc/Titanium/UI/Picker.yml
+++ b/apidoc/Titanium/UI/Picker.yml
@@ -205,6 +205,9 @@ properties:
     summary: Background color of the picker, as a color name or hex triplet.
     description: |
         For information about color values, see the "Colors" section of <Titanium.UI>.
+
+        Android: If you want to change the backgroundColor you have to set the `borderStyle` to
+        `Ti.UI.INPUT_BORDERSTYLE_ROUNDED` or `Ti.UI.INPUT_BORDERSTYLE_NONE`
     type: [String, Titanium.UI.Color]
     platforms: [iphone, ipad, android, macos]
     since: { iphone: "5.2.0", ipad: "5.2.0", android: "0.9.0"}
@@ -216,7 +219,7 @@ properties:
         This is an Android only property which only applies to pickers of type:
 
         * [PICKER_TYPE_DATE](Titanium.UI.PICKER_TYPE_DATE) or [PICKER_TYPE_TIME](Titanium.UI.PICKER_TYPE_TIME)
-        that also have [datePickerStyle](Titanium.UI.Picker.datePickerStyle) set to 
+        that also have [datePickerStyle](Titanium.UI.Picker.datePickerStyle) set to
         [DATE_PICKER_STYLE_COMPACT](Titanium.UI.DATE_PICKER_STYLE_COMPACT).
 
         * [PICKER_TYPE_PLAIN](Titanium.UI.PICKER_TYPE_PLAIN) that also have property
@@ -297,7 +300,7 @@ properties:
         This is an Android only property which only applies to pickers of type:
 
         * [PICKER_TYPE_DATE](Titanium.UI.PICKER_TYPE_DATE) or [PICKER_TYPE_TIME](Titanium.UI.PICKER_TYPE_TIME)
-        that also have [datePickerStyle](Titanium.UI.Picker.datePickerStyle) set to 
+        that also have [datePickerStyle](Titanium.UI.Picker.datePickerStyle) set to
         [DATE_PICKER_STYLE_COMPACT](Titanium.UI.DATE_PICKER_STYLE_COMPACT).
 
         * [PICKER_TYPE_PLAIN](Titanium.UI.PICKER_TYPE_PLAIN) that also have property
@@ -514,6 +517,13 @@ properties:
         for android, and <Titanium.UI.PickerRow> for iphone / ipad.
     type: Font
     platforms: [android]
+
+  - name: color
+    summary: Text color of the Picker
+    type: [String, Titanium.UI.Color]
+    platforms: [android]
+    availability: creation
+    since: { android: "12.0.0"}
 
 examples:
   - title: Multi-Column Picker using Alloy XML Markup


### PR DESCRIPTION
Expose the `color` property to change the text color of the Picker:


![Screenshot_20220914-205518](https://user-images.githubusercontent.com/4334997/190239267-dc5524f9-2422-48e9-8b24-436f2b913027.png)



```js
Ti.UI.backgroundColor = 'white';
var win = Ti.UI.createWindow();

var picker = Ti.UI.createPicker({
	borderStyle: Ti.UI.INPUT_BORDERSTYLE_NONE,
	backgroundColor: "#000",
	color: "#ff0"
});

var data = [];
data[0]=Ti.UI.createPickerRow({title:'Bananas'});
data[1]=Ti.UI.createPickerRow({title:'Strawberries'});
data[2]=Ti.UI.createPickerRow({title:'Mangos'});
data[3]=Ti.UI.createPickerRow({title:'Grapes'});

picker.add(data);
win.add(picker);
win.open();
```