### PR TITLE
fix(android): null check in ScrollView getAttributeSet

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIScrollView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIScrollView.java
@@ -353,6 +353,9 @@ public class TiUIScrollView extends TiUIView
 	private AttributeSet getAttributeSet(Context context, int resourceId)
 	{
 		AttributeSet attr = null;
+		if (context == null || context.getResources() == null) {
+			return null;
+		}
 		try {
 			XmlPullParser parser = context.getResources().getXml(resourceId);
 			try {


### PR DESCRIPTION
Searching for a random error:

> Error: Attempt to invoke virtual method 'android.content.res.Resources android.content.Context.getResources()' on a null object reference

that occurs when using ScrollView.scrollTo

`getResources` appears in one place in TiUIScrollView and I've added a null check for `context` around it. It's in a try/catch so it might not be the place that causes this. But it's worth a try