### PR TITLE
14279 Patch ActivityKit so it works with macCatalyst

### DIFF
--- a/iphone/Classes/TiActivityAttributes.swift
+++ b/iphone/Classes/TiActivityAttributes.swift
@@ -6,6 +6,7 @@
  */
 
 #if canImport(ActivityKit)
+#if !targetEnvironment(macCatalyst)
 import Foundation
 import ActivityKit
 
@@ -15,4 +16,5 @@ public struct TiActivityAttributes: ActivityAttributes {
     var value: [String: String]
   }
 }
+#endif
 #endif

--- a/iphone/Classes/TiAppiOSActivityAttributesProxy+startActivity.swift
+++ b/iphone/Classes/TiAppiOSActivityAttributesProxy+startActivity.swift
@@ -7,9 +7,12 @@
 
 import TitaniumKit
 #if canImport(ActivityKit)
+#if !targetEnvironment(macCatalyst)
 import ActivityKit
 #endif
+#endif
 
+#if !targetEnvironment(macCatalyst)
 extension TiAppiOSActivityAttributesProxy {
 
   @objc(_startActivity:)
@@ -34,3 +37,4 @@ extension TiAppiOSActivityAttributesProxy {
 #endif
   }
 }
+#endif


### PR DESCRIPTION
**GitHub discussions:** https://github.com/tidev/titanium-sdk/issues/14279

**Optional Description:**

The macCatalyst build fails for 13.x because ActivityKit is not supported. TiActivityAttributes and TiAppiOSActivityAttributesProxy+startActivity need to exclude macCatalyst specifically - #if canImport(ActivityKit) is not enough.

I have come up with a patch for this issue that fixes the problem by adding #if !targetEnvironment(macCatalyst) to these files.

Apps now build with macCatalyst with these fixes, and continues to build under iOS, using Xcode 16.4 and 26.0

See issue above