### PR TITLE
fix: handle x/y position for touch in dragstart/dragend events on iOS

### DIFF
--- a/iphone/Classes/TiUIScrollViewProxy.m
+++ b/iphone/Classes/TiUIScrollViewProxy.m
@@ -435,7 +435,8 @@ static NSArray *scrollViewKeySequence;
                                               NUMFLOAT(offset.x), @"x",
                                           NUMFLOAT(offset.y), @"y",
                                           NUMBOOL([scrollView isDecelerating]), @"decelerating",
-                                          [TiUtils sizeToDictionary:scrollView.contentSize], @"contentSize", nil];
+                                          [TiUtils sizeToDictionary:scrollView.contentSize], @"contentSize",
+                                          nil];
   if ([self _hasListeners:@"dragStart"]) { // TODO: Deprecate old event
     [self fireEvent:@"dragStart" withObject:drag_dict];
   }
@@ -445,7 +446,6 @@ static NSArray *scrollViewKeySequence;
 }
 
 // listerner which tells when dragging ended in the scroll view.
-
 - (void)scrollViewDidEndDragging:(UIScrollView *)scrollView willDecelerate:(BOOL)decelerate
 {
   CGPoint offset = [scrollView contentOffset];
@@ -453,8 +453,8 @@ static NSArray *scrollViewKeySequence;
                                               NUMFLOAT(offset.x), @"x",
                                           NUMFLOAT(offset.y), @"y",
                                           [NSNumber numberWithBool:decelerate], @"decelerate", nil,
-                                          [TiUtils sizeToDictionary:scrollView.contentSize], @"contentSize", nil];
-    
+                                          [TiUtils sizeToDictionary:scrollView.contentSize], @"contentSize",
+                                          nil];
   if ([self _hasListeners:@"dragEnd"]) { // TODO: Deprecate old event
     [self fireEvent:@"dragEnd" withObject:drag_dict];
   }

--- a/iphone/Classes/TiUIScrollViewProxy.m
+++ b/iphone/Classes/TiUIScrollViewProxy.m
@@ -430,11 +430,17 @@ static NSArray *scrollViewKeySequence;
 
 - (void)scrollViewWillBeginDragging:(UIScrollView *)scrollView
 {
+  CGPoint offset = [scrollView contentOffset];
+  NSDictionary *drag_dict = [NSDictionary dictionaryWithObjectsAndKeys:
+                                              NUMFLOAT(offset.x), @"x",
+                                          NUMFLOAT(offset.y), @"y",
+                                          NUMBOOL([scrollView isDecelerating]), @"decelerating",
+                                          [TiUtils sizeToDictionary:scrollView.contentSize], @"contentSize", nil];
   if ([self _hasListeners:@"dragStart"]) { // TODO: Deprecate old event
-    [self fireEvent:@"dragStart" withObject:nil];
+    [self fireEvent:@"dragStart" withObject:drag_dict];
   }
   if ([self _hasListeners:@"dragstart"]) {
-    [self fireEvent:@"dragstart" withObject:nil];
+    [self fireEvent:@"dragstart" withObject:drag_dict];
   }
 }
 
@@ -442,11 +448,18 @@ static NSArray *scrollViewKeySequence;
 
 - (void)scrollViewDidEndDragging:(UIScrollView *)scrollView willDecelerate:(BOOL)decelerate
 {
+  CGPoint offset = [scrollView contentOffset];
+  NSDictionary *drag_dict = [NSDictionary dictionaryWithObjectsAndKeys:
+                                              NUMFLOAT(offset.x), @"x",
+                                          NUMFLOAT(offset.y), @"y",
+                                          [NSNumber numberWithBool:decelerate], @"decelerate", nil,
+                                          [TiUtils sizeToDictionary:scrollView.contentSize], @"contentSize", nil];
+    
   if ([self _hasListeners:@"dragEnd"]) { // TODO: Deprecate old event
-    [self fireEvent:@"dragEnd" withObject:[NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithBool:decelerate], @"decelerate", nil]];
+    [self fireEvent:@"dragEnd" withObject:drag_dict];
   }
   if ([self _hasListeners:@"dragend"]) {
-    [self fireEvent:@"dragend" withObject:[NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithBool:decelerate], @"decelerate", nil]];
+    [self fireEvent:@"dragend" withObject:drag_dict];
   }
 }
 

