### PR TITLE
feat(android): headerTitle color properties

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/ListViewHolder.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/ListViewHolder.java
@@ -337,6 +337,13 @@ public class ListViewHolder extends TiRecyclerViewHolder<ListItemProxy>
 
 				// Handle header title.
 				this.headerTitle.setText(properties.getString(TiC.PROPERTY_HEADER_TITLE));
+				if (properties.containsKeyAndNotNull("headerBackgroundColor")) {
+					this.headerTitle.setBackgroundColor(
+						TiConvert.toColor(properties.get("headerBackgroundColor"), context));
+				}
+				if (properties.containsKeyAndNotNull(TiC.PROPERTY_COLOR)) {
+					this.headerTitle.setTextColor(TiConvert.toColor(properties.get(TiC.PROPERTY_COLOR), context));
+				}
 				this.headerTitle.setVisibility(View.VISIBLE);
 
 			} else if (properties.containsKeyAndNotNull(TiC.PROPERTY_HEADER_VIEW)) {

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TableViewHolder.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TableViewHolder.java
@@ -569,6 +569,13 @@ public class TableViewHolder extends TiRecyclerViewHolder<TableViewRowProxy>
 
 				// Handle header title.
 				this.headerTitle.setText(headerTitle);
+				if (properties.containsKeyAndNotNull("headerBackgroundColor")) {
+					this.headerTitle.setBackgroundColor(
+						TiConvert.toColor(properties.get("headerBackgroundColor"), context));
+				}
+				if (properties.containsKeyAndNotNull(TiC.PROPERTY_COLOR)) {
+					this.headerTitle.setTextColor(TiConvert.toColor(properties.get(TiC.PROPERTY_COLOR), context));
+				}
 				this.headerTitle.setVisibility(View.VISIBLE);
 
 			} else if (properties.containsKeyAndNotNull(TiC.PROPERTY_HEADER_VIEW)) {

--- a/apidoc/Titanium/UI/ListView.yml
+++ b/apidoc/Titanium/UI/ListView.yml
@@ -388,7 +388,7 @@ events:
     summary: Fired when a list row has started moving.
     description: |
       This event can be used to change the UI once a new drag-and-drop interaction starts.
-      The event properties are available in Titanium SDK 12.0.0+ 
+      The event properties are available in Titanium SDK 12.0.0+
     since: "11.1.0"
     platforms: [android, iphone, ipad, macos]
     properties:
@@ -842,6 +842,20 @@ properties:
   - name: headerTitle
     summary: List view header title.
     type: String
+
+  - name: headerColor
+    summary: Text color of the list view header title.
+    type: [String, Titanium.UI.Color]
+    default: platform-specific default color
+    since: 12.1.0
+    platforms: [android]
+
+  - name: headerBackgroundColor
+    summary: Background color of the list view header title.
+    type: [String, Titanium.UI.Color]
+    default: platform-specific default color
+    since: 12.1.0
+    platforms: [android]
 
   - name: headerView
     summary: List view header as a view that will be rendered instead of a label.

--- a/apidoc/Titanium/UI/TableView.yml
+++ b/apidoc/Titanium/UI/TableView.yml
@@ -1290,6 +1290,20 @@ properties:
     summary: Table view header title.
     type: String
 
+  - name: headerColor
+    summary: Text color of the table view header title.
+    type: [String, Titanium.UI.Color]
+    default: platform-specific default color
+    since: 12.1.0
+    platforms: [android]
+
+  - name: headerBackgroundColor
+    summary: Background color of the table view header title.
+    type: [String, Titanium.UI.Color]
+    default: platform-specific default color
+    since: 12.1.0
+    platforms: [android]
+
   - name: headerView
     summary: Table view header as a view that will be rendered instead of a label.
     description: |


### PR DESCRIPTION
properties to set the headerTitle color and backgroundColor: `headerColor` and `headerBackgroundColor`
Current way is using a theme https://fromzerotoapp.com/android-styling-in-titanium-using-themes/#link8

```js
var win = Ti.UI.createWindow({backgroundColor: 'gray'});
var listView = Ti.UI.createListView();
var sections = [];

var fruitDataSet = [
    {properties: { title: 'Apple'}},
    {properties: { title: 'Banana'}},
];
var fruitSection = Ti.UI.createListSection({ headerTitle: 'Fruits', color: "#000", headerBackgroundColor:"#00f", items: fruitDataSet});
sections.push(fruitSection);

var vegDataSet = [
    {properties: { title: 'Carrots'}},
    {properties: { title: 'Potatoes'}},
];
var vegSection = Ti.UI.createListSection({ headerTitle: 'Vegetables', color: "#ff0", headerBackgroundColor:"#f00", items: vegDataSet});
sections.push(vegSection);

listView.sections = sections;
win.add(listView);
win.open();

var fishDataSet = [
    {properties: { title: 'Cod'}},
    {properties: { title: 'Haddock'}},
];
var fishSection = Ti.UI.createListSection({ headerTitle: 'Fish', items: fishDataSet});
listView.appendSection(fishSection);
```

![Screenshot_20230307-092904](https://user-images.githubusercontent.com/4334997/223366813-3f857e51-e401-4b3c-8da5-097fccf0ebf2.jpg)

<b>TODO</b>
* [x] docs

Would be great if someone looks at iOS parity