### PR TITLE
fix(ios): properly handle containment of tab group to fix crash on start up

### DIFF
--- a/iphone/Classes/TiUITabGroup.m
+++ b/iphone/Classes/TiUITabGroup.m
@@ -664,12 +664,13 @@ DEFINE_EXCEPTIONS
 {
   TiThreadPerformOnMainThread(
       ^{
-        [self.tabController willMoveToParentViewController:TiApp.controller.topPresentedController];
-
+        UIViewController *parentController = TiApp.controller.topPresentedController;
+        // Establish proper containment: add child, add its view, then notify didMove
+        [parentController addChildViewController:self.tabController];
         self.tabController.view.frame = self.bounds;
         [self addSubview:self.tabController.view];
         isTabBarHidden = NO;
-        [TiApp.controller.topPresentedController addChildViewController:self.tabController];
+        [self.tabController didMoveToParentViewController:parentController];
       },
       NO);
 }

--- a/iphone/Classes/TiUITabGroupProxy.m
+++ b/iphone/Classes/TiUITabGroupProxy.m
@@ -227,9 +227,7 @@ static NSArray *tabGroupKeySequence;
 {
   if ([self viewAttached]) {
     UITabBarController *tabController = [(TiUITabGroup *)[self view] tabController];
-    UIViewController *parentController = [self windowHoldingController];
-    [parentController addChildViewController:tabController];
-    [tabController didMoveToParentViewController:parentController];
+    // Containment is managed in TiUITabGroup.open. Avoid double-adding here.
     [tabController viewWillAppear:animated];
   }
   [super viewWillAppear:animated];


### PR DESCRIPTION
This PR fixes a crash “UIViewControllerHierarchyInconsistency” when opening a UI.TabGroup. It ensures `UITabBarController` is contained by a single parent and attached using the correct lifecycle order.

Stack trace:
```
 Fatal Exception: UIViewControllerHierarchyInconsistency
child view controller:<UITabBarController: 0x129904500> should have parent view controller:<TiRootViewController: 0x1076193c0> but requested parent is:<TiViewController: 0x129805000> 

0  CoreFoundation                 0x11a0c0 __exceptionPreprocess
1  libobjc.A.dylib                0x31abc objc_exception_throw
2  CoreFoundation                 0x178d4c -[NSException initWithCoder:]
3  UIKitCore                      0x9f104 -[UIViewController _addChildViewController:performHierarchyCheck:notifyWillMove:]
4  libdispatch.dylib              0x1aac _dispatch_call_block_and_release
5  libdispatch.dylib              0x1b584 _dispatch_client_callout
6  libdispatch.dylib              0x385c8 _dispatch_main_queue_drain.cold.5
7  libdispatch.dylib              0x10d30 _dispatch_main_queue_drain
8  libdispatch.dylib              0x10c6c _dispatch_main_queue_callback_4CF
9  CoreFoundation                 0x6cc30 __CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__
10 CoreFoundation                 0x10394 __CFRunLoopRun
11 CoreFoundation                 0x11adc CFRunLoopRunSpecific
12 GraphicsServices               0x1454 GSEventRunModal
13 UIKitCore                      0x135274 -[UIApplication _run]
14 UIKitCore                      0x100a28 UIApplicationMain
15 MyApp                       0x6ed8 main + 77 (main.m:77)
16 ???                            0x1b8379f08 (Missing)   
```

## Details

### Exception
- Message: “child view controller:<UITabBarController: …> should have parent view controller:<TiRootViewController: …> but requested parent is:<TiViewController: …>”
- Stack shows _addChildViewController:performHierarchyCheck: during main queue drain.

### Root Cause
- Double containment of the same UITabBarController:
    - Added under TiRootViewController in TiUITabGroup.open.
    - Added again under TiViewController in TiUITabGroupProxy.viewWillAppear.
- Incorrect containment order in TiUITabGroup.open (willMove + subview before addChild, and missing didMove).

### What Changed
- iphone/Classes/TiUITabGroup.m
    - Use correct containment sequence:
    - `addChildViewController` → add child’s view → `didMoveToParentViewController`.
- Parent is TiApp.controller.topPresentedController (aka TiRootViewController).
- iphone/Classes/TiUITabGroupProxy.m
    - Removed duplicate addChildViewController/didMove from viewWillAppear.
    - Still forwards view lifecycle to the tab controller.

### Why This Works
- iOS requires a child VC to have exactly one parent and a strict add/move order.
- We now add the tab controller once (to the root), and in the correct order, eliminating the hierarchy mismatch.

### Testing
- Open an app with Ti.UI.TabGroup several times (from closed state).
- Verify no crash and no logs about hierarchy inconsistency.
- Confirm tab selection, appearance updates, and show/hide tab bar behaviors still work.
- Note: It may take a while to reproduce
