### PR TITLE
feat(ios): allow images in ListItem editActions

### DIFF
--- a/apidoc/Titanium/UI/ListItem.yml
+++ b/apidoc/Titanium/UI/ListItem.yml
@@ -715,5 +715,6 @@ properties:
     description: |
         You can combine this property with the `color` property to apply an icon + background color in combination.
         Note: When using this property, the `title` property is ignored.
-        Available since Titanium SDK 12.1.0
     optional: true
+    since: 12.1.0
+    platforms: [iphone, ipad, macos]

--- a/apidoc/Titanium/UI/ListItem.yml
+++ b/apidoc/Titanium/UI/ListItem.yml
@@ -708,3 +708,11 @@ properties:
         By default the background color of the row action is defined by the style applied. Use this property to 
         override the default background color of the row action.
     optional: true
+
+  - name: image
+    type: String
+    summary: The image/icon of the row action.
+    description: |
+        You can combine this property with the `color` property to apply an icon + background color in combination.
+        Available since Titanium SDK 12.1.0
+    optional: true

--- a/apidoc/Titanium/UI/ListItem.yml
+++ b/apidoc/Titanium/UI/ListItem.yml
@@ -714,5 +714,6 @@ properties:
     summary: The image/icon of the row action.
     description: |
         You can combine this property with the `color` property to apply an icon + background color in combination.
+        Note: When using this property, the `title` property is ignored.
         Available since Titanium SDK 12.1.0
     optional: true

--- a/iphone/Classes/TiUIListView.m
+++ b/iphone/Classes/TiUIListView.m
@@ -1154,6 +1154,7 @@ static TiViewProxy *FindViewProxyWithBindIdContainingPoint(UIView *view, CGPoint
     NSString *identifier = [TiUtils stringValue:@"identifier" properties:prop];
     int actionStyle = [TiUtils intValue:@"style" properties:prop def:UITableViewRowActionStyleDefault];
     TiColor *color = [TiUtils colorValue:@"color" properties:prop];
+    id image = [prop objectForKey:@"image"];
 
     UITableViewRowAction *theAction = [UITableViewRowAction rowActionWithStyle:actionStyle
                                                                          title:title
@@ -1192,6 +1193,14 @@ static TiViewProxy *FindViewProxyWithBindIdContainingPoint(UIView *view, CGPoint
     if (color) {
       theAction.backgroundColor = [color color];
     }
+    if (image) {
+      NSURL *url = [TiUtils toURL:image proxy:(TiProxy *)self.proxy];
+      UIImage *nativeImage = [[ImageLoader sharedLoader] loadImmediateImage:url];
+      if (color) {
+        nativeImage = [self generateImage:nativeImage withBackgroundColor:[color color]];
+      }
+      theAction.backgroundColor = [UIColor colorWithPatternImage:nativeImage];
+    }
     if (!returnArray) {
       returnArray = [NSMutableArray arrayWithObject:theAction];
     } else {
@@ -1200,6 +1209,24 @@ static TiViewProxy *FindViewProxyWithBindIdContainingPoint(UIView *view, CGPoint
   }
 
   return returnArray;
+}
+
+- (UIImage *)generateImage:(UIImage *)image withBackgroundColor:(UIColor *)bgColor
+{
+  CGRect imageRect = CGRectMake(0, 0, image.size.width, image.size.height);
+  UIGraphicsBeginImageContextWithOptions(imageRect.size, false, [UIScreen mainScreen].scale);
+
+  CGContextRef context = UIGraphicsGetCurrentContext();
+  CGContextSaveGState(context);
+
+  [bgColor setFill];
+  CGContextFillRect(context, imageRect);
+  [image drawInRect:imageRect];
+
+  UIImage *result = UIGraphicsGetImageFromCurrentImageContext();
+  UIGraphicsEndImageContext();
+
+  return result;
 }
 
 #pragma mark - Editing Support Datasource methods.


### PR DESCRIPTION
This PR enhances [Titanium.UI.ListView.editActions](https://titaniumsdk.com/api/titanium/ui/listitem.html#editactions) to support an `image` parameter as part of the [RowActionType](https://titaniumsdk.com/api/structs/rowactiontype.html) definition.

This provides a nice alternative when swiping on a row in a `ListView`, to show an image instead of text.

<img src="https://user-images.githubusercontent.com/901045/212551011-6e746d14-8f72-498f-ba3d-ef8f5d7924f0.jpg" width="448">
