### PR TITLE
chore: fix webpack command name issue

### DIFF
--- a/cli/hooks/webpack.js
+++ b/cli/hooks/webpack.js
@@ -35,6 +35,9 @@ exports.init = (logger, config, cli) => {
 	cli.on('cli:command-loaded', (hookData) => {
 		const command = hookData.command;
 		commandName = command.name;
+		if (typeof command.name === 'function') {
+			commandName = command.name();
+		}
 	});
 
 	cli.on('cli:post-validate', () => {


### PR DESCRIPTION
It looks like the webpack version of Ti is a bit outdated and not compatible with the latest node version.
I quickly tried to run it and the first issue was that it didn't find the connection.

Turns out `command.name` is a function now and I had to run `command.name()` to get the command name.


After that it will still fail with
```
[ERROR] PluginError: Failed to load plugin: Cannot find module 'node:util'
Require stack:
- /usr/local/lib/node_modules/@appcd/plugin-webpack/node_modules/@nuxt/core/node_modules/consola/dist/shared/consola.deac7d5a.cjs
    at Function._resolveFilename (internal/modules/cjs/loader.js:880:15)
    at PluginModule.require (/usr/local/lib/node_modules/appcd/node_modules/appcd-plugin/dist/plugin-module.js:139:22)
    at require (/usr/local/lib/node_modules/appcd/node_modules/appcd-plugin/dist/plugin-module.js:181:36)
    at Object.apply (/usr/local/lib/node_modules/@appcd/plugin-webpack/node_modules/@nuxt/core/node_modules/consola/dist/shared/consola.deac7d5a.cjs:4:19)
    at PluginModule._compile (/usr/local/lib/node_modules/appcd/node_modules/appcd-plugin/dist/plugin-module.js:196:19)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1092:10)
    at PluginModule.load (internal/modules/cjs/loader.js:928:32)
    at Function.load (/usr/local/lib/node_modules/appcd/node_modules/appcd-plugin/dist/plugin-module.js:71:11)
    at PluginModule.require (/usr/local/lib/node_modules/appcd/node_modules/appcd-plugin/dist/plugin-module.js:142:23)
    at require (/usr/local/lib/node_modules/appcd/node_modules/appcd-plugin/dist/plugin-module.js:181:36)

```
but that is not part of this PR as it is in `appcd`