### PR TITLE
fix(android): fix compileSDK to be 34

### DIFF
--- a/android/package.json
+++ b/android/package.json
@@ -17,7 +17,7 @@
 		"integrity": "sha512-A0tV+fYtkpKfIF5roRTCFPtdULMFygmfWlEuuHOBjC3q4rz/mKnAsJTYBlqayC/4oYEWehj867Oh1o6vy26XHQ=="
 	},
 	"minSDKVersion": "21",
-	"compileSDKVersion": "33",
+	"compileSDKVersion": "34",
 	"vendorDependencies": {
 		"android sdk": ">=23.x <=34.x",
 		"android build tools": ">=30.0.2 <=34.x",

--- a/android/titanium/build.gradle
+++ b/android/titanium/build.gradle
@@ -46,7 +46,7 @@ android {
 	ndkVersion project.ext.tiNdkVersion
 	namespace 'org.appcelerator.titanium'
 	defaultConfig {
-		compileSdk 33
+		compileSdk 34
 		minSdkVersion 21
 		targetSdkVersion 34
 		versionName tiBuildVersionString


### PR DESCRIPTION
Already merged into the main branch (12.7.0) with this PR: https://github.com/tidev/titanium-sdk/pull/14155/files

**Just porting it back to 12.6.x** to fix `:app is currently compiled against android-33.` errors if you build a module that requires Android SDK 34 (which works as that is already set to 34)