### PR TITLE
docs: correct method name for isTranslatedBinaryOnAppleSilicon

### DIFF
--- a/apidoc/Titanium/Platform/Platform.yml
+++ b/apidoc/Titanium/Platform/Platform.yml
@@ -271,7 +271,7 @@ properties:
     permission: read-only
     since: "7.0.0"
 
-  - name: isRunningOnAppleSilicon
+  - name: isTranslatedBinaryOnAppleSilicon
     summary: |
         A Boolean value that indicates whether the current app is running as a translated
         binary using Rosetta on an Apple Silicon device.


### PR DESCRIPTION
This fixes the docs for `isTranslatedBinaryOnAppleSilicon` to use the correct method name. We missed that in #13592 after implementing review feedback.