### PR TITLE
feat(android): padding for Ti.UI.Button

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/ButtonProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/ButtonProxy.java
@@ -30,7 +30,8 @@ import ti.modules.titanium.ui.widget.TiUIButton;
 		TiC.PROPERTY_SHADOW_OFFSET,
 		TiC.PROPERTY_SHADOW_COLOR,
 		TiC.PROPERTY_SHADOW_RADIUS,
-		TiC.PROPERTY_TINT_COLOR
+		TiC.PROPERTY_TINT_COLOR,
+		TiC.PROPERTY_PADDING
 	})
 public class ButtonProxy extends TiViewProxy
 {

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIButton.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIButton.java
@@ -27,6 +27,7 @@ import org.appcelerator.kroll.KrollProxy;
 import org.appcelerator.kroll.common.Log;
 import org.appcelerator.titanium.TiApplication;
 import org.appcelerator.titanium.TiC;
+import org.appcelerator.titanium.TiDimension;
 import org.appcelerator.titanium.proxy.TiViewProxy;
 import org.appcelerator.titanium.util.TiConvert;
 import org.appcelerator.titanium.util.TiUIHelper;
@@ -141,14 +142,15 @@ public class TiUIButton extends TiUIView
 		super.processProperties(d);
 
 		boolean needShadow = false;
-
 		Activity activity = proxy.getActivity();
 		AppCompatButton btn = (AppCompatButton) getNativeView();
-		if (!d.containsKey(TiC.PROPERTY_IMAGE) && d.containsKey(TiC.PROPERTY_BACKGROUND_COLOR)) {
-			// Reset the padding here if the background color is set. By default the padding will be calculated
-			// for the button, but if we set a background color, it will not look centered unless we reset the padding.
-			btn.setPadding(8, 0, 8, 0);
+
+		if (d.containsKey(TiC.PROPERTY_PADDING) || (!d.containsKey(TiC.PROPERTY_IMAGE)
+			&& d.containsKey(TiC.PROPERTY_BACKGROUND_COLOR))) {
+			HashMap padding = (HashMap) d.get(TiC.PROPERTY_PADDING);
+			setPadding(padding);
 		}
+
 		if ((btn instanceof MaterialButton) && d.containsKey(TiC.PROPERTY_TOUCH_FEEDBACK)) {
 			// We only override MaterialButton's native ripple effect if "touchFeedback" property is defined.
 			ColorStateList colorStateList = null;
@@ -213,6 +215,35 @@ public class TiUIButton extends TiUIView
 		btn.invalidate();
 	}
 
+	private void setPadding(HashMap padding)
+	{
+		int paddingLeft = nativeView.getPaddingLeft();
+		int paddingTop = nativeView.getPaddingTop();
+		int paddingRight = nativeView.getPaddingRight();
+		int paddingBottom = nativeView.getPaddingBottom();
+		Activity activity = proxy.getActivity();
+		AppCompatButton btn = (AppCompatButton) getNativeView();
+
+		if (padding.containsKey(TiC.PROPERTY_LEFT)) {
+			paddingLeft = TiConvert.toTiDimension(TiConvert.toInt(padding.get(TiC.PROPERTY_LEFT), 0),
+				TiDimension.TYPE_LEFT).getAsPixels(nativeView);
+		}
+		if (padding.containsKey(TiC.PROPERTY_RIGHT)) {
+			paddingRight = TiConvert.toTiDimension(TiConvert.toInt(padding.get(TiC.PROPERTY_RIGHT), 0),
+				TiDimension.TYPE_RIGHT).getAsPixels(nativeView);
+		}
+		if (padding.containsKey(TiC.PROPERTY_TOP)) {
+			paddingTop = TiConvert.toTiDimension(TiConvert.toInt(padding.get(TiC.PROPERTY_TOP), 0),
+				TiDimension.TYPE_TOP).getAsPixels(nativeView);
+		}
+		if (padding.containsKey(TiC.PROPERTY_BOTTOM)) {
+			paddingBottom = TiConvert.toTiDimension(TiConvert.toInt(padding.get(TiC.PROPERTY_BOTTOM), 0),
+				TiDimension.TYPE_BOTTOM).getAsPixels(nativeView);
+		}
+
+		btn.setPadding(paddingLeft, paddingTop, paddingRight, paddingBottom);
+	}
+
 	@Override
 	public void propertyChanged(String key, Object oldValue, Object newValue, KrollProxy proxy)
 	{
@@ -274,6 +305,8 @@ public class TiUIButton extends TiUIView
 		} else if (key.equals(TiC.PROPERTY_SHADOW_COLOR)) {
 			shadowColor = TiConvert.toColor(TiConvert.toString(newValue), activity);
 			btn.setShadowLayer(shadowRadius, shadowX, shadowY, shadowColor);
+		} else if (key.equals(TiC.PROPERTY_PADDING)) {
+			setPadding((HashMap) newValue);
 		} else {
 			super.propertyChanged(key, oldValue, newValue, proxy);
 		}

--- a/apidoc/Titanium/UI/Button.yml
+++ b/apidoc/Titanium/UI/Button.yml
@@ -258,6 +258,12 @@ properties:
     default: true
     since: "11.0.0"
 
+  - name: padding
+    summary: Sets the padding of this Button.
+    type: ButtonPadding
+    platforms: [android]
+    since:  {android: 12.7.0}
+
   - name: selectedColor
     summary: Button text color used to indicate the selected state, as a color name or hex triplet.
     description: |
@@ -356,7 +362,7 @@ properties:
     description: Only one of `title` or `titleid` should be specified.
     type: String
     since: "1.5"
-  
+
   - name: tooltip
     summary: The default text to display in the control's tooltip.
     description: |
@@ -416,3 +422,26 @@ examples:
             Titanium.API.info("You clicked the button");
         };
         ```
+
+---
+name: ButtonPadding
+extends: Padding
+summary: Dictionary object of parameters for the <Titanium.UI.Button.padding> that describes the padding.
+since: "12.7.0"
+platforms: [android]
+properties:
+  - name: left
+    type: Number
+    summary: Left padding
+
+  - name: right
+    type: Number
+    summary: Right padding
+
+  - name: top
+    type: Number
+    summary: Top padding
+
+  - name: bottom
+    type: Number
+    summary: Bottom padding


### PR DESCRIPTION
**Currently Android only:**

Adding `padding` to the Ti.UI.Button

![Screenshot_20250403-173638](https://github.com/user-attachments/assets/d8fbb4af-cb48-4861-9277-8a87d9f4d176)

Button 2 and 4 are default Ti buttons (without and with a custom background color). Currently there was no way to set a custom padding. Even worse: we've set the default padding for a button with background to a very small value for buttons with background color:

**12.6.3.GA**
![Screenshot_20250403-174004](https://github.com/user-attachments/assets/b7ae6fb3-ca9d-4cc7-b5c3-b1c4830731b4)
(top: default color, bottom: custom background color).

**Fix**
This PR will set the default padding for a button with backgroundColor to the native padding again (first image, button 4) and gives the option to define a custom padding (first image, button 1 and 3).

**Example**
```js
var win = Ti.UI.createWindow({layout:"vertical"});
var btn1 = Ti.UI.createButton({
	title: "just a text in a button",
	padding: {
		left: 50, right: 50, top: 20, bottom: 20
	}
});
var btn2 = Ti.UI.createButton({
	title: "just a text in a button",
});
var btn3 = Ti.UI.createButton({
	title: "just a text in a button",
	backgroundColor:"red",
	padding: {
		left: 50, right: 50, top: 20, bottom: 20
	}
});
var btn4 = Ti.UI.createButton({
	title: "just a text in a button",
	backgroundColor:"red"
});
btn2.addEventListener("click", function() {
	btn2.padding = {left: 50, right: 50, top: 20, bottom: 20};
});
btn4.addEventListener("click", function() {
	btn4.padding = {left: 50, right: 50, top: 20, bottom: 20};
});
win.add([btn1, btn2, btn3, btn4]);
win.open();
```

You can click Button 2 and 3 to test the property change.