### PR TITLE
fix(ios): TabBar appearance issue on iPhone landscape & iPad

### DIFF
--- a/iphone/Classes/TiUITabProxy.m
+++ b/iphone/Classes/TiUITabProxy.m
@@ -653,12 +653,14 @@
     if ([TiUtils isIOSVersionOrGreater:@"15.0"]) {
       UITabBarAppearance *appearance = UITabBarAppearance.new;
       if (titleColor != nil) {
-        UITabBarItemStateAppearance *normalAppearance = appearance.stackedLayoutAppearance.normal;
-        normalAppearance.titleTextAttributes = @{ NSForegroundColorAttributeName : [titleColor color] };
+        appearance.stackedLayoutAppearance.normal.titleTextAttributes = @{ NSForegroundColorAttributeName : [titleColor color] };
+        appearance.inlineLayoutAppearance.normal.titleTextAttributes = @{ NSForegroundColorAttributeName : [titleColor color] };
+        appearance.compactInlineLayoutAppearance.normal.titleTextAttributes = @{ NSForegroundColorAttributeName : [titleColor color] };
       }
       if (activeTitleColor != nil) {
-        UITabBarItemStateAppearance *selectedAppearance = appearance.stackedLayoutAppearance.selected;
-        selectedAppearance.titleTextAttributes = @{ NSForegroundColorAttributeName : [activeTitleColor color] };
+        appearance.stackedLayoutAppearance.selected.titleTextAttributes = @{ NSForegroundColorAttributeName : [activeTitleColor color] };
+        appearance.inlineLayoutAppearance.selected.titleTextAttributes = @{ NSForegroundColorAttributeName : [activeTitleColor color] };
+        appearance.compactInlineLayoutAppearance.selected.titleTextAttributes = @{ NSForegroundColorAttributeName : [activeTitleColor color] };
       }
       TiColor *backgroundColor = [TiUtils colorValue:[tabGroup valueForKey:@"tabsBackgroundColor"]];
       if (backgroundColor != nil) {


### PR DESCRIPTION
Fixes https://github.com/tidev/titanium-sdk/issues/13314.

**Description:**
- set `inlineLayoutAppearance` and `compactInlineLayoutAppearance` of a `UITabBarItem` in class `TiUITabProxy`, only `stackedLayoutAppearance` had been set so far
  - so `activeTitleColor` also works on iPhone in landscape mode and on iPad

Before:
<img width="2248" height="488" alt="tab1" src="https://github.com/user-attachments/assets/a4ce4d6f-6715-4efd-b4a7-1a0fbd9b6102" />

After:
<img width="1122" height="247" alt="tab2" src="https://github.com/user-attachments/assets/e95fbe55-2949-4b28-b356-e73e8b45e8fc" />

**Note:**
- on **iPad** this fix takes effect under iPadOS 15&ndash;17, under iPadOS 18+ the design has changed (floating tab bar)