### PR TITLE
fix(android): set correct title after titleAttributes update

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/WindowProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/WindowProxy.java
@@ -533,8 +533,8 @@ public class WindowProxy extends TiWindowProxy implements TiActivityWindow
 						&& windowActivity.get().getSupportActionBar() != null) {
 						ActionBar actionBar = windowActivity.get().getSupportActionBar();
 						if (actionBar.getTitle() instanceof SpannableStringBuilder) {
-							SpannableStringBuilder stringBuilder;
-							stringBuilder = new SpannableStringBuilder(TiConvert.toString((Object) (msg.obj), ""));
+							SpannableStringBuilder stringBuilder =
+								new SpannableStringBuilder(TiConvert.toString((Object) (msg.obj), ""));
 							if (barColor != -1) {
 								stringBuilder.setSpan(new ForegroundColorSpan(barColor),
 									0, stringBuilder.length(), Spannable.SPAN_INCLUSIVE_INCLUSIVE);

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/WindowProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/WindowProxy.java
@@ -81,6 +81,7 @@ public class WindowProxy extends TiWindowProxy implements TiActivityWindow
 	protected static final int MSG_LAST_ID = MSG_FIRST_ID + 999;
 
 	private static int id_toolbar;
+	private int barColor = -1;
 
 	private WeakReference<TiBaseActivity> windowActivity;
 
@@ -349,6 +350,7 @@ public class WindowProxy extends TiWindowProxy implements TiActivityWindow
 			ssb = new SpannableStringBuilder(abTitle);
 		}
 
+		barColor = colorInt;
 		ssb.setSpan(new ForegroundColorSpan(colorInt),
 			0, ssb.length(), Spannable.SPAN_INCLUSIVE_INCLUSIVE);
 		actionBar.setTitle(ssb);
@@ -534,6 +536,10 @@ public class WindowProxy extends TiWindowProxy implements TiActivityWindow
 							SpannableStringBuilder ssb;
 							ssb = (SpannableStringBuilder) actionBar.getTitle();
 							ssb = new SpannableStringBuilder(TiConvert.toString((Object) (msg.obj), ""));
+							if (barColor != -1) {
+								ssb.setSpan(new ForegroundColorSpan(barColor),
+									0, ssb.length(), Spannable.SPAN_INCLUSIVE_INCLUSIVE);
+							}
 							actionBar.setTitle(ssb);
 						} else {
 							actionBar.setTitle(TiConvert.toString((Object) (msg.obj), ""));

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/WindowProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/WindowProxy.java
@@ -533,14 +533,13 @@ public class WindowProxy extends TiWindowProxy implements TiActivityWindow
 						&& windowActivity.get().getSupportActionBar() != null) {
 						ActionBar actionBar = windowActivity.get().getSupportActionBar();
 						if (actionBar.getTitle() instanceof SpannableStringBuilder) {
-							SpannableStringBuilder ssb;
-							ssb = (SpannableStringBuilder) actionBar.getTitle();
-							ssb = new SpannableStringBuilder(TiConvert.toString((Object) (msg.obj), ""));
+							SpannableStringBuilder stringBuilder;
+							stringBuilder = new SpannableStringBuilder(TiConvert.toString((Object) (msg.obj), ""));
 							if (barColor != -1) {
-								ssb.setSpan(new ForegroundColorSpan(barColor),
-									0, ssb.length(), Spannable.SPAN_INCLUSIVE_INCLUSIVE);
+								stringBuilder.setSpan(new ForegroundColorSpan(barColor),
+									0, stringBuilder.length(), Spannable.SPAN_INCLUSIVE_INCLUSIVE);
 							}
-							actionBar.setTitle(ssb);
+							actionBar.setTitle(stringBuilder);
 						} else {
 							actionBar.setTitle(TiConvert.toString((Object) (msg.obj), ""));
 						}

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/WindowProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/WindowProxy.java
@@ -526,6 +526,19 @@ public class WindowProxy extends TiWindowProxy implements TiActivityWindow
 				Activity activity = getWindowActivity();
 				if (activity != null) {
 					activity.setTitle(TiConvert.toString((Object) (msg.obj), ""));
+
+					if (windowActivity != null && windowActivity.get() != null
+						&& windowActivity.get().getSupportActionBar() != null) {
+						ActionBar actionBar = windowActivity.get().getSupportActionBar();
+						if (actionBar.getTitle() instanceof SpannableStringBuilder) {
+							SpannableStringBuilder ssb;
+							ssb = (SpannableStringBuilder) actionBar.getTitle();
+							ssb = new SpannableStringBuilder(TiConvert.toString((Object) (msg.obj), ""));
+							actionBar.setTitle(ssb);
+						} else {
+							actionBar.setTitle(TiConvert.toString((Object) (msg.obj), ""));
+						}
+					}
 				}
 				return true;
 			}

--- a/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
@@ -34,6 +34,7 @@ import org.appcelerator.titanium.proxy.TiWindowProxy;
 import org.appcelerator.titanium.util.TiActivityResultHandler;
 import org.appcelerator.titanium.util.TiActivitySupport;
 import org.appcelerator.titanium.util.TiActivitySupportHelper;
+import org.appcelerator.titanium.util.TiColorHelper;
 import org.appcelerator.titanium.util.TiConvert;
 import org.appcelerator.titanium.util.TiLocaleManager;
 import org.appcelerator.titanium.util.TiMenuSupport;
@@ -46,6 +47,8 @@ import org.appcelerator.titanium.view.TiCompositeLayout.LayoutArrangement;
 import org.appcelerator.titanium.view.TiInsetsProvider;
 
 import android.app.Activity;
+
+import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
 import android.app.Dialog;
 import android.content.Context;
@@ -67,6 +70,9 @@ import androidx.appcompat.app.AppCompatDelegate;
 import androidx.appcompat.widget.Toolbar;
 import androidx.core.app.ActivityCompat;
 
+import android.text.Spannable;
+import android.text.SpannableStringBuilder;
+import android.text.style.ForegroundColorSpan;
 import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -338,7 +344,8 @@ public abstract class TiBaseActivity extends AppCompatActivity implements TiActi
 		if (window.hasProperty(TiC.PROPERTY_TITLE)) {
 			String oldTitle = (String) getTitle();
 			String newTitle = TiConvert.toString(window.getProperty(TiC.PROPERTY_TITLE));
-
+			int colorInt = -1;
+			
 			if (oldTitle == null) {
 				oldTitle = "";
 			}
@@ -347,17 +354,32 @@ public abstract class TiBaseActivity extends AppCompatActivity implements TiActi
 				newTitle = "";
 			}
 
+			if (window.hasProperty(TiC.PROPERTY_TITLE_ATTRIBUTES)) {
+				KrollDict innerAttributes = window.getProperties().getKrollDict(TiC.PROPERTY_TITLE_ATTRIBUTES);
+				colorInt = TiColorHelper.parseColor(
+					TiConvert.toString(innerAttributes.getString(TiC.PROPERTY_COLOR)), this);
+			}
+
 			if (!newTitle.equals(oldTitle)) {
 				final String fnewTitle = newTitle;
+				final int finalColorInt = colorInt;
 				runOnUiThread(new Runnable() {
 					public void run()
 					{
 						setTitle(fnewTitle);
-						/* TODO fix this
-						ActionBarProxy actionBarProxy = activityProxy.getActionBar();
-						if (actionBarProxy != null) {
-							actionBarProxy.setTitle(fnewTitle);
-						}*/
+
+						ActionBar actionBar = getSupportActionBar();
+						if (actionBar != null) {
+							if (finalColorInt != -1) {
+								SpannableStringBuilder ssb;
+								ssb = new SpannableStringBuilder(fnewTitle);
+								ssb.setSpan(new ForegroundColorSpan(finalColorInt),
+									0, ssb.length(), Spannable.SPAN_INCLUSIVE_INCLUSIVE);
+								actionBar.setTitle(ssb);
+							} else {
+								actionBar.setTitle(fnewTitle);
+							}
+						}
 					}
 				});
 			}

--- a/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
@@ -353,6 +353,11 @@ public abstract class TiBaseActivity extends AppCompatActivity implements TiActi
 					public void run()
 					{
 						setTitle(fnewTitle);
+
+						ActionBarProxy actionBarProxy = activityProxy.getActionBar();
+						if (actionBarProxy != null) {
+							actionBarProxy.setTitle(fnewTitle);
+						}
 					}
 				});
 			}

