### PR TITLE
chore: add “Optimize for Mac” option for macOS catalyst builds, add tooltip API

### DIFF
--- a/apidoc/Titanium/UI/Button.yml
+++ b/apidoc/Titanium/UI/Button.yml
@@ -356,6 +356,16 @@ properties:
     description: Only one of `title` or `titleid` should be specified.
     type: String
     since: "1.5"
+  
+  - name: tooltip
+    summary: The default text to display in the control's tooltip.
+    description: |
+         Assigning a value to this property causes the tool tip to be displayed for the view.
+         Setting the property to `null` cancels the display of the tool tip for the view.
+         Note: This property is only used for apps targeting macOS Catalyst.
+    type: String
+    osver: { ios: { min: "15.0" } }
+    since: "12.1.0"
 
   - name: verticalAlign
     summary: |

--- a/apidoc/Titanium/UI/View.yml
+++ b/apidoc/Titanium/UI/View.yml
@@ -1866,6 +1866,16 @@ properties:
     default: null
     platforms: [iphone, ipad, macos]
 
+  - name: tooltip
+    summary: The default text to display in the control's tooltip.
+    description: |
+         Assigning a value to this property causes the tool tip to be displayed for the view.
+         Setting the property to `null` cancels the display of the tool tip for the view.
+         Note: This property is only used for apps targeting macOS Catalyst.
+    type: String
+    osver: { ios: { min: "15.0" } }
+    since: "12.1.0"
+
   - name: top
     summary: The view's top position.
     description: |

--- a/iphone/Classes/TiUIButton.m
+++ b/iphone/Classes/TiUIButton.m
@@ -273,6 +273,11 @@
   [[self button] setEnabled:[TiUtils boolValue:value]];
 }
 
+- (void)setTooltip_:(id)value
+{
+  [[self button] setToolTip:[TiUtils stringValue:value]];
+}
+
 - (void)setTitle_:(id)value
 {
   [[self button] setTitle:[TiUtils stringValue:value] forState:UIControlStateNormal];

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiUIView.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiUIView.m
@@ -600,6 +600,12 @@ DEFINE_EXCEPTIONS
   }
 }
 
+- (void)setTooltip_:(id)value
+{
+  UIToolTipInteraction *toolTipInteraction = [[UIToolTipInteraction alloc] initWithDefaultToolTip:[TiUtils stringValue:value]];
+  [self addInteraction:toolTipInteraction];
+}
+
 - (void)setOpacity_:(id)opacity
 {
   self.alpha = [TiUtils floatValue:opacity];

--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -3209,6 +3209,12 @@ iOSBuilder.prototype.createXcodeProject = function createXcodeProject(next) {
 		}
 	});
 
+	// If we're building for macOS catalyst, set the "Optimize for Mac" flag
+	let deviceFamily = this.deviceFamilies[this.deviceFamily];
+	if (this.target === 'macos') {
+		deviceFamily = [ ...deviceFamily.split(','), '6' ].join(',');
+	}
+
 	const projectUuid = xcodeProject.hash.project.rootObject,
 		pbxProject = xobjs.PBXProject[projectUuid],
 		mainTargetUuid = pbxProject.targets.filter(function (t) { return t.comment.replace(/^"/, '').replace(/"$/, '') === appName; })[0].value,
@@ -3229,7 +3235,7 @@ iOSBuilder.prototype.createXcodeProject = function createXcodeProject(next) {
 		caps = this.tiapp.ios.capabilities,
 		buildSettings = {
 			IPHONEOS_DEPLOYMENT_TARGET: appc.version.format(this.minIosVer, 2),
-			TARGETED_DEVICE_FAMILY: '"' + this.deviceFamilies[this.deviceFamily] + '"',
+			TARGETED_DEVICE_FAMILY: '"' + deviceFamily + '"',
 			ONLY_ACTIVE_ARCH: 'NO',
 			DEAD_CODE_STRIPPING: 'YES',
 			SDKROOT: 'iphoneos',


### PR DESCRIPTION
Enables the "Optimize for Mac" flag like visually in Xcode:

<img width="451" alt="Screenshot 2023-03-02 at 22 11 21" src="https://user-images.githubusercontent.com/10667698/222554169-f12d0410-948d-4a45-b259-2f8dde454973.png">

Also adds tooltip support for views and buttons
<img width="269" alt="Screenshot 2023-03-02 at 22 39 55" src="https://user-images.githubusercontent.com/10667698/222675744-3ef9cd2e-9cca-418a-8569-02feecd4b413.png"> <img width="230" alt="Screenshot 2023-03-02 at 22 40 52" src="https://user-images.githubusercontent.com/10667698/222675747-f242a5cd-67b7-46ce-b091-88a2e9111021.png">

Example (views):
```js
const win = Ti.UI.createWindow({
    backgroundColor: '#fff'
});

const btn = Ti.UI.createView({
    backgroundColor: 'red',
    width: 200,
    height: 100,
    tooltip: 'Click me!'
});

win.add(btn);
win.open();
```

Example (buttons):
```js
const win = Ti.UI.createWindow({
    backgroundColor: '#fff'
});

const btn = Ti.UI.createButton({
    title: 'Trigger',
    tooltip: 'Click me!'
});

win.add(btn);
win.open();
```