### PR TITLE
fix(android): missing null checks in Ti.UI.Label methods

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUILabel.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUILabel.java
@@ -803,12 +803,20 @@ public class TiUILabel extends TiUIView
 	public int getLineCount()
 	{
 		MaterialTextView textView = (MaterialTextView) getNativeView();
-		return textView.getLineCount();
+		if (textView != null && textView.getLayout() != null) {
+			return textView.getLineCount();
+		} else {
+			return 0;
+		}
 	}
 
 	public String getVisibleText()
 	{
 		MaterialTextView textView = (MaterialTextView) getNativeView();
-		return textView.getLayout().getText().toString();
+		if (textView != null && textView.getLayout() != null) {
+			return textView.getLayout().getText().toString();
+		} else {
+			return "";
+		}
 	}
 }


### PR DESCRIPTION
missing null checks. Found with mocha tests from https://github.com/tidev/titanium-sdk/pull/14158