### PR TITLE
chore: github actions

### DIFF
--- a/.github/actions/build-android/action.yml
+++ b/.github/actions/build-android/action.yml
@@ -20,13 +20,13 @@ runs:
       shell: bash
 
     - name: Setup Node.js
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ inputs.node-version }}
         cache: 'npm'
 
     - name: Setup Java
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         distribution: 'adopt'
         java-version: ${{ inputs.java-version }}
@@ -36,7 +36,7 @@ runs:
       shell: bash
 
     - name: Cache Gradle packages
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           ~/.gradle/caches
@@ -58,7 +58,7 @@ runs:
       shell: bash
 
     - name: Retrieve ccache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ${{ env.CCACHE_DIR }}
         key: ${{ runner.os }}-ccache-${{ github.sha }}
@@ -66,7 +66,7 @@ runs:
           ${{ runner.os }}-ccache-
 
     - name: Cache V8
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: dist/android/libv8
         key: libv8-${{ hashFiles('dist/android/libv8/**') }}
@@ -92,7 +92,7 @@ runs:
         dist/tmp/common
       shell: bash
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: android-build
         retention-days: 1

--- a/.github/actions/build-ios/action.yml
+++ b/.github/actions/build-ios/action.yml
@@ -10,7 +10,7 @@ runs:
   using: composite
   steps:
     - name: Use Node.js 16.x
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: '16.x'
         cache: 'npm'
@@ -21,7 +21,7 @@ runs:
 
     - name: Lint
       run: npm run lint:ios
-      shell: bash 
+      shell: bash
 
     - name: Build
       run: npm run build:ios
@@ -34,7 +34,7 @@ runs:
         iphone/TitaniumKit/build/TitaniumKit.xcframework
       shell: bash
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: ios-build
         retention-days: 1

--- a/.github/actions/package/action.yml
+++ b/.github/actions/package/action.yml
@@ -16,13 +16,13 @@ runs:
   using: composite
   steps:
     - name: Use Node.js 16.x
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ inputs.node-version }}
         cache: 'npm'
 
     - name: Use JDK 11
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         distribution: 'adopt'
         java-version: ${{ inputs.java-version }}
@@ -32,7 +32,7 @@ runs:
       shell: bash
 
     - name: Cache Gradle packages
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           ~/.gradle/caches
@@ -41,7 +41,7 @@ runs:
         restore-keys: |
           ${{ runner.os }}-gradle-
 
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v3
       with:
         name: android-build
 
@@ -49,7 +49,7 @@ runs:
       run: tar -xzvf android-build.tar.gz
       shell: bash
 
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v3
       with:
         name: ios-build
 
@@ -58,7 +58,7 @@ runs:
       shell: bash
 
     - name: Cache Native Modules
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ${{ env.SDK_BUILD_CACHE_DIR }}
         key: native-modules-${{ github.sha }}
@@ -70,21 +70,21 @@ runs:
       shell: bash
 
     - name: Archive OSX artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: mobilesdk-${{ inputs.vtag }}-osx
         path: |
           dist/mobilesdk-*-osx.zip
 
     - name: Archive win32 artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: mobilesdk-${{ inputs.vtag }}-win32
         path: |
           dist/mobilesdk-*-win32.zip
 
     - name: Archive Linux artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: mobilesdk-${{ inputs.vtag }}-linux
         path: |
@@ -98,7 +98,7 @@ runs:
         rm -f ~/.gradle/caches/modules-2/gc.properties
       shell: bash
 
-    - uses: geekyeggo/delete-artifact@v1
+    - uses: geekyeggo/delete-artifact@v2
       with:
         name: |
           android-build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
         fetch-depth: 0
 
     - name: Use Node.js 16.x
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: '16.x'
         cache: 'npm'
@@ -61,7 +61,7 @@ jobs:
 
     - name: Lint
       run: npm run lint:js
-  
+
   package:
     runs-on: macos-12
     name: Package

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,7 @@ jobs:
         with:
             fetch-depth: 0
       - name: Use Node.js 16.x
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '16.x'
           cache: 'npm'

--- a/.github/workflows/regen-docs.yml
+++ b/.github/workflows/regen-docs.yml
@@ -19,7 +19,7 @@ jobs:
         fetch-depth: 0
 
     - name: Setup node
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: '16'
         registry-url: 'https://registry.npmjs.org'
@@ -30,7 +30,7 @@ jobs:
 
     - run: npm run lint:docs
       name: Lint
-      
+
     - name: Repository Dispatch
       uses: peter-evans/repository-dispatch@v2
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,15 +129,15 @@ jobs:
         ref: ${{ github.event.inputs.branch }}
     - run: echo ${{ env.vtag }}
     - name: Download Linux artifact
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: mobilesdk-${{ env.vtag }}-linux
     - name: Download MacOS artifact
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: mobilesdk-${{ env.vtag }}-osx
     - name: Download Windows artifact
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: mobilesdk-${{ env.vtag }}-win32
     - name: Create and push tag


### PR DESCRIPTION
Update github actions to newer version. 

Some of the current actions use node 12 internally and produce a warning