### PR TITLE
fix(ios): build module platform/*.xcframwork keep symbolic links (maccatalyst)

### DIFF
--- a/cli/lib/gather.js
+++ b/cli/lib/gather.js
@@ -302,7 +302,7 @@ class Categorizer {
 					// managed by their bundles.
 
 					if (this.useAppThinning && !relPath.match(BUNDLE_FILE_REGEXP)) {
-						if (this.excludeAssestsDir != null) {
+						if (this.excludeAssestsDir !== null) {
 							const checkRegEx = new RegExp(this.excludeAssestsDir);
 							if (!relPath.match(checkRegEx)) {
 								results.imageAssets.set(relPath, info);

--- a/cli/lib/gather.js
+++ b/cli/lib/gather.js
@@ -271,6 +271,17 @@ class Categorizer {
 						results.launchImages.set(relPath, info);
 						return;
 					}
+					if (this.excludeAssestsDir !== null) {
+						let testPath = this.excludeAssestsDir;
+						const checkRegEx = new RegExp(`${testPath}`);
+						if (!relPath.match(checkRegEx)) {
+							results.imageAssets.set(relPath, info);
+							return;
+						}
+					} else {
+						results.imageAssets.set(relPath, info);
+						return;
+					}
 				}
 				// fall through to lump with JPG...
 
@@ -303,7 +314,8 @@ class Categorizer {
 
 					if (this.useAppThinning && !relPath.match(BUNDLE_FILE_REGEXP)) {
 						if (this.excludeAssestsDir !== null) {
-							const checkRegEx = new RegExp(this.excludeAssestsDir);
+							let testPath = this.excludeAssestsDir;
+							const checkRegEx = new RegExp(`${testPath}`);
 							if (!relPath.match(checkRegEx)) {
 								results.imageAssets.set(relPath, info);
 								return;

--- a/cli/lib/gather.js
+++ b/cli/lib/gather.js
@@ -302,16 +302,15 @@ class Categorizer {
 					// managed by their bundles.
 
 					if (this.useAppThinning && !relPath.match(BUNDLE_FILE_REGEXP)) {
-						if (this.excludeAssestsDir != null) {
+						if (this.excludeAssestsDir !== null) {
 							const checkRegEx = new RegExp(this.excludeAssestsDir);
 							if (!relPath.match(checkRegEx)) {
 								results.imageAssets.set(relPath, info);
 								return;
 							}
-						}
-						else {
+						} else {
 							results.imageAssets.set(relPath, info);
-							return;						
+							return;
 						}
 					}
 				}

--- a/cli/lib/gather.js
+++ b/cli/lib/gather.js
@@ -161,6 +161,7 @@ class Walker {
 	 */
 	async _visitListing(results, dirent, src, dest, ignore, origSrc, prefix) {
 		const name = dirent.name;
+
 		if (ignore && ignore.test(name)) { // if we should ignore this file/dir, skip it
 			return;
 		}
@@ -193,6 +194,7 @@ class Walker {
 	 */
 	_visitFile(results, from, to, name, src, origSrc, prefix) {
 		// if we should ignore this file, skip it
+
 		if (this.ignoreFiles && this.ignoreFiles.test(name)) {
 			return;
 		}
@@ -211,6 +213,7 @@ class Categorizer {
 	 * @param {string} [options.platform] 'ios', 'android'
 	 */
 	constructor(options) {
+		this.excludeAssestsDir = options.excludeAssestsDir ? options.excludeAssestsDir : null;
 		this.useAppThinning = options.useAppThinning;
 		this.platform = options.platform;
 		this.jsFilesNotToProcess = options.jsFilesNotToProcess || [];
@@ -297,14 +300,24 @@ class Categorizer {
 					// if we are using app thinning, then don't copy the image, instead mark the
 					// image to be injected into the asset catalog. Also, exclude images that are
 					// managed by their bundles.
+
 					if (this.useAppThinning && !relPath.match(BUNDLE_FILE_REGEXP)) {
-						results.imageAssets.set(relPath, info);
-						return;
+						if (this.excludeAssestsDir != null) {
+							const checkRegEx = new RegExp(this.excludeAssestsDir);
+							if (!relPath.match(checkRegEx)) {
+								results.imageAssets.set(relPath, info);
+								return;
+							}
+						}
+						else {
+							results.imageAssets.set(relPath, info);
+							return;						
+						}
 					}
 				}
-
 				// Normal PNG/JPG, so just copy it
 				results.resourcesToCopy.set(relPath, info);
+
 				break;
 
 			case 'html':

--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -5229,6 +5229,7 @@ iOSBuilder.prototype.gatherResources = async function gatherResources() {
 		tiappIcon: this.tiapp.icon,
 		useAppThinning: this.useAppThinning,
 		platform: 'ios',
+		excludeAssestsDir: this.tiapp.ios['exclude-dir-from-asset-catalog'] ? this.tiapp.ios['exclude-dir-from-asset-catalog'] : undefined,
 	});
 	const categorized = await categorizer.run(combined);
 

--- a/iphone/cli/commands/_buildModule.js
+++ b/iphone/cli/commands/_buildModule.js
@@ -910,12 +910,7 @@ iOSModuleBuilder.prototype.packageModule = function packageModule(next) {
 
 		// 3. platform folder
 		if (fs.existsSync(this.platformDir)) {
-			this.dirWalker(this.platformDir, function (file, name) {
-				var stat = fs.statSync(file);
-				if (name !== 'README.md') {
-					dest.append(fs.createReadStream(file), { name: path.join(moduleFolders, 'platform', path.relative(this.platformDir, file)), mode: stat.mode });
-				}
-			}.bind(this));
+			dest.directory(this.platformDir, path.join(moduleFolders, 'platform'));
 		}
 
 		// 4. hooks folder


### PR DESCRIPTION

**Optional Description:**
build iOS modules with XCFramework(s) in the /platform folder and keep the symbolic linking for MacCatalyst xcframework folder, else the symbolic links are resolved and building the app for target 'macos' will fail