### PR TITLE
feat(all): remove debug/trace functions from production builds

### DIFF
--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -914,6 +914,7 @@ AndroidBuilder.prototype.validate = function validate(logger, config, cli) {
 			this.minifyJS = true;
 			this.encryptJS = true;
 			this.minifyCSS = true;
+			this.removeLogs = true;
 			this.allowDebugging = false;
 			this.allowProfiling = false;
 			this.proguard = false;
@@ -2637,6 +2638,7 @@ AndroidBuilder.prototype.processJSFiles = async function processJSFiles(jsFilesM
 			transpile: this.transpile,
 			sourceMap: this.sourceMaps,
 			resourcesDir: this.buildAssetsDir,
+			removeLogs: this.removeLogs,
 			logger: this.logger,
 			targets: {
 				chrome: this.chromeVersion

--- a/cli/lib/tasks/process-js-task.js
+++ b/cli/lib/tasks/process-js-task.js
@@ -33,6 +33,7 @@ class ProcessJsTask extends IncrementalFileTask {
 	 * @param {Object} options.defaultAnalyzeOptions Default configuration options for jsanalyze.
 	 * @param {Boolean} options.defaultAnalyzeOptions.minify Whether to minify the JS files or not.
 	 * @param {Boolean} options.defaultAnalyzeOptions.transpile Whether to transpile the JS files or not.
+	 * @param {Boolean} options.defaultAnalyzeOptions.removeLogs Whether to remove the logs in the JS files or not.
 	 * @param {Boolean} options.defaultAnalyzeOptions.sourceMaps Whether to generate source maps or not.
 	 * @param {String} options.defaultAnalyzeOptions.resourcesDir Path to the directory where JS files will be copied to.
 	 * @param {Object} options.defaultAnalyzeOptions.logger Appc logger instance.
@@ -292,10 +293,12 @@ class ProcessJsTask extends IncrementalFileTask {
 		const isFileFromCommonFolder = from.startsWith(this.sdkCommonFolder);
 		const transpile = isFileFromCommonFolder ? false : this.defaultAnalyzeOptions.transpile;
 		const minify = isFileFromCommonFolder ? false : this.defaultAnalyzeOptions.minify;
+		const removeLogs = isFileFromCommonFolder ? false : this.defaultAnalyzeOptions.removeLogs;
 		const analyzeOptions = Object.assign({}, this.defaultAnalyzeOptions, {
 			filename: from,
 			minify,
 			transpile,
+			removeLogs
 		});
 
 		let newContents;


### PR DESCRIPTION
fixes #13837 

Needs: https://github.com/tidev/node-titanium-sdk/pull/651

Instead of just hiding the debug/trace Ti.API calls in a production build it will `NULL` them and not execute the parameters! More info in the issue ticket.

```js
let i = 0;
let c = 0;
Ti.API.info(`-------------INFO: ${++i}`);
Ti.API.debug(`-------------DEBUG: ${++i}`);
Ti.API.info(`-------------INFO: ${++i}`);
```

**Test:**
* create a dev build
* build with `-l info` and you should see `INFO 1` and `INFO 3`
* build a store build
* run `adb logcat | grep -i tiapi` and launch your app
* you should see `INFO 1` and `INFO 2`

**TODO:**
* Currently only a draft to see if it is useful or should be like this.
* either do the same for `console.debug` or add the existing babel remover for that