### PR TITLE
docs: improve the ScrollableView clipView description

### DIFF
--- a/apidoc/Titanium/UI/ScrollableView.yml
+++ b/apidoc/Titanium/UI/ScrollableView.yml
@@ -389,7 +389,10 @@ properties:
     description: |
         Set to `false` to allow the previous or next pages to be seen. Note that
         ScrollableView's [width](Titanium.UI.ScrollableView.width) must be smaller than its parent
-        view in order to make this property effective.
+        view in order to make this property effective on iOS.
+        For Android you have to set the [padding](Titanium.UI.ScrollableView.padding) property.
+
+        Check the `Scrollable View with multiple visible views` example for both platforms.
     type: Boolean
     availability: creation
     default: true


### PR DESCRIPTION
Improve the description of `clipView`: 
* Android uses the `padding` property while iOS uses the `width`. 
* added a note that there is an example 