### PR TITLE
chore(android): library updates

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -86,6 +86,7 @@ dependencies {
 //		exclude group: 'com.google.android.gms'
 	}
 
+  implementation "androidx.activity:activity:1.8.0"
 	implementation "androidx.appcompat:appcompat:${project.ext.tiAndroidXAppCompatLibVersion}"
 	implementation "com.google.android.material:material:${project.ext.tiMaterialLibVersion}"
 }

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -9,7 +9,7 @@ apply plugin: 'com.android.application'
 
 // Set up Android app project.
 android {
-  compileSdkVersion 34
+	compileSdkVersion 34
 	ndkVersion project.ext.tiNdkVersion
 	defaultConfig {
 		applicationId 'com.titanium.test'
@@ -86,7 +86,7 @@ dependencies {
 //		exclude group: 'com.google.android.gms'
 	}
 
-  implementation "androidx.activity:activity:1.8.0"
+	implementation "androidx.activity:activity:1.8.0"
 	implementation "androidx.appcompat:appcompat:${project.ext.tiAndroidXAppCompatLibVersion}"
 	implementation "com.google.android.material:material:${project.ext.tiMaterialLibVersion}"
 }

--- a/android/package.json
+++ b/android/package.json
@@ -17,7 +17,7 @@
 		"integrity": "sha512-A0tV+fYtkpKfIF5roRTCFPtdULMFygmfWlEuuHOBjC3q4rz/mKnAsJTYBlqayC/4oYEWehj867Oh1o6vy26XHQ=="
 	},
 	"minSDKVersion": "21",
-	"compileSDKVersion": "33",
+	"compileSDKVersion": "34",
 	"vendorDependencies": {
 		"android sdk": ">=23.x <=34.x",
 		"android build tools": ">=30.0.2 <=34.x",

--- a/android/templates/build/ti.constants.gradle
+++ b/android/templates/build/ti.constants.gradle
@@ -7,11 +7,11 @@
 
 project.ext {
 	tiNdkVersion = '26.2.11394342'
-	tiAndroidXAppCompatLibVersion = '1.4.1'
+	tiAndroidXAppCompatLibVersion = '1.7.0'
 	tiAndroidXCoreLibVersion = '1.9.0'
-	tiAndroidXFragmentLibVersion = '1.5.7'
-	tiMaterialLibVersion = '1.6.1'
-	tiPlayServicesBaseLibVersion = '18.2.0'
+	tiAndroidXFragmentLibVersion = '1.7.1'
+	tiMaterialLibVersion = '1.12.0'
+	tiPlayServicesBaseLibVersion = '18.3.0'
 	tiManifestPlaceholders = [
 		tiActivityConfigChanges: 'density|fontScale|keyboard|keyboardHidden|layoutDirection|locale|mcc|mnc|navigation|orientation|screenLayout|screenSize|smallestScreenSize|touchscreen|uiMode'
 	]

--- a/android/titanium/build.gradle
+++ b/android/titanium/build.gradle
@@ -46,7 +46,7 @@ android {
 	ndkVersion project.ext.tiNdkVersion
 	namespace 'org.appcelerator.titanium'
 	defaultConfig {
-		compileSdk 33
+		compileSdk 34
 		minSdkVersion 21
 		targetSdkVersion 34
 		versionName tiBuildVersionString
@@ -284,11 +284,11 @@ dependencies {
 	implementation 'androidx.drawerlayout:drawerlayout:1.2.0'
 	implementation 'androidx.exifinterface:exifinterface:1.3.7'
 	implementation "androidx.fragment:fragment:${project.ext.tiAndroidXFragmentLibVersion}"
-	implementation 'androidx.media:media:1.6.0'
+	implementation 'androidx.media:media:1.7.0'
 	implementation 'androidx.recyclerview:recyclerview:1.3.2'
 	implementation 'androidx.recyclerview:recyclerview-selection:1.1.0'
 	implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
-	implementation 'androidx.transition:transition:1.4.1'
+	implementation 'androidx.transition:transition:1.5.1'
 	implementation 'androidx.vectordrawable:vectordrawable:1.1.0'
 	implementation 'androidx.vectordrawable:vectordrawable-animated:1.1.0'
 	implementation 'androidx.viewpager:viewpager:1.0.0'


### PR DESCRIPTION
Update Android libraries:
* appCompat: 1.7.0
* fragment: 1.7.1
* material: 1.12.0
* ti.playservices: 18.3.0
* media: 1.7.0
* transition: 1.5.1

setting compileSDK to 34 and added activity:1.8.0 (needed for Material 1.12.0)


Tested: kitchensink, custom app (one with a M3 theme, one with a normal theme), hyperloop-examples