### PR TITLE
feat(android): hide scrollbars in WebView

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/WebViewProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/WebViewProxy.java
@@ -54,7 +54,8 @@ import ti.modules.titanium.ui.widget.webview.TiUIWebView;
 		TiC.PROPERTY_OVER_SCROLL_MODE,
 		TiC.PROPERTY_CACHE_MODE,
 		TiC.PROPERTY_LIGHT_TOUCH_ENABLED,
-		TiC.PROPERTY_ON_LINK
+		TiC.PROPERTY_ON_LINK,
+		TiC.PROPERTY_SCROLLBARS
 })
 public class WebViewProxy extends ViewProxy implements Handler.Callback, OnLifecycleEvent, interceptOnBackPressedEvent
 {

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/android/AndroidModule.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/android/AndroidModule.java
@@ -253,6 +253,15 @@ public class AndroidModule extends KrollModule
 	@Kroll.constant
 	public static final int SCROLL_FLAG_SNAP_MARGINS = 32;
 
+	@Kroll.constant
+	public static final int WEBVIEW_SCROLLBARS_DEFAULT = 0;
+	@Kroll.constant
+	public static final int WEBVIEW_SCROLLBARS_HIDE_VERTICAL = 1;
+	@Kroll.constant
+	public static final int WEBVIEW_SCROLLBARS_HIDE_HORIZONTAL = 2;
+	@Kroll.constant
+	public static final int WEBVIEW_SCROLLBARS_HIDE_ALL = 3;
+
 	public AndroidModule()
 	{
 		super();

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
@@ -456,6 +456,14 @@ public class TiUIWebView extends TiUIView
 		if (d.containsKey(TiC.PROPERTY_ZOOM_LEVEL)) {
 			zoomBy(getWebView(), TiConvert.toFloat(d, TiC.PROPERTY_ZOOM_LEVEL));
 		}
+
+		if (d.containsKey(TiC.PROPERTY_SCROLLBARS)) {
+			int scrollbarValue = TiConvert.toInt(d, TiC.PROPERTY_SCROLLBARS);
+			webView.setVerticalScrollBarEnabled(scrollbarValue == AndroidModule.WEBVIEW_SCROLLBARS_DEFAULT
+				|| scrollbarValue == AndroidModule.WEBVIEW_SCROLLBARS_HIDE_HORIZONTAL);
+			webView.setHorizontalScrollBarEnabled(scrollbarValue == AndroidModule.WEBVIEW_SCROLLBARS_DEFAULT
+				|| scrollbarValue == AndroidModule.WEBVIEW_SCROLLBARS_HIDE_VERTICAL);
+		}
 	}
 
 	@Override
@@ -496,6 +504,12 @@ public class TiUIWebView extends TiUIView
 			zoomBy(webView, TiConvert.toFloat(newValue, 1.0f));
 		} else if (TiC.PROPERTY_USER_AGENT.equals(key)) {
 			((WebViewProxy) getProxy()).setUserAgent(TiConvert.toString(newValue));
+		} else if (TiC.PROPERTY_SCROLLBARS.equals(key)) {
+			int scrollbarValue = TiConvert.toInt(newValue);
+			webView.setVerticalScrollBarEnabled(scrollbarValue == AndroidModule.WEBVIEW_SCROLLBARS_DEFAULT
+				|| scrollbarValue == AndroidModule.WEBVIEW_SCROLLBARS_HIDE_HORIZONTAL);
+			webView.setHorizontalScrollBarEnabled(scrollbarValue == AndroidModule.WEBVIEW_SCROLLBARS_DEFAULT
+				|| scrollbarValue == AndroidModule.WEBVIEW_SCROLLBARS_HIDE_VERTICAL);
 		} else {
 			super.propertyChanged(key, oldValue, newValue, proxy);
 		}

--- a/android/titanium/src/java/org/appcelerator/titanium/TiC.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiC.java
@@ -689,6 +689,7 @@ public class TiC
 	public static final String PROPERTY_SCROLL_ENABLED = "scrollEnabled";
 	public static final String PROPERTY_SCROLL_TYPE = "scrollType";
 	public static final String PROPERTY_SCROLLABLE = "scrollable";
