### PR TITLE
chore: use core.js 3.27.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
         "commander": "^8.2.0",
         "commitizen": "^4.2.4",
         "conventional-changelog-cli": "^2.1.1",
-        "core-js": "^3.23.4",
+        "core-js": "^3.27.2",
         "cz-conventional-changelog": "^3.3.0",
         "danger": "^10.6.6",
         "eslint": "^8.13.0",
@@ -6609,9 +6609,9 @@
       }
     },
     "node_modules/core-js": {
-      "version": "3.23.4",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.23.4.tgz",
-      "integrity": "sha512-vjsKqRc1RyAJC3Ye2kYqgfdThb3zYnx9CrqoCcjMOENMtQPC7ZViBvlDxwYU/2z2NI/IPuiXw5mT4hWhddqjzQ==",
+      "version": "3.27.2",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.27.2.tgz",
+      "integrity": "sha512-9ashVQskuh5AZEZ1JdQWp1GqSoC1e1G87MzRqg2gIfVAQ7Qn9K+uFj8EcniUFA4P2NLZfV+TOlX1SzoKfo+s7w==",
       "dev": true,
       "hasInstallScript": true,
       "funding": {
@@ -22945,9 +22945,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "3.23.4",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.23.4.tgz",
-      "integrity": "sha512-vjsKqRc1RyAJC3Ye2kYqgfdThb3zYnx9CrqoCcjMOENMtQPC7ZViBvlDxwYU/2z2NI/IPuiXw5mT4hWhddqjzQ==",
+      "version": "3.27.2",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.27.2.tgz",
+      "integrity": "sha512-9ashVQskuh5AZEZ1JdQWp1GqSoC1e1G87MzRqg2gIfVAQ7Qn9K+uFj8EcniUFA4P2NLZfV+TOlX1SzoKfo+s7w==",
       "dev": true
     },
     "core-js-compat": {

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "commander": "^8.2.0",
     "commitizen": "^4.2.4",
     "conventional-changelog-cli": "^2.1.1",
-    "core-js": "^3.23.4",
+    "core-js": "^3.27.2",
     "cz-conventional-changelog": "^3.3.0",
     "danger": "^10.6.6",
     "eslint": "^8.13.0",


### PR DESCRIPTION
This package includes common polyfills for modern JS development. I updated it for enhanced [`structuredClone`](https://developer.mozilla.org/en-US/docs/Web/API/structuredClone) support, which is the modern way of `JSON.parse(JSON.stringify(obj))`.

Note: This does not affect the app, yet, but rather the tooling.