### PR TITLE
chore: update ioslib to fix node-ios-device x64 issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "ejs": "3.1.9",
         "fields": "0.1.24",
         "fs-extra": "11.2.0",
-        "ioslib": "1.7.36",
+        "ioslib": "1.7.37",
         "liveview": "1.5.6",
         "lodash.merge": "4.6.2",
         "markdown": "0.5.0",
@@ -2285,6 +2285,7 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz",
       "integrity": "sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "detect-libc": "^2.0.0",
         "https-proxy-agent": "^5.0.0",
@@ -2305,6 +2306,7 @@
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
       "integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
       "deprecated": "This package is no longer supported.",
+      "license": "ISC",
       "dependencies": {
         "delegates": "^1.0.0",
         "readable-stream": "^3.6.0"
@@ -2318,6 +2320,7 @@
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
       "integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
       "deprecated": "This package is no longer supported.",
+      "license": "ISC",
       "dependencies": {
         "aproba": "^1.0.3 || ^2.0.0",
         "color-support": "^1.1.2",
@@ -2337,6 +2340,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
       "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+      "license": "ISC",
       "dependencies": {
         "abbrev": "1"
       },
@@ -2352,6 +2356,7 @@
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
       "integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
       "deprecated": "This package is no longer supported.",
+      "license": "ISC",
       "dependencies": {
         "are-we-there-yet": "^2.0.0",
         "console-control-strings": "^1.1.0",
@@ -3744,7 +3749,8 @@
     "node_modules/@yarnpkg/lockfile": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
-      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ=="
+      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/@yarnpkg/parsers": {
       "version": "3.0.0-rc.41",
@@ -5192,7 +5198,8 @@
     "node_modules/ci-info": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
-      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="
+      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+      "license": "MIT"
     },
     "node_modules/clang-format": {
       "version": "1.6.0",
@@ -6493,6 +6500,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
       "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
       }
@@ -7590,6 +7598,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
       "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "micromatch": "^4.0.2"
       }
@@ -8813,9 +8822,10 @@
       }
     },
     "node_modules/ioslib": {
-      "version": "1.7.36",
-      "resolved": "https://registry.npmjs.org/ioslib/-/ioslib-1.7.36.tgz",
-      "integrity": "sha512-LxmVa7TrKPXOE2IWxlNyNASTonSLjizxfG1dO8wZwGWowng+9/YBeIbPcQxaFgT8GMGeSMkkK1Npi2XUl7iiVQ==",
+      "version": "1.7.37",
+      "resolved": "https://registry.npmjs.org/ioslib/-/ioslib-1.7.37.tgz",
+      "integrity": "sha512-D4SrH3QocN2GBlzSBcv9V1WKpmcOVUk3F6rjHafWXtrAFs7ZrsPtyR0nA4t1ubqjOYwkTZLgMliEUrs5bpfqXQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "always-tail": "0.2.0",
         "async": "^3.2.4",
@@ -8823,7 +8833,7 @@
         "debug": "^4.3.4",
         "mkdirp": "0.5.1",
         "node-appc": "1.1.6",
-        "node-ios-device": "1.12.0"
+        "node-ios-device": "^1.12.1"
       },
       "engines": {
         "node": ">=10.13"
@@ -8982,6 +8992,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
       "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+      "license": "MIT",
       "dependencies": {
         "ci-info": "^2.0.0"
       },
@@ -9019,6 +9030,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
       "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "license": "MIT",
       "bin": {
         "is-docker": "cli.js"
       },
@@ -9302,6 +9314,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
       "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "license": "MIT",
       "dependencies": {
         "is-docker": "^2.0.0"
       },
@@ -9799,6 +9812,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
       "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.1.11"
       }
@@ -11429,7 +11443,8 @@
     "node_modules/nan": {
       "version": "2.20.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.20.0.tgz",
-      "integrity": "sha512-bk3gXBZDGILuuo/6sKtr0DQmSThYHLtNCdSdXk9YkxD/jK6X2vmCyyXBBxyqZ4XcnzTyYEAThfX3DCEnLf6igw=="
+      "integrity": "sha512-bk3gXBZDGILuuo/6sKtr0DQmSThYHLtNCdSdXk9YkxD/jK6X2vmCyyXBBxyqZ4XcnzTyYEAThfX3DCEnLf6igw==",
+      "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.1",
@@ -11694,10 +11709,11 @@
       }
     },
     "node_modules/node-ios-device": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/node-ios-device/-/node-ios-device-1.12.0.tgz",
-      "integrity": "sha512-ewGLYmcW1LbsTqs5UYmlLcm/52GCmGcuFTysWBqWnHPp88PfOh7uVm4zonb9r4MR/Nublt0vt0mNDIum0R71pw==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/node-ios-device/-/node-ios-device-1.12.1.tgz",
+      "integrity": "sha512-qcCfQw5qXek1l4NDuKt19w4gCZK4Sra4AM2PXQrpW5NhhCCl0pGfDKknBNzB0UmVd+lRm5CF5Wvy8c2Nor2jEQ==",
       "hasInstallScript": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@mapbox/node-pre-gyp": "^1.0.10",
         "debug": "^4.3.4",
