### PR TITLE
feat(android): customView in BottomNavigation

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIBottomNavigationTabGroup.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIBottomNavigationTabGroup.java
@@ -25,7 +25,7 @@ import com.google.android.material.badge.BadgeDrawable;
 import com.google.android.material.bottomnavigation.BottomNavigationItemView;
 import com.google.android.material.bottomnavigation.BottomNavigationMenuView;
 import com.google.android.material.bottomnavigation.BottomNavigationView;
-import com.google.android.material.bottomnavigation.LabelVisibilityMode;
+import com.google.android.material.navigation.NavigationBarView;
 import com.google.android.material.shape.CornerFamily;
 import com.google.android.material.shape.MaterialShapeDrawable;
 import com.google.android.material.shape.ShapeAppearanceModel;
@@ -58,6 +58,7 @@ public class TiUIBottomNavigationTabGroup extends TiUIAbstractTabGroup implement
 	private final ArrayList<MenuItem> mMenuItemsArray = new ArrayList<>();
 	// endregion
 	private TiViewProxy customView;
+	private static boolean isCustomView = false;
 
 	public TiUIBottomNavigationTabGroup(TabGroupProxy proxy, TiBaseActivity activity)
 	{
@@ -87,6 +88,7 @@ public class TiUIBottomNavigationTabGroup extends TiUIAbstractTabGroup implement
 		int resourceID = activity.getResources().getIdentifier("design_bottom_navigation_height", "dimen",
 															   activity.getPackageName());
 		this.mBottomNavigationHeightValue = activity.getResources().getDimensionPixelSize(resourceID);
+		isCustomView = this.proxy.hasPropertyAndNotNull(TiC.PROPERTY_CUSTOM_VIEW);
 
 		// Fetch padding properties. If at least 1 property is non-zero, then show a floating tab bar.
 		final TiDimension paddingLeft = TiConvert.toTiDimension(
@@ -102,57 +104,60 @@ public class TiUIBottomNavigationTabGroup extends TiUIAbstractTabGroup implement
 
 		// Create the bottom tab navigation view.
 		mBottomNavigationView = new BottomNavigationView(activity);
-		mBottomNavigationView.addOnLayoutChangeListener(new View.OnLayoutChangeListener() {
-			@Override
-			public void onLayoutChange(
-				View view, int left, int top, int right, int bottom,
-				int oldLeft, int oldTop, int oldRight, int oldBottom)
-			{
-				// Update bottom inset based on tab bar's height and position in window.
-				insetsProvider.setBottomBasedOn(view);
-			}
-		});
-		if (isFloating) {
-			// Set up tab bar to look like a floating toolbar with rounded corners.
-			MaterialShapeDrawable shapeDrawable = null;
-			Drawable background = this.mBottomNavigationView.getBackground();
-			if (background instanceof MaterialShapeDrawable) {
-				shapeDrawable = (MaterialShapeDrawable) background;
-			} else {
-				shapeDrawable = new MaterialShapeDrawable();
-				background = shapeDrawable;
-				mBottomNavigationView.setBackground(shapeDrawable);
-			}
-			ShapeAppearanceModel model = shapeDrawable.getShapeAppearanceModel();
-			float radius = (new TiDimension("17dp", TiDimension.TYPE_LEFT)).getAsPixels(mBottomNavigationView);
-			model = model.toBuilder().setAllCorners(CornerFamily.ROUNDED, radius).build();
-			shapeDrawable.setShapeAppearanceModel(model);
-			this.mBottomNavigationView.setPadding((int) (radius * 0.75), 0, (int) (radius * 0.75), 0);
-			mBottomNavigationView.setElevation(
-				(new TiDimension("8dp", TiDimension.TYPE_BOTTOM)).getAsPixels(mBottomNavigationView));
-			this.mBottomNavigationView.setOnApplyWindowInsetsListener((view, insets) -> {
-				// Add additional padding to compensate for device notch and translucent status/nav bars.
-				int leftInsetPixels
-					= ((paddingLeft != null) ? paddingLeft.getAsPixels(view) : 0)
-					+ insets.getStableInsetLeft();
-				int rightInsetPixels
-					= ((paddingRight != null) ? paddingRight.getAsPixels(view) : 0)
-					+ insets.getStableInsetRight();
-				int bottomInsetPixels
-					= ((paddingBottom != null) ? paddingBottom.getAsPixels(view) : 0)
-					+ insets.getStableInsetBottom();
-				TiCompositeLayout.LayoutParams params = (TiCompositeLayout.LayoutParams) view.getLayoutParams();
-				params.optionLeft = new TiDimension(leftInsetPixels, TiDimension.TYPE_LEFT);
-				params.optionRight = new TiDimension(rightInsetPixels, TiDimension.TYPE_RIGHT);
-				params.optionBottom = new TiDimension(bottomInsetPixels, TiDimension.TYPE_BOTTOM);
-				insets.consumeSystemWindowInsets();
-				return insets;
-			});
-		}
-		this.mBottomNavigationView.setFitsSystemWindows(!isFloating);
-		this.mBottomNavigationView.setItemRippleColor(
-			TiUIAbstractTabGroup.createRippleColorStateListFrom(getColorPrimary()));
 
+		if (!isCustomView) {
+			mBottomNavigationView.addOnLayoutChangeListener(new View.OnLayoutChangeListener()
+			{
+				@Override
+				public void onLayoutChange(
+					View view, int left, int top, int right, int bottom,
+					int oldLeft, int oldTop, int oldRight, int oldBottom)
+				{
+					// Update bottom inset based on tab bar's height and position in window.
+					insetsProvider.setBottomBasedOn(view);
+				}
+			});
+			if (isFloating) {
+				// Set up tab bar to look like a floating toolbar with rounded corners.
+				MaterialShapeDrawable shapeDrawable = null;
+				Drawable background = this.mBottomNavigationView.getBackground();
+				if (background instanceof MaterialShapeDrawable) {
+					shapeDrawable = (MaterialShapeDrawable) background;
+				} else {
+					shapeDrawable = new MaterialShapeDrawable();
+					background = shapeDrawable;
+					mBottomNavigationView.setBackground(shapeDrawable);
+				}
+				ShapeAppearanceModel model = shapeDrawable.getShapeAppearanceModel();
+				float radius = (new TiDimension("17dp", TiDimension.TYPE_LEFT)).getAsPixels(mBottomNavigationView);
+				model = model.toBuilder().setAllCorners(CornerFamily.ROUNDED, radius).build();
+				shapeDrawable.setShapeAppearanceModel(model);
+				this.mBottomNavigationView.setPadding((int) (radius * 0.75), 0, (int) (radius * 0.75), 0);
+				mBottomNavigationView.setElevation(
+					(new TiDimension("8dp", TiDimension.TYPE_BOTTOM)).getAsPixels(mBottomNavigationView));
+				this.mBottomNavigationView.setOnApplyWindowInsetsListener((view, insets) -> {
+					// Add additional padding to compensate for device notch and translucent status/nav bars.
+					int leftInsetPixels
+						= ((paddingLeft != null) ? paddingLeft.getAsPixels(view) : 0)
+						+ insets.getStableInsetLeft();
+					int rightInsetPixels
+						= ((paddingRight != null) ? paddingRight.getAsPixels(view) : 0)
+						+ insets.getStableInsetRight();
+					int bottomInsetPixels
+						= ((paddingBottom != null) ? paddingBottom.getAsPixels(view) : 0)
+						+ insets.getStableInsetBottom();
+					TiCompositeLayout.LayoutParams params = (TiCompositeLayout.LayoutParams) view.getLayoutParams();
+					params.optionLeft = new TiDimension(leftInsetPixels, TiDimension.TYPE_LEFT);
+					params.optionRight = new TiDimension(rightInsetPixels, TiDimension.TYPE_RIGHT);
+					params.optionBottom = new TiDimension(bottomInsetPixels, TiDimension.TYPE_BOTTOM);
+					insets.consumeSystemWindowInsets();
+					return insets;
+				});
+			}
+			this.mBottomNavigationView.setFitsSystemWindows(!isFloating);
+			this.mBottomNavigationView.setItemRippleColor(
+				TiUIAbstractTabGroup.createRippleColorStateListFrom(getColorPrimary()));
+		}
 		// Add tab bar and view pager to the root Titanium view.
 		// Note: If getFitsSystemWindows() returns false, then Titanium window's "extendSafeArea" is set true.
 		//       This means the bottom tab bar should overlap/overlay the view pager content.
@@ -176,7 +181,7 @@ public class TiUIBottomNavigationTabGroup extends TiUIAbstractTabGroup implement
 			} else {
 				params.optionBottom = new TiDimension(0, TiDimension.TYPE_BOTTOM);
 			}
-			if (this.proxy.hasPropertyAndNotNull(TiC.PROPERTY_CUSTOM_VIEW)) {
+			if (isCustomView) {
 				customView = (TiViewProxy) this.proxy.getProperty(TiC.PROPERTY_CUSTOM_VIEW);
 				customView.getOrCreateView().getNativeView().setMinimumHeight(mBottomNavigationHeightValue);
 				compositeLayout.addView(customView.getOrCreateView().getNativeView(), params);
@@ -209,11 +214,16 @@ public class TiUIBottomNavigationTabGroup extends TiUIAbstractTabGroup implement
 		}
 
 		// Show/hide the tab bar.
-		this.mBottomNavigationView.setVisibility(disable ? View.GONE : View.VISIBLE);
-		this.mBottomNavigationView.requestLayout();
+		if (isCustomView) {
+			customView.getOrCreateView().getNativeView().setVisibility(disable ? View.GONE : View.VISIBLE);
+			this.insetsProvider.setBottomBasedOn(customView.getOrCreateView().getNativeView());
+		} else {
+			this.mBottomNavigationView.setVisibility(disable ? View.GONE : View.VISIBLE);
+			this.mBottomNavigationView.requestLayout();
 
-		// Update top inset. (Will remove bottom inset if tab bar is "gone".)
-		this.insetsProvider.setBottomBasedOn(this.mBottomNavigationView);
+			// Update top inset. (Will remove bottom inset if tab bar is "gone".)
+			this.insetsProvider.setBottomBasedOn(this.mBottomNavigationView);
+		}
 	}
 
 	@Override
@@ -237,14 +247,14 @@ public class TiUIBottomNavigationTabGroup extends TiUIAbstractTabGroup implement
 		final int shiftMode = proxy.getProperties().optInt(TiC.PROPERTY_SHIFT_MODE, 1);
 		switch (shiftMode) {
 			case 0:
-				this.mBottomNavigationView.setLabelVisibilityMode(LabelVisibilityMode.LABEL_VISIBILITY_LABELED);
+				this.mBottomNavigationView.setLabelVisibilityMode(NavigationBarView.LABEL_VISIBILITY_LABELED);
 				break;
 			case 1:
-				this.mBottomNavigationView.setLabelVisibilityMode(LabelVisibilityMode.LABEL_VISIBILITY_AUTO);
+				this.mBottomNavigationView.setLabelVisibilityMode(NavigationBarView.LABEL_VISIBILITY_AUTO);
 				break;
 			case 2:
 				// NOTE: Undocumented for now, will create new property that has parity with iOS.
-				this.mBottomNavigationView.setLabelVisibilityMode(LabelVisibilityMode.LABEL_VISIBILITY_UNLABELED);
+				this.mBottomNavigationView.setLabelVisibilityMode(NavigationBarView.LABEL_VISIBILITY_UNLABELED);
 				break;
 		}
 	}
