### PR TITLE
fix(android): code optimizations

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/TiRecyclerViewHolder.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/TiRecyclerViewHolder.java
@@ -176,6 +176,7 @@ public abstract class TiRecyclerViewHolder<V extends TiViewProxy> extends Recycl
 
 			// Create the RippleDrawable.
 			drawable = new RippleDrawable(colorStateList, drawable, maskDrawable);
+			colorControlHighlight.recycle();
 		}
 
 		return drawable;

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiWebChromeClient.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiWebChromeClient.java
@@ -28,7 +28,6 @@ import android.webkit.WebStorage.QuotaUpdater;
 import android.webkit.WebView;
 import android.widget.FrameLayout;
 import androidx.annotation.NonNull;
-import androidx.annotation.RequiresApi;
 import java.util.ArrayList;
 import java.util.HashMap;
 import org.appcelerator.kroll.KrollDict;
@@ -139,7 +138,6 @@ public class TiWebChromeClient extends WebChromeClient
 	 * @param request Object providing the grant/deny callback and the resoruces being requested.
 	 */
 	@Override
-	@RequiresApi(21)
 	public void onPermissionRequest(final PermissionRequest request)
 	{
 		// Validate argument
@@ -406,7 +404,6 @@ public class TiWebChromeClient extends WebChromeClient
 	 * Returns false if not and the system should do its default handling.
 	 */
 	@Override
-	@RequiresApi(21)
 	public boolean onShowFileChooser(
 		final WebView webView, final ValueCallback<Uri[]> filePathCallback,
 		final WebChromeClient.FileChooserParams chooserParams)
@@ -561,7 +558,6 @@ public class TiWebChromeClient extends WebChromeClient
 	 * @return Returns an intent to be passed to the startActivityForResult() method.
 	 */
 	@NonNull
-	@RequiresApi(21)
 	private Intent createFileChooserIntentFrom(WebChromeClient.FileChooserParams chooserParams)
 	{
 		// Create the intent.

--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiBorderWrapperView.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiBorderWrapperView.java
@@ -42,7 +42,7 @@ public class TiBorderWrapperView extends FrameLayout
 	private Paint paint;
 	private Rect bounds;
 	private ViewOutlineProvider viewOutlineProvider;
-
+	Path outerPath;
 	public TiBorderWrapperView(Context context)
 	{
 		super(context);
@@ -61,6 +61,7 @@ public class TiBorderWrapperView extends FrameLayout
 
 		paint = new Paint(Paint.ANTI_ALIAS_FLAG);
 		bounds = new Rect();
+		outerPath = new Path();
 	}
 
 	public void reset()
@@ -91,7 +92,6 @@ public class TiBorderWrapperView extends FrameLayout
 			paint.setAlpha(alpha);
 		}
 
-		Path outerPath = new Path();
 		if (hasRadius()) {
 			float[] innerRadius = new float[this.radius.length];
 			for (int i = 0; i < this.radius.length; i++) {

--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiCompositeLayout.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiCompositeLayout.java
@@ -67,7 +67,8 @@ public class TiCompositeLayout extends ViewGroup implements OnHierarchyChangeLis
 	private boolean enableHorizontalWrap = true;
 	private int horizontalLayoutLastIndexBeforeWrap = 0;
 	private int horiztonalLayoutPreviousRight = 0;
-
+	int[] horizontal = new int[2];
+	int[] vertical = new int[2];
 	/**
 	 * Custom pixel width to be used by child views when calculating percentage based lengths/positions.
 	 * Set to a negative value if child should be relative to the parent view.
@@ -855,9 +856,6 @@ public class TiCompositeLayout extends ViewGroup implements OnHierarchyChangeLis
 		// viewSorter is not needed after this. It's a source of
 		// memory leaks if it retains the views it's holding.
 		viewSorter.clear();
-
-		int[] horizontal = new int[2];
-		int[] vertical = new int[2];
 
 		int currentHeight = 0; // Used by vertical arrangement calcs
 

--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiDrawableReference.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiDrawableReference.java
@@ -535,8 +535,8 @@ public class TiDrawableReference
 	 */
 	public Bitmap getBitmap(int destWidth, int destHeight)
 	{
-		return getBitmap(null, TiConvert.toTiDimension(new Integer(destWidth), TiDimension.TYPE_WIDTH),
-						 TiConvert.toTiDimension(new Integer(destHeight), TiDimension.TYPE_HEIGHT));
+		return getBitmap(null, TiConvert.toTiDimension(Integer.valueOf(destWidth), TiDimension.TYPE_WIDTH),
+						 TiConvert.toTiDimension(Integer.valueOf(destHeight), TiDimension.TYPE_HEIGHT));
 	}
 	/**
 	 * Gets the bitmap, scaled to a specific width, with the height matching the


### PR DESCRIPTION
Splitting up https://github.com/tidev/titanium_mobile/pull/13669 even more :smile: 

Should be even easier to read an test, I left out the two possible memory leaks from the other ticket as they have more complex code.

--- 

Unnecessary `@RequiresApi(21)` in TiWebChromeClient

----

> Should use valueOf instead of new  You should not call the constructor for wrapper classes directly, such as`new Integer(42)`. Instead, call the valueOf factory method, such as Integer.valueOf(42). This will typically use less memory because common integers such as 0 and 1 will share a single instance.  Issue id: UseValueOf

in TiDrawableReference

----

> Missing recycle() calls  Many resources, such as TypedArrays, VelocityTrackers, etc., should be recycled (with a recycle() call) after use. This lint check looks for missing recycle() calls.  Issue id: Recycle

`recycle` missing in TiRecyclerViewHolder

----

> Memory allocations within drawing code  You should avoid allocating objects during a drawing or layout operation. These are called frequently, so a smooth UI can be interrupted by garbage collection pauses caused by the object allocations.  The way this is generally handled is to allocate the needed objects up front and to reuse them for each drawing operation.

in TiBorderWrapperView and TiCompositeLayout.java

----

Tested two bigger apps and the test suite again.