### PR TITLE
fix(android): lifecycle listeners and states

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
@@ -1670,8 +1670,6 @@ public abstract class TiBaseActivity extends AppCompatActivity implements TiActi
 	@Override
 	protected void onSaveInstanceState(Bundle outState)
 	{
-		super.onSaveInstanceState(outState);
-
 		// If activity is being temporarily destroyed, then save settings to be restored when activity is recreated.
 		if (!isFinishing()) {
 			if (supportHelper != null) {
@@ -1692,6 +1690,8 @@ public abstract class TiBaseActivity extends AppCompatActivity implements TiActi
 				}
 			}
 		}
+
+		super.onSaveInstanceState(outState);
 	}
 
 	@Override

--- a/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
@@ -1317,9 +1317,39 @@ public abstract class TiBaseActivity extends AppCompatActivity implements TiActi
 		onPrepareOptionsMenuListeners.add(new WeakReference<>(listener));
 	}
 
-	public void removeOnLifecycleEventListener(OnLifecycleEvent listener)
+	public boolean removeOnLifecycleEventListener(OnLifecycleEvent listener)
 	{
-		// TODO stub
+		return lifecycleListeners.remove(listener);
+	}
+
+	public boolean removeOnInstanceStateEventListener(OnInstanceStateEvent listener)
+	{
+		return instanceStateListeners.remove(listener);
+	}
+
+	public boolean removeOnWindowFocusChangedEventListener(OnWindowFocusChangedEvent listener)
+	{
+		return windowFocusChangedListeners.remove(listener);
+	}
+
+	public boolean removeInterceptOnBackPressedEventListener(interceptOnBackPressedEvent listener)
+	{
+		return interceptOnBackPressedListeners.remove(listener);
+	}
+
+	public boolean removeOnActivityResultListener(OnActivityResultEvent listener)
+	{
+		return onActivityResultListeners.remove(listener);
+	}
+
+	public boolean removeOnCreateOptionsMenuEventListener(OnCreateOptionsMenuEvent listener)
+	{
+		return onCreateOptionsMenuListeners.remove(listener);
+	}
+
+	public boolean removeOnPrepareOptionsMenuEventListener(OnPrepareOptionsMenuEvent listener)
+	{
+		return onPrepareOptionsMenuListeners.remove(listener);
 	}
 
 	private void dispatchCallback(String propertyName, KrollDict data)


### PR DESCRIPTION
Fixes:
1. Save activity instance state after further states are updated.
2. Add support to remove various listeners from proxies to avoid holding its activity reference and calling them when a proxy is removed.

Further fixes to come:
1. Some internal views like a WebView holds activity reference after being removed and still be able to call its callbacks repeatedly when added/removed multiple times. (check below screenshot).
   - Though I could not find any memory leaks as these are all WeakReference, but it's still a safe check to remove their listeners once the relevant view-proxy is removed.

![Screenshot 2025-03-17 at 2 44 40 PM](https://github.com/user-attachments/assets/4cfc3067-af86-43fa-be19-7e6ea4e42f09)
