### PR TITLE
feat(ios): add cli.ignoreLog to ios

### DIFF
--- a/android/cli/hooks/run.js
+++ b/android/cli/hooks/run.js
@@ -268,10 +268,8 @@ exports.init = function (logger, config, cli) {
 						}
 
 						// ignore some Android logs in info log level
-						for (let i = 0, len = ignoreLog.length; i < len; ++i) {
-							if (line.includes(ignoreLog[i])) {
-								return;
-							}
+						if (ignoreLog.some(ignoreItem => line.includes(ignoreItem))) {
+							return;
 						}
 
 						switch (logLevel) {

--- a/iphone/cli/hooks/run.js
+++ b/iphone/cli/hooks/run.js
@@ -75,10 +75,8 @@ exports.init = function (logger, config, cli) {
 				}
 
 				// ignore logs from cli ignoreLog
-				for (let i = 0, len = ignoreLog.length; i < len; ++i) {
-					if (line.includes(ignoreLog[i])) {
-						return;
-					}
+				if (ignoreLog.some(ignoreItem => line.includes(ignoreItem))) {
+					return;
 				}
 
 				if (levels.indexOf(lastLogger) === -1) {

--- a/iphone/cli/hooks/run.js
+++ b/iphone/cli/hooks/run.js
@@ -20,6 +20,7 @@ exports.init = function (logger, config, cli) {
 			const i18n = require('node-appc').i18n(__dirname);
 			const __ = i18n.__;
 			const __n = i18n.__n;
+			const ignoreLog = config.cli.ignoreLog || [];
 
 			if (cli.argv['build-only']) {
 				logger.info(__('Performed build only, skipping running of the application'));
@@ -72,6 +73,14 @@ exports.init = function (logger, config, cli) {
 					lastLogger = m[2].toLowerCase();
 					line = m[4].trim();
 				}
+
+				// ignore logs from cli ignoreLog
+				for (let i = 0, len = ignoreLog.length; i < len; ++i) {
+					if (line.includes(ignoreLog[i])) {
+						return;
+					}
+				}
+
 				if (levels.indexOf(lastLogger) === -1) {
 					logger.log(('[' + lastLogger.toUpperCase() + '] ').cyan + line);
 				} else {


### PR DESCRIPTION
same as https://github.com/tidev/titanium-sdk/pull/13560 but for iOS.

New key: `cli.ignoreLog = []`
if one of the lines is in the log line it will be ignored.

Example:

```js
"cli": {
  "ignoreLog": [
    "Too many Flogger logs received before configuration",
    "Counters: exceeded sample count in FrameTime",
    "OpenGLRenderer: Davey!"
  ]
}
```