### PR TITLE
fix(android): keep Tab tintColor when changing icons

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIBottomNavigationTabGroup.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIBottomNavigationTabGroup.java
@@ -498,6 +498,7 @@ public class TiUIBottomNavigationTabGroup extends TiUIAbstractTabGroup implement
 		if (tabProxy == null) {
 			return;
 		}
+
 		final Drawable drawable = TiUIHelper.getResourceDrawable(tabProxy.getProperty(TiC.PROPERTY_ICON));
 		this.mBottomNavigationView.getMenu().getItem(index).setIcon(drawable);
 		updateIconTint();

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIBottomNavigationTabGroup.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIBottomNavigationTabGroup.java
@@ -498,9 +498,9 @@ public class TiUIBottomNavigationTabGroup extends TiUIAbstractTabGroup implement
 		if (tabProxy == null) {
 			return;
 		}
-
 		final Drawable drawable = TiUIHelper.getResourceDrawable(tabProxy.getProperty(TiC.PROPERTY_ICON));
 		this.mBottomNavigationView.getMenu().getItem(index).setIcon(drawable);
+		updateIconTint();
 	}
 
 	@Override

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUITabLayoutTabGroup.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUITabLayoutTabGroup.java
@@ -361,6 +361,7 @@ public class TiUITabLayoutTabGroup extends TiUIAbstractTabGroup implements TabLa
 		TabLayout.Tab tab = this.mTabLayout.getTabAt(index);
 		tab.setIcon(TiUIHelper.getResourceDrawable(tabProxy.getProperty(TiC.PROPERTY_ICON)));
 		scaleIconToFit(tab);
+		updateIconTint();
 	}
 
 	@Override


### PR DESCRIPTION
Fixes https://github.com/tidev/titanium-sdk/issues/14079

```js
var tabs = [];
function createTab(title, icon) {
	const window = Ti.UI.createWindow({ title: title });
	window.add(Ti.UI.createLabel({ text: title + " View" }));
	const tab = Ti.UI.createTab({
		title: title,
		icon: icon,
		window: window,
	});
	tabs.push(tab);
	return tab;
}

const tabGroup = Ti.UI.createTabGroup({
	tabs: [
		createTab("Tab 1", "/images/appicon.png"),
		createTab("Tab 2", "/images/appicon.png"),
		createTab("Tab 3", "/images/appicon.png")
	],
	activeTintColor: "red",
	activeTitleColor: "red",
	tintColor: "purple",
	titleColor: "purple",
	tabsBackgroundColor: "#F7F7F7",
});

setTimeout(function(){
	tabs[0].icon = "/images/appicon.png"
	tabGroup.activeTintColor = "red"
},1000)

tabGroup.open();
```

**before this PR:**


https://github.com/user-attachments/assets/25702c83-8ed5-448e-b364-474da4dea396

Red icon will lose activeTintColor. 

**After the PR:** 
icon stays red
