### PR TITLE
fix(ios): only show popover presentation style if popover view exists

### DIFF
--- a/iphone/Classes/MediaModule.m
+++ b/iphone/Classes/MediaModule.m
@@ -1738,8 +1738,7 @@ MAKE_SYSTEM_PROP(VIDEO_REPEAT_MODE_ONE, VideoRepeatModeOne);
 - (void)showPHPicker:(NSDictionary *)args
 {
   if (_phPicker != nil) {
-    [self sendPickerError:MediaModuleErrorBusy];
-    return;
+    [self destroyPicker];
   }
 
   animatedPicker = YES;

--- a/iphone/Classes/MediaModule.m
+++ b/iphone/Classes/MediaModule.m
@@ -1470,10 +1470,12 @@ MAKE_SYSTEM_PROP(VIDEO_REPEAT_MODE_ONE, VideoRepeatModeOne);
 - (void)updatePopoverNow:(UIViewController *)picker_
 {
   UIViewController *theController = picker_;
-  [theController setModalPresentationStyle:UIModalPresentationPopover];
-  UIPopoverPresentationController *thePresenter = [theController popoverPresentationController];
-  [thePresenter setPermittedArrowDirections:arrowDirection];
-  [thePresenter setDelegate:self];
+  if (self.popoverView != nil) {
+    [theController setModalPresentationStyle:UIModalPresentationPopover];
+    UIPopoverPresentationController *thePresenter = [theController popoverPresentationController];
+    [thePresenter setPermittedArrowDirections:arrowDirection];
+    [thePresenter setDelegate:self];
+  }
   [[TiApp app] showModalController:theController animated:animatedPicker];
   return;
 }


### PR DESCRIPTION
Prior to this change, the photo gallery would always attempt to be presented as a popover, even if no popover view was provided. This change fixes that behavior, resulting in proper gallery dialogs.

In addition, this PR fixes an issues where the dialog would fail on every 2nd run when being dismissed interactively.

|Before |After |
|---|---|
| <img src="https://user-images.githubusercontent.com/10667698/232238093-2f58f427-9196-431f-8cb2-e2fd0b732a7e.png" width="300" /> | <img src="https://user-images.githubusercontent.com/10667698/232238115-2982e45e-041a-47ea-861b-fc546fb89255.png" width="300" /> |

Example:
```js
const win = Ti.UI.createWindow({
	backgroundColor: '#fff'
});

const btn = Ti.UI.createButton({
	title: 'Show Photo Gallery'
});

btn.addEventListener('click', () => {
	Ti.Media.openPhotoGallery({
		success: () => {}
	});
});

win.add(btn);
win.open();
```