### PR TITLE
feat(ios): add direction to ListView scrolling

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/TiListView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/TiListView.java
@@ -153,6 +153,8 @@ public class TiListView extends TiSwipeRefreshLayout implements OnSearchChangeLi
 						payload.put(TiC.PROPERTY_DIRECTION, "up");
 					} else if (dy < 0) {
 						payload.put(TiC.PROPERTY_DIRECTION, "down");
+					} else {
+						payload.put(TiC.PROPERTY_DIRECTION, "unknown");
 					}
 					payload.put(TiC.EVENT_PROPERTY_VELOCITY, 0);
 					if (continuousUpdate) {

--- a/apidoc/Titanium/UI/ListView.yml
+++ b/apidoc/Titanium/UI/ListView.yml
@@ -648,7 +648,7 @@ events:
         ipad: 5.4.0
     properties:
       - name: direction
-        summary: Direction of the scroll either 'up', or 'down'.
+        summary: Direction of the scroll either 'up', 'down' or 'unknown'.
         type: String
 
       - name: velocity

--- a/apidoc/Titanium/UI/TableView.yml
+++ b/apidoc/Titanium/UI/TableView.yml
@@ -453,7 +453,7 @@ events:
     since: { android: "2.1.0", iphone: "2.1.0", ipad: "2.1.0" }
     properties:
       - name: direction
-        summary: Direction of the swipe, either `left` or `right`.
+        summary: Direction of the swipe, either `left`, `right` or `unknown`.
         type: String
 
       - name: index

--- a/iphone/Classes/TiUIListView.m
+++ b/iphone/Classes/TiUIListView.m
@@ -2012,7 +2012,7 @@ static TiViewProxy *FindViewProxyWithBindIdContainingPoint(UIView *view, CGPoint
         TiUIListSectionProxy *section;
         CGFloat topSpacing = scrollView.contentOffset.y + scrollView.adjustedContentInset.top;
 
-        NSString *direction = nil;
+        NSString *direction = [NSNull null];
 
         if (self.lastContentOffset > scrollView.contentOffset.y) {
           direction = @"down";

--- a/iphone/Classes/TiUIListView.m
+++ b/iphone/Classes/TiUIListView.m
@@ -2012,7 +2012,7 @@ static TiViewProxy *FindViewProxyWithBindIdContainingPoint(UIView *view, CGPoint
         TiUIListSectionProxy *section;
         CGFloat topSpacing = scrollView.contentOffset.y + scrollView.adjustedContentInset.top;
 
-        NSString *direction = [NSNull null];
+        NSString *direction = @"unknown";
 
         if (self.lastContentOffset > scrollView.contentOffset.y) {
           direction = @"down";
@@ -2122,7 +2122,7 @@ static TiViewProxy *FindViewProxyWithBindIdContainingPoint(UIView *view, CGPoint
 - (void)scrollViewWillEndDragging:(UIScrollView *)scrollView withVelocity:(CGPoint)velocity targetContentOffset:(inout CGPoint *)targetContentOffset
 {
   if ([[self proxy] _hasListeners:@"scrolling"]) {
-    NSString *direction = nil;
+    NSString *direction = @"unknown";
 
     if (velocity.y > 0) {
       direction = @"up";

--- a/iphone/Classes/TiUIListView.m
+++ b/iphone/Classes/TiUIListView.m
@@ -24,6 +24,7 @@
 @property (nonatomic, readonly) TiUIListViewProxy *listViewProxy;
 @property (nonatomic, copy, readwrite) NSString *searchString;
 @property (nonatomic, copy, readwrite) NSString *searchedString;
+@property (nonatomic, assign) CGFloat lastContentOffset;
 @end
 
 static TiViewProxy *FindViewProxyWithBindIdContainingPoint(UIView *view, CGPoint point);
@@ -2011,6 +2012,15 @@ static TiViewProxy *FindViewProxyWithBindIdContainingPoint(UIView *view, CGPoint
         TiUIListSectionProxy *section;
         CGFloat topSpacing = scrollView.contentOffset.y + scrollView.adjustedContentInset.top;
 
+        NSString *direction = nil;
+
+        if (self.lastContentOffset > scrollView.contentOffset.y) {
+          direction = @"down";
+        } else if (self.lastContentOffset < scrollView.contentOffset.y) {
+          direction = @"up";
+        }
+        self.lastContentOffset = scrollView.contentOffset.y;
+
         if ([indexPaths count] > 0) {
           NSIndexPath *indexPath = [self pathForSearchPath:[indexPaths objectAtIndex:0]];
           NSUInteger visibleItemCount = [indexPaths count];
@@ -2022,6 +2032,7 @@ static TiViewProxy *FindViewProxyWithBindIdContainingPoint(UIView *view, CGPoint
           [eventArgs setValue:section forKey:@"firstVisibleSection"];
           [eventArgs setValue:[section itemAtIndex:[indexPath row]] forKey:@"firstVisibleItem"];
           [eventArgs setValue:NUMINTEGER(topSpacing) forKey:@"top"];
+          [eventArgs setValue:direction forKey:@"direction"];
 
           if (lastVisibleItem != [indexPath row] || lastVisibleSection != [indexPath section] || forceUpdates) {
             // only log if the item changes or forced
@@ -2038,6 +2049,7 @@ static TiViewProxy *FindViewProxyWithBindIdContainingPoint(UIView *view, CGPoint
           [eventArgs setValue:section forKey:@"firstVisibleSection"];
           [eventArgs setValue:NUMINTEGER(-1) forKey:@"firstVisibleItem"];
           [eventArgs setValue:NUMINTEGER(topSpacing) forKey:@"top"];
+          [eventArgs setValue:direction forKey:@"direction"];
         }
       });
     }

--- a/iphone/Classes/TiUIListView.m
+++ b/iphone/Classes/TiUIListView.m
@@ -80,8 +80,8 @@ static TiViewProxy *FindViewProxyWithBindIdContainingPoint(UIView *view, CGPoint
   BOOL isSearched;
   UIView *dimmingView;
   BOOL isSearchBarInNavigation;
-  int lastVisibleItem;
-  int lastVisibleSection;
+  NSInteger lastVisibleItem;
+  NSInteger lastVisibleSection;
   BOOL forceUpdates;
 }
 


### PR DESCRIPTION
iOS currently only adds `direction` in the scrolling event when you release the finger. This PR adds it to the continuous scrolling ([old PR](https://github.com/tidev/titanium-sdk/pull/13830))

```js
var toggle = false;
var sections = [];
const win = Ti.UI.createWindow();
const btn = Ti.UI.createButton({
	title: "change",
	bottom: 20
});
const lbl = Ti.UI.createLabel({
	top: 10,
	right: 10,
	width: Ti.UI.SIZE,
	height: Ti.UI.SIZE
})
const listView = Ti.UI.createListView({
	height: Ti.UI.FILL,
	width: Ti.UI.FILL,
	continuousUpdate: true,
  forceUpdates: false
});

btn.addEventListener("click", function() {
	toggle = !toggle;
	listView.forceUpdates = toggle
	console.log(listView.forceUpdates);
})

for (var s = 0; s < 5; s++) {
	var section = Ti.UI.createListSection({
		headerTitle: 'Section ' + s
	});
	var set = [];
	for (var i = 0; i < 20; ++i) {
		set.push({
			properties: {
				title: 'Item 0 ' + i
			}
		})
	}
	section.setItems(set);
	sections.push(section);
}

listView.sections = sections;
win.add([listView, btn, lbl]);

listView.addEventListener("scrolling", function(e) {
	lbl.text = "Item: " + e.firstVisibleItemIndex + " section:" + e.firstVisibleSectionIndex;
	console.log("Item", e.direction, e.firstVisibleItemIndex, e.firstVisibleSectionIndex, e.top);
})
win.open();
```

https://github.com/user-attachments/assets/f5c36153-0ef1-4e90-a21c-f4a1d121b75b


