### PR TITLE
fix(ios): fix some open issues related to scenes

### DIFF
--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiApp.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiApp.m
@@ -1198,11 +1198,19 @@ extern void UIColorFlushCache(void);
   [self tryToInvokeSelector:@selector(scene:willConnectToSession:options:)
               withArguments:[NSOrderedSet orderedSetWithObjects:scene, connectionOptions, nil]];
 
-  // If a "application-launch-url" is set, launch it directly
-  [self launchToUrl];
+  // Catch exceptions
+  [TiExceptionHandler defaultExceptionHandler];
+
+  // Enable device logs (e.g. for physical devices)
+  if ([[TiSharedConfig defaultConfig] logServerEnabled]) {
+    [[TiLogServer defaultLogServer] start];
+  }
 
   // Initialize the root-controller
   [self initController];
+
+  // If a "application-launch-url" is set, launch it directly
+  [self launchToUrl];
 
   // Boot our kroll-core
   [self boot];

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiApp.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiApp.m
@@ -324,7 +324,20 @@ extern void UIColorFlushCache(void);
   return YES;
 }
 
-// Handle URL-schemes / iOS >= 9
+- (void)scene:(UIScene *)scene openURLContexts:(NSSet<UIOpenURLContext *> *)URLContexts
+{
+  UIOpenURLContext *primaryContext = URLContexts.allObjects.firstObject;
+
+  NSDictionary<UIApplicationOpenURLOptionsKey, id> *options = @{
+    UIApplicationOpenURLOptionsSourceApplicationKey : NULL_IF_NIL(primaryContext.options.sourceApplication)
+  };
+
+  [self application:[UIApplication sharedApplication] openURL:primaryContext.URL options:options];
+}
+
+// Handle URL-schemes. Note that this selector is not called automatically anymore in iOS 13+
+// because of the scene management. Instead, the above "scene:openURLContexts:" selector is called
+// that forwards the call for maximum backwards compatibility
 - (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<NSString *, id> *)options
 {
   [self tryToInvokeSelector:@selector(application:openURL:options:)


### PR DESCRIPTION
This PR should fix two of the three issues described in https://github.com/tidev/titanium-sdk/issues/13997 so far:
 
- 01fca4418ed1fa65d24e592a3fb9065dd5fddac8: fix “handleurl” event when using scenes
- 5d8d617a9124718f7cfb0e362632ba6ec68e5de4: fix log server from not being started on physical device

The `Ti.Network.registerForPushNotifications` issue still needs to be investigates. If someone has a test case, I'm happy to use it! 