### PR TITLE
fix(android): fullscreen mode

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/TiWindowProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/TiWindowProxy.java
@@ -532,7 +532,9 @@ public abstract class TiWindowProxy extends TiViewProxy
 		//Set the fullscreen flag
 		if (hasProperty(TiC.PROPERTY_FULLSCREEN)) {
 			boolean flagVal = TiConvert.toBoolean(getProperty(TiC.PROPERTY_FULLSCREEN), false);
+
 			if (flagVal) {
+				intent.putExtra(TiC.PROPERTY_FULLSCREEN, flagVal);
 				windowFlags = windowFlags | WindowManager.LayoutParams.FLAG_FULLSCREEN;
 			}
 		}

--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/TiWindowProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/TiWindowProxy.java
@@ -532,7 +532,6 @@ public abstract class TiWindowProxy extends TiViewProxy
 		//Set the fullscreen flag
 		if (hasProperty(TiC.PROPERTY_FULLSCREEN)) {
 			boolean flagVal = TiConvert.toBoolean(getProperty(TiC.PROPERTY_FULLSCREEN), false);
-
 			if (flagVal) {
 				intent.putExtra(TiC.PROPERTY_FULLSCREEN, flagVal);
 				windowFlags = windowFlags | WindowManager.LayoutParams.FLAG_FULLSCREEN;


### PR DESCRIPTION
The fullscreen mode is not applied to the window on Android at the moment:

```js
const window = Ti.UI.createWindow({
	fullscreen: true,
	backgroundColor: "#fff"
});
window.open();
```

The current way is to read the `getIntentBoolean` in
https://github.com/tidev/titanium_mobile/blob/81d3f4a1bfa69a5367b8cf05af40b608b62ebe3b/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java#L517-L523
and use `setFullscreen` to set 
```
int uiOptions = View.SYSTEM_UI_FLAG_HIDE_NAVIGATION | View.SYSTEM_UI_FLAG_FULLSCREEN;
decorView.setSystemUiVisibility(uiOptions);
```

But that check is always `false` (it will only be `true` for the root activity if you set `<fullscreen>true</fullscreen>` in your tiapp.xml. I've added `intent.putExtra(TiC.PROPERTY_FULLSCREEN, flagVal);` to set the value to the new intent too.

normal window:
![Screenshot_20230215-152429](https://user-images.githubusercontent.com/4334997/219054492-6afbb45b-6de0-4d8c-bfe9-2b010d530dd4.png)

fullscreen window:
![Screenshot_20230215-152438](https://user-images.githubusercontent.com/4334997/219054515-2bc252b4-4f17-4447-a8b3-e13df2aa26fd.png)
