### PR TITLE
feat(android): expose contentOffset getter in TableView/ListView

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TableViewProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TableViewProxy.java
@@ -414,7 +414,7 @@ public class TableViewProxy extends RecyclerViewProxy
 		return "Ti.UI.TableView";
 	}
 
-	// NOTE: For internal use only.
+	@Kroll.getProperty
 	public KrollDict getContentOffset()
 	{
 		final TiTableView tableView = getTableView();

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/ListViewProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/ListViewProxy.java
@@ -450,7 +450,7 @@ public class ListViewProxy extends RecyclerViewProxy
 		}
 	}
 
-	// NOTE: For internal use only.
+	@Kroll.getProperty
 	public KrollDict getContentOffset()
 	{
 		final TiListView listView = getListView();

--- a/apidoc/Titanium/UI/ListView.yml
+++ b/apidoc/Titanium/UI/ListView.yml
@@ -684,6 +684,12 @@ properties:
         ipad: 3.2.0
     platforms: [android, iphone, ipad, macos]
 
+  - name: contentOffset
+    summary: X and Y coordinates to which to reposition the top-left point of the content region.
+    type: Point
+    since: {android: "12.4.0"}
+    platforms: [android]
+
   - name: disableBounce
     summary: Determines whether the scroll-bounce of the list view should be disabled.
     description: |

--- a/apidoc/Titanium/UI/TableView.yml
+++ b/apidoc/Titanium/UI/TableView.yml
@@ -1073,6 +1073,12 @@ properties:
     type: [String, Titanium.UI.Color]
     default: transparent on non-iOS platforms, white on the iOS platform
 
+  - name: contentOffset
+    summary: X and Y coordinates to which to reposition the top-left point of the content region.
+    type: Point
+    since: {android: "12.4.0"}
+    platforms: [android]
+
   - name: data
     summary: Rows of the table view.
     type: [Array<Titanium.UI.TableViewRow>, Array<Titanium.UI.TableViewSection>]


### PR DESCRIPTION
Method was already but not exposed as a getter.

```js
const win = Ti.UI.createWindow();

var tableData = [];
for (var i = 0; i < 100; ++i) {
	tableData.push({
		title: "id" + i
	})
}

const tbl = Ti.UI.createTableView({
	data: tableData
});
win.add(tbl)
win.open();

win.addEventListener("open", function() {
	console.log(tbl.contentOffset);

	tbl.setContentOffset({
		x: 0,
		y: 200
	}, {
		animated: false
	})

	setTimeout(function() {
		console.log(tbl.contentOffset);
	}, 500)
})
```

ListView
```js
var win = Ti.UI.createWindow({backgroundColor: 'gray'});
var listView = Ti.UI.createListView();
var sections = [];

var fruitDataSet = []
for (var i=0;i<100;++i){
	fruitDataSet.push({properties: { title: 'Apple'}})
}
var fruitSection = Ti.UI.createListSection({ headerTitle: 'Fruits', items: fruitDataSet});
sections.push(fruitSection);

listView.sections = sections;
win.add(listView);
win.open();

win.addEventListener("open", function() {
	console.log(listView.contentOffset);

	listView.setContentOffset({
		x: 0,
		y: 200
	}, {
		animated: false
	})

	setTimeout(function() {
		console.log(listView.contentOffset);
	}, 500)
})
```