### PR TITLE
feat(android): layerType property for WebView

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/WebViewProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/WebViewProxy.java
@@ -245,22 +245,22 @@ public class WebViewProxy extends ViewProxy implements Handler.Callback, OnLifec
 	}
 
 	@Kroll.setProperty
-	public void setSoftwareMode(Boolean value)
+	public void setLayerType(int value)
 	{
 		TiUIWebView currWebView = getWebView();
 		if (currWebView != null) {
-			currWebView.setSoftwareMode(value);
+			currWebView.setLayerType(value);
 		}
 	}
 
 	@Kroll.getProperty
-	public boolean getSoftwareMode()
+	public int getLayerType()
 	{
 		TiUIWebView currWebView = getWebView();
 		if (currWebView != null) {
-			return currWebView.softwareMode;
+			return currWebView.layerType;
 		}
-		return false;
+		return 0;
 	}
 
 	@Kroll.setProperty

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/WebViewProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/WebViewProxy.java
@@ -15,6 +15,7 @@ import android.print.PrintAttributes;
 import android.print.PrintDocumentAdapter;
 import android.print.PrintManager;
 import android.util.DisplayMetrics;
+import android.view.View;
 import android.webkit.ValueCallback;
 import android.webkit.WebView;
 
@@ -75,6 +76,13 @@ public class WebViewProxy extends ViewProxy implements Handler.Callback, OnLifec
 	private static String fpassword;
 	PrintManager printManager;
 	private Message postCreateMessage;
+
+	@Kroll.constant
+	public static final int LAYER_TYPE_NONE = View.LAYER_TYPE_NONE;
+	@Kroll.constant
+	public static final int LAYER_TYPE_SOFTWARE = View.LAYER_TYPE_SOFTWARE;
+	@Kroll.constant
+	public static final int LAYER_TYPE_HARDWARE = View.LAYER_TYPE_HARDWARE;
 
 	public WebViewProxy()
 	{

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/WebViewProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/WebViewProxy.java
@@ -75,7 +75,6 @@ public class WebViewProxy extends ViewProxy implements Handler.Callback, OnLifec
 	private static String fpassword;
 	PrintManager printManager;
 	private Message postCreateMessage;
-	private boolean softwareMode = false;
 
 	public WebViewProxy()
 	{
@@ -250,7 +249,6 @@ public class WebViewProxy extends ViewProxy implements Handler.Callback, OnLifec
 	{
 		TiUIWebView currWebView = getWebView();
 		if (currWebView != null) {
-			softwareMode = value;
 			currWebView.setSoftwareMode(value);
 		}
 	}
@@ -258,7 +256,11 @@ public class WebViewProxy extends ViewProxy implements Handler.Callback, OnLifec
 	@Kroll.getProperty
 	public boolean getSoftwareMode()
 	{
-		return softwareMode;
+		TiUIWebView currWebView = getWebView();
+		if (currWebView != null) {
+			return currWebView.softwareMode;
+		}
+		return false;
 	}
 
 	@Kroll.setProperty

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/WebViewProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/WebViewProxy.java
@@ -75,6 +75,7 @@ public class WebViewProxy extends ViewProxy implements Handler.Callback, OnLifec
 	private static String fpassword;
 	PrintManager printManager;
 	private Message postCreateMessage;
+	private boolean softwareMode = false;
 
 	public WebViewProxy()
 	{
@@ -242,6 +243,22 @@ public class WebViewProxy extends ViewProxy implements Handler.Callback, OnLifec
 			return currWebView.getRequestHeaders();
 		}
 		return new HashMap<String, String>();
+	}
+
+	@Kroll.setProperty
+	public void setSoftwareMode(Boolean value)
+	{
+		TiUIWebView currWebView = getWebView();
+		if (currWebView != null) {
+			softwareMode = value;
+			currWebView.setSoftwareMode(value);
+		}
+	}
+
+	@Kroll.getProperty
+	public boolean getSoftwareMode()
+	{
+		return softwareMode;
 	}
 
 	@Kroll.setProperty

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
@@ -475,8 +475,8 @@ public class TiUIWebView extends TiUIView
 				|| scrollbarValue == AndroidModule.WEBVIEW_SCROLLBARS_HIDE_VERTICAL);
 		}
 
