### PR TITLE
feat(ios): be able to get a list of available system font families

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/UIModule.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/UIModule.java
@@ -28,6 +28,8 @@ import android.content.res.Resources;
 import android.graphics.Color;
 import android.graphics.Rect;
 import android.graphics.drawable.Drawable;
+import android.graphics.fonts.Font;
+import android.graphics.fonts.SystemFonts;
 import android.os.Build;
 import android.text.InputType;
 import android.text.util.Linkify;
@@ -40,7 +42,9 @@ import android.widget.Toast;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatDelegate;
 
+import java.io.File;
 import java.util.List;
+import java.util.Set;
 
 @Kroll.module
 public class UIModule extends KrollModule implements TiApplication.ConfigurationChangedListener
@@ -474,6 +478,31 @@ public class UIModule extends KrollModule implements TiApplication.Configuration
 		}
 	}
 
+	@Kroll.getProperty
+	public String[] availableSystemFontFamilies()
+	{
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+			Set<Font> fonts = SystemFonts.getAvailableFonts();
+			String[] list = new String[fonts.size()];
+			int count = 0;
+			for (Font font: fonts) {
+				list[count] = font.getFile().getName().replaceFirst("[.][^.]+$", "");
+				count++;
+			}
+			return list;
+		} else {
+			String path = "/system/fonts";
+			File file = new File(path);
+			File[] ff = file.listFiles();
+			String[] list = new String[ff.length];
+			int count = 0;
+			for (File font: ff) {
+				list[count] = font.getName().replaceFirst("[.][^.]+$", "");
+				count++;
+			}
+			return list;
+		}
+	}
 	@Kroll.setProperty(runOnUiThread = true)
 	public void setBackgroundImage(Object image)
 	{

--- a/apidoc/Titanium/UI/UI.yml
+++ b/apidoc/Titanium/UI/UI.yml
@@ -2754,7 +2754,7 @@ properties:
     summary: Returns a list of font families that are provided by the system.
     type: Array<String>
     permission: read-only
-    platforms: [iphone, ipad, macos]
+    platforms: [android, iphone, ipad, macos]
     since: "12.1.0"
 
   - name: backgroundColor

--- a/apidoc/Titanium/UI/UI.yml
+++ b/apidoc/Titanium/UI/UI.yml
@@ -2750,6 +2750,13 @@ properties:
     osver: {ios: {min: "13.0"}}
     since: "9.1.0"
 
+  - name: availableSystemFontFamilies
+    summary: Returns a list of font families that are provided by the system.
+    type: Array<String>
+    permissions: read-only
+    platforms: [iphone, ipad, macos]
+    since: "12.1.0"
+
   - name: backgroundColor
     summary: |
         Sets the background color of the master view (when there are no windows or other top-level

--- a/apidoc/Titanium/UI/UI.yml
+++ b/apidoc/Titanium/UI/UI.yml
@@ -2753,7 +2753,7 @@ properties:
   - name: availableSystemFontFamilies
     summary: Returns a list of font families that are provided by the system.
     type: Array<String>
-    permissions: read-only
+    permission: read-only
     platforms: [iphone, ipad, macos]
     since: "12.1.0"
 

--- a/iphone/Classes/UIModule.m
+++ b/iphone/Classes/UIModule.m
@@ -553,6 +553,11 @@ MAKE_SYSTEM_PROP(EXTEND_EDGE_ALL, 15); //UIEdgeRectAll
   return [self createMatrix3D:args];
 }
 
+- (id)availableSystemFontFamilies
+{
+  return [UIFont familyNames];
+}
+
 #ifdef USE_TI_UICLIPBOARD
 - (id)Clipboard
 {


### PR DESCRIPTION
Maybe Android parity could be added, but it seems like there is no convenient way to do so.