### PR TITLE
fix(android): add networkMode ethernet to networkType

### DIFF
--- a/android/modules/network/src/java/ti/modules/titanium/network/NetworkModule.java
+++ b/android/modules/network/src/java/ti/modules/titanium/network/NetworkModule.java
@@ -212,6 +212,9 @@ public class NetworkModule extends KrollModule
 				case ConnectivityManager.TYPE_MOBILE:
 					type = NetworkModule.NETWORK_MOBILE;
 					break;
+				case ConnectivityManager.TYPE_ETHERNET:
+					type = NetworkModule.NETWORK_LAN;
+					break;
 				default:
 					type = NetworkModule.NETWORK_UNKNOWN;
 			}


### PR DESCRIPTION
`NetworkModule.NETWORK_LAN` is currently not used in the `networkType` property but mentioned in the docs.

Found and tested by a Slack user.