### PR TITLE
fix(android): fix Android camera with overlay issues

### DIFF
--- a/android/modules/media/src/java/ti/modules/titanium/media/MediaModule.java
+++ b/android/modules/media/src/java/ti/modules/titanium/media/MediaModule.java
@@ -93,7 +93,8 @@ public class MediaModule extends KrollModule implements Handler.Callback
 	public static final int NO_CAMERA = 2;
 	@Kroll.constant
 	public static final int NO_VIDEO = 3;
-
+	@Kroll.constant
+	public static final int NO_FOCUS = 4;
 	@Kroll.constant
 	public static final int IMAGE_SCALING_AUTO = -1;
 	@Kroll.constant

--- a/android/modules/media/src/java/ti/modules/titanium/media/TiCameraActivity.java
+++ b/android/modules/media/src/java/ti/modules/titanium/media/TiCameraActivity.java
@@ -20,6 +20,7 @@ import org.appcelerator.titanium.TiBlob;
 import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.io.TiContentFile;
 import org.appcelerator.titanium.proxy.TiViewProxy;
+import org.appcelerator.titanium.view.TiUIView;
 
 import android.Manifest;
 import android.app.Activity;
@@ -246,14 +247,23 @@ public class TiCameraActivity extends TiBaseActivity implements SurfaceHolder.Ca
 		cameraActivity = this;
 		previewLayout.addView(preview,
 							  new FrameLayout.LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT));
-		View overlayView = localOverlayProxy.getOrCreateView().getNativeView();
-		ViewGroup parent = (ViewGroup) overlayView.getParent();
-		// Detach from the parent if applicable
-		if (parent != null) {
-			parent.removeView(overlayView);
+		if (localOverlayProxy != null) {
+			TiUIView localView = localOverlayProxy.getOrCreateView();
+			if (localView != null) {
+				View overlayView = localView.getNativeView();
+				ViewGroup parent = (ViewGroup) overlayView.getParent();
+				// Detach from the parent if applicable
+				if (parent != null) {
+					parent.removeView(overlayView);
+				}
+				cameraLayout.addView(overlayView,
+					new FrameLayout.LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT));
+			} else {
+				Log.e(TAG, "Overlay view is null");
+			}
+		} else {
+			Log.e(TAG, "Overlay is null");
 		}
-		cameraLayout.addView(overlayView,
-							 new FrameLayout.LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT));
 	}
 
 	public static void setFlashMode(int cameraFlashMode)
@@ -729,6 +739,18 @@ public class TiCameraActivity extends TiBaseActivity implements SurfaceHolder.Ca
 									}
 								} else {
 									Log.w(TAG, "Unable to focus.");
+									if (errorCallback != null) {
+										KrollDict response = new KrollDict();
+										response.putCodeAndMessage(MediaModule.NO_FOCUS, "Couldn't focus");
+										errorCallback.callAsync(callbackContext, response);
+									}
+									try {
+										camera.cancelAutoFocus();
+										camera.autoFocus(null);
+									} catch (Exception e) {
+										Log.w(TAG, "Failed to cancel auto focus: " + e.toString());
+									}
+									takingPicture = false;
 								}
 							}
 						}

--- a/apidoc/Titanium/Media/Media.yml
+++ b/apidoc/Titanium/Media/Media.yml
@@ -1228,6 +1228,11 @@ properties:
     type: Number
     permission: read-only
 
+  - name: NO_FOCUS
+    summary: Constant for camera didn't focus when taking a trying to take a picture.
+    type: Number
+    permission: read-only
+
   - name: VIDEO_CONTROL_DEFAULT
     deprecated:
         since: "7.0.0"
@@ -2370,7 +2375,7 @@ properties:
   - name: code
     summary: Error code, if applicable.
     type: Number
-    constants: [Titanium.Media.DEVICE_BUSY, Titanium.Media.NO_CAMERA, Titanium.Media.UNKNOWN_ERROR]
+    constants: [Titanium.Media.DEVICE_BUSY, Titanium.Media.NO_CAMERA, Titanium.Media.UNKNOWN_ERROR, Titanium.Media.NO_FOCUS]
     accessors: false
 
   - name: success

--- a/apidoc/Titanium/Media/Media.yml
+++ b/apidoc/Titanium/Media/Media.yml
@@ -1232,6 +1232,8 @@ properties:
     summary: Constant for camera didn't focus when taking a trying to take a picture.
     type: Number
     permission: read-only
+    since:
+        android: "12.2.1"
 
   - name: VIDEO_CONTROL_DEFAULT
     deprecated:


### PR DESCRIPTION
Fixing two bugs:

**1. Unable to focus**

When `[WARN]  TiCameraActivity: (main) [10472,43572] Unable to focus.` is called the app is not informed that there was an issue while taking the photo and the app could get stuck.

To test it you can run the code below and make your camera not focus while pressing the button. You'll see the warning in the code and then `wait` is never set to false again (no success or error is called).

This PR will add a new error code `NO_FOCUS` and trigger the error callback.

---

**2. Crashlytics crash**

> Unable to resume activity {ti.modules.titanium.media.TiCameraActivity}: java.lang.NullPointerException: Attempt to invoke virtual method 'org.appcelerator.titanium.view.TiUIView org.appcelerator.titanium.proxy.TiViewProxy.getOrCreateView()' on a null object reference() at ti.modules.titanium.media.TiCameraActivity.onResume(TiCameraActivity.java:249)

Couldn't replicate it but adding `if (localOverlayProxy != null)` and `if (localView != null)` with an error log in the console to eliminate that error. It might not show an overlay but at least it won't crash.

----

**Example**
```js
function generateUI() {
	limit = 10;
	wait = false;
	num = 0;

	function closeCamera() {
		overlay.removeAllChildren();
		overlay = null;

		Ti.Media.hideCamera();
	}

	var scanner = Ti.UI.createView({ width: 200, height: 150,borderColor: "green", borderWidth: 5,	borderRadius: 15});
	var button = Ti.UI.createView({bottom: 40,width: 40,height: 40, backgroundColor: "green"});
	var done = Ti.UI.createLabel({color: "#fff",top: 15,right: 15, font: {fontSize: 20},text: "done"});

	var overlay = Ti.UI.createView();
	overlay.add(scanner);
	overlay.add(button);
	overlay.add(done);

	done.addEventListener('click', function() {
		closeCamera();
	});

	button.addEventListener('click', function() {
		if (wait == false) {
			wait = true;
			scanner.borderColor = "black";

			Ti.Media.takePicture();
		}
	});

	var error = function(error) {
		if (error.code == Ti.Media.NO_FOCUS) {
			wait = false;
			success();
			return;
		}
	};

	var cancel = function() {
		overlay.removeAllChildren();
		overlay = null;
	};

	var success = function(e) {
		console.log("callback")
		num++;
		if (num >= limit) {
			console.log("close camera")
			closeCamera();
		}
		
		scanner.borderColor = "green";
		wait = false;
	};

	Ti.Media.showCamera({
		saveToPhotoGallery: false,
		success: success,
		cancel: cancel,
		error: error,
		overlay: overlay,
		showControls: false,
		mediaTypes: [Ti.Media.MEDIA_TYPE_PHOTO],
		autohide: false
	});
}

var win = Ti.UI.createWindow({});
win.addEventListener("click", function() {
	console.log("click")
	generateUI();
})
win.open();
```