### PR TITLE
feat(android): searchBar iconColor

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/searchbar/TiUISearchBar.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/searchbar/TiUISearchBar.java
@@ -8,6 +8,7 @@ package ti.modules.titanium.ui.widget.searchbar;
 
 import android.app.Activity;
 import android.content.Context;
+import android.graphics.PorterDuff;
 import android.graphics.drawable.Drawable;
 import android.text.InputType;
 import android.view.View;
@@ -157,11 +158,27 @@ public class TiUISearchBar extends TiUIView
 		if (properties.containsKey(TiC.PROPERTY_ICONIFIED_BY_DEFAULT)) {
 			searchView.setIconifiedByDefault(TiConvert.toBoolean(properties, TiC.PROPERTY_ICONIFIED_BY_DEFAULT, false));
 		}
+		if (properties.containsKey(TiC.PROPERTY_ICON_COLOR)) {
+			updateIconColor(searchView, TiConvert.toColor(properties, TiC.PROPERTY_ICON_COLOR, activity));
+		}
 		updateCloseButton();
 		updateInputType();
 
 		// Let base class handle all other properties.
 		super.processProperties(properties);
+	}
+
+	private void updateIconColor(SearchView searchView, int color)
+	{
+		ImageView imgSearch = searchView.findViewById(R.id.search_mag_icon);
+		ImageView imgClose = searchView.findViewById(R.id.search_close_btn);
+
+		if (imgSearch != null) {
+			imgSearch.setColorFilter(color, PorterDuff.Mode.SRC_IN);
+		}
+		if (imgClose != null) {
+			imgClose.setColorFilter(color, PorterDuff.Mode.SRC_IN);
+		}
 	}
 
 	@Override
@@ -206,6 +223,8 @@ public class TiUISearchBar extends TiUIView
 			searchView.setIconifiedByDefault(TiConvert.toBoolean(newValue, false));
 		} else if (key.equals(TiC.PROPERTY_AUTOCAPITALIZATION) || key.equals(TiC.PROPERTY_AUTOCORRECT)) {
 			updateInputType();
+		} else if (key.equals(TiC.PROPERTY_ICON_COLOR)) {
+			updateIconColor(searchView, TiConvert.toColor(newValue, proxy.getActivity()));
 		} else {
 			super.propertyChanged(key, oldValue, newValue, proxy);
 		}

--- a/android/titanium/src/java/org/appcelerator/titanium/TiC.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiC.java
@@ -485,6 +485,7 @@ public class TiC
 	public static final String PROPERTY_HTML = "html";
 	public static final String PROPERTY_HTTP_ONLY = "httponly";
 	public static final String PROPERTY_ICON = "icon";
+	public static final String PROPERTY_ICON_COLOR = "iconColor";
 	public static final String PROPERTY_ICON_LEVEL = "iconLevel";
 	public static final String PROPERTY_ICONIFIED = "iconified";
 	public static final String PROPERTY_ICONIFIED_BY_DEFAULT = "iconifiedByDefault";

--- a/apidoc/Titanium/UI/SearchBar.yml
+++ b/apidoc/Titanium/UI/SearchBar.yml
@@ -231,6 +231,12 @@ properties:
     type: Boolean
     default: false
 
+  - name: iconColor
+    summary: Color of the search and close icon. Search icon will only work for `iconified:false`.
+    type: [String, Titanium.UI.Color]
+    platforms: [android]
+    since: "12.0.0"
+
   - name: keyboardType
     summary: Keyboard type constant to use when the field is focused.
     type: Number


### PR DESCRIPTION
Ability to change the search icon and cancel icon in an Andorid Searchbar:

**Test**:
```js
var win = Ti.UI.createWindow();
var search = Titanium.UI.createSearchBar({
	barColor: '#000',
	showCancel: true,
	iconColor: "#0f0",
});

setTimeout(function() {
	search.iconColor = "#f00";
}, 3000)

win.add(search);
win.open()
```

* Searchbar has green icons (initial property)
* after 3 sec. searchbar icons turn red (setter)

![Screenshot_20221027-103041](https://user-images.githubusercontent.com/4334997/198233209-cc7e48af-199e-48d8-8332-2438c0d4c251.jpg)
