### PR TITLE
chore: remove URL question in 'ti create'

### DIFF
--- a/cli/lib/creators/app.js
+++ b/cli/lib/creators/app.js
@@ -79,7 +79,6 @@ AppCreator.prototype.init = function init() {
 			name:          this.configOptionName(140),
 			platforms:     this.configOptionPlatforms(120),
 			template:      this.configOptionTemplate(110),
-			url:           this.configOptionUrl(160),
 			'workspace-dir': this.configOptionWorkspaceDir(170)
 		}
 	};


### PR DESCRIPTION
fixes https://github.com/tidev/titanium-cli/issues/845

When you run `ti create` the current questions are:
* sdk version
* type (app, module)
* target platform
* project name
* app id
* **company URL**
* directory

The *company URL* is not used inside the app project and can be set in the tiapp.xml if needed. But I don't think it should be part of the `ti create` menu as it is not that important. The CLI parameter `-u` is still there so it shouldn't break any editor package