### PR TITLE
fix(ios): building for MacOS (Catalyst) now works with that fix

### DIFF
--- a/iphone/Classes/TiUIScrollableViewProxy.m
+++ b/iphone/Classes/TiUIScrollableViewProxy.m
@@ -6,8 +6,12 @@
  */
 #ifdef USE_TI_UISCROLLABLEVIEW
 
-#import "TiUIScrollableViewProxy.h"
+#if TARGET_OS_MACCATALYST
+#import <AppKit/AppKit.h>
+#endif
+
 #import "TiUIScrollableView.h"
+#import "TiUIScrollableViewProxy.h"
 
 @implementation TiUIScrollableViewProxy
 @synthesize viewProxies;
@@ -88,10 +92,7 @@
 #else
     TiThreadPerformOnMainThread(
         ^{
-            [self makeViewPerformSelector:@selector(removeSubview:)
-                               withObject:[oldViewProxy view]
-                           createIfNeeded:NO
-                            waitUntilDone:NO];
+          [[oldViewProxy view] performSelector:@selector(removeFromSuperview)];
         },
         YES);
 #endif

--- a/iphone/Classes/TiUIScrollableViewProxy.m
+++ b/iphone/Classes/TiUIScrollableViewProxy.m
@@ -88,7 +88,10 @@
 #else
     TiThreadPerformOnMainThread(
         ^{
-          [[oldViewProxy view] removeFromSuperview];
+            [self makeViewPerformSelector:@selector(removeSubview:)
+                               withObject:[oldViewProxy view]
+                           createIfNeeded:NO
+                            waitUntilDone:NO];
         },
         YES);
 #endif

--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -1909,7 +1909,7 @@ iOSBuilder.prototype.validate = function validate(logger, config, cli) {
 			// make sure they have Apple's WWDR cert installed
 			if (!this.iosInfo.certs.wwdr) {
 				logger.error(__('WWDR Intermediate Certificate not found') + '\n');
-				logger.log(__('Download and install the certificate from %s', 'https://www.apple.com/certificateauthority/AppleWWDRCAG2.cer'.cyan) + '\n');
+				logger.log(__('Download and install the certificate from %s', 'https://www.apple.com/certificateauthority/AppleWWDRCAG3.cer'.cyan) + '\n');
 				process.exit(1);
 			}
 
@@ -5937,10 +5937,10 @@ iOSBuilder.prototype.createAppIconSetAndiTunesArtwork = async function createApp
 
 	// Do we need to flatten the default icon?
 	let osName = this.xcodeTargetOS;
- 	if (this.target === 'macos' || this.target === 'dist-macappstore') {
- 		osName = 'maccatalyst';
- 	}
- 	if (missingIcons.length !== 0 && defaultIcon && defaultIconChanged && defaultIconHasAlpha && osName !== 'maccatalyst') {
+	if (this.target === 'macos' || this.target === 'dist-macappstore') {
+		osName = 'maccatalyst';
+	}
+	if (missingIcons.length !== 0 && defaultIcon && defaultIconChanged && defaultIconHasAlpha && osName !== 'maccatalyst') {
 		this.defaultIcons = [ flattenedDefaultIconDest ];
 		flattenIcons.push({
 			name: path.basename(defaultIcon),

--- a/iphone/iphone/Titanium.entitlements
+++ b/iphone/iphone/Titanium.entitlements
@@ -4,9 +4,9 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
-	<key>com.apple.security.cs.disable-library-validation</key>
-	<true/>
 	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+	<key>com.apple.security.cs.disable-library-validation</key>
 	<true/>
 	<key>com.apple.security.device.audio-input</key>
 	<true/>

--- a/iphone/iphone/Titanium.xcodeproj/project.pbxproj
+++ b/iphone/iphone/Titanium.xcodeproj/project.pbxproj
@@ -2382,7 +2382,6 @@
 				CODE_SIGN_ENTITLEMENTS = Titanium.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
-				DERIVE_MACCATALYST_PRODUCT_BUNDLE_IDENTIFIER = YES;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;
 				"ENABLE_HARDENED_RUNTIME[sdk=macosx*]" = YES;
@@ -2420,7 +2419,9 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.appcelerator.titanium;
 				PRODUCT_NAME = Titanium;
 				STRIP_STYLE = debugging;
-				SUPPORTS_MACCATALYST = NO;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = YES;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_OBJC_BRIDGING_HEADER = "Titanium-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -2443,7 +2444,6 @@
 				CODE_SIGN_ENTITLEMENTS = Titanium.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = YES;
-				DERIVE_MACCATALYST_PRODUCT_BUNDLE_IDENTIFIER = YES;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;
 				"ENABLE_HARDENED_RUNTIME[sdk=macosx*]" = YES;
@@ -2479,7 +2479,9 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.appcelerator.titanium;
 				PRODUCT_NAME = Titanium;
 				STRIP_STYLE = debugging;
-				SUPPORTS_MACCATALYST = NO;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = YES;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_OBJC_BRIDGING_HEADER = "Titanium-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";


### PR DESCRIPTION
Building was not working because of not longer supported removeFromSuperView in MacOSCatalyst Updated Titanium.xcodeproj to correct destination settings for using same bundleId for iOS and MacOS

