### PR TITLE
fix(android): change deprecated view.setBackgroundDrawable

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiUIView.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiUIView.java
@@ -1173,7 +1173,7 @@ public abstract class TiUIView implements KrollProxyListener, OnFocusChangeListe
 						background.setBackgroundDrawable(currentDrawable);
 
 					} else {
-						nativeView.setBackgroundDrawable(null);
+						nativeView.setBackground(null);
 						currentDrawable.setCallback(null);
 						if (currentDrawable instanceof TiBackgroundDrawable) {
 							((TiBackgroundDrawable) currentDrawable).releaseDelegate();
@@ -1181,7 +1181,7 @@ public abstract class TiUIView implements KrollProxyListener, OnFocusChangeListe
 					}
 				}
 			}
-			nativeView.setBackgroundDrawable(background);
+			nativeView.setBackground(background);
 		}
 	}
 


### PR DESCRIPTION
switching from `setBackgroundDrawable` to `setBackground` in TiUIView. Parameter is the same

https://developer.android.com/reference/android/view/View#setBackgroundDrawable(android.graphics.drawable.Drawable)

>This method was deprecated in API level 16.
use [setBackground(android.graphics.drawable.Drawable)](https://developer.android.com/reference/android/view/View#setBackground(android.graphics.drawable.Drawable)) instead