### PR TITLE
feat(ios): support iOS 26+ source views for non-iPad devices

### DIFF
--- a/apidoc/Titanium/UI/OptionDialog.yml
+++ b/apidoc/Titanium/UI/OptionDialog.yml
@@ -382,13 +382,7 @@ properties:
     optional: true
 
   - name: view
-    summary: View to which to attach the dialog.
+    summary: |
+        View to which to attach the dialog. Prior to iOS 26, this was only
+        used on iPad.
     type: Titanium.UI.View
-
-  - name: rect
-    summary: Positions the arrow of the option dialog relative to the attached view's dimensions.
-    description: |
-        Setting the x, y coordinates to (0, 0) places the dialog in the top-left corner of the
-        view object.  Set both the `width` and `height` properties to 1.
-    type: Dimension
-    optional: true

--- a/iphone/Classes/TiUIOptionDialogProxy.h
+++ b/iphone/Classes/TiUIOptionDialogProxy.h
@@ -14,7 +14,6 @@
   UIAlertController *alertController;
   TiViewProxy *dialogView;
   UIColor *tintColor;
-  CGRect dialogRect;
   BOOL animated;
   NSUInteger accumulatedOrientationChanges;
   BOOL showDialog;

--- a/iphone/Classes/TiUIOptionDialogProxy.m
+++ b/iphone/Classes/TiUIOptionDialogProxy.m
@@ -115,6 +115,7 @@
   if (!isPopover) {
     UIPopoverPresentationController *presentationController = alertController.popoverPresentationController;
     presentationController.permittedArrowDirections = UIPopoverArrowDirectionAny;
+    presentationController.delegate = self;
 
     // Configure anchor using `view` for all iOS devices (not iPad only)
     if (dialogView != nil) {
@@ -230,6 +231,13 @@
       presentationController.sourceView = view;
     }
   }
+}
+
+#pragma mark UIPopoverPresentationControllerDelegate
+
+- (void)presentationControllerDidDismiss:(UIPresentationController *)presentationController
+{
+  [self cleanup];
 }
 
 @end

--- a/iphone/Classes/TiUIOptionDialogProxy.m
+++ b/iphone/Classes/TiUIOptionDialogProxy.m
@@ -8,6 +8,7 @@
 
 #import "TiUIOptionDialogProxy.h"
 #import "TiToolbarButton.h"
+#import "TiUIButtonProxy.h"
 #import <TitaniumKit/TiApp.h>
 #import <TitaniumKit/TiTab.h>
 #import <TitaniumKit/TiToolbar.h>
@@ -67,9 +68,7 @@
   animated = [TiUtils boolValue:@"animated" properties:args def:YES];
   id obj = [args objectForKey:@"rect"];
   if (obj != nil) {
-    dialogRect = [TiUtils rectValue:obj];
-  } else {
-    dialogRect = CGRectZero;
+    DEPRECATED_REMOVED(@"UI.OptionDialog", @"13.0.0", @"13.0.0");
   }
 
   RELEASE_TO_NIL(alertController);
@@ -110,23 +109,17 @@
   if ([TiUtils isIPad]) {
     UIViewController *topVC = [[[TiApp app] controller] topPresentedController];
     isPopover = ((topVC.modalPresentationStyle == UIModalPresentationPopover) && (![topVC isKindOfClass:[UIAlertController class]]));
-    /**
-         ** This block commented out since it seems to have no effect on the alert controller.
-         ** If you read the modalPresentationStyle after setting the value, it still shows UIModalPresentationPopover
-         ** However not configuring the UIPopoverPresentationController seems to do the trick.
-         ** This hack in place to conserve current behavior. Should revisit when iOS7 is dropped so that
-         ** option dialogs are always presented in UIModalPresentationPopover
-         if (isPopover) {
-         alertController.modalPresentationStyle = UIModalPresentationCurrentContext;
-         alertController.modalTransitionStyle = UIModalTransitionStyleCoverVertical;
-         }
-         */
   }
+
   /*See Comment above. Remove if condition to see difference in behavior on iOS8*/
   if (!isPopover) {
     UIPopoverPresentationController *presentationController = alertController.popoverPresentationController;
     presentationController.permittedArrowDirections = UIPopoverArrowDirectionAny;
-    presentationController.delegate = self;
+
+    // Configure anchor using `view` for all iOS devices (not iPad only)
+    if (dialogView != nil) {
+      [self configureSourceView:presentationController];
+    }
   }
 
   [self retain];
@@ -159,76 +152,6 @@
   if (!persistentFlag) {
     [self hide:[NSArray arrayWithObject:[NSDictionary dictionaryWithObject:NUMBOOL(NO) forKey:@"animated"]]];
   }
