### PR TITLE
feat(android): delete notification channel

### DIFF
--- a/android/modules/android/src/java/ti/modules/titanium/android/notificationmanager/NotificationManagerModule.java
+++ b/android/modules/android/src/java/ti/modules/titanium/android/notificationmanager/NotificationManagerModule.java
@@ -14,6 +14,7 @@ import org.appcelerator.kroll.common.Log;
 
 import ti.modules.titanium.android.AndroidModule;
 
+import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
 import android.app.Activity;
 import android.app.Notification;
@@ -84,6 +85,7 @@ public class NotificationManagerModule extends KrollModule
 		return notificationManager;
 	}
 
+	@TargetApi(26)
 	public static boolean useDefaultChannel()
 	{
 		// use default channel if we are targeting API 26+
@@ -119,6 +121,15 @@ public class NotificationManagerModule extends KrollModule
 		return notificationChannelProxy;
 	}
 
+	@TargetApi(26)
+	@Kroll.method
+	public void deleteNotificationChannel(String notificationId)
+	{
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+			getManager().deleteNotificationChannel(notificationId);
+		}
+	}
+
 	@Kroll.method
 	public void cancel(int id)
 	{
@@ -131,6 +142,7 @@ public class NotificationManagerModule extends KrollModule
 		getManager().cancelAll();
 	}
 
+	@SuppressLint("InvalidWakeLockTag")
 	@Kroll.method
 	public void notify(int id, NotificationProxy notificationProxy)
 	{

--- a/apidoc/Titanium/Android/NotificationManager/NotificationManager.yml
+++ b/apidoc/Titanium/Android/NotificationManager/NotificationManager.yml
@@ -47,6 +47,15 @@ methods:
     returns:
         type: Titanium.Android.NotificationChannel
 
+  - name: deleteNotificationChannel
+    osver: {android: {min: "8.0"}}
+    summary: Deletes a notification channel.
+    since: "12.0.0"
+    parameters:
+      - name: id
+        summary: The id of the channel
+        type: String
+
   - name: areNotificationsEnabled
     summary: Returns whether showing notifications is enabled for the application.
     returns:


### PR DESCRIPTION
Currently it is only possible to create a notification channel but not to delete it.

```js
var channel = Ti.Android.NotificationManager.createNotificationChannel({
	id: 'my_channel',
	name: 'TEST CHANNEL',
	importance: Ti.Android.IMPORTANCE_DEFAULT
})

Ti.Android.NotificationManager.deleteNotificationChannel('my_channel') // <- new
```

**test**
* run app with `createNotificationChannel` only first
* check the notification channels
![Screenshot_20220920-095719](https://user-images.githubusercontent.com/4334997/191202451-b95b0da8-c334-4981-b151-4cd6dbe5f788.png)
* run app with `deleteNotificationChannel` and check the channels again. It should be gone now
