### PR TITLE
fix: fix trailing new line on html labels

### DIFF
--- a/iphone/Classes/TiUILabel.m
+++ b/iphone/Classes/TiUILabel.m
@@ -510,13 +510,25 @@
   ENSURE_SINGLE_ARG(html, NSString);
   [[self proxy] replaceValue:html forKey:@"html" notification:NO];
 
-  NSAttributedString *attributedString = [[NSAttributedString alloc] initWithData:[html dataUsingEncoding:NSUTF8StringEncoding]
-                                                                          options:@{ NSDocumentTypeDocumentAttribute : NSHTMLTextDocumentType,
-                                                                            NSCharacterEncodingDocumentAttribute : @(NSUTF8StringEncoding) }
-                                                               documentAttributes:nil
-                                                                            error:nil];
+  NSMutableAttributedString *attributedString = [[NSMutableAttributedString alloc] initWithData:[html dataUsingEncoding:NSUTF8StringEncoding]
+                                                                                        options:@{ NSDocumentTypeDocumentAttribute : NSHTMLTextDocumentType,
+                                                                                          NSCharacterEncodingDocumentAttribute : @(NSUTF8StringEncoding) }
+                                                                             documentAttributes:nil
+                                                                                          error:nil];
+
+  // For parity with Android: Trim trailing newline characters which UIKit often appends for block tags.
+  while (attributedString.length > 0) {
+    unichar c = [[attributedString string] characterAtIndex:attributedString.length - 1];
+    if (c == '\n' || c == '\r') {
+      [attributedString deleteCharactersInRange:NSMakeRange(attributedString.length - 1, 1)];
+    } else {
+      break;
+    }
+  }
 
   [[self label] setAttributedText:attributedString];
+  [attributedString release];
+
   [self padLabel];
   [(TiViewProxy *)[self proxy] contentsWillChange];
 }


### PR DESCRIPTION
This pull request improves the handling of HTML content in the `TiUILabel` component to better match Android behavior. The main change is trimming any trailing newline or carriage return characters that UIKit may add when rendering HTML, ensuring consistency across platforms.

Test case:
```js
const win = Ti.UI.createWindow({
    backgroundColor: '#fff'
});

const label = Ti.UI.createLabel({
    html: '<p>Hello world</p>',
    backgroundColor: 'red',
});

win.add(label);
win.open();
```

| Before | After |
|--------|--------|
| <img width="320" alt="simulator_screenshot_C2AEE8B2-85B5-4B82-997C-FC78E6ABA228" src="https://github.com/user-attachments/assets/6e54c525-e266-4432-9db4-46d467f0c334" /> | <img width="320" alt="Simulator Screenshot - iPhone 16e - 2025-08-26 at 10 55 14" src="https://github.com/user-attachments/assets/dd6450e3-6341-44d9-8482-5047adab55db" /> |
