### PR TITLE
fix(ios): fix textfield autocorrect:false

### DIFF
--- a/iphone/Classes/TiUITextWidget.m
+++ b/iphone/Classes/TiUITextWidget.m
@@ -151,6 +151,7 @@
 - (void)setAutocorrect_:(id)value
 {
   [[self textWidgetView] setAutocorrectionType:[TiUtils boolValue:value] ? UITextAutocorrectionTypeYes : UITextAutocorrectionTypeNo];
+  [[self textWidgetView] setSpellCheckingType:[TiUtils boolValue:value] ? UITextSpellCheckingTypeYes : UITextSpellCheckingTypeNo];
 }
 
 - (void)setAutofillType_:(id)value


### PR DESCRIPTION
follwing up an issue reported on Slack where `autocorrect: false` still leaves a empty grey box above the keyboard.

The fix was found on Stackoverlow: https://stackoverflow.com/questions/24140116/ios-8-how-to-hide-suggestion-list-above-keyboard/73421015#73421015 and tested by a slack user: https://app.slack.com/client/T03CVLS0L/threads/thread/C03CVQX2A-1669974259.169689