-}
-
-#pragma mark UIPopoverPresentationControllerDelegate
-- (void)prepareForPopoverPresentation:(UIPopoverPresentationController *)popoverPresentationController
-{
-  if (dialogView != nil) {
-    if ([dialogView supportsNavBarPositioning] && [dialogView isUsingBarButtonItem]) {
-      UIBarButtonItem *theItem = [dialogView barButtonItem];
-      if (theItem != nil) {
-        popoverPresentationController.barButtonItem = [dialogView barButtonItem];
-        return;
-      }
-    }
-
-    if ([dialogView conformsToProtocol:@protocol(TiToolbar)]) {
-      UIToolbar *toolbar = [(id<TiToolbar>)dialogView toolbar];
-      if (toolbar != nil) {
-        popoverPresentationController.sourceView = toolbar;
-        popoverPresentationController.sourceRect = [toolbar bounds];
-        return;
-      }
-    }
-
-    if ([dialogView conformsToProtocol:@protocol(TiTab)]) {
-      id<TiTab> tab = (id<TiTab>)dialogView;
-      UITabBar *tabbar = [[tab tabGroup] tabbar];
-      if (tabbar != nil) {
-        popoverPresentationController.sourceView = tabbar;
-        popoverPresentationController.sourceRect = [tabbar bounds];
-        return;
-      }
-    }
-
-    UIView *view = [dialogView view];
-    if (view != nil) {
-      popoverPresentationController.sourceView = view;
-      popoverPresentationController.sourceRect = (CGRectEqualToRect(CGRectZero, dialogRect) ? CGRectMake(view.bounds.size.width / 2, view.bounds.size.height / 2, 1, 1) : dialogRect);
-      return;
-    }
-  }
-
-  // Fell through.
-  UIViewController *presentingController = [alertController presentingViewController];
-  popoverPresentationController.permittedArrowDirections = 0;
-  popoverPresentationController.sourceView = [presentingController view];
-  popoverPresentationController.sourceRect = (CGRectEqualToRect(CGRectZero, dialogRect) ? CGRectMake(presentingController.view.bounds.size.width / 2, presentingController.view.bounds.size.height / 2, 1, 1) : dialogRect);
-  ;
-}
-
-- (void)popoverPresentationController:(UIPopoverPresentationController *)popoverPresentationController willRepositionPopoverToRect:(inout CGRect *)rect inView:(inout UIView **)view
-{
-  // This will never be called when using bar button item
-  BOOL canUseDialogRect = !CGRectEqualToRect(CGRectZero, dialogRect);
-  UIView *theSourceView = *view;
-  BOOL shouldUseViewBounds = ([theSourceView isKindOfClass:[UIToolbar class]] || [theSourceView isKindOfClass:[UITabBar class]]);
-
-  if (shouldUseViewBounds) {
-    rect->origin = CGPointMake(theSourceView.bounds.origin.x, theSourceView.bounds.origin.y);
-    rect->size = CGSizeMake(theSourceView.bounds.size.width, theSourceView.bounds.size.height);
-  } else if (!canUseDialogRect) {
-    rect->origin = CGPointMake(theSourceView.bounds.size.width / 2, theSourceView.bounds.size.height / 2);
-    rect->size = CGSizeMake(1, 1);
-  }
-
-  popoverPresentationController.sourceRect = *rect;
-}
-
-- (void)popoverPresentationControllerDidDismissPopover:(UIPopoverPresentationController *)popoverPresentationController
-{
-  [self cleanup];
 }
 
 #pragma mark Internal Use Only
@@ -268,6 +191,44 @@
     [[NSNotificationCenter defaultCenter] removeObserver:self];
     [self forgetSelf];
     [self release];
+  }
+}
+
+- (void)configureSourceView:(UIPopoverPresentationController *)presentationController
+{
+  if ([dialogView isKindOfClass:TiUIButtonProxy.class]) {
+    if ([dialogView isUsingBarButtonItem]) {
+      UIBarButtonItem *theItem = [dialogView barButtonItem];
+      if (theItem != nil) {
+        presentationController.barButtonItem = theItem;
+      }
+    } else {
+      UIView *btnView = [dialogView view];
+      if (btnView != nil) {
+        presentationController.sourceView = btnView;
+      }
+    }
+  } else if ([dialogView supportsNavBarPositioning] && [dialogView isUsingBarButtonItem]) {
+    UIBarButtonItem *theItem = [dialogView barButtonItem];
+    if (theItem != nil) {
+      presentationController.barButtonItem = theItem;
+    }
+  } else if ([dialogView conformsToProtocol:@protocol(TiToolbar)]) {
+    UIToolbar *toolbar = [(id<TiToolbar>)dialogView toolbar];
+    if (toolbar != nil) {
+      presentationController.sourceView = toolbar;
+    }
+  } else if ([dialogView conformsToProtocol:@protocol(TiTab)]) {
+    id<TiTab> tab = (id<TiTab>)dialogView;
+    UITabBar *tabbar = [[tab tabGroup] tabbar];
+    if (tabbar != nil) {
+      presentationController.sourceView = tabbar;
+    }
+  } else {
+    UIView *view = [dialogView view];
+    if (view != nil) {
+      presentationController.sourceView = view;
+    }
   }
 }
 


### PR DESCRIPTION
This pull request adds support for using the source view ("view") parameter outside of the iPad as well. It also removes the manual "rect" handling, as modern iOS versions are able to infer the rect from the source view directly. That also makes the code more lightweight by removing manual positioning code.

This way, the option dialogs be shown as nicely presented popovers on iOS 26+:

```js

const win = Ti.UI.createWindow({
    backgroundColor: '#fff'
});

const btn = Ti.UI.createButton({
    title: 'Show options'
});

btn.addEventListener('click', () => {
    const dialog = Ti.UI.createOptionDialog({
        title: 'Delete item',
        message: 'Do you want to delete this item?',
        options: ['Delete', 'Rename', 'Cancel'],
        cancel: 2,
        destructive: 1
    });
    
    // optional: shows as popover on iOS 26+
    dialog.show({ view: btn });
});

win.add(btn);
win.open();

```

| iOS 18.5 | iOS 26 (without `view`) | iOS 26 (with `view`) |
|--------|--------|--------|
| <img width="200" alt="Simulator Screenshot - iPhone 16e - 2025-08-28 at 10 53 43" src="https://github.com/user-attachments/assets/2acf5286-be5d-4485-af09-a7337718d985" /> | <img width="200" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-27 at 20 38 58" src="https://github.com/user-attachments/assets/1d603170-ea22-4897-8fb5-3ec7c5e9db2e" /> | <img width="200" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-27 at 20 38 08" src="https://github.com/user-attachments/assets/3afdd498-a6c8-407d-8190-8f54de0053cf" /> |
