### PR TITLE
fix(win): permission issues when building a module

### DIFF
--- a/cli/commands/build.js
+++ b/cli/commands/build.js
@@ -420,8 +420,13 @@ function patchLogger(logger, cli) {
 
 		fs.ensureDirSync(buildDir, 0o766);
 
-		// create our write stream
-		logger.log.filestream = fs.createWriteStream(path.join(buildDir, 'build_' + platform + '.log'), { flags: 'w', encoding: 'utf8', mode: 0o666 });
+		if (process.platform === 'win32' && cli.argv.type === 'module') {
+			// disable file logging for windows when building a module
+			logger.fileWriteEnabled = false;
+		} else {
+			// create our write stream
+			logger.log.filestream = fs.createWriteStream(path.join(buildDir, 'build_' + platform + '.log'), { flags: 'w', encoding: 'utf8', mode: 0o666 });
+		}
 
 		function styleHeading(s) {
 			return ('' + s).bold;


### PR DESCRIPTION
Fixes https://github.com/tidev/titanium-sdk/issues/14077

```
ti create -t module --id com.test -n test --android-code-base java -p android -d . && cd test/android && ti build -p android -b
```

will disable logging to file when you build a module on Windows. 
BTW: on Linux I don't even have the build_android.log file but it won't show a permission error.