### PR TITLE
feat(android): add SOFT_INPUT_ADJUST_NOTHING

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/android/AndroidModule.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/android/AndroidModule.java
@@ -85,7 +85,8 @@ public class AndroidModule extends KrollModule
 	public static final int SOFT_INPUT_ADJUST_RESIZE = WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE;
 	@Kroll.constant
 	public static final int SOFT_INPUT_ADJUST_UNSPECIFIED = WindowManager.LayoutParams.SOFT_INPUT_ADJUST_UNSPECIFIED;
-
+	@Kroll.constant
+	public static final int SOFT_INPUT_ADJUST_NOTHING = WindowManager.LayoutParams.SOFT_INPUT_ADJUST_NOTHING;
 	@Kroll.constant
 	public static final int SOFT_INPUT_STATE_ALWAYS_HIDDEN = WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN;
 	@Kroll.constant

--- a/apidoc/Titanium/UI/Android/Android.yml
+++ b/apidoc/Titanium/UI/Android/Android.yml
@@ -545,6 +545,7 @@ properties:
     type: Number
     availability: creation
     permission: read-only
+    since: 12.1.0
 
   - name: SOFT_INPUT_ADJUST_UNSPECIFIED
     summary: |

--- a/apidoc/Titanium/UI/Android/Android.yml
+++ b/apidoc/Titanium/UI/Android/Android.yml
@@ -537,6 +537,15 @@ properties:
     availability: creation
     permission: read-only
 
+  - name: SOFT_INPUT_ADJUST_NOTHING
+    summary: |
+        The window will not be resized, and it will not be panned to make its focus visible.
+    description: |
+        Used with the <Titanium.UI.Window.windowSoftInputMode> property.
+    type: Number
+    availability: creation
+    permission: read-only
+
   - name: SOFT_INPUT_ADJUST_UNSPECIFIED
     summary: |
         Use the system-default behavior to determine how the soft input area (ie software keyboard)


### PR DESCRIPTION
Add another SOFT_INPUT value: `SOFT_INPUT_ADJUST_NOTHING`. It won't move any content when the keyboard is visible:

```js
const win = Ti.UI.createWindow({windowSoftInputMode: Titanium.UI.Android.SOFT_INPUT_ADJUST_NOTHING});
const lbl = Ti.UI.createLabel({text:" asf asdf asfd asdfas dfasf asdf s"});
const tf = Ti.UI.createTextField({bottom: 0});
win.add([lbl, tf]);
win.open();
```

Test:
* open app
* focus textfield


**Workaround:**
You can always use the corresponding int value: `windowSoftInputMode: 48` in current SDKs. Check [Android docs](https://developer.android.com/reference/android/view/WindowManager.LayoutParams#SOFT_INPUT_ADJUST_NOTHING) for the value