### PR TITLE
feat(ios): support for iOS 26+ bottomAccessoryView API

### DIFF
--- a/apidoc/Titanium/UI/TabGroup.yml
+++ b/apidoc/Titanium/UI/TabGroup.yml
@@ -243,18 +243,18 @@ methods:
         notes: Use the <Titanium.UI.TabGroup.tabs> property instead.
   
   - name: showTabBar
-    summary: Shows the tab bar with animation.
+    summary: Shows the tab group with animation.
     description: |
         This method also updates iOS 18+ [Elevated Tab Bar on iPad](https://developer.apple.com/documentation/uikit/elevating-your-ipad-app-with-a-tab-bar-and-sidebar).
-        To show tab bar without animation, set [tabBarVisible](Titanium.UI.TabGroup.tabBarVisible) property to `false`.
+        To show tab group without animation, set [tabBarVisible](Titanium.UI.TabGroup.tabBarVisible) property to `false`.
     platforms: [android, iphone, ipad, macos]
     since: "12.7.0"
 
   - name: hideTabBar
-    summary: Hides the tab bar with animation.
+    summary: Hides the tab group with animation.
     description: |
         This method also updates iOS 18+ [Elevated Tab Bar on iPad](https://developer.apple.com/documentation/uikit/elevating-your-ipad-app-with-a-tab-bar-and-sidebar).
-        To hide tab bar without animation, set [tabBarVisible](Titanium.UI.TabGroup.tabBarVisible) property to `true`.
+        To hide tab group without animation, set [tabBarVisible](Titanium.UI.TabGroup.tabBarVisible) property to `true`.
     platforms: [android, iphone, ipad, macos]
     since: "12.7.0"
 
@@ -308,12 +308,21 @@ properties:
     platforms: [iphone, ipad, android, macos]
 
   - name: bottomAccessoryView
-    summary: View shown as a bottom accessory attached to the tab bar.
+    summary: View shown as a bottom accessory attached to the tab group.
     description: |
-        Adds a custom view as a bottom accessory of the tab bar. Available on iOS 26+ only (uses the new iOS tab bar accessories).
+        Adds a custom view as a bottom accessory of the tab group. Available on iOS 26+ only (uses the new iOS tab group accessories).
 
         Note: Label subviews require explicit width and height set to render properly. Be sure to set `width` and `height` on any `Ti.UI.Label` added to this view.
     type: Titanium.UI.View
+    osver: {ios: {min: "26.0"}}
+    platforms: [iphone, ipad, macos]
+    since: "13.0.0"
+
+  - name: minimizeBehavior
+    summary: Defines the minimize behavior for the tab group, if it is supported.
+    type: Number
+    constants: Titanium.UI.iOS.TAB_GROUP_MINIMIZE_BEHAVIOR_*
+    osver: {ios: {min: "26.0"}}
     platforms: [iphone, ipad, macos]
     since: "13.0.0"
 
@@ -544,16 +553,16 @@ properties:
         notes: Deprecated in favor of [Titanium.UI.TabGroup.tintColor](Titanium.UI.TabGroup.tintColor) or alternatively [Titanium.UI.Tab.tintColor](Titanium.UI.Tab.tintColor).
 
   - name: tabsTranslucent
-    summary: A Boolean value that indicates whether the tab bar is translucent.
+    summary: A Boolean value that indicates whether the tab group is translucent.
     description: |
         When the value of this property is `true`, the tab group adds a translucent effect to its background
-        image or tint color. When translucency is enabled, part of the tab bar's underlying content is able
-        to show through, although the amount that shows through depends on the rest of the tab bar configuration.
+        image or tint color. When translucency is enabled, part of the tab group's underlying content is able
+        to show through, although the amount that shows through depends on the rest of the tab group configuration.
         For example, a background image can wholly or partially obscure the background content. Setting this
-        property to NO causes the tab bar to render its bar tint color or background image on top of an opaque backdrop.
+        property to NO causes the tab group to render its bar tint color or background image on top of an opaque backdrop.
 
-        The default value of this property is dependent on the configuration of the tab bar:
-          * The default value is `true` when the tab bar does not have a custom background image.
+        The default value of this property is dependent on the configuration of the tab group:
+          * The default value is `true` when the tab group does not have a custom background image.
           * The default value is `true` when a custom background image contains any transparency - that is,
             at least one pixel has an alpha value of less than 1.0.
           * The default value is `false` when the custom background image is completely opaque - that is,
@@ -616,7 +625,7 @@ properties:
         notes: Deprecated in favor of [Titanium.UI.TabGroup.tintColor](Titanium.UI.TabGroup.tintColor) or alternatively [Titanium.UI.Tab.tintColor](Titanium.UI.Tab.tintColor).
 
   - name: shadowImage
-    summary: Image of the shadow placed between the tab bar and the content area.
+    summary: Image of the shadow placed between the tab group and the content area.
     description: |
         The <Titanium.UI.TabGroup.tabsBackgroundImage> property must also be set
         in order for this to take effect.
@@ -656,7 +665,7 @@ properties:
     since: { iphone: "3.1.0", ipad: "3.1.0" }
 
   - name: tabBarVisible
-    summary: Programmatically shows / hides the bottom tab bar of the tab group.
+    summary: Programmatically shows / hides the bottom tab group of the tab group.
     description: |
         This method also updates iOS 18+ [Elevated Tab Bar on iPad](https://developer.apple.com/documentation/uikit/elevating-your-ipad-app-with-a-tab-bar-and-sidebar).
         Notes: Animation effect is applied on iOS <= 17, but will be removed in SDK 13.0.0. 

--- a/apidoc/Titanium/UI/TabGroup.yml
+++ b/apidoc/Titanium/UI/TabGroup.yml
@@ -307,6 +307,16 @@ properties:
     type: [String, Titanium.UI.Color]
     platforms: [iphone, ipad, android, macos]
 
+  - name: bottomAccessoryView
+    summary: View shown as a bottom accessory attached to the tab bar.
+    description: |
+        Adds a custom view as a bottom accessory of the tab bar. Available on iOS 26+ only (uses the new iOS tab bar accessories).
+
+        Note: Label subviews require explicit width and height set to render properly. Be sure to set `width` and `height` on any `Ti.UI.Label` added to this view.
+    type: Titanium.UI.View
+    platforms: [iphone, ipad, macos]
+    since: "13.0.0"
+
   - name: enabled
     summary: |
         Enables or disables the menu in a BottomNavigation. If disabled you can't change to a different tab.

--- a/apidoc/Titanium/UI/iOS/iOS.yml
+++ b/apidoc/Titanium/UI/iOS/iOS.yml
@@ -1290,6 +1290,46 @@ properties:
     since: "8.0.0"
     permission: read-only
 
+  - name: TAB_GROUP_MINIMIZE_BEHAVIOR_AUTOMATIC
+    summary: Automatically determine when the tab group minimizes.
+    description: |
+        Use with <Titanium.UI.TabGroup.minimizeBehavior> to let the system choose the appropriate
+        minimize behavior based on context and platform conventions.
+    type: Number
+    osver: { ios: { min: "26.0" } }
+    since: "13.0.0"
+    permission: read-only
+
+  - name: TAB_GROUP_MINIMIZE_BEHAVIOR_NEVER
+    summary: Do not minimize the tab group.
+    description: |
+        Use with <Titanium.UI.TabGroup.minimizeBehavior> to keep the tab group visible and prevent
+        it from minimizing in response to scrolling.
+    type: Number
+    osver: { ios: { min: "26.0" } }
+    since: "13.0.0"
+    permission: read-only
+
+  - name: TAB_GROUP_MINIMIZE_BEHAVIOR_ON_SCROLL_UP
+    summary: Minimize the tab group when scrolling up.
+    description: |
+        Use with <Titanium.UI.TabGroup.minimizeBehavior> to minimize the tab group as the user scrolls
+        upward.
+    type: Number
+    osver: { ios: { min: "26.0" } }
+    since: "13.0.0"
+    permission: read-only
+
+  - name: TAB_GROUP_MINIMIZE_BEHAVIOR_ON_SCROLL_DOWN
+    summary: Minimize the tab group when scrolling down.
+    description: |
+        Use with <Titanium.UI.TabGroup.minimizeBehavior> to minimize the tab group as the user scrolls
+        downward.
+    type: Number
+    osver: { ios: { min: "26.0" } }
+    since: "13.0.0"
+    permission: read-only
+
 ---
 name: SystemImageParameters
 summary: |

--- a/iphone/Classes/TiUITabGroup.h
+++ b/iphone/Classes/TiUITabGroup.h
@@ -22,6 +22,7 @@
   NSMutableDictionary *theAttributes;
 
   BOOL isTabBarHidden;
+  TiUIView *bottomAccessoryView;
 }
 
 - (UITabBarController *)tabController;

--- a/iphone/Classes/TiUITabGroup.m
+++ b/iphone/Classes/TiUITabGroup.m
@@ -413,7 +413,7 @@ DEFINE_EXCEPTIONS
       }];
 }
 
