### PR TITLE
ci: trigger regen builds on release backport

### DIFF
--- a/.github/workflows/regen-builds.yml
+++ b/.github/workflows/regen-builds.yml
@@ -1,7 +1,5 @@
 name: Regen Builds
 on:
-  release:
-    types: [published, released]
   workflow_run:
     workflows: [Build]
     types: [completed]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,13 @@ on:
         options:
           - GA
           - RC
+          - RC2
+          - RC3
+          - RC4
           - Beta
+          - Beta2
+          - Beta3
+          - Beta4
 
 jobs:
   validate:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,4 +171,9 @@ jobs:
         git add package-lock.json
         git commit -m "chore(release): bump version"
         git push
-
+    - name: Regen Builds
+      uses: peter-evans/repository-dispatch@v2
+      with:
+        event-type: regen-builds
+        repository: tidev/downloads-www
+        token: ${{ secrets.REGEN_BUILDS_DOCS_GITHUB_TOKEN }}


### PR DESCRIPTION
Adds "RC2", "RC3", "RC4", "Beta2", "Beta3", and "Beta4" release types.