### PR TITLE
fix(android): add null checks on ListView/TableView item/row proxy

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/ItemTouchHandler.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/ItemTouchHandler.java
@@ -118,13 +118,17 @@ public class ItemTouchHandler extends ItemTouchHelper.SimpleCallback
 	 */
 	private boolean canSwipe(TiViewProxy holderProxy)
 	{
+		// Obtain default edit value from RecyclerView proxy.
 		String editProperty = TiC.PROPERTY_EDITABLE;
+		final boolean defaultValue = this.recyclerViewProxy.getProperties().optBoolean(editProperty, false);
+
+		if (holderProxy == null) {
+			return defaultValue;
+		}
+
 		if (holderProxy instanceof ListItemProxy) {
 			editProperty = TiC.PROPERTY_CAN_EDIT;
 		}
-
-		// Obtain default edit value from RecyclerView proxy.
-		final boolean defaultValue = this.recyclerViewProxy.getProperties().optBoolean(editProperty, false);
 
 		// Obtain edit value from current holder proxy.
 		return holderProxy.getProperties().optBoolean(editProperty, defaultValue);
@@ -202,6 +206,9 @@ public class ItemTouchHandler extends ItemTouchHelper.SimpleCallback
 	{
 		final TiRecyclerViewHolder holder = (TiRecyclerViewHolder) viewHolder;
 		final TiViewProxy holderProxy = holder.getProxy();
+		if (holderProxy == null) {
+			return 0;
+		}
 
 		if ((isEditing() || isMoving()) && canMove(holderProxy)) {
 			return ItemTouchHelper.UP | ItemTouchHelper.DOWN;
@@ -342,6 +349,10 @@ public class ItemTouchHandler extends ItemTouchHelper.SimpleCallback
 		final TiRecyclerViewHolder holder = (TiRecyclerViewHolder) viewHolder;
 		final TiViewProxy holderProxy = holder.getProxy();
 		final View view = holder.itemView;
+
+		if (holderProxy == null) {
+			return;
+		}
 
 		if (!isEditing() && !isMoving()) {
 

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/TiListView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/TiListView.java
@@ -261,8 +261,8 @@ public class TiListView extends TiSwipeRefreshLayout implements OnSearchChangeLi
 							@Override
 							public boolean inSelectionHotspot(@NonNull MotionEvent e)
 							{
-								if (holder.getProxy() instanceof ListItemProxy) {
-									final ListItemProxy item = (ListItemProxy) holder.getProxy();
+								if (holder.getProxy() != null) {
+									final ListItemProxy item = holder.getProxy();
 
 									// Prevent selection of placeholders.
 									return !item.isPlaceholder();
@@ -567,7 +567,7 @@ public class TiListView extends TiSwipeRefreshLayout implements OnSearchChangeLi
 				(ListViewHolder) recyclerView.getChildViewHolder(firstVisibleView);
 
 			// Obtain first visible list item proxy.
-			return (ListItemProxy) firstVisibleHolder.getProxy();
+			return firstVisibleHolder.getProxy();
 		}
 
 		return null;
@@ -601,7 +601,7 @@ public class TiListView extends TiSwipeRefreshLayout implements OnSearchChangeLi
 				(ListViewHolder) recyclerView.getChildViewHolder(lastVisibleView);
 
 			// Obtain last visible list item proxy.
-			return (ListItemProxy) lastVisibleHolder.getProxy();
+			return lastVisibleHolder.getProxy();
 		}
 
 		return null;

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiTableView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TiTableView.java
@@ -221,8 +221,8 @@ public class TiTableView extends TiSwipeRefreshLayout implements OnSearchChangeL
 							@Override
 							public boolean inSelectionHotspot(@NonNull MotionEvent e)
 							{
-								if (holder.getProxy() instanceof TableViewRowProxy) {
-									final TableViewRowProxy row = (TableViewRowProxy) holder.getProxy();
+								if (holder.getProxy() != null) {
+									final TableViewRowProxy row = holder.getProxy();
 
 									// Prevent selection of placeholders.
 									return !row.isPlaceholder();
@@ -342,7 +342,7 @@ public class TiTableView extends TiSwipeRefreshLayout implements OnSearchChangeL
 		if (firstVisibleView != null) {
 			final TableViewHolder firstVisibleHolder =
 				(TableViewHolder) recyclerView.getChildViewHolder(firstVisibleView);
-			final TableViewRowProxy firstVisibleProxy = (TableViewRowProxy) firstVisibleHolder.getProxy();
+			final TableViewRowProxy firstVisibleProxy = firstVisibleHolder.getProxy();
 			int firstVisibleIndex = -1;
 			if (firstVisibleProxy != null) {
 				firstVisibleIndex = firstVisibleProxy.getIndexInSection();
@@ -534,7 +534,7 @@ public class TiTableView extends TiSwipeRefreshLayout implements OnSearchChangeL
 				(TableViewHolder) recyclerView.getChildViewHolder(firstVisibleView);
 
 			// Obtain first visible table row proxy.
-			return (TableViewRowProxy) firstVisibleHolder.getProxy();
+			return firstVisibleHolder.getProxy();
 		}
 
 		return null;
@@ -556,7 +556,7 @@ public class TiTableView extends TiSwipeRefreshLayout implements OnSearchChangeL
 				(TableViewHolder) recyclerView.getChildViewHolder(lastVisibleView);
 
 			// Obtain last visible table row proxy.
-			return (TableViewRowProxy) lastVisibleHolder.getProxy();
+			return lastVisibleHolder.getProxy();
 		}
 
 		return null;


### PR DESCRIPTION
Adds the required null checks where a ListItem proxy can be null when asynchronous updates happen to the ListView.