### PR TITLE
feat(ios, android): add tabBarVisible API

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TabGroupProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TabGroupProxy.java
@@ -112,6 +112,16 @@ public class TabGroupProxy extends TiWindowProxy implements TiActivityWindow
 		}
 	}
 
+	@Kroll.setProperty
+	public void setTabBarVisible(boolean visible)
+	{
+		TiUIBottomNavigationTabGroup tabGroup = (TiUIBottomNavigationTabGroup) view;
+
+		if (tabGroup != null) {
+			tabGroup.setTabBarVisible(visible);
+		}
+	}
+
 	@Kroll.method
 	public void removeTab(TabProxy tab)
 	{

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIBottomNavigationTabGroup.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIBottomNavigationTabGroup.java
@@ -363,6 +363,15 @@ public class TiUIBottomNavigationTabGroup extends TiUIAbstractTabGroup implement
 		this.mBottomNavigationView.getMenu().getItem(index).setTitle(title);
 	}
 
+	public void setTabBarVisible(boolean visible)
+	{
+		if (visible) {
+			mBottomNavigationView.animate().translationY(0f);
+		} else {
+			mBottomNavigationView.animate().translationY(mBottomNavigationView.getHeight());
+		}
+	}
+
 	@SuppressLint("RestrictedApi")
 	@Override
 	public void updateBadge(int index)

--- a/apidoc/Titanium/UI/TabGroup.yml
+++ b/apidoc/Titanium/UI/TabGroup.yml
@@ -591,8 +591,8 @@ properties:
   - name: tabBarVisible
     summary: Programmatically shows / hides the bottom tab bar of the tab group.
     type: Boolean
-    platforms: [iphone, ipad, macos]
-    since: "11.1.0"
+    platforms: [android, iphone, ipad, macos]
+    since: "12.1.0"
 
 examples:
   - title: Alloy XML Markup

--- a/apidoc/Titanium/UI/TabGroup.yml
+++ b/apidoc/Titanium/UI/TabGroup.yml
@@ -588,6 +588,12 @@ properties:
     platforms: [iphone, ipad, macos]
     since: { iphone: "3.1.0", ipad: "3.1.0" }
 
+  - name: tabBarVisible
+    summary: Programmatically shows / hides the bottom tab bar of the tab group.
+    type: Boolean
+    platforms: [iphone, ipad, macos]
+    since: "11.1.0"
+
 examples:
   - title: Alloy XML Markup
     example: |

--- a/iphone/Classes/TiUITabGroup.m
+++ b/iphone/Classes/TiUITabGroup.m
@@ -368,6 +368,29 @@ DEFINE_EXCEPTIONS
   }
 }
 
+- (void)setTabBarVisible_:(id)value
+{
+  BOOL visible = [TiUtils boolValue:value];
+
+  if ([self tabBarIsVisible] == visible) {
+    return;
+  }
+
+  CGRect frame = self.tabController.tabBar.frame;
+  CGFloat height = frame.size.height;
+
+  [UIView animateWithDuration:0.3
+                   animations:^{
+                     self.tabController.tabBar.frame = CGRectOffset(frame, 0, visible ? -height : height);
+                   }
+                   completion:nil];
+}
+
+- (BOOL)tabBarIsVisible
+{
+  return self.tabController.tabBar.frame.origin.y < CGRectGetMaxY(self.tabController.view.frame);
+}
+
 - (void)setTabsBackgroundColor_:(id)value
 {
   TiColor *color = [TiUtils colorValue:value];


### PR DESCRIPTION
Example:

```js
const isAndroid = Ti.Platform.osname === 'android';
let tabGroup;
let isVisible = true;

const window = Ti.UI.createWindow({
	title: 'Window 1',
	backgroundColor: '#fff'
});

const btn = Ti.UI.createButton({
	title: 'Show / hide tab group'
});

btn.addEventListener('click', () => {
	isVisible = !isVisible;
	tabGroup.tabBarVisible = isVisible;
});

window.add(btn);

tabGroup = Ti.UI.createTabGroup({
	style: isAndroid ? Ti.UI.Android.TABS_STYLE_BOTTOM_NAVIGATION : undefined,
	tabs: [
		Ti.UI.createTab({ window, title: window.title })
	]
});

tabGroup.open();
```