@@ -391,13 +401,25 @@ public class TiUIBottomNavigationTabGroup extends TiUIAbstractTabGroup implement
 			this.tabGroupViewPager.setLayoutParams(params);
 		}
 
-		if (visible) {
-			this.mBottomNavigationView.animate().translationY(0f).setDuration(200);
+		if (isCustomView) {
+			// custom view
+			if (visible) {
+				customView.getOrCreateView().getNativeView()
+					.animate().translationY(0f).setDuration(200);
+			} else {
+				customView.getOrCreateView().getNativeView()
+					.animate().translationY(mBottomNavigationHeightValue).setDuration(200);
+			}
+			this.insetsProvider.setBottomBasedOn(customView.getOrCreateView().getNativeView());
 		} else {
-			this.mBottomNavigationView.animate().translationY(mBottomNavigationView.getHeight()).setDuration(200);
+			// bottom navigation view
+			if (visible) {
+				this.mBottomNavigationView.animate().translationY(0f).setDuration(200);
+			} else {
+				this.mBottomNavigationView.animate().translationY(mBottomNavigationView.getHeight()).setDuration(200);
+			}
+			this.insetsProvider.setBottomBasedOn(this.mBottomNavigationView);
 		}
-
-		this.insetsProvider.setBottomBasedOn(this.mBottomNavigationView);
 	}
 
 	@SuppressLint("RestrictedApi")

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIBottomNavigationTabGroup.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIBottomNavigationTabGroup.java
@@ -57,6 +57,7 @@ public class TiUIBottomNavigationTabGroup extends TiUIAbstractTabGroup implement
 	private BottomNavigationView mBottomNavigationView;
 	private final ArrayList<MenuItem> mMenuItemsArray = new ArrayList<>();
 	// endregion
