### PR TITLE
fix(ios): fix touch issue on Apple Silicon simulators

### DIFF
--- a/iphone/Classes/TiUIButton.m
+++ b/iphone/Classes/TiUIButton.m
@@ -146,7 +146,10 @@
     touchStarted = NO;
     fireEvent = @"touchend";
     if (button.highlighted) {
-      fireActionEvent = [touch tapCount] == 1 ? @"click" : ([touch tapCount] == 2 ? @"dblclick" : nil);
+      // NOTE: The "!touch.tapCount" fixes an issue on Apple Silicon Simulator
+      // where touches are not received.
+      BOOL shouldFireClickEvent = [touch tapCount] == 1 || !touch.tapCount;
+      fireActionEvent = shouldFireClickEvent ? @"click" : ([touch tapCount] == 2 ? @"dblclick" : nil);
     }
     break;
   case UITouchPhaseCancelled:

--- a/iphone/Classes/TiUIiOSStepper.m
+++ b/iphone/Classes/TiUIiOSStepper.m
@@ -223,7 +223,11 @@
     touchStarted = NO;
     fireEvent = @"touchend";
     if (stepper.highlighted) {
-      fireActionEvent = [touch tapCount] == 1 ? @"click" : ([touch tapCount] == 2 ? @"dblclick" : nil);
+      // NOTE: The "!touch.tapCount" fixes an issue on Apple Silicon Simulator
+      // where touches are not received.
+      BOOL shouldFireClickEvent = [touch tapCount] == 1 || !touch.tapCount;
+
+      fireActionEvent = shouldFireClickEvent ? @"click" : ([touch tapCount] == 2 ? @"dblclick" : nil);
     }
     break;
   case UITouchPhaseCancelled:

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiUIView.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiUIView.m
@@ -1579,10 +1579,14 @@ DEFINE_EXCEPTIONS
       [self handleControlEvents:UIControlEventTouchCancel];
     }
 
+    // NOTE: The "!touch.tapCount" fixes an issue on Apple Silicon Simulator
+    // where touches are not received.
+    BOOL shouldFireClickEvent = [touch tapCount] == 1 || !touch.tapCount;
+
     // Click handling is special; don't propagate if we have a delegate,
     // but DO invoke the touch delegate.
     // clicks should also be handled by any control the view is embedded in.
-    if ([touch tapCount] == 1 && [proxy _hasListeners:@"click"]) {
+    if (shouldFireClickEvent && [proxy _hasListeners:@"click"]) {
       if (touchDelegate == nil) {
         [proxy fireEvent:@"click" withObject:evt propagate:YES];
         return;


### PR DESCRIPTION
This PR fixes an issue on Apple Silicon Simulator where touches are not received. I would suggest to also take it for the 11.1.1 release if approved.