### PR TITLE
fix(android): apply required null checks on TiUIEditText

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIText.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIText.java
@@ -143,7 +143,8 @@ public class TiUIText extends TiUIView implements TextWatcher, OnEditorActionLis
 				@Override
 				public boolean onKey(View v, int keyCode, KeyEvent event)
 				{
-					if (tv.getText().length() == 0) {
+					Editable editable = getText();
+					if (editable != null && editable.length() == 0) {
 						KrollDict data = new KrollDict();
 						data.put("keyCode", keyCode);
 						fireEvent("empty", data);
@@ -167,6 +168,12 @@ public class TiUIText extends TiUIView implements TextWatcher, OnEditorActionLis
 		this.defaultPadding.put(TiC.PROPERTY_BOTTOM, this.tv.getPaddingBottom());
 		this.defaultPadding.put(TiC.PROPERTY_LEFT, this.tv.getPaddingLeft());
 		setNativeView(textInputLayout);
+	}
+
+	private Editable getText()
+	{
+		if (tv == null) return null;
+		return tv.getText();
 	}
 
 	@Override
@@ -517,7 +524,10 @@ public class TiUIText extends TiUIView implements TextWatcher, OnEditorActionLis
 		// Fire change events, but only if it's coming from the end-user (ignore programmatic text changes).
 		if (!disableChangeEvent) {
 			// Fire a text "change" event.
-			String newText = tv.getText().toString();
+			Editable editable = getText();
+			if (editable == null) return;
+
+			String newText =  editable.toString();
 			if (proxy.shouldFireChange(proxy.getProperty(TiC.PROPERTY_VALUE), newText)) {
 				KrollDict data = new KrollDict();
 				data.put(TiC.PROPERTY_VALUE, newText);
@@ -579,8 +589,9 @@ public class TiUIText extends TiUIView implements TextWatcher, OnEditorActionLis
 	@Override
 	protected KrollDict getFocusEventObject(boolean hasFocus)
 	{
+		Editable editable = getText();
 		KrollDict event = new KrollDict();
-		event.put(TiC.PROPERTY_VALUE, tv.getText().toString());
+		event.put(TiC.PROPERTY_VALUE, editable == null ? "" : editable.toString());
 		return event;
 	}
 
@@ -600,7 +611,10 @@ public class TiUIText extends TiUIView implements TextWatcher, OnEditorActionLis
 			inputManager.hideSoftInputFromWindow(tv.getWindowToken(), 0);
 		}
 
-		String value = tv.getText().toString();
+		Editable editable = getText();
+		if (editable == null) return true;
+
+		String value = editable.toString();
 		KrollDict data = new KrollDict();
 		data.put(TiC.PROPERTY_VALUE, value);
 
@@ -902,6 +916,8 @@ public class TiUIText extends TiUIView implements TextWatcher, OnEditorActionLis
 
 	public void setSelection(int start, int end)
 	{
+		if (tv == null) return;
+
 		// Validate arguments.
 		int textLength = tv.length();
 		if (start < 0 || start > textLength || end < 0 || end > textLength) {
@@ -916,8 +932,8 @@ public class TiUIText extends TiUIView implements TextWatcher, OnEditorActionLis
 
 		// This works-around an Android 4.x bug where the "end" index will be ignored
 		// if setSelection() is called just after tapping the text field. (See: TIMOB-19639)
-		Editable text = tv.getText();
-		if (text.length() > 0) {
+		Editable text = getText();
+		if (text != null && text.length() > 0) {
 			boolean wasDisabled = this.disableChangeEvent;
 			this.disableChangeEvent = true;
 			text.replace(0, 1, text.subSequence(0, 1), 0, 1);


### PR DESCRIPTION
Fixes some cases where the `TextField/TextArea` can be accessed after their native view is released, and might trigger events like `change/return` etc.