### PR TITLE
chore: removing old Appc strings

### DIFF
--- a/android/modules/network/src/java/ti/modules/titanium/network/TiHTTPClient.java
+++ b/android/modules/network/src/java/ti/modules/titanium/network/TiHTTPClient.java
@@ -89,7 +89,7 @@ public class TiHTTPClient
 	private static final int PROTOCOL_DEFAULT_PORT = -1;
 	private static final String TITANIUM_ID_HEADER = "X-Titanium-Id";
 	private static final String TITANIUM_USER_AGENT =
-		"Appcelerator Titanium/" + TiApplication.getInstance().getTiBuildVersion() + " (" + Build.MODEL
+		"Titanium SDK/" + TiApplication.getInstance().getTiBuildVersion() + " (" + Build.MODEL
 		+ "; Android API Level: " + Integer.toString(Build.VERSION.SDK_INT) + "; "
 		+ TiPlatformHelper.getInstance().getLocale() + ";)";
 	private static final String[] FALLBACK_CHARSETS = { "UTF_8", "ISO_8859_1" };

--- a/apidoc/Titanium/UI/AttributedString.yml
+++ b/apidoc/Titanium/UI/AttributedString.yml
@@ -52,7 +52,7 @@ examples:
 
         win.open();
 
-        var text =  'Bacon ipsum dolor Appcelerator Titanium rocks! sit amet fatback leberkas salami sausage tongue strip steak.';
+        var text =  'Bacon ipsum dolor Titanium SDK rocks! sit amet fatback leberkas salami sausage tongue strip steak.';
 
         var attr = Titanium.UI.createAttributedString({
             text: text,
@@ -112,7 +112,7 @@ examples:
 
         win.open();
 
-        var text =  'Bacon ipsum dolor Appcelerator Titanium rocks! sit amet fatback leberkas salami sausage tongue strip steak.';
+        var text =  'Bacon ipsum dolor Titanium SDK rocks! sit amet fatback leberkas salami sausage tongue strip steak.';
 
         var attr = Titanium.UI.createAttributedString({
             text: text

--- a/apidoc/Titanium/UI/EmailDialog.yml
+++ b/apidoc/Titanium/UI/EmailDialog.yml
@@ -165,7 +165,7 @@ examples:
         var emailDialog = Ti.UI.createEmailDialog()
         emailDialog.subject = "Hello from Titanium";
         emailDialog.toRecipients = ['foo@yahoo.com'];
-        emailDialog.messageBody = '<b>Appcelerator Titanium Rocks!</b>';
+        emailDialog.messageBody = '<b>Titanium SDK Rocks!</b>';
         var f = Ti.Filesystem.getFile('cricket.wav');
         emailDialog.addAttachment(f);
         emailDialog.open();

--- a/build/scons-xcode-project-build.js
+++ b/build/scons-xcode-project-build.js
@@ -74,7 +74,7 @@ async function generateI18n () {
 	const project = path.join(projectDir, '..');
 
 	const i18nData = i18n.load(project);
-	const fileHeader = '/**\n * Appcelerator Titanium\n * this is a generated file - DO NOT EDIT\n */\n\n';
+	const fileHeader = '/**\n * Titanium SDK\n * this is a generated file - DO NOT EDIT\n */\n\n';
 	for (const [ language, data ] of Object.entries(i18nData)) {
 		const dir = path.join(appDir, `${language}.lproj`);
 		await fs.ensureDir(dir);

--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -6568,7 +6568,7 @@ iOSBuilder.prototype.writeI18NFiles = function writeI18NFiles() {
 
 	const data = ti.i18n.load(this.projectDir, this.logger),
 		header = '/**\n'
-			+ ' * Appcelerator Titanium\n'
+			+ ' * Titanium SDK\n'
 			+ ' * this is a generated file - DO NOT EDIT\n'
 			+ ' */\n\n';
 

--- a/tests/Resources/es6.async.await.test.js
+++ b/tests/Resources/es6.async.await.test.js
@@ -1,5 +1,5 @@
 /*
- * Axway Appcelerator Titanium Mobile
+ * Titanium SDK
  * Copyright TiDev, Inc. 04/07/2022-Present. All Rights Reserved.
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.

--- a/tests/Resources/ti.android.actionbar.test.js
+++ b/tests/Resources/ti.android.actionbar.test.js
@@ -1,5 +1,5 @@
 /*
- * Axway Appcelerator Titanium Mobile
+ * Titanium SDK
  * Copyright TiDev, Inc. 04/07/2022-Present. All Rights Reserved.
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.

--- a/tests/Resources/ti.android.notificationmanager.test.js
+++ b/tests/Resources/ti.android.notificationmanager.test.js
@@ -1,5 +1,5 @@
 /*
- * Axway Appcelerator Titanium Mobile
+ * Titanium SDK
  * Copyright TiDev, Inc. 04/07/2022-Present. All Rights Reserved.
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.

--- a/tests/Resources/ti.android.service.interval.js
+++ b/tests/Resources/ti.android.service.interval.js
@@ -1,5 +1,5 @@
 /*
- * Axway Appcelerator Titanium Mobile
+ * Titanium SDK
  * Copyright TiDev, Inc. 04/07/2022-Present. All Rights Reserved.
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.

--- a/tests/Resources/ti.android.service.normal.js
+++ b/tests/Resources/ti.android.service.normal.js
@@ -1,5 +1,5 @@
 /*
- * Axway Appcelerator Titanium Mobile
+ * Titanium SDK
  * Copyright TiDev, Inc. 04/07/2022-Present. All Rights Reserved.
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.

--- a/tests/Resources/ti.android.service.test.js
+++ b/tests/Resources/ti.android.service.test.js
@@ -1,5 +1,5 @@
 /*
- * Axway Appcelerator Titanium Mobile
+ * Titanium SDK
  * Copyright TiDev, Inc. 04/07/2022-Present. All Rights Reserved.
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.

--- a/tests/Resources/ti.bootstrap.test.js
+++ b/tests/Resources/ti.bootstrap.test.js
@@ -1,5 +1,5 @@
 /*
- * Axway Appcelerator Titanium Mobile
+ * Titanium SDK
  * Copyright TiDev, Inc. 04/07/2022-Present. All Rights Reserved.
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.

--- a/tests/Resources/ti.ui.webview.script.tag.js
+++ b/tests/Resources/ti.ui.webview.script.tag.js
@@ -1,5 +1,5 @@
 /*
- * Axway Appcelerator Titanium Mobile
+ * Titanium SDK
  * Copyright TiDev, Inc. 04/07/2022-Present. All Rights Reserved.
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.


### PR DESCRIPTION
Found some Appcelerator strings:
* test file headers
* user agent Android
* in some example strings
* in the "do net edit" files

I'm not sure about the iOS user agent: https://github.com/search?q=repo%3Atidev%2Ftitanium-sdk%20kTitaniumUserAgentPrefix&type=code