### PR TITLE
feat(android): add 5G detection to Ti.Network

### DIFF
--- a/android/modules/network/src/java/ti/modules/titanium/network/NetworkModule.java
+++ b/android/modules/network/src/java/ti/modules/titanium/network/NetworkModule.java
@@ -128,6 +128,7 @@ public class NetworkModule extends KrollModule
 	private boolean isListeningForConnectivity;
 	private TiNetworkListener networkListener;
 	private ConnectivityManager connectivityManager;
+	private DisplayInfoCallback displayInfoCallback;
 
 	private final Handler messageHandler = new Handler() {
 		public void handleMessage(Message msg)
@@ -211,15 +212,25 @@ public class NetworkModule extends KrollModule
 	}
 
 	@Kroll.method
-	public void getNetworkOverride(KrollDict options)
+	public void registerForNetworkOverride(KrollDict options)
 	{
 		Context a = TiApplication.getAppRootOrCurrentActivity();
 		if (a != null && options.containsKeyAndNotNull(TiC.PROPERTY_SUCCESS)
 			&& Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
 			KrollFunction clbSuccess = (KrollFunction) options.get(TiC.PROPERTY_SUCCESS);
-			DisplayInfoCallback callback = new DisplayInfoCallback(clbSuccess);
+			displayInfoCallback = new DisplayInfoCallback(clbSuccess);
 			TelephonyManager telephonyManager = (TelephonyManager) a.getSystemService(Context.TELEPHONY_SERVICE);
-			telephonyManager.registerTelephonyCallback(a.getMainExecutor(), callback);
+			telephonyManager.registerTelephonyCallback(a.getMainExecutor(), displayInfoCallback);
+		}
+	}
+
+	@Kroll.method
+	public void removeNetworkOverride()
+	{
+		Context a = TiApplication.getAppRootOrCurrentActivity();
+		if (a != null && displayInfoCallback != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+			TelephonyManager telephonyManager = (TelephonyManager) a.getSystemService(Context.TELEPHONY_SERVICE);
+			telephonyManager.unregisterTelephonyCallback(displayInfoCallback);
 		}
 	}
 

--- a/android/modules/network/src/java/ti/modules/titanium/network/NetworkModule.java
+++ b/android/modules/network/src/java/ti/modules/titanium/network/NetworkModule.java
@@ -79,6 +79,8 @@ public class NetworkModule extends KrollModule
 	public static final int NETWORK_TYPE_3G = 3;
 	@Kroll.constant
 	public static final int NETWORK_TYPE_WIFI = 4;
+	@Kroll.constant
+	public static final int NETWORK_TYPE_5G_SA = 5;
 
 	@Kroll.constant
 	public static final int TLS_DEFAULT = 0;
@@ -333,6 +335,9 @@ public class NetworkModule extends KrollModule
 				break;
 			case TelephonyManager.NETWORK_TYPE_LTE:
 				type = NETWORK_TYPE_4G;
+				break;
+			case TelephonyManager.NETWORK_TYPE_NR:
+				type = (Build.VERSION.SDK_INT  >= 29 ? NETWORK_TYPE_5G_SA : NETWORK_UNKNOWN);
 				break;
 			case TelephonyManager.NETWORK_TYPE_IWLAN:
 				type = NETWORK_TYPE_WIFI;

--- a/android/modules/network/src/java/ti/modules/titanium/network/NetworkModule.java
+++ b/android/modules/network/src/java/ti/modules/titanium/network/NetworkModule.java
@@ -73,6 +73,12 @@ public class NetworkModule extends KrollModule
 	public static final int NETWORK_TYPE_4G = 0;
 	@Kroll.constant
 	public static final int NETWORK_TYPE_5G_NSA = 1;
+	@Kroll.constant
+	public static final int NETWORK_TYPE_2G = 2;
+	@Kroll.constant
+	public static final int NETWORK_TYPE_3G = 3;
+	@Kroll.constant
+	public static final int NETWORK_TYPE_WIFI = 4;
 
 	@Kroll.constant
 	public static final int TLS_DEFAULT = 0;
