### PR TITLE
fix(tests): update canOpenURL test

### DIFF
--- a/tests/Resources/ti.platform.test.js
+++ b/tests/Resources/ti.platform.test.js
@@ -308,8 +308,8 @@ describe('Titanium.Platform', () => {
 				should(Ti.Platform.canOpenURL).be.a.Function();
 			});
 
-			it('returns true for typical http URL', () => {
-				should(Ti.Platform.canOpenURL('http://www.google.com/')).be.true();
+			it('returns true for typical https URL', () => {
+				should(Ti.Platform.canOpenURL('https://www.google.com/')).be.true();
 			});
 
 			it('returns true for app-sepcific URI scheme', () => {

--- a/tests/platform/android/AndroidManifest.xml
+++ b/tests/platform/android/AndroidManifest.xml
@@ -3,4 +3,21 @@
 	<application>
 		<meta-data android:name="metatadata1" android:value="Metadata 1"/>
 	</application>
+	<queries>
+		<!-- Allows "http://" and "https://" web URLs. -->
+		<intent>
+			<action android:name="android.intent.action.VIEW"/>
+			<data android:scheme="https"/>
+		</intent>
+		<!-- Allows "mailto:" URLs to an e-mail app. -->
+		<intent>
+			<action android:name="android.intent.action.VIEW"/>
+			<data android:scheme="mailto"/>
+		</intent>
+		<!-- Allows file URLs to local image files. -->
+		<intent>
+			<action android:name="android.intent.action.VIEW"/>
+			<data android:mimeType="image/*"/>
+		</intent>
+	</queries>
 </manifest>


### PR DESCRIPTION
Adds the <queries> to the manifest to make the `canOpenURL()` test work again and switching to https.

That brings us to:
`5169 Total Tests: 5165 passed, 4 failed, 0 skipped.`

two failing tests are locale date related ("Date" and "Intl.DateTimeFormat"), one is a notification test ("Notifications enabled by default") and the last one is a `android:resource://` ("Titanium.Filesystem.File.constructed via URIs") issue.