### PR TITLE
feat(android): update libraries

### DIFF
--- a/android/templates/build/ti.constants.gradle
+++ b/android/templates/build/ti.constants.gradle
@@ -7,9 +7,9 @@
 
 project.ext {
 	tiAndroidXAppCompatLibVersion = '1.5.0'
-	tiAndroidXCoreLibVersion = '1.8.0'
-	tiAndroidXFragmentLibVersion = '1.5.2'
-	tiMaterialLibVersion = '1.6.1'
+	tiAndroidXCoreLibVersion = '1.9.0'
+	tiAndroidXFragmentLibVersion = '1.5.5'
+	tiMaterialLibVersion = '1.6.0'
 	tiPlayServicesBaseLibVersion = '18.1.0'
 	tiManifestPlaceholders = [
 		tiActivityConfigChanges: 'density|fontScale|keyboard|keyboardHidden|layoutDirection|locale|mcc|mnc|navigation|orientation|screenLayout|screenSize|smallestScreenSize|touchscreen|uiMode'

--- a/android/templates/build/ti.constants.gradle
+++ b/android/templates/build/ti.constants.gradle
@@ -9,7 +9,7 @@ project.ext {
 	tiAndroidXAppCompatLibVersion = '1.5.0'
 	tiAndroidXCoreLibVersion = '1.9.0'
 	tiAndroidXFragmentLibVersion = '1.5.5'
-	tiMaterialLibVersion = '1.6.0'
+	tiMaterialLibVersion = '1.6.1'
 	tiPlayServicesBaseLibVersion = '18.1.0'
 	tiManifestPlaceholders = [
 		tiActivityConfigChanges: 'density|fontScale|keyboard|keyboardHidden|layoutDirection|locale|mcc|mnc|navigation|orientation|screenLayout|screenSize|smallestScreenSize|touchscreen|uiMode'

--- a/android/titanium/build.gradle
+++ b/android/titanium/build.gradle
@@ -251,7 +251,7 @@ dependencies {
 	implementation 'androidx.cardview:cardview:1.0.0'
 	implementation "androidx.core:core:${project.ext.tiAndroidXCoreLibVersion}"
 	implementation 'androidx.drawerlayout:drawerlayout:1.1.1'
-	implementation 'androidx.exifinterface:exifinterface:1.3.4'
+	implementation 'androidx.exifinterface:exifinterface:1.3.5'
 	implementation "androidx.fragment:fragment:${project.ext.tiAndroidXFragmentLibVersion}"
 	implementation 'androidx.media:media:1.6.0'
 	implementation 'androidx.recyclerview:recyclerview:1.2.1'
@@ -269,7 +269,7 @@ dependencies {
 	// The Google Play Services libraries are only used by Titanium's geolocation feature.
 	// We link to them dynamically at runtime. So, they can be safely excluded when in the app project.
 	implementation "com.google.android.gms:play-services-base:${project.ext.tiPlayServicesBaseLibVersion}"
-	implementation 'com.google.android.gms:play-services-location:20.0.0'
+	implementation 'com.google.android.gms:play-services-location:21.0.1'
 
 	// XML library providing XPath support to our Ti.XML APIs.
 	implementation 'jaxen:jaxen:1.2.0'


### PR DESCRIPTION
for the next release

Changelogs:
* https://developer.android.com/jetpack/androidx/releases/fragment
* https://developer.android.com/jetpack/androidx/releases/exifinterface
* https://developer.android.com/jetpack/androidx/releases/core#1.9.0
* https://developers.google.com/android/guides/releases#november_03_2022

Note:
* Material 1.7.0 will show an error when compiling. Looks like an issue other people have too. Sticking to 1.6.0 
