### PR TITLE
fix(ios): ensure default icon is not flattened during maccatalyst builds to avoid white background

### DIFF
--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -5922,7 +5922,11 @@ iOSBuilder.prototype.createAppIconSetAndiTunesArtwork = async function createApp
 	missingIcons = missingIcons.concat(await this.processLaunchLogos(launchLogos, resourcesToCopy, defaultIcon, defaultIconChanged));
 
 	// Do we need to flatten the default icon?
-	if (missingIcons.length !== 0 && defaultIcon && defaultIconChanged && defaultIconHasAlpha) {
+	let osName = this.xcodeTargetOS;
+	if (this.target === 'macos' || this.target === 'dist-macappstore') {
+		osName = 'maccatalyst';
+	}
+	if (missingIcons.length !== 0 && defaultIcon && defaultIconChanged && defaultIconHasAlpha && osName !== 'maccatalyst') {
 		this.defaultIcons = [ flattenedDefaultIconDest ];
 		flattenIcons.push({
 			name: path.basename(defaultIcon),


### PR DESCRIPTION
When running the Catalyst build, the DefaultIcon-ios.png is used to generate the Mac Catalyst app icon. This message is displayed:
`The default icon "DefaultIcon-ios.png" contains an alpha channel and will be flattened against a white background`
This is in the iOS build in iphone/cli/commands/_build.js:5925
I can get around it by doing:
```
// Do we need to flatten the default icon?
	let osName = this.xcodeTargetOS;
	if (this.target === 'macos' || this.target === 'dist-macappstore') {
		osName = 'maccatalyst';
	}
	if (missingIcons.length !== 0 && defaultIcon && defaultIconChanged && defaultIconHasAlpha && osName !== 'maccatalyst') {
```
This means that the flattening won't happen for catalyst builds.
What would be better is to have a DefaultIcon-catalyst.png or something like that because I now would have to copy an alpha png to DefaultIcon-ios.png for Catalyst builds to differentiate between these and iOS builds.
@hansemannn @m1ga 