### PR TITLE
chore(android): ndk update

### DIFF
--- a/android/templates/module/generated/build.gradle
+++ b/android/templates/module/generated/build.gradle
@@ -16,6 +16,7 @@ def tiModuleBindingsJsonPath = "${buildDir}/ti-generated/json/<%- moduleName %>.
 
 android {
 	compileSdkVersion <%- compileSdkVersion %>
+	ndkVersion '22.1.7171670'
 	defaultConfig {
 		minSdkVersion 19
 		targetSdkVersion <%- compileSdkVersion %>
@@ -59,7 +60,8 @@ android {
 				arguments.addAll([
 					'APP_STL:=c++_shared',
 					"-j${Runtime.runtime.availableProcessors()}".toString(),
-					'--output-sync=none'
+					'--output-sync=none',
+					'APP_LD=deprecated'
 				])
 			}
 		}


### PR DESCRIPTION
Another small update to bring the Android toolchain to higher versions. Can be merged with https://github.com/tidev/titanium-sdk/pull/13966 (cmake, checkstyle update).

Current NDK is 21. This will update the module build to use 22.1.7171670.

I had to add `APP_LD=deprecated` 

>LLD is now used by default. If your build is not yet compatible with LLD, you can continue using the deprecated linkers, set APP_LD=deprecated for ndk-build, ANDROID_LD=deprecated for CMake, or use an explicit -fuse-ld=gold or -fuse-ld=bfd in your custom build system.

so something we'll need to look out for in a future update.

NDK is installed the first time you've build a module. Gradle will automatically use 21, using the build.gradle file we can override that version. You can even put a build.gradle into your module and use a different NDK version if needed. 

**Tests**:
* build a module
* ndk22 will install during first build
* module should build fine
* app with module should run