### PR TITLE
chore: ios workflow update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
       run: npm run lint:js
 
   package:
-    runs-on: macos-12
+    runs-on: macos-13
     name: Package
     env:
       SDK_BUILD_CACHE_DIR: ${{ github.workspace }}/.native-modules

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,7 @@ jobs:
           node-version: '20.x'
 
   package:
-    runs-on: macos-12
+    runs-on: macos-13
     name: Package
     env:
       SDK_BUILD_CACHE_DIR: ${{ github.workspace }}/.native-modules


### PR DESCRIPTION
Current workflow is using macos-12 and it is throwing an error now:
 
> The macOS-12 environment is deprecated, consider switching to macOS-13, macOS-14 (macos-latest) or macOS-15. For more details, see https://github.com/actions/runner-images/issues/10721

Raising to macos-13