### PR TITLE
feat(android): android optimizations

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/ListViewAdapter.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/ListViewAdapter.java
@@ -6,7 +6,7 @@
  */
 package ti.modules.titanium.ui.widget.listview;
 
-import java.util.LinkedList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.TreeMap;
 
@@ -24,7 +24,7 @@ public class ListViewAdapter extends TiRecyclerViewAdapter<ListViewHolder, ListI
 {
 	private static final String TAG = "ListViewAdapter";
 
-	private final TreeMap<String, LinkedList<ListItemProxy>> recyclableItemsMap = new TreeMap<>();
+	private final TreeMap<String, LinkedHashSet<ListItemProxy>> recyclableItemsMap = new TreeMap<>();
 
 	public ListViewAdapter(@NonNull Context context, @NonNull List<ListItemProxy> models)
 	{
@@ -74,7 +74,7 @@ public class ListViewAdapter extends TiRecyclerViewAdapter<ListViewHolder, ListI
 		final boolean selected = this.tracker != null ? this.tracker.isSelected(item) : false;
 
 		// Check if we have any recyclable items for the current template.
-		LinkedList<ListItemProxy> recyclableItems = this.recyclableItemsMap.get(item.getTemplateId());
+		LinkedHashSet<ListItemProxy> recyclableItems = this.recyclableItemsMap.get(item.getTemplateId());
 		if (recyclableItems != null) {
 			// If item is in recycle collection, then remove it.
 			recyclableItems.remove(item);
@@ -82,10 +82,10 @@ public class ListViewAdapter extends TiRecyclerViewAdapter<ListViewHolder, ListI
 			// If item has no child proxies/views, then take the children from a recyclable item.
 			// This significantly boosts scroll performance by avoiding creating new views.
 			if (!item.hasChildren()) {
-				while (!recyclableItems.isEmpty()) {
-					ListItemProxy oldItem = recyclableItems.poll();
+				for (ListItemProxy oldItem : recyclableItems) {
 					if ((oldItem != null) && (oldItem.getHolder() == null) && oldItem.hasChildren()) {
 						oldItem.moveChildrenTo(item);
+						recyclableItems.remove(oldItem);
 						break;
 					}
 				}
@@ -132,9 +132,9 @@ public class ListViewAdapter extends TiRecyclerViewAdapter<ListViewHolder, ListI
 			// Add item to recycle list so that it's child proxies/views can be re-used by another item.
 			ListItemProxy item = (ListItemProxy) view;
 			if (item.hasChildren() && (item.getHolder() == holder)) {
-				LinkedList<ListItemProxy> recyclableItems = this.recyclableItemsMap.get(item.getTemplateId());
+				LinkedHashSet<ListItemProxy> recyclableItems = this.recyclableItemsMap.get(item.getTemplateId());
 				if (recyclableItems == null) {
-					recyclableItems = new LinkedList<>();
+					recyclableItems = new LinkedHashSet<>();
 					this.recyclableItemsMap.put(item.getTemplateId(), recyclableItems);
 				}
 				if (!recyclableItems.contains(item)) {

--- a/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
@@ -519,7 +519,6 @@ public abstract class TiBaseActivity extends AppCompatActivity implements TiActi
 		int softInputMode = getIntentInt(TiC.PROPERTY_WINDOW_SOFT_INPUT_MODE, -1);
 		int windowFlags = getIntentInt(TiC.PROPERTY_WINDOW_FLAGS, 0);
 		boolean hasSoftInputMode = softInputMode != -1;
-
 		setFullscreen(fullscreen);
 
 		// Add additional window flags to better handle fullscreen support on devices with notches.


### PR DESCRIPTION
I've used ChatGPT and put in three methods and asked for optimizations :smile: 

Here are the changes:

<b>ListView:</b>
* Instead of using a LinkedList to store the recyclable items, you can use a LinkedHashSet to store the recyclable items in a more efficient way. A LinkedHashSet provides fast lookups and preserves the order of insertion.
This code uses a LinkedHashSet to store the recyclable items for each template, and it iterates over the recyclable items using a for-each loop to find a recyclable item with child views that can be reused by the current item. When a recyclable item is found, it removes it from the set and transfers its child views to the current item.

<b>removeAllChildren</b>
* One small optimization you could make is to avoid creating a new list if there are no children to remove. This would save a little bit of memory and processing time

<b>remove</b>
* The check for peekView() != null could be moved to the beginning of the function to avoid unnecessary computations if the parent view has not yet been attached to a window.
* The check for child.parent != null && child.parent.get() == this can be replaced with a simpler child.parent = null, since this statement removes the child view from the current parent, if any.

<b>toImage</b>
* The unnecessary blob variable was removed, since it's only used to hold a default result value


Android tests run fine, App runs fine. 


I like the `toImage` and `removeAllChildren` changes! Makes the code a bit easier to read. Don't see any performance improvements. We can ignore the ListView part since it's a bit out of my knowledge if its better or not.