### PR TITLE
feat(android): adding Ti.UI.Button.padding

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/ButtonProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/ButtonProxy.java
@@ -29,7 +29,8 @@ import android.app.Activity;
 		TiC.PROPERTY_SHADOW_OFFSET,
 		TiC.PROPERTY_SHADOW_COLOR,
 		TiC.PROPERTY_SHADOW_RADIUS,
-		TiC.PROPERTY_TINT_COLOR
+		TiC.PROPERTY_TINT_COLOR,
+		TiC.PROPERTY_PADDING
 })
 public class ButtonProxy extends TiViewProxy
 {

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIButton.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIButton.java
@@ -48,6 +48,10 @@ public class TiUIButton extends TiUIView
 	private float shadowX = 0f;
 	private float shadowY = 0f;
 	private int shadowColor = Color.TRANSPARENT;
+	private int paddingLeft = 0;
+	private int paddingRight = 0;
+	private int paddingTop = 0;
+	private int paddingBottom = 0;
 
 	public TiUIButton(final TiViewProxy proxy)
 	{
@@ -209,6 +213,28 @@ public class TiUIButton extends TiUIView
 		if (needShadow) {
 			btn.setShadowLayer(shadowRadius, shadowX, shadowY, shadowColor);
 		}
+
+		if (d.containsKey(TiC.PROPERTY_PADDING)) {
+
+			if (d.get(TiC.PROPERTY_PADDING) instanceof HashMap) {
+				HashMap dict = (HashMap) d.get(TiC.PROPERTY_PADDING);
+				if (dict.containsKey(TiC.PROPERTY_LEFT)) {
+					paddingLeft = TiConvert.toInt(dict.get(TiC.PROPERTY_LEFT), 0);
+				}
+
+				if (dict.containsKey(TiC.PROPERTY_RIGHT)) {
+					paddingRight = TiConvert.toInt(dict.get(TiC.PROPERTY_RIGHT), 0);
+				}
+
+				if (dict.containsKey(TiC.PROPERTY_TOP)) {
+					paddingTop = TiConvert.toInt(dict.get(TiC.PROPERTY_TOP), 0);
+				}
+
+				if (dict.containsKey(TiC.PROPERTY_BOTTOM)) {
+					paddingBottom = TiConvert.toInt(dict.get(TiC.PROPERTY_BOTTOM), 0);
+				}
+			}
+		}
 		updateButtonImage();
 		btn.invalidate();
 	}
@@ -220,7 +246,6 @@ public class TiUIButton extends TiUIView
 			Log.d(TAG, "Property: " + key + " old: " + oldValue + " new: " + newValue, Log.DEBUG_MODE);
 		}
 		Activity activity = proxy.getActivity();
-
 		AppCompatButton btn = (AppCompatButton) getNativeView();
 		if (key.equals(TiC.PROPERTY_TITLE)) {
 			btn.setText((String) newValue);
@@ -274,6 +299,26 @@ public class TiUIButton extends TiUIView
 		} else if (key.equals(TiC.PROPERTY_SHADOW_COLOR)) {
 			shadowColor = TiConvert.toColor(TiConvert.toString(newValue), activity);
 			btn.setShadowLayer(shadowRadius, shadowX, shadowY, shadowColor);
+		} else if (key.equals(TiC.PROPERTY_PADDING)) {
+			if (newValue instanceof HashMap) {
+				HashMap d = (HashMap) newValue;
+				if (d.containsKey(TiC.PROPERTY_LEFT)) {
+					paddingLeft = TiConvert.toInt(d.get(TiC.PROPERTY_LEFT), 0);
+				}
+
+				if (d.containsKey(TiC.PROPERTY_RIGHT)) {
+					paddingRight = TiConvert.toInt(d.get(TiC.PROPERTY_RIGHT), 0);
+				}
+
+				if (d.containsKey(TiC.PROPERTY_TOP)) {
+					paddingTop = TiConvert.toInt(d.get(TiC.PROPERTY_TOP), 0);
+				}
+
+				if (d.containsKey(TiC.PROPERTY_BOTTOM)) {
+					paddingBottom = TiConvert.toInt(d.get(TiC.PROPERTY_BOTTOM), 0);
+				}
+				updateButtonImage();
+			}
 		} else {
 			super.propertyChanged(key, oldValue, newValue, proxy);
 		}
