### PR TITLE
feat(android): textAlignment for DatePicker

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/picker/TiUIDatePicker.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/picker/TiUIDatePicker.java
@@ -7,6 +7,7 @@
 package ti.modules.titanium.ui.widget.picker;
 
 import android.os.Build;
+import android.view.Gravity;
 import android.view.View;
 import android.widget.DatePicker;
 import android.widget.DatePicker.OnDateChangedListener;
@@ -100,6 +101,15 @@ public class TiUIDatePicker extends TiUIView implements OnDateChangedListener
 				};
 				textInputLayout.getEditText().setOnClickListener(clickListener);
 				textInputLayout.setEndIconOnClickListener(clickListener);
+
+				if (proxy.hasPropertyAndNotNull(TiC.PROPERTY_TEXT_ALIGN)) {
+					String textAlign = TiConvert.toString(proxy.getProperty(TiC.PROPERTY_TEXT_ALIGN));
+					if (textAlign.equals("center")) {
+						textInputLayout.getEditText().setGravity(Gravity.CENTER_VERTICAL | Gravity.CENTER);
+					} else if (textAlign.equals("right")) {
+						textInputLayout.getEditText().setGravity(Gravity.CENTER_VERTICAL | Gravity.END);
+					}
+				}
 				view = textInputLayout;
 			}
 		}

--- a/apidoc/Titanium/UI/Picker.yml
+++ b/apidoc/Titanium/UI/Picker.yml
@@ -394,6 +394,15 @@ properties:
     platforms: [android]
     since: "5.0.0"
 
+  - name: textAlign
+    summary: |
+        Horizontal text alignment of the date picker when using <Titanium.UI.PICKER_TYPE_DATE>.
+    type: [String, Number]
+    constants: Titanium.UI.TEXT_ALIGNMENT_*
+    default: <Titanium.UI.TEXT_ALIGNMENT_LEFT>,
+    platforms: [android]
+    since: "12.4.0"
+
   - name: datePickerStyle
     summary: Determines how a date or time picker should appear.
     description: |


### PR DESCRIPTION
expose the normal `textAlignment` property in the DatePicker

![Screenshot_20240322-153621](https://github.com/tidev/titanium-sdk/assets/4334997/962f7427-4434-422a-ad34-3bc99c635600)

default, `textAlign: Ti.UI.TEXT_ALIGNMENT_CENTER` and `textAlign: Ti.UI.TEXT_ALIGNMENT_RIGHT`

**Test**
```js
var win = Ti.UI.createWindow({layout: 'vertical'});

var picker = Ti.UI.createPicker({
  type:Ti.UI.PICKER_TYPE_DATE,
  width: 400,
});

win.add(picker);
var picker = Ti.UI.createPicker({
  type:Ti.UI.PICKER_TYPE_DATE,
  width: 400,
	textAlign: Ti.UI.TEXT_ALIGNMENT_CENTER
});

win.add(picker);
var picker = Ti.UI.createPicker({
  type:Ti.UI.PICKER_TYPE_DATE,
  width: 400,
	textAlign: Ti.UI.TEXT_ALIGNMENT_RIGHT
});

win.add(picker);
win.open();
```