-#ifndef IS_SDK_IOS_26
+#if IS_SDK_IOS_26
 - (void)setBottomAccessoryView_:(id)bottomAccessoryViewProxy
 {
   if (bottomAccessoryViewProxy == [NSNull null]) {

--- a/iphone/Classes/TiUITabGroup.m
+++ b/iphone/Classes/TiUITabGroup.m
@@ -413,6 +413,7 @@ DEFINE_EXCEPTIONS
       }];
 }
 
+#ifndef IS_SDK_IOS_26
 - (void)setBottomAccessoryView_:(id)bottomAccessoryViewProxy
 {
   if (bottomAccessoryViewProxy == [NSNull null]) {
@@ -438,6 +439,7 @@ DEFINE_EXCEPTIONS
 {
   [[self tabController] setTabBarMinimizeBehavior:minimizeBehavior.integerValue];
 }
+#endif
 
 - (void)setTabsBackgroundColor_:(id)value
 {

--- a/iphone/Classes/TiUITabGroup.m
+++ b/iphone/Classes/TiUITabGroup.m
@@ -413,6 +413,27 @@ DEFINE_EXCEPTIONS
       }];
 }
 
+- (void)setBottomAccessoryView_:(id)bottomAccessoryViewProxy
+{
+  if (bottomAccessoryViewProxy == [NSNull null]) {
+    [[self tabController] setBottomAccessory:nil];
+    return;
+  }
+
+  [self.proxy rememberProxy:bottomAccessoryViewProxy];
+
+  if (bottomAccessoryView != nil) {
+    [self.proxy forgetProxy:bottomAccessoryView.proxy];
+    RELEASE_TO_NIL(bottomAccessoryView);
+  }
+
+  bottomAccessoryView = [(TiViewProxy *)bottomAccessoryViewProxy view];
+  [bottomAccessoryView retain];
+
+  UITabAccessory *tabAccessory = [[UITabAccessory alloc] initWithContentView:bottomAccessoryView];
+  [[self tabController] setBottomAccessory:tabAccessory animated:NO];
+}
+
 - (void)setTabsBackgroundColor_:(id)value
 {
   TiColor *color = [TiUtils colorValue:value];

--- a/iphone/Classes/TiUITabGroup.m
+++ b/iphone/Classes/TiUITabGroup.m
@@ -416,17 +416,17 @@ DEFINE_EXCEPTIONS
 #if IS_SDK_IOS_26
 - (void)setBottomAccessoryView_:(id)bottomAccessoryViewProxy
 {
+  if (bottomAccessoryView != nil) {
+    [self.proxy forgetProxy:bottomAccessoryView.proxy];
+    RELEASE_TO_NIL(bottomAccessoryView);
+  }
+
   if (bottomAccessoryViewProxy == [NSNull null]) {
     [[self tabController] setBottomAccessory:nil];
     return;
   }
 
   [self.proxy rememberProxy:bottomAccessoryViewProxy];
-
-  if (bottomAccessoryView != nil) {
-    [self.proxy forgetProxy:bottomAccessoryView.proxy];
-    RELEASE_TO_NIL(bottomAccessoryView);
-  }
 
   bottomAccessoryView = [(TiViewProxy *)bottomAccessoryViewProxy view];
   [bottomAccessoryView retain];

--- a/iphone/Classes/TiUITabGroup.m
+++ b/iphone/Classes/TiUITabGroup.m
@@ -434,6 +434,11 @@ DEFINE_EXCEPTIONS
   [[self tabController] setBottomAccessory:tabAccessory animated:NO];
 }
 
+- (void)setMinimizeBehavior_:(NSNumber *)minimizeBehavior
+{
+  [[self tabController] setTabBarMinimizeBehavior:minimizeBehavior.integerValue];
+}
+
 - (void)setTabsBackgroundColor_:(id)value
 {
   TiColor *color = [TiUtils colorValue:value];

--- a/iphone/Classes/TiUIiOSProxy.h
+++ b/iphone/Classes/TiUIiOSProxy.h
@@ -169,6 +169,11 @@
 @property (nonatomic, readonly) NSNumber *LARGE_TITLE_DISPLAY_MODE_ALWAYS;
 @property (nonatomic, readonly) NSNumber *LARGE_TITLE_DISPLAY_MODE_NEVER;
 
+@property (nonatomic, readonly) NSNumber *TAB_GROUP_MINIMIZE_BEHAVIOR_AUTOMATIC;
+@property (nonatomic, readonly) NSNumber *TAB_GROUP_MINIMIZE_BEHAVIOR_NEVER;
+@property (nonatomic, readonly) NSNumber *TAB_GROUP_MINIMIZE_BEHAVIOR_ON_SCROLL_DOWN;
+@property (nonatomic, readonly) NSNumber *TAB_GROUP_MINIMIZE_BEHAVIOR_ON_SCROLL_UP;
+
 /**
  * Checks the force touch capibility of the current device.
  */

--- a/iphone/Classes/TiUIiOSProxy.m
+++ b/iphone/Classes/TiUIiOSProxy.m
@@ -853,6 +853,50 @@ MAKE_SYSTEM_PROP(INJECTION_TIME_DOCUMENT_START, WKUserScriptInjectionTimeAtDocum
 MAKE_SYSTEM_PROP(INJECTION_TIME_DOCUMENT_END, WKUserScriptInjectionTimeAtDocumentEnd);
 #endif
 
+- (NSNumber *)TAB_GROUP_MINIMIZE_BEHAVIOR_AUTOMATIC
+{
+#if IS_SDK_IOS_26
+  if (@available(iOS 26.0, *)) {
+    return @(UITabBarMinimizeBehaviorAutomatic);
+  }
+#endif
+
+  return @(-1);
+}
+
+- (NSNumber *)TAB_GROUP_MINIMIZE_BEHAVIOR_NEVER
+{
+#if IS_SDK_IOS_26
+  if (@available(iOS 26.0, *)) {
+    return @(UITabBarMinimizeBehaviorNever);
+  }
+#endif
+
+  return @(-1);
+}
+
+- (NSNumber *)TAB_GROUP_MINIMIZE_BEHAVIOR_ON_SCROLL_UP
+{
+#if IS_SDK_IOS_26
+  if (@available(iOS 26.0, *)) {
+    return @(UITabBarMinimizeBehaviorOnScrollUp);
+  }
+#endif
+
+  return @(-1);
+}
+
+- (NSNumber *)TAB_GROUP_MINIMIZE_BEHAVIOR_ON_SCROLL_DOWN
+{
+#if IS_SDK_IOS_26
+  if (@available(iOS 26.0, *)) {
+    return @(UITabBarMinimizeBehaviorOnScrollDown);
+  }
+#endif
+
+  return @(-1);
+}
+
 - (TiColor *)fetchSemanticColor:(id)color
 {
   ENSURE_SINGLE_ARG(color, NSString);


### PR DESCRIPTION
This PR adds support for the iOS 26+ "bottomAccessoryView" API on the Ti.UI.TabGroup. It creates a floating bottom view that can be shown / hidden by setting the property. It also adds support for the "minimizeBehavior" property to control the automatic showing / hiding of the view based on certain gestures.

```js
const window = Ti.UI.createWindow({
	title: "Window 1",
	backgroundColor: "#fff",
});

const items = Array.from({ length: 100 }, (_, i) => ({ properties: { title: `Item ${i + 1}` } }));
const listView = Ti.UI.createListView({ sections: [Ti.UI.createListSection({ items })] });
window.add(listView);

const bottomAccessoryView = Ti.UI.createView();
bottomAccessoryView.add(Ti.UI.createLabel({ text: 'Hello world', width: Ti.UI.FILL, height: Ti.UI.FILL, textAlign: 'center' }));


const tabGroup = Ti.UI.createTabGroup({
	tabs: [Ti.UI.createTab({ window, title: "Tab 1" })],
	bottomAccessoryView,
	minimizeBehavior: Ti.UI.iOS.TAB_GROUP_MINIMIZE_BEHAVIOR_ON_SCROLL_DOWN
});

tabGroup.open();
```

https://github.com/user-attachments/assets/08366f82-eca3-40ed-8718-6a5252783f5e

