### PR TITLE
chore: update ubuntu in github action

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   backport:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     name: Backport
     steps:
       - name: Backport

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   android:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       CCACHE_DIR: ${{ github.workspace }}/.ccache
       USE_CCACHE: 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
             console.log(`${process.env.vtag} does not exist so continuing`)
 
   android:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs: [validate]
     env:
       CCACHE_DIR: ${{ github.workspace }}/.ccache


### PR DESCRIPTION
> We have started the deprecation process for Ubuntu 18.04. While the image is being deprecated, You may experience longer queue times during peak usage hours. Deprecation will begin on 2022/08/08 and the image will be fully unsupported by 2023/04/03

Doing the smaller version update for now to `ubuntu-20.04`  (`ubuntu-22.04` should be the next, but let's see if the 20.04 works fine)