### PR TITLE
chore: fine-tune iOS 16.4 debugger changes

### DIFF
--- a/iphone/Classes/AppModule.m
+++ b/iphone/Classes/AppModule.m
@@ -379,6 +379,15 @@ extern NSString *const TI_APPLICATION_GUID;
   [nc addObserver:self selector:@selector(keyboardFrameChanged:) name:UIKeyboardWillChangeFrameNotification object:nil];
   [nc addObserver:self selector:@selector(timeChanged:) name:UIApplicationSignificantTimeChangeNotification object:nil];
 
+  // Ensure that the JSContext is debuggable during development
+  if (@available(iOS 16.4, *)) {
+    BOOL isProduction = [TiSharedConfig.defaultConfig.applicationDeployType isEqualToString:@"production"];
+
+    if (!isProduction) {
+      JSGlobalContextSetInspectable([[(KrollBridge *)TiApp.app.krollBridge krollContext] context], YES);
+    }
+  }
+
   [super startup];
 }
 

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiApp.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiApp.m
@@ -248,15 +248,6 @@ TI_INLINE void waitForMemoryPanicCleared(void); //WARNING: This must never be ru
       }
       [_queuedApplicationSelectors removeAllObjects];
     }
-
-    // Ensure that the JSContext is debuggable during development
-#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 160400
-    BOOL isProduction = [TiSharedConfig.defaultConfig.applicationDeployType isEqualToString:@"production"];
-
-    if (!isProduction) {
-      JSGlobalContextSetInspectable([[(KrollBridge *)bridge krollContext] context], YES);
-    }
-#endif
   }
 }
 


### PR DESCRIPTION
- Move to an entry point that's not pre-compiled by the SDK core build
- Use a different util to check the iOS version