### PR TITLE
chore(android): filter out logs in production build

### DIFF
--- a/common/Resources/ti.internal/extensions/js/console.js
+++ b/common/Resources/ti.internal/extensions/js/console.js
@@ -75,6 +75,11 @@ class Console {
 	}
 
 	_writeToConsole(level, string) {
+		// filter out console logs in production apps
+		if (Ti.App.deployType === 'production') {
+			return;
+		}
+
 		if (this._groupIndent.length !== 0) {
 			if (string.includes('\n')) {
 				string = string.replace(/\n/g, `\n${this._groupIndent}`);


### PR DESCRIPTION
Currently `console.log()`, `console.warn()` and `console.error()` are displayed in production builds. This PR will remove that.

```js
Ti.API.info("#### api info")
Ti.API.warn("#### api warn")
Ti.API.error("#### api error")

console.log("#### console log")
console.warn("#### console warn")
console.error("#### console error")
```

**Test**
* run the code above in a dev/device build and you see all the log
* build for production and install the APK
* run `adb logcat | grep -i "####"` to get all the logs


**Todo**
Still searching for the Ti.API.info stuff. That shouldn't be there either! I thought it was already blocked in the past