### PR TITLE
fix(android): add error code when http-client request is timed out

### DIFF
--- a/android/modules/network/src/java/ti/modules/titanium/network/TiHTTPClient.java
+++ b/android/modules/network/src/java/ti/modules/titanium/network/TiHTTPClient.java
@@ -24,6 +24,7 @@ import java.net.HttpCookie;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.ProtocolException;
+import java.net.SocketTimeoutException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -1368,12 +1369,16 @@ public class TiHTTPClient
 						}
 					}
 					handleResponse(client);
-
 				} catch (IOException e) {
 					if (!aborted) {
 						KrollDict data = new KrollDict();
-						data.putCodeAndMessage((getStatus() >= 400) ? getStatus() : TiC.ERROR_CODE_UNKNOWN,
-							e.getMessage());
+						int errorCode = TiC.ERROR_CODE_UNKNOWN;
+						if (e instanceof SocketTimeoutException) {
+							errorCode = TiC.ERROR_CODE_TIMEOUT;
+						} else if (getStatus() >= 400) {
+							errorCode = getStatus();
+						}
+						data.putCodeAndMessage(errorCode, e.getMessage());
 						dispatchCallback(TiC.PROPERTY_ONERROR, data);
 						return;
 					}

--- a/android/titanium/src/java/org/appcelerator/titanium/TiC.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiC.java
@@ -45,6 +45,7 @@ public class TiC
 	 */
 	public static final int ERROR_CODE_UNKNOWN = -1;
 	public static final int ERROR_CODE_NO_ERROR = 0;
+	public static final int ERROR_CODE_TIMEOUT = -1001;
 
 	public static final String EVENT_ADDED_TO_TAB = "addedtotab";
 	public static final String EVENT_ANDROID_BACK = "androidback";

--- a/apidoc/Titanium/Network/HTTPClient.yml
+++ b/apidoc/Titanium/Network/HTTPClient.yml
@@ -412,9 +412,7 @@ properties:
     summary: Function to be called upon a error response.
     description: |
         Must be set before calling `open`.
-
-        The callback's argument is an object with a single property, `error`, containing the error
-        string.
+        The `code` property of the callback's argument is -1001 for timed-out requests.
     type: Callback<FailureResponse>
 
   - name: onload


### PR DESCRIPTION
- Android: Adds the missing timeout error code -1001 for http-client `onerror` callback.
- Update the docs.