### PR TITLE
ci(android): install python before ccache

### DIFF
--- a/.github/actions/build-android/action.yml
+++ b/.github/actions/build-android/action.yml
@@ -49,18 +49,10 @@ runs:
       run: npm run lint:android
       shell: bash
 
-    - name: Set up Homebrew
-      id: set-up-homebrew
-      uses: Homebrew/actions/setup-homebrew@master
-
     - name: Install ccache
-      run: brew install ccache
-      shell: bash
-
-    - name: Retrieve ccache
-      uses: actions/cache@v3
+      uses: hendrikmuhs/ccache-action@v1.2
       with:
-        path: ${{ env.CCACHE_DIR }}
+        create-symlink: true
         key: ${{ runner.os }}-ccache-${{ github.sha }}
         restore-keys: |
           ${{ runner.os }}-ccache-


### PR DESCRIPTION
Trying to fix failure here https://github.com/tidev/titanium-sdk/actions/runs/7927871631/job/21646099047, looks like ccache is failing to install python so maybe a manual install will work?