### PR TITLE
fix(android): hide error for empty http decode charset

### DIFF
--- a/android/modules/network/src/java/ti/modules/titanium/network/TiHTTPClient.java
+++ b/android/modules/network/src/java/ti/modules/titanium/network/TiHTTPClient.java
@@ -492,6 +492,11 @@ public class TiHTTPClient
 	private String decodeResponseData(String charsetName)
 	{
 		Charset charset;
+
+		if (charsetName.isEmpty()) {
+			return null;
+		}
+
 		try {
 			charset = Charset.forName(charsetName);
 


### PR DESCRIPTION
If you have a HTTP request that returns nothing and doesn't have a return value charset it tries to decode it and always fail with
```
Could not find charset: 
```

This way I return before running in the try/catch. Will skip the test and the `error` in the console output.