### PR TITLE
fix(ios): keep TableView search results on enter

### DIFF
--- a/iphone/Classes/TiUITableView.m
+++ b/iphone/Classes/TiUITableView.m
@@ -1589,7 +1589,10 @@
 {
   // Finished editing, always dismiss search controller.
   // Only one search controller can be active at a time.
-  [self performSelector:@selector(dismissSearchController) withObject:nil afterDelay:.2];
+  //
+  // NOTE: removing this for now as it breaks the search button. Needed for multiple TableView searches in one Window
+  // https://github.com/tidev/titanium-sdk/issues/13246
+  // [self performSelector:@selector(dismissSearchController) withObject:nil afterDelay:.2];
 }
 
 - (void)searchBarSearchButtonClicked:(UISearchBar *)searchBar


### PR DESCRIPTION
Fixes https://github.com/tidev/titanium-sdk/issues/13246

I'm commenting it out with a note to the ticket.

Test:
```js
const win = Ti.UI.createWindow({title: 'Window'});
var newData = Ti.UI.createTableViewRow({title: 'element 1'})
var newData2 = Ti.UI.createTableViewRow({title: 'row 2'})
var newData3 = Ti.UI.createTableViewRow({title: 'item 3'})
const table = Ti.UI.createTableView({
	search: Ti.UI.createSearchBar(),
	data: [newData, newData2, newData3]
});
win.add(table);
win.open();
```

search for "item" and press the "search" button on the keyboard.
Results should still be visible.

Before this PR it will return to the full tableView.