### PR TITLE
fix(android): gradle warning log

### DIFF
--- a/android/cli/lib/gradle-wrapper.js
+++ b/android/cli/lib/gradle-wrapper.js
@@ -174,8 +174,9 @@ class GradleWrapper {
 		}
 
 		// Function which returns a stdout/stderr "data" reading function object and outputs it to given "logFunction".
-		// The "logFunction" argument is expected to be an appc "logger.info" or "logger.error" object.
-		const createReadableDataHandlerUsing = (logFunction) => {
+		// The "logFunction" argument is expected to be a "logger" object that conatins "logger.info" or "logger.error".
+		// The "logType" is a string "error" or "info" to call the correct logger function
+		const createReadableDataHandlerUsing = (logFunction, logType) => {
 			let stringBuffer = '';
 			return (data) => {
 				// Append the received string data to existing buffer.
@@ -190,7 +191,8 @@ class GradleWrapper {
 				// Log the received messages, split by newline. (Strip out carriage returns on Windows.)
 				const messageArray = stringBuffer.substr(0, index).split('\n');
 				for (const nextMessage of messageArray) {
-					logFunction('[GRADLE] ' + nextMessage.replace(/\r/g, ''));
+					var logMethod = (logType === 'info') ? 'info' : nextMessage.includes('Warning: ') ? 'warn' : 'error';
+					logFunction[logMethod]('[GRADLE] ' + nextMessage.replace(/\r/g, ''));
 				}
 
 				// Remove the above logged strings from the buffer.
@@ -207,8 +209,8 @@ class GradleWrapper {
 		await new Promise((resolve, reject) => {
 			const childProcess = exec(commandLineString, { cwd: this._gradlewDirPath });
 			if (this._logger) {
-				childProcess.stdout.on('data', createReadableDataHandlerUsing(this._logger.info));
-				childProcess.stderr.on('data', createReadableDataHandlerUsing(this._logger.error));
+				childProcess.stdout.on('data', createReadableDataHandlerUsing(this._logger, 'info'));
+				childProcess.stderr.on('data', createReadableDataHandlerUsing(this._logger, 'error'));
 			}
 			childProcess.on('error', reject);
 			childProcess.on('exit', (exitCode) => {

--- a/android/cli/lib/gradle-wrapper.js
+++ b/android/cli/lib/gradle-wrapper.js
@@ -191,7 +191,7 @@ class GradleWrapper {
 				// Log the received messages, split by newline. (Strip out carriage returns on Windows.)
 				const messageArray = stringBuffer.substr(0, index).split('\n');
 				for (const nextMessage of messageArray) {
-					var logMethod = (logType === 'info') ? 'info' : nextMessage.includes('Warning: ') ? 'warn' : 'error';
+					let logMethod = (logType === 'info') ? 'info' : nextMessage.includes('Warning: ') ? 'warn' : 'error';
 					logFunction[logMethod]('[GRADLE] ' + nextMessage.replace(/\r/g, ''));
 				}
 


### PR DESCRIPTION
Will show the gradle warnings as warnings and not as errors:
![210062035-8f0429e7-d4f1-401c-9c87-19fbcb46cc10](https://user-images.githubusercontent.com/4334997/210084464-001ab405-e4b2-4a4d-a7e1-5a7ffe9cee9f.png)

* using `Warning: ` as a string to check. Hopefully other gradle parts won't just have that string in the middle somewhere :smile: 
* default still `info`
* error still `error`