### PR TITLE
feat(android): defaultLang option in tiapp.xml

### DIFF
--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -3206,7 +3206,7 @@ AndroidBuilder.prototype.generateI18N = async function generateI18N() {
 		root.appendChild(dom.createTextNode('\n'));
 
 		// Create the XML file under the Android "res/values-<locale>" folder.
-		const defaultLang = this.tiapp.defaultLang ? this.tiapp.defaultLang : 'en';
+		const defaultLang = this.tiapp.defaultLang || 'en';
 		const localeSuffixName = (locale === defaultLang ? '' : '-' + resolveRegionName(locale));
 		const dirPath = path.join(this.buildAppMainResDir, `values${localeSuffixName}`);
 		const filePath = path.join(dirPath, 'ti_i18n_strings.xml');

--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -3206,7 +3206,8 @@ AndroidBuilder.prototype.generateI18N = async function generateI18N() {
 		root.appendChild(dom.createTextNode('\n'));
 
 		// Create the XML file under the Android "res/values-<locale>" folder.
-		const localeSuffixName = (locale === 'en' ? '' : '-' + resolveRegionName(locale));
+		const defaultLang = this.tiapp.defaultLang ? this.tiapp.defaultLang : 'en';
+		const localeSuffixName = (locale === defaultLang ? '' : '-' + resolveRegionName(locale));
 		const dirPath = path.join(this.buildAppMainResDir, `values${localeSuffixName}`);
 		const filePath = path.join(dirPath, 'ti_i18n_strings.xml');
 		this.logger.debug(__('Writing %s strings => %s', locale.cyan, filePath.cyan));


### PR DESCRIPTION
Currently when you create an app that only uses one language that isn't EN it won't create the correct string structure. In the build file EN is set to always be the default language.

This PR will allow you to set `<defaultLang>de</defaultLang>` inside the tiapp.xml file so it will use a different language as the default file. If it is not set it will still use `en` 

**Test:**
* download: [demo.zip](https://github.com/tidev/titanium-sdk/files/15169498/demo.zip)
* run it
* it will show "test" in the logs (which is the name, not the translated string)
* uncomment the `<defaultLang>de</defaultLang>` setting in tiapp.xml
* run again
* it will show "testDE"

Note: only tested and added it to Android as iOS already has a plist entry for default lang.

