### PR TITLE
fix(ios): restore compatibility for Ti.App._resumeRestart()

### DIFF
--- a/iphone/Classes/AppModule.m
+++ b/iphone/Classes/AppModule.m
@@ -48,9 +48,12 @@ extern NSString *const TI_APPLICATION_GUID;
 #ifndef TI_USE_AUTOLAYOUT
   [TiLayoutQueue resetQueue];
 #endif
+
+  UIScene *activeScene = UIApplication.sharedApplication.connectedScenes.allObjects.firstObject;
+
   /* Begin backgrounding simulation */
-  [appDelegate applicationWillResignActive:app];
-  [appDelegate applicationDidEnterBackground:app];
+  [appDelegate sceneWillResignActive:activeScene];
+  [appDelegate sceneDidEnterBackground:activeScene];
   [appDelegate endBackgrounding];
   /* End backgrounding simulation */
 
@@ -76,8 +79,8 @@ extern NSString *const TI_APPLICATION_GUID;
 
   /* Begin foregrounding simulation */
   [appDelegate application:app didFinishLaunchingWithOptions:[appDelegate launchOptions]];
-  [appDelegate applicationWillEnterForeground:app];
-  [appDelegate applicationDidBecomeActive:app];
+  [appDelegate sceneWillEnterForeground:activeScene];
+  [appDelegate sceneDidBecomeActive:activeScene];
   /* End foregrounding simulation */
 }
 

--- a/iphone/Classes/AppModule.m
+++ b/iphone/Classes/AppModule.m
@@ -79,6 +79,7 @@ extern NSString *const TI_APPLICATION_GUID;
 
   /* Begin foregrounding simulation */
   [appDelegate application:app didFinishLaunchingWithOptions:[appDelegate launchOptions]];
+  [appDelegate scene:activeScene willConnectToSession:activeScene.session options:TiApp.app.connectionOptions];
   [appDelegate sceneWillEnterForeground:activeScene];
   [appDelegate sceneDidBecomeActive:activeScene];
   /* End foregrounding simulation */

--- a/iphone/Classes/AppModule.m
+++ b/iphone/Classes/AppModule.m
@@ -49,7 +49,18 @@ extern NSString *const TI_APPLICATION_GUID;
   [TiLayoutQueue resetQueue];
 #endif
 
-  UIScene *activeScene = UIApplication.sharedApplication.connectedScenes.allObjects.firstObject;
+  // Get the currently active scene
+  UIScene *activeScene = nil;
+  for (UIScene *scene in UIApplication.sharedApplication.connectedScenes) {
+    if (scene.activationState == UISceneActivationStateForegroundActive) {
+      activeScene = scene;
+      break;
+    }
+  }
+
+  if (activeScene == nil) {
+    NSLog(@"[ERROR] No active scene connected - this may lead to an undefined behavior");
+  }
 
   /* Begin backgrounding simulation */
   [appDelegate sceneWillResignActive:activeScene];

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiApp.h
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiApp.h
@@ -26,6 +26,7 @@
   KrollBridge *kjsBridge;
 
   NSMutableDictionary *launchOptions;
+  UISceneConnectionOptions *_connectionOptions;
   NSTimeInterval started;
 
   int32_t networkActivityCount;
@@ -111,6 +112,13 @@
  @return Dictionary containing details about local notification, or _nil_.
  */
 @property (nonatomic, readonly) NSDictionary *localNotification;
+
+/**
+ Returns details for the last remote notification.
+ 
+ Dictionary containing details about remote notification, or _nil_.
+ */
+@property (nonatomic, readonly) UISceneConnectionOptions *connectionOptions;
 
 /**
  Returns the application's root view controller.

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiApp.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiApp.m
@@ -48,6 +48,7 @@ extern void UIColorFlushCache(void);
 @synthesize localNotification;
 @synthesize appBooted;
 @synthesize userAgent;
+@synthesize connectionOptions;
 
 + (TiApp *)app
 {
@@ -1062,6 +1063,7 @@ extern void UIColorFlushCache(void);
   RELEASE_TO_NIL(queuedBootEvents);
   RELEASE_TO_NIL(_queuedApplicationSelectors);
   RELEASE_TO_NIL(_applicationDelegates);
+  RELEASE_TO_NIL(_connectionOptions);
 
   [super dealloc];
 }
@@ -1109,6 +1111,12 @@ extern void UIColorFlushCache(void);
 
   // Initialize the launch options to be used by the client
   launchOptions = [[NSMutableDictionary alloc] init];
+
+  // Retain connectionOptions for later use
+  if (_connectionOptions != connectionOptions) {
+    [_connectionOptions release]; // Release any existing object
+    _connectionOptions = [connectionOptions retain]; // Retain the new object
+  }
 
   // If we have a APNS-UUID, assign it
   NSString *apnsUUID = [[NSUserDefaults standardUserDefaults] stringForKey:@"APNSRemoteDeviceUUID"];

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiRootViewController.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiRootViewController.m
@@ -696,7 +696,8 @@
   if (![TiSharedConfig defaultConfig].debugEnabled) {
     return;
   }
-  //FIRST DISMISS ALL MODAL WINDOWS
+
+  // Dismiss all currently opened windows
   UIViewController *topVC = [self topPresentedController];
   if (topVC != self) {
     UIViewController *presenter = [topVC presentingViewController];
@@ -706,7 +707,8 @@
                                   }];
     return;
   }
-  //At this point all modal stuff is done. Go ahead and clean up proxies.
+
+  // Clean up proxies.
   NSArray *modalCopy = [modalWindows copy];
   NSArray *windowCopy = [containedWindows copy];
 
@@ -725,7 +727,8 @@
     [windowCopy release];
   }
 
-  DebugLog(@"[INFO] UI SHUTDOWN COMPLETE. TRYING TO RESUME RESTART");
+  DebugLog(@"[WARN] Calling the private `_restart()` API should not be done in production, as restarting an app is not a recommended native concept.");
+
   if ([arg respondsToSelector:@selector(_resumeRestart:)]) {
     [arg performSelector:@selector(_resumeRestart:) withObject:nil];
   } else {


### PR DESCRIPTION
Fixes https://github.com/tidev/titanium-sdk/issues/13988

### Test Case:
```js
const win = Ti.UI.createWindow({
	backgroundColor: '#fff'
});

win.addEventListener('open', () => console.warn('OPEN'));
win.addEventListener('focus', () => console.warn('FOCUS'));
win.addEventListener('blur', () => console.warn('BLUR'));
win.addEventListener('close', () => console.warn('CLOSE'));

const btn = Ti.UI.createButton({
	title: 'Restart app'
});

btn.addEventListener('click', () => {
	Ti.App._restart();
});

win.add(btn);
win.open();
```

### Expected Behavior

The app should show the `open` and `focus` events on app start and `blur` -> `close` -> `open` -> `focus` after hitting the restart button.