### PR TITLE
fix(android): collapseToolbar Alloy fix

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/android/CollapseToolbarProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/android/CollapseToolbarProxy.java
@@ -11,6 +11,7 @@ import android.app.Activity;
 import org.appcelerator.kroll.KrollFunction;
 import org.appcelerator.kroll.annotations.Kroll;
 import org.appcelerator.titanium.TiApplication;
+import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.proxy.TiViewProxy;
 import org.appcelerator.titanium.util.TiConvert;
 import org.appcelerator.titanium.view.TiDrawableReference;
@@ -49,7 +50,7 @@ public class CollapseToolbarProxy extends TiViewProxy
 	public void setContentView(Object obj)
 	{
 		if (obj instanceof TiViewProxy) {
-			collapseToolbar.setContentView((TiViewProxy) obj);
+			setPropertyAndFire(TiC.PROPERTY_CONTENT_VIEW, (TiViewProxy) obj);
 		}
 	}
 

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUICollapseToolbar.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUICollapseToolbar.java
@@ -96,7 +96,7 @@ public class TiUICollapseToolbar extends TiUIView
 
 			setNativeView(layout);
 		} catch (Exception e) {
-			Log.i(TAG, "Layout error: " + e.getMessage());
+			Log.e(TAG, "Layout error: " + e.getMessage());
 		}
 	}
 

--- a/apidoc/Titanium/UI/Android/CollapseToolbar.yml
+++ b/apidoc/Titanium/UI/Android/CollapseToolbar.yml
@@ -120,3 +120,21 @@ examples:
         win.add(collapsingToolbar);
         win.open();
         ```
+  - title: Alloy example
+    example: |
+        ``` js
+        <Alloy>
+        	<Window>
+
+        		<CollapseToolbar platform="android">
+
+        			<ContentView>
+        				<View backgroundColor="red" height="Ti.UI.SIZE">
+        					<Label>test</Label>
+        				</View>
+        			</ContentView>
+        		</CollapseToolbar>
+
+        	</Window>
+        </Alloy>
+        ```


### PR DESCRIPTION
* fix needed for alloy (contentView is not yet available when using Alloy)
* moving error to `Log.e` instead of `Log.i`

```
<Alloy>
	<Window>

		<CollapseToolbar platform="android">

			<ContentView>
				<View backgroundColor="red" height="Ti.UI.SIZE">
					<Label>test</Label>
				</View>
			</ContentView>
		</CollapseToolbar>

	</Window>
</Alloy>
```

<b>Attention</b>
<strike>Needs a patched Alloy so it will use the correct namespace. PR will follow</strike>
Alloy PR is merged https://github.com/tidev/alloy/pull/1360 :+1: 
