### PR TITLE
feat(android): add moveToBackground method

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/android/AndroidModule.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/android/AndroidModule.java
@@ -328,6 +328,11 @@ public class AndroidModule extends KrollModule
 		return String.format("#%06X",
 			(0xFFFFFF & MaterialColors.harmonizeWithPrimary(TiApplication.getAppCurrentActivity(), color)));
 	}
+	@Kroll.method
+	public void moveToBackground()
+	{
+		TiApplication.getAppRootOrCurrentActivity().moveTaskToBack(true);
+	}
 
 	@Override
 	public String getApiName()

--- a/apidoc/Titanium/UI/Android/Android.yml
+++ b/apidoc/Titanium/UI/Android/Android.yml
@@ -29,6 +29,11 @@ methods:
         type: String
     since: { android: "12.0.0" }
 
+  - name: moveToBackground
+    summary: Moves the app to the background
+    platforms: [android]
+    since: { android: "12.4.0" }
+
   - name: hideSoftKeyboard
     summary: |
         Hides the soft keyboard.


### PR DESCRIPTION
Simple method to put your app into background: `Ti.UI.Android.moveToBackground();`

**Current workarounds are:** 
using an intent
```
	var intent = Ti.Android.createIntent({
		action: Ti.Android.ACTION_MAIN,
		flags: Ti.Android.FLAG_ACTIVITY_NEW_TASK
	});
	intent.addCategory(Ti.Android.CATEGORY_HOME);
	Ti.Android.currentActivity.startActivity(intent);
```
 or hyperloop. 
This method will make it quicker to put your app to the background. 