### PR TITLE
feat: add swipe actions support for Ti.UI.TableView

### DIFF
--- a/apidoc/Titanium/UI/ListItem.yml
+++ b/apidoc/Titanium/UI/ListItem.yml
@@ -674,12 +674,21 @@ properties:
 
 ---
 name: RowActionType
-summary: Represents the custom edit action for a ListItem.
+summary: Represents the custom edit action for a ListItem or TableViewRow.
 description: |
-    By default when a listItem has [canEdit](Titanium.UI.ListItem.canEdit) set to true, a left swipe on the the row presens the 'Delete' button.
+    *List Views*:
+    By default when a ListItem has [canEdit](Titanium.UI.ListItem.canEdit) set to `true`, a left swipe on the the row presens the localized 'Delete' button.
     This object lets developers define custom titles for editing actions supported on the row.
     This object is used in conjunction with the [editActions](Titanium.UI.ListItem.editActions) property and
     [editaction](Titanium.UI.ListView.editaction) event.
+    
+    *Table Views*:
+    By default when a TableViewRow has [editable](Titanium.UI.TableViewRow.editable) set to `true`, a left swipe on the the row presens the localized 'Delete' button.
+    This object lets developers define custom titles for editing actions supported on the row.
+    This object is used in conjunction with the [editActions](Titanium.UI.TableViewRow.editActions) property and
+    [editaction](Titanium.UI.TableView.editaction) event.
+    
+    Note: For table views, this property was added in Titanium SDK 12.3.0.
 platforms: [ipad, iphone, macos]
 since: '4.1.0'
 properties:

--- a/apidoc/Titanium/UI/ListItem.yml
+++ b/apidoc/Titanium/UI/ListItem.yml
@@ -676,6 +676,11 @@ properties:
 name: RowActionType
 summary: Represents the custom edit action for a ListItem or TableViewRow.
 description: |
+    Edit actions can be used to add contextual buttons to your list items / table view rows. The configuration of
+    this API is the same for list items (if you use <Titanium.UI.ListView>) and table view rows (if you use <Titanium.UI.TableView).
+
+    But please note that the trigger to activate these edit actions can defer based on the API you're integrating the edit actions:
+
     *List Views*:
     By default when a ListItem has [canEdit](Titanium.UI.ListItem.canEdit) set to `true`, a left swipe on the the row presens the localized 'Delete' button.
     This object lets developers define custom titles for editing actions supported on the row.
@@ -686,9 +691,10 @@ description: |
     By default when a TableViewRow has [editable](Titanium.UI.TableViewRow.editable) set to `true`, a left swipe on the the row presens the localized 'Delete' button.
     This object lets developers define custom titles for editing actions supported on the row.
     This object is used in conjunction with the [editActions](Titanium.UI.TableViewRow.editActions) property and
-    [editaction](Titanium.UI.TableView.editaction) event.
+    [editaction](Titanium.UI.TableView.editaction) event. For table views, this property was added in Titanium SDK 12.4.0.
     
-    Note: For table views, this property was added in Titanium SDK 12.3.0.
+    In addition, the new property "state" was added in 12.4.0 and can either equal "leading" or "trailing" to show them on a right swipe (leading)
+    or left swipe (trailing). If the "state" property is not set, it defaults to "trailing" for backwards compatibility.
 platforms: [ipad, iphone, macos]
 since: '4.1.0'
 properties:
@@ -727,4 +733,14 @@ properties:
         Note: When using this property, the `title` property is ignored.
     optional: true
     since: 12.1.0
+    platforms: [iphone, ipad, macos]
+
+  - name: state
+    type: String
+    summary: The state to show this edit action. Either "trailing" (default) or "leading".
+    description: |
+        In a LTR layout (e.g English, German), the "leading" state is the left area of the screen and the "trailing" state in the right.
+        In a RTL layout (e.g. Hebrew, Arabic), the "leading" state is the right area of the screen and the "trailing" state in the left.
+    optional: true
+    since: 12.4.0
     platforms: [iphone, ipad, macos]

--- a/apidoc/Titanium/UI/TableView.yml
+++ b/apidoc/Titanium/UI/TableView.yml
@@ -695,6 +695,40 @@ events:
         type: Boolean
     since: '3.0.0'
 
