### PR TITLE
[14281]: fix (ios): ensure eventStoreChanged notification is not over-registered

### DIFF
--- a/iphone/Classes/CalendarModule.m
+++ b/iphone/Classes/CalendarModule.m
@@ -20,11 +20,10 @@
 {
   if (store == nil) {
     store = [[EKEventStore alloc] init];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(eventStoreChanged:) name:EKEventStoreChangedNotification object:nil];
   }
   if (store == NULL) {
     DebugLog(@"[WARN] Could not access EventStore. ");
-  } else {
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(eventStoreChanged:) name:EKEventStoreChangedNotification object:nil];
   }
   return store;
 }


### PR DESCRIPTION
**GitHub discussions:** https://github.com/tidev/titanium-sdk/discussions/14281

**Optional Description:**
Ensure eventStoreChanged notification is not over-registered. See issue for details