### PR TITLE
ci: add more release type tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,13 @@ on:
         options:
           - GA
           - RC
+          - RC2
+          - RC3
+          - RC4
           - Beta
+          - Beta2
+          - Beta3
+          - Beta4
 
 jobs:
   validate:


### PR DESCRIPTION
Adds "RC2", "RC3", "RC4", "Beta2", "Beta3", and "Beta4" release types.