### PR TITLE
refactor(ios): modernize kroll core with GCD

### DIFF
--- a/iphone/TitaniumKit/TitaniumKit.xcodeproj/project.pbxproj
+++ b/iphone/TitaniumKit/TitaniumKit.xcodeproj/project.pbxproj
@@ -22,7 +22,7 @@
 
 /* Begin PBXBuildFile section */
 		4A175276218B64E70094C7B6 /* KrollTimerManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 4A175274218B64E70094C7B6 /* KrollTimerManager.h */; };
-		4A175277218B64E70094C7B6 /* KrollTimerManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A175275218B64E70094C7B6 /* KrollTimerManager.m */; };
+		4A175277218B64E70094C7B6 /* KrollTimerManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A175275218B64E70094C7B6 /* KrollTimerManager.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		4A1FF4432523262A00A0F923 /* ErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A1FF4422523262A00A0F923 /* ErrorView.swift */; };
 		B106A6FD24535CB800B1305E /* JSValue+Addons.h in Headers */ = {isa = PBXBuildFile; fileRef = B106A6FB24535CB800B1305E /* JSValue+Addons.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B106A6FE24535CB800B1305E /* JSValue+Addons.m in Sources */ = {isa = PBXBuildFile; fileRef = B106A6FC24535CB800B1305E /* JSValue+Addons.m */; };

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/Mimetypes.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/Mimetypes.m
@@ -10,20 +10,24 @@
 
 const NSString *svgMimeType = @"image/svg+xml";
 
-static NSDictionary *mimeTypeFromExtensionDict = nil;
+static NSDictionary *MimeTypesDict(void)
+{
+  static NSDictionary *dict = nil;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    // This dictionary contains info on mimetypes currently missing on iOS platform.
+    dict = [[NSDictionary alloc] initWithObjectsAndKeys:
+                                     @"text/css", @"css",
+                                 @"video/x-m4v", @"m4v",
+                                 nil];
+  });
+  return dict;
+}
 
 @implementation Mimetypes
 
 + (void)initialize
 {
-  // This dictionary contains info on mimetypes surrently missing on IOS platform.
-  // This should be updated on a case by case basis.
-  if (mimeTypeFromExtensionDict == nil) {
-    mimeTypeFromExtensionDict = [[NSDictionary alloc] initWithObjectsAndKeys:
-                                                          @"text/css", @"css",
-                                                      @"video/x-m4v", @"m4v",
-                                                      nil];
-  }
 }
 
 + (NSString *)extensionForMimeType:(NSString *)mimetype
@@ -40,9 +44,9 @@ static NSDictionary *mimeTypeFromExtensionDict = nil;
 
   if (extension == NULL) {
     // Missing info is retrieved from dictionary
-    [Mimetypes initialize];
-    for (NSString *key in mimeTypeFromExtensionDict) {
-      NSString *value = [mimeTypeFromExtensionDict objectForKey:key];
+    NSDictionary *extra = MimeTypesDict();
+    for (NSString *key in extra) {
+      NSString *value = [extra objectForKey:key];
       if ([value isEqualToString:mimetype]) {
         return key;
       }
@@ -67,8 +71,7 @@ static NSDictionary *mimeTypeFromExtensionDict = nil;
 
   if (mimetype == NULL) {
     // Missing info is retrieved from dictionary
-    [Mimetypes initialize];
-    NSString *result = [mimeTypeFromExtensionDict objectForKey:[ext pathExtension]];
+    NSString *result = [MimeTypesDict() objectForKey:[ext pathExtension]];
 
     if (result == nil)
       result = @"application/octet-stream";

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/OperationQueue.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/OperationQueue.m
@@ -8,7 +8,8 @@
 #import "OperationQueue.h"
 #import "TiBase.h"
 
-OperationQueue *sharedQueue = nil;
+// Use dispatch_once to ensure thread-safe, one-time singleton init.
+static OperationQueue *sharedQueue = nil;
 
 @interface OperationQueueOp : NSOperation {
   SEL selector;
@@ -93,9 +94,10 @@ OperationQueue *sharedQueue = nil;
 
 + (OperationQueue *)sharedQueue
 {
-  if (sharedQueue == nil) {
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
     sharedQueue = [[OperationQueue alloc] init];
-  }
+  });
   return sharedQueue;
 }
 

--- a/iphone/TitaniumKit/TitaniumKit/Sources/Kroll/KrollTimerManager.h
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/Kroll/KrollTimerManager.h
@@ -28,7 +28,7 @@
 /**
  * The method that will be triggered when a timer fires.
  */
-- (void)timerFired:(nonnull NSTimer *)timer;
+- (void)timerFired:(nullable NSTimer *)timer;
 
 @end
 
@@ -38,9 +38,10 @@
 @interface KrollTimerManager : NSObject
 
 /**
- * Map of timer identifiers and the underlying native NSTimer.
+ * Map of timer identifiers to the underlying native timer objects.
+ * Backed by GCD timers for lower overhead and better accuracy.
  */
-@property (nonatomic, strong, nullable) NSMapTable<NSNumber *, NSTimer *> *timers;
+@property (nonatomic, strong, nullable) NSMapTable<NSNumber *, id> *timers;
 
 /**
  * Initializes the timer manager in the given JS context. Exposes the global set/clear


### PR DESCRIPTION
This pull request modernizes and improves thread safety and timer management throughout the TitaniumKit code base. The main changes replace legacy locking and timer APIs with more efficient and safer alternatives, update the timer manager to use GCD-based timers for better performance and accuracy, and refactor singleton and static initialization patterns for thread safety.

These changes collectively improve the reliability, safety, and maintainability of the TitaniumKit core, especially in multithreaded and timer-heavy scenarios.