### PR TITLE
fix(android): fix toString() call when adb devices fails

### DIFF
--- a/android/cli/hooks/run.js
+++ b/android/cli/hooks/run.js
@@ -87,7 +87,7 @@ exports.init = function (logger, config, cli) {
 				const adb = new ADB(config);
 				adb.devices(function (err, devices) {
 					if (err) {
-						err.toString.split('\n').forEach(logger.error);
+						err.toString().split('\n').forEach(logger.error);
 						logger.log();
 						process.exit(1);
 					}


### PR DESCRIPTION
Wow! 11 year old bug: https://github.com/tidev/titanium-sdk/commit/a17e4df9ce774b068cf467a7e0b026b5eb9645d7.

Fixes #14127