### PR TITLE
feat(android): adjust Android 13 requestPhotoGalleryPermissions

### DIFF
--- a/android/modules/media/src/java/ti/modules/titanium/media/MediaModule.java
+++ b/android/modules/media/src/java/ti/modules/titanium/media/MediaModule.java
@@ -499,13 +499,14 @@ public class MediaModule extends KrollModule implements Handler.Callback
 	@Kroll.method
 	public boolean hasPhotoGalleryPermissions()
 	{
-		// We don't have to request permission on versions older than Android 6.0.
-		if (Build.VERSION.SDK_INT < 23) {
-			return true;
-		}
-
-		// We don't need write permission on Android 10 and above.
-		if (Build.VERSION.SDK_INT >= 29) {
+		if (Build.VERSION.SDK_INT >= 31) {
+			// Android 13+
+			// check for video and image permissions
+			int status_img = TiApplication.getInstance().checkSelfPermission(Manifest.permission.READ_MEDIA_IMAGES);
+			int status_vid = TiApplication.getInstance().checkSelfPermission(Manifest.permission.READ_MEDIA_VIDEO);
+			return (status_img == PackageManager.PERMISSION_GRANTED && status_vid == PackageManager.PERMISSION_GRANTED);
+		} else if (Build.VERSION.SDK_INT < 23 || Build.VERSION.SDK_INT >= 29) {
+			// We don't have to request permission on versions older than Android 6.0 or Android 10/11
 			return true;
 		}
 
@@ -650,11 +651,20 @@ public class MediaModule extends KrollModule implements Handler.Callback
 				return;
 			}
 
-			// Show dialog requesting permission.
-			TiBaseActivity.registerPermissionRequestCallback(
-				TiC.PERMISSION_CODE_EXTERNAL_STORAGE, permissionCallback, callbackThisObject, promise);
-			activity.requestPermissions(
-				new String[] { Manifest.permission.WRITE_EXTERNAL_STORAGE }, TiC.PERMISSION_CODE_EXTERNAL_STORAGE);
+			if (Build.VERSION.SDK_INT < 31) {
+				// Show dialog requesting permission.
+				TiBaseActivity.registerPermissionRequestCallback(
+					TiC.PERMISSION_CODE_EXTERNAL_STORAGE, permissionCallback, callbackThisObject, promise);
+				activity.requestPermissions(
+					new String[] { Manifest.permission.WRITE_EXTERNAL_STORAGE }, TiC.PERMISSION_CODE_EXTERNAL_STORAGE);
+			} else {
+				// Show dialog requesting permission.
+				TiBaseActivity.registerPermissionRequestCallback(
+					TiC.PERMISSION_CODE_MEDIA, permissionCallback, callbackThisObject, promise);
+				activity.requestPermissions(
+					new String[] { Manifest.permission.READ_MEDIA_IMAGES, Manifest.permission.READ_MEDIA_VIDEO },
+					TiC.PERMISSION_CODE_MEDIA);
+			}
 		});
 	}
 

--- a/android/titanium/src/java/org/appcelerator/titanium/TiC.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiC.java
@@ -24,6 +24,7 @@ public class TiC
 	public static final int PERMISSION_CODE_OLD_CALENDAR = 105;
 	public static final int PERMISSION_CODE_MICROPHONE = 106;
 	public static final int PERMISSION_CODE_PUSH_NOTIFICATIONS = 107;
+	public static final int PERMISSION_CODE_MEDIA = 108;
 
 	public static final String PERMISSION_CALENDAR = "calendar";
 	public static final String PERMISSION_CAMERA = "camera";

