### PR TITLE
feat(android): expose videoPlayer buffer

### DIFF
--- a/android/modules/media/src/java/android/widget/TiVideoView8.java
+++ b/android/modules/media/src/java/android/widget/TiVideoView8.java
@@ -552,6 +552,9 @@ public class TiVideoView8 extends SurfaceView implements MediaPlayerControl
 			public void onBufferingUpdate(MediaPlayer mp, int percent)
 			{
 				mCurrentBufferPercentage = percent;
+				if (mPlaybackListener != null) {
+					mPlaybackListener.onBuffer(percent);
+				}
 			}
 		};
 

--- a/android/modules/media/src/java/ti/modules/titanium/media/TiPlaybackListener.java
+++ b/android/modules/media/src/java/ti/modules/titanium/media/TiPlaybackListener.java
@@ -19,4 +19,6 @@ public interface TiPlaybackListener {
 	void onSeekingBackward();
 
 	void onSeekingForward();
+
+	void onBuffer(int value);
 }

--- a/android/modules/media/src/java/ti/modules/titanium/media/TiUIVideoView.java
+++ b/android/modules/media/src/java/ti/modules/titanium/media/TiUIVideoView.java
@@ -372,6 +372,12 @@ public class TiUIVideoView
 	}
 
 	@Override
+	public void onBuffer(int value)
+	{
+		getPlayerProxy().onBuffer(value);
+	}
+
+	@Override
 	public void onSeekingBackward()
 	{
 		getPlayerProxy().onSeekingBackward();

--- a/android/modules/media/src/java/ti/modules/titanium/media/VideoPlayerProxy.java
+++ b/android/modules/media/src/java/ti/modules/titanium/media/VideoPlayerProxy.java
@@ -686,6 +686,13 @@ public class VideoPlayerProxy extends TiViewProxy implements TiLifecycle.OnLifec
 		firePlaybackState(MediaModule.VIDEO_PLAYBACK_STATE_SEEKING_BACKWARD);
 	}
 
+	public void onBuffer(int value)
+	{
+		KrollDict kd = new KrollDict();
+		kd.put("percentage", value);
+		fireEvent("buffer", kd);
+	}
+
 	private String getActionName(int action)
 	{
 		switch (action) {

--- a/apidoc/Titanium/Media/VideoPlayer.yml
+++ b/apidoc/Titanium/Media/VideoPlayer.yml
@@ -205,6 +205,16 @@ methods:
     summary: Stops playing the video.
 
 events:
+  - name: buffer
+    summary: |
+        Fired when the video is loading/buffering.
+    properties:
+      - name: percentage
+        summary: Percentage of the video that is buffered/loaded.
+        type: Number
+    since: '12.1.0'
+    platforms: [android]
+
   - name: complete
     summary: Fired when movie playback ends or a user exits playback.
     description: |

--- a/apidoc/Titanium/Media/VideoPlayer.yml
+++ b/apidoc/Titanium/Media/VideoPlayer.yml
@@ -212,7 +212,7 @@ events:
       - name: percentage
         summary: Percentage of the video that is buffered/loaded.
         type: Number
-    since: '12.1.0'
+    since: '12.3.0'
     platforms: [android]
 
   - name: complete


### PR DESCRIPTION
Expose the Android VideoPlayer `buffer` event

```js
var win = Ti.UI.createWindow();
var v = Ti.Media.createVideoPlayer({
	width: 300,
	height: 300,
	url: "http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerEscapes.mp4"
});
var lbl = Ti.UI.createLabel({top: 0});

v.addEventListener("buffer", function(e){
	lbl.text = e.percentage
})

win.add([v,lbl]);
win.open();
```
label at the top should fill up to 100