### PR TITLE
chore: handle dynamic border radii on blur view

### DIFF
--- a/iphone/Classes/TiUIiOSBlurView.m
+++ b/iphone/Classes/TiUIiOSBlurView.m
@@ -75,24 +75,28 @@
 
 - (void)setBorderRadius_:(id)borderRadius
 {
+
 #if IS_SDK_IOS_26
   // The UICornerConfiguration is necessary to use the iOS 26+ glass effect API
   if (@available(iOS 26.0, *)) {
-    if ([borderRadius isKindOfClass:[NSArray class]]) {
-      NSArray<NSNumber *> *borderRadii = (NSArray *)borderRadius;
-      UICornerRadius *topLeft = [[UICornerRadius fixedRadius:borderRadii[0].floatValue] retain];
-      UICornerRadius *topRight = [[UICornerRadius fixedRadius:borderRadii[1].floatValue] retain];
-      UICornerRadius *bottomLeft = [[UICornerRadius fixedRadius:borderRadii[2].floatValue] retain];
-      UICornerRadius *bottomRight = [[UICornerRadius fixedRadius:borderRadii[3].floatValue] retain];
+    NSArray<NSNumber *> *cornerArray = [TiUtils cornerArrayFromRadius:borderRadius];
 
-      blurView.cornerConfiguration = [UICornerConfiguration configurationWithTopLeftRadius:topLeft
-                                                                            topRightRadius:topRight
-                                                                          bottomLeftRadius:bottomLeft
-                                                                         bottomRightRadius:bottomRight];
-    } else {
-      CGFloat fixedBorderRadius = [(NSNumber *)borderRadius floatValue];
+    if (cornerArray.count == 1) {
+      CGFloat fixedBorderRadius = [cornerArray.firstObject floatValue];
       blurView.cornerConfiguration = [UICornerConfiguration configurationWithRadius:[UICornerRadius fixedRadius:fixedBorderRadius]];
+      return;
     }
+
+    UICornerRadius *topLeft = [[UICornerRadius fixedRadius:cornerArray[0].floatValue] retain];
+    UICornerRadius *topRight = [[UICornerRadius fixedRadius:cornerArray[1].floatValue] retain];
+    UICornerRadius *bottomLeft = [[UICornerRadius fixedRadius:cornerArray[2].floatValue] retain];
+    UICornerRadius *bottomRight = [[UICornerRadius fixedRadius:cornerArray[3].floatValue] retain];
+
+    blurView.cornerConfiguration = [UICornerConfiguration configurationWithTopLeftRadius:topLeft
+                                                                          topRightRadius:topRight
+                                                                        bottomLeftRadius:bottomLeft
+                                                                       bottomRightRadius:bottomRight];
+
     return;
   }
 #endif

--- a/iphone/Classes/TiUIiOSBlurView.m
+++ b/iphone/Classes/TiUIiOSBlurView.m
@@ -73,12 +73,26 @@
 }
 #endif
 
-- (void)setBorderRadius_:(NSNumber *)borderRadius
+- (void)setBorderRadius_:(id)borderRadius
 {
 #if IS_SDK_IOS_26
   // The UICornerConfiguration is necessary to use the iOS 26+ glass effect API
   if (@available(iOS 26.0, *)) {
-    blurView.cornerConfiguration = [UICornerConfiguration configurationWithRadius:[UICornerRadius fixedRadius:borderRadius.floatValue]];
+    if ([borderRadius isKindOfClass:[NSArray class]]) {
+      NSArray<NSNumber *> *borderRadii = (NSArray *)borderRadius;
+      UICornerRadius *topLeft = [[UICornerRadius fixedRadius:borderRadii[0].floatValue] retain];
+      UICornerRadius *topRight = [[UICornerRadius fixedRadius:borderRadii[1].floatValue] retain];
+      UICornerRadius *bottomLeft = [[UICornerRadius fixedRadius:borderRadii[2].floatValue] retain];
+      UICornerRadius *bottomRight = [[UICornerRadius fixedRadius:borderRadii[3].floatValue] retain];
+
+      blurView.cornerConfiguration = [UICornerConfiguration configurationWithTopLeftRadius:topLeft
+                                                                            topRightRadius:topRight
+                                                                          bottomLeftRadius:bottomLeft
+                                                                         bottomRightRadius:bottomRight];
+    } else {
+      CGFloat fixedBorderRadius = [(NSNumber *)borderRadius floatValue];
+      blurView.cornerConfiguration = [UICornerConfiguration configurationWithRadius:[UICornerRadius fixedRadius:fixedBorderRadius]];
+    }
     return;
   }
 #endif

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiUIView.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiUIView.m
@@ -531,7 +531,7 @@ DEFINE_EXCEPTIONS
 - (CAShapeLayer *)borderLayer
 {
   // If borderRadius has multiple values, create a custom borderlayer and add as sublayer on self.layer. Otherwise use self.layer.
-  NSArray *array = [self cornerArrayFromRadius:[proxy valueForUndefinedKey:@"borderRadius"]];
+  NSArray *array = [TiUtils cornerArrayFromRadius:[proxy valueForUndefinedKey:@"borderRadius"]];
   if ((!array || array.count <= 1) && _borderLayer != self.layer) {
     self.layer.mask = nil;
     self.layer.borderColor = _borderLayer.strokeColor;
@@ -704,7 +704,7 @@ DEFINE_EXCEPTIONS
     bgdImageLayer = [[CALayer alloc] init];
     [bgdImageLayer setFrame:[self bounds]];
     bgdImageLayer.masksToBounds = YES;
-    NSArray *cornerRadiusArray = [self cornerArrayFromRadius:[proxy valueForUndefinedKey:@"borderRadius"]];
+    NSArray *cornerRadiusArray = [TiUtils cornerArrayFromRadius:[proxy valueForUndefinedKey:@"borderRadius"]];
     if (cornerRadiusArray && cornerRadiusArray.count > 0) {
       [self addCornerRadius:cornerRadiusArray toLayer:bgdImageLayer];
     } else {
@@ -823,22 +823,9 @@ DEFINE_EXCEPTIONS
   [self updateViewShadowPath];
 }
 
-- (NSArray *)cornerArrayFromRadius:(id)radius
-{
-  NSArray *cornerRadiusArray = nil;
-  if ([radius isKindOfClass:[NSString class]]) {
-    cornerRadiusArray = [(NSString *)radius componentsSeparatedByString:@" "];
-  } else if ([radius isKindOfClass:[NSArray class]]) {
-    cornerRadiusArray = radius;
-  } else if ([radius isKindOfClass:[NSNumber class]]) {
-    cornerRadiusArray = [NSArray arrayWithObject:radius];
-  }
-  return cornerRadiusArray;
-}
-
 - (void)updateBorderRadius:(id)radius
 {
-  NSArray *cornerRadiusArray = [self cornerArrayFromRadius:radius];
+  NSArray *cornerRadiusArray = [TiUtils cornerArrayFromRadius:radius];
 
   if (!cornerRadiusArray) {
     NSLog(@"[WARN] No value specified for borderRadius.");
@@ -948,7 +935,7 @@ DEFINE_EXCEPTIONS
     [gradientLayer setNeedsDisplayOnBoundsChange:YES];
     [gradientLayer setFrame:[self bounds]];
     [gradientLayer setNeedsDisplay];
-    NSArray *cornerRadiusArray = [self cornerArrayFromRadius:[proxy valueForUndefinedKey:@"borderRadius"]];
+    NSArray *cornerRadiusArray = [TiUtils cornerArrayFromRadius:[proxy valueForUndefinedKey:@"borderRadius"]];
     if (cornerRadiusArray && cornerRadiusArray.count > 0) {
       [self addCornerRadius:cornerRadiusArray toLayer:gradientLayer];
     } else {
@@ -1007,7 +994,7 @@ DEFINE_EXCEPTIONS
   // If there is single cborderRadius, use self.layer as shadwoLayer.
   // Shadow animation does not work if shadowLayer is added on self.layer.superlayer
   // But in this case, shadwoLayer is self.layer. So animation will work on shadow as well.
-  NSArray *array = [self cornerArrayFromRadius:[proxy valueForUndefinedKey:@"borderRadius"]];
+  NSArray *array = [TiUtils cornerArrayFromRadius:[proxy valueForUndefinedKey:@"borderRadius"]];
   if ((!array || array.count <= 1) && _shadowLayer != self.layer) {
     self.layer.mask = nil;
     [self assignShadowPropertyFromLayer:_shadowLayer toLayer:self.layer];
@@ -1028,7 +1015,7 @@ DEFINE_EXCEPTIONS
 - (UIBezierPath *)bezierPathOfView
 {
   if ([proxy valueForUndefinedKey:@"borderRadius"]) {
-    NSArray *array = [self cornerArrayFromRadius:[proxy valueForUndefinedKey:@"borderRadius"]];
+    NSArray *array = [TiUtils cornerArrayFromRadius:[proxy valueForUndefinedKey:@"borderRadius"]];
     if (array.count > 1) {
       return [self bezierPathOfSize:self.bounds.size forRadiusArray:array];
     }

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiUtils.h
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiUtils.h
@@ -876,4 +876,6 @@ typedef enum {
  */
 + (UIImageSymbolWeight)symbolWeightFromString:(NSString *)string NS_AVAILABLE_IOS(13_0);
 
++ (NSArray *)cornerArrayFromRadius:(id)radius;
+
 @end

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiUtils.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiUtils.m
@@ -2321,4 +2321,28 @@ If the new path starts with / and the base url is app://..., we have to massage 
   return UIImageSymbolWeightRegular;
 }
 
++ (NSArray *)cornerArrayFromRadius:(id)radius
+{
+  NSArray<NSNumber *> *cornerRadiusArray = nil;
+
+  if ([radius isKindOfClass:[NSString class]]) {
+    NSArray<NSString *> *stringComponents = [(NSString *)radius componentsSeparatedByString:@" "];
+    NSMutableArray<NSNumber *> *numberArray = [NSMutableArray arrayWithCapacity:stringComponents.count];
+
+    // Properly convert string values to numbers
+    for (NSString *component in stringComponents) {
+      NSString *trimmedComponent = [component stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+      if (trimmedComponent.length > 0) {
+        [numberArray addObject:@([trimmedComponent doubleValue])];
+      }
+    }
+    cornerRadiusArray = [numberArray copy];
+  } else if ([radius isKindOfClass:[NSArray class]]) {
+    cornerRadiusArray = radius;
+  } else if ([radius isKindOfClass:[NSNumber class]]) {
+    cornerRadiusArray = [NSArray arrayWithObject:radius];
+  }
+  return cornerRadiusArray;
+}
+
 @end


### PR DESCRIPTION
Example:
```js
const win = Ti.UI.createWindow({
	backgroundColor: "#fff"
});

const backgroundView = Ti.UI.createImageView({
	image: 'https://s1.directupload.eu/images/250817/ufgix5hy.jpg',
	width: Ti.UI.FILL,
	height: Ti.UI.FILL,
	scalingMode: Ti.Media.IMAGE_SCALING_ASPECT_FILL
});

const container = Ti.UI.createView({ layout: 'vertical', top: 200 });

const effectView1 = Ti.UI.iOS.createBlurView({
	width: 80,
	height: 80,
	top: 5,
	borderRadius: [20, 20, 0, 0],
	glassEffect: { style: Ti.UI.iOS.GLASS_EFFECT_STYLE_CLEAR }
});
const effectView2 = Ti.UI.iOS.createBlurView({
	width: 80,
	height: 80,
	top: 5,
	borderRadius: '20 20 0 0',
	glassEffect: { style: Ti.UI.iOS.GLASS_EFFECT_STYLE_CLEAR }
});
const effectView3 = Ti.UI.iOS.createBlurView({
	width: 80,
	height: 80,
	top: 5,
	borderRadius: [20],
	glassEffect: { style: Ti.UI.iOS.GLASS_EFFECT_STYLE_CLEAR }
});

const effectView4 = Ti.UI.iOS.createBlurView({
	width: 80,
	height: 80,
	top: 5,
	borderRadius: 20,
	glassEffect: { style: Ti.UI.iOS.GLASS_EFFECT_STYLE_CLEAR }
});

container.add([effectView1, effectView2, effectView3, effectView4]);
backgroundView.add(container);

win.add(backgroundView);
win.open();
```

<img src="https://github.com/user-attachments/assets/361665ec-7178-453b-9de7-d4d341902b34" width="400" />

