### PR TITLE
feat(android): animated parameter for disableTabNavigation

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TabGroupProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TabGroupProxy.java
@@ -8,6 +8,7 @@ package ti.modules.titanium.ui;
 
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
+import java.util.HashMap;
 
 import org.appcelerator.kroll.KrollDict;
 import org.appcelerator.kroll.annotations.Kroll;
@@ -85,11 +86,23 @@ public class TabGroupProxy extends TiWindowProxy implements TiActivityWindow
 	}
 
 	@Kroll.method
-	public void disableTabNavigation(boolean disable)
+	public void disableTabNavigation(Object params)
 	{
-		TiUIAbstractTabGroup tabGroup = (TiUIAbstractTabGroup) view;
-		if (tabGroup != null) {
-			tabGroup.disableTabNavigation(disable);
+		if (params instanceof Boolean) {
+			TiUIAbstractTabGroup tabGroup = (TiUIAbstractTabGroup) view;
+			if (tabGroup != null) {
+				tabGroup.disableTabNavigation(TiConvert.toBoolean(params, false));
+			}
+		} else if (params instanceof HashMap<?, ?>) {
+			KrollDict options = new KrollDict((HashMap<String, Object>) params);
+			TiUIAbstractTabGroup tabGroup = (TiUIAbstractTabGroup) view;
+			if (tabGroup != null) {
+				if (options.getBoolean(TiC.PROPERTY_ANIMATED)) {
+					setTabBarVisible(options.getBoolean(TiC.PROPERTY_ENABLED));
+				} else {
+					tabGroup.disableTabNavigation(options.getBoolean(TiC.PROPERTY_ENABLED));
+				}
+			}
 		}
 	}
 

--- a/apidoc/Titanium/UI/TabGroup.yml
+++ b/apidoc/Titanium/UI/TabGroup.yml
@@ -193,9 +193,8 @@ methods:
         the last selected tab window is shown.
     parameters:
       - name: params
-        summary: Boolean to disable tab navigation or dictionary.
+        summary: Boolean to disable tab navigation or dictionary (since 12.1.0).
         type: disableTabOptions
-        optional: true
     platforms: [android]
     since: 3.6.0
 

--- a/apidoc/Titanium/UI/TabGroup.yml
+++ b/apidoc/Titanium/UI/TabGroup.yml
@@ -192,9 +192,10 @@ methods:
         Disable (or re-enable) tab navigation. If tab navigation is disabled, the tabs are hidden and
         the last selected tab window is shown.
     parameters:
-      - name: disable
-        summary: True to disable tab navigation, false to re-enable the tabs.
-        type: Boolean
+      - name: params
+        summary: Boolean to disable tab navigation or dictionary.
+        type: disableTabOptions
+        optional: true
     platforms: [android]
     since: 3.6.0
 
@@ -678,3 +679,19 @@ examples:
         });
         tabGroup.open();
         ```
+---
+name: disableTabOptions
+summary: Dictionary of options for the <Titanium.UI.TabGroup.disableTabOptions> method.
+platforms: [android, iphone, ipad, macos]
+since: {android: "12.1.0", iphone: "12.1.0", ipad: "12.1.0", macos: "12.1.0"}
+properties:
+  - name: animated
+    summary: |
+        Determines whether to use an animated effect to hide/show the navigation bar.
+    type: Boolean
+    default: false
+  - name: enabled
+    summary: |
+        Show or hide the navigation bar.
+    type: Boolean
+    default: false


### PR DESCRIPTION
current static way to hide the Android tab navigation:
```js
tabGroup.disableTabNavigation(isVisible);
```

https://github.com/tidev/titanium_mobile/pull/13769 added 
```js
tabGroup.tabBarVisible = isVisible;
```
that always animates it.


This PR extends `disableTabNavigation` parameters to be used like this:
```js
tabGroup.disableTabNavigation({
  enabled: isVisible,
  animated: true
});
```

it will call the `tabBarVisible` method internally