--- a/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
@@ -353,11 +353,11 @@ public abstract class TiBaseActivity extends AppCompatActivity implements TiActi
 					public void run()
 					{
 						setTitle(fnewTitle);
-
+						/* TODO fix this
 						ActionBarProxy actionBarProxy = activityProxy.getActionBar();
 						if (actionBarProxy != null) {
 							actionBarProxy.setTitle(fnewTitle);
-						}
+						}*/
 					}
 				});
 			}


### PR DESCRIPTION
Fixes an issue that came with https://github.com/tidev/titanium-sdk/pull/13954 and window titles. Title where not shown in all (sub)windows:

### Test 1:
```js
var win = Titanium.UI.createWindow({
	barColor: "pink",
	backgroundColor: "white",
	title: 'Autos',
	titleAttributes: {
		top: 0,
		color: "blue",
	},
});

win.addEventListener("click", function() {
	win.titleAttributes = {
		color: "yellow"
	}
})
win.open();
```
open and click

### Test 2:
```js
var win = Titanium.UI.createWindow({
	barColor: "pink",
	backgroundColor: "white",
	title: 'Autos',
	titleAttributes: {
		top: 0,
		color: "blue",
	},
});

var navWin = Titanium.UI.createNavigationWindow({
	window: win,
});

win.addEventListener("click", function() {
	win.titleAttributes = {
		color: "yellow"
	}
	win.title = "new"

	var w2 = Ti.UI.createWindow({
		barColor: "black",
		backgroundColor: "white",
		title: 'subwindow',
		titleAttributes: {
			top: 0,
			color: "green",
		},
	})
	navWin.openWindow(w2);
	setTimeout(function() {
		w2.title = "subwindow 2";
	}, 2000);
})
navWin.open();
```

open and click, wait, close window after title changed.

