### PR TITLE
fix(ios): use proxy viewCount in ScrollableView to prevent empty display

### DIFF
--- a/iphone/Classes/TiUIScrollableView.m
+++ b/iphone/Classes/TiUIScrollableView.m
@@ -571,8 +571,8 @@ static NSInteger const ScrollableSubviewTag = 100;
 #ifndef TI_USE_AUTOLAYOUT
 - (void)setViews_:(id)args
 {
-  if ((scrollview != nil) && (self.scrollableSubviews.count > 0)) {
-    [self refreshScrollView:[self bounds] reAdd:YES];
+  if (scrollview != nil && self.proxy.viewCount > 0) {
+    [self refreshScrollView:self.bounds reAdd:YES];
   }
 }
 #endif
@@ -599,9 +599,9 @@ static NSInteger const ScrollableSubviewTag = 100;
 #endif
   }
 
-  if ((scrollview != nil) && (self.scrollableSubviews.count > 0)) {
+  if (scrollview != nil && self.proxy.viewCount > 0) {
     // No need to re-add. Just set up the correct frame bounds
-    [self refreshScrollView:[self bounds] reAdd:NO];
+    [self refreshScrollView:self.bounds reAdd:NO];
   }
 }
 
@@ -615,9 +615,9 @@ static NSInteger const ScrollableSubviewTag = 100;
     pagingControlHeight = 20.0;
   }
 
-  if (showPageControl && (scrollview != nil) && (self.scrollableSubviews.count > 0)) {
+  if (showPageControl && scrollview != nil && self.proxy.viewCount > 0) {
     // No need to re-add. Just set up the correct frame bounds
-    [self refreshScrollView:[self bounds] reAdd:NO];
+    [self refreshScrollView:self.bounds reAdd:NO];
   }
 }
 
@@ -630,8 +630,8 @@ static NSInteger const ScrollableSubviewTag = 100;
   if (val != nil) {
     RELEASE_TO_NIL(pageControlBackgroundColor);
     pageControlBackgroundColor = [[val _color] retain];
-    if (showPageControl && (scrollview != nil) && (self.scrollableSubviews.count > 0)) {
-      [[self pagecontrol] setBackgroundColor:pageControlBackgroundColor];
+    if (showPageControl && scrollview != nil && self.proxy.viewCount > 0) {
+      [self.pagecontrol setBackgroundColor:pageControlBackgroundColor];
     }
   }
 }
@@ -644,8 +644,8 @@ static NSInteger const ScrollableSubviewTag = 100;
   if (val != nil) {
     RELEASE_TO_NIL(pageIndicatorColor);
     pageIndicatorColor = [[val _color] retain];
-    if (showPageControl && (scrollview != nil) && (self.scrollableSubviews.count > 0)) {
-      [[self pagecontrol] setPageIndicatorTintColor:pageIndicatorColor];
+    if (showPageControl && scrollview != nil && self.proxy.viewCount > 0) {
+      [self.pagecontrol setPageIndicatorTintColor:pageIndicatorColor];
     }
   }
 }
@@ -659,8 +659,8 @@ static NSInteger const ScrollableSubviewTag = 100;
   if (val != nil) {
     RELEASE_TO_NIL(currentPageIndicatorColor);
     currentPageIndicatorColor = [[val _color] retain];
-    if (showPageControl && (scrollview != nil) && (self.scrollableSubviews.count > 0)) {
-      [[self pagecontrol] setCurrentPageIndicatorTintColor:currentPageIndicatorColor];
+    if (showPageControl && scrollview != nil && self.proxy.viewCount > 0) {
+      [self.pagecontrol setCurrentPageIndicatorTintColor:currentPageIndicatorColor];
     }
   }
 }
@@ -677,8 +677,8 @@ static NSInteger const ScrollableSubviewTag = 100;
   if (pagingControlAlpha < 0.0) {
     pagingControlAlpha = 0;
   }
-  if (showPageControl && (scrollview != nil) && (self.scrollableSubviews.count > 0)) {
-    [[self pagecontrol] setAlpha:pagingControlAlpha];
+  if (showPageControl && scrollview != nil && self.proxy.viewCount > 0) {
+    [self.pagecontrol setAlpha:pagingControlAlpha];
   }
 }
 
@@ -711,9 +711,9 @@ static NSInteger const ScrollableSubviewTag = 100;
   UIScrollView *scrollview = [self scrollview];
 #endif
   pagingControlOnTop = [TiUtils boolValue:args def:NO];
-  if (showPageControl && (scrollview != nil) && (self.scrollableSubviews.count > 0)) {
+  if (showPageControl && scrollview != nil && self.proxy.viewCount > 0) {
     // No need to re-add. Just set up the correct frame bounds
-    [self refreshScrollView:[self bounds] reAdd:NO];
+    [self refreshScrollView:self.bounds reAdd:NO];
   }
 }
 
@@ -723,9 +723,9 @@ static NSInteger const ScrollableSubviewTag = 100;
   UIScrollView *scrollview = [self scrollview];
 #endif
   overlayEnabled = [TiUtils boolValue:args def:NO];
-  if (showPageControl && (scrollview != nil) && (self.scrollableSubviews.count > 0)) {
+  if (showPageControl && scrollview != nil && self.proxy.viewCount > 0) {
     // No need to re-add. Just set up the correct frame bounds
-    [self refreshScrollView:[self bounds] reAdd:NO];
+    [self refreshScrollView:self.bounds reAdd:NO];
   }
 }
 


### PR DESCRIPTION
## Summary

Fix a bug where ScrollableView would remain empty after `setViews_` was called because the computed `scrollableSubviews` array was not yet populated when the refresh logic was executed.

## Problem

When `setViews_` was triggered through the proxy-view pattern, the conditional checks using `self.scrollableSubviews.count` would return 0 because the scrollable subviews array had not been computed yet. This caused `refreshScrollView` to be skipped, leaving the ScrollableView empty even though views were properly set on the proxy.

## Solution

- Replace `self.scrollableSubviews.count` with `self.proxy.viewCount` in all conditional checks outside of `refreshScrollView:reAdd`.
- Use proxy-based view count which reflects the actual number of views set on the proxy
- This ensures refresh logic executes correctly regardless of computed array state. We need two states because `self.scrollableSubviews` stores the intermediate wrapper views currently added to the native `UIScrollView`. These will update when the `views` on the proxy change, but they are not in sync due to the way the scrollable view is implemented.
- Also includes minor code style improvements (removed unnecessary parentheses, simplified method calls)