### PR TITLE
chore: optimize test output

### DIFF
--- a/build/lib/builder.js
+++ b/build/lib/builder.js
@@ -78,6 +78,7 @@ class Builder {
 	 * @param {boolean} [options.select=false] select the built SDK in Ti CLI after install?
 	 * @param {boolean} [options.skipZip] Optionally skip zipping up the result
 	 * @param {boolean} [options.docs] Generate docs?
+	 * @param {boolean} [options.onlyFailedTests] only show failed tests
 	 * @param {string[]} [platforms] command line arguments (platform listing)
 	 */
 	constructor(options, platforms) {
@@ -97,6 +98,7 @@ class Builder {
 
 		this.options = options;
 		this.options.timestamp = utils.timestamp();
+		this.options.onlyFailedTests = options.onlyFailed || false;
 		this.options.versionTag = options.versionTag || options.sdkVersion;
 	}
 

--- a/build/lib/test/index.js
+++ b/build/lib/test/index.js
@@ -16,6 +16,7 @@ const { test, outputResults } = require('./test');
  * @param {string} [program.deviceId] Titanium device id target to run the tests on
  * @param {string} [program.deployType] 'development' || 'test'
  * @param {string} [program.deviceFamily] 'ipad' || 'iphone'
+ * @param {string} [program.onlyFailedTests] boolean
  * @returns {Promise<object>} returns an object whose keys are platform names
  */
 async function runTests(platforms, program) {
@@ -25,7 +26,7 @@ async function runTests(platforms, program) {
 		fs.emptyDir(path.join(snapshotDir, '..', 'generated')),
 		fs.emptyDir(path.join(snapshotDir, '..', 'diffs'))
 	]);
-	return test(platforms, program.target, program.deviceId, program.deployType, program.deviceFamily, program.junitPrefix, snapshotDir);
+	return test(platforms, program.target, program.deviceId, program.deployType, program.deviceFamily, program.junitPrefix, snapshotDir, program.onlyFailedTests);
 }
 
 /**

--- a/build/lib/test/test.js
+++ b/build/lib/test/test.js
@@ -42,6 +42,8 @@ const OS_VERSION_PREFIX = 'OS_VERSION: ';
 // Sniff if we're on Travis/Jenkins
 const isCI = !!(process.env.BUILD_NUMBER || process.env.CI || false);
 
+var showFailedOnly = false;
+
 /**
  * Generates a test app, then runs the app for each platform with our
  * test suite. Outputs the results in a JUnit test report,
@@ -54,9 +56,11 @@ const isCI = !!(process.env.BUILD_NUMBER || process.env.CI || false);
  * @param {string} [deviceFamily] 'ipad' || 'iphone'
  * @param {string} [junitPrefix] A prefix for the junit filename
  * @param {string} [snapshotDir='../../../tests/Resources'] directory to place generated snapshot images
+ * @param {string} [failedOnly] Show only failed tests
  * @returns {Promise<object>}
  */
-async function test(platforms, target, deviceId, deployType, deviceFamily, junitPrefix, snapshotDir = path.join(__dirname, '../../../tests/Resources')) {
+async function test(platforms, target, deviceId, deployType, deviceFamily, junitPrefix, snapshotDir = path.join(__dirname, '../../../tests/Resources'), failedOnly) {
+	showFailedOnly = failedOnly;
 	const snapshotPromises = []; // place to stick commands we've fired off to pull snapshot images
 	console.log(platforms);
 	// delete old test app (if does not exist, this will no-op)
@@ -1002,7 +1006,9 @@ async function outputResults(results) {
 				--indents;
 			} else {
 				passes++;
-				console.log(indent() + '  ✓'.green + ' %s '.gray, test.title);
+				if (!showFailedOnly) {
+					console.log(indent() + '  ✓'.green + ' %s '.gray, test.title);
+				}
 			}
 		});
 		--indents;

--- a/build/lib/test/test.js
+++ b/build/lib/test/test.js
@@ -42,7 +42,7 @@ const OS_VERSION_PREFIX = 'OS_VERSION: ';
 // Sniff if we're on Travis/Jenkins
 const isCI = !!(process.env.BUILD_NUMBER || process.env.CI || false);
 
-var showFailedOnly = false;
+let showFailedOnly = false;
 
 /**
  * Generates a test app, then runs the app for each platform with our

--- a/build/scons-test.js
+++ b/build/scons-test.js
@@ -10,6 +10,7 @@ program
 	.option('-D, --deploy-type <type>', 'Override the deploy type used to build the project', /^(development|test)$/)
 	.option('-F, --device-family <value>', 'Override the device family used to build the project', /^(iphone|ipad)$/)
 	.option('-J --junit-prefix <value>', 'A prefix to add to junit tests to help distinguish them. Useful if targeting same platform and target', '')
+	.option('-O --only-failed <value>', 'Show only failed tests', '')
 	.parse(process.argv);
 
 async function main(program) {

--- a/build/scons-test.js
+++ b/build/scons-test.js
@@ -10,7 +10,7 @@ program
 	.option('-D, --deploy-type <type>', 'Override the deploy type used to build the project', /^(development|test)$/)
 	.option('-F, --device-family <value>', 'Override the device family used to build the project', /^(iphone|ipad)$/)
 	.option('-J --junit-prefix <value>', 'A prefix to add to junit tests to help distinguish them. Useful if targeting same platform and target', '')
-	.option('-O --only-failed <value>', 'Show only failed tests', '')
+	.option('-O --only-failed', 'Show only failed tests', '')
 	.parse(process.argv);
 
 async function main(program) {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "test:ipad": "npm run cleanbuild:ios -- --skip-zip --no-docs --symlink && ti sdk select $npm_package_version && npm run test:integration -- ios -F ipad",
     "test:mac": "npm run cleanbuild:ios -- --skip-zip --no-docs --symlink && ti sdk select $npm_package_version && npm run test:integration -- ios -T macos",
     "test:integration": "node ./build/scons test",
-    "test:integration:onlyFailed": "node ./build/scons test --only-failed true"
+    "test:integration:onlyFailed": "node ./build/scons test --only-failed"
   },
   "commitlint": {
     "extends": [

--- a/package.json
+++ b/package.json
@@ -61,12 +61,14 @@
     "postinstall": "husky install",
     "test": "npm run ios-sanity-check && npm run lint",
     "test:android": "npm run cleanbuild:android -- --skip-zip --no-docs --symlink && ti sdk select $npm_package_version && npm run test:integration -- android",
+    "test:android:onlyFailed": "npm run cleanbuild:android -- --skip-zip --no-docs --symlink && ti sdk select $npm_package_version && npm run test:integration:onlyFailed -- android",
     "test:cli": "JUNIT_REPORT_PATH=junit.cli.report.xml nyc mocha **/cli/tests/test-*.js build/**/test-*.js --reporter=mocha-jenkins-reporter",
     "test:ios": "npm run test:iphone",
     "test:iphone": "npm run cleanbuild:ios -- --skip-zip --no-docs --symlink && ti sdk select $npm_package_version && npm run test:integration -- ios -F iphone",
     "test:ipad": "npm run cleanbuild:ios -- --skip-zip --no-docs --symlink && ti sdk select $npm_package_version && npm run test:integration -- ios -F ipad",
     "test:mac": "npm run cleanbuild:ios -- --skip-zip --no-docs --symlink && ti sdk select $npm_package_version && npm run test:integration -- ios -T macos",
-    "test:integration": "node ./build/scons test"
+    "test:integration": "node ./build/scons test",
+    "test:integration:onlyFailed": "node ./build/scons test --only-failed true"
   },
   "commitlint": {
     "extends": [

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "test:cli": "JUNIT_REPORT_PATH=junit.cli.report.xml nyc mocha **/cli/tests/test-*.js build/**/test-*.js --reporter=mocha-jenkins-reporter",
     "test:ios": "npm run test:iphone",
     "test:iphone": "npm run cleanbuild:ios -- --skip-zip --no-docs --symlink && ti sdk select $npm_package_version && npm run test:integration -- ios -F iphone",
+    "test:iphone:onlyFailed": "npm run cleanbuild:ios -- --skip-zip --no-docs --symlink && ti sdk select $npm_package_version && npm run test:integration:onlyFailed -- ios -F iphone",
     "test:ipad": "npm run cleanbuild:ios -- --skip-zip --no-docs --symlink && ti sdk select $npm_package_version && npm run test:integration -- ios -F ipad",
     "test:mac": "npm run cleanbuild:ios -- --skip-zip --no-docs --symlink && ti sdk select $npm_package_version && npm run test:integration -- ios -T macos",
     "test:integration": "node ./build/scons test",


### PR DESCRIPTION
adding two new tests to the `npm`  scripts:
`npm run test:android:onlyFailed` and `npm run test:iphone:onlyFailed`

**What it does**
It will skip outputting all successful tests in the lists at the end. This way it is easier to spot failed tests. 

**Why**
Because we have over 5000 tests and if the 20th tests failed you will only see "failed 1" at the end but it might not be possible to scroll up the whole list to position 20 :smile: 
The rest of the output stays the same.

```
5167 Total Tests: 5167 passed, 0 failed, 0 skipped.
```
and the list of all tests above, just not the `✓ success...` rows