### PR TITLE
fix(android): fix crash when calling `TabGroup.open()`

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TabGroupProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TabGroupProxy.java
@@ -34,6 +34,7 @@ import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.TiRootActivity;
 import org.appcelerator.titanium.proxy.ActivityProxy;
 import org.appcelerator.titanium.proxy.TiWindowProxy;
+import org.appcelerator.titanium.util.TiSafeDisplay;
 import org.appcelerator.titanium.util.TiColorHelper;
 import org.appcelerator.titanium.util.TiConvert;
 import org.appcelerator.titanium.util.TiRHelper;
@@ -392,55 +393,75 @@ public class TabGroupProxy extends TiWindowProxy implements TiActivityWindow
 		}
 
 		/**
+		 * Only applicable on Android 12 or Android 13.
 		 * As reported here on Google: https://issuetracker.google.com/issues/293645024
 		 * WindowContainer may not be available in very rare cases on devices running Android 12/13.
-		 * Internally, it seems that the WindowContainer will always be used from the top-most activity,
-		 * so perhaps we can post this call again on main-handler looper to open the TabGroup anyhow?
+		 * Wait for the view to be attached to a window before opening the TabGroup.
 		 */
-		Window window = topActivity.getWindow();
-		View decorView = window != null ? window.getDecorView() : null;
-		if (decorView == null || decorView.getDisplay() == null) {
-			return;
-		}
+		if (Build.VERSION.SDK_INT >= 31 && Build.VERSION.SDK_INT <= 33) {
+			Window window = topActivity.getWindow();
+			View decorView = window != null ? window.getDecorView() : null;
+			if (decorView == null) {
+				return;
+			}
 
-		// set theme for XML layout
-		if (hasProperty(TiC.PROPERTY_STYLE)
-			&& ((Integer) getProperty(TiC.PROPERTY_STYLE)) == AndroidModule.TABS_STYLE_BOTTOM_NAVIGATION
-			&& getProperty(TiC.PROPERTY_THEME) != null) {
-			try {
-				String themeName = getProperty(TiC.PROPERTY_THEME).toString();
-				int theme = TiRHelper.getResource("style."
-					+ themeName.replaceAll("[^A-Za-z0-9_]", "_"));
-				topActivity.setTheme(theme);
-				topActivity.getApplicationContext().setTheme(theme);
-			} catch (Exception e) {
+			if (decorView.getDisplay() == null) {
+				TiSafeDisplay.getDisplaySafely(decorView, isDisplayAvailable -> {
+					// Display may not be available in very very rare cases,
+					// but we open it since it's now in try-catch.
+					openTabGroup(topActivity, options);
+				});
+				return;
 			}
 		}
 
-		Intent intent = new Intent(topActivity, TiActivity.class);
-		fillIntent(topActivity, intent);
+		openTabGroup(topActivity, options);
+	}
 
-		int windowId = TiActivityWindows.addWindow(this);
-		intent.putExtra(TiC.INTENT_PROPERTY_WINDOW_ID, windowId);
-
-		boolean animated = TiConvert.toBoolean(options, TiC.PROPERTY_ANIMATED, true);
-		if (!animated) {
-			intent.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION);
-			topActivity.startActivity(intent);
-			topActivity.overridePendingTransition(0, 0);
-		} else if (options.containsKey(TiC.PROPERTY_ACTIVITY_ENTER_ANIMATION)
-			|| options.containsKey(TiC.PROPERTY_ACTIVITY_EXIT_ANIMATION)) {
-			topActivity.startActivity(intent);
-			int enterAnimation = TiConvert.toInt(options.get(TiC.PROPERTY_ACTIVITY_ENTER_ANIMATION), 0);
-			int exitAnimation = TiConvert.toInt(options.get(TiC.PROPERTY_ACTIVITY_EXIT_ANIMATION), 0);
-			topActivity.overridePendingTransition(enterAnimation, exitAnimation);
-		} else {
-			topActivity.startActivity(intent);
-			if (topActivity instanceof TiRootActivity) {
-				// A fade-in transition from root splash screen to first window looks better than a slide-up.
-				// Also works-around issue where splash in mid-transition might do a 2nd transition on cold start.
-				topActivity.overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out);
+	private void openTabGroup(Activity topActivity, KrollDict options)
+	{
+		try {
+			// set theme for XML layout
+			if (hasProperty(TiC.PROPERTY_STYLE)
+				&& ((Integer) getProperty(TiC.PROPERTY_STYLE)) == AndroidModule.TABS_STYLE_BOTTOM_NAVIGATION
+				&& getProperty(TiC.PROPERTY_THEME) != null) {
+				try {
+					String themeName = getProperty(TiC.PROPERTY_THEME).toString();
+					int theme = TiRHelper.getResource("style."
+						+ themeName.replaceAll("[^A-Za-z0-9_]", "_"));
+					topActivity.setTheme(theme);
+					topActivity.getApplicationContext().setTheme(theme);
+				} catch (Exception e) {
+				}
 			}
+
+			Intent intent = new Intent(topActivity, TiActivity.class);
+			fillIntent(topActivity, intent);
+
+			int windowId = TiActivityWindows.addWindow(this);
+			intent.putExtra(TiC.INTENT_PROPERTY_WINDOW_ID, windowId);
+
+			boolean animated = TiConvert.toBoolean(options, TiC.PROPERTY_ANIMATED, true);
+			if (!animated) {
+				intent.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION);
+				topActivity.startActivity(intent);
+				topActivity.overridePendingTransition(0, 0);
+			} else if (options.containsKey(TiC.PROPERTY_ACTIVITY_ENTER_ANIMATION)
+				|| options.containsKey(TiC.PROPERTY_ACTIVITY_EXIT_ANIMATION)) {
+				topActivity.startActivity(intent);
+				int enterAnimation = TiConvert.toInt(options.get(TiC.PROPERTY_ACTIVITY_ENTER_ANIMATION), 0);
+				int exitAnimation = TiConvert.toInt(options.get(TiC.PROPERTY_ACTIVITY_EXIT_ANIMATION), 0);
+				topActivity.overridePendingTransition(enterAnimation, exitAnimation);
+			} else {
+				topActivity.startActivity(intent);
+				if (topActivity instanceof TiRootActivity) {
+					// A fade-in transition from root splash screen to first window looks better than a slide-up.
+					// Also works-around issue where splash in mid-transition might do a 2nd transition on cold start.
+					topActivity.overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out);
+				}
+			}
+		} catch (Exception e) {
+			throw new RuntimeException("TabGroup could not be opened: " + e);
 		}
 	}
 

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiSafeDisplay.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiSafeDisplay.java
@@ -1,0 +1,44 @@
+package org.appcelerator.titanium.util;
+
+import android.view.Display;
+import android.view.View;
+
+public class TiSafeDisplay
+{
+	public interface DisplayCallback {
+		void onDisplayAvailable(Boolean isDisplayAvailable);
+	}
+
+	public static void getDisplaySafely(View view, DisplayCallback callback)
+	{
+		if (view == null || callback == null) return;
+
+		if (view.isAttachedToWindow()) {
+			Display display = view.getDisplay();
+			if (display != null) {
+				callback.onDisplayAvailable(true);
+				return;
+			}
+		}
+
+		view.addOnAttachStateChangeListener(new View.OnAttachStateChangeListener() {
+			@Override
+			public void onViewAttachedToWindow(View v)
+			{
+				v.removeOnAttachStateChangeListener(this);
+
+				/**
+				 * It's rare that a display is not available even at this stage.
+				 * Since `getDisplay()` returns null, send a boolean to make proper decisions.
+				 */
+				callback.onDisplayAvailable(v.getDisplay() != null);
+			}
+
+			@Override
+			public void onViewDetachedFromWindow(View v)
+			{
+				v.removeOnAttachStateChangeListener(this);
+			}
+		});
+	}
+}


### PR DESCRIPTION
This PR attempts to fix a rare scenario where the `TabGroup open()` call might lead to a crash as reported on [Google Issues](https://issuetracker.google.com/issues/293645024).

We are seeing the similar crash reports in our internal app.
 
- Reproducing this issue turned out a nightmare even after trying all sorts of cases like opening a TabGroup or any of its window as well, via timeouts/async-await, etc.
- The possible fix I could think of for now is to check if the `DisplayContent` is null.

I added another possible fallback when this happens in the code comment. I'd appreciate to hear better fixes!