### PR TITLE
feat(android): use newer APIs for battery level/status properties

### DIFF
--- a/android/modules/platform/src/java/ti/modules/titanium/platform/PlatformModule.java
+++ b/android/modules/platform/src/java/ti/modules/titanium/platform/PlatformModule.java
@@ -6,6 +6,8 @@
  */
 package ti.modules.titanium.platform;
 
+import static android.content.Context.BATTERY_SERVICE;
+
 import org.appcelerator.kroll.KrollDict;
 import org.appcelerator.kroll.KrollFunction;
 import org.appcelerator.kroll.KrollInvocation;
@@ -399,13 +401,27 @@ public class PlatformModule extends KrollModule
 	@Kroll.getProperty
 	public int getBatteryState()
 	{
-		return batteryState;
+		if (Build.VERSION.SDK_INT >= 26) {
+			Context context = TiApplication.getInstance().getApplicationContext();
+			BatteryManager bm = (BatteryManager) context.getSystemService(BATTERY_SERVICE);
+			int batStatus = bm.getIntProperty(BatteryManager.BATTERY_PROPERTY_STATUS);
+			return batStatus;
+		} else {
+			return batteryState;
+		}
 	}
 
 	@Kroll.getProperty
 	public double getBatteryLevel()
 	{
-		return batteryLevel;
+		if (Build.VERSION.SDK_INT >= 21) {
+			Context context = TiApplication.getInstance().getApplicationContext();
+			BatteryManager bm = (BatteryManager) context.getSystemService(BATTERY_SERVICE);
+			int batLevel = bm.getIntProperty(BatteryManager.BATTERY_PROPERTY_CAPACITY);
+			return batLevel;
+		} else {
+			return batteryLevel;
+		}
 	}
 
 	@Kroll.getProperty

--- a/android/modules/platform/src/java/ti/modules/titanium/platform/PlatformModule.java
+++ b/android/modules/platform/src/java/ti/modules/titanium/platform/PlatformModule.java
@@ -77,7 +77,6 @@ public class PlatformModule extends KrollModule
 	private int versionMinor;
 	private int versionPatch;
 	protected int batteryState;
-	protected double batteryLevel;
 	protected boolean batteryStateReady;
 
 	protected BroadcastReceiver batteryStateReceiver;
@@ -87,7 +86,6 @@ public class PlatformModule extends KrollModule
 		super();
 
 		batteryState = BATTERY_STATE_UNKNOWN;
-		batteryLevel = -1;
 
 		// Extract "<major>.<minor>" integers from OS version string.
 		String[] versionComponents = Build.VERSION.RELEASE.split("\\.");
@@ -414,14 +412,10 @@ public class PlatformModule extends KrollModule
 	@Kroll.getProperty
 	public double getBatteryLevel()
 	{
-		if (Build.VERSION.SDK_INT >= 21) {
-			Context context = TiApplication.getInstance().getApplicationContext();
-			BatteryManager bm = (BatteryManager) context.getSystemService(BATTERY_SERVICE);
-			int batLevel = bm.getIntProperty(BatteryManager.BATTERY_PROPERTY_CAPACITY);
-			return batLevel;
-		} else {
-			return batteryLevel;
-		}
+		Context context = TiApplication.getInstance().getApplicationContext();
+		BatteryManager bm = (BatteryManager) context.getSystemService(BATTERY_SERVICE);
+		int batLevel = bm.getIntProperty(BatteryManager.BATTERY_PROPERTY_CAPACITY);
+		return batLevel;
 	}
 
 	@Kroll.getProperty
@@ -511,7 +505,7 @@ public class PlatformModule extends KrollModule
 			public void onReceive(Context context, Intent intent)
 			{
 				int scale = intent.getIntExtra(TiC.PROPERTY_SCALE, -1);
-				batteryLevel = convertBatteryLevel(intent.getIntExtra(TiC.PROPERTY_LEVEL, -1), scale);
+				double batteryLevel = convertBatteryLevel(intent.getIntExtra(TiC.PROPERTY_LEVEL, -1), scale);
 				batteryState = convertBatteryStatus(intent.getIntExtra(TiC.PROPERTY_STATUS, -1));
 
 				KrollDict event = new KrollDict();


### PR DESCRIPTION
The current implementation of the battery level/state properties are returning the stored values from the BroadcastReceiver. Android introduced a way to query the value using the BatteryManager starting in 21 (level) and 26 (state).

Android docs:
https://developer.android.com/reference/android/os/BatteryManager.html#BATTERY_PROPERTY_STATUS
https://developer.android.com/reference/android/os/BatteryManager.html#BATTERY_PROPERTY_CAPACITY


Currently the [initial value is -1](https://github.com/tidev/titanium-sdk/blob/e963c721567cfd643f9bb3a974f7e6085c5b0a8a/android/modules/platform/src/java/ti/modules/titanium/platform/PlatformModule.java#L88C3-L88C15) and if the receiver wasn't called yet (e.g. timing or it was somehow removed) [it won't update the values](https://github.com/tidev/titanium-sdk/blob/e963c721567cfd643f9bb3a974f7e6085c5b0a8a/android/modules/platform/src/java/ti/modules/titanium/platform/PlatformModule.java#L498-L499).

The new way should still return a fresh value because it reads it when your fetch the property.

**Update**
Battery level: since 21 is the current minSDK I removed the `if` and just use the new value. 

**Test:**
```
var win = Ti.UI.createWindow();
win.open();

win.addEventListener("open", function() {
	console.log("Level", Titanium.Platform.batteryLevel);
	console.log("Status", Titanium.Platform.batteryState);
})
```