### PR TITLE
fix(android): android modules with timodule.xml manifest entry breaks since 12.6.x

### DIFF
--- a/android/cli/commands/_buildModule.js
+++ b/android/cli/commands/_buildModule.js
@@ -496,6 +496,7 @@ AndroidModuleBuilder.prototype.generateRootProjectFiles = async function generat
 	// Create a "gradle.properties" file. Will add network proxy settings if needed.
 	const gradleProperties = await gradlew.fetchDefaultGradleProperties();
 	gradleProperties.push({ key: 'android.useAndroidX', value: 'true' });
+	gradleProperties.push({ key: 'android.nonTransitiveRClass', value: 'false' });
 	gradleProperties.push({
 		key: 'org.gradle.jvmargs',
 		value: `-Xmx${this.javacMaxMemory} -Dkotlin.daemon.jvm.options="-Xmx${this.javacMaxMemory}"`

--- a/android/cli/commands/_buildModule.js
+++ b/android/cli/commands/_buildModule.js
@@ -616,6 +616,8 @@ AndroidModuleBuilder.prototype.generateModuleProject = async function generateMo
 		throw err;
 	}
 
+	await mainManifest.writeToFilePath(path.join(moduleMainDir, 'AndroidManifest.xml'));
+
 	// Generate Java file used to provide this module's JS source code to Titanium's JS runtime.
 	let fileContent = await fs.readFile(path.join(this.moduleTemplateDir, 'CommonJsSourceProvider.java'));
 	fileContent = ejs.render(fileContent.toString(), { moduleId: moduleId });


### PR DESCRIPTION
Since this [Gradle-8 PR](https://github.com/tidev/titanium-sdk/pull/14014), modules with their own manifest in `timodule.xml` are breaking due to:
1. Missing merge process of `timodule.xml manifest` entry in main manifest.
2. Not disabling `android:nonTransitiveRClass` for module build, but disabling for app build.