-		if (d.containsKeyAndNotNull(TiC.PROPERTY_SOFTWARE_MODE)) {
-			setLayerType(TiConvert.toInt(d, TiC.PROPERTY_SOFTWARE_MODE));
+		if (d.containsKeyAndNotNull(TiC.PROPERTY_LAYER_TYPE)) {
+			setLayerType(TiConvert.toInt(d, TiC.PROPERTY_LAYER_TYPE));
 		}
 	}
 

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
@@ -308,7 +308,6 @@ public class TiUIWebView extends TiUIView
 		WebSettings settings = webView.getSettings();
 		settings.setUseWideViewPort(true);
 		settings.setJavaScriptEnabled(true);
-//		webView.setLayerType(View.LAYER_TYPE_SOFTWARE, null);
 		settings.setSupportMultipleWindows(true);
 		settings.setJavaScriptCanOpenWindowsAutomatically(true);
 		settings.setLoadsImagesAutomatically(true);

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
@@ -64,8 +64,6 @@ public class TiUIWebView extends TiUIView
 	private float zoomLevel = TiApplication.getInstance().getResources().getDisplayMetrics().density;
 	private float initScale = zoomLevel;
 
-	public boolean softwareMode = false;
-
 	public static final int PLUGIN_STATE_OFF = 0;
 	public static final int PLUGIN_STATE_ON = 1;
 	public static final int PLUGIN_STATE_ON_DEMAND = 2;
@@ -82,6 +80,14 @@ public class TiUIWebView extends TiUIView
 	public static final int PDF_PAGE_DIN_A1 = 4;
 	@Kroll.constant
 	public static final int PDF_PAGE_AUTO = 5;
+
+	@Kroll.constant
+	public static final int LAYER_TYPE_NONE = View.LAYER_TYPE_NONE;
+	@Kroll.constant
+	public static final int LAYER_TYPE_SOFTWARE = View.LAYER_TYPE_SOFTWARE;
+	@Kroll.constant
+	public static final int LAYER_TYPE_HARDWARE = View.LAYER_TYPE_HARDWARE;
+	public int layerType = LAYER_TYPE_NONE;
 
 	private static enum reloadTypes { DEFAULT, DATA, HTML, URL }
 
@@ -470,7 +476,7 @@ public class TiUIWebView extends TiUIView
 		}
 
 		if (d.containsKeyAndNotNull(TiC.PROPERTY_SOFTWARE_MODE)) {
-			setSoftwareMode(TiConvert.toBoolean(d, TiC.PROPERTY_SOFTWARE_MODE));
+			setLayerType(TiConvert.toInt(d, TiC.PROPERTY_SOFTWARE_MODE));
 		}
 	}
 
@@ -1077,16 +1083,11 @@ public class TiUIWebView extends TiUIView
 		Log.d(TAG, "Do not disable HW acceleration for WebView.", Log.DEBUG_MODE);
 	}
 
-	public void setSoftwareMode(Boolean value)
+	public void setLayerType(int value)
 	{
 		WebView webView = getWebView();
 		if (webView != null) {
-			softwareMode = value;
-			if (value) {
-				webView.setLayerType(View.LAYER_TYPE_SOFTWARE, null);
-			} else {
-				webView.setLayerType(View.LAYER_TYPE_HARDWARE, null);
-			}
+			webView.setLayerType(value, null);
 		}
 	}
 

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
@@ -308,6 +308,7 @@ public class TiUIWebView extends TiUIView
 		WebSettings settings = webView.getSettings();
 		settings.setUseWideViewPort(true);
 		settings.setJavaScriptEnabled(true);
+//		webView.setLayerType(View.LAYER_TYPE_SOFTWARE, null);
 		settings.setSupportMultipleWindows(true);
 		settings.setJavaScriptCanOpenWindowsAutomatically(true);
 		settings.setLoadsImagesAutomatically(true);
@@ -1070,4 +1071,17 @@ public class TiUIWebView extends TiUIView
 	{
 		Log.d(TAG, "Do not disable HW acceleration for WebView.", Log.DEBUG_MODE);
 	}
+
+	public void setSoftwareMode(Boolean value)
+	{
+		WebView webView = getWebView();
+		if (webView != null) {
+			if (value) {
+				webView.setLayerType(View.LAYER_TYPE_SOFTWARE, null);
+			} else {
+				webView.setLayerType(View.LAYER_TYPE_HARDWARE, null);
+			}
+		}
+	}
+
 }

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
@@ -64,6 +64,8 @@ public class TiUIWebView extends TiUIView
 	private float zoomLevel = TiApplication.getInstance().getResources().getDisplayMetrics().density;
 	private float initScale = zoomLevel;
 
+	public boolean softwareMode = false;
+
 	public static final int PLUGIN_STATE_OFF = 0;
 	public static final int PLUGIN_STATE_ON = 1;
 	public static final int PLUGIN_STATE_ON_DEMAND = 2;
