### PR TITLE
fix(android): return more httpclient errors to Ti

### DIFF
--- a/android/modules/network/src/java/ti/modules/titanium/network/TiHTTPClient.java
+++ b/android/modules/network/src/java/ti/modules/titanium/network/TiHTTPClient.java
@@ -1371,7 +1371,11 @@ public class TiHTTPClient
 
 				} catch (IOException e) {
 					if (!aborted) {
-						throw e;
+						KrollDict data = new KrollDict();
+						data.putCodeAndMessage((getStatus() >= 400) ? getStatus() : TiC.ERROR_CODE_UNKNOWN,
+							e.getMessage());
+						dispatchCallback(TiC.PROPERTY_ONERROR, data);
+						return;
 					}
 				} finally {
 					if (client != null) {


### PR DESCRIPTION
Before when you hit a timeout error for your httpclient it will always throw an error in your logs and call `onerror`:

```
[ERROR] TiHTTPClient: (TiHttpClient-1) [136,232] HTTP Error (java.net.SocketTimeoutException): failed to connect to httpbin.org/35.153.249.234 (port 443) from /192.168.0.21 (port 37704) after 10ms
[ERROR] TiHTTPClient: java.net.SocketTimeoutException: failed to connect to httpbin.org/35.153.249.234 (port 443) from /192.168.0.21 (port 37704) after 10ms
[ERROR] TiHTTPClient:   at libcore.io.IoBridge.connectErrno(IoBridge.java:235)
[ERROR] TiHTTPClient:   at libcore.io.IoBridge.connect(IoBridge.java:179)
[ERROR] TiHTTPClient:   at java.net.PlainSocketImpl.socketConnect(PlainSocketImpl.java:142)
[ERROR] TiHTTPClient:   at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:390)
[ERROR] TiHTTPClient:   at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:230)
[ERROR] TiHTTPClient:   at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:212)
[ERROR] TiHTTPClient:   at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:436)
[ERROR] TiHTTPClient:   at java.net.Socket.connect(Socket.java:646)
[ERROR] TiHTTPClient:   at com.android.okhttp.internal.Platform.connectSocket(Platform.java:182)
[ERROR] TiHTTPClient:   at com.android.okhttp.internal.io.RealConnection.connectSocket(RealConnection.java:145)
[ERROR] TiHTTPClient:   at com.android.okhttp.internal.io.RealConnection.connect(RealConnection.java:116)
[ERROR] TiHTTPClient:   at com.android.okhttp.internal.http.StreamAllocation.findConnection(StreamAllocation.java:186)
[ERROR] TiHTTPClient:   at com.android.okhttp.internal.http.StreamAllocation.findHealthyConnection(StreamAllocation.java:128)
[ERROR] TiHTTPClient:   at com.android.okhttp.internal.http.StreamAllocation.newStream(StreamAllocation.java:97)
[ERROR] TiHTTPClient:   at com.android.okhttp.internal.http.HttpEngine.connect(HttpEngine.java:289)
[ERROR] TiHTTPClient:   at com.android.okhttp.internal.http.HttpEngine.sendRequest(HttpEngine.java:232)
[ERROR] TiHTTPClient:   at com.android.okhttp.internal.huc.HttpURLConnectionImpl.execute(HttpURLConnectionImpl.java:465)
[ERROR] TiHTTPClient:   at com.android.okhttp.internal.huc.HttpURLConnectionImpl.getResponse(HttpURLConnectionImpl.java:411)
[ERROR] TiHTTPClient:   at com.android.okhttp.internal.huc.HttpURLConnectionImpl.getResponseCode(HttpURLConnectionImpl.java:542)
[ERROR] TiHTTPClient:   at com.android.okhttp.internal.huc.DelegatingHttpsURLConnection.getResponseCode(DelegatingHttpsURLConnection.java:106)
[ERROR] TiHTTPClient:   at com.android.okhttp.internal.huc.HttpsURLConnectionImpl.getResponseCode(HttpsURLConnectionImpl.java:30)
[ERROR] TiHTTPClient:   at ti.modules.titanium.network.TiHTTPClient$ClientRunnable.run(TiHTTPClient.java:1348)
[ERROR] TiHTTPClient:   at java.lang.Thread.run(Thread.java:1012)

```

with this PR it won't throw the error and only go into your `onerror` callback.

```js
var client = Ti.Network.createHTTPClient({
	onload: function(e) {
		console.log(1)
	},
	onerror: function(e) {
		console.log(2)
		console.log(e.error)
	},
	timeout: 10
});
client.open("GET", "https://httpbin.org");
client.send();
```