### PR TITLE
Revert "fix(ios): fix touch issue on Apple Silicon simulators"

### DIFF
--- a/iphone/Classes/TiUIButton.m
+++ b/iphone/Classes/TiUIButton.m
@@ -146,10 +146,7 @@
     touchStarted = NO;
     fireEvent = @"touchend";
     if (button.highlighted) {
-      // NOTE: The "!touch.tapCount" fixes an issue on Apple Silicon Simulator
-      // where touches are not received.
-      BOOL shouldFireClickEvent = [touch tapCount] == 1 || !touch.tapCount;
-      fireActionEvent = shouldFireClickEvent ? @"click" : ([touch tapCount] == 2 ? @"dblclick" : nil);
+      fireActionEvent = [touch tapCount] == 1 ? @"click" : ([touch tapCount] == 2 ? @"dblclick" : nil);
     }
     break;
   case UITouchPhaseCancelled:

--- a/iphone/Classes/TiUIiOSStepper.m
+++ b/iphone/Classes/TiUIiOSStepper.m
@@ -223,11 +223,7 @@
     touchStarted = NO;
     fireEvent = @"touchend";
     if (stepper.highlighted) {
-      // NOTE: The "!touch.tapCount" fixes an issue on Apple Silicon Simulator
-      // where touches are not received.
-      BOOL shouldFireClickEvent = [touch tapCount] == 1 || !touch.tapCount;
-
-      fireActionEvent = shouldFireClickEvent ? @"click" : ([touch tapCount] == 2 ? @"dblclick" : nil);
+      fireActionEvent = [touch tapCount] == 1 ? @"click" : ([touch tapCount] == 2 ? @"dblclick" : nil);
     }
     break;
   case UITouchPhaseCancelled:

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiUIView.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiUIView.m
@@ -1579,14 +1579,10 @@ DEFINE_EXCEPTIONS
       [self handleControlEvents:UIControlEventTouchCancel];
     }
 
-    // NOTE: The "!touch.tapCount" fixes an issue on Apple Silicon Simulator
-    // where touches are not received.
-    BOOL shouldFireClickEvent = [touch tapCount] == 1 || !touch.tapCount;
-
     // Click handling is special; don't propagate if we have a delegate,
     // but DO invoke the touch delegate.
     // clicks should also be handled by any control the view is embedded in.
-    if (shouldFireClickEvent && [proxy _hasListeners:@"click"]) {
+    if ([touch tapCount] == 1 && [proxy _hasListeners:@"click"]) {
       if (touchDelegate == nil) {
         [proxy fireEvent:@"click" withObject:evt propagate:YES];
         return;


### PR DESCRIPTION
Reverts tidev/titanium_mobile#13582 since it caused a regression, where long-press events would also trigger a click event. The root cause is a arm64 compatibility mode that requires affected developers (on Apple Silicon devices) to make sure they have recompiled their modules. 