+	public static final String PROPERTY_SCROLLBARS = "scrollbars";
 	public static final String PROPERTY_SEARCH = "search";
 	public static final String PROPERTY_SEARCH_AS_CHILD = "searchAsChild";
 	public static final String PROPERTY_SEARCH_TEXT = "searchText";

--- a/apidoc/Titanium/UI/Android/Android.yml
+++ b/apidoc/Titanium/UI/Android/Android.yml
@@ -957,6 +957,34 @@ properties:
     platforms: [android]
     since: "12.1.0"
 
+  - name: WEBVIEW_SCROLLBARS_DEFAULT
+    summary: Show horizontal and vertical scrollbar in a Ti.UI.WebView.
+    type: Number
+    permission: read-only
+    platforms: [android]
+    since: "12.3.0"
+
+  - name: WEBVIEW_SCROLLBARS_HIDE_VERTICAL
+    summary: Hide vertical scrollbar in a Ti.UI.WebView.
+    type: Number
+    permission: read-only
+    platforms: [android]
+    since: "12.3.0"
+
+  - name: WEBVIEW_SCROLLBARS_HIDE_HORIZONTAL
+    summary: Hide horizontal scrollbar in a Ti.UI.WebView.
+    type: Number
+    permission: read-only
+    platforms: [android]
+    since: "12.3.0"
+
+  - name: WEBVIEW_SCROLLBARS_HIDE_ALL
+    summary: Hide all scrollbars in a Ti.UI.WebView.
+    type: Number
+    permission: read-only
+    platforms: [android]
+    since: "12.3.0"
+
 examples:
   - title: Android Preferences Example
     example: |

--- a/apidoc/Titanium/UI/WebView.yml
+++ b/apidoc/Titanium/UI/WebView.yml
@@ -1130,6 +1130,14 @@ properties:
     platforms: [android, iphone, ipad, macos]
     since: {android: "7.3.0", iphone: "7.3.0", ipad: "7.3.0", macos: "9.2.0"}
 
+  - name: scrollbars
+    summary: Enable or disable horizontal/vertical scrollbars in a WebView.
+    type: Number
+    constants: Titanium.UI.Android.WEBVIEW_SCROLLBARS_*
+    platforms: [android]
+    since: "12.3.0"
+    default: <Titanium.UI.Android.WEBVIEW_SCROLLBARS_DEFAULT>
+
   - name: allowsBackForwardNavigationGestures
     summary: |
         A Boolean value indicating whether horizontal swipe gestures will trigger back-forward list navigations.


### PR DESCRIPTION
Android WebView allows you to hide the horizontal/vertical scrollbar but still keeping it scrollable.

**Test:**

```js
var html = '<!DOCTYPE html><html><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1"></head><body>';
html += "<div style='height:400px;width:400px;background-color:black'></div>";
html += "</body></html>";
var win = Ti.UI.createWindow({
	layout: "vertical"
})

var text = ["default", "hide vertical", "hide horizontal", "hide all"];
for (var i = 0; i <= 3; ++i) {
	var lbl = Ti.UI.createLabel({
		text: text[i]
	});
	win.add(lbl);
	var www = Ti.UI.createWebView({
		html: html,
		height: 140,
		width: 300,
		scrollbars: i,
		enableZoomControls: false,
		bottom: 5
	})
	win.add(www);
}
win.open();

console.log(Ti.UI.Android.WEBVIEW_SCROLLBARS_DEFAULT)
console.log(Ti.UI.Android.WEBVIEW_SCROLLBARS_HIDE_VERTICAL)
console.log(Ti.UI.Android.WEBVIEW_SCROLLBARS_HIDE_HORIZONTAL)
console.log(Ti.UI.Android.WEBVIEW_SCROLLBARS_HIDE_ALL)
```

Run the code and scroll the black div in the webview.

https://github.com/tidev/titanium-sdk/assets/4334997/c47ab8d4-0bb2-4a0b-a78a-dd13e006f967

