### PR TITLE
feat(ios): support html in text areas

### DIFF
--- a/apidoc/Titanium/UI/TextArea.yml
+++ b/apidoc/Titanium/UI/TextArea.yml
@@ -359,7 +359,7 @@ properties:
         Note that complex html structures like images are not supported.
         Use a <Titanium.UI.WebView> for those cases.
     platforms: [android, iphone, ipad, macos]
-    since: { iphone: "12.7.0", ipad: "12.7.0", macos: "12.7.0" }
+    since: { android: "12.7.0", iphone: "12.7.0", ipad: "12.7.0", macos: "12.7.0" }
     type: String
 
   - name: keyboardToolbar

--- a/apidoc/Titanium/UI/TextArea.yml
+++ b/apidoc/Titanium/UI/TextArea.yml
@@ -359,7 +359,7 @@ properties:
         Note that complex html structures like images are not supported.
         Use a <Titanium.UI.WebView> for those cases.
     platforms: [android, iphone, ipad, macos]
-    since: { android: "12.7.0", iphone: "12.7.0", ipad: "12.7.0", macos: "12.7.0" }
+    since: "12.7.0"
     type: String
 
   - name: keyboardToolbar

--- a/apidoc/Titanium/UI/TextArea.yml
+++ b/apidoc/Titanium/UI/TextArea.yml
@@ -353,6 +353,15 @@ properties:
     platforms: [iphone,ipad, macos]
     since: 3.2.0
 
+  - name: html
+    summary: Pass a HTML-based string and it will be formatted accordingly.
+    description: |
+        Note that complex html structures like images are not supported.
+        Use a <Titanium.UI.WebView> for those cases.
+    platforms: [android, iphone, ipad, macos]
+    since: { iphone: "12.7.0", ipad: "12.7.0", macos: "12.7.0" }
+    type: String
+
   - name: keyboardToolbar
     summary: |
         Array of toolbar button objects or a [toolbar](Titanium.UI.Toolbar) to be used when the

--- a/iphone/Classes/TiUITextArea.m
+++ b/iphone/Classes/TiUITextArea.m
@@ -400,6 +400,20 @@
   [[self proxy] replaceValue:NUMBOOL(handleLinks) forKey:@"handleLinks" notification:NO];
 }
 
+- (void)setHtml_:(id)html
+{
+  ENSURE_SINGLE_ARG(html, NSString);
+  [[self proxy] replaceValue:html forKey:@"html" notification:NO];
+
+  NSAttributedString *attributedString = [[NSAttributedString alloc] initWithData:[html dataUsingEncoding:NSUTF8StringEncoding]
+                                                                          options:@{ NSDocumentTypeDocumentAttribute : NSHTMLTextDocumentType,
+                                                                            NSCharacterEncodingDocumentAttribute : @(NSUTF8StringEncoding) }
+                                                               documentAttributes:nil
+                                                                            error:nil];
+
+  [(UITextView *)[self textWidgetView] setAttributedText:attributedString];
+}
+
 /*
 Text area constrains the text event though the content offset and edge insets are set to 0
 */


### PR DESCRIPTION
This change adds support for HTML-based content in the Ti.UI.TextArea. Maybe Android has something similar?