### PR TITLE
fix(ios): improve safe area layout lifecycle

### DIFF
--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiLayoutQueue.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiLayoutQueue.m
@@ -74,6 +74,8 @@ void performLayoutRefresh(CFRunLoopTimerRef timer, void *info)
   } else {
     [thisProxy refreshView:nil];
   }
+
+  [thisProxy didFinishLayout];
 }
 
 + (void)addViewProxy:(TiViewProxy *)newViewProxy

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiViewProxy.h
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiViewProxy.h
@@ -535,6 +535,11 @@ enum {
  */
 - (void)parentWillHide;
 
+/**
+ Tells the view proxy that rendering via the layout queue finished.
+ */
+- (void)didFinishLayout;
+
 #pragma mark Layout actions
 
 - (void)refreshView:(TiUIView *)transferView;

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiViewProxy.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiViewProxy.m
@@ -2293,7 +2293,7 @@ LAYOUTFLAGS_SETTER(setHorizontalWrap, horizontalWrap, horizontalWrap, [self will
     if ([self respondsToSelector:@selector(processForSafeArea)]) {
       TiUIWindowProxy *windowProxy = (TiUIWindowProxy *)self;
 
-      bool safeAreaInsetsChanged = [windowProxy processForSafeArea];
+      BOOL safeAreaInsetsChanged = [windowProxy processForSafeArea];
       layoutChanged = layoutChanged || safeAreaInsetsChanged;
       if (safeAreaInsetsChanged && windowProxy.pendingSafeAreaUpdate) {
         // Reset the pending safe area update here because it was already updated in the current layout cycle

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiViewProxy.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiViewProxy.m
@@ -2083,6 +2083,13 @@ LAYOUTFLAGS_SETTER(setHorizontalWrap, horizontalWrap, horizontalWrap, [self will
   }
 }
 
+- (void)didFinishLayout
+{
+  VerboseLog(@"[INFO] Did finish layout for %@", self);
+
+  // Noop, can be overridden by subclasses.
+}
+
 #pragma mark Layout actions
 
 // Need this so we can overload the sandbox bounds on split view detail/master
@@ -2286,9 +2293,12 @@ LAYOUTFLAGS_SETTER(setHorizontalWrap, horizontalWrap, horizontalWrap, [self will
     if ([self respondsToSelector:@selector(processForSafeArea)]) {
       TiUIWindowProxy *windowProxy = (TiUIWindowProxy *)self;
 
-      [windowProxy processForSafeArea];
-      layoutChanged = layoutChanged || windowProxy.safeAreaInsetsUpdated;
-      windowProxy.safeAreaInsetsUpdated = NO;
+      bool safeAreaInsetsChanged = [windowProxy processForSafeArea];
+      layoutChanged = layoutChanged || safeAreaInsetsChanged;
+      if (safeAreaInsetsChanged && windowProxy.pendingSafeAreaUpdate) {
+        // Reset the pending safe area update here because it was already updated in the current layout cycle
+        windowProxy.pendingSafeAreaUpdate = NO;
+      }
     }
 
     if (layoutChanged && [self _hasListeners:@"postlayout" checkParent:NO]) {

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiViewProxy.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiViewProxy.m
@@ -2087,7 +2087,7 @@ LAYOUTFLAGS_SETTER(setHorizontalWrap, horizontalWrap, horizontalWrap, [self will
 {
   VerboseLog(@"[INFO] Did finish layout for %@", self);
 
-  // Noop, can be overridden by subclasses.
+  // No-op, can be overridden by subclasses.
 }
 
 #pragma mark Layout actions

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiWindowProxy.h
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiWindowProxy.h
@@ -38,9 +38,9 @@
 @property (nonatomic, readonly) TiProxy *tabGroup;
 @property (nonatomic) BOOL isMasterWindow;
 @property (nonatomic) BOOL isDetailWindow;
-@property (nonatomic) BOOL safeAreaInsetsUpdated;
+@property (nonatomic) BOOL pendingSafeAreaUpdate;
 
-- (void)processForSafeArea;
+- (bool)processForSafeArea;
 - (UIViewController *)windowHoldingController;
 - (TiUIiOSTransitionAnimationProxy *)transitionAnimation;
 

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiWindowProxy.h
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiWindowProxy.h
@@ -40,7 +40,7 @@
 @property (nonatomic) BOOL isDetailWindow;
 @property (nonatomic) BOOL pendingSafeAreaUpdate;
 
-- (bool)processForSafeArea;
+- (BOOL)processForSafeArea;
 - (UIViewController *)windowHoldingController;
 - (TiUIiOSTransitionAnimationProxy *)transitionAnimation;
 

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiWindowProxy.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiWindowProxy.m
@@ -999,7 +999,7 @@
   [self rememberProxy:transitionProxy];
 }
 
-- (bool)processForSafeArea
+- (BOOL)processForSafeArea
 {
   // Overridden in subclass
   return NO;

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiWindowProxy.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiWindowProxy.m
@@ -94,6 +94,28 @@
   return [super suppressesRelayout];
 }
 
+- (void)didFinishLayout
+{
+  if (self.pendingSafeAreaUpdate) {
+    self.pendingSafeAreaUpdate = NO;
+    [self willChangeSizeForSafeArea];
+  }
+
+  [super didFinishLayout];
+}
+
+- (void)willChangeSizeForSafeArea
+{
+  if ((*((char *)&dirtyflags) & (1 << (7 - TiRefreshViewSize))) != 0) {
+    // Layout is in progress, defer the safe area update
+    self.pendingSafeAreaUpdate = YES;
+    return;
+  }
+
+  // Proceed with normal size change logic
+  [self willChangeSize];
+}
+
 #pragma mark - Utility Methods
 - (void)windowWillOpen
 {
@@ -762,7 +784,7 @@
 
 - (void)viewSafeAreaInsetsDidChange
 {
-  [self willChangeSize];
+  [self willChangeSizeForSafeArea];
 }
 
 - (void)viewWillDisappear:(BOOL)animated
@@ -977,9 +999,10 @@
   [self rememberProxy:transitionProxy];
 }
 
-- (void)processForSafeArea
+- (bool)processForSafeArea
 {
   // Overridden in subclass
+  return NO;
 }
 
 @end

--- a/iphone/TitaniumKit/TitaniumKit/Sources/Modules/TiUIWindowProxy.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/Modules/TiUIWindowProxy.m
@@ -1074,7 +1074,7 @@
   return self.safeAreaViewProxy;
 }
 
-- (void)processForSafeArea
+- (bool)processForSafeArea
 {
   [self setValue:@{ @"top" : NUMFLOAT(0.0),
     @"left" : NUMFLOAT(0.0),
@@ -1096,18 +1096,17 @@
     edgeInsets = [self defaultEdgeInsetsForSafeAreaInset:safeAreaInset];
   }
 
-  if (self.shouldExtendSafeArea) {
-    [self setValue:@{ @"top" : NUMFLOAT(edgeInsets.top),
-      @"left" : NUMFLOAT(edgeInsets.left),
-      @"bottom" : NUMFLOAT(edgeInsets.bottom),
-      @"right" : NUMFLOAT(edgeInsets.right) }
-            forKey:@"safeAreaPadding"];
+  [self setValue:@{ @"top" : NUMFLOAT(edgeInsets.top),
+    @"left" : NUMFLOAT(edgeInsets.left),
+    @"bottom" : NUMFLOAT(edgeInsets.bottom),
+    @"right" : NUMFLOAT(edgeInsets.right) }
+          forKey:@"safeAreaPadding"];
 
-    if (!UIEdgeInsetsEqualToEdgeInsets(edgeInsets, oldSafeAreaInsets)) {
-      self.safeAreaInsetsUpdated = YES;
-    }
-    oldSafeAreaInsets = edgeInsets;
-    return;
+  bool safeAreaInsetsChanged = !UIEdgeInsetsEqualToEdgeInsets(edgeInsets, oldSafeAreaInsets);
+  oldSafeAreaInsets = edgeInsets;
+
+  if (self.shouldExtendSafeArea) {
+    return safeAreaInsetsChanged;
   }
 
   TiViewProxy *safeAreaProxy = [self safeAreaViewProxy];
@@ -1128,6 +1127,8 @@
   if (!oldRight || [oldRight floatValue] != edgeInsets.right) {
     [safeAreaProxy setRight:NUMFLOAT(edgeInsets.right)];
   }
+
+  return safeAreaInsetsChanged;
 }
 
 - (UIEdgeInsets)tabGroupEdgeInsetsForSafeAreaInset:(UIEdgeInsets)safeAreaInset

--- a/iphone/TitaniumKit/TitaniumKit/Sources/Modules/TiUIWindowProxy.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/Modules/TiUIWindowProxy.m
@@ -1074,7 +1074,7 @@
   return self.safeAreaViewProxy;
 }
 
-- (bool)processForSafeArea
+- (BOOL)processForSafeArea
 {
   [self setValue:@{ @"top" : NUMFLOAT(0.0),
     @"left" : NUMFLOAT(0.0),
@@ -1102,7 +1102,7 @@
     @"right" : NUMFLOAT(edgeInsets.right) }
           forKey:@"safeAreaPadding"];
 
-  bool safeAreaInsetsChanged = !UIEdgeInsetsEqualToEdgeInsets(edgeInsets, oldSafeAreaInsets);
+  BOOL safeAreaInsetsChanged = !UIEdgeInsetsEqualToEdgeInsets(edgeInsets, oldSafeAreaInsets);
   oldSafeAreaInsets = edgeInsets;
 
   if (self.shouldExtendSafeArea) {


### PR DESCRIPTION
## Summary

  - Introduces a new `didFinishLayout` callback system to handle post-layout operations
  - Refactors safe area processing to return boolean indicating actual changes
  - Implements deferred safe area updates to make sure updates are not lost during active layout cycles
  - Consolidates safe area padding updates for consistent behavior across window types

  ## Key Changes

  - **TiLayoutQueue**: Added `didFinishLayout` callback after layout completion
  - **TiViewProxy**: New `didFinishLayout` method with base implementation and override support
  - **TiWindowProxy**: Introduced `pendingSafeAreaUpdate` flag and `willChangeSizeForSafeArea` method to defer safe area updates during active layouts
  - **TiUIWindowProxy**: Updated `processForSafeArea` to return boolean and consistently set `safeAreaPadding` regardless of `shouldExtendSafeArea` setting

  ## Technical Details

  - Prevents race conditions between safe area updates and ongoing layout operations
  - Eliminates redundant safe area processing by tracking actual inset changes
  - Ensures safe area padding is always available to JavaScript regardless of extend mode
  - Maintains backward compatibility with existing safe area handling

  This builds on recent safe area improvements (#14267, #14268) to create a more robust and efficient layout system.