### PR TITLE
Revert "feat(ios): support iOS 26+ source views for non-iPad devices"

### DIFF
--- a/apidoc/Titanium/UI/OptionDialog.yml
+++ b/apidoc/Titanium/UI/OptionDialog.yml
@@ -382,7 +382,13 @@ properties:
     optional: true
 
   - name: view
-    summary: |
-        View to which to attach the dialog. Prior to iOS 26, this was only
-        used on iPad.
+    summary: View to which to attach the dialog.
     type: Titanium.UI.View
+
+  - name: rect
+    summary: Positions the arrow of the option dialog relative to the attached view's dimensions.
+    description: |
+        Setting the x, y coordinates to (0, 0) places the dialog in the top-left corner of the
+        view object.  Set both the `width` and `height` properties to 1.
+    type: Dimension
+    optional: true

--- a/iphone/Classes/TiUIOptionDialogProxy.h
+++ b/iphone/Classes/TiUIOptionDialogProxy.h
@@ -14,6 +14,7 @@
   UIAlertController *alertController;
   TiViewProxy *dialogView;
   UIColor *tintColor;
+  CGRect dialogRect;
   BOOL animated;
   NSUInteger accumulatedOrientationChanges;
   BOOL showDialog;


### PR DESCRIPTION
Having to delete this one for now, as it crashes for iPad devices. As it's a non-blocking iOS 26 improvement, we'll revisit this after the initial SDK 13.0.0.GA release.