### PR TITLE
fix(ios): improve safe area detection and trigger relayout

### DIFF
--- a/iphone/Classes/TiUINavigationWindowProxy.m
+++ b/iphone/Classes/TiUINavigationWindowProxy.m
@@ -265,7 +265,6 @@
     }
   }
   TiWindowProxy *theWindow = (TiWindowProxy *)[(TiViewController *)viewController proxy];
-  [theWindow processForSafeArea];
   if ((theWindow != rootWindow) && [theWindow opening]) {
     [theWindow windowWillOpen];
     [theWindow windowDidOpen];

--- a/iphone/Classes/TiUITabGroup.m
+++ b/iphone/Classes/TiUITabGroup.m
@@ -666,8 +666,7 @@ DEFINE_EXCEPTIONS
       focusedTabProxy = [theActiveTab retain];
     }
 
-    [self tabController].viewControllers = nil;
-    [self tabController].viewControllers = controllers;
+    self.tabController.viewControllers = controllers;
 
     if (focusedTabProxy != nil && ![tabs containsObject:focusedTabProxy]) {
       if (theActiveTab != nil) {
@@ -692,12 +691,12 @@ DEFINE_EXCEPTIONS
 {
   TiThreadPerformOnMainThread(
       ^{
-        [self.tabController willMoveToParentViewController:TiApp.controller.topPresentedController];
-
-        self.tabController.view.frame = self.bounds;
-        [self addSubview:self.tabController.view];
         isTabBarHidden = NO;
-        [TiApp.controller.topPresentedController addChildViewController:self.tabController];
+        UIViewController *parentController = TiApp.controller.topPresentedController;
+        [parentController addChildViewController:self.tabController];
+        [self addSubview:self.tabController.view];
+        self.tabController.view.frame = self.bounds;
+        [self.tabController didMoveToParentViewController:parentController];
       },
       NO);
 }

--- a/iphone/Classes/TiUITabProxy.m
+++ b/iphone/Classes/TiUITabProxy.m
@@ -320,8 +320,6 @@
   TiWindowProxy *window = [args objectAtIndex:0];
   ENSURE_TYPE(window, TiWindowProxy); // FIXME: Should we catch and return a rejected Promise? Or throw sync like this?
 
-  [window processForSafeArea];
-
   if (window == rootWindow) {
     [rootWindow windowWillOpen];
     [rootWindow windowDidOpen];
@@ -468,8 +466,6 @@
     }
   }
   TiWindowProxy *theWindow = (TiWindowProxy *)[(TiViewController *)viewController proxy];
-  [theWindow processForSafeArea];
-
   if (theWindow == rootWindow) {
     // This is probably too late for the root view controller.
     // Figure out how to call open before this callback

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiControllerProtocols.h
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiControllerProtocols.h
@@ -39,6 +39,7 @@
 
 // Containing controller will call these callbacks(appearance/rotation) on contained windows when it receives them.
 - (void)viewWillAppear:(BOOL)animated;
+- (void)viewSafeAreaInsetsDidChange;
 - (void)viewWillDisappear:(BOOL)animated;
 - (void)viewDidAppear:(BOOL)animated;
 - (void)viewDidDisappear:(BOOL)animated;

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiViewController.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiViewController.m
@@ -149,6 +149,15 @@
   }
   [super viewWillAppear:animated];
 }
+
+- (void)viewSafeAreaInsetsDidChange
+{
+  if (_proxy != nil && [_proxy conformsToProtocol:@protocol(TiWindowProtocol)]) {
+    [(id<TiWindowProtocol>)_proxy viewSafeAreaInsetsDidChange];
+  }
+  [super viewSafeAreaInsetsDidChange];
+}
+
 - (void)viewWillDisappear:(BOOL)animated
 {
   if (_proxy != nil) {
@@ -159,6 +168,7 @@
   }
   [super viewWillDisappear:animated];
 }
+
 - (void)viewDidAppear:(BOOL)animated
 {
   if (_proxy != nil && [_proxy conformsToProtocol:@protocol(TiWindowProtocol)]) {
@@ -166,6 +176,7 @@
   }
   [super viewDidAppear:animated];
 }
+
 - (void)viewDidDisappear:(BOOL)animated
 {
   if (_proxy != nil && [_proxy conformsToProtocol:@protocol(TiWindowProtocol)]) {

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiWindowProxy.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiWindowProxy.m
@@ -466,7 +466,6 @@
         [(id)thisProxy gainFocus];
       }
     }
-    [self processForSafeArea];
   }
   TiThreadPerformOnMainThread(
       ^{
@@ -685,7 +684,7 @@
     id properties = (args != nil && [args count] > 0) ? [args objectAtIndex:0] : nil;
     BOOL animated = [TiUtils boolValue:@"animated" properties:properties def:YES];
     [[controller navigationController] setNavigationBarHidden:NO animated:animated];
-    [self processForSafeArea];
+    [self willChangeSize];
   }
 }
 
