### PR TITLE
fix(android): lower build gradle

### DIFF
--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -2184,6 +2184,7 @@ AndroidBuilder.prototype.generateRootProjectFiles = async function generateRootP
 	const gradleProperties = await gradlew.fetchDefaultGradleProperties();
 	gradleProperties.push({ key: 'android.useAndroidX', value: 'true' });
 	gradleProperties.push({ key: 'android.enableJetifier', value: 'true' });
+	gradleProperties.push({ key: 'android.suppressUnsupportedCompileSdk', value: '33' });
 	gradleProperties.push({ key: 'org.gradle.jvmargs', value: `-Xmx${this.javacMaxMemory}` });
 	await gradlew.writeGradlePropertiesFile(gradleProperties);
 

--- a/android/templates/build/root.build.gradle
+++ b/android/templates/build/root.build.gradle
@@ -7,7 +7,7 @@ buildscript {
 		mavenCentral()
 	}
 	dependencies {
-		classpath 'com.android.tools.build:gradle:7.2.2'
+		classpath 'com.android.tools.build:gradle:7.0.4'
 		classpath 'com.google.gms:google-services:4.3.10'
 		classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 	}


### PR DESCRIPTION
fixes #13570 

**Test** 
* build a module for Android
* include the module in an app

currently SDK and apps have a different build.gradle since I can't update the SDKs version. It looks like modules don't like that :smile: 