### PR TITLE
fix: defer loading kroll-core to scene initialization

### DIFF
--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiApp.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiApp.m
@@ -416,12 +416,6 @@ extern void UIColorFlushCache(void);
   // If a "application-launch-url" is set, launch it directly
   [self launchToUrl];
 
-  // Boot our kroll-core
-  [self boot];
-
-  // Create application support directory if not exists
-  [self createDefaultDirectories];
-
   return YES;
 }
 
@@ -1238,6 +1232,12 @@ extern void UIColorFlushCache(void);
 
   // Initialize the root-controller
   [self initController];
+
+  // Boot our kroll-core
+  [self boot];
+
+  // Create application support directory if not exists
+  [self createDefaultDirectories];
 }
 
 #pragma mark Background Tasks


### PR DESCRIPTION
It does show the debugger in Safari, let's see!

<img src="https://github.com/tidev/titanium-sdk/assets/10667698/636f240f-2589-4483-8a27-6c294922cb67" height="200" />

#### ⚠️  Please do not merge directly - I would clean up the PR for master first and then cherry-pick this change