### PR TITLE
fix: allow ignoreLog to be a single string

### DIFF
--- a/android/cli/hooks/run.js
+++ b/android/cli/hooks/run.js
@@ -268,7 +268,11 @@ exports.init = function (logger, config, cli) {
 						}
 
 						// ignore some Android logs in info log level
-						if (ignoreLog.some(ignoreItem => line.includes(ignoreItem))) {
+						if (typeof ignoreLog === 'string') {
+							if (line.includes(ignoreLog)) {
+								return;
+							}
+						} else if (ignoreLog.some(ignoreItem => line.includes(ignoreItem))) {
 							return;
 						}
 

--- a/iphone/cli/hooks/run.js
+++ b/iphone/cli/hooks/run.js
@@ -75,7 +75,11 @@ exports.init = function (logger, config, cli) {
 				}
 
 				// ignore logs from cli ignoreLog
-				if (ignoreLog.some(ignoreItem => line.includes(ignoreItem))) {
+				if (typeof ignoreLog === 'string') {
+					if (line.includes(ignoreLog)) {
+						return;
+					}
+				} else if (ignoreLog.some(ignoreItem => line.includes(ignoreItem))) {
 					return;
 				}
 


### PR DESCRIPTION
Currently if you use `ignoreLog` with just a single string instead of an array it will show lots of
```
TypeError: ignoreLog.some is not a function at printData`
```
errors in the log.

This PR will allow strings.

**Test**
* edit ~/.titanium/config.json and set `"ignoreLog": "Too many Flogger logs received before configuration"`
* build an app 
