### PR TITLE
fix(android): adjust picker min/maxDate

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/PickerProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/PickerProxy.java
@@ -645,8 +645,14 @@ public class PickerProxy extends TiViewProxy implements PickerColumnProxy.OnChan
 		if (inDate == null) {
 			return null;
 		}
+
+		Calendar calIn = Calendar.getInstance();
+		calIn.setTime(inDate);
+
 		Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
-		cal.setTime(inDate);
+		cal.set(Calendar.MONTH, calIn.get(Calendar.MONTH));
+		cal.set(Calendar.DAY_OF_MONTH, calIn.get(Calendar.DAY_OF_MONTH));
+		cal.set(Calendar.YEAR, calIn.get(Calendar.YEAR));
 		cal.set(Calendar.HOUR_OF_DAY, 0);
 		cal.set(Calendar.MINUTE, 0);
 		cal.set(Calendar.SECOND, 0);


### PR DESCRIPTION
Currently the picker (date) shows a different max value when you run this on Android and iOS.
Android will go up to the 19th and iOS to the 20th.

```js
var win = Ti.UI.createWindow();

var picker = Ti.UI.createPicker({
	type: Ti.UI.PICKER_TYPE_DATE,
	maxDate: new Date(2023, 7, 20),
});

win.add(picker);
win.open();
```

The issue is that before it uses `cal.setTime(inDate);` and moved the date:
```
inDate: Thu Aug 03 00:00:00 GMT+02:00 2023
out date: Wed Aug 02 02:00:00 GMT+02:00 2023
```

This fix will keep the correct day, month and year from the `inDate` value.

It should be save since the old workaround was to e.g. use `new Date(2023, 7, 20, 12, 0),`. But since the internal method removes hours anyways it shouldn't matter.

Still would need to have some users tests here so we know that it doesn't break existing apps that use a min/maxDate