### PR TITLE
fix(ios): fix orientation of the thumbnail image created from a video

### DIFF
--- a/iphone/Classes/TiMediaVideoPlayerProxy.m
+++ b/iphone/Classes/TiMediaVideoPlayerProxy.m
@@ -413,6 +413,8 @@ NSArray *moviePlayerKeys = nil;
       imageGenerator.requestedTimeToleranceAfter = kCMTimeZero;
     }
 
+    imageGenerator.appliesPreferredTrackTransform = YES;
+
     [imageGenerator cancelAllCGImageGeneration];
 
     RELEASE_TO_NIL(thumbnailCallback);


### PR DESCRIPTION
This will fix the orientation of the thumbnail

**GitHub discussions:** https://github.com/tidev/titanium-sdk/discussions/[ID]

Provide a clear PR title prefixed with `[ID]`

**Optional Description:**
