### PR TITLE
fix(android): touchEnabled for ListView

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/ListItemProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/ListItemProxy.java
@@ -128,8 +128,11 @@ public class ListItemProxy extends TiViewProxy
 			final Object sourceObject = payload.containsKeyAndNotNull(TiC.EVENT_PROPERTY_SOURCE)
 				? payload.get(TiC.EVENT_PROPERTY_SOURCE) : this;
 			final TiViewProxy source = sourceObject instanceof TiViewProxy ? (TiViewProxy) sourceObject : this;
+			final KrollDict properties = getProperties();
 
 			final Object parent = getParent();
+			boolean sectionTouchEnabled = true;
+
 			if (parent instanceof ListSectionProxy) {
 				final ListSectionProxy section = (ListSectionProxy) parent;
 
@@ -137,9 +140,10 @@ public class ListItemProxy extends TiViewProxy
 				payload.putIfAbsent(TiC.PROPERTY_SECTION, section);
 				payload.putIfAbsent(TiC.PROPERTY_SECTION_INDEX, listViewProxy.getIndexOfSection(section));
 				payload.putIfAbsent(TiC.PROPERTY_ITEM_INDEX, getIndexInSection());
+				sectionTouchEnabled = section.getProperties().optBoolean(TiC.PROPERTY_TOUCH_ENABLED, true);
 			}
 
-			final Object itemId = getProperties().get(TiC.PROPERTY_ITEM_ID);
+			final Object itemId = properties.get(TiC.PROPERTY_ITEM_ID);
 			if (itemId != null) {
 
 				// Include `itemId` if specified.
@@ -156,9 +160,12 @@ public class ListItemProxy extends TiViewProxy
 				}
 			}
 
-			final int accessoryType = getProperties().optInt(TiC.PROPERTY_ACCESSORY_TYPE,
+			final int accessoryType = properties.optInt(TiC.PROPERTY_ACCESSORY_TYPE,
 				UIModule.LIST_ACCESSORY_TYPE_NONE);
 			final boolean isAccessoryDetail = accessoryType == UIModule.LIST_ACCESSORY_TYPE_DETAIL;
+			final boolean touchEnabled = properties.optBoolean(TiC.PROPERTY_TOUCH_ENABLED, true);
+			final boolean listViewTouchEnabled = listViewProxy.getProperties()
+				.optBoolean(TiC.PROPERTY_TOUCH_ENABLED, true);
 
 			// If item is `LIST_ACCESSORY_TYPE_DETAIL` then `accessoryClicked` will be `true`.
 			payload.put(TiC.EVENT_PROPERTY_ACCESSORY_CLICKED, isAccessoryDetail);
@@ -167,7 +174,8 @@ public class ListItemProxy extends TiViewProxy
 			data = payload;
 
 			// Fire `itemclick` event on ListView.
-			if (fireItemClick && eventName.equals(TiC.EVENT_CLICK)) {
+			if (fireItemClick && eventName.equals(TiC.EVENT_CLICK) && touchEnabled
+				&& sectionTouchEnabled && listViewTouchEnabled) {
 				listViewProxy.fireSyncEvent(TiC.EVENT_ITEM_CLICK, data);
 			}
 		}


### PR DESCRIPTION
Currently a ListView on Android doesn't reflect the `touchEnabled` state. If you set it to false it will still fire the `itemclick` event.

This PR checks `touchEnabled` before it fires the itemclick event. You can set it for an item, section and the whole listview.

```js
var win = Ti.UI.createWindow();
var listView = Ti.UI.createListView();
var btn = Ti.UI.createButton({bottom:0, title:"disable all"});
var sections = [];

var fruitDataSet = [
    {properties: { title: 'Apple (no touch)', touchEnabled:false}},
    {properties: { title: 'Banana'}},
];
var fruitSection = Ti.UI.createListSection({ headerTitle: 'Fruits', items: fruitDataSet});
sections.push(fruitSection);

var vegDataSet = [
    {properties: { title: 'Carrots'}},
    {properties: { title: 'Potatoes (no touch)', touchEnabled:false}},
];
var vegSection = Ti.UI.createListSection({ headerTitle: 'Vegetables (no touch)', items: vegDataSet, touchEnabled: false});
sections.push(vegSection);

listView.sections = sections;
win.add([listView, btn]);
win.open();

var fishDataSet = [
    {properties: { title: 'Cod'}},
    {properties: { title: 'Haddock'}},
];
var fishSection = Ti.UI.createListSection({ headerTitle: 'Fish', items: fishDataSet});
listView.appendSection(fishSection);
listView.addEventListener("itemclick", function(){
  console.log("click")
})

var isEnabled = true;
btn.addEventListener("click", function(){
  if (isEnabled) {
    listView.touchEnabled = false;
    btn.title = "enable"
  } else {
    listView.touchEnabled = true;
    btn.title = "disable all"
  }
  isEnabled = !isEnabled;
})
```

Test:
* run the app above. 
* 12.2.1.GA will show "click" for all items, even after clicking the bottom button
* with this PR it won't show a click event for the items with `no touch`, for the whole `no touch` section and when you click the button it won't show it for all items