### PR TITLE
fix(ios): only apply custom String.format for non-64 Bit Simulators

### DIFF
--- a/iphone/TitaniumKit/TitaniumKit/Sources/Kroll/KrollContext.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/Kroll/KrollContext.m
@@ -194,7 +194,7 @@ static JSValueRef StringFormatCallback(JSContextRef jsContext, JSObjectRef jsFun
 
   KrollContext *ctx = GetKrollContext(jsContext);
   NSString *format = [KrollObject toID:ctx value:args[0]];
-#if TARGET_OS_SIMULATOR
+#if TARGET_OS_SIMULATOR && !__LP64__
   // convert string references to objects
   format = [format stringByReplacingOccurrencesOfString:@"%@" withString:@"%@_TIDELIMITER_"];
   format = [format stringByReplacingOccurrencesOfString:@"%s" withString:@"%@_TIDELIMITER_"];


### PR DESCRIPTION
This one was hard to find: When using more than one formatting strings (e.g. in translations), iOS apps currently produce a hard crash without any log. The reason is the following from 9 (!) years ago, adding a wrapper for Simulators that have a different architecture compared to devices.

Recently, with M1/M2 macs, Simulator can now run 64 Bit natively. Unfortunately, the check only checked for Simulators, not for 64 Bit native Simulators and the app crashes. This PR adds a 64 Bit check that fixed it for the following test case:

```js
const win = Ti.UI.createWindow({
    backgroundColor: '#fff'
});

const btn = Ti.UI.createButton({
    title: 'Show formatted log!'
});

btn.addEventListener('click', () => {
    Ti.API.info(String.format('Hello %1$s my name is %2$s and I\'m from %3$s!', 'Wayne', 'John', 'Winterset, Iowa'));
});

win.add(btn);
win.open();
```

Output (before):
> Hello Wayne my name is (null) and I'm from (null)!

Output (after):
> Hello Wayne my name is John and I'm from Winterset, Iowa!

Important: This only effects Simulator builds, production builds are not affected!