### PR TITLE
fix(ios): fix dimBackgroundForSearch in tableview

### DIFF
--- a/iphone/Classes/TiUITableView.m
+++ b/iphone/Classes/TiUITableView.m
@@ -1875,6 +1875,7 @@
     [self createDimmingView];
   } else {
     _dimsBackgroundDuringPresentation = [TiUtils boolValue:arg def:YES];
+    dimmingView = nil;
   }
 }
 


### PR DESCRIPTION
Fixes https://github.com/tidev/titanium_mobile/issues/13303

```js
const win = Ti.UI.createWindow({title: 'Window'});
var newData = Ti.UI.createTableViewRow({title: 'element 1'})
var newData2 = Ti.UI.createTableViewRow({title: 'row 2'})
var newData3 = Ti.UI.createTableViewRow({title: 'item 3'})
const table = Ti.UI.createTableView({
        dimBackgroundForSearch: false,
	search: Ti.UI.createSearchBar(),
	data: [newData, newData2, newData3]
});
win.add(table);
win.open();
````

Overlay shouldn't be visible.

**Note:** 
I'm not sure if this is the best fix :wink: I only added some logs and saw that:
https://github.com/tidev/titanium_mobile/blob/master/iphone/Classes/TiUITableView.m#L1865-L1867
is called before the value is set here (so it is always YES):
https://github.com/tidev/titanium_mobile/blob/master/iphone/Classes/TiUITableView.m#L1879-L1883
so it will always create it, even if you say false. If its false I just set it to nil again.