### PR TITLE
chore: update WWDRCA links

### DIFF
--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -1895,7 +1895,7 @@ iOSBuilder.prototype.validate = function validate(logger, config, cli) {
 			// make sure they have Apple's WWDR cert installed
 			if (!this.iosInfo.certs.wwdr) {
 				logger.error(__('WWDR Intermediate Certificate not found') + '\n');
-				logger.log(__('Download and install the certificate from %s', 'https://www.apple.com/certificateauthority/AppleWWDRCAG2.cer'.cyan) + '\n');
+				logger.log(__('Download and install the certificate from %s', 'https://www.apple.com/certificateauthority/AppleWWDRCAG3.cer'.cyan) + '\n');
 				process.exit(1);
 			}
 

--- a/iphone/cli/lib/info.js
+++ b/iphone/cli/lib/info.js
@@ -79,7 +79,7 @@ exports.detect = function (types, config, next) {
 						+ __('The maximum supported Xcode version by Titanium SDK %s is Xcode %s.', manifestJson.version, issue.maxSupportedVer);
 					break;
 				case 'IOS_NO_WWDR_CERT_FOUND':
-					issue.message += '\n' + __('Download and install the certificate from %s', '__https://www.apple.com/certificateauthority/AppleWWDRCAG2.cer__');
+					issue.message += '\n' + __('Download and install the certificate from %s', '__https://www.apple.com/certificateauthority/AppleWWDRCAG3.cer__');
 					break;
 				case 'IOS_NO_KEYCHAINS_FOUND':
 					issue.message += '\n' + __('Titanium will most likely not be able to detect any developer or App Store distribution certificates.');


### PR DESCRIPTION
I still don't understand why there are 6 different links at https://www.apple.com/certificateauthority/
but I got feedback that the currently linked G2 certificate (old PR https://github.com/tidev/titanium-sdk/pull/13747) doesn't work and G3 works.

I found this issue `https://github.com/tomasmcguinness/pkpassvalidator/issues/12` that says G1, G3, G5 have the same issuer name and G2 and G6 are the same. I'm not sure where Titaniums check is but since we've used G1 before it makes sense to use G3 and not G2.