### PR TITLE
feat(ios): read status bar height programmatically

### DIFF
--- a/apidoc/Titanium/UI/UI.yml
+++ b/apidoc/Titanium/UI/UI.yml
@@ -2814,7 +2814,7 @@ properties:
         when allowing rotation, we recommend using the <Titanium.UI.Window.safeAreaPadding> property of the related window.
     type: Number
     permission: read-only
-    platforms: [iphone, ipad, macos]
+    platforms: [iphone, ipad, macos, android]
     since: "12.1.0"
 
 examples:

--- a/apidoc/Titanium/UI/UI.yml
+++ b/apidoc/Titanium/UI/UI.yml
@@ -2807,6 +2807,16 @@ properties:
     osver: {ios: {min: "13.0"}}
     since: "9.1.0"
 
+  - name: statusBarHeight
+    summary: The total height of the status bar including safe area padding.
+    description: |
+        Use this property to determine an absolute spacing to the top in full screen windows. Note: For a more flexible approach, e.g.
+        when allowing rotation, we recommend using the <Titanium.UI.Window.safeAreaPadding> property of the related window.
+    type: Number
+    permission: read-only
+    platforms: [iphone, ipad, macos]
+    since: "12.1.0"
+
 examples:
   - title: Color Demo
     example: |

--- a/iphone/Classes/UIModule.m
+++ b/iphone/Classes/UIModule.m
@@ -492,6 +492,11 @@ MAKE_SYSTEM_PROP(EXTEND_EDGE_ALL, 15); //UIEdgeRectAll
   return tiColor;
 }
 
+- (NSNumber *)statusBarHeight
+{
+  return @(UIApplication.sharedApplication.keyWindow.windowScene.statusBarManager.statusBarFrame.size.height);
+}
+
 #pragma mark iPhone namespace
 
 #ifdef USE_TI_UIIPAD


### PR DESCRIPTION
Requested via Slack to have a common solution that's more flexible for newer devices.

### Test Case

```js

const win = Ti.UI.createWindow({
    backgroundColor: '#fff'
});

const view = Ti.UI.createView({ top: 0, height: 0, backgroundColor: 'red' });

const btn = Ti.UI.createButton({
    title: 'Get status bar height'
});

btn.addEventListener('click', () => {
    view.animate({ height: Ti.UI.statusBarHeight });
    console.warn('statusBarHeight = ', Ti.UI.statusBarHeight);
});

win.add([view, btn]);
win.open();
```

### Example

https://user-images.githubusercontent.com/10667698/215262914-e1abb396-cab8-4136-9428-c89056795cc0.mp4

