### PR TITLE
fix(android): drawer events for rightView

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIDrawerLayout.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIDrawerLayout.java
@@ -301,6 +301,10 @@ public class TiUIDrawerLayout extends TiUIView
 		rightFrame.setLayoutParams(frameLayout);
 
 		layout.addView(rightFrame);
+
+		if (drawerToggle == null) {
+			initDrawerToggle();
+		}
 	}
 
 	public void setCenterView(TiViewProxy viewProxy)

--- a/tests/Resources/ti.ui.android.drawerlayout.test.js
+++ b/tests/Resources/ti.ui.android.drawerlayout.test.js
@@ -172,7 +172,7 @@ describe.android('Titanium.UI.Android.DrawerLayout', () => {
 			drawerWindow = Ti.UI.createWindow();
 			centerView = Ti.UI.createView();
 			menuView = Ti.UI.createView({
-				backgroundColor: "red"
+				backgroundColor: 'red'
 			});
 		});
 
@@ -181,15 +181,15 @@ describe.android('Titanium.UI.Android.DrawerLayout', () => {
 				centerView: centerView,
 				leftView: menuView,
 			});
-			drawer.addEventListener("open", function(e) {
+			drawer.addEventListener('open', function (e) {
 				should(e.drawer).eql('left');
 				finish();
 			});
 			drawerWindow.add(drawer);
 			drawerWindow.open();
-			drawerWindow.addEventListener("open", function(){
-				setTimeout(function(){
-					drawer.toggleLeft()
+			drawerWindow.addEventListener('open', function () {
+				setTimeout(function () {
+					drawer.toggleLeft();
 				}, 500);
 			});
 		});
@@ -199,16 +199,16 @@ describe.android('Titanium.UI.Android.DrawerLayout', () => {
 				centerView: centerView,
 				rightView: menuView,
 			});
-			drawer.addEventListener("open", function(e) {
+			drawer.addEventListener('open', function (e) {
 				should(e.drawer).eql('right');
 				finish();
 			});
 			drawerWindow.add(drawer);
-			drawerWindow.addEventListener("open", function(){
-				setTimeout(function(){
-					drawer.toggleRight()
+			drawerWindow.addEventListener('open', function () {
+				setTimeout(function () {
+					drawer.toggleRight();
 				}, 500);
-			})
+			});
 			drawerWindow.open();
 		});
 	});

--- a/tests/Resources/ti.ui.android.drawerlayout.test.js
+++ b/tests/Resources/ti.ui.android.drawerlayout.test.js
@@ -106,9 +106,16 @@ describe.android('Titanium.UI.Android.DrawerLayout', () => {
 		});
 
 		it('.toolbar', finish => {
-			const window = Ti.UI.createWindow({ theme: 'Theme.Titanium.NoTitleBar' });
-			const toolbar = Ti.UI.createToolbar({ titleTextColor: 'red', backgroundColor: 'cyan' });
-			drawerLayout = Ti.UI.Android.createDrawerLayout({ toolbar: toolbar });
+			const window = Ti.UI.createWindow({
+				theme: 'Theme.Titanium.NoTitleBar'
+			});
+			const toolbar = Ti.UI.createToolbar({
+				titleTextColor: 'red',
+				backgroundColor: 'cyan'
+			});
+			drawerLayout = Ti.UI.Android.createDrawerLayout({
+				toolbar: toolbar
+			});
 			window.add(drawerLayout);
 			window.addEventListener('open', () => {
 				try {
@@ -135,7 +142,9 @@ describe.android('Titanium.UI.Android.DrawerLayout', () => {
 
 			// Test for theme with disabled default ActionBar
 			it('for Theme.Titanium.NoTitleBar', () => {
-				const window = Ti.UI.createWindow({ theme: 'Theme.Titanium.NoTitleBar' });
+				const window = Ti.UI.createWindow({
+					theme: 'Theme.Titanium.NoTitleBar'
+				});
 				drawerLayout = Titanium.UI.Android.createDrawerLayout();
 				window.add(drawerLayout);
 				should(drawerLayout.toolbarEnabled).be.true(); // default value
@@ -144,6 +153,63 @@ describe.android('Titanium.UI.Android.DrawerLayout', () => {
 				drawerLayout.toolbarEnabled = true;
 				should(drawerLayout.toolbarEnabled).be.true();
 			});
+		});
+	});
+
+	describe('events', () => {
+
+		let drawerWindow;
+		let centerView;
+		let menuView;
+
+		afterEach(() => {
+			drawerWindow = null;
+			centerView = null;
+			menuView = null;
+		});
+
+		beforeEach(() => {
+			drawerWindow = Ti.UI.createWindow();
+			centerView = Ti.UI.createView();
+			menuView = Ti.UI.createView({
+				backgroundColor: "red"
+			});
+		});
+
+		it('check left open event', finish => {
+			const drawer = Ti.UI.Android.createDrawerLayout({
+				centerView: centerView,
+				leftView: menuView,
+			});
+			drawer.addEventListener("open", function(e) {
+				should(e.drawer).eql('left');
+				finish();
+			});
+			drawerWindow.add(drawer);
+			drawerWindow.open();
+			drawerWindow.addEventListener("open", function(){
+				setTimeout(function(){
+					drawer.toggleLeft()
+				}, 500);
+			});
+		});
+
+		it('check right open event', finish => {
+			const drawer = Ti.UI.Android.createDrawerLayout({
+				centerView: centerView,
+				rightView: menuView,
+			});
+			drawer.addEventListener("open", function(e) {
+				should(e.drawer).eql('right');
+				finish();
+			});
+			drawerWindow.add(drawer);
+			drawerWindow.addEventListener("open", function(){
+				setTimeout(function(){
+					drawer.toggleRight()
+				}, 500);
+			})
+			drawerWindow.open();
 		});
 	});
 });


### PR DESCRIPTION
Currently the drawer events are not connected when you don't use a `leftView`.

**Test:**
```js
const drawerWindow = Ti.UI.createWindow();
const centerView = Ti.UI.createView();
const menuView = Ti.UI.createView({backgroundColor:"red"});
const btn = Ti.UI.createButton({title:"open"});
centerView.add(btn);
btn.addEventListener("click", function(e){ drawer.toggleRight() });

const drawer = Ti.UI.Android.createDrawerLayout({
	centerView: centerView,
	rightView: menuView,
});

drawerWindow.add(drawer);
drawerWindow.open();

drawer.addEventListener("close", function(e) {
	Ti.API.info("drawer close");
});
drawer.addEventListener("open", function(e) {
	Ti.API.info("drawer open");
});
drawer.addEventListener("slide", function(e) {
	Ti.API.info("drawer slide");
});
drawer.addEventListener("change", function(e) {
	Ti.API.info("drawer change");
});
```

**Ti 11.1.1**: no events are shown in the logs
**with this PR**: events are shown.