### PR TITLE
feat(android): badgeTextColor property

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TabProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TabProxy.java
@@ -25,6 +25,7 @@ import android.app.Activity;
 		TiC.PROPERTY_ACTIVE_TITLE_COLOR,
 		TiC.PROPERTY_BADGE,
 		TiC.PROPERTY_BADGE_COLOR,
+		TiC.PROPERTY_BADGE_TEXT_COLOR,
 		TiC.PROPERTY_ICON,
 		TiC.PROPERTY_TINT_COLOR,
 		TiC.PROPERTY_TITLE,
@@ -245,7 +246,7 @@ public class TabProxy extends TiViewProxy
 			tabGroupView.updateTabIcon(this.tabGroupProxy.getTabIndex(this));
 		} else if (name.equals(TiC.PROPERTY_BADGE)) {
 			tabGroupView.updateBadge(this.tabGroupProxy.getTabIndex(this));
-		} else if (name.equals(TiC.PROPERTY_BADGE_COLOR)) {
+		} else if (name.equals(TiC.PROPERTY_BADGE_COLOR) || name.equals(TiC.PROPERTY_BADGE_TEXT_COLOR)) {
 			tabGroupView.updateBadgeColor(this.tabGroupProxy.getTabIndex(this));
 		}
 	}

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TabProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TabProxy.java
@@ -24,7 +24,8 @@ import android.app.Activity;
 		TiC.PROPERTY_ACTIVE_TINT_COLOR,
 		TiC.PROPERTY_ACTIVE_TITLE_COLOR,
 		TiC.PROPERTY_BADGE,
-		TiC.PROPERTY_BADGE_COLOR,
+		TiC.PROPERTY_BADGE_COLOR, // DEPRECATED: Superseded by PROPERTY_BADGE_BACKGROUND_COLOR.
+		TiC.PROPERTY_BADGE_BACKGROUND_COLOR,
 		TiC.PROPERTY_BADGE_TEXT_COLOR,
 		TiC.PROPERTY_ICON,
 		TiC.PROPERTY_TINT_COLOR,
@@ -246,7 +247,8 @@ public class TabProxy extends TiViewProxy
 			tabGroupView.updateTabIcon(this.tabGroupProxy.getTabIndex(this));
 		} else if (name.equals(TiC.PROPERTY_BADGE)) {
 			tabGroupView.updateBadge(this.tabGroupProxy.getTabIndex(this));
-		} else if (name.equals(TiC.PROPERTY_BADGE_COLOR) || name.equals(TiC.PROPERTY_BADGE_TEXT_COLOR)) {
+		} else if (name.equals(TiC.PROPERTY_BADGE_COLOR) || name.equals(TiC.PROPERTY_BADGE_BACKGROUND_COLOR)
+			|| name.equals(TiC.PROPERTY_BADGE_TEXT_COLOR)) {
 			tabGroupView.updateBadgeColor(this.tabGroupProxy.getTabIndex(this));
 		}
 	}

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIBottomNavigationTabGroup.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIBottomNavigationTabGroup.java
@@ -435,10 +435,17 @@ public class TiUIBottomNavigationTabGroup extends TiUIAbstractTabGroup implement
 
 		// TODO: reset to default value when property is null
 		if (tabProxy.hasPropertyAndNotNull(TiC.PROPERTY_BADGE_COLOR)) {
+			Log.w(TAG, "badgeColor is deprecated.  Use badgeBackgroundColor instead.");
 			int menuItemId = this.mBottomNavigationView.getMenu().getItem(index).getItemId();
 			BadgeDrawable badgeDrawable = this.mBottomNavigationView.getOrCreateBadge(menuItemId);
 			badgeDrawable.setBackgroundColor(
 				TiConvert.toColor(tabProxy.getProperty(TiC.PROPERTY_BADGE_COLOR), tabProxy.getActivity()));
+		}
+		if (tabProxy.hasPropertyAndNotNull(TiC.PROPERTY_BADGE_BACKGROUND_COLOR)) {
+			int menuItemId = this.mBottomNavigationView.getMenu().getItem(index).getItemId();
+			BadgeDrawable badgeDrawable = this.mBottomNavigationView.getOrCreateBadge(menuItemId);
+			badgeDrawable.setBackgroundColor(
+				TiConvert.toColor(tabProxy.getProperty(TiC.PROPERTY_BADGE_BACKGROUND_COLOR), tabProxy.getActivity()));
 		}
 		if (tabProxy.hasPropertyAndNotNull(TiC.PROPERTY_BADGE_TEXT_COLOR)) {
 			int menuItemId = this.mBottomNavigationView.getMenu().getItem(index).getItemId();

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIBottomNavigationTabGroup.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIBottomNavigationTabGroup.java
@@ -440,6 +440,12 @@ public class TiUIBottomNavigationTabGroup extends TiUIAbstractTabGroup implement
 			badgeDrawable.setBackgroundColor(
 				TiConvert.toColor(tabProxy.getProperty(TiC.PROPERTY_BADGE_COLOR), tabProxy.getActivity()));
 		}
