### PR TITLE
feat(ios): add overrideUserInterfaceStyle to Picker

### DIFF
--- a/apidoc/Titanium/UI/Picker.yml
+++ b/apidoc/Titanium/UI/Picker.yml
@@ -282,6 +282,21 @@ properties:
     since: "5.2.0"
     default: "black"
 
+  - name: overrideUserInterfaceStyle
+    summary: Forces the picker to used assigned theme instead of the system theme.
+    description: |
+        When set to [USER_INTERFACE_STYLE_DARK](Titanium.UI.USER_INTERFACE_STYLE_DARK) or
+        [USER_INTERFACE_STYLE_LIGHT](Titanium.UI.USER_INTERFACE_STYLE_LIGHT), the picker will ignore
+        the system's current theme and use the theme assigned to this property instead.
+
+        When set to [USER_INTERFACE_STYLE_UNSPECIFIED](Titanium.UI.USER_INTERFACE_STYLE_UNSPECIFIED),
+        the picker will use the system's current theme.
+    type: Number
+    default: Titanium.UI.USER_INTERFACE_STYLE_UNSPECIFIED
+    constants: Titanium.UI.USER_INTERFACE_STYLE_*
+    osver: {ios: {min: "13.0"}}
+    since: "12.4.0"
+
   - name: format24
     summary: |
         Determines whether the Time pickers display in 24-hour or 12-hour clock format.

--- a/iphone/Classes/TiUIPicker.m
+++ b/iphone/Classes/TiUIPicker.m
@@ -225,6 +225,15 @@ USE_PROXY_FOR_VERIFY_AUTORESIZING
   }
 }
 
+- (void)setOverrideUserInterfaceStyle_:(id)args
+{
+  ENSURE_SINGLE_ARG(args, NSNumber);
+  if (picker != nil) {
+    int style = [TiUtils intValue:args def:UIUserInterfaceStyleUnspecified];
+    ((UIDatePicker *)[self picker]).overrideUserInterfaceStyle = style;
+  }
+}
+
 - (void)setDateTimeColor_:(id)value
 {
   // Guard date picker and iOS 14+ date picker style


### PR DESCRIPTION
The compact UI picker doesn't allow the user to set a text color. If you use your phone in light mode but have a dark background it will look like this:

![Simulator Screenshot - iPhone 15 Pro Max - 2024-05-18 at 15 52 51](https://github.com/tidev/titanium-sdk/assets/4334997/1306d2aa-572d-47a0-aae8-422fe899e35f)

This PR will allow you to switch the `overrideUserInterfaceStyle` for the Picker. I took most of the code/docs from the app `overrideUserInterfaceStyle` and modified it to use the picker instead of the whole app.

That way you can at least set the text color to white!

**Test**

```js
var win = Ti.UI.createWindow({backgroundColor:"black"});

var picker = Ti.UI.createPicker({
  type:Ti.UI.DATE_PICKER_STYLE_COMPACT,
  minDate:new Date(2009,0,1),
  maxDate:new Date(2014,11,31),
  value:new Date(2014,3,12),
  backgroundColor:"transparent"
});
var btn = Ti.UI.createButton({
  title:"toggle", bottom: 40
});
var isLight = true;
btn.addEventListener("click", function(e){
  picker.overrideUserInterfaceStyle = isLight ? Titanium.UI.USER_INTERFACE_STYLE_DARK:Titanium.UI.USER_INTERFACE_STYLE_LIGHT;
  isLight = !isLight;
})
win.add([picker,btn]);
win.open();
```

* Run app in light mode
* click the toggle button to switch between the styles.

![Simulator Screenshot - iPhone 15 Pro Max - 2024-05-18 at 15 56 22](https://github.com/tidev/titanium-sdk/assets/4334997/45261b02-df71-4959-8888-f043c378ca4d)
