### PR TITLE
fix(android): tableView fixes

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiTableView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiTableView.java
@@ -342,7 +342,10 @@ public class TiTableView extends TiSwipeRefreshLayout implements OnSearchChangeL
 			final TableViewHolder firstVisibleHolder =
 				(TableViewHolder) recyclerView.getChildViewHolder(firstVisibleView);
 			final TableViewRowProxy firstVisibleProxy = (TableViewRowProxy) firstVisibleHolder.getProxy();
-			final int firstVisibleIndex = firstVisibleProxy.getIndexInSection();
+			int firstVisibleIndex = -1;
+			if (firstVisibleProxy != null) {
+				firstVisibleIndex = firstVisibleProxy.getIndexInSection();
+			}
 			payload.put(TiC.PROPERTY_FIRST_VISIBLE_ITEM, firstVisibleIndex);
 		}
 
@@ -746,7 +749,12 @@ public class TiTableView extends TiSwipeRefreshLayout implements OnSearchChangeL
 		}
 
 		// Notify adapter of changes on UI thread.
-		this.adapter.update(this.rows, force);
+		recyclerView.post(new Runnable() {
+			public void run()
+			{
+				adapter.update(rows, force);
+			}
+		});
 
 		// FIXME: This is not an ideal workaround for an issue where recycled items that were in focus
 		//        lose their focus when the data set changes. There are improvements to be made here.


### PR DESCRIPTION
Fixes #13767, #13766

both rare cases. 2nd one is just a warning but it will be removed with this PR (had it in one app). And the first error appeared in my test app while fixing the other warning :smile: Code below.

----

### Attempt to invoke virtual method 'int ti.modules.titanium.ui.TableViewRowProxy.getIndexInSection()' on a null object reference

let it running for a while and always scroll up and down:
```js
const win = Ti.UI.createWindow();
const tableView = Ti.UI.createTableView({});
var tableData = [];

setInterval(function() {
	for (var i = 1; i <= 10; i++) {
		var entryRow = Ti.UI.createTableViewRow({ height: 40 });
		var entryNameLabel = Ti.UI.createLabel({ text: "test" });
		entryRow.add(entryNameLabel);
		tableData.push(entryRow);
	}
	tableView.data = tableData;
}, 1000);

win.add(tableView);
win.open();
```
(it will fill up the memory, so intended to get slower and slower)

---

### Cannot call this method in a scroll callback

<b>RecyclerView: Cannot call this method in a scroll callback. Scroll callbacks mightbe run during a measure & layout pass where you cannot change theRecyclerView data. Any method call that might change the structureof the RecyclerView or the adapter contents should be postponed tothe next frame.</b>

Don't have code but in my app it will show this error when scrolling the tableView and it does and update.
Fix according to https://stackoverflow.com/questions/42944005/recyclerview-cannot-call-this-method-in-a-scroll-callback/59570583#59570583