@@ -697,8 +696,7 @@
     id properties = (args != nil && [args count] > 0) ? [args objectAtIndex:0] : nil;
     BOOL animated = [TiUtils boolValue:@"animated" properties:properties def:YES];
     [[controller navigationController] setNavigationBarHidden:YES animated:animated];
-    [self processForSafeArea];
-    // TODO: need to fix height
+    [self willChangeSize];
   }
 }
 
@@ -761,6 +759,12 @@
 
   [self willShow];
 }
+
+- (void)viewSafeAreaInsetsDidChange
+{
+  [self willChangeSize];
+}
+
 - (void)viewWillDisappear:(BOOL)animated
 {
   if (controller != nil) {
@@ -768,6 +772,7 @@
   }
   [self willHide];
 }
+
 - (void)viewDidAppear:(BOOL)animated
 {
   if (isModal && opening) {
@@ -777,6 +782,7 @@
     [self gainFocus];
   }
 }
+
 - (void)viewDidDisappear:(BOOL)animated
 {
   if (isModal && closing) {

--- a/iphone/TitaniumKit/TitaniumKit/Sources/Modules/TiUIWindowProxy.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/Modules/TiUIWindowProxy.m
@@ -236,10 +236,6 @@
 
 - (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator
 {
-  [self performSelector:@selector(processForSafeArea)
-             withObject:nil
-             afterDelay:[[UIApplication sharedApplication] statusBarOrientationAnimationDuration]];
-
   [self performSelector:@selector(updateStatusBarView)
              withObject:nil
              afterDelay:[[UIApplication sharedApplication] statusBarOrientationAnimationDuration]];
@@ -688,7 +684,6 @@
       ^{
         if (controller != nil) {
           [controller setHidesBottomBarWhenPushed:[TiUtils boolValue:value]];
-          [self processForSafeArea];
         }
       },
       NO);
@@ -1090,8 +1085,8 @@
   UIEdgeInsets edgeInsets = UIEdgeInsetsZero;
   UIEdgeInsets safeAreaInset = UIEdgeInsetsZero;
 
-  UIViewController<TiControllerContainment> *topContainerController = [[[TiApp app] controller] topContainerController];
-  safeAreaInset = [[topContainerController hostingView] safeAreaInsets];
+  // Prefer safe area from our own controller hierarchy so tab/nav containers are respected.
+  safeAreaInset = self.hostingController.view.safeAreaInsets;
 
   if (self.tabGroup) {
     edgeInsets = [self tabGroupEdgeInsetsForSafeAreaInset:safeAreaInset];
@@ -1153,12 +1148,10 @@
       edgeInsets.right = safeAreaInset.right;
     }
   }
-  if ([TiUtils boolValue:[self valueForUndefinedKey:@"navBarHidden"] def:NO]) {
-    edgeInsets.top = safeAreaInset.top;
-  }
-  if ([TiUtils boolValue:[self valueForUndefinedKey:@"tabBarHidden"] def:NO]) {
-    edgeInsets.bottom = safeAreaInset.bottom;
-  }
+
+  edgeInsets.top = safeAreaInset.top;
+  edgeInsets.bottom = safeAreaInset.bottom;
+
   return edgeInsets;
 }
 


### PR DESCRIPTION
## Summary

- Improves safe area inset detection on iOS by using view controller's lifecycle method viewSafeAreaInsetsDidChange
  instead of manual triggers
- Fixes tab group containment hierarchy to properly add child view controllers
- Simplifies safe area calculation logic for better accuracy

## Changes

- Added viewSafeAreaInsetsDidChange callback to properly detect safe area changes in TiViewController
- Fixed tab group view controller containment by calling didMoveToParentViewController after adding child
- Removed redundant processForSafeArea calls that were triggered manually
- Simplified safe area inset calculation to use controller's own view hierarchy
- Trigger proper relayout when navigation bar visibility changes

## Technical Details

With iOS 26 and the new glass effect design safe areas become more important for correctly laying out views. Titanium currently differs from the native iOS behavior in two properties:

- `extendsEdges`: This is currently set to `UIRectEdgeNone` by default, which means that a window does not extend under bars from navigation controllers or tab bar controllers. The matching native iOS property is `edgesForExtendedLayout` which usually defaults to `UIRectEdgeAll`.
- `autoAdjustScrollViewInsets`: This maps to [automaticallyAdjustsScrollViewInsets](https://developer.apple.com/documentation/uikit/uiviewcontroller/automaticallyadjustsscrollviewinsets?language=objc) on iOS and is actually deprecated since iOS 11. Titanium will set this to `false` by default, which differs from the native default value, which is `true`.

To achieve a native like look and feel for views that contain list views or scroll views the following style has to be set:

```
'Window[platform=ios]': {
  extendEdges: [Ti.UI.EXTEND_EDGE_ALL],
  autoAdjustScrollViewInsets: true
}
```

Using this window configuration revealed that we have issues that would not compute the correct safe area for windows inside navigation windows or tab groups. This PR tries to address this so Titanium apps that use this property combination can layout content at the top or bottom of a window using proper safe area insets that respect navigations bars and tab bars.