+	private TiViewProxy customView;
 
 	public TiUIBottomNavigationTabGroup(TabGroupProxy proxy, TiBaseActivity activity)
 	{
@@ -175,7 +176,13 @@ public class TiUIBottomNavigationTabGroup extends TiUIAbstractTabGroup implement
 			} else {
 				params.optionBottom = new TiDimension(0, TiDimension.TYPE_BOTTOM);
 			}
-			compositeLayout.addView(this.mBottomNavigationView, params);
+			if (this.proxy.hasPropertyAndNotNull(TiC.PROPERTY_CUSTOM_VIEW)) {
+				customView = (TiViewProxy) this.proxy.getProperty(TiC.PROPERTY_CUSTOM_VIEW);
+				customView.getOrCreateView().getNativeView().setMinimumHeight(mBottomNavigationHeightValue);
+				compositeLayout.addView(customView.getOrCreateView().getNativeView(), params);
+			} else {
+				compositeLayout.addView(this.mBottomNavigationView, params);
+			}
 		}
 
 		// Set the ViewPager as a native view.

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIBottomNavigationTabGroup.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIBottomNavigationTabGroup.java
@@ -171,6 +171,8 @@ public class TiUIBottomNavigationTabGroup extends TiUIAbstractTabGroup implement
 			}
 			compositeLayout.addView(this.tabGroupViewPager, params);
 		}
