### PR TITLE
feat(android): detect foldables

### DIFF
--- a/android/modules/app/src/java/ti/modules/titanium/app/AndroidModule.java
+++ b/android/modules/app/src/java/ti/modules/titanium/app/AndroidModule.java
@@ -19,7 +19,9 @@ import org.appcelerator.titanium.proxy.RProxy;
 import android.app.Activity;
 import android.content.Intent;
 import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
 import android.content.pm.PackageManager.NameNotFoundException;
+import android.os.Build;
 
 @Kroll.module(parentModule = AppModule.class)
 public class AndroidModule extends KrollModule
@@ -68,6 +70,17 @@ public class AndroidModule extends KrollModule
 			initializeVersionValues();
 		}
 		return appVersionCode;
+	}
+
+	@Kroll.getProperty
+	public boolean getIsFoldable()
+	{
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+			return TiApplication.getInstance().getPackageManager()
+				.hasSystemFeature(PackageManager.FEATURE_SENSOR_HINGE_ANGLE);
+		} else {
+			return false;
+		}
 	}
 
 	@Kroll.getProperty

--- a/android/titanium/build.gradle
+++ b/android/titanium/build.gradle
@@ -293,6 +293,7 @@ dependencies {
 	implementation 'androidx.vectordrawable:vectordrawable-animated:1.1.0'
 	implementation 'androidx.viewpager:viewpager:1.0.0'
 	implementation 'androidx.annotation:annotation:1.7.1'
+	implementation 'androidx.window:window-java:1.3.0'
 
 	// Google's "Material Components" themed UI library.
 	implementation "com.google.android.material:material:${project.ext.tiMaterialLibVersion}"

--- a/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
@@ -9,6 +9,7 @@ package org.appcelerator.titanium;
 import java.lang.ref.WeakReference;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.appcelerator.kroll.KrollDict;
@@ -1981,16 +1982,16 @@ public abstract class TiBaseActivity extends AppCompatActivity implements TiActi
 		public void accept(WindowLayoutInfo newLayoutInfo)
 		{
 			TiBaseActivity.this.runOnUiThread(() -> {
-				try {
-					DisplayFeature displayFeatureList = newLayoutInfo.getDisplayFeatures().get(0);
-					if (displayFeatureList instanceof FoldingFeature foldingFeature) {
+				List<DisplayFeature> displayFeatures = newLayoutInfo.getDisplayFeatures();
+				for (DisplayFeature feature : displayFeatures) {
+					if (feature instanceof FoldingFeature foldingFeature) {
 						KrollDict kd = new KrollDict();
 						kd.put("state", foldingFeature.getState().toString());
 						kd.put("occlusionType", foldingFeature.getOcclusionType().toString());
+						kd.put("orientation", foldingFeature.getOrientation().toString());
+						kd.put("isSeparating", foldingFeature.isSeparating());
 						TiApplication.getInstance().fireAppEvent("windowState", kd);
 					}
-				} catch (Exception ex) {
-					
 				}
 			});
 		}


### PR DESCRIPTION
currently only for testing
```js
const win = Titanium.UI.createWindow({});
win.open();

console.log("isFoldable: " + Ti.App.Android.isFoldable);

Ti.App.addEventListener("windowState", function(e) {
	console.log("--------------------------------");
	console.log("folding state: " + e.state)
	console.log("folding occlusionType: " + e.occlusionType)
	console.log("folding orientation: " + e.orientation)
	console.log("folding isSeparating: " + e.isSeparating)
	console.log("--------------------------------");
})
```

* new event `windowState` that will fire when the window state of a foldable is changing (opening up)
* new property `Ti.App.Android.isFoldable` that will be true if there is a hinge (so a foldable)

**Note:**
Not sure if it is an emulator thing or not: it only works when you start the app in the open state. If it is closed it won't attach the listener and shows a warning that the size doesn't match :shrug: And the "closed" state is never fired, only the open and half open state.
Have to do some more tests here. 