### PR TITLE
fix(ios): fix border refresh issue

### DIFF
--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiUIView.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiUIView.m
@@ -335,10 +335,17 @@ DEFINE_EXCEPTIONS
 {
   [super traitCollectionDidChange:previousTraitCollection];
 
+  BOOL isInBackground = UIApplication.sharedApplication.applicationState == UIApplicationStateBackground;
+  BOOL isDifferentColor = [self.traitCollection hasDifferentColorAppearanceComparedToTraitCollection:previousTraitCollection];
+
+  if (!isDifferentColor || isInBackground) {
+    return;
+  }
+
   // Redraw the border color
   id borderColor = [self.proxy valueForKey:@"borderColor"];
   if (borderColor != nil) {
-    [self setBorderColor_:borderColor];
+    [self refreshBorder:[TiUtils colorValue:borderColor]._color shouldRefreshWidth:NO];
   }
 
   // Redraw the view shadow color
@@ -547,14 +554,22 @@ DEFINE_EXCEPTIONS
 
 - (void)setBorderColor_:(id)color
 {
-  TiColor *ticolor = [TiUtils colorValue:color];
+  [self refreshBorder:[TiUtils colorValue:color]._color shouldRefreshWidth:YES];
+}
+
+- (void)refreshBorder:(UIColor *)color shouldRefreshWidth:(BOOL)shouldRefreshWidth
+{
   CAShapeLayer *layer = [self borderLayer];
   if (layer == self.layer) {
-    layer.borderWidth = MAX(layer.borderWidth, 1);
-    layer.borderColor = [ticolor _color].CGColor;
+    if (shouldRefreshWidth) {
+      layer.borderWidth = MAX(layer.borderWidth, 1);
+    }
+    layer.borderColor = color.CGColor;
   } else {
-    layer.lineWidth = MAX(layer.lineWidth * 2, 1 * 2);
-    layer.strokeColor = [ticolor _color].CGColor;
+    if (shouldRefreshWidth) {
+      layer.lineWidth = MAX(layer.lineWidth * 2, 1 * 2);
+    }
+    layer.strokeColor = color.CGColor;
   }
 }
 


### PR DESCRIPTION
The line width of the border layer was always adjusted as well, causing rendering artifacts. This PR changes that behavior and also reduces memory load by guarding the setters during a trait collection change.

Fixes https://github.com/tidev/titanium_mobile/issues/13728