### PR TITLE
fix(android): set default exitOnClose property to true

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/TiWindowProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/TiWindowProxy.java
@@ -568,6 +568,9 @@ public abstract class TiWindowProxy extends TiViewProxy
 			// We're opening child activity from Titanium root activity. Have it exit out of app by default.
 			// Note: If launched via startActivityForResult(), then root activity won't be the task's root.
 			intent.putExtra(TiC.INTENT_PROPERTY_FINISH_ROOT, true);
+
+			// Set default value on first window proxy also if not already set above.
+			setProperty(TiC.PROPERTY_EXIT_ON_CLOSE, true);
 		}
 
 		// Set the theme property


### PR DESCRIPTION
fixes https://github.com/tidev/titanium-sdk/issues/13791

```
var win1 = Ti.UI.createWindow({
	backgroundColor: "green"
})
win1.addEventListener("click", function() {
	var win2 = Ti.UI.createWindow({
		backgroundColor: "red"
	})
	win2.open();
})
win1.open();
```

**Steps to reproduce**

* open the app (green window)
* click to open the second window (red)
* close the red window and close the green window right away
* you will see the root activity


more infos in the [ticket](https://github.com/tidev/titanium-sdk/issues/13791) 