### PR TITLE
chore: java/node version update

### DIFF
--- a/.github/actions/build-android/action.yml
+++ b/.github/actions/build-android/action.yml
@@ -16,7 +16,7 @@ runs:
       run: |
         sudo dpkg --add-architecture i386
         sudo apt-get update -y -qq
-        sudo apt-get install -y -qq gperf libatomic1:i386 libc6:i386 libncurses5:i386 libstdc++6:i386
+#        sudo apt-get install -y -qq gperf libatomic1:i386 libc6:i386 libncurses5:i386 libstdc++6:i386
       shell: bash
 
     - name: Setup Node.js
@@ -28,7 +28,8 @@ runs:
     - name: Setup Java
       uses: actions/setup-java@v4
       with:
-        distribution: 'oracle'
+        distribution: 'temurin'
+        cache: 'gradle'
         java-version: ${{ inputs.java-version }}
 
     - name: Install dependencies

--- a/.github/actions/build-android/action.yml
+++ b/.github/actions/build-android/action.yml
@@ -26,9 +26,9 @@ runs:
         cache: 'npm'
 
     - name: Setup Java
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
-        distribution: 'adopt'
+        distribution: 'oracle'
         java-version: ${{ inputs.java-version }}
 
     - name: Install dependencies

--- a/.github/actions/build-android/action.yml
+++ b/.github/actions/build-android/action.yml
@@ -16,7 +16,7 @@ runs:
       run: |
         sudo dpkg --add-architecture i386
         sudo apt-get update -y -qq
-#        sudo apt-get install -y -qq gperf libatomic1:i386 libc6:i386 libncurses5:i386 libstdc++6:i386
+        sudo apt-get install -y -qq gperf
       shell: bash
 
     - name: Setup Node.js

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,8 +21,8 @@ jobs:
       - name: Android build
         uses: ./.github/actions/build-android
         with:
-          node-version: '16.x'
-          java-version: '11'
+          node-version: '20.x'
+          java-version: '17'
 
   ios:
     runs-on: macos-13
@@ -39,7 +39,7 @@ jobs:
       - name: iOS build
         uses: ./.github/actions/build-ios
         with:
-          node-version: '16.x'
+          node-version: '20.x'
 
   js:
     runs-on: ubuntu-latest
@@ -50,10 +50,10 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Use Node.js 16.x
+    - name: Use Node.js 20.x
       uses: actions/setup-node@v3
       with:
-        node-version: '16.x'
+        node-version: '20.x'
         cache: 'npm'
 
     - name: Install dependencies
@@ -83,6 +83,6 @@ jobs:
     - name: Package
       uses: ./.github/actions/package
       with:
-        node-version: '16.x'
-        java-version: '11'
+        node-version: '20.x'
+        java-version: '17'
         vtag: ${{ env.vtag }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       USE_CCACHE: 1
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Android build
@@ -33,7 +33,7 @@ jobs:
       DEVELOPER_DIR: /Applications/Xcode_14.3.app/Contents/Developer
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: iOS build
@@ -46,7 +46,7 @@ jobs:
     name: JavaScript
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
@@ -71,7 +71,7 @@ jobs:
     needs: [android, ios, js]
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Create version tag

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   android:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       CCACHE_DIR: ${{ github.workspace }}/.ccache
       USE_CCACHE: 1

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 		mavenCentral()
 	}
 	dependencies {
-		classpath 'com.android.tools.build:gradle:7.0.4'
+		classpath 'com.android.tools.build:gradle:7.1.3'
 		classpath 'com.google.gms:google-services:4.3.15'
 		classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 		classpath 'org.codehaus.groovy:groovy-json:3.0.11'

--- a/android/package.json
+++ b/android/package.json
@@ -19,10 +19,10 @@
 	"minSDKVersion": "21",
 	"compileSDKVersion": "33",
 	"vendorDependencies": {
-		"android sdk": ">=23.x <=34.x",
-		"android build tools": ">=30.0.2 <=34.x",
-		"android platform tools": "33.x",
-		"android tools": "<=34.x",
+		"android sdk": ">=23 <=34",
+		"android build tools": ">=30.0.2 <=34",
+		"android platform tools": "33",
+		"android tools": "<=34",
 		"android ndk": ">=r21 <=r22b",
 		"java": ">=11.x"
 	},

--- a/android/templates/build/root.build.gradle
+++ b/android/templates/build/root.build.gradle
@@ -7,7 +7,7 @@ buildscript {
 		mavenCentral()
 	}
 	dependencies {
-		classpath 'com.android.tools.build:gradle:7.0.4'
+		classpath 'com.android.tools.build:gradle:7.1.3'
 		classpath 'com.google.gms:google-services:4.3.10'
 		classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 	}


### PR DESCRIPTION
Testing if I can remove the 
```
 Not a number: 33x:
java.lang.NumberFormatException: Not a number: 33x
	at com.sun.xml.bind.DatatypeConverterImpl._parseInt(DatatypeConverterImpl.java:95)
```
warnings. I don't have them when I build locally. 

Updating various version in the github action to see if anything helps. It still builds the SDK and I don't see them locally (Fedora).