### PR TITLE
fix(ios): fix crash when setting navTintColor during a view transition

### DIFF
--- a/iphone/TitaniumKit/TitaniumKit/Sources/Modules/TiUIWindowProxy.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/Modules/TiUIWindowProxy.m
@@ -318,7 +318,7 @@
 
 - (void)setNavTintColor:(id)color
 {
-  __block TiColor *newColor = [TiUtils colorValue:color];
+  __block TiColor *newColor = [[TiUtils colorValue:color] retain];
 
   [self replaceValue:newColor forKey:@"navTintColor" notification:NO];
   TiThreadPerformOnMainThread(
@@ -331,6 +331,7 @@
           UINavigationBar *navBar = [[controller navigationController] navigationBar];
           [navBar setTintColor:[newColor color]];
           [self performSelector:@selector(refreshBackButton) withObject:nil afterDelay:0.0];
+          [newColor release];
         }
       },
       NO);


### PR DESCRIPTION
Fixes #13910

After some debugging, it seems like the native `TiColor` instance that wraps the proposed `UIColor` can be deallocated, so we explicitly retain it until the color is set async on the UI thread.  

Test case:
```js
const win1 = Ti.UI.createWindow({});
win1.add(Ti.UI.createLabel({ text: 'Click', touchEnabled: false }));

const win2 = Ti.UI.createWindow({});

const tab1 = Ti.UI.createTab({ window: win1, title: 'win1' });
const tab2 = Ti.UI.createTab({ window: win2, title: 'win2' });
const tabGroup = Ti.UI.createTabGroup({ tabs: [ tab1, tab2 ] });

tabGroup.open();

win1.addEventListener('click', function () {
	const win3 = Ti.UI.createWindow({ navTintColor: 'red' });
	tabGroup.activeTab.openWindow(win3);

	setTimeout(function () {
		win3.applyProperties({
			navTintColor: 'yellow'
		});
	}, 0);         // <----- 0 = crash, 1000 = no crash
});
```