### PR TITLE
fix(build/ios): simulator and macos builds don't require wwdr

### DIFF
--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -1905,7 +1905,7 @@ iOSBuilder.prototype.validate = function validate(logger, config, cli) {
 		}, this);
 
 		// if in the prepare phase and doing a device/dist build...
-		if (cli.argv.target !== 'simulator' || cli.argv.target !== 'macos') {
+		if (cli.argv.target !== 'simulator' && cli.argv.target !== 'macos') {
 			// make sure they have Apple's WWDR cert installed
 			if (!this.iosInfo.certs.wwdr) {
 				logger.error(__('WWDR Intermediate Certificate not found') + '\n');


### PR DESCRIPTION
The current check will always step into the if because it will always not equal one of those, and the WWDR cert is not required for these.

To test, remove your WWDR cert from Keychain