### PR TITLE
fix(android): fix titleAttribute when it's not a creation parameter

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/TiWindowProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/TiWindowProxy.java
@@ -51,6 +51,7 @@ import android.view.ViewParent;
 	TiC.PROPERTY_ON_BACK,
 	TiC.PROPERTY_TITLE,
 	TiC.PROPERTY_TITLEID,
+	TiC.PROPERTY_TITLE_ATTRIBUTES,
 	TiC.PROPERTY_WINDOW_SOFT_INPUT_MODE
 })
 public abstract class TiWindowProxy extends TiViewProxy


### PR DESCRIPTION
If you don't set `titleAttributes` at window creation and try to set it after that it won't set the color:

```js
var win = Titanium.UI.createWindow({
	barColor: "pink",
	backgroundColor: "white",
	title: 'foo',
});


win.addEventListener("click", function() {
	win.titleAttributes = {
		color: "yellow"
	}
	win.title = "test"
})
win.open();
```

**Test**
* run the code
* click the window
* title and color should change