### PR TITLE
feat(android): add stopAnimation() to View

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/TiViewProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/TiViewProxy.java
@@ -854,11 +854,14 @@ public abstract class TiViewProxy extends KrollProxy
 	}
 
 	@Kroll.method
-	public void animate(Object arg, @Kroll.argument(optional = true) KrollFunction callback)
+	public void animate(@Kroll.argument(optional = true) Object arg,
+		@Kroll.argument(optional = true) KrollFunction callback)
 	{
 		synchronized (pendingAnimationLock)
 		{
-			if (arg instanceof HashMap) {
+			if (arg == null) {
+				stopAnimation();
+			} else if (arg instanceof HashMap) {
 				@SuppressWarnings("rawtypes")
 				HashMap options = (HashMap) arg;
 				pendingAnimation = new TiAnimationBuilder();
@@ -876,6 +879,16 @@ public abstract class TiViewProxy extends KrollProxy
 			}
 
 			handlePendingAnimation(false);
+		}
+	}
+
+	@Kroll.method
+	public void stopAnimation()
+	{
+		TiUIView tiv = peekView();
+
+		if (tiv != null) {
+			tiv.stopAnimation();
 		}
 	}
 

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiAnimationBuilder.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiAnimationBuilder.java
@@ -127,6 +127,7 @@ public class TiAnimationBuilder
 	protected View view;
 	protected AnimatorHelper animatorHelper;
 	protected TiViewProxy viewProxy;
+	protected AnimatorSet animatorSet;
 
 	public TiAnimationBuilder()
 	{
@@ -615,7 +616,7 @@ public class TiAnimationBuilder
 		if (delay != null) {
 			as.setStartDelay(delay.longValue());
 		}
-
+		animatorSet = as;
 		return as;
 	}
 
@@ -1017,6 +1018,20 @@ public class TiAnimationBuilder
 
 		if (tdm == null || tdm.canUsePropertyAnimators()) {
 			buildPropertyAnimators().start();
+		}
+	}
+
+	public void stop(View view)
+	{
+		if (animatorSet != null) {
+			animatorSet.removeAllListeners();
+			animatorSet.cancel();
+			animatorSet = null;
+		}
+		view.clearAnimation();
+		setAnimationRunningFor(view, false);
+		if (animationProxy != null) {
+			animationProxy.fireEvent(TiC.EVENT_CANCEL, null);
 		}
 	}
 

--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiUIView.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiUIView.java
@@ -154,6 +154,7 @@ public abstract class TiUIView implements KrollProxyListener, OnFocusChangeListe
 	private final AtomicBoolean bLayoutPending = new AtomicBoolean();
 	private final AtomicBoolean bTransformPending = new AtomicBoolean();
 
