### PR TITLE
fix(ios): correct safe area for standalone windows

### DIFF
--- a/iphone/TitaniumKit/TitaniumKit/Sources/Modules/TiUIWindowProxy.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/Modules/TiUIWindowProxy.m
@@ -1085,8 +1085,12 @@
   UIEdgeInsets edgeInsets = UIEdgeInsetsZero;
   UIEdgeInsets safeAreaInset = UIEdgeInsetsZero;
 
-  // Prefer safe area from our own controller hierarchy so tab/nav containers are respected.
-  safeAreaInset = self.hostingController.view.safeAreaInsets;
+  if (self.isManaged && self.tab) {
+    // Prefer safe area from our own controller hierarchy so tab/nav containers are respected.
+    safeAreaInset = self.hostingController.view.safeAreaInsets;
+  } else {
+    safeAreaInset = TiApp.controller.topContainerController.hostingView.safeAreaInsets;
+  }
 
   if (self.tabGroup) {
     edgeInsets = [self tabGroupEdgeInsetsForSafeAreaInset:safeAreaInset];


### PR DESCRIPTION
This adds an additional check when determining the safe area inset to handle standalone windows that are not part of a navigation controller or tab bar. We will fallback to use the top container controller in that case which was also used before the recent safe area changes in #14267.