--- a/apidoc/Titanium/Android/Android.yml
+++ b/apidoc/Titanium/Android/Android.yml
@@ -99,12 +99,17 @@ description: |
 
     Starting from Android 6.0 (API level 23), users need to grant certain permissions to apps while the
     app is running. You can read it more [here](https://developer.android.com/training/permissions/requesting.html).
+    Starting with Android 13 you have to use more granular media permissions. Check the [official documentation](https://developer.android.com/about/versions/13/behavior-changes-13#granular-media-permissions).
 
     In Titanium SDK, to support this, we have the <Titanium.Android.requestPermissions> method. It is used to
     request any permission you may need. An example of using it is shown below:
 
     ``` js
     var permissions = [ 'android.permission.CAMERA', 'android.permission.READ_EXTERNAL_STORAGE', 'android.permission.WRITE_EXTERNAL_STORAGE' ];
+    if (Ti.Platform.versionMajor >= 13) {
+      // example for camera and image permission on Android 13
+      permissions = [ 'android.permission.CAMERA', 'android.permission.READ_MEDIA_IMAGES' ]
+    }
     Ti.Android.requestPermissions(permissions, function (e) {
         if (e.success) {
             Ti.API.info('SUCCESS');

--- a/apidoc/Titanium/Android/Android.yml
+++ b/apidoc/Titanium/Android/Android.yml
@@ -100,6 +100,7 @@ description: |
     Starting from Android 6.0 (API level 23), users need to grant certain permissions to apps while the
     app is running. You can read it more [here](https://developer.android.com/training/permissions/requesting.html).
     Starting with Android 13 you have to use more granular media permissions. Check the [official documentation](https://developer.android.com/about/versions/13/behavior-changes-13#granular-media-permissions).
+    Make sure to add e.g. `<uses-permission android:name="android.permission.READ_MEDIA_IMAGES"/>` to your tiapp.xml too.
 
     In Titanium SDK, to support this, we have the <Titanium.Android.requestPermissions> method. It is used to
     request any permission you may need. An example of using it is shown below:

--- a/apidoc/Titanium/Media/Media.yml
+++ b/apidoc/Titanium/Media/Media.yml
@@ -301,6 +301,15 @@ methods:
 
   - name: hasPhotoGalleryPermissions
     summary: Returns `true` if the app has photo gallery permissions.
+    description: |
+        If you use Android 13+ you have to add the following permissions to your tiapp.xml:
+        ``` xml
+        <uses-permission android:name="android.permission.READ_MEDIA_VIDEO"/>
+        <uses-permission android:name="android.permission.READ_MEDIA_IMAGES"/>
+        ```
+
+        You don't need to check this before using <Titanium.Media.requestPhotoGalleryPermissions>. If you already have the permission and use
+        <Titanium.Media.requestPhotoGalleryPermissions> it will call the success event, no second permission request is displayed.
     returns:
         type: Boolean
     platforms: [android, iphone, ipad, macos]
@@ -319,6 +328,13 @@ methods:
         user needs to change it in the device settings.
 
         iOS Apps that do not include this method, will present the system-dialog while the dialog is opened with <Titanium.Media.openPhotoGallery>.
+
+        If you use Android 13+ you have to add the following permissions to your tiapp.xml:
+        ``` xml
+        <uses-permission android:name="android.permission.READ_MEDIA_VIDEO"/>
+        <uses-permission android:name="android.permission.READ_MEDIA_IMAGES"/>
+        ```
+        When you only want to use it for images you can use `<Titanium.Android.requestPermissions>` and request `android.permission.READ_MEDIA_IMAGES`.
     parameters:
       - name: callback
         summary: |


### PR DESCRIPTION
* quick info about granular media permissions for Android 13+
* adjust `requestPhotoGalleryPermissions()` and `hasPhotoGalleryPermissions()`

Test
```js
const window = Ti.UI.createWindow({});
window.addEventListener("click", function() {
	console.log("has permission: " + Ti.Media.hasPhotoGalleryPermissions());

	Ti.Media.requestPhotoGalleryPermissions(function(e) {
		console.log("Success: " + e.success);
		if (e.success) {
			Ti.Media.openPhotoGallery({});
		}
	})
})
window.open();
```

open the app and click in the window. It should display the permission check and after that the photo gallery. Second click just the photo gallery.

Add
```xml
<uses-permission android:name="android.permission.READ_MEDIA_VIDEO"/>
<uses-permission android:name="android.permission.READ_MEDIA_IMAGES"/>
```
in your tiapp.xml into `<manifest>`
