### PR TITLE
feat(android): indent log correctly

### DIFF
--- a/android/cli/hooks/run.js
+++ b/android/cli/hooks/run.js
@@ -254,10 +254,10 @@ exports.init = function (logger, config, cli) {
 
 						// start of a new log message
 						if (device.appPidRegExp.test(line)) {
-							line = line.trim().replace(device.appPidRegExp, ':');
+							line = line.replace(/^ {1,2}/, '').replace(device.appPidRegExp, ':');
 							logLevel = line.charAt(0).toLowerCase();
 							if (tiapiRegExp.test(line)) {
-								line = line.replace(tiapiRegExp, '').trim();
+								line = line.replace(tiapiRegExp, '').replace(/^ {1,2}/, '');
 							} else {
 								line = line.replace(/^\w\/(\w+)\s*:/g, '$1:').grey;
 							}


### PR DESCRIPTION
Remove the trim() from the logout put to keep e.g. JSON indentation. 

```
console.log("#TEST#");
console.log([{"foo":"bar", "test": 1}]);
console.log(JSON.stringify([{"foo":"bar", "test": 1}]));
console.log(JSON.stringify([{"foo":"bar", "test": 1}], null, 2));
```

output with the PR:
```
[INFO]  #TEST#
[INFO]  [ { foo: 'bar', test: 1 } ]
[INFO]  [{"foo":"bar","test":1}]
[INFO]  [
[INFO]   {
[INFO]     "foo": "bar",
[INFO]     "test": 1
[INFO]   }
[INFO]  ]
```

output before:
```
[INFO]  #TEST#
[INFO]  [ { foo: 'bar', test: 1 } ]
[INFO]  [{"foo":"bar","test":1}]
[INFO]  [
[INFO]  {
[INFO]  "foo": "bar",
[INFO]  "test": 1
[INFO]  }
[INFO]  ]

```