### PR TITLE
feat(android): add support for Android's API 33 Per-app languages

### DIFF
--- a/android/modules/locale/src/java/ti/modules/titanium/locale/LocaleModule.java
+++ b/android/modules/locale/src/java/ti/modules/titanium/locale/LocaleModule.java
@@ -43,7 +43,7 @@ public class LocaleModule extends KrollModule
 	public void setApplicationLocales(String locales)
 	{
 		if (Build.VERSION.SDK_INT < 33) {
-			Log.w(TAG, "This property is only supported on android API 33 and above.");
+			Log.w(TAG, "This property is only supported on Android API level 33 and above.");
 			return;
 		}
 		LocaleListCompat appLocale = LocaleListCompat.forLanguageTags(locales);

--- a/android/modules/locale/src/java/ti/modules/titanium/locale/LocaleModule.java
+++ b/android/modules/locale/src/java/ti/modules/titanium/locale/LocaleModule.java
@@ -54,7 +54,7 @@ public class LocaleModule extends KrollModule
 	public KrollDict[] getApplicationLocales()
 	{
 		if (Build.VERSION.SDK_INT < 33) {
-			Log.w(TAG, "This property is only supported on android API 33 and above.");
+			Log.w(TAG, "This property is only supported on Android API level 33 and above.");
 			return new KrollDict[0];
 		}
 		LocaleListCompat localeListCompat = AppCompatDelegate.getApplicationLocales();

--- a/android/modules/locale/src/java/ti/modules/titanium/locale/LocaleModule.java
+++ b/android/modules/locale/src/java/ti/modules/titanium/locale/LocaleModule.java
@@ -10,8 +10,10 @@ import java.text.Collator;
 import java.text.DateFormat;
 import java.text.NumberFormat;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.Locale;
 
+import org.appcelerator.kroll.KrollDict;
 import org.appcelerator.kroll.KrollModule;
 import org.appcelerator.kroll.annotations.Kroll;
 import org.appcelerator.kroll.common.Log;
@@ -21,7 +23,11 @@ import org.appcelerator.titanium.util.TiLocaleManager;
 import org.appcelerator.titanium.util.TiPlatformHelper;
 import org.appcelerator.titanium.util.TiRHelper;
 
+import android.os.Build;
 import android.telephony.PhoneNumberUtils;
+
+import androidx.appcompat.app.AppCompatDelegate;
+import androidx.core.os.LocaleListCompat;
 
 @Kroll.module
 public class LocaleModule extends KrollModule
@@ -31,6 +37,62 @@ public class LocaleModule extends KrollModule
 	public LocaleModule()
 	{
 		super("Locale");
+	}
+
+	@Kroll.setProperty
+	public void setApplicationLocales(String locales)
+	{
+		if (Build.VERSION.SDK_INT < 33) {
+			Log.w(TAG, "This property is only supported on android API 33 and above.");
+			return;
+		}
+		LocaleListCompat appLocale = LocaleListCompat.forLanguageTags(locales);
+		AppCompatDelegate.setApplicationLocales(appLocale);
+	}
+
+	@Kroll.getProperty
+	public KrollDict[] getApplicationLocales()
+	{
+		if (Build.VERSION.SDK_INT < 33) {
+			Log.w(TAG, "This property is only supported on android API 33 and above.");
+			return new KrollDict[0];
+		}
+		LocaleListCompat localeListCompat = AppCompatDelegate.getApplicationLocales();
+		int size = localeListCompat.size();
+		KrollDict[] locales = new KrollDict[size];
+		for (int i = 0; i < size; i++) {
+			Locale locale = localeListCompat.get(i);
+			if (locale != null) {
+				KrollDict localeObj = new KrollDict();
+				localeObj.put("country", locale.getCountry());
+				localeObj.put("iso3_country", locale.getISO3Country());
+				localeObj.put("display_country", locale.getDisplayCountry());
+				localeObj.put("language", locale.getLanguage());
+				localeObj.put("iso3_language", locale.getISO3Language());
+				localeObj.put("display_language", locale.getDisplayLanguage());
+				localeObj.put("variant", locale.getVariant());
+				localeObj.put("display_variant", locale.getDisplayVariant());
+				localeObj.put("script", locale.getScript());
+				localeObj.put("display_script", locale.getDisplayScript());
+				localeObj.put("display_name", locale.getDisplayName());
+				localeObj.put("language_tag", locale.toLanguageTag());
+				Character[] extensionKeys = new Character[locale.getExtensionKeys().size()];
+				String[] extensions = new String[locale.getExtensionKeys().size()];
+				Iterator<Character> extensionKeysSize = locale.getExtensionKeys().iterator();
+				int l = 0;
+				while (extensionKeysSize.hasNext()) {
+					extensionKeys[l] = extensionKeysSize.next();
+					extensions[l] = locale.getExtension(extensionKeys[l]);
+					l++;
+				}
+				localeObj.put("extension_keys", extensionKeys);
+				localeObj.put("extensions", extensions);
+				locales[i] = localeObj;
+			} else {
+				locales[i] = null;
+			}
+		}
+		return locales;
 	}
 
 	@Kroll.getProperty

--- a/android/modules/locale/src/java/ti/modules/titanium/locale/LocaleModule.java
+++ b/android/modules/locale/src/java/ti/modules/titanium/locale/LocaleModule.java
@@ -65,17 +65,17 @@ public class LocaleModule extends KrollModule
 			if (locale != null) {
 				KrollDict localeObj = new KrollDict();
 				localeObj.put("country", locale.getCountry());
-				localeObj.put("iso3_country", locale.getISO3Country());
-				localeObj.put("display_country", locale.getDisplayCountry());
+				localeObj.put("iso3Country", locale.getISO3Country());
+				localeObj.put("displayCountry", locale.getDisplayCountry());
 				localeObj.put("language", locale.getLanguage());
-				localeObj.put("iso3_language", locale.getISO3Language());
-				localeObj.put("display_language", locale.getDisplayLanguage());
+				localeObj.put("iso3Language", locale.getISO3Language());
+				localeObj.put("displayLanguage", locale.getDisplayLanguage());
 				localeObj.put("variant", locale.getVariant());
-				localeObj.put("display_variant", locale.getDisplayVariant());
+				localeObj.put("displayVariant", locale.getDisplayVariant());
 				localeObj.put("script", locale.getScript());
-				localeObj.put("display_script", locale.getDisplayScript());
-				localeObj.put("display_name", locale.getDisplayName());
-				localeObj.put("language_tag", locale.toLanguageTag());
+				localeObj.put("displayScript", locale.getDisplayScript());
+				localeObj.put("displayName", locale.getDisplayName());
+				localeObj.put("languageTag", locale.toLanguageTag());
 				Character[] extensionKeys = new Character[locale.getExtensionKeys().size()];
 				String[] extensions = new String[locale.getExtensionKeys().size()];
 				Iterator<Character> extensionKeysSize = locale.getExtensionKeys().iterator();
@@ -141,10 +141,9 @@ public class LocaleModule extends KrollModule
 
 	/**
 	 * Undocumented method used to implement the JavaScript Intl.getCanonicalLocales() static method.
-	 * @param locales
-	 * Can be a string or array of strings providing locale IDs to convert to canonical locale IDs. Can be null.
-	 * @return
-	 * Returns the given locale string IDs converted to "canonical" string IDs. Duplicate locales are removed.
+	 *
+	 * @param locales Can be a string or array of strings providing locale IDs to convert to canonical locale IDs. Can be null.
+	 * @return Returns the given locale string IDs converted to "canonical" string IDs. Duplicate locales are removed.
 	 * Returns an empty array if given locales are invalid/unsupported or if given a null locales argument.
 	 */
 	@Kroll.method
@@ -166,10 +165,10 @@ public class LocaleModule extends KrollModule
 
 	/**
 	 * Undocumented method used to implement the JavaScript Intl.Collator.supportedLocalesOf() static method.
+	 *
 	 * @param locales Can be a string or array of strings providing the locale IDs to search for. Can be null.
 	 * @param options The Intl.Collator.supportedLocalesOf() argument. Currently ignored.
-	 * @return
-	 * Returns a subset of locale IDs from the given argument that are supported by the system.
+	 * @return Returns a subset of locale IDs from the given argument that are supported by the system.
 	 * Returns an empty array if none of the locales are supported or if given a null locales argument.
 	 */
 	@Kroll.method
@@ -182,10 +181,10 @@ public class LocaleModule extends KrollModule
 
 	/**
 	 * Undocumented method used to implement the JavaScript Intl.DateTimeFormat.supportedLocalesOf() static method.
+	 *
 	 * @param locales Can be a string or array of strings providing the locale IDs to search for. Can be null.
 	 * @param options The Intl.DateTimeFormat.supportedLocalesOf() argument. Currently ignored.
-	 * @return
-	 * Returns a subset of locale IDs from the given argument that are supported by the system.
+	 * @return Returns a subset of locale IDs from the given argument that are supported by the system.
 	 * Returns an empty array if none of the locales are supported or if given a null locales argument.
 	 */
 	@Kroll.method
@@ -198,10 +197,10 @@ public class LocaleModule extends KrollModule
 
 	/**
 	 * Undocumented method used to implement the JavaScript Intl.NumberFormat.supportedLocalesOf() static method.
+	 *
 	 * @param locales Can be a string or array of strings providing the locale IDs to search for. Can be null.
 	 * @param options The Intl.NumberFormat.supportedLocalesOf() argument. Currently ignored.
-	 * @return
-	 * Returns a subset of locale IDs from the given argument that are supported by the system.
+	 * @return Returns a subset of locale IDs from the given argument that are supported by the system.
 	 * Returns an empty array if none of the locales are supported or if given a null locales argument.
 	 */
 	@Kroll.method

--- a/android/templates/build/ti.constants.gradle
+++ b/android/templates/build/ti.constants.gradle
@@ -7,7 +7,7 @@
 
 project.ext {
 	tiNdkVersion = '26.2.11394342'
-	tiAndroidXAppCompatLibVersion = '1.4.1'
+	tiAndroidXAppCompatLibVersion = '1.6.1'
 	tiAndroidXCoreLibVersion = '1.9.0'
 	tiAndroidXFragmentLibVersion = '1.5.7'
 	tiMaterialLibVersion = '1.6.1'

--- a/android/templates/build/ti.constants.gradle
+++ b/android/templates/build/ti.constants.gradle
@@ -7,7 +7,7 @@
 
 project.ext {
 	tiNdkVersion = '26.2.11394342'
-	tiAndroidXAppCompatLibVersion = '1.6.1'
+	tiAndroidXAppCompatLibVersion = '1.6.0'
 	tiAndroidXCoreLibVersion = '1.9.0'
 	tiAndroidXFragmentLibVersion = '1.5.7'
 	tiMaterialLibVersion = '1.6.1'

--- a/apidoc/Titanium/Locale/Locale.yml
+++ b/apidoc/Titanium/Locale/Locale.yml
@@ -242,7 +242,7 @@ properties:
     description: |
         This property holds the values of Android's Per-app languages which is an array of defined Per-app languages, 
         if no languages defined, an empty array will be returned. You can set the value of it like this `en-US,en-GB,ar-SA`.
-        This property requires android API 33 and above.
+        This property requires Android API level 33 and above.
         See the [Android's Per-app languages](https://developer.android.com/guide/topics/resources/app-languages).
     type: Array
     since: "12.6.0"

--- a/apidoc/Titanium/Locale/Locale.yml
+++ b/apidoc/Titanium/Locale/Locale.yml
@@ -235,3 +235,14 @@ properties:
         sections of wikipedia for reference.
     type: String
     permission: read-only
+
+  - name: applicationLocales
+    summary: Update or retrieve Android's Per-app languages.
+    platforms: [android]
+    description: |
+        This property holds the values of Android's Per-app languages which is an array of defined Per-app languages, 
+        if no languages defined, an empty array will be returned. You can set the value of it like this `en-US,en-GB,ar-SA`.
+        This property requires android API 33 and above.
+        See the [Android's Per-app languages](https://developer.android.com/guide/topics/resources/app-languages).
+    type: String | Array
+    since: "12.6.0"

--- a/apidoc/Titanium/Locale/Locale.yml
+++ b/apidoc/Titanium/Locale/Locale.yml
@@ -244,5 +244,5 @@ properties:
         if no languages defined, an empty array will be returned. You can set the value of it like this `en-US,en-GB,ar-SA`.
         This property requires android API 33 and above.
         See the [Android's Per-app languages](https://developer.android.com/guide/topics/resources/app-languages).
-    type: String | Array
+    type: Array
     since: "12.6.0"


### PR DESCRIPTION
This PR adds support for Android's Per-app languages presented in Android API 33/Android 12.

See [Per-app languages preferences](https://developer.android.com/guide/topics/resources/app-languages)