### PR TITLE
fix(android): fix hidding actionbar in drawerLayout

### DIFF
--- a/android/modules/ui/res/layout/titanium_ui_drawer_layout.xml
+++ b/android/modules/ui/res/layout/titanium_ui_drawer_layout.xml
@@ -1,11 +1,11 @@
 <androidx.drawerlayout.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
 	android:layout_width="match_parent"
-	android:layout_height="match_parent"
-	android:fitsSystemWindows="true">
+	android:layout_height="match_parent">
 
 	<LinearLayout
 		android:id="@+id/drawer_layout_container"
 		android:layout_width="match_parent"
+		android:fitsSystemWindows="true"
 		android:layout_height="match_parent"
 		android:orientation="vertical">
 
@@ -14,12 +14,11 @@
 			android:layout_width="match_parent"
 			android:layout_height="wrap_content"
 			android:background="?attr/colorPrimary"
-			android:fitsSystemWindows="true"
 			android:minHeight="?attr/actionBarSize"
 			android:visibility="gone" />
 
 		<org.appcelerator.titanium.view.TiCompositeLayout
 			android:layout_width="match_parent"
-			android:layout_height="match_parent" />
+			android:layout_height="match_parent"/>
 	</LinearLayout>
 </androidx.drawerlayout.widget.DrawerLayout>

--- a/android/modules/ui/res/layout/titanium_ui_drawer_layout.xml
+++ b/android/modules/ui/res/layout/titanium_ui_drawer_layout.xml
@@ -5,7 +5,6 @@
 	<LinearLayout
 		android:id="@+id/drawer_layout_container"
 		android:layout_width="match_parent"
-		android:fitsSystemWindows="true"
 		android:layout_height="match_parent"
 		android:orientation="vertical">
 
@@ -19,6 +18,6 @@
 
 		<org.appcelerator.titanium.view.TiCompositeLayout
 			android:layout_width="match_parent"
-			android:layout_height="match_parent"/>
+			android:layout_height="match_parent" />
 	</LinearLayout>
 </androidx.drawerlayout.widget.DrawerLayout>


### PR DESCRIPTION
fixes https://github.com/tidev/titanium-sdk/issues/14249

In https://github.com/tidev/titanium-sdk/pull/14181 I already added some parts that should help with the edge-to-edge design in the DrawerLayout XML (not used as we opt-out of edge-to-edge for all layouts). But It turns out to make issues when you try to hide the actionbar with JS.

The following code:
```js
var win = Ti.UI.createWindow({
	extendSafeArea: true,
});

var centerView = Ti.UI.createView({
	backgroundColor: 'yellow'
});
var rightView = Ti.UI.createView({
	backgroundColor: 'orange'
});

var drawer = Ti.UI.Android.createDrawerLayout({
	centerView: centerView,
	rightView: rightView
});
var btn = Ti.UI.createButton({
	title: 'RIGHT'
});

btn.addEventListener('click', function() {
	drawer.toggleRight();
});

centerView.add(btn);

win.addEventListener('open', function() {
	var activity = win.activity;
	setTimeout(function() {
		activity.actionBar.hide();
	}, 1000)
});

win.add(drawer);
win.open();
```

will move out the actionbar after one second. In 12.8.0 it will keep an empty space above the window. 12.7.1 still works fine. 

Current workaround:

1. option: create a file called titanium_ui_drawer_layout.xml and put it into /platform/android/res/layout/ (classic) and copy the content of the file in the PR to the xml.

2. option: use `<navbar-hidden>true</navbar-hidden>` in your tiapp.xml or a "noTitlebar" theme. It will remove the actionbar but of course you can't use JS for it to show/hide it.