### PR TITLE
chore: pass platform to tiappxml

### DIFF
--- a/cli/commands/build.js
+++ b/cli/commands/build.js
@@ -121,7 +121,7 @@ exports.config = function config(logger, config, cli) {
 								if (fs.existsSync(path.join(projectDir, 'tiapp.xml'))) {
 									let tiapp;
 									try {
-										tiapp = cli.tiapp = new tiappxml(path.join(projectDir, 'tiapp.xml'));
+										tiapp = cli.tiapp = new tiappxml(path.join(projectDir, 'tiapp.xml'), cli.argv.platform);
 									} catch (ex) {
 										logger.error(ex);
 										logger.log();


### PR DESCRIPTION
Will pass the current target platform to tiappxml.

**TODO**
Requires https://github.com/tidev/node-titanium-sdk/pull/655 to be merged and released and then the package.json needs to be updated.

Merge https://github.com/tidev/titanium-sdk/pull/14026 first for the package.json