### PR TITLE
fix(ios): fix console.log formatting crash on non Apple Silicon devices

### DIFF
--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiBase.h
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiBase.h
@@ -536,6 +536,10 @@ enum {
 
 #define VAL_OR_NSNULL(foo) (((foo) != nil) ? ((id)foo) : [NSNull null])
 
+#if (defined(__arm64__) || defined(__ARM_ARCH_8_32__))
+#define IS_APPLE_SILICON_DEVICE
+#endif
+
 NSString *hexString(NSData *thedata);
 
 typedef enum {

--- a/iphone/TitaniumKit/TitaniumKit/Sources/Kroll/KrollContext.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/Kroll/KrollContext.m
@@ -194,7 +194,7 @@ static JSValueRef StringFormatCallback(JSContextRef jsContext, JSObjectRef jsFun
 
   KrollContext *ctx = GetKrollContext(jsContext);
   NSString *format = [KrollObject toID:ctx value:args[0]];
-#if TARGET_OS_SIMULATOR && !__LP64__
+#if TARGET_OS_SIMULATOR && !defined(IS_APPLE_SILICON_DEVICE)
   // convert string references to objects
   format = [format stringByReplacingOccurrencesOfString:@"%@" withString:@"%@_TIDELIMITER_"];
   format = [format stringByReplacingOccurrencesOfString:@"%s" withString:@"%@_TIDELIMITER_"];


### PR DESCRIPTION
I could not reproduce the initial crash on my device, but this change could fix https://github.com/tidev/titanium_mobile/pull/13738