### PR TITLE
fix(android): fix path error on Windows module builds

### DIFF
--- a/android/templates/module/generated/build.gradle
+++ b/android/templates/module/generated/build.gradle
@@ -194,7 +194,7 @@ tasks.withType(JavaCompile).configureEach {
 			environment 'TI_MODULE_GENERATED_JS_DIR', "${projectDir}/build/ti-generated/js"
 			environment 'TI_MODULE_ID', '<%- moduleId %>'
 			environment 'TI_MODULE_NAMESPACE', '<%- moduleId.toLowerCase() %>'
-			environment 'TI_MODULE_TEMPLATE_DIR', '<%- tiSdkModuleTemplateDir.replace(/\\/g, ' \ \ \ \ ') %>'
+			environment 'TI_MODULE_TEMPLATE_DIR', '<%- tiSdkModuleTemplateDir.replace(/\\/g, '\\\\') %>'
 			executable = 'node'
 			workingDir = projectDir
 			args = ['generate-cpp-files.js']


### PR DESCRIPTION
This was a change in the gradle update https://github.com/tidev/titanium-sdk/pull/14014 and it breaks windows module builds. 
It will generate `C:\     ProgramData     Titanium     mobilesdk     win32     12.6.1.GA     android     templates     module     generated\TiModuleBootstrap.cpp'` as an output path which breaks the build. 

This change will generate the proper path again by reverting back to the initial replace string (OSX and Linux are using `/` so it was never an issue there).

It would also be great to merge https://github.com/tidev/titanium-sdk/pull/14078 . While it might not be the best solution it will enable the windows module builds again. More details in https://github.com/tidev/titanium-sdk/issues/14077#issuecomment-2225442113 (there is no log anyways for all platforms, so even if we fix the bigger part it won't log more then ti info).