### PR TITLE
fix(android): fix Android FAB tintColor

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIFloatingActionButton.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIFloatingActionButton.java
@@ -7,6 +7,7 @@
 package ti.modules.titanium.ui.widget;
 
 import android.content.res.ColorStateList;
+import android.graphics.PorterDuff;
 
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 
@@ -54,6 +55,9 @@ public class TiUIFloatingActionButton extends TiUIView
 		if (d.containsKey("maxImageSize")) {
 			setMaxImageSize(TiConvert.toInt(d.get("maxImageSize")));
 		}
+		if (d.containsKey(TiC.PROPERTY_TINT_COLOR)) {
+			setTintColor(d.getString("tintColor"));
+		}
 		if (d.containsKeyAndNotNull(TiC.PROPERTY_TOUCH_FEEDBACK_COLOR)) {
 			ColorStateList colorStateList = null;
 			colorStateList = ColorStateList.valueOf(
@@ -91,6 +95,12 @@ public class TiUIFloatingActionButton extends TiUIView
 		}
 	}
 
+	public void setTintColor(String color)
+	{
+		int tintColor = TiConvert.toColor(color, TiApplication.getAppCurrentActivity());
+		fab.setColorFilter(tintColor, PorterDuff.Mode.SRC_IN);
+	}
+
 	@Override
 	public void propertyChanged(String key, Object oldValue, Object newValue, KrollProxy proxy)
 	{
@@ -106,6 +116,8 @@ public class TiUIFloatingActionButton extends TiUIView
 			ColorStateList colorStateList = null;
 			colorStateList = ColorStateList.valueOf(TiConvert.toColor(newValue, proxy.getActivity()));
 			fab.setRippleColor(colorStateList);
+		} else if (key.equals(TiC.PROPERTY_TINT_COLOR)) {
+			setTintColor(TiConvert.toString(newValue));
 		}
 	}
 }

--- a/apidoc/Titanium/UI/Android/FloatingActionButton.yml
+++ b/apidoc/Titanium/UI/Android/FloatingActionButton.yml
@@ -17,7 +17,7 @@ excludes:
                  backgroundImage, backgroundLeftCap, backgroundRepeat, backgroundSelectedColor,
                  backgroundSelectedImage, backgroundTopCap, borderColor, borderRadius, borderWidth, center,
                  children, clipMode, focusable, height, horizontalWrap, keepScreenOn, layout, opacity, overrideCurrentAnimation,
-                 pullBackgroundColor, rect, size, softKeyboardOnFocus, tintColor, touchEnabled, touchFeedback, transform,
+                 pullBackgroundColor, rect, size, softKeyboardOnFocus, touchEnabled, touchFeedback, transform,
                  viewShadowColor, viewShadowOffset, viewShadowRadius, width, zIndex]
 
 events:


### PR DESCRIPTION
Fixes #13971 

Currently `tintColor` is not tinting the icon. This PR will fix that

**Test:**

```js
const win = Ti.UI.createWindow();
const fab = Ti.UI.Android.createFloatingActionButton({
	bottom: 10,
	right: 10,
	tintColor: "blue",
	image: "/appicon.png"
});
win.add(fab);

setTimeout(function() {
	fab.tintColor = "red";
}, 2000)
win.open();
```

* icon will be blue
* after 2 sec it will be red