### PR TITLE
fix(ios): fix error handling

### DIFF
--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiApp.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiApp.m
@@ -1134,8 +1134,9 @@ TI_INLINE void waitForMemoryPanicCleared(void); //WARNING: This must never be ru
 //TODO: this should be compiled out in production mode
 - (void)showModalError:(NSString *)message
 {
+  NSLog(@"[ERROR] Application received error: %@", message);
+
   if ([[TiSharedConfig defaultConfig] showErrorController] == NO) {
-    NSLog(@"[ERROR] Application received error: %@", message);
     return;
   }
   ENSURE_UI_THREAD(showModalError, message);

--- a/iphone/TitaniumKit/TitaniumKit/Sources/Misc/TiSharedConfig.h
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/Misc/TiSharedConfig.h
@@ -95,8 +95,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  Indicates whether or not the error screen should be shown if an
- error occurs. Defaults to `true` for `production` and `test` deploy types,
- `false` for deploy type `development`. Can be overriden by the `hide-error-controller`
+ error occurs. Defaults to `false` for `production` and `true` for `development` and `test`
+ deploy types. Can be overriden by the `hide-error-controller`
  CLI parameter.
  */
 @property (nonatomic, assign) BOOL showErrorController;


### PR DESCRIPTION
This PR fixes two incorrect implementations:
1. The documented behavior of the error dialog is incorrect (see the config [here](https://github.com/hansemannn/titanium_mobile/blob/fix/ios-error-handling/iphone/cli/commands/_build.js#L1799-L1836))
2. The error message is currently only shown if not in development. This can suppress error messages sometimes, e.g. when the error dialog cannot be displayed due to a crash that happens before the dialog is able to pop up.