### PR TITLE
feat(ios): backgroundColor for RefreshControl

### DIFF
--- a/apidoc/Titanium/UI/RefreshControl.yml
+++ b/apidoc/Titanium/UI/RefreshControl.yml
@@ -61,7 +61,7 @@ properties:
         For information about color values, see the "Colors" section of <Titanium.UI>.
     type: [String, Titanium.UI.Color]
     platforms: [iphone, ipad, macos]
-    since: { iphone: "12.4.0", ipad: "12.4.0" }
+    since: { iphone: "12.4.0", ipad: "12.4.0", macos: "12.4.0" }
 
 events:
   - name: refreshstart

--- a/apidoc/Titanium/UI/RefreshControl.yml
+++ b/apidoc/Titanium/UI/RefreshControl.yml
@@ -55,6 +55,14 @@ properties:
     platforms: [android, iphone, ipad, macos]
     since: { android: "6.2.0", iphone: "3.2.0", ipad: "3.2.0" }
 
+  - name: backgroundColor
+    summary: The background color for the refresh control, as a color name or hex triplet.
+    description: |
+        For information about color values, see the "Colors" section of <Titanium.UI>.
+    type: [String, Titanium.UI.Color]
+    platforms: [iphone, ipad, macos]
+    since: { iphone: "12.4.0", ipad: "12.4.0" }
+
 events:
   - name: refreshstart
     summary: |

--- a/iphone/Classes/TiUIRefreshControlProxy.m
+++ b/iphone/Classes/TiUIRefreshControlProxy.m
@@ -78,6 +78,17 @@
       NO);
 }
 
+- (void)setBackgroundColor:(id)value
+{
+  [self replaceValue:value forKey:@"backgroundColor" notification:NO];
+
+  TiThreadPerformOnMainThread(
+      ^{
+        [[self control] setBackgroundColor:[[TiUtils colorValue:value] color]];
+      },
+      NO);
+}
+
 - (void)beginRefreshing:(id)unused
 {
   TiThreadPerformOnMainThread(


### PR DESCRIPTION
Adds the ability to change the backgroundColor of the refresh box:

**Test**
```js
const win = Ti.UI.createWindow();
let counter = 0;
function genData() {
    const data = [];
    for (let i = 1; i <= 3; i++) {
        data.push({ properties:{ title: `ROW ${counter + i}` } });
    }
    counter += 3;
    return data;
}
const section = Ti.UI.createListSection();
section.items = genData();
const control = Ti.UI.createRefreshControl({
    tintColor: 'red',
    backgroundColor: "green"
});
const listView = Ti.UI.createListView({
    sections: [section],
    refreshControl: control
});
control.addEventListener('refreshstart', () => {
    Ti.API.info('refreshstart');
    setTimeout(() => {
        Ti.API.debug('Timeout');
        section.appendItems(genData());
        control.endRefreshing();
    }, 2000);
});
win.add(listView);
win.open();
```
![screenshot](https://github.com/tidev/titanium-sdk/assets/4334997/5511ea85-ad41-4f9e-a46b-f75854a52c4b)