+  - name: editaction
+    summary: Fired when the user interacts with one of the custom edit actions defined by <Titanium.UI.TableViewRow.editActions>.
+    description: |
+        Do not rely on the `source` property to determine which item fired the event.  Use the
+        `row` and `section`, or the `index` to determine the table row that generated
+        the event.
+
+        Note that the `index` property of this event correspond to the list view state
+        before the user action.
+    platforms: [iphone, ipad, macos]
+    since: 12.4.0
+    properties:
+      - name: action
+        summary: The [title](RowActionType.title) as defined in the row action object.
+        type: String
+
+      - name: identifier
+        summary: |
+            The [identifier](RowActionType. identifier) of the row action. Only included in the event
+            if previously defined.
+        type: String
+
+      - name: row
+        summary: The row that fired this event.
+        type: [Titanium.UI.TableViewRow, Dictionary<Titanium.UI.TableViewRow>]
+
+      - name: section
+        summary: The section that fired this event.
+        type: Titanium.UI.TableViewSection
+
+      - name: index
+        summary: The index of the row that fired this event.
+        type: Number
+
 methods:
   - name: appendRow
     summary: Appends a single row or an array of rows to the end of the table.

--- a/apidoc/Titanium/UI/TableViewRow.yml
+++ b/apidoc/Titanium/UI/TableViewRow.yml
@@ -226,6 +226,14 @@ properties:
     platforms: [android, iphone, ipad, macos]
     since: {android: "9.3.0", iphone: "3.2.0", ipad: "3.2.0", macos: "9.2.0"}
 
+  - name: editActions
+    summary: Specifies custom action items to be shown when when a list item is edited.
+    description: |
+        For more information see the "Editing Support" section of <Titanium.UI.TableView>.
+    type: Array<RowActionType>
+    since: 12.4.0
+    platforms: [iphone, ipad, macos]
+
   - name: filterAlwaysInclude
     summary: |
       This row will always be visible when you filter your content.

--- a/iphone/Classes/TiUIListView.m
+++ b/iphone/Classes/TiUIListView.m
@@ -1146,23 +1146,49 @@ static TiViewProxy *FindViewProxyWithBindIdContainingPoint(UIView *view, CGPoint
   return [session canLoadObjectsOfClass:[NSString class]];
 }
 
-- (NSArray *)editActionsFromValue:(id)value
+- (UISwipeActionsConfiguration *)tableView:(UITableView *)tableView leadingSwipeActionsConfigurationForRowAtIndexPath:(NSIndexPath *)indexPath
 {
-  ENSURE_ARRAY(value);
-  NSArray *propArray = (NSArray *)value;
-  NSMutableArray *returnArray = nil;
+  return [self swipeConfigurationForState:@"leading" withIndexPath:indexPath isDefault:NO];
+}
 
