### PR TITLE
fix(android): rotation value

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiUIView.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiUIView.java
@@ -1811,9 +1811,11 @@ public abstract class TiUIView implements KrollProxyListener, OnFocusChangeListe
 				// Calculate the angle between the two fingers
 				float deltaX = event.getX(0) - event.getX(1);
 				float deltaY = event.getY(0) - event.getY(1);
-				double radians = Math.atan(deltaY / deltaX);
+				double radians = Math.atan2(deltaY, deltaX);
 				double degrees = Math.toDegrees(radians);
-
+				if (degrees < 0) {
+					degrees += 360;
+				}
 				if (event.getActionMasked() == MotionEvent.ACTION_MOVE) {
 					KrollDict data = new KrollDict();
 					data.put(TiC.PROPERTY_ROTATE, degrees);


### PR DESCRIPTION
Return proper 360° values.

```js
const win = Ti.UI.createWindow();
const v = Ti.UI.createView({
	width: 100,
	height: 100,
	backgroundColor: "#f00",
	touchEnabled: false
});
const v2 = Ti.UI.createView({
	width: 10,
	height: 10,
	backgroundColor: "#0f0",
	touchEnabled: false,
	top: 0
});

const lbl2 = Ti.UI.createLabel({
	top: 40,
	text: "Rotation: -"
});
v.add(v2);

win.addEventListener("rotate", onRotate);

win.add([v, lbl2]);
win.open();

function onRotate(e) {
	lbl2.text = Math.round(e.rotate);
	v.rotation = e.rotate;
}
```

Thanks to @prashantsaini1 for the info