### PR TITLE
chore: update some build steps to use Xcode 14.x

### DIFF
--- a/.github/actions/build-ios/action.yml
+++ b/.github/actions/build-ios/action.yml
@@ -9,7 +9,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Use Node.js 12.x
+    - name: Use Node.js 16.x
       uses: actions/setup-node@v2
       with:
         node-version: '16.x'

--- a/.github/actions/package/action.yml
+++ b/.github/actions/package/action.yml
@@ -15,7 +15,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Use Node.js 12.x
+    - name: Use Node.js 16.x
       uses: actions/setup-node@v2
       with:
         node-version: ${{ inputs.node-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,12 +25,12 @@ jobs:
           java-version: '11'
 
   ios:
-    runs-on: macos-11
+    runs-on: macos-12
     name: iOS
     env:
       CCACHE_DIR: ${{ github.workspace }}/.ccache
       USE_CCACHE: 1
-      DEVELOPER_DIR: /Applications/Xcode_13.2.1.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_14.2.app/Contents/Developer
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -50,7 +50,7 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Use Node.js 12.x
+    - name: Use Node.js 16.x
       uses: actions/setup-node@v2
       with:
         node-version: '16.x'
@@ -63,11 +63,11 @@ jobs:
       run: npm run lint:js
   
   package:
-    runs-on: macos-11
+    runs-on: macos-12
     name: Package
     env:
       SDK_BUILD_CACHE_DIR: ${{ github.workspace }}/.native-modules
-      DEVELOPER_DIR: /Applications/Xcode_13.2.1.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_14.2.app/Contents/Developer
     needs: [android, ios, js]
     steps:
     - name: Checkout repository

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v3
         with:
             fetch-depth: 0
-      - name: Use Node.js 12.x
+      - name: Use Node.js 16.x
         uses: actions/setup-node@v2
         with:
           node-version: '16.x'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,13 +75,13 @@ jobs:
           java-version: '11'
 
   ios:
-    runs-on: macos-11
+    runs-on: macos-12
     name: iOS
     needs: [validate]
     env:
       CCACHE_DIR: ${{ github.workspace }}/.ccache
       USE_CCACHE: 1
-      DEVELOPER_DIR: /Applications/Xcode_13.2.1.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_14.2.app/Contents/Developer
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -94,11 +94,11 @@ jobs:
           node-version: '16.x'
 
   package:
-    runs-on: macos-11
+    runs-on: macos-12
     name: Package
     env:
       SDK_BUILD_CACHE_DIR: ${{ github.workspace }}/.native-modules
-      DEVELOPER_DIR: /Applications/Xcode_13.2.1.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_14.2.app/Contents/Developer
       vtag: ${{ needs.validate.outputs.vtag }}
     needs: [validate, android, ios]
     steps:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -128,7 +128,7 @@ def androidUnitTests(testName, nodeVersion, npmVersion, deviceId) {
 
 def macosUnitTests(nodeVersion, npmVersion) {
 	return {
-		node('git && xcode-13') {
+		node('git && xcode-14') {
 			// TODO: Do a shallow checkout rather than stash/unstash?
 			unstash 'mocha-tests'
 			try {
@@ -165,7 +165,7 @@ def macosUnitTests(nodeVersion, npmVersion) {
 
 def iosUnitTests(deviceFamily, nodeVersion, npmVersion) {
 	return {
-		node('git && xcode-13') {
+		node('git && xcode-14') {
 			// TODO: Do a shallow checkout rather than stash/unstash?
 			unstash 'mocha-tests'
 			try {
@@ -225,7 +225,7 @@ def cliUnitTests(nodeVersion, npmVersion) {
 // Wrap in timestamper
 timestamps {
 	try {
-		node('git && android-sdk && gperf && xcode-13') {
+		node('git && android-sdk && gperf && xcode-14') {
 			env.JAVA_HOME="${tool name:'OpenJDK 11.0.11+9', type: 'jdk'}"
 			env.PATH="${env.JAVA_HOME}/bin:${env.PATH}"
 


### PR DESCRIPTION
This might fix https://github.com/tidev/titanium_mobile/issues/13739 as there are currently discrepancies between local- and cloud-generated builds.

EDIT: Seems to work now, yey! Test cloud-built artifact: https://github.com/tidev/titanium_mobile/suites/11121238842/artifacts/566844964