@@ -11713,6 +11729,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/node-pre-gyp-init/-/node-pre-gyp-init-1.2.1.tgz",
       "integrity": "sha512-gbC2fERRmWbJFvj54f4yyiY/O6J1kkLrN7jkwRvzNmgMgPCufZLv76l2luzWjj+Ge0xQF6zDalZ6iIgzCHJ95Q==",
+      "license": "MIT",
       "dependencies": {
         "@mapbox/node-pre-gyp": "^1.0.1"
       }
@@ -12383,6 +12400,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12476,6 +12494,7 @@
       "version": "7.4.2",
       "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
       "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "license": "MIT",
       "dependencies": {
         "is-docker": "^2.0.0",
         "is-wsl": "^2.1.1"
@@ -12864,6 +12883,7 @@
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-6.5.1.tgz",
       "integrity": "sha512-I/4Zsalfhc6bphmJTlrLoOcAF87jcxko4q0qsv4bGcurbr8IskEOtdnt9iCmsQVGL1B+iUhSQqweyTLJfCF9rA==",
+      "license": "MIT",
       "dependencies": {
         "@yarnpkg/lockfile": "^1.1.0",
         "chalk": "^4.1.2",
@@ -12892,6 +12912,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -12906,6 +12927,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -12921,6 +12943,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -12931,12 +12954,14 @@
     "node_modules/patch-package/node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
     },
     "node_modules/patch-package/node_modules/cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
       "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "license": "MIT",
       "dependencies": {
         "nice-try": "^1.0.4",
         "path-key": "^2.0.1",
@@ -12952,6 +12977,7 @@
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
       "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "license": "MIT",
       "dependencies": {
         "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
@@ -12967,6 +12993,7 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "deprecated": "Glob versions prior to v9 are no longer supported",
+      "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -12986,6 +13013,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -12994,6 +13022,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
       "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -13003,6 +13032,7 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
       "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "license": "ISC",
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -13014,6 +13044,7 @@
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
       "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver"
       }
@@ -13022,6 +13053,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
+      "license": "MIT",
       "dependencies": {
         "shebang-regex": "^1.0.0"
       },
@@ -13033,6 +13065,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13041,6 +13074,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -13052,6 +13086,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -14543,6 +14578,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
       "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -22690,9 +22726,9 @@
       }
     },
     "ioslib": {
-      "version": "1.7.36",
-      "resolved": "https://registry.npmjs.org/ioslib/-/ioslib-1.7.36.tgz",
-      "integrity": "sha512-LxmVa7TrKPXOE2IWxlNyNASTonSLjizxfG1dO8wZwGWowng+9/YBeIbPcQxaFgT8GMGeSMkkK1Npi2XUl7iiVQ==",
+      "version": "1.7.37",
+      "resolved": "https://registry.npmjs.org/ioslib/-/ioslib-1.7.37.tgz",
+      "integrity": "sha512-D4SrH3QocN2GBlzSBcv9V1WKpmcOVUk3F6rjHafWXtrAFs7ZrsPtyR0nA4t1ubqjOYwkTZLgMliEUrs5bpfqXQ==",
       "requires": {
         "always-tail": "0.2.0",
         "async": "^3.2.4",
@@ -22700,7 +22736,7 @@
         "debug": "^4.3.4",
         "mkdirp": "0.5.1",
         "node-appc": "1.1.6",
-        "node-ios-device": "1.12.0"
+        "node-ios-device": "^1.12.1"
       },
       "dependencies": {
         "@xmldom/xmldom": {
@@ -24852,9 +24888,9 @@
       }
     },
     "node-ios-device": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/node-ios-device/-/node-ios-device-1.12.0.tgz",
-      "integrity": "sha512-ewGLYmcW1LbsTqs5UYmlLcm/52GCmGcuFTysWBqWnHPp88PfOh7uVm4zonb9r4MR/Nublt0vt0mNDIum0R71pw==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/node-ios-device/-/node-ios-device-1.12.1.tgz",
+      "integrity": "sha512-qcCfQw5qXek1l4NDuKt19w4gCZK4Sra4AM2PXQrpW5NhhCCl0pGfDKknBNzB0UmVd+lRm5CF5Wvy8c2Nor2jEQ==",
       "requires": {
         "@mapbox/node-pre-gyp": "^1.0.10",
         "debug": "^4.3.4",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "ejs": "3.1.9",
     "fields": "0.1.24",
     "fs-extra": "11.2.0",
-    "ioslib": "1.7.36",
+    "ioslib": "1.7.37",
     "liveview": "1.5.6",
     "lodash.merge": "4.6.2",
     "markdown": "0.5.0",


### PR DESCRIPTION
Updates ioslib to bring in the new node-ios-device version that fixes usage on x64 based macs

Reference https://tidev.slack.com/archives/C03CVQX2A/p1720779166000019