### PR TITLE
fix(ios): patch to build for MacCatalyst

### DIFF
--- a/iphone/Classes/TiUIScrollableViewProxy.m
+++ b/iphone/Classes/TiUIScrollableViewProxy.m
@@ -88,7 +88,10 @@
 #else
     TiThreadPerformOnMainThread(
         ^{
-          [[oldViewProxy view] removeFromSuperview];
+          [self makeViewPerformSelector:@selector(removeSubview:)
+                             withObject:[oldViewProxy view]
+                         createIfNeeded:NO
+                          waitUntilDone:NO];
         },
         YES);
 #endif


### PR DESCRIPTION
Patch from Slack

error message when building for Mac Catalyst and 14.2:
```
[TRACE] warning: `DERIVE_MACCATALYST_PRODUCT_BUNDLE_IDENTIFIER` is not supported. Remove the build setting and conditionalize `PRODUCT_BUNDLE_IDENTIFIER` instead. (in target 'App' from project 'App')
[ERROR] 2023-07-13 15:02:31.214 xcodebuild[41305:21115059] DVTCoreDeviceEnabledState: DVTCoreDeviceEnabledState_Disabled set via user default (DVTEnableCoreDevice=disabled)
[ERROR] warning: conditional compilation flags do not have values in Swift; they are either present or absent (rather than 'DEPLOYTYPE=development')
[ERROR] warning: conditional compilation flags do not have values in Swift; they are either present or absent (rather than 'DEPLOYTYPE=development')
[ERROR] warning: conditional compilation flags do not have values in Swift; they are either present or absent (rather than '__LOG__ID__=111111-2bf8-4992-8d06-111111111')
[ERROR] warning: conditional compilation flags do not have values in Swift; they are either present or absent (rather than '__LOG__ID__=111111-2bf8-4992-8d06-111111111')
[ERROR] warning: conditional compilation flags do not have values in Swift; they are either present or absent (rather than 'DEBUG=1')
[ERROR] warning: conditional compilation flags do not have values in Swift; they are either present or absent (rather than 'DEBUG=1')
[ERROR] warning: conditional compilation flags do not have values in Swift; they are either present or absent (rather than 'LAUNCHSCREEN_STORYBOARD=1')
[ERROR] warning: conditional compilation flags do not have values in Swift; they are either present or absent (rather than 'LAUNCHSCREEN_STORYBOARD=1')
[ERROR] warning: conditional compilation flags do not have values in Swift; they are either present or absent (rather than 'DEFAULT_BGCOLOR_RED=0.027450980392156862')
[ERROR] warning: conditional compilation flags do not have values in Swift; they are either present or absent (rather than 'DEFAULT_BGCOLOR_RED=0.027450980392156862')
[ERROR] warning: conditional compilation flags do not have values in Swift; they are either present or absent (rather than 'DEFAULT_BGCOLOR_GREEN=0.027450980392156862')
[ERROR] warning: conditional compilation flags do not have values in Swift; they are either present or absent (rather than 'DEFAULT_BGCOLOR_GREEN=0.027450980392156862')
[ERROR] warning: conditional compilation flags do not have values in Swift; they are either present or absent (rather than 'DEFAULT_BGCOLOR_BLUE=0.027450980392156862')
[ERROR] warning: conditional compilation flags do not have values in Swift; they are either present or absent (rather than 'DEFAULT_BGCOLOR_BLUE=0.027450980392156862')
[ERROR] warning: conditional compilation flags do not have values in Swift; they are either present or absent (rather than 'DISABLE_TI_LOG_SERVER=1')
[ERROR] warning: conditional compilation flags do not have values in Swift; they are either present or absent (rather than 'DISABLE_TI_LOG_SERVER=1')
[ERROR] warning: conditional compilation flags do not have values in Swift; they are either present or absent (rather than 'TI_VERSION=12.2.0')
[ERROR] warning: conditional compilation flags do not have values in Swift; they are either present or absent (rather than 'TI_VERSION=12.2.0')
[ERROR] ** BUILD FAILED **
[ERROR] The following build commands failed:
[ERROR]         CompileC /user/Projects/app/app/build/iphone/build/Intermediates/app/Debug-maccatalyst/app/Objects-normal/x86_64/TiUIScrollableViewProxy.o /user/Projects/app/app/build/iphone/Classes/TiUIScrollableViewProxy.m normal x86_64 objective-c com.apple.compilers.llvm.clang.1_0.compiler (in target 'App' from project 'App')
[ERROR] (1 failure)
```

I only made the PR here! Have no clue why :smile: 