### PR TITLE
fix(android): fixed some TiConvert.toColor warnings

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/PickerProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/PickerProxy.java
@@ -226,7 +226,7 @@ public class PickerProxy extends TiViewProxy implements PickerColumnProxy.OnChan
 			TextInputLayout.LayoutParams.MATCH_PARENT, TextInputLayout.LayoutParams.MATCH_PARENT));
 
 		if (hasPropertyAndNotNull(TiC.PROPERTY_COLOR)) {
-			editText.setTextColor(TiConvert.toColor(getProperty(TiC.PROPERTY_COLOR).toString()));
+			editText.setTextColor(TiConvert.toColor(getProperty(TiC.PROPERTY_COLOR).toString(), activity));
 		}
 
 		return textInputLayout;

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/android/AndroidModule.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/android/AndroidModule.java
@@ -303,7 +303,7 @@ public class AndroidModule extends KrollModule
 	@Kroll.method
 	public String harmonizedColor(String value)
 	{
-		int color = TiConvert.toColor(value);
+		int color = TiConvert.toColor(value, TiApplication.getAppCurrentActivity());
 		return String.format("#%06X",
 			(0xFFFFFF & MaterialColors.harmonizeWithPrimary(TiApplication.getAppCurrentActivity(), color)));
 	}

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiAnimationBuilder.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiAnimationBuilder.java
@@ -14,6 +14,7 @@ import java.util.List;
 import org.appcelerator.kroll.KrollDict;
 import org.appcelerator.kroll.KrollFunction;
 import org.appcelerator.kroll.common.Log;
+import org.appcelerator.titanium.TiApplication;
 import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.TiDimension;
 import org.appcelerator.titanium.proxy.TiViewProxy;
@@ -229,11 +230,12 @@ public class TiAnimationBuilder
 		}
 
 		if (options.containsKey(TiC.PROPERTY_BACKGROUND_COLOR)) {
-			backgroundColor = TiConvert.toColor(options, TiC.PROPERTY_BACKGROUND_COLOR);
+			backgroundColor = TiConvert.toColor(options, TiC.PROPERTY_BACKGROUND_COLOR,
+				TiApplication.getAppCurrentActivity());
 		}
 
 		if (options.containsKey(TiC.PROPERTY_COLOR)) {
-			color = TiConvert.toColor(options, TiC.PROPERTY_COLOR);
+			color = TiConvert.toColor(options, TiC.PROPERTY_COLOR, TiApplication.getAppCurrentActivity());
 		}
 
 		if (options.containsKey(TiC.PROPERTY_ELEVATION)) {

--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiGradientDrawable.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiGradientDrawable.java
@@ -10,6 +10,7 @@ import java.util.HashMap;
 
 import org.appcelerator.kroll.KrollDict;
 import org.appcelerator.kroll.common.Log;
+import org.appcelerator.titanium.TiApplication;
 import org.appcelerator.titanium.TiDimension;
 import org.appcelerator.titanium.TiPoint;
 import org.appcelerator.titanium.util.TiConvert;
@@ -299,7 +300,7 @@ public class TiGradientDrawable extends ShapeDrawable
 				// We were given a Titanium "GradientColorRef" dictionary. Fetch its color.
 				@SuppressWarnings({ "rawtypes", "unchecked" })
 				HashMap<String, Object> colorRefObject = (HashMap) color;
-				this.colors[i] = TiConvert.toColor(colorRefObject, "color");
+				this.colors[i] = TiConvert.toColor(colorRefObject, "color", TiApplication.getAppCurrentActivity());
 
 				// Fetch the offset from the "GradientColorRef" dictionary.
 				// Note: Make sure value does not exceed the 0.0 - 1.0 normalized range.
@@ -319,7 +320,7 @@ public class TiGradientDrawable extends ShapeDrawable
 				}
 			} else {
 				// Fetch the color value from the array.
-				this.colors[i] = TiConvert.toColor(color.toString());
+				this.colors[i] = TiConvert.toColor(color.toString(), TiApplication.getAppCurrentActivity());
 			}
 		}
 


### PR DESCRIPTION
found some missing TiConvert.toColor() places that will show the warning
`TiConvert: (main) [0,283] Calling .toColor() without Context parameter is deprecated`

Was using a backgroundGradient
```
backgroundGradient: {
    type: 'linear',
    colors: [
      'rgba(0,0,0,0.5)', 'rgba(0,0,0,0)'
    ],
    startPoint: {
      x: '0%',
      y: '100%'
    },
    endPoint: {
      x: '0%',
      y: '0%'
    },
    backFillStart: true
  }
```
and saw the warning.
