### PR TITLE
feat(android): dashed borders

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/TiC.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiC.java
@@ -393,6 +393,7 @@ public class TiC
 	public static final String PROPERTY_CROP_RECT = "cropRect";
 	public static final String PROPERTY_CURRENT_PAGE = "currentPage";
 	public static final String PROPERTY_CURVE = "curve";
+	public static final String PROPERTY_DASHED = "dashed";
 	public static final String PROPERTY_DATA = "data";
 	public static final String PROPERTY_DATE = "date";
 	public static final String PROPERTY_DATE_PICKER_STYLE = "datePickerStyle";

--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/TiViewProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/TiViewProxy.java
@@ -59,6 +59,7 @@ import android.view.ViewAnimationUtils;
 	TiC.PROPERTY_BORDER_COLOR,
 	TiC.PROPERTY_BORDER_RADIUS,
 	TiC.PROPERTY_BORDER_WIDTH,
+	TiC.PROPERTY_DASHED,
 	// layout / dimension (size/width/height have custom accessors)
 	TiC.PROPERTY_LEFT,
 	TiC.PROPERTY_TOP,

--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiBorderWrapperView.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiBorderWrapperView.java
@@ -10,9 +10,11 @@ import org.appcelerator.kroll.common.Log;
 import org.appcelerator.titanium.TiDimension;
 import org.appcelerator.titanium.util.TiConvert;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.Color;
+import android.graphics.DashPathEffect;
 import android.graphics.Outline;
 import android.graphics.Paint;
 import android.graphics.Path;
@@ -38,6 +40,7 @@ public class TiBorderWrapperView extends FrameLayout
 	private int backgroundColor = Color.TRANSPARENT;
 	private final float[] radius = { 0, 0, 0, 0, 0, 0, 0, 0 };
 	private float borderWidth = 0;
+	private float[] dashed = null;
 	private int alpha = -1;
 	private Paint paint;
 	private Rect bounds;
@@ -74,6 +77,7 @@ public class TiBorderWrapperView extends FrameLayout
 		}
 	}
 
+	@SuppressLint("DrawAllocation")
 	@Override
 	protected void onDraw(Canvas canvas)
 	{
@@ -81,6 +85,7 @@ public class TiBorderWrapperView extends FrameLayout
 
 		int maxPadding = (int) Math.min(bounds.right / 2, bounds.bottom / 2);
 		int padding = (int) Math.min(borderWidth, maxPadding);
+		float halfPadding = padding * 0.5f;
 		RectF innerRect =
 			new RectF(bounds.left + padding, bounds.top + padding, bounds.right - padding, bounds.bottom - padding);
 		RectF outerRect = new RectF(bounds);
@@ -114,7 +119,18 @@ public class TiBorderWrapperView extends FrameLayout
 			}
 		} else {
 			outerPath.addRect(outerRect, Direction.CW);
-			outerPath.addRect(innerRect, Direction.CCW);
+			innerRect = new RectF(bounds.left + halfPadding, bounds.top + halfPadding,
+				bounds.right - halfPadding, bounds.bottom - halfPadding);
+			paint.setStyle(Paint.Style.STROKE);
+			paint.setStrokeWidth(borderWidth);
+
+			if (dashed != null) {
+				try {
+					paint.setPathEffect(new DashPathEffect(dashed, 0f));
+				} catch (Exception ex) {
+					Log.e(TAG, "dashed needs to have at least two values");
+				}
+			}
 			canvas.drawPath(outerPath, paint);
 			canvas.clipRect(innerRect);
 		}
@@ -148,6 +164,10 @@ public class TiBorderWrapperView extends FrameLayout
 	public void setBgColor(int color)
 	{
 		this.backgroundColor = color;
+	}
+	public void setDashed(float[] value)
+	{
+		this.dashed = value;
 	}
 
 	public boolean hasRadius()

--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiUIView.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiUIView.java
@@ -1533,6 +1533,18 @@ public abstract class TiUIView implements KrollProxyListener, OnFocusChangeListe
 					borderView.setRadius(d.get(TiC.PROPERTY_BORDER_RADIUS));
 				}
 
+				if (d.containsKeyAndNotNull(TiC.PROPERTY_DASHED)) {
+					try {
+						Object[] inArray = (Object[]) d.get(TiC.PROPERTY_DASHED);
+						float[] outArray = new float[inArray.length];
+						for (int i = 0; i < inArray.length; i++) {
+							outArray[i] = ((Number) inArray[i]).intValue();
+						}
+						borderView.setDashed(outArray);
+					} catch (Exception ex) {
+						Log.e(TAG, "dashed needs to be an array of float values with 2 or more values");
+					}
+				}
 				if (bgColor != null) {
 					borderView.setBgColor(bgColor);
 					borderView.setColor(bgColor);


### PR DESCRIPTION
Dashed border:

![Screenshot_20250708-152944](https://github.com/user-attachments/assets/84950e94-663e-46c4-a9d9-6f9ee4a941f5)

```js
var win = Ti.UI.createWindow({
	layout: "vertical"
})

let views = [];

function addView(dashed) {
	var view = Ti.UI.createView({
		borderWidth: 5,
		borderColor: "yellow",
		width: 100,
		height: 100,
		backgroundColor: "red",
		bottom: 20,
		dashed: dashed,
		title: "test"
	})

	var lbl = Ti.UI.createLabel({
		text: "test",
		touchEnabled: false
	});
	views.push(view);
	view.add(lbl);
	win.add(view);
}


addView();
addView([10, 100, 50, 200]);
addView([20, 5]);
addView([20, 20]);

win.open()
```

* only creation only (it doesn't rerender the views yet)
* only if no borderRadius is set