### PR TITLE
fix(ios): properly clean build folder to fix CI build issues

### DIFF
--- a/.github/actions/build-ios/action.yml
+++ b/.github/actions/build-ios/action.yml
@@ -27,8 +27,8 @@ runs:
       run: npm run lint:ios
       shell: bash
 
-    - name: Build
-      run: npm run build:ios
+    - name: Build (clean)
+      run: npm run cleanbuild:ios
       shell: bash
 
     - name: Package build output

--- a/support/iphone/build_titaniumkit.sh
+++ b/support/iphone/build_titaniumkit.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 SCRIPT_PATH=$(cd "$(dirname "$0")"; pwd)
 cd $SCRIPT_PATH
@@ -56,7 +57,10 @@ UNIVERSAL_LIBRARY_DIR="$(pwd)/build"
 
 FRAMEWORK="${UNIVERSAL_LIBRARY_DIR}/${FRAMEWORK_NAME}.xcframework"
 
-mkdir "${UNIVERSAL_LIBRARY_DIR}"
+mkdir -p "${UNIVERSAL_LIBRARY_DIR}"
+
+# Clean previous archives/output if they exist
+rm -rf "$MAC_ARCHIVE_PATH" "$DEVICE_ARCHIVE_PATH" "$SIMULATOR_ARCHIVE_PATH" "$FRAMEWORK"
 
 #----- Make macCatalyst archive
 xcodebuild archive \
@@ -72,20 +76,26 @@ xcodebuild archive \
 -scheme $FRAMEWORK_NAME \
 -archivePath $SIMULATOR_ARCHIVE_PATH \
 -sdk iphonesimulator \
-SKIP_INSTALL=NO BUILD_LIBRARIES_FOR_DISTRIBUTION=YES
+SKIP_INSTALL=NO \
+BUILD_LIBRARIES_FOR_DISTRIBUTION=YES \
+SUPPORTS_MACCATALYST=NO
 
 #----- Make iOS device archive
 xcodebuild archive \
 -scheme $FRAMEWORK_NAME \
 -archivePath $DEVICE_ARCHIVE_PATH \
 -sdk iphoneos \
-SKIP_INSTALL=NO BUILD_LIBRARIES_FOR_DISTRIBUTION=YES
+SKIP_INSTALL=NO \
+BUILD_LIBRARIES_FOR_DISTRIBUTION=YES \
+SUPPORTS_MACCATALYST=NO
 
 # restore TopTiModule.m
 rm TitaniumKit/Sources/API/TopTiModule.m
 mv TitaniumKit/Sources/API/TopTiModule.bak TitaniumKit/Sources/API/TopTiModule.m
 
 #----- Make XCFramework
+# Ensure we remove any pre-existing output to avoid duplicate variant errors
+rm -rf "$FRAMEWORK"
 xcodebuild -create-xcframework \
 -framework $SIMULATOR_ARCHIVE_PATH/Products/Library/Frameworks/$FRAMEWORK_NAME.framework \
 -framework $DEVICE_ARCHIVE_PATH/Products/Library/Frameworks/$FRAMEWORK_NAME.framework \


### PR DESCRIPTION
A test to fix the CI-only build issues with Xcode 26:
```
** ARCHIVE SUCCEEDED **
A library with the identifier 'ios-arm64_x86_64-maccatalyst' already exists.
Error: TitaniumKit build exited with code 70
    at ChildProcess.<anonymous> (/Users/runner/work/titanium-sdk/titanium-sdk/build/lib/ios.js:70:18)
    at ChildProcess.emit (node:events:524:28)
    at ChildProcess._handle.onexit (node:internal/child_process:293:12)
Error: TitaniumKit build exited with code 70
    at ChildProcess.<anonymous> (/Users/runner/work/titanium-sdk/titanium-sdk/build/lib/ios.js:70:18)
    at ChildProcess.emit (node:events:524:28)
    at ChildProcess._handle.onexit (node:internal/child_process:293:12)
    ```