### PR TITLE
chore: remove obsolete Android tools folder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "markdown": "0.5.0",
         "moment": "2.29.4",
         "node-appc": "1.1.6",
-        "node-titanium-sdk": "5.1.8",
+        "node-titanium-sdk": "5.1.9",
         "node-uuid": "1.4.8",
         "nodeify": "1.0.1",
         "p-limit": "3.1.0",
@@ -11923,9 +11923,9 @@
       "integrity": "sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w=="
     },
     "node_modules/node-titanium-sdk": {
-      "version": "5.1.8",
-      "resolved": "https://registry.npmjs.org/node-titanium-sdk/-/node-titanium-sdk-5.1.8.tgz",
-      "integrity": "sha512-x9R2UijoOsg4CkVga0jhsDEvHvFGJLHNehnBQoCQHOqM0CpeFXIFCU9y7OL2UUcch4agQ2YqqT60vkVBshwksw==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/node-titanium-sdk/-/node-titanium-sdk-5.1.9.tgz",
+      "integrity": "sha512-pIX1zji5Enwx7V3JW+mr/BZnBBbaa9UcrVmEj0L+Rp/w3v8YhsAnZrDlAj0/mQ6XkIl8pbjZsL4CQQ1XurlsWg==",
       "dependencies": {
         "@babel/core": "7.11.6",
         "@babel/parser": "7.11.5",
@@ -25815,9 +25815,9 @@
       "integrity": "sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w=="
     },
     "node-titanium-sdk": {
-      "version": "5.1.8",
-      "resolved": "https://registry.npmjs.org/node-titanium-sdk/-/node-titanium-sdk-5.1.8.tgz",
-      "integrity": "sha512-x9R2UijoOsg4CkVga0jhsDEvHvFGJLHNehnBQoCQHOqM0CpeFXIFCU9y7OL2UUcch4agQ2YqqT60vkVBshwksw==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/node-titanium-sdk/-/node-titanium-sdk-5.1.9.tgz",
+      "integrity": "sha512-pIX1zji5Enwx7V3JW+mr/BZnBBbaa9UcrVmEj0L+Rp/w3v8YhsAnZrDlAj0/mQ6XkIl8pbjZsL4CQQ1XurlsWg==",
       "requires": {
         "@babel/core": "7.11.6",
         "@babel/parser": "7.11.5",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "markdown": "0.5.0",
     "moment": "2.29.4",
     "node-appc": "1.1.6",
-    "node-titanium-sdk": "5.1.8",
+    "node-titanium-sdk": "5.1.9",
     "node-uuid": "1.4.8",
     "nodeify": "1.0.1",
     "p-limit": "3.1.0",


### PR DESCRIPTION
update node-titanium-sdk to get rid of the obsolete "Android SDK tools" folder 

More infos in here: https://github.com/tidev/node-titanium-sdk/pull/644#issue-1564339635