### PR TITLE
fix(android): add deselectItem to Androids ListView

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/ListViewProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/ListViewProxy.java
@@ -314,6 +314,12 @@ public class ListViewProxy extends RecyclerViewProxy
 		}
 	}
 
+	// not needed on Android but parity for iOS method call
+	@Kroll.method
+	public void deselectItem(int section, int item)
+	{
+	}
+
 	@Override
 	public String getApiName()
 	{


### PR DESCRIPTION
On iOS you use `$.lst_open.deselectItem(0, e.itemIndex)` to deselect a clicked item. This method is not needed on Android but also not available in the SDK so you have to add an `if OS_IOS` all the time.

This PR will just add an empty method to the Android ListView so you can remove the `if OS_IOS` statement.