### PR TITLE
feat(android): window titleAttributes parity

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/TiC.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiC.java
@@ -773,6 +773,7 @@ public class TiC
 	public static final String PROPERTY_TINT = "tint";
 	public static final String PROPERTY_TINT_COLOR = "tintColor";
 	public static final String PROPERTY_TITLE = "title";
+	public static final String PROPERTY_TITLE_ATTRIBUTES = "titleAttributes";
 	public static final String PROPERTY_TITLE_COLOR = "titleColor";
 	public static final String PROPERTY_TITLE_CONDENSED = "titleCondensed";
 	public static final String PROPERTY_TITLEID = "titleid";

--- a/apidoc/Titanium/UI/Window.yml
+++ b/apidoc/Titanium/UI/Window.yml
@@ -1409,8 +1409,8 @@ properties:
     summary: Title text attributes of the window.
     description: |
         Use this property to specify the color, font and shadow attributes of the title.
-    platforms: [iphone, ipad, macos]
-    since: {iphone: "3.2.0", ipad: "3.2.0", macos: "9.2.0"}
+    platforms: [android, iphone, ipad, macos]
+    since: {android: "12.3.0", iphone: "3.2.0", ipad: "3.2.0", macos: "9.2.0"}
     type: titleAttributesParams
 
   - name: titleControl
@@ -1993,8 +1993,8 @@ properties:
 ---
 name: titleAttributesParams
 summary: Dictionary of options for the <Titanium.UI.Window.titleAttributes> property.
-platforms: [iphone, ipad, macos]
-since: {iphone: "3.2.0", ipad: "3.2.0", macos: "9.2.0"}
+platforms: [android, iphone, ipad, macos]
+since: {android: "12.3.0", iphone: "3.2.0", ipad: "3.2.0", macos: "9.2.0"}
 examples:
   - title: Simple Example
     example: |
@@ -2017,14 +2017,18 @@ properties:
     description: |
         For information about color values, see the "Colors" section of <Titanium.UI>.
     type: [String, Titanium.UI.Color]
+    platforms: [android, iphone, ipad, macos]
+    since: {android: "12.3.0", iphone: "3.2.0", ipad: "3.2.0", macos: "9.2.0"}
 
   - name: font
     summary: Font to use for the window title.
     type: Font
+    platforms: [iphone, ipad, macos]
 
   - name: shadow
     summary: Shadow color and offset for the window title.
     type: shadowDict
+    platforms: [iphone, ipad, macos]
 
 ---
 name: shadowDict


### PR DESCRIPTION
Parity for `titleAttribues: {color}`.

iOS allows you to quickly set the window title color with `titleAttributes: { color: #fff}`. It has more options but for now I only added color to Android.

![Screenshot_20231217-122719](https://github.com/tidev/titanium-sdk/assets/4334997/9ff3309c-6a7b-4e70-ab6a-cac809901703)


### Test 1:

```js
var win = Titanium.UI.createWindow({
	barColor: "pink",
	backgroundColor: "white",
	title: 'Autos',
	titleAttributes: {
		top: 0,
		color: "blue",
	},
});

win.addEventListener("click", function() {
	win.titleAttributes = {
		color: "yellow"
	}
})
win.open();
```
* title color is blue
* click the window and it is yellow

### Test 2:

Same but with a navigation window setup:
```js
var win = Titanium.UI.createWindow({
	barColor: "pink",
	backgroundColor: "white",
	title: 'Autos',
	titleAttributes: {
		top: 0,
		color: "blue",
	},
});

var navWin = Titanium.UI.createNavigationWindow({
	window: win,
});

win.addEventListener("click", function() {
	win.titleAttributes = {
		color: "yellow"
	}
})
navWin.open();
```
* title color is blue
* click the window and it is yellow

### Workaround

Currently you have to either add a custom toolbar/actionbar or use a theme
```xml
   <style name="MyTheme" parent="Theme.Titanium.DayNight">
        <item name="toolbarStyle">@style/Widget.App.Toolbar</item>
    </style>

    <style name="Widget.App.Toolbar" parent="Widget.MaterialComponents.Toolbar.Primary">
        <item name="titleTextColor">#ffffff</item>
        <item name="android:background">#ff00ff</item>
    </style>
```