+		if (tabProxy.hasPropertyAndNotNull(TiC.PROPERTY_BADGE_TEXT_COLOR)) {
+			int menuItemId = this.mBottomNavigationView.getMenu().getItem(index).getItemId();
+			BadgeDrawable badgeDrawable = this.mBottomNavigationView.getOrCreateBadge(menuItemId);
+			badgeDrawable.setBadgeTextColor(
+				TiConvert.toColor(tabProxy.getProperty(TiC.PROPERTY_BADGE_TEXT_COLOR), tabProxy.getActivity()));
+		}
 	}
 
 	@Override

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUITabLayoutTabGroup.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUITabLayoutTabGroup.java
@@ -333,6 +333,11 @@ public class TiUITabLayoutTabGroup extends TiUIAbstractTabGroup implements TabLa
 			badgeDrawable.setBackgroundColor(
 				TiConvert.toColor(tabProxy.getProperty(TiC.PROPERTY_BADGE_COLOR), tabProxy.getActivity()));
 		}
+		if (tabProxy.hasPropertyAndNotNull(TiC.PROPERTY_BADGE_TEXT_COLOR)) {
+			BadgeDrawable badgeDrawable = this.mTabLayout.getTabAt(index).getOrCreateBadge();
+			badgeDrawable.setBadgeTextColor(
+				TiConvert.toColor(tabProxy.getProperty(TiC.PROPERTY_BADGE_TEXT_COLOR), tabProxy.getActivity()));
+		}
 	}
 
 	@Override

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUITabLayoutTabGroup.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUITabLayoutTabGroup.java
@@ -329,9 +329,15 @@ public class TiUITabLayoutTabGroup extends TiUIAbstractTabGroup implements TabLa
 
 		// TODO: reset to default value when property is null
 		if (tabProxy.hasPropertyAndNotNull(TiC.PROPERTY_BADGE_COLOR)) {
+			Log.w(TAG, "badgeColor is deprecated.  Use badgeBackgroundColor instead.");
 			BadgeDrawable badgeDrawable = this.mTabLayout.getTabAt(index).getOrCreateBadge();
 			badgeDrawable.setBackgroundColor(
 				TiConvert.toColor(tabProxy.getProperty(TiC.PROPERTY_BADGE_COLOR), tabProxy.getActivity()));
+		}
+		if (tabProxy.hasPropertyAndNotNull(TiC.PROPERTY_BADGE_BACKGROUND_COLOR)) {
+			BadgeDrawable badgeDrawable = this.mTabLayout.getTabAt(index).getOrCreateBadge();
+			badgeDrawable.setBackgroundColor(
+				TiConvert.toColor(tabProxy.getProperty(TiC.PROPERTY_BADGE_BACKGROUND_COLOR), tabProxy.getActivity()));
 		}
 		if (tabProxy.hasPropertyAndNotNull(TiC.PROPERTY_BADGE_TEXT_COLOR)) {
 			BadgeDrawable badgeDrawable = this.mTabLayout.getTabAt(index).getOrCreateBadge();

--- a/android/titanium/src/java/org/appcelerator/titanium/TiC.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiC.java
@@ -292,7 +292,8 @@ public class TiC
 	public static final String PROPERTY_BACKGROUND_SELECTED_COLOR = "backgroundSelectedColor";
 	public static final String PROPERTY_BACKGROUND_SELECTED_IMAGE = "backgroundSelectedImage";
 	public static final String PROPERTY_BADGE = "badge";
-	public static final String PROPERTY_BADGE_COLOR = "badgeColor";
+	public static final String PROPERTY_BADGE_COLOR = "badgeColor"; // DEPRECATED: Superseded by PROPERTY_BADGE_BACKGROUND_COLOR.
+	public static final String PROPERTY_BADGE_BACKGROUND_COLOR = "badgeBackgroundColor";
 	public static final String PROPERTY_BADGE_TEXT_COLOR = "badgeTextColor";
 	public static final String PROPERTY_TARGET_ITEM_INDEX = "targetItemIndex";
 	public static final String PROPERTY_TARGET_SECTION = "targetSection";

--- a/android/titanium/src/java/org/appcelerator/titanium/TiC.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiC.java
@@ -293,6 +293,7 @@ public class TiC
 	public static final String PROPERTY_BACKGROUND_SELECTED_IMAGE = "backgroundSelectedImage";
 	public static final String PROPERTY_BADGE = "badge";
 	public static final String PROPERTY_BADGE_COLOR = "badgeColor";
+	public static final String PROPERTY_BADGE_TEXT_COLOR = "badgeTextColor";
 	public static final String PROPERTY_TARGET_ITEM_INDEX = "targetItemIndex";
 	public static final String PROPERTY_TARGET_SECTION = "targetSection";
 	public static final String PROPERTY_TARGET_SECTION_INDEX = "targetSectionIndex";

--- a/apidoc/Titanium/UI/Tab.yml
+++ b/apidoc/Titanium/UI/Tab.yml
@@ -196,6 +196,9 @@ properties:
     since: {android: "9.3.0"}
 
   - name: badgeColor
+    deprecated:
+        since: "12.2.0"
+        notes: Use [Titanium.UI.Tab.badgeBackgroundColor](Titanium.UI.Tab.badgeBackgroundColor) instead.
     summary: |
         If this item displays a badge, this color will be used for the badge's background.
         If set to null, the default background color will be used instead.
@@ -204,6 +207,16 @@ properties:
     type: [String, Titanium.UI.Color]
     platforms: [android, iphone, ipad, macos]
     since: {android: "9.3.0", iphone: "6.1.0", ipad: "6.1.0", macos: "9.2.0"}
+
+  - name: badgeBackgroundColor
+    summary: |
+        If this item displays a badge, this color will be used for the badge's background.
+        If set to null, the default background color will be used instead.
+    description: |
+        For information about color values, see the "Colors" section of <Titanium.UI>.
+    type: [String, Titanium.UI.Color]
+    platforms: [android, iphone, ipad, macos]
+    since: {android: "12.2.0"}
 
   - name: badgeTextColor
     summary: |

--- a/apidoc/Titanium/UI/Tab.yml
+++ b/apidoc/Titanium/UI/Tab.yml
@@ -205,6 +205,15 @@ properties:
     platforms: [android, iphone, ipad, macos]
     since: {android: "9.3.0", iphone: "6.1.0", ipad: "6.1.0", macos: "9.2.0"}
 
+  - name: badgeTextColor
+    summary: |
+        Set the text color of the badge.
+    description: |
+        For information about color values, see the "Colors" section of <Titanium.UI>.
+    type: [String, Titanium.UI.Color]
+    platforms: [android]
+    since: {android: "12.2.0"}
+
   - name: icon
     summary: Icon URL for this tab.
     description: |


### PR DESCRIPTION
Currently you can only set the badgeColor (background) but not the text color. `badgeTextColor` can be used to do that now.

added  `badgeBackgroundColor` and added a deprecation warning to `badgeColor` to use the new property

```js
const isAndroid = Ti.Platform.osname === 'android';
let tabGroup;

const window = Ti.UI.createWindow();

tabGroup = Ti.UI.createTabGroup({
	style: isAndroid ? Ti.UI.Android.TABS_STYLE_BOTTOM_NAVIGATION : undefined,
	tabs: [
		Ti.UI.createTab({
			window,
			title: "test"
		}),
		Ti.UI.createTab({
			window:Ti.UI.createWindow(),
			title: "test"
		})
	]
});

//tabGroup.tabs[0].badgeColor = "black" // deprecated - shows a warning
tabGroup.tabs[0].badgeBackgroundColor = "black"
tabGroup.tabs[0].badgeTextColor = "white"
tabGroup.tabs[0].badge = 1

tabGroup.open();
```

![Screenshot_20230628-122134](https://github.com/tidev/titanium-sdk/assets/4334997/1a09e271-56d2-47d7-9239-1b994432b8e6)


Code is a copy of the `badgeColor` part and just using `setBadgeTextColor` instead of `setBackgroundColor`