### PR TITLE
fix(android): null check for registerPush callbacks

### DIFF
--- a/android/modules/network/src/java/ti/modules/titanium/network/NetworkModule.java
+++ b/android/modules/network/src/java/ti/modules/titanium/network/NetworkModule.java
@@ -522,7 +522,9 @@ public class NetworkModule extends KrollModule
 			KrollDict event = new KrollDict();
 			event.put("success", true);
 			event.put("type", "remote");
-			successCallback.callAsync(getKrollObject(), new KrollDict());
+			if (successCallback != null) {
+				successCallback.callAsync(getKrollObject(), new KrollDict());
+			}
 			return;
 		}
 
@@ -543,9 +545,13 @@ public class NetworkModule extends KrollModule
 				event.put("type", "remote");
 
 				if (isGranted) {
-					successCallback.callAsync(getKrollObject(), event);
+					if (successCallback != null) {
+						successCallback.callAsync(getKrollObject(), event);
+					}
 				} else {
-					errorCallback.callAsync(getKrollObject(), event);
+					if (errorCallback != null) {
+						errorCallback.callAsync(getKrollObject(), event);
+					}
 				}
 
 				// Unregister this callback.

--- a/android/modules/network/src/java/ti/modules/titanium/network/NetworkModule.java
+++ b/android/modules/network/src/java/ti/modules/titanium/network/NetworkModule.java
@@ -538,7 +538,10 @@ public class NetworkModule extends KrollModule
 				@NonNull TiBaseActivity activity, int requestCode,
 				@NonNull String[] permissions, @NonNull int[] grantResults)
 			{
-				Boolean isGranted = grantResults[0] == PackageManager.PERMISSION_GRANTED;
+				Boolean isGranted = false;
+				if (grantResults.length > 0) {
+					isGranted = grantResults[0] == PackageManager.PERMISSION_GRANTED;
+				}
 
 				KrollDict event = new KrollDict();
 				event.put("success", isGranted);

--- a/apidoc/Titanium/Network/Network.yml
+++ b/apidoc/Titanium/Network/Network.yml
@@ -353,6 +353,25 @@ methods:
 
         **Android Notes**:
         Make sure to also add the `<uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>` permission in the `<manifest>` tag of your tiapp.xml.
+        Example:
+
+        ``` js
+        const win = Ti.UI.createWindow();
+        win.addEventListener("open", function() {
+          console.log("Is enabled", Ti.Network.remoteNotificationsEnabled);
+
+          Ti.Network.registerForPushNotifications({
+            success: (e) => {
+              console.log("success", e);
+            },
+            error: (e) => {
+               console.log("error", e);
+            }
+          });
+        });
+        win.open();
+        ```
+        The permission request will only be shown twice. After that it won't show up again and the user has to go to the app permissions to enable it.
     platforms: [iphone, ipad, macos, android]
     parameters:
       - name: config


### PR DESCRIPTION
If you don't use an error callback in `registerForPushNotifications` it wiill crash in 12.0.0:

```js
  Ti.Network.registerForPushNotifications({
        success: function() {
          fcm.registerForPushNotifications();
        },
        // error: function() {}  // crash
    });
```

adding a null check around the callbacks to fix that.

Also fixing 
```
TiExceptionHandler: Ti.Network.registerForPushNotifications({
TiExceptionHandler:            ^
TiExceptionHandler: Error: length=0; index=0
TiExceptionHandler:     ti.modules.titanium.network.NetworkModule$2.onRequestPermissionsResult(NetworkModule.java:539)
```

where `grantResults` was empty so it couldn't access `grantResults[0]`

Added an example to the docs