### PR TITLE
fix(android): guard holder proxy when moving cells

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/ItemTouchHandler.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/ItemTouchHandler.java
@@ -86,6 +86,10 @@ public class ItemTouchHandler extends ItemTouchHelper.SimpleCallback
 	 */
 	private boolean canMove(TiViewProxy holderProxy)
 	{
+		if (holderProxy == null) {
+			return false;
+		}
+
 		final KrollDict recyclerProperties = this.recyclerViewProxy.getProperties();
 		final KrollDict holderProperties = holderProxy.getProperties();
 


### PR DESCRIPTION
Quick one - noted here:
```
       at (not set).Attempt to invoke virtual method 'org.appcelerator.kroll.KrollDict org.appcelerator.titanium.proxy.TiViewProxy.getProperties()' on a null object reference()
       at ti.modules.titanium.ui.widget.listview.ItemTouchHandler.canMove(ItemTouchHandler.java:90)
       at ti.modules.titanium.ui.widget.listview.ItemTouchHandler.getDragDirs(ItemTouchHandler.java:202)
       at ti.modules.titanium.ui.widget.listview.ItemTouchHandler.getMovementFlags(ItemTouchHandler.java:239)
       at androidx.recyclerview.widget.ItemTouchHelper$Callback.getAbsoluteMovementFlags(ItemTouchHelper.java:1597)
       at androidx.recyclerview.widget.ItemTouchHelper.checkSelectForSwipe(ItemTouchHelper.java:995)
       at androidx.recyclerview.widget.ItemTouchHelper$2.onInterceptTouchEvent(ItemTouchHelper.java:353)
       at androidx.recyclerview.widget.RecyclerView.findInterceptingOnItemTouchListener(RecyclerView.java:3286)
       at androidx.recyclerview.widget.RecyclerView.onInterceptTouchEvent(RecyclerView.java:3305)
       at ti.modules.titanium.ui.widget.listview.TiNestedRecyclerView.onInterceptTouchEvent(TiNestedRecyclerView.java:119)
```