--- a/iphone/Classes/TiUIScrollViewProxy.m
+++ b/iphone/Classes/TiUIScrollViewProxy.m
@@ -431,17 +431,17 @@ static NSArray *scrollViewKeySequence;
 - (void)scrollViewWillBeginDragging:(UIScrollView *)scrollView
 {
   CGPoint offset = [scrollView contentOffset];
-  NSDictionary *drag_dict = [NSDictionary dictionaryWithObjectsAndKeys:
-                                              NUMFLOAT(offset.x), @"x",
-                                          NUMFLOAT(offset.y), @"y",
-                                          NUMBOOL([scrollView isDecelerating]), @"decelerating",
-                                          [TiUtils sizeToDictionary:scrollView.contentSize], @"contentSize",
-                                          nil];
+  NSDictionary *dict = [NSDictionary dictionaryWithObjectsAndKeys:
+                                         NUMFLOAT(offset.x), @"x",
+                                     NUMFLOAT(offset.y), @"y",
+                                     NUMBOOL([scrollView isDecelerating]), @"decelerating",
+                                     [TiUtils sizeToDictionary:scrollView.contentSize], @"contentSize",
+                                     nil];
   if ([self _hasListeners:@"dragStart"]) { // TODO: Deprecate old event
-    [self fireEvent:@"dragStart" withObject:drag_dict];
+    [self fireEvent:@"dragStart" withObject:dict];
   }
   if ([self _hasListeners:@"dragstart"]) {
-    [self fireEvent:@"dragstart" withObject:drag_dict];
+    [self fireEvent:@"dragstart" withObject:dict];
   }
 }
 
@@ -449,17 +449,17 @@ static NSArray *scrollViewKeySequence;
 - (void)scrollViewDidEndDragging:(UIScrollView *)scrollView willDecelerate:(BOOL)decelerate
 {
   CGPoint offset = [scrollView contentOffset];
-  NSDictionary *drag_dict = [NSDictionary dictionaryWithObjectsAndKeys:
-                                              NUMFLOAT(offset.x), @"x",
-                                          NUMFLOAT(offset.y), @"y",
-                                          [NSNumber numberWithBool:decelerate], @"decelerate", nil,
-                                          [TiUtils sizeToDictionary:scrollView.contentSize], @"contentSize",
-                                          nil];
+  NSDictionary *dict = [NSDictionary dictionaryWithObjectsAndKeys:
+                                         NUMFLOAT(offset.x), @"x",
+                                     NUMFLOAT(offset.y), @"y",
+                                     [NSNumber numberWithBool:decelerate], @"decelerate", nil,
+                                     [TiUtils sizeToDictionary:scrollView.contentSize], @"contentSize",
+                                     nil];
   if ([self _hasListeners:@"dragEnd"]) { // TODO: Deprecate old event
-    [self fireEvent:@"dragEnd" withObject:drag_dict];
+    [self fireEvent:@"dragEnd" withObject:dict];
   }
   if ([self _hasListeners:@"dragend"]) {
-    [self fireEvent:@"dragend" withObject:drag_dict];
+    [self fireEvent:@"dragend" withObject:dict];
   }
 }
 


### PR DESCRIPTION
 ```js
var win = Ti.UI.createWindow();

var scrollView = Ti.UI.createScrollView({
  showVerticalScrollIndicator: true,
  showHorizontalScrollIndicator: true,
  height: '80%',
  width: '80%'
});
var view = Ti.UI.createView({
  backgroundColor:'#336699',
  borderRadius: 10,
  top: 10,
  height: 2000,
  width: 1000
});
scrollView.add(view);
scrollView.addEventListener("dragstart", function(e){
	console.log(e.x, e.y);
})
scrollView.addEventListener("dragend", function(e){
	console.log(e.x, e.y);
})
win.add(scrollView);
win.open();
 ```

The Android version is this:
https://github.com/tidev/titanium-sdk/pull/14102