### PR TITLE
fix: sdk build on windows needs shell: true to run batch files

### DIFF
--- a/build/lib/android/index.js
+++ b/build/lib/android/index.js
@@ -173,7 +173,11 @@ class Android {
 
 async function gradlew(args) {
 	await new Promise((resolve, reject) => {
-		const childProcess = spawn(GRADLEW_FILE_PATH, args, { cwd: TITANIUM_ANDROID_PATH, stdio: 'inherit' });
+		const childProcess = spawn(GRADLEW_FILE_PATH, args, {
+			cwd: TITANIUM_ANDROID_PATH,
+			shell: process.platform === 'win32',
+			stdio: 'inherit'
+		});
 		childProcess.on('error', reject);
 		childProcess.on('exit', (exitCode) => {
 			if (exitCode === 0) {

--- a/build/lib/docs.js
+++ b/build/lib/docs.js
@@ -23,7 +23,10 @@ class Documentation {
 		const outputFile = path.join(this.outputDir, filename);
 
 		return new Promise((resolve, reject) => {
-			const prc = spawn(cmdPath, args, { cwd: DOC_DIR });
+			const prc = spawn(cmdPath, args, {
+				cwd: DOC_DIR,
+				shell: process.platform === 'win32'
+			});
 			prc.stdout.on('data', data => console.log(data.toString().trim()));
 			prc.stderr.on('data', data => console.error(data.toString().trim()));
 			prc.on('close', code => {


### PR DESCRIPTION
Not sure if it's a Node 22 thing or what, but I get a `EINVAL` error doing `npm run cleanbuild:local` because it spawns a batch file which requires a shell to be true. 