### PR TITLE
fix(ios/build): support passing target and device id to the module build

### DIFF
--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -1400,7 +1400,9 @@ iOSBuilder.prototype.configOptionWatchDeviceId = function configOptionWatchDevic
  * error.
  */
 iOSBuilder.prototype.initTiappSettings = function initTiappSettings() {
-	if (this._tiappSettingsInitialized) {
+	// This logic will also run on a module build when a --device-id argument is provided,
+	// so skip if we're not building an app.
+	if (this._tiappSettingsInitialized || this.cli.argv.type !== 'app') {
 		return;
 	}
 

--- a/iphone/cli/commands/_buildModule.js
+++ b/iphone/cli/commands/_buildModule.js
@@ -1091,12 +1091,10 @@ iOSModuleBuilder.prototype.runModule = function runModule(cli, next) {
 			];
 
 			if (this.target) {
-				buildArgs.push('-T');
-				buildArgs.push(this.target);
+				buildArgs.push('-T', this.target);
 			}
 			if (this.deviceId) {
-				buildArgs.push('-C');
-				buildArgs.push(this.deviceId);
+				buildArgs.push('-C', this.deviceId);
 			}
 
 			runTiCommand(buildArgs, cb);

--- a/iphone/cli/commands/_buildModule.js
+++ b/iphone/cli/commands/_buildModule.js
@@ -58,6 +58,9 @@ iOSModuleBuilder.prototype.validate = function validate(logger, config, cli) {
 
 	this.buildOnly     = cli.argv['build-only'];
 	this.xcodeEnv      = null;
+	this.target        = cli.argv['target'];
+	this.deviceId      = cli.argv['device-id'];
+
 	const sdkModuleAPIVersion = cli.sdk.manifest && cli.sdk.manifest.moduleAPIVersion && cli.sdk.manifest.moduleAPIVersion['iphone'];
 	if (this.manifest.apiversion && sdkModuleAPIVersion && this.manifest.apiversion !== sdkModuleAPIVersion) {
 		logger.error(__('The module manifest apiversion is currently set to %s', this.manifest.apiversion));
@@ -1078,17 +1081,25 @@ iOSModuleBuilder.prototype.runModule = function runModule(cli, next) {
 		function (cb) {
 			// 6. run the app
 			this.logger.debug(__('Running example project...', tmpDir.cyan));
-			runTiCommand(
-				[
-					'build',
-					'-p', 'ios',
-					'-d', tmpProjectDir,
-					'--no-prompt',
-					'--no-colors',
-					'--no-progress-bars'
-				],
-				cb
-			);
+			const buildArgs = [
+				'build',
+				'-p', 'ios',
+				'-d', tmpProjectDir,
+				'--no-prompt',
+				'--no-colors',
+				'--no-progress-bars'
+			];
+
+			if (this.target) {
+				buildArgs.push('-T');
+				buildArgs.push(this.target);
+			}
+			if (this.deviceId) {
+				buildArgs.push('-C');
+				buildArgs.push(this.deviceId);
+			}
+
+			runTiCommand(buildArgs, cb);
 		}
 	], next);
 };


### PR DESCRIPTION
The arguments are copied as is over to the app build process at the end of the module build, there is also a change to return early in `initTiappSettings` in the app build. This is because all build options are ran so `--device-id` to a module build triggers the app build checks, which then subsequently fail. There is definitely a better fix for this, but this for now at least allows it to work and unblocks the related VS Code feature

This is related to #13432