+
+		// add navigation menu
 		{
 			TiCompositeLayout.LayoutParams params = new TiCompositeLayout.LayoutParams();
 			params.autoFillsWidth = true;
@@ -182,9 +184,19 @@ public class TiUIBottomNavigationTabGroup extends TiUIAbstractTabGroup implement
 				params.optionBottom = new TiDimension(0, TiDimension.TYPE_BOTTOM);
 			}
 			if (isCustomView) {
+				params.height = mBottomNavigationHeightValue;
 				customView = (TiViewProxy) this.proxy.getProperty(TiC.PROPERTY_CUSTOM_VIEW);
-				customView.getOrCreateView().getNativeView().setMinimumHeight(mBottomNavigationHeightValue);
-				compositeLayout.addView(customView.getOrCreateView().getNativeView(), params);
+				View view = customView.getOrCreateView().getNativeView();
+				view.setMinimumHeight(mBottomNavigationHeightValue);
+				params.optionHeight = new TiDimension(mBottomNavigationHeightValue, TiDimension.TYPE_HEIGHT);
+				view.setLayoutParams(params);
+				if (view.getLayoutParams() != null) {
+					view.getLayoutParams().height = mBottomNavigationHeightValue;
+				}
+
+				compositeLayout.addView(view, params);
+				compositeLayout.setClipChildren(
+					TiConvert.toBoolean(this.proxy.getProperty(TiC.PROPERTY_CLIP_VIEWS), true));
 			} else {
 				compositeLayout.addView(this.mBottomNavigationView, params);
 			}

