### PR TITLE
fix(ios): fixed ref counting of navTintColor

### DIFF
--- a/iphone/TitaniumKit/TitaniumKit/Sources/Modules/TiUIWindowProxy.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/Modules/TiUIWindowProxy.m
@@ -320,15 +320,16 @@
   TiThreadPerformOnMainThread(
       ^{
         if (controller != nil) {
-          if (newColor == nil) {
+          TiColor *newTintColor = newColor;
+          if (newTintColor == nil) {
             // Get from TabGroup
-            newColor = [TiUtils colorValue:[[self tabGroup] valueForKey:@"navTintColor"]];
+            newTintColor = [TiUtils colorValue:[[self tabGroup] valueForKey:@"navTintColor"]];
           }
           UINavigationBar *navBar = [[controller navigationController] navigationBar];
-          [navBar setTintColor:[newColor color]];
+          [navBar setTintColor:[newTintColor color]];
           [self performSelector:@selector(refreshBackButton) withObject:nil afterDelay:0.0];
-          [newColor release];
         }
+        [newColor release];
       },
       NO);
 }


### PR DESCRIPTION
Fixes https://github.com/tidev/titanium-sdk/issues/14211.

**Description:**

- https://github.com/tidev/titanium-sdk/commit/951877b29c0655a2f2e9d053d25ddfcdf464c7dd created a new issue setting `navTintColor` for a **tab group**, not for window
  - in this case `newColor` was set to a new object and was unretained when later released
- fixed ref counting through use of a temporary object `newTintColor` inside the block to hold `newColor`
- additionally fixed a potential memory leak by also releasing `newColor` if `controller == nil`

Successfully tested with both code examples https://github.com/tidev/titanium-sdk/issues/14211#issue-3023033146 and https://github.com/tidev/titanium-sdk/pull/13917#issue-1909950302 in simulator.
