### PR TITLE
feat(android): add x/y to ScrollView drag events

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIScrollView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIScrollView.java
@@ -53,6 +53,8 @@ public class TiUIScrollView extends TiUIView
 	private static int verticalAttrId = -1;
 	private static int horizontalAttrId = -1;
 	private int type;
+	private TiDimension xDimension;
+	private TiDimension yDimension;
 
 	public class TiScrollViewLayout extends TiCompositeLayout
 	{
@@ -405,6 +407,9 @@ public class TiUIScrollView extends TiUIView
 		@Override
 		public boolean onTouchEvent(MotionEvent event)
 		{
+			xDimension = new TiDimension((double) event.getX(), TiDimension.TYPE_LEFT);
+			yDimension = new TiDimension((double) event.getY(), TiDimension.TYPE_TOP);
+
 			if (event.getAction() == MotionEvent.ACTION_MOVE && !mScrollingEnabled) {
 				return false;
 			}
@@ -416,6 +421,9 @@ public class TiUIScrollView extends TiUIView
 				isTouching = false;
 				KrollDict data = new KrollDict();
 				data.put("decelerate", true);
+
+				data.put(TiC.EVENT_PROPERTY_X, xDimension.getAsDefault(scrollView));
+				data.put(TiC.EVENT_PROPERTY_Y, yDimension.getAsDefault(scrollView));
 				getProxy().fireEvent(TiC.EVENT_DRAGEND, data);
 			}
 			//There's a known Android bug (version 3.1 and above) that will throw an exception when we use 3+ fingers to touch the scrollview.
@@ -475,6 +483,8 @@ public class TiUIScrollView extends TiUIView
 			if (!isScrolling && isTouching) {
 				isScrolling = true;
 				KrollDict data = new KrollDict();
+				data.put(TiC.EVENT_PROPERTY_X, xDimension.getAsDefault(scrollView));
+				data.put(TiC.EVENT_PROPERTY_Y, yDimension.getAsDefault(scrollView));
 				getProxy().fireEvent(TiC.EVENT_DRAGSTART, data);
 			}
 
@@ -553,6 +563,9 @@ public class TiUIScrollView extends TiUIView
 		@Override
 		public boolean onTouchEvent(MotionEvent event)
 		{
+			xDimension = new TiDimension((double) event.getX(), TiDimension.TYPE_LEFT);
+			yDimension = new TiDimension((double) event.getY(), TiDimension.TYPE_TOP);
+
 			if (event.getAction() == MotionEvent.ACTION_MOVE && !mScrollingEnabled) {
 				return false;
 			}
@@ -564,6 +577,8 @@ public class TiUIScrollView extends TiUIView
 				isTouching = false;
 				KrollDict data = new KrollDict();
 				data.put("decelerate", true);
+				data.put(TiC.EVENT_PROPERTY_X, xDimension.getAsDefault(scrollView));
+				data.put(TiC.EVENT_PROPERTY_Y, yDimension.getAsDefault(scrollView));
 				getProxy().fireEvent(TiC.EVENT_DRAGEND, data);
 			}
 			//There's a known Android bug (version 3.1 and above) that will throw an exception when we use 3+ fingers to touch the scrollview.
@@ -603,6 +618,8 @@ public class TiUIScrollView extends TiUIView
 
 			if (!isScrolling && isTouching) {
 				isScrolling = true;
+				data.put(TiC.EVENT_PROPERTY_X, xDimension.getAsDefault(scrollView));
+				data.put(TiC.EVENT_PROPERTY_Y, yDimension.getAsDefault(scrollView));
 				getProxy().fireEvent(TiC.EVENT_DRAGSTART, data);
 			}
 

--- a/apidoc/Titanium/UI/ScrollView.yml
+++ b/apidoc/Titanium/UI/ScrollView.yml
@@ -220,6 +220,7 @@ events:
             Indicates whether scrolling will continue but decelerate, now that the drag gesture has
             been released by the touch. If `false`, scrolling will stop immediately.
             Is always `true` on Android.
+        type: Boolean
       - name: x
         summary: X coordinate from the scrollable touch position.
         type: Number

--- a/apidoc/Titanium/UI/ScrollView.yml
+++ b/apidoc/Titanium/UI/ScrollView.yml
@@ -198,6 +198,14 @@ events:
         A dragging gesture is when a touch remains in contact with the display to physically drag
         the view, as opposed to it being the result of scrolling momentum.
     platforms: [android, iphone, ipad, macos]
+    properties:
+      - name: x
+        summary: X coordinate from the scrollable touch position.
+        type: Number
+
+      - name: y
+        summary: Y coordinate from the scrollable touch position.
+        type: Number
     since: { iphone: "3.0.0", ipad: "3.0.0", android: "6.2.0" }
 
   - name: dragend
@@ -212,7 +220,13 @@ events:
             Indicates whether scrolling will continue but decelerate, now that the drag gesture has
             been released by the touch. If `false`, scrolling will stop immediately.
             Is always `true` on Android.
-        type: Boolean
+      - name: x
+        summary: X coordinate from the scrollable touch position.
+        type: Number
+
+      - name: y
+        summary: Y coordinate from the scrollable touch position.
+        type: Number
     since: { iphone: "3.0.0", ipad: "3.0.0", android: "6.2.0" }
 
 properties:


### PR DESCRIPTION
x/y position of the touch when using dragstart/dragend:

```js
var win = Ti.UI.createWindow();

var scrollView = Ti.UI.createScrollView({
  showVerticalScrollIndicator: true,
  showHorizontalScrollIndicator: true,
  height: '80%',
  width: '80%'
});
var view = Ti.UI.createView({
  backgroundColor:'#336699',
  borderRadius: 10,
  top: 10,
  height: 2000,
  width: 1000
});
scrollView.add(view);
scrollView.addEventListener("dragstart", function(e){
	console.log(e.x, e.y);
})
scrollView.addEventListener("dragend", function(e){
	console.log(e.x, e.y);
})
win.add(scrollView);
win.open();
```