### PR TITLE
fix(ios): link to AppleWWDRCA

### DIFF
--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -1900,7 +1900,7 @@ iOSBuilder.prototype.validate = function validate(logger, config, cli) {
 			// make sure they have Apple's WWDR cert installed
 			if (!this.iosInfo.certs.wwdr) {
 				logger.error(__('WWDR Intermediate Certificate not found') + '\n');
-				logger.log(__('Download and install the certificate from %s', 'http://developer.apple.com/certificationauthority/AppleWWDRCA.cer'.cyan) + '\n');
+				logger.log(__('Download and install the certificate from %s', 'https://www.apple.com/certificateauthority/AppleWWDRCAG2.cer'.cyan) + '\n');
 				process.exit(1);
 			}
 

--- a/iphone/cli/lib/info.js
+++ b/iphone/cli/lib/info.js
@@ -79,7 +79,7 @@ exports.detect = function (types, config, next) {
 						+ __('The maximum supported Xcode version by Titanium SDK %s is Xcode %s.', manifestJson.version, issue.maxSupportedVer);
 					break;
 				case 'IOS_NO_WWDR_CERT_FOUND':
-					issue.message += '\n' + __('Download and install the certificate from %s', '__http://developer.apple.com/certificationauthority/AppleWWDRCA.cer__');
+					issue.message += '\n' + __('Download and install the certificate from %s', '__https://www.apple.com/certificateauthority/AppleWWDRCAG2.cer__');
 					break;
 				case 'IOS_NO_KEYCHAINS_FOUND':
 					issue.message += '\n' + __('Titanium will most likely not be able to detect any developer or App Store distribution certificates.');


### PR DESCRIPTION
Just saw this post on SO https://stackoverflow.com/q/75433379/5193915
and according to https://www.apple.com/certificateauthority/ the old link (G1) expired 02/07/23

Is it correct to use the next link :shrug: 