-  for (id prop in propArray) {
-    ENSURE_DICT(prop);
+- (UISwipeActionsConfiguration *)tableView:(UITableView *)tableView trailingSwipeActionsConfigurationForRowAtIndexPath:(NSIndexPath *)indexPath
+{
+  return [self swipeConfigurationForState:@"trailing" withIndexPath:indexPath isDefault:YES];
+}
+
+- (UISwipeActionsConfiguration *)swipeConfigurationForState:(NSString *)state withIndexPath:(NSIndexPath *)indexPath isDefault:(BOOL)isDefault
+{
+  NSIndexPath *realIndexPath = [self pathForSearchPath:indexPath];
+
+  if (![self canEditRowAtIndexPath:realIndexPath]) {
+    return nil;
+  }
+
+  id editActionProxies = [self valueWithKey:@"editActions" atIndexPath:realIndexPath];
+
+  if (IS_NULL_OR_NIL(editActionProxies)) {
+    return nil;
+  }
+
+  NSPredicate *predicate = [NSPredicate predicateWithFormat:isDefault ? @"state == nil OR state == %@" : @"state == %@", state];
+  NSArray<NSDictionary *> *editActions = [editActionProxies filteredArrayUsingPredicate:predicate];
+  NSMutableArray<UIContextualAction *> *nativeEditActions = [NSMutableArray arrayWithCapacity:editActions.count];
+
+  if (IS_NULL_OR_NIL(editActions) || editActions.count == 0) {
+    return nil;
+  }
+
+  for (id prop in editActions) {
     NSString *title = [TiUtils stringValue:@"title" properties:prop];
     NSString *identifier = [TiUtils stringValue:@"identifier" properties:prop];
-    int actionStyle = [TiUtils intValue:@"style" properties:prop def:UITableViewRowActionStyleDefault];
+    UIContextualActionStyle style = [TiUtils intValue:@"style" properties:prop def:UIContextualActionStyleNormal];
     TiColor *color = [TiUtils colorValue:@"color" properties:prop];
     id image = [prop objectForKey:@"image"];
 
-    UITableViewRowAction *theAction = [UITableViewRowAction rowActionWithStyle:actionStyle
+    UIContextualAction *action = [UIContextualAction contextualActionWithStyle:style
                                                                          title:title
-                                                                       handler:^(UITableViewRowAction *action, NSIndexPath *indexPath) {
+                                                                       handler:^(UIContextualAction *_Nonnull action, __kindof UIView *_Nonnull sourceView, void (^_Nonnull completionHandler)(BOOL)) {
+                                                                         completionHandler(YES);
                                                                          NSString *eventName = @"editaction";
 
                                                                          NSIndexPath *realIndexPath = [self pathForSearchPath:indexPath];
@@ -1192,27 +1218,22 @@ static TiViewProxy *FindViewProxyWithBindIdContainingPoint(UIView *view, CGPoint
                                                                          }
 
                                                                          // Hide editActions after selection
-                                                                         [[self tableView] setEditing:NO];
+                                                                         // [[self tableView] setEditing:NO];
                                                                        }];
-    if (color) {
-      theAction.backgroundColor = [color color];
+
+    if (color != nil) {
+      action.backgroundColor = color.color;
     }
-    if (image) {
+
+    if (image != nil) {
       NSURL *url = [TiUtils toURL:image proxy:(TiProxy *)self.proxy];
-      UIImage *nativeImage = [[ImageLoader sharedLoader] loadImmediateImage:url];
-      if (color) {
-        nativeImage = [self generateImage:nativeImage withBackgroundColor:[color color]];
-      }
-      theAction.backgroundColor = [UIColor colorWithPatternImage:nativeImage];
+      action.image = [[ImageLoader sharedLoader] loadImmediateImage:url];
     }
-    if (!returnArray) {
-      returnArray = [NSMutableArray arrayWithObject:theAction];
-    } else {
-      [returnArray addObject:theAction];
-    }
+
+    [nativeEditActions addObject:action];
   }
 
-  return returnArray;
+  return [UISwipeActionsConfiguration configurationWithActions:nativeEditActions];
 }
 
 - (UIImage *)generateImage:(UIImage *)image withBackgroundColor:(UIColor *)bgColor
@@ -1386,23 +1407,6 @@ static TiViewProxy *FindViewProxyWithBindIdContainingPoint(UIView *view, CGPoint
   }
 
   return UITableViewCellEditingStyleNone;
-}
-
-- (NSArray *)tableView:(UITableView *)tableView editActionsForRowAtIndexPath:(NSIndexPath *)indexPath
-{
-  NSIndexPath *realIndexPath = [self pathForSearchPath:indexPath];
-
-  if (![self canEditRowAtIndexPath:realIndexPath]) {
-    return nil;
-  }
-
-  id editValue = [self valueWithKey:@"editActions" atIndexPath:realIndexPath];
-
-  if (IS_NULL_OR_NIL(editValue)) {
-    return nil;
-  }
-
-  return [self editActionsFromValue:editValue];
 }
 
 - (BOOL)tableView:(UITableView *)tableView shouldIndentWhileEditingRowAtIndexPath:(NSIndexPath *)indexPath

--- a/iphone/Classes/TiUITableView.m
+++ b/iphone/Classes/TiUITableView.m
@@ -1653,7 +1653,7 @@
 - (void)setSeparatorInsets_:(id)arg
 {
   DEPRECATED_REPLACED(@"UI.TableView.separatorInsets", @"5.2.0", @"UI.TableView.tableSeparatorInsets")
-      [self setTableSeparatorInsets_:arg];
+  [self setTableSeparatorInsets_:arg];
 }
 
 - (void)setTableSeparatorInsets_:(id)arg

--- a/iphone/Classes/TiUIiOSProxy.h
+++ b/iphone/Classes/TiUIiOSProxy.h
@@ -67,7 +67,7 @@
 @property (nonatomic, readonly) NSNumber *CLIP_MODE_ENABLED;
 @property (nonatomic, readonly) NSNumber *CLIP_MODE_DISABLED;
 
-#ifdef USE_TI_UILISTVIEW
+#if defined(USE_TI_UILISTVIEW) || defined(USE_TI_UITABLEVIEW)
 @property (nonatomic, readonly) NSNumber *ROW_ACTION_STYLE_DEFAULT;
 @property (nonatomic, readonly) NSNumber *ROW_ACTION_STYLE_DESTRUCTIVE;
 @property (nonatomic, readonly) NSNumber *ROW_ACTION_STYLE_NORMAL;

--- a/iphone/Classes/TiUIiOSProxy.m
+++ b/iphone/Classes/TiUIiOSProxy.m
@@ -154,19 +154,10 @@
   return NUMINT(-1);
 }
 
-#ifdef USE_TI_UILISTVIEW
-- (NSNumber *)ROW_ACTION_STYLE_DEFAULT
-{
-  return @(UIContextualActionStyleNormal);
-}
-- (NSNumber *)ROW_ACTION_STYLE_DESTRUCTIVE
-{
-  return @(UIContextualActionStyleDestructive);
-}
-- (NSNumber *)ROW_ACTION_STYLE_NORMAL
-{
-  return @(UIContextualActionStyleNormal);
-}
+#if defined(USE_TI_UILISTVIEW) || defined(USE_TI_UITABLEVIEW)
+MAKE_SYSTEM_PROP(ROW_ACTION_STYLE_DEFAULT, UIContextualActionStyleNormal);
+MAKE_SYSTEM_PROP(ROW_ACTION_STYLE_DESTRUCTIVE, UIContextualActionStyleDestructive);
+MAKE_SYSTEM_PROP(ROW_ACTION_STYLE_NORMAL, UIContextualActionStyleNormal);
 #endif
 
 #ifdef USE_TI_UIPICKER


### PR DESCRIPTION
This PR adds support for swipe actions inside the `Ti.UI.TableView` component. It also refactors the old list view API for edit actions to use the new swipe actions API as well, which brings support for supporting both leading and trailing edit actions.

https://github.com/tidev/titanium-sdk/assets/10667698/b271c11e-5195-4172-bf6f-5a3cede0a0b7

Test Case:
```js
const win = Ti.UI.createWindow({ backgroundColor: 'white' });
const editActions = [ {
	identifier: 'approve',
	title: 'Approve',
	color: 'green',
	state: 'leading'
}, {
	identifier: 'edit',
	title: 'Edit',
	color: 'blue',
	state: 'trailing'
}, {
	identifier: 'insert',
	title: 'Insert',
	color: 'orange' // defaults to "trailing"
}, {
	identifier: 'delete',
	title: 'Delete',
	style: Ti.UI.iOS.ROW_ACTION_STYLE_DESTRUCTIVE,
	state: 'trailing'
} ];

const tableData = [
	{
		title: 'Apples'
	},
	{
		title: 'Bananas'
	},
	{
		editable: true, // used by table views
		canEdit: true, // used by list views
		title: 'Potatoes (swipe!)',
		editActions
	}
];

let selectedIndex = 0;
const [ table, list, tabs ] = [ createTable(), createList(), createTabs() ];

win.add([ table, list, tabs ]);
win.open();

function createTable() {
	const table = Ti.UI.createTableView({ top: 80, data: tableData });
	table.addEventListener('editaction', onEditActionSelected);

	return table;
}

function createList() {
	const listView = Ti.UI.createListView({
		visible: false,
		top: 80,
		sections: [ Ti.UI.createListSection({
			items: tableData.map(cell => ({ properties: cell }))
		}) ]
	});

	listView.addEventListener('editaction', onEditActionSelected);

	return listView;
}

function createTabs() {
	const tabs = Ti.UI.createTabbedBar({ labels: [ 'Table View', 'List View' ], index: selectedIndex, top: 55 });

	tabs.addEventListener('click', ({ index }) => {
		selectedIndex = index;

		if (index === 0) {
			list.visible = false;
			table.visible = true;
		} else {
			list.visible = true;
			table.visible = false;
		}
	});

	return tabs;
}

function onEditActionSelected(event) {
	console.warn(event);

	if (event.identifier === 'delete') {
		if (selectedIndex === 0) {
			table.deleteRow(event.row);
		} else {
			list.sections[0].deleteItemsAt(event.itemIndex, 1);
		}
	}
}
```