### PR TITLE
chore: update ti.map (android)

### DIFF
--- a/support/module/packaged/modules.json
+++ b/support/module/packaged/modules.json
@@ -35,8 +35,8 @@
 			"integrity": "sha512-RhHIP6xq+KDx1/ErTfLaEK1gdX8UqfXm7//zxiwXLLWmhDwPa5SXDAlpXgkGeqS089bJIUiwD2e1k9gwhUZYCQ=="
 		},
 		"ti.map": {
-			"url": "https://github.com/tidev/ti.map/releases/download/v5.5.1-android/ti.map-android-5.5.1.zip",
-			"integrity": "sha512-v2wyc+RUgfNUpj/44VQnw1+F/EWh8eOK55Us0SnkaUXRMTv/IslPVla6WvvLNRZtUymFH7TKwoLYq66MxE/6Hg=="
+			"url": "https://github.com/tidev/ti.map/releases/download/v5.5.2-android/ti.map-android-5.5.2.zip",
+			"integrity": "sha512-6pXkhmi4zBI4cunRfDcLQrugRhlH4z9GntscLvpoBiK6QQ1i+Te3gQ9HaT1YzF5KyRrOLlleiTGtD4WTlTWvGA=="
 		},
 		"ti.webdialog": {
 			"url": "https://github.com/tidev/titanium-web-dialog/releases/download/v2.2.0-android/ti.webdialog-android-2.2.0.zip",


### PR DESCRIPTION
use the latest ti.map module with the ` fixes toColor deprecation warnings (#635)` fix 
https://github.com/tidev/ti.map/releases/tag/v5.5.2-android

we've merged it three weeks ago but forgot to update it here too