### PR TITLE
chore: remove interactive dismiss mode

### DIFF
--- a/apidoc/Titanium/UI/NavigationWindow.yml
+++ b/apidoc/Titanium/UI/NavigationWindow.yml
@@ -40,6 +40,10 @@ properties:
     platforms: [iphone, ipad, macos]
     since: "12.5.0"
     availability: creation
+    deprecated:
+      since: "13.0.0"
+      removed: "13.0.0"
+      notes: This is handled by the operation system in newer versions of iOS.
 
 methods:
   - name: closeWindow

--- a/apidoc/Titanium/UI/TabGroup.yml
+++ b/apidoc/Titanium/UI/TabGroup.yml
@@ -683,6 +683,10 @@ properties:
     platforms: [iphone, ipad, macos]
     since: "12.5.0"
     availability: creation
+    deprecated:
+      since: "13.0.0"
+      removed: "13.0.0"
+      notes: This is handled by the operation system in newer versions of iOS.
 
   - name: experimental
     summary: |

--- a/iphone/Classes/TiUINavigationWindowProxy.m
+++ b/iphone/Classes/TiUINavigationWindowProxy.m
@@ -95,44 +95,13 @@
     [TiUtils configureController:navController withObject:self];
     [navController.interactivePopGestureRecognizer addTarget:self action:@selector(popGestureStateHandler:)];
     [[navController interactivePopGestureRecognizer] setDelegate:self];
-
-    BOOL interactiveDismissModeEnabled = [TiUtils boolValue:[self valueForKey:@"interactiveDismissModeEnabled"] def:NO];
-    if (interactiveDismissModeEnabled) {
-      [self configureFullWidthSwipeToClose];
-    }
   }
   return navController;
-}
-
-- (void)configureFullWidthSwipeToClose
-{
-  fullWidthBackGestureRecognizer = [[UIPanGestureRecognizer alloc] init];
-
-  if (navController.interactivePopGestureRecognizer == nil) {
-    return;
-  }
-
-  id targets = [navController.interactivePopGestureRecognizer valueForKey:@"targets"];
-  if (targets == nil) {
-    return;
-  }
-
-  [fullWidthBackGestureRecognizer setValue:targets forKey:@"targets"];
-  [fullWidthBackGestureRecognizer setDelegate:self];
-  [navController.view addGestureRecognizer:fullWidthBackGestureRecognizer];
 }
 
 - (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer
 {
   BOOL isRootWindow = (current == rootWindow);
-
-  BOOL interactiveDismissModeEnabled = [TiUtils boolValue:[self valueForKey:@"interactiveDismissModeEnabled"] def:NO];
-  if (interactiveDismissModeEnabled && [gestureRecognizer isKindOfClass:[UIPanGestureRecognizer class]]) {
-    BOOL isSystemSwipeToCloseEnabled = navController.interactivePopGestureRecognizer.isEnabled == YES;
-    BOOL areThereStackedViewControllers = navController.viewControllers.count > 1;
-
-    return isSystemSwipeToCloseEnabled || areThereStackedViewControllers;
-  }
 
   if (current != nil && !isRootWindow) {
     return [TiUtils boolValue:[current valueForKey:@"swipeToClose"] def:YES];

--- a/iphone/Classes/TiUITabProxy.m
+++ b/iphone/Classes/TiUITabProxy.m
@@ -267,43 +267,12 @@
     [controllerStack addObject:[self rootController]];
     [controller.interactivePopGestureRecognizer addTarget:self action:@selector(popGestureStateHandler:)];
     [[controller interactivePopGestureRecognizer] setDelegate:self];
-
-    BOOL interactiveDismissModeEnabled = [TiUtils boolValue:[tabGroup valueForKey:@"interactiveDismissModeEnabled"] def:NO];
-    if (interactiveDismissModeEnabled) {
-      [self configureFullWidthSwipeToClose];
-    }
   }
   return controller;
 }
 
-- (void)configureFullWidthSwipeToClose
-{
-  fullWidthBackGestureRecognizer = [[UIPanGestureRecognizer alloc] init];
-
-  if (controller.interactivePopGestureRecognizer == nil) {
-    return;
-  }
-
-  id targets = [controller.interactivePopGestureRecognizer valueForKey:@"targets"];
-  if (targets == nil) {
-    return;
-  }
-
-  [fullWidthBackGestureRecognizer setValue:targets forKey:@"targets"];
-  [fullWidthBackGestureRecognizer setDelegate:self];
-  [controller.view addGestureRecognizer:fullWidthBackGestureRecognizer];
-}
-
 - (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer
 {
-  BOOL interactiveDismissModeEnabled = [TiUtils boolValue:[self valueForKey:@"interactiveDismissModeEnabled"] def:NO];
-  if (interactiveDismissModeEnabled && [gestureRecognizer isKindOfClass:[UIPanGestureRecognizer class]]) {
-    BOOL isSystemSwipeToCloseEnabled = controller.interactivePopGestureRecognizer.isEnabled == YES;
-    BOOL areThereStackedViewControllers = controller.viewControllers.count > 1;
-
-    return isSystemSwipeToCloseEnabled || areThereStackedViewControllers;
-  }
-
   if (current != nil) {
     return [TiUtils boolValue:[current valueForKey:@"swipeToClose"] def:YES];
   }


### PR DESCRIPTION
The dismiss mode is handled by the operating system in newer iOS versions, so a manual interception causes more problems than it solves and should therefore be discontinued. Spotted by @designbymind