### PR TITLE
chore(android): forward --sdk in module build process

### DIFF
--- a/android/cli/commands/_buildModule.js
+++ b/android/cli/commands/_buildModule.js
@@ -33,6 +33,8 @@ const androidDetect = require('../lib/detect').detect,
 	__ = appc.i18n(__dirname).__,
 	version = appc.version;
 
+let tiSdkVersion = '12.6.0.GA';
+
 function AndroidModuleBuilder() {
 	Builder.apply(this, arguments);
 
@@ -58,6 +60,7 @@ AndroidModuleBuilder.prototype.migrate = async function migrate() {
 	const manifestModuleAPIVersion = this.manifest.apiversion;
 	const manifestTemplateFile = path.join(this.platformPath, 'templates', 'module', 'default', 'template', 'android', 'manifest.ejs');
 	let newVersion = semver.inc(this.manifest.version, 'major');
+	tiSdkVersion = cliSDKVersion;
 
 	// Determine if the "manifest" file's "apiversion" needs updating.
 	let isApiVersionUpdateRequired = false;
@@ -873,6 +876,7 @@ AndroidModuleBuilder.prototype.runModule = async function (cli) {
 			'-u', 'localhost',
 			'-d', tmpDir,
 			'-p', 'android',
+			'--sdk', tiSdkVersion,
 			'--force'
 		],
 		this.logger
@@ -917,7 +921,7 @@ AndroidModuleBuilder.prototype.runModule = async function (cli) {
 
 	// Run the temp app.
 	this.logger.debug(__('Running example project...', tmpDir.cyan));
-	let buildArgs = [ process.argv[1], 'build', '-p', 'android', '-d', tmpProjectDir ];
+	let buildArgs = [ process.argv[1], 'build', '-p', 'android', '-d', tmpProjectDir, '--sdk', tiSdkVersion ];
 	if (this.target) {
 		buildArgs.push('-T');
 		buildArgs.push(this.target);

--- a/android/cli/commands/_buildModule.js
+++ b/android/cli/commands/_buildModule.js
@@ -33,8 +33,6 @@ const androidDetect = require('../lib/detect').detect,
 	__ = appc.i18n(__dirname).__,
 	version = appc.version;
 
-let tiSdkVersion = '12.6.0.GA';
-
 function AndroidModuleBuilder() {
 	Builder.apply(this, arguments);
 
@@ -60,7 +58,7 @@ AndroidModuleBuilder.prototype.migrate = async function migrate() {
 	const manifestModuleAPIVersion = this.manifest.apiversion;
 	const manifestTemplateFile = path.join(this.platformPath, 'templates', 'module', 'default', 'template', 'android', 'manifest.ejs');
 	let newVersion = semver.inc(this.manifest.version, 'major');
-	tiSdkVersion = cliSDKVersion;
+	this.tiSdkVersion = cliSDKVersion;
 
 	// Determine if the "manifest" file's "apiversion" needs updating.
 	let isApiVersionUpdateRequired = false;
@@ -876,7 +874,7 @@ AndroidModuleBuilder.prototype.runModule = async function (cli) {
 			'-u', 'localhost',
 			'-d', tmpDir,
 			'-p', 'android',
-			'--sdk', tiSdkVersion,
+			'--sdk', this.tiSdkVersion,
 			'--force'
 		],
 		this.logger
@@ -921,7 +919,7 @@ AndroidModuleBuilder.prototype.runModule = async function (cli) {
 
 	// Run the temp app.
 	this.logger.debug(__('Running example project...', tmpDir.cyan));
-	let buildArgs = [ process.argv[1], 'build', '-p', 'android', '-d', tmpProjectDir, '--sdk', tiSdkVersion ];
+	let buildArgs = [ process.argv[1], 'build', '-p', 'android', '-d', tmpProjectDir, '--sdk', this.tiSdkVersion ];
 	if (this.target) {
 		buildArgs.push('-T');
 		buildArgs.push(this.target);


### PR DESCRIPTION
When testing the gradle8 PR I saw that inside a module when I run `ti build -p android --sdk 12.6.0` it was building the module with 12.6.0 but the example app was still starting with `12.4.0.GA`. 

This PR will forward the `--sdk` parameter and it won't crash with `Unsupported Class File Major Version 61` errors (module is build with java 17 but then run with java 11)

**Testing:**
* build an Android module with an example folder
* `ti build -p android -l trace --sdk 12.6.0`  should show:
```
[DEBUG] Running example project...
[DEBUG] Titanium Command-Line Interface v7.1.1 SDK v12.6.0
```
after building the module ZIP. 

* copy `android/cli/commands/_buildModule.js` to 12.4.0.GA and build the module again:
* `ti build -p android -l trace`  (no custom SDK, it should take the default SDK) should show:
```
[DEBUG] Running example project...
[DEBUG] Titanium Command-Line Interface v7.1.1 SDK v12.4.0
``` 