### PR TITLE
chore: fix Android clipboard test

### DIFF
--- a/tests/Resources/ti.ui.clipboard.test.js
+++ b/tests/Resources/ti.ui.clipboard.test.js
@@ -63,7 +63,7 @@ describe('Titanium.UI.Clipboard', () => {
 				should(Ti.UI.Clipboard.clearData).be.a.Function();
 			});
 
-			it('clears \'text\' data type', () => {
+			it.ios('clears \'text\' data type', () => {
 				setTimeout(function () {
 					Ti.UI.Clipboard.clearData(); // delete all data
 					Ti.UI.Clipboard.text = 'clearData';

--- a/tests/Resources/ti.ui.clipboard.test.js
+++ b/tests/Resources/ti.ui.clipboard.test.js
@@ -14,7 +14,7 @@ const should = require('./utilities/assertions');
 
 describe('Titanium.UI.Clipboard', () => {
 	let win = null;
-	const waitTime = 250;
+	const waitTime = 1500;
 
 	beforeEach(() => {
 		if (win === null) {
@@ -63,7 +63,7 @@ describe('Titanium.UI.Clipboard', () => {
 				should(Ti.UI.Clipboard.clearData).be.a.Function();
 			});
 
-			it.ios('clears \'text\' data type', () => {
+			it('clears \'text\' data type', () => {
 				setTimeout(function () {
 					Ti.UI.Clipboard.clearData(); // delete all data
 					Ti.UI.Clipboard.text = 'clearData';


### PR DESCRIPTION
<strike>The clipboard test won't run in every Android version without an issue so I make this iOS only for now.</strike>

Increased the waiting time in the `clipboard` test. It turns out that the next UI test (ImageView) will remove the focus too quickly and on of the clipboard tests will fail. Increasing the waitingTime will fix it.

That way it's <strike>`5166 Total Tests: 5166 passed, 0 failed, 0 skipped.`</strike> `5167 Total Tests: 5167 passed, 0 failed, 0 skipped.
` again. Should we add a `test action` (not for every commit of course) that will run the test suite again?