### PR TITLE
fix(docs): adding missing platform to Progressbar.tintColor

### DIFF
--- a/apidoc/Titanium/UI/ProgressBar.yml
+++ b/apidoc/Titanium/UI/ProgressBar.yml
@@ -60,6 +60,8 @@ properties:
   - name: tintColor
     summary: The color shown for the portion of the progress bar that is filled.
     type: [String, Titanium.UI.Color]
+    platforms: [iphone, ipad, android, macos]
+    since: {iphone: "3.1.3", ipad: "3.1.3", android: "8.0.0"}
 
   - name: trackTintColor
     summary: The color shown for the portion of the progress bar that is not filled.


### PR DESCRIPTION
Property was [added in 8.0.0](https://github.com/tidev/titanium_mobile/pull/10478) but not added to the docs (only `trackTintColor` was added)