@@ -338,12 +383,24 @@ public class TiUIButton extends TiUIView
 				materialButton.setIcon(drawable);
 				materialButton.setIconTintMode(imageIsMask ? Mode.SRC_IN : Mode.DST);
 				materialButton.setIconTint(ColorStateList.valueOf(colorValue));
+
+				if (materialButton.getText().length() == 0) {
+					materialButton.setIconPadding(0);
+					materialButton.setIconGravity(MaterialButton.ICON_GRAVITY_TEXT_TOP);
+				}
 			} else {
 				if (imageIsMask) {
 					drawable = drawable.mutate();
 					drawable.setColorFilter(colorValue, Mode.SRC_IN);
 				}
-				button.setCompoundDrawablesRelativeWithIntrinsicBounds(drawable, null, null, null);
+
+				if (button.getText().length() == 0) {
+					button.setPadding(paddingLeft, paddingTop, paddingRight, paddingBottom);
+					button.setGravity(Gravity.CENTER_VERTICAL | Gravity.CENTER_HORIZONTAL);
+					button.setCompoundDrawablesRelativeWithIntrinsicBounds(null, drawable, null, null);
+				} else {
+					button.setCompoundDrawablesRelativeWithIntrinsicBounds(drawable, null, null, null);
+				}
 			}
 		} else {
 			if (button instanceof MaterialButton) {

--- a/apidoc/Titanium/UI/Button.yml
+++ b/apidoc/Titanium/UI/Button.yml
@@ -250,6 +250,7 @@ properties:
 
         On Android, you can set this to a numeric resource drawable ID via `Ti.App.Android.R.drawable.*`
         which lets you use native vector drawbles that are commonly used as icons.
+        If you use just an image without a title you can use the `padding` to move the image around.
     type: [String, Number, Titanium.Blob]
 
   - name: imageIsMask
@@ -257,6 +258,12 @@ properties:
     type: Boolean
     default: true
     since: "11.0.0"
+
+  - name: padding
+    summary: Sets the padding of icon when using an image.
+    type: ButtonPadding
+    platforms: [android]
+    since: "12.0.0"
 
   - name: selectedColor
     summary: Button text color used to indicate the selected state, as a color name or hex triplet.
@@ -403,3 +410,30 @@ examples:
             Titanium.API.info("You clicked the button");
         };
         ```
+
+---
+name: ButtonPadding
+extends: Padding
+summary: Dictionary object of parameters for the <Titanium.UI.Button.padding> that describes the padding.
+since: "12.0.0"
+platforms: [android]
+properties:
+  - name: left
+    type: Number
+    summary: Left padding
+    platforms: [android]
+
+  - name: right
+    type: Number
+    summary: Right padding
+    platforms: [android]
+
+  - name: top
+    type: Number
+    summary: Top padding
+    platforms: [android]
+
+  - name: bottom
+    type: Number
+    summary: Bottom padding
+    platforms: [android]


### PR DESCRIPTION
### Issue
The default material button places the image on the left side and the text next to it with some padding.
If you just use the image it won't be in the center

### Solution
Center the image in a button when you don't use a `title` and adding the `padding` property to center it.

If you don't use a `borderRadius` the app will use a MaterialButton and automatically center the image. With a borderRadius it will be horizontally centered but you have to use the `padding` the align it vertically.

```js
const win = Ti.UI.createWindow();
const btn = Ti.UI.createButton({
	top: 5,
	image:"/images/appicon.png",
	width: 200,
	height: 200,
	backgroundColor:"red"
})
const btn2 = Ti.UI.createButton({
	top: 205,
	image:"/images/appicon.png",
	width: 200,
	height: 200,
	backgroundColor:"red",
	borderRadius: 100,
	padding: {
		top: 70
	}
})
const btn3 = Ti.UI.createButton({
	top: 410,
	image:"/images/appicon.png",
	width: 200,
	height: 200,
	backgroundColor:"red",
	borderRadius: 100
})
btn3.padding = {
	top: 70
}
win.add([btn, btn2, btn3]);
win.open();
```
![Screenshot_20221029-211442](https://user-images.githubusercontent.com/4334997/198848972-2218462c-01f9-4e0b-a033-2606f11358dd.jpg)

