### PR TITLE
build: bump compatibility versions of the iOS SDK and Node.js

### DIFF
--- a/iphone/package.json
+++ b/iphone/package.json
@@ -15,8 +15,8 @@
 	"minIosVersion": "13.0",
 	"minWatchosVersion": "6.0",
 	"vendorDependencies": {
-		"xcode": ">=12.0 <=14.x",
-		"ios sdk": ">=13.0 <=16.x"
+		"xcode": ">=12.0 <=15.x",
+		"ios sdk": ">=13.0 <=17.x"
 	},
 	"engines": {
 		"node": ">=12.13.0"

--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
     "url": "git://github.com/tidev/titanium_mobile.git"
   },
   "vendorDependencies": {
-    "node": "12.x || 14.x || 16.x"
+    "node": "12.x || 14.x || 16.x || 18.x"
   },
   "engines": {
     "node": ">=12.13.0"

--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
     "url": "git://github.com/tidev/titanium_mobile.git"
   },
   "vendorDependencies": {
-    "node": "12.x || 14.x || 16.x || 18.x"
+    "node": "12.x || 14.x || 16.x || 18.x || 20.x"
   },
   "engines": {
     "node": ">=12.13.0"


### PR DESCRIPTION
Note: I am not sure if this change will remove the Node.js warning or if the log originates from somewhere else:
```
[WARN]  Support for Node.js v18.16.0 has not been verified for Titanium SDK 12.2.1.GA
[WARN]  If you run into issues, try downgrading to Node.js v16
```