### PR TITLE
Drop Node 16 and 18, remove engines.node

### DIFF
--- a/android/package.json
+++ b/android/package.json
@@ -26,9 +26,6 @@
 		"android ndk": ">=r21 <=r22b",
 		"java": ">=11.x"
 	},
-	"engines": {
-		"node": ">=16.0.0"
-	},
 	"repository": {
 		"type": "git",
 		"url": "git://github.com/tidev/titanium_mobile.git"

--- a/iphone/package.json
+++ b/iphone/package.json
@@ -18,9 +18,6 @@
 		"xcode": ">=12.0 <=16.x",
 		"ios sdk": ">=13.0 <=18.x"
 	},
-	"engines": {
-		"node": ">=16.0.0"
-	},
 	"repository": {
 		"type": "git",
 		"url": "git://github.com/tidev/titanium_mobile_ios.git"

--- a/package-lock.json
+++ b/package-lock.json
@@ -85,9 +85,6 @@
         "strip-ansi": "6.0.1",
         "titanium": "6.1.1",
         "titanium-docgen": "4.10.4"
-      },
-      "engines": {
-        "node": ">=16.0.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -165,12 +165,6 @@
     "type": "git",
     "url": "git://github.com/tidev/titanium_mobile.git"
   },
-  "vendorDependencies": {
-    "node": "16.x || 18.x || 20.x"
-  },
-  "engines": {
-    "node": ">=16.0.0"
-  },
   "nyc": {
     "exclude": [
       "**/cli/tests/test-*.js",

--- a/package.json
+++ b/package.json
@@ -165,6 +165,9 @@
     "type": "git",
     "url": "git://github.com/tidev/titanium_mobile.git"
   },
+  "vendorDependencies": {
+    "node": ">=20.18.1"
+  },
   "nyc": {
     "exclude": [
       "**/cli/tests/test-*.js",


### PR DESCRIPTION
Back in the day, we talked about publishing `android` and `iphone` (as well as `mobileweb`, `windows`, and `blackberry`) as individual npm packages. This never happened. The `engines` property in the top-level and platform `package.json` files have never been used.

In the top-level SDK's `package.json`, the `vendorDependencies` only has one property: `node`. It is referenced by the CLI, but it's not actually enforced. If the Node.js version is incompatible, it throws and the catch does nothing with the error. In other words, it's unused, but the CLI should probably and if it does, we might as well bump the Node version.