### PR TITLE
fix(android): prevent BaseActivity to stay with exitOnClose:false

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/TiApplication.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiApplication.java
@@ -196,6 +196,15 @@ public abstract class TiApplication extends Application implements KrollApplicat
 
 	public static void removeFromActivityStack(Activity activity)
 	{
+		// check if no windows are left - happens when closing windows quickly with exitOnClose:false
+		if (TiActivityWindows.getWindowCount() == 0) {
+			Activity currentActivity = getAppCurrentActivity();
+			if (currentActivity instanceof TiBaseActivity) {
+				// close app otherwise it won't restore correctly
+				currentActivity.finishAffinity();
+				TiApplication.terminateActivityStack();
+			}
+		}
 		if (activity != null) {
 			activityStack.remove(activity);
 		}


### PR DESCRIPTION
Fixes https://github.com/tidev/titanium-sdk/pull/13889

A better attempt to fix the isse where the splashscreens stays open when you close two windows quickly and the root window has `exitOnClose:false`. 

```js
var win1 = Ti.UI.createWindow({
	backgroundColor: "green",
	exitOnClose: false
})

Ti.App.addEventListener("pause", function(){console.log("---pause---");})
Ti.App.addEventListener("resume", function(){console.log("---resume---");})
win1.addEventListener("close", function(){console.log("---close---");})
win1.addEventListener("open", function(){console.log("---open---");})

win1.activity.onCreate = () => { console.log("activity create"); }
win1.activity.onPause = () => { console.log("activity pause"); }
win1.activity.onDestroy = () => { console.log("activity destroy"); }

win1.addEventListener("click", function() {
	var win2 = Ti.UI.createWindow({
		backgroundColor: "red"
	})
	win2.open();
})
win1.open();
```

The `TiActivityWindows.getWindowCount()` check is already used in TiBaseActivity to check if the app should be put into the background (search for `onBackPressed: suspend to background`). In this case we actually need to finish it otherwise it will be in a non resumable state.


**12.6.0**

[Bildschirmaufnahme_20241219_095358.webm](https://github.com/user-attachments/assets/11bf0ca2-7e90-4e67-b8da-10a794cd76ff)


**this PR**

[Bildschirmaufnahme_20241219_095239.webm](https://github.com/user-attachments/assets/419ab2d9-fbd2-4cf6-b43a-f95cdc505b15)


**Different approach:**
The Back button event is already fired before the first "remove from stack" is finished and that is why it still has 2 windows instead of 1 and runs another "remove from stack" instead of putting it to the background. 
I can also block the "back event" until https://github.com/tidev/titanium-sdk/blob/master/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java#L1662 is done and then enable it again. This will stay at the green window when you close both quickly. 

[Bildschirmaufnahme_20241218_221941.webm](https://github.com/user-attachments/assets/0dcaed6e-082a-4ba5-adb9-25101eea778b)


But to me it looks more like a bug if I want to close two windows quickly I want to be closed and not stop at the parent window.

@prashantsaini1: would love to get your feedback on this approach