### PR TITLE
feat(all): create Alloy project optimization

### DIFF
--- a/cli/commands/create.js
+++ b/cli/commands/create.js
@@ -20,6 +20,7 @@ const appc = require('node-appc'),
 	i18n = appc.i18n(__dirname),
 	path = require('path'),
 	ti = require('node-titanium-sdk'),
+	{ execSync } = require('child_process'),
 	__ = i18n.__;
 
 exports.cliVersion = '>=3.2.1';
@@ -181,6 +182,11 @@ CreateCommand.prototype.run = function run(logger, config, cli, finished) {
 			} else {
 				logger.info(__('Project created successfully in %s', appc.time.prettyDiff(cli.startTime, Date.now())) + '\n');
 			}
+
+			if (cli.argv.alloy !== undefined) {
+				execSync('alloy new ' + cli.argv['workspace-dir'] + '/' + cli.argv.name);
+			}
+
 			finished(err);
 		});
 	});


### PR DESCRIPTION
I know the template create will be changed but for now you always have to run two commands to create an Alloy app:
`ti create`
and then 
`alloy new`

This PR will add a `--alloy` parameter to `ti create` so you can run `ti create --alloy` and it will run `alloy new` for the new folder at the end

Test:
```bash
ti create -t app -f -d . -n test -p all --id test -u .  --alloy
```
will create a project "test" that will be an Alloy project right away.


**Todo:**
still need to find the place again where I can put it in the `--help` :smile: I did it once but forgot where it was