### PR TITLE
fix(android): xml parser null check

### DIFF
--- a/android/modules/xml/src/java/ti/modules/titanium/xml/NamedNodeMapProxy.java
+++ b/android/modules/xml/src/java/ti/modules/titanium/xml/NamedNodeMapProxy.java
@@ -25,6 +25,9 @@ public class NamedNodeMapProxy extends KrollProxy
 	@Kroll.getProperty
 	public int getLength()
 	{
+		if (map == null) {
+			return 0;
+		}
 		return map.getLength();
 	}
 


### PR DESCRIPTION
**Error:**
```
[ERROR] TiExceptionHandler: (main) [110,110] <embedded>:3480
[ERROR] TiExceptionHandler:   throw err;
[ERROR] TiExceptionHandler:   ^
[ERROR] TiExceptionHandler: Error: Attempt to invoke interface method 'int org.w3c.dom.NamedNodeMap.getLength()' on a null object reference
[ERROR] TiExceptionHandler:     at Function.getOwnPropertyDescriptor (<anonymous>)
[ERROR] TiExceptionHandler:     at formatProperty (<embedded>:3314:23)
[ERROR] TiExceptionHandler:     at formatRaw (<embedded>:3099:19)
[ERROR] TiExceptionHandler:     at formatValue (<embedded>:2905:10)
[ERROR] TiExceptionHandler:     at formatProperty (<embedded>:3321:11)
[ERROR] TiExceptionHandler:     at formatRaw (<embedded>:3099:19)
[ERROR] TiExceptionHandler:     at formatValue (<embedded>:2905:10)
[ERROR] TiExceptionHandler:     at inspect (<embedded>:2589:10)
[ERROR] TiExceptionHandler:     at formatWithOptions (<embedded>:3948:40)
[ERROR] TiExceptionHandler:     at Console.info (<embedded>:4068:34)
[ERROR] TiExceptionHandler:
[ERROR] TiExceptionHandler:     ti.modules.titanium.xml.NamedNodeMapProxy.getLength(NamedNodeMapProxy.java:28)
[ERROR] TiExceptionHandler:     org.appcelerator.kroll.runtime.v8.V8Runtime.nativeRunModule(Native Method)
[ERROR] TiExceptionHandler:     org.appcelerator.kroll.runtime.v8.V8Runtime.doRunModule(V8Runtime.java:172)
[ERROR] TiExceptionHandler:     org.appcelerator.titanium.TiApplication.launch(TiApplication.java:875)
[ERROR] TiExceptionHandler:     org.appcelerator.titanium.TiLaunchActivity.loadScript(TiLaunchActivity.java:96)
[ERROR] TiExceptionHandler:     org.appcelerator.titanium.TiRootActivity.loadScript(TiRootActivity.java:506)
[ERROR] TiExceptionHandler:     org.appcelerator.titanium.TiLaunchActivity.onResume(TiLaunchActivity.java:177)
[ERROR] TiExceptionHandler:     org.appcelerator.titanium.TiRootActivity.onResume(TiRootActivity.java:525)
[ERROR] TiExceptionHandler:     android.app.Instrumentation.callActivityOnResume(Instrumentation.java:1603)
[ERROR] TiExceptionHandler:     android.app.Activity.performResume(Activity.java:8743)
```

**Test:** 
```js
var xml = '<?xml version="1.0" encoding="utf-8"?><Service><Request><errorCode>0</errorCode><printerError>1</printerError><paperEnd>1</paperEnd><coverOpen>0</coverOpen><lastCmd>0</lastCmd><ECRStatus><mode>REG</mode><idleState>0</idleState></ECRStatus><lastZ>1336</lastZ><lastDocF>5</lastDocF><lastDocNF>0</lastDocNF><lastCreditNoteN>0</lastCreditNoteN><lastInvoiceN>0</lastInvoiceN><busy>0</busy></Request></Service>';
var doc = Ti.XML.parseString(xml);
console.log(doc)
```