### PR TITLE
feat(android): optionBar color properties

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIOptionBar.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIOptionBar.java
@@ -215,13 +215,10 @@ public class TiUIOptionBar extends TiUIView
 				new int[][] {
 					new int[] { -android.R.attr.state_checked },
 					new int[] { android.R.attr.state_checked },
-					new int[] {}
-
 				},
 				new int[] {
 					oldColors.getColorForState(new int[] { -android.R.attr.state_checked }, R.attr.colorOnSurface),
-					col,
-					oldColors.getColorForState(new int[] { }, R.attr.colorOnSurface),
+					col
 				}
 			);
 			button.setBackgroundTintList(trackStates);
@@ -233,12 +230,10 @@ public class TiUIOptionBar extends TiUIView
 				new int[][] {
 					new int[] { -android.R.attr.state_checked },
 					new int[] { android.R.attr.state_checked },
-					new int[] {}
 				},
 				new int[] {
 					oldColors.getColorForState(new int[] { -android.R.attr.state_checked }, R.attr.colorOnSurface),
-					col,
-					oldColors.getColorForState(new int[] { }, R.attr.colorOnSurface),
+					col
 				}
 			);
 			button.setStrokeColor(trackStates);

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIOptionBar.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIOptionBar.java
@@ -7,6 +7,7 @@
 package ti.modules.titanium.ui.widget;
 
 import android.content.Context;
+import android.content.res.ColorStateList;
 import android.graphics.drawable.Drawable;
 import android.view.View;
 import android.view.ViewGroup;
@@ -207,6 +208,63 @@ public class TiUIOptionBar extends TiUIView
 		MaterialButton button = new MaterialButton(context, null, attributeId);
 		button.setEnabled(isEnabled);
 		button.setText(title);
+		if (proxy.hasPropertyAndNotNull(TiC.PROPERTY_SELECTED_BACKGROUND_COLOR)) {
+			ColorStateList oldColors = button.getBackgroundTintList();
+			int col = TiConvert.toColor((String) proxy.getProperty(TiC.PROPERTY_SELECTED_BACKGROUND_COLOR), context);
+			ColorStateList trackStates = new ColorStateList(
+				new int[][] {
+					new int[] { -android.R.attr.state_checked },
+					new int[] { android.R.attr.state_checked },
+					new int[] {}
+
+				},
+				new int[] {
+					oldColors.getColorForState(new int[] { -android.R.attr.state_checked }, R.attr.colorOnSurface),
+					col,
+					oldColors.getColorForState(new int[] { }, R.attr.colorOnSurface),
+				}
+			);
+			button.setBackgroundTintList(trackStates);
+		}
+		if (proxy.hasPropertyAndNotNull("selectedBorderColor")) {
+			ColorStateList oldColors = button.getStrokeColor();
+			int col = TiConvert.toColor((String) proxy.getProperty("selectedBorderColor"), context);
+			ColorStateList trackStates = new ColorStateList(
+				new int[][] {
+					new int[] { -android.R.attr.state_checked },
+					new int[] { android.R.attr.state_checked },
+					new int[] {}
+				},
+				new int[] {
+					oldColors.getColorForState(new int[] { -android.R.attr.state_checked }, R.attr.colorOnSurface),
+					col,
+					oldColors.getColorForState(new int[] { }, R.attr.colorOnSurface),
+				}
+			);
+			button.setStrokeColor(trackStates);
+		}
+		if (proxy.hasPropertyAndNotNull("selectedTextColor") || proxy.hasPropertyAndNotNull(TiC.PROPERTY_COLOR)) {
+			int textCol = button.getCurrentHintTextColor();
+			int selCol = button.getCurrentTextColor();
+
+			if (proxy.hasPropertyAndNotNull("selectedTextColor")) {
+				selCol = TiConvert.toColor((String) proxy.getProperty("selectedTextColor"), context);
+			}
+			if (proxy.hasPropertyAndNotNull(TiC.PROPERTY_COLOR)) {
+				textCol = TiConvert.toColor((String) proxy.getProperty(TiC.PROPERTY_COLOR), context);
+			}
+			ColorStateList trackStates = new ColorStateList(
+				new int[][] {
+					new int[] { -android.R.attr.state_checked },
+					new int[] { android.R.attr.state_checked },
+				},
+				new int[] {
+					textCol,
+					selCol,
+				}
+			);
+			button.setTextColor(trackStates);
+		}
 		if ((accessibilityLabel != null) && !accessibilityLabel.isEmpty()) {
 			button.setContentDescription(accessibilityLabel);
 		}

--- a/apidoc/Titanium/UI/OptionBar.yml
+++ b/apidoc/Titanium/UI/OptionBar.yml
@@ -60,6 +60,30 @@ properties:
     default: horizontal
     availability: creation
 
+  - name: selectedBackgroundColor
+    summary: Background color of the selected button
+    type: [String, Titanium.UI.Color]
+    platforms: [android]
+    since: { android: "12.4.0"}
+
+  - name: selectedTextColor
+    summary: Text color of the selected button
+    type: [String, Titanium.UI.Color]
+    platforms: [android]
+    since: { android: "12.4.0"}
+
+  - name: selectedBorderColor
+    summary: Border color of the selected button
+    type: [String, Titanium.UI.Color]
+    platforms: [android]
+    since: { android: "12.4.0"}
+
+  - name: color
+    summary: Text color of the unselected button
+    type: [String, Titanium.UI.Color]
+    platforms: [android]
+    since: { android: "12.4.0"}
+
 examples:
   - title: Text-Only Buttons
     example: |


### PR DESCRIPTION
If you want to change the colors in an OptionBar you'll have to use a theme. This PR adds new properties `selectectedBackgroundColor`, `selectedBorderColor`, `selectedTextColor` and maps the `color` to the inactive text colors.

![Screenshot_20240618-120614](https://github.com/tidev/titanium-sdk/assets/4334997/a9b935f3-16be-45f3-b75f-fb41b84f4f64)

```js
const win = Ti.UI.createWindow();

const optionBarDefault = Ti.UI.createOptionBar({
	top: 0,
  labels: [ 'Option 1', 'Option 2', 'Option 3' ]
});
const optionBar1 = Ti.UI.createOptionBar({
	top: 50,
	selectedBackgroundColor: "red",
	selectedBorderColor: "#fff",
	selectedTextColor: "blue",
	color: "yellow",
  labels: [ 'Option 1', 'Option 2', 'Option 3' ]
});
const optionBar2 = Ti.UI.createOptionBar({
	top: 100,
	color: "yellow",
  labels: [ 'Option 1', 'Option 2', 'Option 3' ]
});
const optionBar3 = Ti.UI.createOptionBar({
	top: 150,
	selectedTextColor: "blue",
  labels: [ 'Option 1', 'Option 2', 'Option 3' ]
});

win.add([optionBarDefault,optionBar1,optionBar2,optionBar3]);

win.open();
```
