### PR TITLE
fix(ios): not conform to protocol warnings

### DIFF
--- a/iphone/Classes/TiCollisionBehavior.m
+++ b/iphone/Classes/TiCollisionBehavior.m
@@ -93,6 +93,11 @@
   return _collisionBehavior;
 }
 
+- (void)updateItems
+{
+  // Nothing to do here
+}
+
 - (void)updatePositioning
 {
   for (TiViewProxy *theItem in _items) {

--- a/iphone/Classes/TiDatabaseResultSetProxy.m
+++ b/iphone/Classes/TiDatabaseResultSetProxy.m
@@ -183,6 +183,11 @@
   return nil;
 }
 
+- (NSString *)getFieldName:(NSInteger)index
+{
+  return [self fieldName:index];
+}
+
 - (NSInteger)fieldCount
 {
   if (results != nil) {


### PR DESCRIPTION
Fixes https://github.com/tidev/titanium-sdk/issues/14286.

**Description:**
- added `updateItems` to make class `TiCollisionBehavior` conform to protocol `TiBehaviorProtocol`
  - no-op method analogous to `TiAnchorAttachBehavior`, `TiSnapBehavior` and `TiViewAttachBehavior`
- added `getFieldName:` to make class `TiDatabaseResultSetProxy` conform to protocol `TiDatabaseResultSetProxyExports`
