### PR TITLE
ci: compile on macos13/xcode 14.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,12 +25,12 @@ jobs:
           java-version: '11'
 
   ios:
-    runs-on: macos-12
+    runs-on: macos-13
     name: iOS
     env:
       CCACHE_DIR: ${{ github.workspace }}/.ccache
       USE_CCACHE: 1
-      DEVELOPER_DIR: /Applications/Xcode_14.2.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_14.3.app/Contents/Developer
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,13 +75,13 @@ jobs:
           java-version: '11'
 
   ios:
-    runs-on: macos-12
+    runs-on: macos-13
     name: iOS
     needs: [validate]
     env:
       CCACHE_DIR: ${{ github.workspace }}/.ccache
       USE_CCACHE: 1
-      DEVELOPER_DIR: /Applications/Xcode_14.2.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_14.3.app/Contents/Developer
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
           echo "vtag=${VTAG}" >> $GITHUB_ENV
           echo "vtag=${VTAG}" >> $GITHUB_OUTPUT
       - name: Validate version
-        uses: actions/github-script@v5
+        uses: actions/github-script@v6
         env:
           vtag: ${{ env.vtag }}
         with:


### PR DESCRIPTION
GitHub [released these](https://github.blog/changelog/2023-04-24-github-actions-macos-13-is-now-available/) this week so we should look to move to using them

Also fixes a warning from release script due to an outdated github-script action version

