### PR TITLE
fix(android): revert borderWrapperView code

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiBorderWrapperView.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiBorderWrapperView.java
@@ -42,7 +42,6 @@ public class TiBorderWrapperView extends FrameLayout
 	private Paint paint;
 	private Rect bounds;
 	private ViewOutlineProvider viewOutlineProvider;
-	Path outerPath;
 	public TiBorderWrapperView(Context context)
 	{
 		super(context);
@@ -61,7 +60,6 @@ public class TiBorderWrapperView extends FrameLayout
 
 		paint = new Paint(Paint.ANTI_ALIAS_FLAG);
 		bounds = new Rect();
-		outerPath = new Path();
 	}
 
 	public void reset()
@@ -92,6 +90,7 @@ public class TiBorderWrapperView extends FrameLayout
 			paint.setAlpha(alpha);
 		}
 
+		Path outerPath = new Path();
 		if (hasRadius()) {
 			float[] innerRadius = new float[this.radius.length];
 			for (int i = 0; i < this.radius.length; i++) {


### PR DESCRIPTION
Need to revert the borderWrapperView part from https://github.com/tidev/titanium_mobile/pull/13765 :disappointed: 

when using a TextField with borderRadius and style none
```
 borderRadius: 20,
 borderStyle: Ti.UI.INPUT_BORDERSTYLE_NONE,
```
it removed the border when opening a new window and going back to the window with the textfield:

https://user-images.githubusercontent.com/4334997/224817828-f779b645-3bd5-456b-8ca0-16cfd28a8811.mp4

This will be the same as before, so we'll need to find a better way to remove the warning:
> Avoid object allocations during draw/layout operations (preallocate and reuse instead)
