### PR TITLE
fix(ios): optimize click event

### DIFF
--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiUIView.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiUIView.m
@@ -1617,6 +1617,9 @@ DEFINE_EXCEPTIONS
     } else if ([touch tapCount] == 2 && [proxy _hasListeners:@"dblclick"]) {
       [proxy fireEvent:@"dblclick" withObject:evt propagate:YES];
       return;
+    } else if ([touch tapCount] > 2 && [proxy _hasListeners:@"click"]) {
+      [proxy fireEvent:@"click" withObject:evt propagate:YES];
+      return;
     }
   }
 }


### PR DESCRIPTION
fixes https://github.com/tidev/titanium-sdk/issues/14051

```js
const win = Ti.UI.createWindow();
win.addEventListener("click", function(e) {
	console.log("click")
})


win.open();
```

This was my initial idea to improve the click event. 

Currently it only uses "click" and "dblclick" but if you continue to click it won't fire click events. More info in the issue https://github.com/tidev/titanium-sdk/issues/14051