### PR TITLE
fix(android): tableview scroll state restoration

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiTableView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiTableView.java
@@ -22,6 +22,7 @@ import android.graphics.drawable.Drawable;
 import android.graphics.drawable.ShapeDrawable;
 import android.graphics.drawable.shapes.RectShape;
 import android.os.Handler;
+import android.os.Parcelable;
 import android.os.SystemClock;
 import android.view.MotionEvent;
 import android.view.View;
@@ -750,6 +751,7 @@ public class TiTableView extends TiSwipeRefreshLayout implements OnSearchChangeL
 			}
 		}
 
+		Parcelable recyclerViewState = recyclerView.getLayoutManager().onSaveInstanceState();
 		// Notify adapter of changes on UI thread.
 		this.adapter.update(rows, force);
 
@@ -792,6 +794,7 @@ public class TiTableView extends TiSwipeRefreshLayout implements OnSearchChangeL
 						}
 					}
 				}
+				recyclerView.getLayoutManager().onRestoreInstanceState(recyclerViewState);
 			}
 		});
 	}


### PR DESCRIPTION
using https://github.com/tidev/titanium_mobile/pull/13493 but for TableViews

Test
```js
var menu = [];
var lab = Ti.UI.createLabel({text: "Row 0"});
var numrows = 0;

var self = Ti.UI.createWindow({title: "Table Test"});
var table = Ti.UI.createTableView({});

table.addEventListener("click", function(e) {
  console.log("Row " + e.index);
  lab.text = "Clicked " + e.index;
  menu[1].title = "Clicked " + e.index;
  if (e.index == numrows - 1)
    AddRows();
});

function AddRows() {
  var row = Ti.UI.createTableViewRow({title: "Row " + numrows});
  if (menu.length == 0)
    row.add(lab);
  menu.push(row);
  numrows++;
  var row = Ti.UI.createTableViewRow({title: "Row " + numrows});
  menu.push(row);
  numrows++;
  table.data = menu;
};

AddRows();
self.add(table);
self.open();
```

* click the last row multiple times
* it won't scroll up when the first rows are out of the view (it stays at the bottom)

**with the fix**

https://user-images.githubusercontent.com/4334997/236804955-6fc5d3ec-d7da-4632-a248-16a327bd7ed0.mp4


**current 12.1.1.GA**


https://user-images.githubusercontent.com/4334997/236805467-5c339364-0291-46c8-a2eb-7b8ef0314a01.mp4

