### PR TITLE
fix(android): focus event in TabGroup

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TabGroupProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TabGroupProxy.java
@@ -569,7 +569,7 @@ public class TabGroupProxy extends TiWindowProxy implements TiActivityWindow
 		tabProxy.onSelectionChanged(true);
 		tabProxy.onFocusChanged(true, focusEventData);
 
-		tabProxy.fireEvent(TiC.EVENT_SELECTED, focusEventData, false);
+		tabProxy.fireEvent(TiC.EVENT_SELECTED, focusEventData.clone(), false);
 	}
 
 	@Override


### PR DESCRIPTION
12.3.1 added more paremeters in the `selected` event of the TabGroup in this PR: https://github.com/tidev/titanium-sdk/commit/abc9e81bd38c01bc3de48219707aa4d1d06e94fe

It looks like the data is cleared before the `focus` event arrives so it won't appear in JS. I still see it in the logs:
`[/home/miga/tools/titanium-sdk/android/runtime/v8/src/native/V8Object.cpp:89] firing event "focus"` but nothing inside the app.

When cloning the data it arrives

**Test code**

```js
const tabGroup = Ti.UI.createTabGroup({
	tabs: [Ti.UI.createTab({
		window: Ti.UI.createWindow(),
		title: 'Tab 1'
	}), Ti.UI.createTab({
		window: Ti.UI.createWindow(),
		title: 'Tab 2'
	})]
});

tabGroup.addEventListener('focus', event => {
	console.warn('FOCUS', tabGroup.activeTab);
});

tabGroup.open();
```

and the old code from the `selected` PR
```js
var win1 = Ti.UI.createWindow();
win1.add(Ti.UI.createLabel({text: 'I am a blue window.'}));

var win2 = Ti.UI.createWindow();
win2.add(Ti.UI.createLabel({text: 'I am a red window.'}));

var tab1 = Ti.UI.createTab({
    window: win1,
    title: 'Blue'
}),
tab2 = Ti.UI.createTab({
    window: win2,
    title: 'Red'
}),
tabGroup = Ti.UI.createTabGroup({
    tabs: [tab1, tab2]
});

tab1.addEventListener("selected", function(e){
  console.log(e.index, e.previousIndex)
})
tab2.addEventListener("selected", function(e){
  console.log(e.index, e.previousIndex)
})

tabGroup.open();
```