@@ -276,6 +282,65 @@ public class NetworkModule extends KrollModule
 			}
 		} catch (SecurityException e) {
 			Log.w(TAG, "Permission has been removed. Cannot determine network type: " + e.getMessage());
+		}
+		return type;
+	}
+	@Kroll.getProperty
+	public int getNetworkSubtype()
+	{
+		int type = NETWORK_UNKNOWN;
+
+		// start event needs network type. So get it if we don't have it.
+		if (connectivityManager == null) {
+			connectivityManager = getConnectivityManager();
+		}
+
+		try {
+			NetworkInfo ni = connectivityManager.getActiveNetworkInfo();
+			if (ni != null && ni.isAvailable() && ni.isConnected()) {
+				type = networkSubTypeToTitanium(true, ni.getSubtype());
+			} else {
+				type = NetworkModule.NETWORK_NONE;
+			}
+		} catch (SecurityException e) {
+			Log.w(TAG, "Permission has been removed. Cannot determine network type: " + e.getMessage());
+		}
+		return type;
+	}
+
+	private int networkSubTypeToTitanium(boolean b, int subtype)
+	{
+		int type = NetworkModule.NETWORK_UNKNOWN;
+		switch (subtype) {
+			case TelephonyManager.NETWORK_TYPE_EDGE:
+			case TelephonyManager.NETWORK_TYPE_GPRS:
+				type = NETWORK_TYPE_2G;
+				break;
+			case TelephonyManager.NETWORK_TYPE_1xRTT:
+			case TelephonyManager.NETWORK_TYPE_CDMA:
+			case TelephonyManager.NETWORK_TYPE_EVDO_0:
+			case TelephonyManager.NETWORK_TYPE_EVDO_A:
+			case TelephonyManager.NETWORK_TYPE_EVDO_B:
+			case TelephonyManager.NETWORK_TYPE_HSDPA:
+			case TelephonyManager.NETWORK_TYPE_HSPA:
+			case TelephonyManager.NETWORK_TYPE_HSUPA:
+			case TelephonyManager.NETWORK_TYPE_IDEN:
+			case TelephonyManager.NETWORK_TYPE_UMTS:
+			case TelephonyManager.NETWORK_TYPE_EHRPD:
+			case TelephonyManager.NETWORK_TYPE_HSPAP:
+			case TelephonyManager.NETWORK_TYPE_TD_SCDMA:
+				type = NETWORK_TYPE_3G;
+				break;
+			case TelephonyManager.NETWORK_TYPE_LTE:
+				type = NETWORK_TYPE_4G;
+				break;
+			case TelephonyManager.NETWORK_TYPE_IWLAN:
+				type = NETWORK_TYPE_WIFI;
+				break;
+			case TelephonyManager.NETWORK_TYPE_GSM:
+			case TelephonyManager.NETWORK_TYPE_UNKNOWN:
+			default:
+				type = NetworkModule.NETWORK_UNKNOWN;
 		}
 		return type;
 	}

--- a/android/modules/network/src/java/ti/modules/titanium/network/NetworkModule.java
+++ b/android/modules/network/src/java/ti/modules/titanium/network/NetworkModule.java
@@ -82,6 +82,16 @@ public class NetworkModule extends KrollModule
 	@Kroll.constant
 	public static final int NETWORK_TYPE_5G_SA = 5;
 
+	@SuppressLint("InlinedApi")
+	@Kroll.constant
+	public static final int NETWORK_OVERRIDE_NSA = TelephonyDisplayInfo.OVERRIDE_NETWORK_TYPE_NR_NSA;
+	@SuppressLint("InlinedApi")
+	@Kroll.constant
+	public static final int NETWORK_OVERRIDE_MMWAVE = TelephonyDisplayInfo.OVERRIDE_NETWORK_TYPE_NR_NSA_MMWAVE;
+	@SuppressLint("InlinedApi")
+	@Kroll.constant
+	public static final int NETWORK_OVERRIDE_ADVANCED = TelephonyDisplayInfo.OVERRIDE_NETWORK_TYPE_NR_ADVANCED;
+
 	@Kroll.constant
 	public static final int TLS_DEFAULT = 0;
 	@Kroll.constant
@@ -902,6 +912,7 @@ public class NetworkModule extends KrollModule
 					|| overrideNetworkType == TelephonyDisplayInfo.OVERRIDE_NETWORK_TYPE_NR_ADVANCED;
 			KrollDict kd = new KrollDict();
 			kd.put("is5gNsa", is5gNsa);
+			kd.put("networkOverrideType", overrideNetworkType);
 			kd.put("networkType", is5gNsa ? NETWORK_TYPE_5G_NSA : NETWORK_TYPE_4G);
 			clbSuccess.call(getKrollObject(), kd);
 		}

--- a/android/modules/network/src/java/ti/modules/titanium/network/NetworkModule.java
+++ b/android/modules/network/src/java/ti/modules/titanium/network/NetworkModule.java
@@ -300,22 +300,20 @@ public class NetworkModule extends KrollModule
 		return type;
 	}
 
