### PR TITLE
fix(android): fix TextArea hinttextid

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TextAreaProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TextAreaProxy.java
@@ -32,6 +32,7 @@ import android.app.Activity;
 		TiC.PROPERTY_ENABLE_RETURN_KEY,
 		TiC.PROPERTY_FONT,
 		TiC.PROPERTY_FULLSCREEN,
+		TiC.PROPERTY_HINT_TEXT_ID,
 		TiC.PROPERTY_HINT_TEXT,
 		TiC.PROPERTY_HINT_TEXT_COLOR,
 		TiC.PROPERTY_HINT_TYPE,
@@ -59,6 +60,14 @@ public class TextAreaProxy extends TiViewProxy
 		defaultValues.put(TiC.PROPERTY_EDITABLE, true);
 		defaultValues.put(TiC.PROPERTY_ENABLE_COPY, true);
 		defaultValues.put(TiC.PROPERTY_HINT_TYPE, UIModule.HINT_TYPE_STATIC);
+	}
+
+	@Override
+	protected KrollDict getLangConversionTable()
+	{
+		KrollDict table = new KrollDict();
+		table.put(TiC.PROPERTY_HINT_TEXT, TiC.PROPERTY_HINT_TEXT_ID);
+		return table;
 	}
 
 	@Override

--- a/apidoc/Titanium/UI/TextArea.yml
+++ b/apidoc/Titanium/UI/TextArea.yml
@@ -300,6 +300,14 @@ properties:
     default: No hint text.
     platforms: [android]
 
+  - name: hinttextid
+    summary: |
+        Key identifying a string from the locale file to use for the
+        [hintText](Titanium.UI.TextArea.hintText) property.
+    description: Only one of `hintText` or `hinttextid` should be specified.
+    type: String
+    since: "6.2.0"
+
   - name: hintTextColor
     summary: Color of hint text that displays when field is empty.
     platforms: [android]


### PR DESCRIPTION
In a `TextArea` you can use `hinttextid`. It is missing in the documentation and it currently doesn't work when setting it on creation. It works fine when you assign in as a property.

**Test**
```js
const window = Ti.UI.createWindow();
const tf = Ti.UI.createTextArea({hinttextid:"myLangId",width: 200,height:200});
window.add(tf);
window.open();
```
(you have to add a language string with `myLangId` to your project)