+	private TiAnimationBuilder tiBuilder;
 	/**
 	 * Constructs a TiUIView object with the associated proxy.
 	 * @param proxy the associated proxy.
@@ -358,12 +359,12 @@ public abstract class TiUIView implements KrollProxyListener, OnFocusChangeListe
 			return;
 		}
 
-		TiAnimationBuilder builder = proxy.getPendingAnimation();
-		if (builder == null) {
+		tiBuilder = proxy.getPendingAnimation();
+		if (tiBuilder == null) {
 			return;
 		}
 
-		proxy.clearAnimation(builder);
+		proxy.clearAnimation(tiBuilder);
 
 		// If a view is "visible" but not currently seen (such as because it's covered or
 		// its position is currently set to be fully outside its parent's region),
@@ -391,12 +392,20 @@ public abstract class TiUIView implements KrollProxyListener, OnFocusChangeListe
 		if (Log.isDebugModeEnabled()) {
 			Log.d(TAG, "starting animation", Log.DEBUG_MODE);
 		}
-
-		builder.start(proxy, outerView);
+		tiBuilder.start(proxy, outerView);
 
 		if (invalidateParent) {
 			((View) viewParent).postInvalidate();
 		}
+	}
+
+	public void stopAnimation()
+	{
+		View outerView = getOuterView();
+		if (outerView == null || bTransformPending.get() || tiBuilder == null) {
+			return;
+		}
+		tiBuilder.stop(outerView);
 	}
 
 	public void listenerAdded(String type, int count, KrollProxy proxy)

--- a/apidoc/Titanium/UI/Animation.yml
+++ b/apidoc/Titanium/UI/Animation.yml
@@ -48,6 +48,11 @@ since: "0.9"
 platforms: [android, iphone, ipad, macos]
 
 events:
+  - name: cancel
+    summary: Fired when the animation is canceled.
+    since: "12.1.0"
+    platforms: [android]
+
   - name: complete
     summary: Fired when the animation completes.
 

--- a/apidoc/Titanium/UI/View.yml
+++ b/apidoc/Titanium/UI/View.yml
@@ -1056,6 +1056,13 @@ methods:
         removed: "9.0.0"
         notes: Use the [Titanium.Proxy.applyProperties](Titanium.Proxy.applyProperties) method to batch-update layout properties.
 
+  - name: stopAnimation
+    summary: Stops a running animation.
+    description: |
+        Stops a running view [Animation](Titanium.UI.Animation).
+    platforms: [android]
+    since: { android: "12.1.0" }
+
   - name: toImage
     summary: Returns an image of the rendered view, as a Blob.
     description: |

--- a/tests/Resources/ti.ui.view.test.js
+++ b/tests/Resources/ti.ui.view.test.js
@@ -730,6 +730,62 @@ describe('Titanium.UI.View', function () {
 		win.open();
 	});
 
+	it.android('animate and stopAnimation', function (finish) {
+		win = Ti.UI.createWindow({ backgroundColor: 'white' });
+		const view = Ti.UI.createView({
+			backgroundColor: 'orange',
+			top: 0,
+			left: 0,
+			width: 100,
+			height: 100,
+		});
+		win.add(view);
+		win.addEventListener('open', () => {
+			const animation = Ti.UI.createAnimation({
+				duration: 2000,
+				left: 200
+			});
+			animation.addEventListener('cancel', () => {
+				should(view.rect.x).be.above(0);
+				should(view.rect.x).be.below(200);
+				finish();
+			});
+			view.animate(animation);
+			setTimeout(function () {
+				view.stopAnimation();
+			}, 500);
+		});
+		win.open();
+	});
+
+	it.android('animate and empty animation', function (finish) {
+		win = Ti.UI.createWindow({ backgroundColor: 'white' });
+		const view = Ti.UI.createView({
+			backgroundColor: 'orange',
+			top: 0,
+			left: 0,
+			width: 100,
+			height: 100,
+		});
+		win.add(view);
+		win.addEventListener('open', () => {
+			const animation = Ti.UI.createAnimation({
+				duration: 2000,
+				left: 200
+			});
+			animation.addEventListener('cancel', () => {
+				should(view.rect.x).be.above(0);
+				should(view.rect.x).be.below(200);
+				finish();
+			});
+			view.animate(animation);
+			setTimeout(function () {
+				view.animate();
+			}, 500);
+		});
+		win.open();
+	});
+
 	it.windowsBroken('convertPointToView', function (finish) {
 		win = Ti.UI.createWindow();
 		const a = Ti.UI.createView({ backgroundColor: 'red' });


### PR DESCRIPTION
Old PR: https://github.com/tidev/titanium_mobile/pull/10130
Moving it to a new PR so the checks will be green again.

---

Android has no possibility to cancel/stop animations like moving an object from left to right before the duration is over. This PR adds a stopAnimation() method to Ti.UI.View

```js
const win = Ti.UI.createWindow();

const lbl = Ti.UI.createLabel({
	text: "-",
	width: Ti.UI.SIZE,
	height: Ti.UI.SIZE
});

const view = Ti.UI.createView({
	backgroundColor: 'red',
	height: 100,
	width: 100,
	top: 0,
	left: 0
});

const btn1 = Ti.UI.createButton({
	title: 'Animate',
	width: 100,
	height: 40,
	bottom: 20,
	left: 10
});
btn1.addEventListener('click', function() {
	view.left = 0;
	view.animate(ani);
});

const btn2 = Ti.UI.createButton({
	title: 'Cancel',
	width: 100,
	height: 40,
	bottom: 20,
	right: 10
});
btn2.addEventListener('click', function() {
	view.stopAnimation();
	view.left = 0;
});

const ani = Ti.UI.createAnimation({
	left: 100,
	duration: 3000
})

ani.addEventListener("start", function() {
	lbl.text = "start";
});

ani.addEventListener("complete", function() {
	lbl.text = "complete";
})

ani.addEventListener("cancel", function() {
	lbl.text = "cancel";
})

win.add([view, btn1, btn2, lbl]);
win.open();
```