+	@SuppressLint("MissingPermission")
 	@Kroll.getProperty
 	public int getNetworkSubtype()
 	{
 		int type = NETWORK_TYPE_UNKNOWN;
-		if (connectivityManager == null) {
-			connectivityManager = getConnectivityManager();
-		}
 
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
 			try {
-				NetworkInfo ni = connectivityManager.getActiveNetworkInfo();
-				if (ni != null && ni.isAvailable() && ni.isConnected()) {
-					type = networkSubTypeToTitanium(ni.getSubtype());
+				if (telephonyManager != null) {
+					type = networkSubTypeToTitanium(telephonyManager.getDataNetworkType());
 				}
 			} catch (Exception e) {
-				Log.w(TAG, "Error reading subType: " + e.getMessage());
+				Log.w(TAG, "getNetworkSubtype needs android.permission.READ_PHONE_STATE "
+					+ "or android.permission.READ_BASIC_PHONE_STATE permission. " + e.getMessage());
 			}
 		}
 		return type;
@@ -327,17 +325,18 @@ public class NetworkModule extends KrollModule
 		switch (subtype) {
 			case TelephonyManager.NETWORK_TYPE_EDGE:
 			case TelephonyManager.NETWORK_TYPE_GPRS:
+			case TelephonyManager.NETWORK_TYPE_CDMA:
+			case TelephonyManager.NETWORK_TYPE_1xRTT:
+			case TelephonyManager.NETWORK_TYPE_GSM:
+			case TelephonyManager.NETWORK_TYPE_IDEN:
 				type = NETWORK_TYPE_2G;
 				break;
-			case TelephonyManager.NETWORK_TYPE_1xRTT:
-			case TelephonyManager.NETWORK_TYPE_CDMA:
 			case TelephonyManager.NETWORK_TYPE_EVDO_0:
 			case TelephonyManager.NETWORK_TYPE_EVDO_A:
 			case TelephonyManager.NETWORK_TYPE_EVDO_B:
 			case TelephonyManager.NETWORK_TYPE_HSDPA:
 			case TelephonyManager.NETWORK_TYPE_HSPA:
 			case TelephonyManager.NETWORK_TYPE_HSUPA:
-			case TelephonyManager.NETWORK_TYPE_IDEN:
 			case TelephonyManager.NETWORK_TYPE_UMTS:
 			case TelephonyManager.NETWORK_TYPE_EHRPD:
 			case TelephonyManager.NETWORK_TYPE_HSPAP:
@@ -353,7 +352,6 @@ public class NetworkModule extends KrollModule
 			case TelephonyManager.NETWORK_TYPE_IWLAN:
 				type = NETWORK_TYPE_WIFI;
 				break;
-			case TelephonyManager.NETWORK_TYPE_GSM:
 			case TelephonyManager.NETWORK_TYPE_UNKNOWN:
 			default:
 				type = NETWORK_TYPE_UNKNOWN;

--- a/apidoc/Titanium/Network/Network.yml
+++ b/apidoc/Titanium/Network/Network.yml
@@ -155,6 +155,22 @@ methods:
     platforms: [android]
     since: "3.2.0"
 
+  - name: registerForNetworkOverride
+    summary: |
+        Registers an event to listen to network override events to identify 4G or 5G networks.
+    parameters:
+      - name: success
+        summary: Callback that is triggered when the network override changes.
+        type: Callback<NetworkOverrideData>
+    platforms: [android]
+    since: "12.7.0"
+
+  - name: removeNetworkOverride
+    summary: |
+        Unregisteres the registerForNetworkOverride event.
+    platforms: [android]
+    since: "12.7.0"
+
   - name: createBonjourBrowser
     summary: Creates and returns a `BonjourBrowser` object.
     platforms: [iphone, ipad, macos]
@@ -458,6 +474,24 @@ properties:
     type: Number
     permission: read-only
 
+  - name: NETWORK_TYPE_4G
+    summary: |
+        Indicates a 4G network
+    description: |
+        This constant is also a possible value for the `networkType` property of the
+        [registerForNetworkOverride](Titanium.Network.registerForNetworkOverride) event.
+    type: Number
+    permission: read-only
+
+  - name: NETWORK_TYPE_5G_NSA
+    summary: |
+        Indicates a 5G NSA network
+    description: |
+        This constant is also a possible value for the `networkType` property of the
+        [registerForNetworkOverride](Titanium.Network.registerForNetworkOverride) event.
+    type: Number
+    permission: read-only
+
   - name: NOTIFICATION_TYPE_ALERT
     summary: Constant value for an Alert style push notification.
     platforms: [iphone, ipad, macos]
@@ -679,3 +713,48 @@ properties:
     summary: Boolean indicating if notification was received while app was in background.
     type: Boolean
     since: "3.1.0"
+
+---
+name: NetworkOverrideData
+summary: |
+    A simple object passed to the
+    [registerForNetworkOverride](Titanium.Network.registerForNetworkOverride) success callback.
+properties:
+  - name: is5gNsa
+    summary: 5G NSA
+    type: Boolean
+    platforms: [android]
+    since: "12.7.0"
+
+  - name: networkType
+    summary: Network type value as a constant.
+    description: |
+        One of the `NETWORK_TYPE` constants defined in <Titanium.Network>.
+    type: Number
+    constants: Titanium.Network.NETWORK_TYPE_*
+    platforms: [android]
+    since: "12.7.0"
+
+examples:
+  - title: Check for 5G networks (Android only)
+    example: |
+      ``` js
+      const win = Ti.UI.createWindow();
+      const lbl = Ti.UI.createLabel({text: "-"});
+      const btn = Ti.UI.createButton({title: "unregister event", bottom: 0});
+      win.add([lbl, btn]);
+
+      btn.addEventListener('click', function() {
+        Ti.Network.removeNetworkOverride();
+      });
+
+      win.addEventListener('open', function() {
+        Ti.Network.registerForNetworkOverride({
+          success: function(e) {
+            lbl.text = "Type: " + ((e.networkType == Ti.Network.NETWORK_TYPE_4G) ? "4G" : "5G_NSA") + " (is5gNsa: " + e.is5gNsa + ")";
+          }
+        });
+      });
+
+      win.open();
+      ```

--- a/apidoc/Titanium/Network/Network.yml
+++ b/apidoc/Titanium/Network/Network.yml
@@ -633,7 +633,8 @@ properties:
   - name: networkSubtype
     summary: Network sub type value as a constant.
     description: |
-        One of the `NETWORK_TYPE` constants defined in <Titanium.Network>.
+        One of the `NETWORK_TYPE` constants defined in <Titanium.Network>. Needs one of the following permissions:
+        `android.permission.READ_PHONE_STATE` or `android.permission.READ_BASIC_PHONE_STATE permission`.
     type: Number
     constants: Titanium.Network.NETWORK_TYPE_*
     permission: read-only

--- a/apidoc/Titanium/Network/Network.yml
+++ b/apidoc/Titanium/Network/Network.yml
@@ -493,6 +493,14 @@ properties:
     type: Number
     permission: read-only
 
+  - name: NETWORK_TYPE_5G_SA
+    summary: |
+        Indicates a 5G SA network
+    description: |
+        This constant is also a possible return value of [networkSubtype](Titanium.Network.networkSubtype).
+    type: Number
+    permission: read-only
+
   - name: NETWORK_TYPE_2G
     summary: |
         Indicates a 2G network

--- a/apidoc/Titanium/Network/Network.yml
+++ b/apidoc/Titanium/Network/Network.yml
@@ -479,7 +479,8 @@ properties:
         Indicates a 4G network
     description: |
         This constant is also a possible value for the `networkType` property of the
-        [registerForNetworkOverride](Titanium.Network.registerForNetworkOverride) event.
+        [registerForNetworkOverride](Titanium.Network.registerForNetworkOverride) event and
+        [networkSubtype](Titanium.Network.networkSubtype) event.
     type: Number
     permission: read-only
 
@@ -489,6 +490,33 @@ properties:
     description: |
         This constant is also a possible value for the `networkType` property of the
         [registerForNetworkOverride](Titanium.Network.registerForNetworkOverride) event.
+    type: Number
+    permission: read-only
+
+  - name: NETWORK_TYPE_2G
+    summary: |
+        Indicates a 2G network
+    description: |
+        This constant is also a possible value for the `networkType` property of the
+        [networkSubtype](Titanium.Network.networkSubtype) event.
+    type: Number
+    permission: read-only
+
+  - name: NETWORK_TYPE_3G
+    summary: |
+        Indicates a 3G network
+    description: |
+        This constant is also a possible value for the `networkType` property of the
+        [networkSubtype](Titanium.Network.networkSubtype) event.
+    type: Number
+    permission: read-only
+
+  - name: NETWORK_TYPE_WIFI
+    summary: |
+        Indicates a WIFI network
+    description: |
+        This constant is also a possible value for the `networkType` property of the
+        [networkSubtype](Titanium.Network.networkSubtype) event.
     type: Number
     permission: read-only
 
@@ -566,6 +594,16 @@ properties:
     type: Number
     constants: Titanium.Network.NETWORK_*
     permission: read-only
+
+  - name: networkSubtype
+    summary: Network sub type value as a constant.
+    description: |
+        One of the `NETWORK_TYPE` constants defined in <Titanium.Network>.
+    type: Number
+    constants: Titanium.Network.NETWORK_TYPE_*
+    permission: read-only
+    platforms: [android]
+    since: "12.7.0"
 
   - name: networkTypeName
     summary: Network type as a String. Returns one of `NONE`, `WIFI`, `LAN`, `MOBILE`, or `UNKNOWN`.

--- a/apidoc/Titanium/Network/Network.yml
+++ b/apidoc/Titanium/Network/Network.yml
@@ -528,6 +528,33 @@ properties:
     type: Number
     permission: read-only
 
+  - name: NETWORK_OVERRIDE_NSA
+    summary: |
+        Indicates a NSA override.
+    description: |
+        This constant is also a possible value for the `networkOverrideType` property of the
+        [networkSubtype](Titanium.Network.networkSubtype) event.
+    type: Number
+    permission: read-only
+
+  - name: NETWORK_OVERRIDE_MMWAVE
+    summary: |
+        Indicates a MMWAVE override.
+    description: |
+        This constant is also a possible value for the `networkOverrideType` property of the
+        [networkSubtype](Titanium.Network.networkSubtype) event.
+    type: Number
+    permission: read-only
+
+  - name: NETWORK_OVERRIDE_ADVANCED
+    summary: |
+        Indicates a ADVANCED override.
+    description: |
+        This constant is also a possible value for the `networkOverrideType` property of the
+        [networkSubtype](Titanium.Network.networkSubtype) event.
+    type: Number
+    permission: read-only
+
   - name: NOTIFICATION_TYPE_ALERT
     summary: Constant value for an Alert style push notification.
     platforms: [iphone, ipad, macos]
@@ -778,6 +805,15 @@ properties:
         One of the `NETWORK_TYPE` constants defined in <Titanium.Network>.
     type: Number
     constants: Titanium.Network.NETWORK_TYPE_*
+    platforms: [android]
+    since: "12.7.0"
+
+  - name: networkOverrideType
+    summary: Network override type value as a constant.
+    description: |
+        One of the `NETWORK_OVERRIDE` constants defined in <Titanium.Network>.
+    type: Number
+    constants: Titanium.Network.NETWORK_OVERRIDE_*
     platforms: [android]
     since: "12.7.0"
 


### PR DESCRIPTION
For testing. 

* adds `Ti.Network.registerForNetworkOverride` to identify 5G NSA networks
* adds `Ti.Network.getSubtypes` to identify network subtypes

```js
const win = Ti.UI.createWindow();
const lbl = Ti.UI.createLabel({
	text: "-"
});
const btn = Ti.UI.createButton({
	title: "unregister event",
	bottom: 0
});
win.add(lbl);
win.add(btn);

btn.addEventListener('click', function() {
	Ti.Network.removeNetworkOverride();
});

win.addEventListener('open', function() {
	Ti.Network.registerForNetworkOverride({
		success: function(e) {

			let subType = "-";
			switch (Ti.Network.networkSubtype) {
				case Ti.Network.NETWORK_TYPE_2G:
					subType = "2G"
					break;
				case Ti.Network.NETWORK_TYPE_3G:
					subType = "3G"
					break;
				case Ti.Network.NETWORK_TYPE_4G:
					subType = "4G"
					break;
				case Ti.Network.NETWORK_TYPE_5G_SA:
					subType = "5G SA"
					break;
				case Ti.Network.NETWORK_TYPE_WIFI:
					subType = "WIFI"
					break;
			}

			let overrideType = "-";
			switch (e.networkOverrideType) {
				case Ti.Network.NETWORK_OVERRIDE_NSA:
					overrideType = "NSA"
					break;
				case Ti.Network.NETWORK_OVERRIDE_MMWAVE:
					overrideType = "MMWAVE"
					break;
				case Ti.Network.NETWORK_OVERRIDE_ADVANCED:
					overrideType = "ADVANCED"
					break;
			}

			lbl.text = "Type: " + ((e.networkType == Ti.Network.NETWORK_TYPE_4G) ? "4G" : "5G_NSA") + "\noverride: " + overrideType + "\nsub type: " + subType + "\nis5gNsa: " + e.is5gNsa;
		}
	});
});

win.open();
```