### PR TITLE
feat(android): optimize referenceTable

### DIFF
--- a/android/runtime/v8/src/java/org/appcelerator/kroll/runtime/v8/ReferenceTable.java
+++ b/android/runtime/v8/src/java/org/appcelerator/kroll/runtime/v8/ReferenceTable.java
@@ -6,10 +6,11 @@
  */
 package org.appcelerator.kroll.runtime.v8;
 
+import android.util.LongSparseArray;
+
 import java.lang.ref.Reference;
 import java.lang.ref.SoftReference;
 import java.lang.ref.WeakReference;
-import java.util.HashMap;
 
 import org.appcelerator.kroll.KrollProxySupport;
 import org.appcelerator.kroll.KrollObject;
@@ -23,7 +24,7 @@ public final class ReferenceTable
 	 * A simple Map used to hold strong/weak reference to the Java objects we have paired/wrapped in native
 	 * titanium::Proxy/JavaObject instances.
 	 */
-	private static final HashMap<Long, Object> references = new HashMap<>(1024);
+	private static final LongSparseArray<Object> references = new LongSparseArray<>(1024);
 
 	/**
 	 * Incrementing key, used to generate new keys when a new strong reference is created. FIXME Handle "wrapping" the


### PR DESCRIPTION
While going trough some native Android optimization posts like
https://medium.com/android-news/app-optimization-with-arraymap-sparsearray-in-android-c0b7de22541a
I found one place where we can switch from HashMap to SparseArray

```
Benefits to use SparseArray over HashMap is:
· More memory efficient by using primitives
· No auto-boxing
· Allocation-free

Drawbacks:
· For large collections, it is slower
· It only available for Android
```

I've build a large app with it and it still worked without any issue. At the moment I couldn't tell if the memory improved that's why I keep it as a draft for now. Need to do some more testing. 

https://youtu.be/ORgucLTtTDI?t=221 gives a pro/cons list when to use it or stay with the HashMap.