### PR TITLE
feat(ios): view rotation parity

### DIFF
--- a/apidoc/Titanium/UI/View.yml
+++ b/apidoc/Titanium/UI/View.yml
@@ -1810,8 +1810,8 @@ properties:
     summary: Clockwise 2D rotation of the view in degrees.
     description: Translation values are applied to the static post layout value.
     type: Number
-    platforms: [android]
-    since: 5.4.0
+    platforms: [android, iphone, ipad]
+    since: {android: "5.4.0", iphone: "12.3.0", ipad: "12.3.0"}
 
   - name: rotationX
     summary: Clockwise rotation of the view in degrees (x-axis).

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiViewProxy.h
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiViewProxy.h
@@ -242,6 +242,7 @@ enum {
 - (id)animatedCenter;
 
 - (void)setBackgroundGradient:(id)arg;
+- (void)setRotation:(id)arg;
 - (TiBlob *)toImage:(id)args;
 - (TiPoint *)contentOffset;
 

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiViewProxy.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiViewProxy.m
@@ -670,6 +670,12 @@ LAYOUTFLAGS_SETTER(setHorizontalWrap, horizontalWrap, horizontalWrap, [self will
   [self replaceValue:newGradient forKey:@"backgroundGradient" notification:YES];
 }
 
+- (void)setRotation:(id)arg
+{
+  float val = ([TiUtils intValue:arg] * M_PI) / 180.0;
+  [self view].transform = CGAffineTransformMakeRotation(val);
+}
+
 - (TiBlob *)toImage:(id)args
 {
   KrollCallback *callback = nil;


### PR DESCRIPTION
Current Android allows you to set the `view.rotation` without transform/matrix2D.

This PR will add the same to iOS

```js
const window = Ti.UI.createWindow({
  backgroundColor: "black",
});

const fadeBackground = Ti.UI.createView({
  backgroundColor: "red",
  width: 100,
  height: 100,
  rotation:45
});

setTimeout(function(){
  fadeBackground.rotation = 90
}, 2000)
window.add(fadeBackground);
window.open();
```

View will show up 45deg rotated and after two seconds it will rotate to 90deg.