### PR TITLE
chore(android): update ti.webdialog

### DIFF
--- a/support/module/packaged/modules.json
+++ b/support/module/packaged/modules.json
@@ -39,7 +39,7 @@
 			"integrity": "sha512-6pXkhmi4zBI4cunRfDcLQrugRhlH4z9GntscLvpoBiK6QQ1i+Te3gQ9HaT1YzF5KyRrOLlleiTGtD4WTlTWvGA=="
 		},
 		"ti.webdialog": {
-			"url": "https://github.com/tidev/titanium-web-dialog/releases/download/v2.2.0-android/ti.webdialog-android-2.2.0.zip",
+			"url": "https://github.com/tidev/titanium-web-dialog/releases/download/v2.3.0-android/ti.webdialog-android-2.3.0.zip",
 			"integrity": "sha512-YG2OJ/DerRA5m/8xma8jg9aqsjTYjKBlJ+U1EYfPRU/EdLnFpIj/tyloPzMjKhdGK12sdE+rhAqYzbK0VNeB4w=="
 		},
 		"ti.playservices": {

--- a/support/module/packaged/modules.json
+++ b/support/module/packaged/modules.json
@@ -40,7 +40,7 @@
 		},
 		"ti.webdialog": {
 			"url": "https://github.com/tidev/titanium-web-dialog/releases/download/v2.3.0-android/ti.webdialog-android-2.3.0.zip",
-			"integrity": "sha512-YG2OJ/DerRA5m/8xma8jg9aqsjTYjKBlJ+U1EYfPRU/EdLnFpIj/tyloPzMjKhdGK12sdE+rhAqYzbK0VNeB4w=="
+			"integrity": "sha512-OsLB3hr6sFqduoUbY2dotQ/Zk7u+eJW8ZKJLG+FzOf9WP/xlUe7S9kz2dMBnI50bnpULnXEYkbr2kb/rNu8lZw=="
 		},
 		"ti.playservices": {
 			"url": "https://github.com/tidev/ti.playservices/releases/download/v18.2.0/ti.playservices-android-18.2.0.zip",


### PR DESCRIPTION
update ti.webdialog (Android).

https://github.com/tidev/titanium-web-dialog/releases/tag/v2.3.0-android was released in May

> Fixes tiColor deprecation message and updating Android library