### PR TITLE
Replace ::set-output with $GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
           PACKAGE_VERSION=$(sed -n 's/^ *"version": *"//p' package.json | tr -d '"' | tr -d ',' | tr -d '[[:space:]]')
           VTAG="${PACKAGE_VERSION}.${{ github.event.inputs.release-type }}"
           echo "vtag=${VTAG}" >> $GITHUB_ENV
-          echo "::set-output name=vtag::${VTAG}"
+          echo "vtag=${VTAG}" >> $GITHUB_OUTPUT
       - name: Validate version
         uses: actions/github-script@v5
         env:


### PR DESCRIPTION
`::set-output` has been deprecated and now they want us to echo the value to a `$GITHUB_OUTPUT` variable.

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/