### PR TITLE
fix(android): prevent ANR Bad Behaviour warnings from Google

### DIFF
--- a/android/runtime/common/src/java/org/appcelerator/kroll/KrollRuntime.java
+++ b/android/runtime/common/src/java/org/appcelerator/kroll/KrollRuntime.java
@@ -538,7 +538,9 @@ public abstract class KrollRuntime implements Handler.Callback
 			}
 
 			// Handle exception with defaultExceptionHandler
-			instance.primaryExceptionHandler.handleException(exceptionMessage);
+			if (instance.primaryExceptionHandler != null) {
+				instance.primaryExceptionHandler.handleException(exceptionMessage);
+			}
 		}
 	}
 

--- a/android/titanium/src/java/org/appcelerator/kroll/KrollProxy.java
+++ b/android/titanium/src/java/org/appcelerator/kroll/KrollProxy.java
@@ -1253,7 +1253,7 @@ public class KrollProxy implements Handler.Callback, KrollProxySupport, OnLifecy
 				}
 			}
 		} catch (Throwable t) {
-			Thread.getDefaultUncaughtExceptionHandler().uncaughtException(null, t);
+			TiApplication.handleInternalException(t);
 		}
 
 		return false;

--- a/android/titanium/src/java/org/appcelerator/titanium/TiApplication.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiApplication.java
@@ -95,6 +95,7 @@ public abstract class TiApplication extends Application implements KrollApplicat
 	private String defaultUnit;
 	private BroadcastReceiver localeReceiver;
 	private AccessibilityManager accessibilityManager = null;
+	private UncaughtExceptionHandler nativeExceptionHandler = null;
 
 	protected TiDeployData deployData;
 	protected ITiAppInfo appInfo;
@@ -346,6 +347,9 @@ public abstract class TiApplication extends Application implements KrollApplicat
 		super.onCreate();
 		Log.d(TAG, "Application onCreate", Log.DEBUG_MODE);
 
+		// Reference to android run-time exception handler to delegate exceptions properly.
+		nativeExceptionHandler = Thread.getDefaultUncaughtExceptionHandler();
+
 		// handle uncaught java exceptions
 		Thread.setDefaultUncaughtExceptionHandler(new UncaughtExceptionHandler() {
 			@Override
@@ -364,6 +368,10 @@ public abstract class TiApplication extends Application implements KrollApplicat
 
 				// throw exception as KrollException
 				KrollRuntime.dispatchException("Runtime Error", e.getMessage(), null, 0, null, 0, null, javaStack);
+
+				if (nativeExceptionHandler != null) {
+					nativeExceptionHandler.uncaughtException(t, e);
+				}
 			}
 		});
 

--- a/android/titanium/src/java/org/appcelerator/titanium/TiApplication.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiApplication.java
@@ -341,6 +341,14 @@ public abstract class TiApplication extends Application implements KrollApplicat
 		}
 	}
 
+	public static void handleInternalException(Throwable throwable)
+	{
+		final UncaughtExceptionHandler currentExceptionHandler = Thread.getDefaultUncaughtExceptionHandler();
+		if (currentExceptionHandler != null) {
+			currentExceptionHandler.uncaughtException(Thread.currentThread(), throwable);
+		}
+	}
+
 	@Override
 	public void onCreate()
 	{

--- a/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
@@ -790,7 +790,7 @@ public abstract class TiBaseActivity extends AppCompatActivity implements TiActi
 		try {
 			windowCreated(savedInstanceState);
 		} catch (Throwable t) {
-			Thread.getDefaultUncaughtExceptionHandler().uncaughtException(null, t);
+			TiApplication.handleInternalException(t);
 		}
 
 		// set the current activity back to what it was originally
@@ -817,7 +817,7 @@ public abstract class TiBaseActivity extends AppCompatActivity implements TiActi
 			try {
 				window.onWindowActivityCreated();
 			} catch (Throwable t) {
-				Thread.getDefaultUncaughtExceptionHandler().uncaughtException(null, t);
+				TiApplication.handleInternalException(t);
 			}
 		}
 		if (activityProxy != null) {
@@ -1338,7 +1338,7 @@ public abstract class TiBaseActivity extends AppCompatActivity implements TiActi
 			data.put(TiC.EVENT_PROPERTY_SOURCE, this.activityProxy);
 			this.activityProxy.callPropertySync(propertyName, new Object[] { data });
 		} catch (Throwable ex) {
-			Thread.getDefaultUncaughtExceptionHandler().uncaughtException(null, ex);
+			TiApplication.handleInternalException(ex);
 		}
 	}
 


### PR DESCRIPTION
**This PR attempts to fix an old issue with Titanium SDK where the `Thread.setDefaultUncaughtExceptionHandler` in `TiApplication.onCreate` prevents uncaught exceptions to be handled by system, leading to ANRs.**

### Side effect:
- This PR only prevents ANRs happening due to main-thread waiting, but not the underlying code which causes it, so this will likely turn such ANRs into crashes now which is expected in case of uncaught exceptions. 
- Crash reports are always more verbose in identifying the root cause of issue than ANR reports.

In order to improve error output in [this commit](https://github.com/tidev/titanium-sdk/commit/49a0998b640d7fd5d3adb80ad4f08c6319ea9378#diff-78de726bd2715a7fb5f52e6c82dd6a1cc6736ca7d9cc67a2fdad5cb0defe5580L365), the delegate call got missed to handle uncaught exceptions by Android system, which eventually turns into ANR than likely crashing the app. (A crash event seems better than ANR in uncaught exceptions scenarios).

An excerpt from Firebase ANR reports:

> The main thread has finished processing events and is shutting down the app.
As part of this process, it waits for all other threads to finish.  If there is a thread that does not finish, it is possible that the app will show an ANR as the system considers it to still be active.
A common cause for this type of ANR is installing a new uncaught exception handler that does not delegate to the previous handler. Failure to call back into the previous handler will cause an ANR.

[Another link which describes similar problem](https://ashishb.net/programming/android-uncaught-exception-handler-and-anr/), there are more such reports out there.

- The JS side errors will still show same error dialog as they are caught by V8 Runtime and not delegated to Android main thread.
- `ti.crashlytics` module should also work as it relies on `KrollRuntime.dispatchException` method call before delegating the exception to system. (I will double verify it further - `verified`).