### PR TITLE
fix(android): crash when clearing cache on low memory

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/TiApplication.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiApplication.java
@@ -448,7 +448,11 @@ public abstract class TiApplication extends Application implements KrollApplicat
 	{
 		if (level >= TRIM_MEMORY_RUNNING_LOW) {
 			// Release all the cached images
-			TiBlobLruCache.getInstance().evictAll();
+			try {
+				TiBlobLruCache.getInstance().evictAll();
+			} catch (Exception ex) {
+				Log.e(TAG, ex.getMessage());
+			}
 			TiImageCache.clear();
 
 			// Perform soft garbage collection to reclaim memory.


### PR DESCRIPTION
For testing

```
TiExceptionHandler: (main) [13208,13801] org.appcelerator.titanium.util.TiBlobLruCache.sizeOf() is reporting inconsistent results!
[ERROR] TiExceptionHandler:
[ERROR] TiExceptionHandler:     androidx.collection.LruCache.trimToSize(LruCache.java:173)
[ERROR] TiExceptionHandler:     androidx.collection.LruCache.evictAll(LruCache.java:281)
[ERROR] TiExceptionHandler:     org.appcelerator.titanium.TiApplication.onTrimMemory(TiApplication.java:451)
[ERROR] TiExceptionHandler:     android.app.ActivityThread.handleTrimMemory(ActivityThread.java:6375)
[ERROR] TiExceptionHandler:     android.app.ActivityThread.access$1200(ActivityThread.java:250)
[ERROR] TiExceptionHandler:     android.app.ActivityThread$ApplicationThread.lambda$scheduleTrimMemory$0(ActivityThread.java:1658)
[ERROR] TiExceptionHandler:     android.app.ActivityThread$ApplicationThread-$$ExternalSyntheticLambda2.accept(Unknown Source:8)
[ERROR] TiExceptionHandler:     com.android.internal.util.function.pooled.PooledLambdaImpl.doInvoke(PooledLambdaImpl.java:278)
[ERROR] TiExceptionHandler:     com.android.internal.util.function.pooled.PooledLambdaImpl.invoke(PooledLambdaImpl.java:201)
[ERROR] TiExceptionHandler:     com.android.internal.util.function.pooled.OmniFunction.run(OmniFunction.java:97)
[ERROR] TiExceptionHandler:     android.view.Choreographer$CallbackRecord.run(Choreographer.java:1002)
[ERROR] TiExceptionHandler:     android.view.Choreographer.doCallbacks(Choreographer.java:823)
[ERROR] TiExceptionHandler:     android.view.Choreographer.doFrame(Choreographer.java:760)
[ERROR] TiExceptionHandler:     android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:987)
[ERROR] TiExceptionHandler:     android.os.Handler.handleCallback(Handler.java:938)
[ERROR] TiExceptionHandler:     android.os.Handler.dispatchMessage(Handler.java:99)
[ERROR] TiExceptionHandler:     android.os.Looper.loopOnce(Looper.java:201)
[ERROR] TiExceptionHandler:     android.os.Looper.loop(Looper.java:288)
[ERROR] TiExceptionHandler:     android.app.ActivityThread.main(ActivityThread.java:7858)
[ERROR] TiExceptionHandler:     java.lang.reflect.Method.invoke(Native Method)
[ERROR] TiExceptionHandler:     com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
[ERROR] TiExceptionHandler:     com.android.internal.os.ZygoteInit.main(ZygoteInit.java:984)
```