### PR TITLE
fix(android): try/catch in ti.blob loadBitmapInfo

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/TiBlob.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiBlob.java
@@ -221,7 +221,11 @@ public class TiBlob extends KrollProxy
 
 			switch (type) {
 				case TYPE_FILE:
-					BitmapFactory.decodeStream(getInputStream(), null, opts);
+					try {
+						BitmapFactory.decodeStream(getInputStream(), null, opts);
+					} catch (Exception e) {
+						Log.e(TAG, "Error decoding stream: " + e.getMessage());
+					}
 					break;
 				case TYPE_DATA:
 					byte[] byteArray = (byte[]) data;


### PR DESCRIPTION
fixing potential error in TiBlob `loadBitmapInfo`:

```
       at android.os.BinderProxy.transactNative(Native method)
       at android.os.BinderProxy.transact(BinderProxy.java:635)
       at android.content.pm.IPackageManager$Stub$Proxy.getNameForUid(IPackageManager.java:5999)
       at android.graphics.BitmapFactory.decodeStream(BitmapFactory.java:920)
       at org.appcelerator.titanium.TiBlob.loadBitmapInfo(TiBlob.java:262)
       at org.appcelerator.titanium.TiBlob.blobFromFile(TiBlob.java:112)
       at org.appcelerator.titanium.TiBlob.blobFromFile(TiBlob.java:96)
       at org.appcelerator.titanium.io.TiBaseFile.read(TiBaseFile.java:371)
       at org.appcelerator.titanium.TiFileProxy.read(TiFileProxy.java:250)
```

saw that in an ANR report. `decodeStream` can throw an error so we should catch it an report it. 