### PR TITLE
feat(android): make rotationX, rotationY animatable

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiAnimationBuilder.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiAnimationBuilder.java
@@ -117,6 +117,7 @@ public class TiAnimationBuilder
 	protected String width = null, height = null;
 	protected Integer backgroundColor = null;
 	protected Integer color = null;
+	protected float rotationY, rotationX = -1;
 	protected TiAnimationCurve curve = TiAnimationBuilder.DEFAULT_CURVE;
 
 	protected TiAnimation animationProxy;
@@ -243,6 +244,13 @@ public class TiAnimationBuilder
 			elevation = TiConvert.toFloat(options, TiC.PROPERTY_ELEVATION, -1);
 		}
 
+		if (options.containsKey(TiC.PROPERTY_ROTATION_Y)) {
+			rotationY = TiConvert.toFloat(options, TiC.PROPERTY_ROTATION_Y, -1);
+		}
+
+		if (options.containsKey(TiC.PROPERTY_ROTATION_X)) {
+			rotationX = TiConvert.toFloat(options, TiC.PROPERTY_ROTATION_X, -1);
+		}
 		this.options = options;
 	}
 
@@ -303,6 +311,13 @@ public class TiAnimationBuilder
 
 		if (elevation >= 0) {
 			addAnimator(animators, ObjectAnimator.ofFloat(view, "elevation", elevation));
+		}
+
+		if (rotationY >= 0) {
+			addAnimator(animators, ObjectAnimator.ofFloat(view, "rotationY", rotationY));
+		}
+		if (rotationX >= 0) {
+			addAnimator(animators, ObjectAnimator.ofFloat(view, "rotationX", rotationX));
 		}
 
 		if (backgroundColor != null) {

--- a/apidoc/Titanium/UI/Animation.yml
+++ b/apidoc/Titanium/UI/Animation.yml
@@ -131,6 +131,18 @@ properties:
     summary: Duration of the animation, in milliseconds.
     type: Number
 
+  - name: rotationY
+    summary: Value of the `rotationY` property at the end of the animation.
+    type: Number
+    platforms: [android]
+    since: { android: "12.2.0" }
+
+  - name: rotationX
+    summary: Value of the `rotationX` property at the end of the animation.
+    type: Number
+    platforms: [android]
+    since: { android: "12.2.0" }
+
   - name: elevation
     summary: Value of the `elevation` property at the end of the animation.
     type: Number


### PR DESCRIPTION
Make the two Android parameters `rotationX` and `rotationY` usable inside an animation:

```js
const window = Ti.UI.createWindow();

var frontView = Ti.UI.createView({
	backgroundColor: 'blue',
	width: 200,
	height: 200,
});

var backView = Ti.UI.createView({
	backgroundColor: 'red',
	width: 200,
	height: 200,
	zIndex: -1
});

var containerView = Ti.UI.createView({
	width: 200,
	height: 200,
});

containerView.add(frontView);
containerView.add(backView);
containerView.rotationY = 0;

containerView.addEventListener('click', function() {
	containerView.animate({
		duration: 500,
		rotationY: 90,
		curve: Titanium.UI.ANIMATION_CURVE_LINEAR,
	}, function() {
		frontView.hide();
		backView.show();
		containerView.animate({
			duration: 500,
			rotationY: 180,
			curve: Titanium.UI.ANIMATION_CURVE_LINEAR,
		});
	});
});

window.add(containerView);
window.open();
```


https://user-images.githubusercontent.com/4334997/235726110-d0963f58-60ce-456f-a816-809543125aa5.mp4

