### PR TITLE
fix(ios): fix unbalanced view controller transitions causing issues on iOS 16+

### DIFF
--- a/iphone/Classes/TiUINavigationWindowProxy.m
+++ b/iphone/Classes/TiUINavigationWindowProxy.m
@@ -393,14 +393,14 @@
     UIViewController *parentController = [self windowHoldingController];
     [parentController addChildViewController:navController];
     [navController didMoveToParentViewController:parentController];
-    [navController viewWillAppear:animated];
+    [navController beginAppearanceTransition:YES animated:animated];
   }
   [super viewWillAppear:animated];
 }
 - (void)viewWillDisappear:(BOOL)animated
 {
   if ([self viewAttached]) {
-    [navController viewWillDisappear:animated];
+    [navController beginAppearanceTransition:NO animated:animated];
   }
   [super viewWillDisappear:animated];
 }
@@ -408,14 +408,14 @@
 - (void)viewDidAppear:(BOOL)animated
 {
   if ([self viewAttached]) {
-    [navController viewDidAppear:animated];
+    [navController beginAppearanceTransition:YES animated:animated];
   }
   [super viewDidAppear:animated];
 }
 - (void)viewDidDisappear:(BOOL)animated
 {
   if ([self viewAttached]) {
-    [navController viewDidDisappear:animated];
+    [navController beginAppearanceTransition:NO animated:animated];
   }
   [super viewDidDisappear:animated];
 }

--- a/iphone/Classes/TiUINavigationWindowProxy.m
+++ b/iphone/Classes/TiUINavigationWindowProxy.m
@@ -400,7 +400,7 @@
 - (void)viewWillDisappear:(BOOL)animated
 {
   if ([self viewAttached]) {
-    [navController beginAppearanceTransition:NO animated:animated];
+    [navController endAppearanceTransition];
   }
   [super viewWillDisappear:animated];
 }
@@ -415,7 +415,7 @@
 - (void)viewDidDisappear:(BOOL)animated
 {
   if ([self viewAttached]) {
-    [navController beginAppearanceTransition:NO animated:animated];
+    [navController endAppearanceTransition];
   }
   [super viewDidDisappear:animated];
 }


### PR DESCRIPTION
This PR fixes an issue that has been open for quite some time, but surfaced with the VC transition changes in iOS 16+, causing the following log(s) to be called every time a modal window (aka `UINavigationWindow` internally) is opened or closed:
> [ViewController] Calling -viewWillAppear: directly on a view controller is not supported, and may result in out-of-order callbacks and other inconsistent behavior. Use the -beginAppearanceTransition:animated: and -endAppearanceTransition APIs on UIViewController to manually drive appearance callbacks instead. Make a symbolic breakpoint at UIViewControllerAlertForAppearanceCallbackMisuse to catch this in the debugger. View controller: <UINavigationController: 0x148845a00>

Because of this behavior, as mentioned in the log, the view controller transitions are unbalanced, causing possible UI glitches in the navigation window (e.g. missing title). No more! 

Test Case (validate if the log disappears and the modal window title is still visible):
```js

const win = Ti.UI.createWindow({
	backgroundColor: '#fff'
});

const btn = Ti.UI.createButton({
	width: 200,
	height: 45,
	title: 'Open Sub Window',
	color: 'white',
	backgroundColor: 'red',
	borderRadius: 12
});

btn.addEventListener('click', () => {
	const window = Ti.UI.createWindow({ title: 'Sub Window', backgroundColor: 'white' });
	const nav = Ti.UI.createNavigationWindow({ window });

	nav.open({ modal: true });
});

win.add(btn);
win.open();
```