### PR TITLE
fix(ios): pause returns false

### DIFF
--- a/iphone/Classes/TiMediaAudioPlayerProxy.m
+++ b/iphone/Classes/TiMediaAudioPlayerProxy.m
@@ -472,11 +472,7 @@
   if (_player.timeControlStatus == AVPlayerTimeControlStatusPlaying) {
     _state = TiAudioPlayerStatePlaying;
   } else if (_player.timeControlStatus == AVPlayerTimeControlStatusPaused) {
-    if (_player.currentItem.currentTime.value == 0.0 || oldState == TiAudioPlayerStateStopping) {
-      _state = TiAudioPlayerStateStopped;
-    } else {
-      _state = TiAudioPlayerStatePaused;
-    }
+    _state = TiAudioPlayerStatePaused;
   } else if (_player.timeControlStatus == AVPlayerTimeControlStatusWaitingToPlayAtSpecifiedRate) {
     _state = TiAudioPlayerStateWaitingForQueueToStart;
   }


### PR DESCRIPTION
- Fixes Issue #14109

#

 Both conditions that the assignment of pause status are somehow logically impossible to happen.

1. it can be triggered at anytime during playing the track.
2. The old status could be playing or something else other than only stopped.
