### PR TITLE
feat(android): optimize module build

### DIFF
--- a/android/cli/commands/_buildModule.js
+++ b/android/cli/commands/_buildModule.js
@@ -413,6 +413,7 @@ AndroidModuleBuilder.prototype.loginfo = async function loginfo() {
 AndroidModuleBuilder.prototype.cleanup = async function cleanup() {
 	// Clean last packaged build in "dist" directory in case this build fails.
 	await fs.emptyDir(this.distDir);
+	await fs.emptyDir(this.buildDir);
 
 	// Delete entire "build" directory tree if we can't find a gradle "module" project directory under it.
 	// This assumes last built module was using older version of Titanium that did not support gradle.
@@ -709,12 +710,14 @@ AndroidModuleBuilder.prototype.packageZip = async function () {
 	}
 
 	// Add the "example" app project files to the archive.
-	if (await fs.exists(this.exampleDir)) {
+	/*
+  if (await fs.exists(this.exampleDir)) {
 		await this.dirWalker(this.exampleDir, (filePath) => {
 			const zipEntryName = path.join(moduleFolder, 'example', path.relative(this.exampleDir, filePath));
 			dest.append(fs.createReadStream(filePath), { name: zipEntryName });
 		});
 	}
+  */
 
 	// Add the event hook plugin scripts to the archive.
 	const hookFiles = {};


### PR DESCRIPTION
* exclude example folder from dist zip 
* clean build folder (currently only dist folder was cleaned)

Advantages:
* when building modules with bigger examples like https://github.com/tidev/ti.compression/pull/250 it won't include all the example data
* currently if you have increase the version number in the manifest and build the module again it will include the old version unless you run `ti clean`. Its not a problem for the module but it increases the files size for no reason

Test:
* clone https://github.com/tidev/ti.compression
* build the android module
* check the dist/zip -> no example folder
* raise manifest version number
* build again without cleaning
* check dist zip. should only show the new version number

![img](https://user-images.githubusercontent.com/4334997/190875192-8052c486-c92d-473f-8361-bda6197aba43.png)

wrong zip:

![Screenshot_20220917_222336](https://user-images.githubusercontent.com/4334997/190875250-510d67ce-b4b4-43e1-b3ff-d738c3bceea6.png)

(5.4.0 shouldn't be included)