### PR TITLE
fix(ios): fix crash on soft-restart

### DIFF
--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiApp.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiApp.m
@@ -355,9 +355,8 @@ TI_INLINE void waitForMemoryPanicCleared(void); //WARNING: This must never be ru
   NSDictionary *userActivityDictionary = launchOptions[UIApplicationLaunchOptionsUserActivityDictionaryKey];
 
   // Map user activity if exists
-  if (userActivityDictionary != nil) {
-    NSUserActivity *userActivity = userActivityDictionary[@"UIApplicationLaunchOptionsUserActivityKey"];
-
+  NSUserActivity *userActivity = userActivityDictionary[@"UIApplicationLaunchOptionsUserActivityKey"];
+  if (userActivity != nil && [userActivity isKindOfClass:[NSUserActivity class]]) {
     NSMutableDictionary *dict = [NSMutableDictionary dictionaryWithDictionary:@{ @"activityType" : [userActivity activityType] }];
 
     if ([TiUtils isIOSVersionOrGreater:@"9.0"] && [[userActivity activityType] isEqualToString:CSSearchableItemActionType]) {


### PR DESCRIPTION
This crash happens when soft-restarting the app (e.g. with https://github.com/rborn/tiapprestart) after opening an Universal Link / User Activities API. The reason is that we override the internal `NSUserActivity` to a `NSDictionary` during initial launch any try to re-access the native value that is already mapped to a dictionary at this point.

The testing setup is a bit complex, but it's basically this:
1. Download the ti.apprestart module: https://github.com/rborn/tiapprestart
2. Setup Universal Links: https://stackoverflow.com/questions/36542001/appcelerator-how-to-add-universal-links-support-in-ios9-app
3. Open a universally-linked URL
4. Return to the app
5. Trigger an app restart

-> App crashes!