### PR TITLE
feat(android): variable fonts

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiUIHelper.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiUIHelper.java
@@ -451,28 +451,33 @@ public class TiUIHelper
 
 					Typeface tf;
 					if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-						Typeface.Builder builder = new Typeface.Builder(mgr, customFontPath + "/" + f);
-						if (fontWeight != null && !fontWeight.equals("")) {
-							int fontValue = 400;
-							if (fontWeight.equals("bold")) {
-								fontValue = 700;
-							} else if (fontWeight.equals("medium")) {
-								fontValue = 500;
-							} else if (fontWeight.equals("semiBold")) {
-								fontValue = 600;
-							} else if (fontWeight.equals("extraBold")) {
-								fontValue = 800;
-							} else if (fontWeight.equals("light")) {
-								fontValue = 300;
-							} else if (fontWeight.equals("thin")) {
-								fontValue = 200;
+						try {
+							Typeface.Builder builder = new Typeface.Builder(mgr, customFontPath + "/" + f);
+							if (fontWeight != null && !fontWeight.equals("")) {
+								int fontValue = 400;
+								if (fontWeight.equals("bold")) {
+									fontValue = 700;
+								} else if (fontWeight.equals("medium")) {
+									fontValue = 500;
+								} else if (fontWeight.equals("semiBold")) {
+									fontValue = 600;
+								} else if (fontWeight.equals("extraBold")) {
+									fontValue = 800;
+								} else if (fontWeight.equals("light")) {
+									fontValue = 300;
+								} else if (fontWeight.equals("thin")) {
+									fontValue = 200;
+								}
+								try {
+									fontValue = Integer.parseInt(fontWeight);
+								} catch (NumberFormatException nfe) {
+								}
+								builder.setFontVariationSettings("'wght' " + fontValue);
 							}
-							try {
-								fontValue = Integer.parseInt(fontWeight);
-							} catch (NumberFormatException nfe) {}
-							builder.setFontVariationSettings("'wght' " + fontValue);
+							tf = builder.build();
+						} catch (Error er) {
+							return null;
 						}
-						tf = builder.build();
 					} else {
 						tf = Typeface.createFromAsset(mgr, customFontPath + "/" + f);
 					}


### PR DESCRIPTION
*Draft*

Use variable fonts to set a custom fontWeight:

https://user-images.githubusercontent.com/4334997/193842235-3cc20cd2-5e5f-477e-95b0-483985d8a796.mp4



**Example:**

Place https://github.com/LettError/mutatorSans/blob/master/MutatorSans-VF.ttf in `/app/assets/fonts`

```js
const win = Ti.UI.createWindow({});
const lbl = Ti.UI.createLabel({
	text: "testtest",
  top: 20,
	font: {
		fontSize: 40,
    fontWeight: "light",
		fontFamily: "MutatorSans-VF"
	}
});
const slider = Ti.UI.createSlider({
	min: 100,
	max: 700,
	value: 100
})
slider.addEventListener("change", function(e) {
  console.log(Math.floor(e.value));
	lbl.font = {
		fontSize: 40,
		fontWeight: Math.floor(e.value),
		fontFamily: "MutatorSans-VF"
	}
});
win.add(slider);
win.add(lbl);
win.open();
```

You can either use int values or `thin`, `light`, `medium`, `bold`, `semiBold`, `extraBold`

**Note**
It will generate a new font for every fontWeight! So using a slider is not the best idea :wink: It could run out of memory. Added a try/catch around it so at least it won't crash the app. Only the font won't be visible