### PR TITLE
fix(ios): include top safe area inset in navigation window

### DIFF
--- a/iphone/TitaniumKit/TitaniumKit/Sources/Modules/TiUIWindowProxy.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/Modules/TiUIWindowProxy.m
@@ -1173,9 +1173,7 @@
       edgeInsets.right = safeAreaInset.right;
     }
   }
-  if ([TiUtils boolValue:[self valueForUndefinedKey:@"navBarHidden"] def:NO]) {
-    edgeInsets.top = safeAreaInset.top;
-  }
+  edgeInsets.top = safeAreaInset.top;
   edgeInsets.bottom = safeAreaInset.bottom;
   return edgeInsets;
 }


### PR DESCRIPTION
This is a follow up fix for #14267 to always include the top safe area inset inside a navigation window context. We already fixed the inset in tab bar context (which automatically includes a navigation window) in the previous PR.