### PR TITLE
chore: node-titanium-sdk update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "markdown": "0.5.0",
         "moment": "2.29.4",
         "node-appc": "1.1.6",
-        "node-titanium-sdk": "5.1.9",
+        "node-titanium-sdk": "6.0.0",
         "node-uuid": "1.4.8",
         "nodeify": "1.0.1",
         "p-limit": "3.1.0",
@@ -11923,9 +11923,9 @@
       "integrity": "sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w=="
     },
     "node_modules/node-titanium-sdk": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/node-titanium-sdk/-/node-titanium-sdk-5.1.9.tgz",
-      "integrity": "sha512-pIX1zji5Enwx7V3JW+mr/BZnBBbaa9UcrVmEj0L+Rp/w3v8YhsAnZrDlAj0/mQ6XkIl8pbjZsL4CQQ1XurlsWg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/node-titanium-sdk/-/node-titanium-sdk-6.0.0.tgz",
+      "integrity": "sha512-CQwGAD2ZRz7UgaISySLgr66miRgfZnXBsH7wQTj1Awf4fBZxUuTXImksWdBYxAeX89kZO7SbSn6Xv9wIQE5f4w==",
       "dependencies": {
         "@babel/core": "7.11.6",
         "@babel/parser": "7.11.5",
@@ -11943,7 +11943,7 @@
         "xmldom": "0.6.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=16"
       }
     },
     "node_modules/node-titanium-sdk/node_modules/@babel/parser": {
@@ -25815,9 +25815,9 @@
       "integrity": "sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w=="
     },
     "node-titanium-sdk": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/node-titanium-sdk/-/node-titanium-sdk-5.1.9.tgz",
-      "integrity": "sha512-pIX1zji5Enwx7V3JW+mr/BZnBBbaa9UcrVmEj0L+Rp/w3v8YhsAnZrDlAj0/mQ6XkIl8pbjZsL4CQQ1XurlsWg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/node-titanium-sdk/-/node-titanium-sdk-6.0.0.tgz",
+      "integrity": "sha512-CQwGAD2ZRz7UgaISySLgr66miRgfZnXBsH7wQTj1Awf4fBZxUuTXImksWdBYxAeX89kZO7SbSn6Xv9wIQE5f4w==",
       "requires": {
         "@babel/core": "7.11.6",
         "@babel/parser": "7.11.5",

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "markdown": "0.5.0",
     "moment": "2.29.4",
     "node-appc": "1.1.6",
-    "node-titanium-sdk": "5.1.9",
+    "node-titanium-sdk": "6.0.0",
     "node-uuid": "1.4.8",
     "nodeify": "1.0.1",
     "p-limit": "3.1.0",


### PR DESCRIPTION
https://github.com/tidev/node-titanium-sdk/releases/tag/v6.0.0
```
chore: use platform for id by @m1ga in https://github.com/tidev/node-titanium-sdk/pull/655
chore(all): update template, update tests by @m1ga in https://github.com/tidev/node-titanium-sdk/pull/653
fix: arm mac emulator fix by @m1ga in https://github.com/tidev/node-titanium-sdk/pull/652
Update cla.yaml by @cb1kenobi in https://github.com/tidev/node-titanium-sdk/pull/656
```

After that we can merge: https://github.com/tidev/titanium-sdk/pull/14017 so we can use `platform` for the `<id>`