@@ -465,6 +467,10 @@ public class TiUIWebView extends TiUIView
 				|| scrollbarValue == AndroidModule.WEBVIEW_SCROLLBARS_HIDE_HORIZONTAL);
 			webView.setHorizontalScrollBarEnabled(scrollbarValue == AndroidModule.WEBVIEW_SCROLLBARS_DEFAULT
 				|| scrollbarValue == AndroidModule.WEBVIEW_SCROLLBARS_HIDE_VERTICAL);
+		}
+
+		if (d.containsKeyAndNotNull(TiC.PROPERTY_SOFTWARE_MODE)) {
+			setSoftwareMode(TiConvert.toBoolean(d, TiC.PROPERTY_SOFTWARE_MODE));
 		}
 	}
 
@@ -1075,6 +1081,7 @@ public class TiUIWebView extends TiUIView
 	{
 		WebView webView = getWebView();
 		if (webView != null) {
+			softwareMode = value;
 			if (value) {
 				webView.setLayerType(View.LAYER_TYPE_SOFTWARE, null);
 			} else {

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
@@ -81,13 +81,7 @@ public class TiUIWebView extends TiUIView
 	@Kroll.constant
 	public static final int PDF_PAGE_AUTO = 5;
 
-	@Kroll.constant
-	public static final int LAYER_TYPE_NONE = View.LAYER_TYPE_NONE;
-	@Kroll.constant
-	public static final int LAYER_TYPE_SOFTWARE = View.LAYER_TYPE_SOFTWARE;
-	@Kroll.constant
-	public static final int LAYER_TYPE_HARDWARE = View.LAYER_TYPE_HARDWARE;
-	public int layerType = LAYER_TYPE_NONE;
+	public int layerType = WebViewProxy.LAYER_TYPE_NONE;
 
 	private static enum reloadTypes { DEFAULT, DATA, HTML, URL }
 
@@ -1087,6 +1081,7 @@ public class TiUIWebView extends TiUIView
 	{
 		WebView webView = getWebView();
 		if (webView != null) {
+			layerType = value;
 			webView.setLayerType(value, null);
 		}
 	}

--- a/android/titanium/src/java/org/appcelerator/titanium/TiC.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiC.java
@@ -863,7 +863,7 @@ public class TiC
 	public static final String PROPERTY_DEPARTMENT = "department";
 	public static final String PROPERTY_FIXED_SIZE = "fixedSize";
 	public static final String PROPERTY_UI_FLAGS = "uiFlags";
-	public static final String PROPERTY_SOFTWARE_MODE = "softwareMode";
+	public static final String PROPERTY_LAYER_TYPE = "layerType";
 
 	public static final String SIZE_AUTO = "auto";
 	public static final String URL_APP_PREFIX = "app://";

--- a/android/titanium/src/java/org/appcelerator/titanium/TiC.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiC.java
@@ -863,6 +863,7 @@ public class TiC
 	public static final String PROPERTY_DEPARTMENT = "department";
 	public static final String PROPERTY_FIXED_SIZE = "fixedSize";
 	public static final String PROPERTY_UI_FLAGS = "uiFlags";
+	public static final String PROPERTY_SOFTWARE_MODE = "softwareMode";
 
 	public static final String SIZE_AUTO = "auto";
 	public static final String URL_APP_PREFIX = "app://";

--- a/apidoc/Titanium/UI/WebView.yml
+++ b/apidoc/Titanium/UI/WebView.yml
@@ -1020,6 +1020,16 @@ properties:
     platforms: [iphone, ipad, macos]
     since: {iphone: "2.0.0", ipad: "2.0.0", macos: "9.2.0"}
 
+  - name: softwareMode
+    summary: A Boolean value indicating the render mode of the WebView
+    description: |
+        Set to `true` (software rendering) if you use `Ti.Media.takeScreensho()` or `toImage()` and the WebView contains local HTML files.
+        Otherwise the WebView might be empty in the screenshot/image.
+    type: Boolean
+    default: false
+    platforms: [android]
+    since: {android: "12.7.0"}
+
   - name: enableZoomControls
     summary: If `true`, zoom controls are enabled.
     type: Boolean

--- a/apidoc/Titanium/UI/WebView.yml
+++ b/apidoc/Titanium/UI/WebView.yml
@@ -1020,13 +1020,14 @@ properties:
     platforms: [iphone, ipad, macos]
     since: {iphone: "2.0.0", ipad: "2.0.0", macos: "9.2.0"}
 
-  - name: softwareMode
-    summary: A Boolean value indicating the render mode of the WebView
+  - name: layerType
+    summary: A value indicating the render mode of the WebView
     description: |
-        Set to `true` (software rendering) if you use `Ti.Media.takeScreensho()` or `toImage()` and the WebView contains local HTML files.
+        Set to Ti.UI.WebView.LAYER_TYPE_SOFTWARE (software rendering) if you use `Ti.Media.takeScreenshot()` or `toImage()` and the WebView contains local HTML files.
         Otherwise the WebView might be empty in the screenshot/image. If you change the setting you will have to assing the HTML content again.
-    type: Boolean
-    default: false
+    type: Number
+    constants: Titanium.UI.WebView.LAYER_TYPE_*
+    default: <Titanium.UI.WebView.LAYER_TYPE_NONE>
     platforms: [android]
     since: {android: "12.7.0"}
 
@@ -1205,6 +1206,27 @@ properties:
     platforms: [iphone, ipad, macos]
     since: {iphone: "8.0.0", ipad: "8.0.0", macos: "9.2.0"}
     permission: read-only
+
+  - name: LAYER_TYPE_NONE
+    summary: Default rendering mode
+    type: Number
+    platforms: [android]
+    permission: read-only
+    since: "12.7.0"
+
+  - name: LAYER_TYPE_SOFTWARE
+    summary: Software rendering mode
+    type: Number
+    platforms: [android]
+    permission: read-only
+    since: "12.7.0"
+
+  - name: LAYER_TYPE_HARDWARE
+    summary: Hardware rendering mode
+    type: Number
+    platforms: [android]
+    permission: read-only
+    since: "12.7.0"
 
   - name: PDF_PAGE_DIN_A5
     summary: PDF paper size

--- a/apidoc/Titanium/UI/WebView.yml
+++ b/apidoc/Titanium/UI/WebView.yml
@@ -1024,7 +1024,7 @@ properties:
     summary: A Boolean value indicating the render mode of the WebView
     description: |
         Set to `true` (software rendering) if you use `Ti.Media.takeScreensho()` or `toImage()` and the WebView contains local HTML files.
-        Otherwise the WebView might be empty in the screenshot/image.
+        Otherwise the WebView might be empty in the screenshot/image. If you change the setting you will have to assing the HTML content again.
     type: Boolean
     default: false
     platforms: [android]


### PR DESCRIPTION
## Issue
Capturing a screenshot of a webview with local content (e.g. GraphJS) will capture an empty webview. External URLs work fine.
iOS does capture local content without issues.

## Solution
Setting the WebView into software rendering mode will make the data appear again. Previously it was done by setting a border or transparent background. As these methods don't work and would lead to visual differences I've added a `.layerType = 0|1|2` property. 

## Test

```js
var win = Ti.UI.createWindow({});
var btn = Ti.UI.createButton({title:"click"});
var img = Ti.UI.createImageView({bottom:0,height:200,borderWidth:1,borderColor:"red",width: 100});
var html =`<div style="height:150px">
	<canvas id="myChart"></canvas>
</div>

<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>

<script>
  const ctx = document.getElementById('myChart');

  new Chart(ctx, {
    type: 'bar',
    data: {
      labels: ['Red', 'Blue', 'Yellow', 'Green', 'Purple', 'Orange'],
      datasets: [{label: '# of Votes',data: [12, 19, 3, 5, 2, 3],borderWidth: 1}]
    },
    options: {
      animation: {duration: 0},
      scales: {y: {beginAtZero: true}}
    }
  });
</script>`;

var webview = Ti.UI.createWebView({top: 0, height: 200, layerType:Ti.UI.WebView.LAYER_TYPE_SOFTWARE, html:html});

console.log(Ti.UI.WebView.LAYER_TYPE_NONE);
console.log(Ti.UI.WebView.LAYER_TYPE_SOFTWARE);
console.log(Ti.UI.WebView.LAYER_TYPE_HARDWARE);

win.add([btn, img,webview]);
win.open();
win.addEventListener("open", function(){
	// webview.layerType = Ti.UI.WebView.LAYER_TYPE_SOFTWARE; // or here
	console.log(webview.layerType)
})
btn.addEventListener("click", function(){
	console.log(webview.layerType)
	Ti.Media.takeScreenshot(function(e){
		img.image = e.media;
	});
})
```

## Workaround
Using Hylerloop to set it:
```js
const WebView = require("android.webkit.WebView");
const View = require("android.view.View");

// this should be in open or your screenshot method
var webView = new WebView($.webview);
webView.setLayerType(View.LAYER_TYPE_SOFTWARE, null);
```