### PR TITLE
docs: update NotificationChannel example

### DIFF
--- a/apidoc/Titanium/Android/NotificationChannel.yml
+++ b/apidoc/Titanium/Android/NotificationChannel.yml
@@ -25,7 +25,7 @@ examples:
                 icon: Ti.Android.R.drawable.ic_dialog_info,
                 contentTitle: 'TITLE',
                 contentText : 'This is a test',
-                channelId: channel.getId()
+                channelId: channel.id
             });
 
         Ti.Android.NotificationManager.notify(100, notification);


### PR DESCRIPTION
fixes https://github.com/tidev/titanium-sdk/issues/14106

`getId()` is a property:

https://github.com/tidev/titanium-sdk/blob/d98f6a6fbf5d6406ceb20492ba89410400b6a95c/android/modules/android/src/java/ti/modules/titanium/android/notificationmanager/NotificationChannelProxy.java#L79-L80

so just `channelId: channel.id`