### PR TITLE
feat(android): enable gradle config caching

### DIFF
--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -2154,9 +2154,9 @@ AndroidBuilder.prototype.generateRootProjectFiles = async function generateRootP
 	const gradleProperties = await gradlew.fetchDefaultGradleProperties();
 	gradleProperties.push({ key: 'android.useAndroidX', value: 'true' });
 	gradleProperties.push({ key: 'android.enableJetifier', value: 'true' });
-	gradleProperties.push({ key: 'android.suppressUnsupportedCompileSdk', value: '33' });
 	gradleProperties.push({ key: 'android.nonTransitiveRClass', value: 'false' });
 	gradleProperties.push({ key: 'org.gradle.jvmargs', value: `-Xmx${this.javacMaxMemory}` });
+	gradleProperties.push({ key: 'org.gradle.configuration-cache', value: 'true' });
 	await gradlew.writeGradlePropertiesFile(gradleProperties);
 
 	// Copy optional "gradle.properties" file contents from Titanium project to the above generated file.

--- a/android/cli/commands/_buildModule.js
+++ b/android/cli/commands/_buildModule.js
@@ -496,7 +496,6 @@ AndroidModuleBuilder.prototype.generateRootProjectFiles = async function generat
 	// Create a "gradle.properties" file. Will add network proxy settings if needed.
 	const gradleProperties = await gradlew.fetchDefaultGradleProperties();
 	gradleProperties.push({ key: 'android.useAndroidX', value: 'true' });
-	gradleProperties.push({ key: 'android.suppressUnsupportedCompileSdk', value: '33' });
 	gradleProperties.push({
 		key: 'org.gradle.jvmargs',
 		value: `-Xmx${this.javacMaxMemory} -Dkotlin.daemon.jvm.options="-Xmx${this.javacMaxMemory}"`


### PR DESCRIPTION
You will see:
```
[INFO]  Generating semantic colors resources
[INFO]  Generating main "AndroidManifest.xml" files
[INFO]  Building app
[INFO]  [GRADLE] Reusing configuration cache.                          <------------
[INFO]  [GRADLE] > Task :app:preBuild UP-TO-DATE
```
for the 2nd build. 

saved ~200ms in my build (gradle bulid):

```
[INFO]  [GRADLE] > Task :app:createDebugApkListingFileRedirect UP-TO-DATE
[INFO]  [GRADLE] 
[INFO]  [GRADLE] BUILD SUCCESSFUL in 360ms                          <------------
[INFO]  [GRADLE] 34 actionable tasks: 34 up-to-date
```

it is already super fast but won't hurt :-)

Also removing `android.suppressUnsupportedCompileSdk', value: '33'` as we do support it now 