### PR TITLE
Revert "fix(ios): ios click speed"

### DIFF
--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiUIView.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiUIView.m
@@ -1312,7 +1312,6 @@ DEFINE_EXCEPTIONS
 {
   if (singleTapRecognizer == nil) {
     singleTapRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(recognizedTap:)];
-    [singleTapRecognizer setNumberOfTapsRequired:1];
     [self configureGestureRecognizer:singleTapRecognizer];
     [self addGestureRecognizer:singleTapRecognizer];
     if (doubleTapRecognizer != nil) {
@@ -1435,8 +1434,6 @@ DEFINE_EXCEPTIONS
       [proxy fireEvent:@"dblclick" withObject:event propagate:YES];
     }
     [proxy fireEvent:@"doubletap" withObject:event];
-  } else if ([recognizer numberOfTapsRequired] == 1 && [proxy _hasListeners:@"click"]) {
-    [proxy fireEvent:@"click" withObject:event propagate:YES];
   } else {
     [proxy fireEvent:@"singletap" withObject:event];
   }
@@ -1612,7 +1609,12 @@ DEFINE_EXCEPTIONS
     // Click handling is special; don't propagate if we have a delegate,
     // but DO invoke the touch delegate.
     // clicks should also be handled by any control the view is embedded in.
-    if ([touch tapCount] == 2 && [proxy _hasListeners:@"dblclick"]) {
+    if ([touch tapCount] == 1 && [proxy _hasListeners:@"click"]) {
+      if (touchDelegate == nil) {
+        [proxy fireEvent:@"click" withObject:evt propagate:YES];
+        return;
+      }
+    } else if ([touch tapCount] == 2 && [proxy _hasListeners:@"dblclick"]) {
       [proxy fireEvent:@"dblclick" withObject:evt propagate:YES];
       return;
     }


### PR DESCRIPTION
Reverting tidev/titanium-sdk#14115 as it caused several issues on views and labels. It can be included again after all test cases (incl. https://tidev.slack.com/archives/C0B2EUWRK/p1734022093447139?thread_ts=1734018645.040859&cid=C0B2EUWRK from Slack) are fixed.