### PR TITLE
fix(android): fix crash when using window.add([]) with a null object

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/TiViewProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/TiViewProxy.java
@@ -587,7 +587,11 @@ public abstract class TiViewProxy extends KrollProxy
 				if (arg instanceof TiViewProxy) {
 					add((TiViewProxy) arg);
 				} else {
-					Log.w(TAG, "add() unsupported array object: " + arg.getClass().getSimpleName());
+					if (arg == null) {
+						Log.w(TAG, "add() unsupported array object: null");
+					} else {
+						Log.w(TAG, "add() unsupported array object: " + arg.getClass().getSimpleName());
+					}
 				}
 			}
 		} else if (args instanceof TiViewProxy) {


### PR DESCRIPTION
**Issue**
If you add a null object when using `.add([])` it will crash with 

```
(main) [178,178] <embedded>:5351
    _add.call(this, child);
         ^
Error: Attempt to invoke virtual method 'java.lang.Class java.lang.Object.getClass()' on a null object reference
    at Window.add (<embedded>:5351:10)
    at new Controller (/alloy/controllers/index.js:93:5)
    at Object.exports.createController (/alloy.js:427:8)
    at /app.js:32:7
    at Module._runScript (ti:/kroll.js:1196:15)
    at Module.load (ti:/kroll.js:734:13)
    at Module.loadJavascriptText (ti:/kroll.js:1062:15)
    at Module.loadAsFile (ti:/kroll.js:1108:22)
    at Module.loadAsFileOrDirectory (ti:/kroll.js:1039:26)
    at Module.require (ti:/kroll.js:865:30)

    org.appcelerator.titanium.proxy.TiViewProxy.add(TiViewProxy.java:590)
```
because it tries to get the class name for the warning. Since it is `null` it will crash instead of showing a warning. 

This PR adds a null check and outputs a different warning.

**Test**
```js
const win = Ti.UI.createWindow({layout:"vertical"});
const lbl1 = Ti.UI.createLabel({text:"lbl"});
const lbl2 = Ti.UI.createLabel({text:"lbl"});
win.add([lbl1, , lbl2]);
win.open();
```