### PR TITLE
fix: remember proxies from section data items

### DIFF
--- a/iphone/Classes/TiUIListSectionProxy.m
+++ b/iphone/Classes/TiUIListSectionProxy.m
@@ -149,30 +149,30 @@
 {
   __weak TiUIListSectionProxy *weakSelf = self;
 
-  [self findProxyInItems:items
-       completionHandler:^(TiProxy *proxy) {
-         TiUIListSectionProxy *strongSelf = weakSelf;
-         if (strongSelf == nil) {
-           return;
-         }
+  [self enumerateProxiesInItems:items
+                     usingBlock:^(TiProxy *proxy) {
+                       TiUIListSectionProxy *strongSelf = weakSelf;
+                       if (strongSelf == nil) {
+                         return;
+                       }
 
-         [strongSelf rememberProxy:proxy];
-       }];
+                       [strongSelf rememberProxy:proxy];
+                     }];
 }
 
 - (void)forgetProxiesInItems:(NSArray<NSDictionary *> *)items
 {
   __weak TiUIListSectionProxy *weakSelf = self;
 
-  [self findProxyInItems:items
-       completionHandler:^(TiProxy *proxy) {
-         TiUIListSectionProxy *strongSelf = weakSelf;
-         if (strongSelf == nil) {
-           return;
-         }
+  [self enumerateProxiesInItems:items
+                     usingBlock:^(TiProxy *proxy) {
+                       TiUIListSectionProxy *strongSelf = weakSelf;
+                       if (strongSelf == nil) {
+                         return;
+                       }
 
-         [strongSelf forgetProxy:proxy];
-       }];
+                       [strongSelf forgetProxy:proxy];
+                     }];
 }
 
 - (void)appendItems:(id)args
@@ -454,7 +454,7 @@
 
 #pragma mark - Utilities
 
-- (void)findProxyInItems:(NSArray<NSDictionary *> *)items completionHandler:(void (^)(TiProxy *proxy))completionHandler
+- (void)enumerateProxiesInItems:(NSArray<NSDictionary *> *)items usingBlock:(void (^)(TiProxy *proxy))block
 {
   for (NSDictionary *item in items) {
     for (NSString *key in item) {
@@ -466,7 +466,7 @@
         for (NSString *bindPropertyName in itemPropertyValue) {
           id propertyValue = itemPropertyValue[bindPropertyName];
           if ([propertyValue isKindOfClass:TiProxy.class]) {
-            completionHandler(propertyValue);
+            block(propertyValue);
           }
         }
       }

--- a/iphone/Classes/TiUIListSectionProxy.m
+++ b/iphone/Classes/TiUIListSectionProxy.m
@@ -147,42 +147,32 @@
 
 - (void)rememberProxiesInItems:(NSArray<NSDictionary *> *)items
 {
-  for (NSDictionary *item in items) {
-    for (NSString *key in item) {
-      if ([key isEqualToString:@"template"] || [key isEqualToString:@"properties"]) {
-        continue;
-      }
-      id itemPropertyValue = item[key];
-      if ([itemPropertyValue isKindOfClass:NSDictionary.class]) {
-        for (NSString *bindPropertyName in itemPropertyValue) {
-          id propertyValue = itemPropertyValue[bindPropertyName];
-          if ([propertyValue isKindOfClass:TiProxy.class]) {
-            [self rememberProxy:propertyValue];
-          }
-        }
-      }
-    }
-  }
+  __weak TiUIListSectionProxy *weakSelf = self;
+
+  [self findProxyInItems:items
+       completionHandler:^(TiProxy *proxy) {
+         TiUIListSectionProxy *strongSelf = weakSelf;
+         if (strongSelf == nil) {
+           return;
+         }
+
+         [strongSelf rememberProxy:proxy];
+       }];
 }
 
 - (void)forgetProxiesInItems:(NSArray<NSDictionary *> *)items
 {
-  for (NSDictionary *item in items) {
-    for (NSString *key in item) {
-      if ([key isEqualToString:@"template"] || [key isEqualToString:@"properties"]) {
-        continue;
-      }
-      id itemPropertyValue = item[key];
-      if ([itemPropertyValue isKindOfClass:NSDictionary.class]) {
-        for (NSString *bindPropertyName in itemPropertyValue) {
-          id propertyValue = itemPropertyValue[bindPropertyName];
-          if ([propertyValue isKindOfClass:TiProxy.class]) {
-            [self forgetProxy:propertyValue];
-          }
-        }
-      }
-    }
-  }
+  __weak TiUIListSectionProxy *weakSelf = self;
+
+  [self findProxyInItems:items
+       completionHandler:^(TiProxy *proxy) {
+         TiUIListSectionProxy *strongSelf = weakSelf;
+         if (strongSelf == nil) {
+           return;
+         }
+
+         [strongSelf forgetProxy:proxy];
+       }];
 }
 
 - (void)appendItems:(id)args
@@ -461,6 +451,29 @@
 {
   return nil;
 }
+
+#pragma mark - Utilities
+
+- (void)findProxyInItems:(NSArray<NSDictionary *> *)items completionHandler:(void (^)(TiProxy *proxy))completionHandler
+{
+  for (NSDictionary *item in items) {
+    for (NSString *key in item) {
+      if ([key isEqualToString:@"template"] || [key isEqualToString:@"properties"]) {
+        continue;
+      }
+      id itemPropertyValue = item[key];
+      if ([itemPropertyValue isKindOfClass:NSDictionary.class]) {
+        for (NSString *bindPropertyName in itemPropertyValue) {
+          id propertyValue = itemPropertyValue[bindPropertyName];
+          if ([propertyValue isKindOfClass:TiProxy.class]) {
+            completionHandler(propertyValue);
+          }
+        }
+      }
+    }
+  }
+}
+
 @end
 
 #endif


### PR DESCRIPTION
A potential fix for https://github.com/tidev/titanium_mobile/issues/13433 we are currently testing. This remember all proxies that are inside a list data item to ensure they are properly protected from garbage collection between setting the `items` on a list section and the list view rerendering.

Fixes https://github.com/tidev/titanium_mobile/issues/13433