### PR TITLE
feat(ios): be able to detect an emulated iOS app on Apple Silicon

### DIFF
--- a/apidoc/Titanium/Platform/Platform.yml
+++ b/apidoc/Titanium/Platform/Platform.yml
@@ -273,8 +273,8 @@ properties:
 
   - name: isRunningOnAppleSilicon
     summary: |
-        A Boolean value that indicates whether the current apps is emulated
-        via an Apple Silicon device.
+        A Boolean value that indicates whether the current app is running as a translated
+        binary using Rosetta on an Apple Silicon device.
     description: |
         Use this utility property to guard API's that may not be available on a non-iOS
         device, e.g. motion activity or some authorization components.

--- a/apidoc/Titanium/Platform/Platform.yml
+++ b/apidoc/Titanium/Platform/Platform.yml
@@ -271,6 +271,18 @@ properties:
     permission: read-only
     since: "7.0.0"
 
+  - name: isRunningOnAppleSilicon
+    summary: |
+        A Boolean value that indicates whether the current apps is emulated
+        via an Apple Silicon device.
+    description: |
+        Use this utility property to guard API's that may not be available on a non-iOS
+        device, e.g. motion activity or some authorization components.
+    platforms: [iphone, ipad, macos]
+    type: Boolean
+    permission: read-only
+    since: "12.0.0"
+
   - name: locale
     summary: System's default language.
     description: |

--- a/iphone/Classes/PlatformModule.h
+++ b/iphone/Classes/PlatformModule.h
@@ -31,7 +31,7 @@ READONLY_PROPERTY(TiPlatformDisplayCaps *, displayCaps, DisplayCaps);
 READONLY_PROPERTY(NSString *, id, Id);
 READONLY_PROPERTY(NSString *, identifierForAdvertising, IdentifierForAdvertising);
 READONLY_PROPERTY(NSString *, identifierForVendor, IdentifierForVendor);
-READONLY_PROPERTY(bool, isRunningOnAppleSilicon, IsRunningOnAppleSilicon);
+READONLY_PROPERTY(bool, isTranslatedBinaryOnAppleSilicon, IsTranslatedBinaryOnAppleSilicon);
 READONLY_PROPERTY(bool, isAdvertisingTrackingEnabled, IsAdvertisingTrackingEnabled);
 READONLY_PROPERTY(NSString *, locale, Locale);
 READONLY_PROPERTY(NSString *, macaddress, Macaddress);

--- a/iphone/Classes/PlatformModule.h
+++ b/iphone/Classes/PlatformModule.h
@@ -31,6 +31,7 @@ READONLY_PROPERTY(TiPlatformDisplayCaps *, displayCaps, DisplayCaps);
 READONLY_PROPERTY(NSString *, id, Id);
 READONLY_PROPERTY(NSString *, identifierForAdvertising, IdentifierForAdvertising);
 READONLY_PROPERTY(NSString *, identifierForVendor, IdentifierForVendor);
+READONLY_PROPERTY(bool, isRunningOnAppleSilicon, IsRunningOnAppleSilicon);
 READONLY_PROPERTY(bool, isAdvertisingTrackingEnabled, IsAdvertisingTrackingEnabled);
 READONLY_PROPERTY(NSString *, locale, Locale);
 READONLY_PROPERTY(NSString *, macaddress, Macaddress);

--- a/iphone/Classes/PlatformModule.m
+++ b/iphone/Classes/PlatformModule.m
@@ -256,6 +256,21 @@ GETTER_IMPL(NSString *, identifierForVendor, IdentifierForVendor);
 }
 #endif
 
+- (bool)isRunningOnAppleSilicon
+{
+  // As noted by Apple in https://developer.apple.com/documentation/apple-silicon/about-the-rosetta-translation-environment
+  int ret = 0;
+  size_t size = sizeof(ret);
+  if (sysctlbyname("sysctl.proc_translated", &ret, &size, NULL, 0) == -1) {
+    if (errno == ENOENT) {
+      return 0;
+    }
+    return -1;
+  }
+  return ret;
+}
+
+GETTER_IMPL(bool, isRunningOnAppleSilicon, IsRunningOnAppleSilicon);
 GETTER_IMPL(bool, isAdvertisingTrackingEnabled, IsAdvertisingTrackingEnabled);
 GETTER_IMPL(NSString *, identifierForAdvertising, IdentifierForAdvertising);
 

--- a/iphone/Classes/PlatformModule.m
+++ b/iphone/Classes/PlatformModule.m
@@ -256,7 +256,7 @@ GETTER_IMPL(NSString *, identifierForVendor, IdentifierForVendor);
 }
 #endif
 
-- (bool)isRunningOnAppleSilicon
+- (bool)isTranslatedBinaryOnAppleSilicon
 {
   // As noted by Apple in https://developer.apple.com/documentation/apple-silicon/about-the-rosetta-translation-environment
   int ret = 0;
@@ -270,7 +270,7 @@ GETTER_IMPL(NSString *, identifierForVendor, IdentifierForVendor);
   return ret;
 }
 
-GETTER_IMPL(bool, isRunningOnAppleSilicon, IsRunningOnAppleSilicon);
+GETTER_IMPL(bool, isTranslatedBinaryOnAppleSilicon, IsTranslatedBinaryOnAppleSilicon);
 GETTER_IMPL(bool, isAdvertisingTrackingEnabled, IsAdvertisingTrackingEnabled);
 GETTER_IMPL(NSString *, identifierForAdvertising, IdentifierForAdvertising);
 


### PR DESCRIPTION
Example code to test (compile an app and run it on an Apple Silicon mac, e.g. via Testflight):
```js
const win = Ti.UI.createWindow({
    backgroundColor: '#fff'
});

const btn = Ti.UI.createButton({
    title: 'Check if emulated'
});

btn.addEventListener('click', () => {
    alert(`Is emulated iOS app on Apple Silicon: ${Ti.Platform.isAppleSiliconTranslated}`);
});

win.add(btn);
win.open();
```