### PR TITLE
chore: update android dependencies

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,7 +6,7 @@
  */
 
 buildscript {
-	ext.kotlin_version = '1.6.21'
+	ext.kotlin_version = '1.8.20'
 
 	repositories {
 		google()

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -14,7 +14,7 @@ buildscript {
 	}
 	dependencies {
 		classpath 'com.android.tools.build:gradle:7.0.4'
-		classpath 'com.google.gms:google-services:4.3.10'
+		classpath 'com.google.gms:google-services:4.3.15'
 		classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 		classpath 'org.codehaus.groovy:groovy-json:3.0.11'
 	}

--- a/android/templates/build/root.build.gradle
+++ b/android/templates/build/root.build.gradle
@@ -1,6 +1,6 @@
 
 buildscript {
-	ext.kotlin_version = '1.6.21'
+	ext.kotlin_version = '1.8.20'
 
 	repositories {
 		google()

--- a/android/templates/build/ti.constants.gradle
+++ b/android/templates/build/ti.constants.gradle
@@ -6,11 +6,11 @@
  */
 
 project.ext {
-	tiAndroidXAppCompatLibVersion = '1.6.0-rc01'
+	tiAndroidXAppCompatLibVersion = '1.6.1'
 	tiAndroidXCoreLibVersion = '1.9.0'
-	tiAndroidXFragmentLibVersion = '1.5.5'
+	tiAndroidXFragmentLibVersion = '1.5.7'
 	tiMaterialLibVersion = '1.6.1'
-	tiPlayServicesBaseLibVersion = '18.1.0'
+	tiPlayServicesBaseLibVersion = '18.2.0'
 	tiManifestPlaceholders = [
 		tiActivityConfigChanges: 'density|fontScale|keyboard|keyboardHidden|layoutDirection|locale|mcc|mnc|navigation|orientation|screenLayout|screenSize|smallestScreenSize|touchscreen|uiMode'
 	]

--- a/android/titanium/build.gradle
+++ b/android/titanium/build.gradle
@@ -250,11 +250,11 @@ dependencies {
 	implementation "androidx.appcompat:appcompat:${project.ext.tiAndroidXAppCompatLibVersion}"
 	implementation 'androidx.cardview:cardview:1.0.0'
 	implementation "androidx.core:core:${project.ext.tiAndroidXCoreLibVersion}"
-	implementation 'androidx.drawerlayout:drawerlayout:1.1.1'
-	implementation 'androidx.exifinterface:exifinterface:1.3.5'
+	implementation 'androidx.drawerlayout:drawerlayout:1.2.0'
+	implementation 'androidx.exifinterface:exifinterface:1.3.6'
 	implementation "androidx.fragment:fragment:${project.ext.tiAndroidXFragmentLibVersion}"
 	implementation 'androidx.media:media:1.6.0'
-	implementation 'androidx.recyclerview:recyclerview:1.2.1'
+	implementation 'androidx.recyclerview:recyclerview:1.3.0'
 	implementation 'androidx.recyclerview:recyclerview-selection:1.1.0'
 	implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
 	implementation 'androidx.transition:transition:1.4.1'


### PR DESCRIPTION
Changelogs I could find:
* https://developer.android.com/jetpack/androidx/releases/drawerlayout#version_12_2
* https://developer.android.com/jetpack/androidx/releases/exifinterface#1.3.6
* https://developer.android.com/jetpack/androidx/releases/annotation#version_16_2
* https://developer.android.com/jetpack/androidx/releases/fragment#1.5.7
* https://github.com/material-components/material-components-android/releases/tag/1.8.0
* https://firebase.google.com/support/release-notes/android#google-services_plugin_v4-3-15

added a note about **material lib** into the ["gradle update" issue](https://github.com/tidev/titanium_mobile/issues/13579). We can only raise that once we figure out how to update the gradle-plugin.

**Tests**
only compiled two bigger apps so far without any visual change or issues. But have to do some more tests e.g. build modules, use newly build modules in old SDK apps, ...
* [x] Build existing app with existing (pre 12.2.0) modules
* [x] build modules
* [x] use 12.2.0 module in 12.2.0 app
* [x] use 12.2.0 module in 12.0.0.GA app
* [x] use 12.2.0 module in 11.1.1.GA  app (with ` compileSdkVersion 33`)
* [x] Ti test suite `5167 Total Tests: 5167 passed, 0 failed, 0 skipped.`
* [x] kitchensink
* [x] hyperloop-examples