### PR TITLE
build: memory display parity with titanium-cli

### DIFF
--- a/cli/commands/build.js
+++ b/cli/commands/build.js
@@ -444,7 +444,7 @@ function patchLogger(logger, cli) {
 				'  ' + rpad(__('Version'))         + ' = ' + styleValue(osInfo.osver),
 				'  ' + rpad(__('Architecture'))    + ' = ' + styleValue(osInfo.ostype),
 				'  ' + rpad(__('# CPUs'))          + ' = ' + styleValue(osInfo.oscpu),
-				'  ' + rpad(__('Memory'))          + ' = ' + styleValue(osInfo.memory),
+				'  ' + rpad(__('Memory'))          + ' = ' + styleValue((osInfo.memory / 1024 / 1024 / 1024).toFixed(1) + 'GB'),
 				'',
 				styleHeading(__('Node.js')),
 				'  ' + rpad(__('Node.js Version')) + ' = ' + styleValue(osInfo.node),

--- a/cli/commands/clean.js
+++ b/cli/commands/clean.js
@@ -436,7 +436,7 @@ function patchLogger(logger, cli) {
 				'  ' + rpad(__('Version'))         + ' = ' + styleValue(osInfo.osver),
 				'  ' + rpad(__('Architecture'))    + ' = ' + styleValue(osInfo.ostype),
 				'  ' + rpad(__('# CPUs'))          + ' = ' + styleValue(osInfo.oscpu),
-				'  ' + rpad(__('Memory'))          + ' = ' + styleValue(osInfo.memory),
+				'  ' + rpad(__('Memory'))          + ' = ' + styleValue((osInfo.memory / 1024 / 1024 / 1024).toFixed(1) + 'GB'),
 				'',
 				styleHeading(__('Node.js')),
 				'  ' + rpad(__('Node.js Version')) + ' = ' + styleValue(osInfo.node),


### PR DESCRIPTION
**Description:**

- currently memory displays are different:

| `ti build`  | `ti info` (titanium-cli) |
| ------------- | ------------- |
| <img width="312" height="96" alt="Bildschirmfoto 2025-10-01 um 20 50 53" src="https://github.com/user-attachments/assets/2d0a3b7a-a70b-4487-9c4e-03e42a821685" />  | <img width="281" height="96" alt="CLI" src="https://github.com/user-attachments/assets/9de56238-10cf-4c22-a3c9-cfe7960a8b30" /> |

- converted memory (RAM) display from Bytes to Gigabytes to reach parity with [titanium-cli](https://github.com/tidev/titanium-cli/blob/16a96975b4909e4ae553163b8ea9332ea6937c7f/src/commands/info.js#L106)