### PR TITLE
feat(android): videoPlayer speed property

### DIFF
--- a/android/modules/media/src/java/ti/modules/titanium/media/TiUIVideoView.java
+++ b/android/modules/media/src/java/ti/modules/titanium/media/TiUIVideoView.java
@@ -19,7 +19,9 @@ import android.media.MediaPlayer;
 import android.media.MediaPlayer.OnCompletionListener;
 import android.media.MediaPlayer.OnErrorListener;
 import android.media.MediaPlayer.OnPreparedListener;
+import android.media.PlaybackParams;
 import android.net.Uri;
+import android.os.Build;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.View.OnTouchListener;
@@ -330,6 +332,13 @@ public class TiUIVideoView
 	@Override
 	public void onPrepared(MediaPlayer mp)
 	{
+
+		if (proxy.hasPropertyAndNotNull(TiC.PROPERTY_SPEED) && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+			PlaybackParams myPlayBackParams = new PlaybackParams();
+			myPlayBackParams.setSpeed(TiConvert.toFloat(proxy.getProperty(TiC.PROPERTY_SPEED)));
+			mp.setPlaybackParams(myPlayBackParams);
+		}
+
 		getPlayerProxy().onPlaybackReady(mp.getDuration());
 	}
 

--- a/apidoc/Titanium/Media/VideoPlayer.yml
+++ b/apidoc/Titanium/Media/VideoPlayer.yml
@@ -575,6 +575,15 @@ properties:
     platforms: [iphone, ipad, macos]
     type: MovieSize
 
+  - name: speed
+    summary: Playback speed of the video.
+    description: |
+      Playback speed of the video. Android: only available for API level >= 23.
+    type: Number
+    platforms: [android]
+    since: 12.4.0
+    availability: creation
+
   - name: overlayView
     summary: Use the overlay view to add additional custom views between the video content and the controls.
     description: |


### PR DESCRIPTION
New property to adjust the playback speed in a VideoPlayer.

**Test**

Add a video `video.mp4` to the assets folder.

```js
var vidWin = Titanium.UI.createWindow({
    title: 'Video View Demo',
    backgroundColor: '#fff'
});

var videoPlayer = Titanium.Media.createVideoPlayer({
    top: 2,
    autoplay: true,
    backgroundColor: 'blue',
    height: 300,
    width: 300,
    speed: 0.5,                 // <------------- new
    url: "./video.mp4",
    mediaControlStyle: Titanium.Media.VIDEO_CONTROL_DEFAULT,
    scalingMode: Titanium.Media.VIDEO_SCALING_RESIZE_ASPECT
});

var videoPlayer2 = Titanium.Media.createVideoPlayer({
    top: 304,
    autoplay: true,
    backgroundColor: 'blue',
    height: 300,
    width: 300,
    speed: 2,                  // <------------- new
    url: "./video.mp4",
    mediaControlStyle: Titanium.Media.VIDEO_CONTROL_DEFAULT,
    scalingMode: Titanium.Media.VIDEO_SCALING_RESIZE_ASPECT
});

vidWin.add(videoPlayer);
vidWin.add(videoPlayer2);
vidWin.open();
```