### PR TITLE
fix(android): initial gesture orientation value

### DIFF
--- a/android/modules/gesture/src/java/ti/modules/titanium/gesture/GestureModule.java
+++ b/android/modules/gesture/src/java/ti/modules/titanium/gesture/GestureModule.java
@@ -14,8 +14,10 @@ import org.appcelerator.kroll.common.Log;
 import org.appcelerator.titanium.ContextSpecific;
 import org.appcelerator.titanium.TiApplication;
 import org.appcelerator.titanium.TiProperties;
+import org.appcelerator.titanium.util.TiDeviceOrientation;
 import org.appcelerator.titanium.util.TiSensorHelper;
 
+import android.content.res.Configuration;
 import android.hardware.Sensor;
 import android.hardware.SensorEvent;
 import android.hardware.SensorEventListener;
@@ -174,12 +176,20 @@ public class GestureModule extends KrollModule implements SensorEventListener
 	@Kroll.getProperty
 	public boolean getPortrait()
 	{
+		if (this.deviceOrientationMonitor.getLastReadOrientation() == TiDeviceOrientation.UNKNOWN) {
+			int orientation = TiApplication.getAppCurrentActivity().getResources().getConfiguration().orientation;
+			return orientation == Configuration.ORIENTATION_PORTRAIT;
+		}
 		return this.deviceOrientationMonitor.getLastReadOrientation().isPortrait();
 	}
 
 	@Kroll.getProperty
 	public boolean getLandscape()
 	{
+		if (this.deviceOrientationMonitor.getLastReadOrientation() == TiDeviceOrientation.UNKNOWN) {
+			int orientation = TiApplication.getAppCurrentActivity().getResources().getConfiguration().orientation;
+			return orientation == Configuration.ORIENTATION_LANDSCAPE;
+		}
 		return this.deviceOrientationMonitor.getLastReadOrientation().isLandscape();
 	}
 
@@ -187,6 +197,12 @@ public class GestureModule extends KrollModule implements SensorEventListener
 	public int getOrientation()
 	{
 		return this.deviceOrientationMonitor.getLastReadOrientation().toTiIntId();
+	}
+
+	@Kroll.method
+	public void stopListener()
+	{
+		this.deviceOrientationMonitor.stop();
 	}
 
 	@Override

--- a/apidoc/Titanium/Gesture/Gesture.yml
+++ b/apidoc/Titanium/Gesture/Gesture.yml
@@ -44,6 +44,15 @@ properties:
     type: Number
     permission: read-only
 
+methods:
+  - name: stopListener
+    summary: Stops the gesture listener.
+    description: |
+        In case you use `Titanium.Gesture.landscape` or `Titanium.Gesture.portrait` it will attach the orientation
+        listener automatically. If you just use it once you can use this method to stop the listener.
+    since: "12.1.0"
+    platforms: [android]
+
 events:
   - name: orientationchange
     summary: Fired when the device orientation changes.


### PR DESCRIPTION
Read configuration value in case lastReadOrientation is still `TiDeviceOrientation.UNKNOWN`

```js
const win = Titanium.UI.createWindow();
win.open();
console.log("landscape:", Ti.Gesture.landscape);
console.log("portrait:", Ti.Gesture.portrait);
```

Ti 12.0.0: will return `false` and `false`
This PR: will return the initical state and e.g. `false` + `true` if you hold it in portrait while starting the app.

I also saw that it will attach the listener automatically if you read those properties even if you just read it once. I've added `Ti.Gesture.stopListener()` to stop that listener again.