### PR TITLE
fix(android): fix Actionbar backgroundImage doc and improve setter

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/ActionBarProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/ActionBarProxy.java
@@ -15,6 +15,7 @@ import org.appcelerator.kroll.common.Log;
 import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.util.TiConvert;
 import org.appcelerator.titanium.util.TiUIHelper;
+import org.appcelerator.titanium.view.TiDrawableReference;
 
 @SuppressWarnings("deprecation")
 @Kroll.proxy(propertyAccessors = { TiC.PROPERTY_ON_HOME_ICON_ITEM_SELECTED, TiC.PROPERTY_CUSTOM_VIEW })
@@ -102,6 +103,17 @@ public class ActionBarProxy extends KrollProxy
 			actionBar.setDisplayShowTitleEnabled(showTitleEnabled);
 
 			actionBar.setBackgroundDrawable(backgroundImage);
+		} else {
+			// fallback check with TiDrawableReference
+			TiDrawableReference source = TiDrawableReference.fromUrl(this, url);
+			if (source.getDrawable() != null) {
+				actionBar.setDisplayShowTitleEnabled(!showTitleEnabled);
+				actionBar.setDisplayShowTitleEnabled(showTitleEnabled);
+				actionBar.setBackgroundDrawable(source.getDrawable());
+			} else {
+				// fail - show error
+				Log.e(TAG, "Image " + url + " not found");
+			}
 		}
 	}
 

--- a/apidoc/Titanium/Android/ActionBar.yml
+++ b/apidoc/Titanium/Android/ActionBar.yml
@@ -55,6 +55,15 @@ examples:
         </Alloy>
         ```
 
+
+        `app/controllers/index.js`:
+        ```
+        function doMenuClick() {}
+        function openSettings() {}
+        function doSearch() {}
+        $.index.open();
+        ```
+
         `app/styles/index.tss`:
         ```
         "MenuItem": {
@@ -85,7 +94,7 @@ examples:
             win.activity.onCreate = () => {
                 const actionBar = win.activity.actionBar;
                 if (actionBar) {
-                    actionBar.backgroundImage = "/bg.png";
+                    actionBar.backgroundImage = Ti.Filesystem.getFile(Ti.Filesystem.resourcesDirectory, 'bg.png').nativePath;
                     actionBar.title = "New Title";
                     actionBar.onHomeIconItemSelected = () => {
                         Ti.API.info("Home icon clicked!");


### PR DESCRIPTION
The current ActionBar "backgroundImage" example: https://titaniumsdk.com/api/titanium/android/actionbar.html#action-bar-example says you can use `"/bg.png"` as a backgroundImage. That calls a function that will check for the String "Resources" in the path: https://github.com/tidev/titanium-sdk/blob/master/android/titanium/src/java/org/appcelerator/titanium/util/TiUIHelper.java#L983-L986 which is not the case.

The current **workaround** is to use `Ti.Filesystem.getFile(Ti.Filesystem.resourcesDirectory, 'bg.png').nativePath;` instead so I've added that in the classic example.

_BUT_ I also made a change in the ActionBar so it will use images with just the image path as a string.

**Changes:**
* at first it tries to use existing drawable code
* if that fails it tries the new TiDrawableReference code (works with just the image file/path)
* if both fail it will show an "image not found" error (new too)

**Changes in the docs:**
* show that you can use the resources folder
* add the missing index.js controller for the Alloy example

**Test**
```js
const win = Ti.UI.createWindow({
	title: "Old Title",
	navBarHidden: false
});
if (OS_ANDROID) {
	win.activity.onCreate = () => {
		const actionBar = win.activity.actionBar;
		if (actionBar) {
			// actionBar.backgroundImage = Ti.Filesystem.getFile(Ti.Filesystem.resourcesDirectory, '/images/bg_intro.jpg').nativePath;
			actionBar.backgroundImage = '/images/bg_intro.jpg';
			actionBar.title = "New Title";
			actionBar.onHomeIconItemSelected = () => {
				Ti.API.info("Home icon clicked!");
			};
		}
	};
}
win.open();
```

* use `actionBar.backgroundImage = Ti.Filesystem.getFile(Ti.Filesystem.resourcesDirectory, '/images/bg_intro.jpg').nativePath;` (will work with 12.3.0.GA too)
* use `actionBar.backgroundImage = '/images/bg_intro.jpg';` (will only work with this PR)
* change it to a none existing image to see the error message