### PR TITLE
fix(ios): enable JSContext to be inspectable

### DIFF
--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiApp.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiApp.m
@@ -248,6 +248,15 @@ TI_INLINE void waitForMemoryPanicCleared(void); //WARNING: This must never be ru
       }
       [_queuedApplicationSelectors removeAllObjects];
     }
+
+    // Ensure that the JSContext is debuggable during development
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 160400
+    BOOL isProduction = [TiSharedConfig.defaultConfig.applicationDeployType isEqualToString:@"production"];
+
+    if (!isProduction) {
+      JSGlobalContextSetInspectable([[(KrollBridge *)bridge krollContext] context], YES);
+    }
+#endif
   }
 }
 

--- a/iphone/TitaniumKit/TitaniumKit/Sources/Kroll/KrollContext.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/Kroll/KrollContext.m
@@ -793,7 +793,10 @@ static JSValueRef StringFormatDecimalCallback(JSContextRef jsContext, JSObjectRe
 {
   pthread_mutex_lock(&KrollEntryLock);
   context = JSGlobalContextCreate(NULL);
-  JSGlobalContextSetInspectable(context, true);
+  // Ensure that the JSContext is debuggable
+  if (@available(iOS 16.4, *)) {
+    JSGlobalContextSetInspectable(context, true);
+  }
   JSObjectRef globalRef = JSContextGetGlobalObject(context);
 
   if (appJsKrollContext == nil) {

--- a/iphone/TitaniumKit/TitaniumKit/Sources/Kroll/KrollContext.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/Kroll/KrollContext.m
@@ -793,10 +793,6 @@ static JSValueRef StringFormatDecimalCallback(JSContextRef jsContext, JSObjectRe
 {
   pthread_mutex_lock(&KrollEntryLock);
   context = JSGlobalContextCreate(NULL);
-  // Ensure that the JSContext is debuggable
-#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 160400
-  JSGlobalContextSetInspectable(context, true);
-#endif
   JSObjectRef globalRef = JSContextGetGlobalObject(context);
 
   if (appJsKrollContext == nil) {

--- a/iphone/TitaniumKit/TitaniumKit/Sources/Kroll/KrollContext.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/Kroll/KrollContext.m
@@ -794,9 +794,9 @@ static JSValueRef StringFormatDecimalCallback(JSContextRef jsContext, JSObjectRe
   pthread_mutex_lock(&KrollEntryLock);
   context = JSGlobalContextCreate(NULL);
   // Ensure that the JSContext is debuggable
-  if (@available(iOS 16.4, *)) {
-    JSGlobalContextSetInspectable(context, true);
-  }
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 160400
+  JSGlobalContextSetInspectable(context, true);
+#endif
   JSObjectRef globalRef = JSContextGetGlobalObject(context);
 
   if (appJsKrollContext == nil) {

--- a/iphone/TitaniumKit/TitaniumKit/Sources/Kroll/KrollContext.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/Kroll/KrollContext.m
@@ -793,9 +793,12 @@ static JSValueRef StringFormatDecimalCallback(JSContextRef jsContext, JSObjectRe
 {
   pthread_mutex_lock(&KrollEntryLock);
   context = JSGlobalContextCreate(NULL);
-  // Ensure that the JSContext is debuggable
+  // Ensure that the JSContext is debuggable on newer iOS versions, but only in non-production builds
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 160400
-  JSGlobalContextSetInspectable(context, true);
+  BOOL isProduction = [TiApp.tiAppProperties[@"ti.deploytype"] isEqualToString:@"production"];
+  if (!isProduction) {
+    JSGlobalContextSetInspectable(context, YES);
+  }
 #endif
   JSObjectRef globalRef = JSContextGetGlobalObject(context);
 

--- a/iphone/TitaniumKit/TitaniumKit/Sources/Kroll/KrollContext.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/Kroll/KrollContext.m
@@ -793,6 +793,7 @@ static JSValueRef StringFormatDecimalCallback(JSContextRef jsContext, JSObjectRe
 {
   pthread_mutex_lock(&KrollEntryLock);
   context = JSGlobalContextCreate(NULL);
+  JSGlobalContextSetInspectable(context, true);
   JSObjectRef globalRef = JSContextGetGlobalObject(context);
 
   if (appJsKrollContext == nil) {

--- a/iphone/TitaniumKit/TitaniumKit/Sources/Misc/TiSharedConfig.h
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/Misc/TiSharedConfig.h
@@ -51,7 +51,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, nullable) NSString *applicationDescription;
 
 /**
- Deploy type of the application, e.g. "development", currently **unused**.
+ Deploy type of the application, e.g. "development", "test" or "production"
  */
 @property (nonatomic, strong, nullable) NSString *applicationDeployType;
 


### PR DESCRIPTION
In iOS 16.4 the default state for whether a JSContext is inspectable became false and the owner of the context must explicitly set it to be inspectable.

This commit enables the JSContext to be inspectable and I have verified this works for both Safari and VS Code debugging. However, for security concerns it's probably best that we disable this in production I assume. How to do that, I have no idea. It probably also needs to be guarded to only be set on iOS 16.4+

To test this just open an app on iOS then go Safari-> Develop -> _simulator/device name_. With this fix, you should see a JSContext listed

Refs
https://webkit.org/blog/13966/webkit-features-in-safari-16-4/ 
https://webkit.org/blog/13936/enabling-the-inspection-of-web-content-in-apps/