### PR TITLE
fix: (iOS) Fix app freezing when trying to hide & show popover repeatedly and popover layout issues

### DIFF
--- a/iphone/Classes/TiUIiPadPopoverProxy.h
+++ b/iphone/Classes/TiUIiPadPopoverProxy.h
@@ -30,8 +30,6 @@
   BOOL deviceRotated;
 }
 
-- (void)updatePopover:(NSNotification *)notification;
-
 @end
 
 #endif

--- a/iphone/Classes/TiUIiPadPopoverProxy.m
+++ b/iphone/Classes/TiUIiPadPopoverProxy.m
@@ -242,7 +242,6 @@ static NSArray *popoverSequence;
 
   popoverInitialized = NO;
   [self fireEvent:@"hide" withObject:nil]; //Checking for listeners are done by fireEvent anyways.
-  [[NSNotificationCenter defaultCenter] removeObserver:self name:UIApplicationWillChangeStatusBarOrientationNotification object:nil];
   [contentViewProxy windowDidClose];
 
   if ([contentViewProxy isKindOfClass:[TiWindowProxy class]]) {
@@ -289,15 +288,6 @@ static NSArray *popoverSequence;
     [self updatePopoverNow];
     [contentViewProxy windowDidOpen];
   }
-}
-
-- (void)updatePopover:(NSNotification *)notification;
-{
-  //This may be due to a possible race condition of rotating the iPad while another popover is coming up.
-  if ((currentPopover != self)) {
-    return;
-  }
-  [self performSelector:@selector(updatePopoverNow) withObject:nil afterDelay:[[UIApplication sharedApplication] statusBarOrientationAnimationDuration] inModes:[NSArray arrayWithObject:NSRunLoopCommonModes]];
 }
 
 - (CGSize)contentSize

--- a/iphone/Classes/TiUIiPadPopoverProxy.m
+++ b/iphone/Classes/TiUIiPadPopoverProxy.m
@@ -393,7 +393,7 @@ static NSArray *popoverSequence;
   popoverPresentationController.sourceRect = (CGRectEqualToRect(CGRectZero, popoverRect) ? CGRectMake(presentingController.view.bounds.size.width / 2, presentingController.view.bounds.size.height / 2, 1, 1) : popoverRect);
 }
 
-- (BOOL)popoverPresentationControllerShouldDismissPopover:(UIPopoverPresentationController *)popoverPresentationController
+- (BOOL)presentationControllerShouldDismiss:(UIPopoverPresentationController *)popoverPresentationController
 {
   if ([[self viewController] presentedViewController] != nil) {
     return NO;
@@ -402,12 +402,12 @@ static NSArray *popoverSequence;
   return YES;
 }
 
-- (void)popoverPresentationControllerDidDismissPopover:(UIPopoverPresentationController *)popoverPresentationController
+- (void)presentationControllerDidDismiss:(UIPresentationController *)presentationController
 {
   [self cleanup];
 }
 
-- (void)popoverPresentationController:(UIPopoverPresentationController *)popoverPresentationController willRepositionPopoverToRect:(inout CGRect *)rect inView:(inout UIView **)view
+- (void)popoverPresentationController:(UIPopoverPresentationController *)popoverPresentationController willRepositionPopoverToRect:(inout CGRect *)rect inView:(inout UIView *_Nonnull *)view
 {
   //This will never be called when using bar button item
   BOOL canUseDialogRect = !CGRectEqualToRect(CGRectZero, popoverRect);

--- a/iphone/Classes/TiUIiPadPopoverProxy.m
+++ b/iphone/Classes/TiUIiPadPopoverProxy.m
@@ -199,12 +199,12 @@ static NSArray *popoverSequence;
           theController.popoverPresentationController.backgroundColor = [[TiColor colorNamed:[self valueForKey:@"backgroundColor"]] _color];
         }
 
-        [[[TiApp app] controller] presentViewController:theController
-                                               animated:animated
-                                             completion:^{
-                                               popoverInitialized = YES;
-                                               [contentViewProxy windowDidOpen];
-                                             }];
+        [TiApp.app.controller.topPresentedController presentViewController:theController
+                                                                  animated:animated
+                                                                completion:^{
+                                                                  popoverInitialized = YES;
+                                                                  [contentViewProxy windowDidOpen];
+                                                                }];
       },
       YES);
 }


### PR DESCRIPTION
Fixes [13915](https://github.com/tidev/titanium-sdk/issues/13915)

**Sample**

```var popover;

const win = Ti.UI.createWindow();

const hidePopover = Ti.UI.createButton({
	title: 'Hide Popover',
	backgroundColor: 'orange',
	width: 160,
	height: 40
});
hidePopover.addEventListener("click", (e) => {
	popover.hide();
});

const showPopover = Ti.UI.createButton({
	title: "Show Popover",
	backgroundColor: 'red',
	width: 120,
	height: 40
});

showPopover.addEventListener("click", (e) => {
	const popoverWin = Ti.UI.createWindow({
		backgroundColor: 'red',
		title: 'Popover Window',
		rightNavButton: hidePopover
	});

	const listView = Ti.UI.createListView({
		backgroundColor: 'blue',
	});
	const sections = [];

	const fruitDataSet = [
		{ properties: { title: 'Apple' } },
		{ properties: { title: 'Banana' } },
	];
	const fruitSection = Ti.UI.createListSection({ headerTitle: 'Fruits', items: fruitDataSet });
	sections.push(fruitSection);

	const vegDataSet = [
		{ properties: { title: 'Carrots' } },
		{ properties: { title: 'Potatoes' } },
	];
	const vegSection = Ti.UI.createListSection({ headerTitle: 'Vegetables', items: vegDataSet });
	sections.push(vegSection);

	listView.sections = sections;

	popoverWin.add(listView);

	const fishDataSet = [
		{ properties: { title: 'Cod' } },
		{ properties: { title: 'Haddock' } },
	];
	const fishSection = Ti.UI.createListSection({ headerTitle: 'Fish', items: fishDataSet });
	listView.appendSection(fishSection);

	const popoverNav = Ti.UI.createNavigationWindow({
		window: popoverWin
	});

	popover = Ti.UI.iPad.createPopover({
		contentView: popoverNav
	});

	popover.show({ view: showPopover });
});

win.add(showPopover);

win.open();