--- a/apidoc/Titanium/UI/TabGroup.yml
+++ b/apidoc/Titanium/UI/TabGroup.yml
@@ -287,6 +287,20 @@ properties:
     type: [String, Titanium.UI.Color]
     platforms: [iphone, ipad, android, macos]
 
+  - name: customView
+    summary: Use a custom Ti.UI.View as your BottomNavigationView.
+    type: Titanium.UI.View
+    since: 12.2.0
+    platforms: [android]
+
+  - name: clipViews
+    summary: If disabled and you use a [customView](Titanium.UI.TabGroup.customView) you can move elements outside of the view bounds.
+    type: Boolean
+    default: true
+    availability: creation
+    since: 12.2.0
+    platforms: [android]
+
   - name: paddingLeft
     summary: Left padding of bottom navigation
     description: |


### PR DESCRIPTION
This will create a fully custom view as a bottomNavigationMenu

```js
const isAndroid = Ti.Platform.osname === 'android';
let tabGroup;

const window1 = Ti.UI.createWindow();
const window2 = Ti.UI.createWindow();
const lbl1 = Ti.UI.createLabel({text: "p 1", top: 10});
const lbl2 = Ti.UI.createLabel({text: "p 2", top: 10});
const btn = Ti.UI.createButton({title: 'Show / hide tab group'});
let tabBarVisible = true;

btn.addEventListener('click', () => {
	tabBarVisible = !tabBarVisible;
	tabGroup.tabBarVisible = tabBarVisible;
});

window1.add([btn, lbl1]);
window2.add(lbl2);

const customView = Ti.UI.createView({backgroundColor: "#333", height: 40});
const btn1 = Ti.UI.createButton({title: "Page 1", width: 100, left: 10});
const btn2 = Ti.UI.createButton({title: "Page 2", width: 100, right: 10});
const view_center = Ti.UI.createView({backgroundColor:"red", height: 80, width: 80, borderRadius: 40, top: -25, elevation: 10});
btn1.addEventListener("click", function() { tabGroup. activeTab = 0; }),
btn2.addEventListener("click", function() { tabGroup. activeTab = 1; });

customView.add([btn1, btn2, view_center]);

tabGroup = Ti.UI.createTabGroup({
	style: isAndroid ? Ti.UI.Android.TABS_STYLE_BOTTOM_NAVIGATION : undefined,
	customView: customView,
	clipViews:  false,
	tabs: [
		Ti.UI.createTab({ window: window1, title: "test 1" }),
		Ti.UI.createTab({ window: window2, title: "test 2" })
	]
});

tabGroup.open();
```

![Screenshot_20230701-164827](https://github.com/tidev/titanium-sdk/assets/4334997/75ab90a8-e4a6-410b-afda-9fc7eb260afb) ![Screenshot_20230701-193027](https://github.com/tidev/titanium-sdk/assets/4334997/d725fc67-eb44-4bfd-83c7-dbac9b38a164)



It will use the space below the TabGroup and adds a normal Ti.UI.View. The user can add fully customized buttons in there and control the normal TabGroup. 
A current workaround is to create a ScrollableView + View.

