### PR TITLE
ci: trigger regen builds on release

### DIFF
--- a/.github/workflows/regen-builds.yml
+++ b/.github/workflows/regen-builds.yml
@@ -1,7 +1,5 @@
 name: Regen Builds
 on:
-  release:
-    types: [published, released]
   workflow_run:
     workflows: [Build]
     types: [completed]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,4 +171,9 @@ jobs:
         git add package-lock.json
         git commit -m "chore(release): bump version"
         git push
-
+    - name: Regen Builds
+      uses: peter-evans/repository-dispatch@v2
+      with:
+        event-type: regen-builds
+        repository: tidev/downloads-www
+        token: ${{ secrets.REGEN_BUILDS_DOCS_GITHUB_TOKEN }}


### PR DESCRIPTION
The current regen builds workflow fires when a PR is created or push as well as when a GA release is created. This PR specifically fixes the GA release processes. When a release is created, it builds the release while also regenerating the builds. The regen builds finishes way before the release build finishes. This results in the release not showing up on downloads.titaniumsdk.com until the regen builds trigger is manually invoked.

This PR no longer regens builds when the release is created, but rather once the release has been approved and is fully released.