### PR TITLE
fix(android): fix ANR caused by the `getNumberOfCameras` method

### DIFF
--- a/android/modules/media/src/java/ti/modules/titanium/media/MediaModule.java
+++ b/android/modules/media/src/java/ti/modules/titanium/media/MediaModule.java
@@ -51,8 +51,6 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.graphics.BitmapFactory;
 import android.graphics.ImageFormat;
-import android.hardware.Camera;
-import android.hardware.Camera.CameraInfo;
 import android.hardware.camera2.CameraCharacteristics;
 import android.hardware.camera2.CameraManager;
 import android.media.CamcorderProfile;
@@ -1725,33 +1723,22 @@ public class MediaModule extends KrollModule implements Handler.Callback
 	@Kroll.getProperty
 	public boolean getIsCameraSupported()
 	{
-		return Camera.getNumberOfCameras() > 0;
+		return TiApplication.getInstance().getPackageManager().hasSystemFeature(PackageManager.FEATURE_CAMERA_ANY);
 	}
 
 	@Kroll.getProperty
 	public int[] getAvailableCameras()
 	{
-		int cameraCount = Camera.getNumberOfCameras();
-		int[] result = new int[cameraCount];
+		int[] result = new int[]{-1, -1};
 
-		if (cameraCount == 0) {
-			return result;
-		}
+		if (TiApplication.getInstance() != null) {
+			PackageManager pm = TiApplication.getInstance().getPackageManager();
+			if (pm.hasSystemFeature(PackageManager.FEATURE_CAMERA_FRONT)) {
+				result[0] = CAMERA_FRONT;
+			}
 
-		CameraInfo cameraInfo = new CameraInfo();
-		for (int i = 0; i < cameraCount; i++) {
-			Camera.getCameraInfo(i, cameraInfo);
-			switch (cameraInfo.facing) {
-				case CameraInfo.CAMERA_FACING_FRONT:
-					result[i] = CAMERA_FRONT;
-					break;
-				case CameraInfo.CAMERA_FACING_BACK:
-					result[i] = CAMERA_REAR;
-					break;
-				default:
-					// This would be odd. As of API level 17,
-					// there are just the two options.
-					result[i] = -1;
+			if (pm.hasSystemFeature(PackageManager.FEATURE_CAMERA)) {
+				result[1] = CAMERA_REAR;
 			}
 		}
 
@@ -1761,7 +1748,7 @@ public class MediaModule extends KrollModule implements Handler.Callback
 	@Kroll.getProperty
 	public boolean getCanRecord()
 	{
-		return TiApplication.getInstance().getPackageManager().hasSystemFeature("android.hardware.microphone");
+		return TiApplication.getInstance().getPackageManager().hasSystemFeature(PackageManager.FEATURE_MICROPHONE);
 	}
 
 	@Override


### PR DESCRIPTION
**Device**: Xiaomi 13T Pro - Android 15

**Problem:** Facing an ANR issue while trying to open the native camera from the app.

**Reason:** As per the stack-trace we received on Firebase, it looks like that the `getNumberOfCameras` method becomes non responsive in few devices. It looks more like an issue from OEM actually, but we need to unblock our users.

_Note:_ Though we still use `getNumberOfCameras` in `TiCameraActivity`, but it has a different implementation to be directly fixed. If we fully migrate to `CameraX`, we can cover all use cases without having to worry about compatibility, so I have not modified the code in `TiCameraActivity` for now.

**ANR Stacktrace:**
```
          main (native):tid=1 systid=13752 
#00 pc 0xc9328 libc.so (__ioctl + 8) (BuildId: 94d417fdb46723bc4d7e45f68d275444)
#01 pc 0x6ac7c libc.so (ioctl + 156) (BuildId: 94d417fdb46723bc4d7e45f68d275444)
#02 pc 0x5f694 libbinder.so (android::IPCThreadState::transact + 1140) (BuildId: ec575ad0b138f2122b15f62f80ba4341)
#03 pc 0x5ee98 libbinder.so (android::BpBinder::transact + 168) (BuildId: ec575ad0b138f2122b15f62f80ba4341)
#04 pc 0x3c3a4 libcamera_client.so (android::hardware::BpCameraService::getNumberOfCameras + 724) (BuildId: 95cd9fb8040259f1e372ba557fca9184)
#05 pc 0x66d58 libcamera_client.so (android::CameraBase<android::Camera, android::CameraTraits<android::Camera>>::getNumberOfCameras + 152) (BuildId: 95cd9fb8040259f1e372ba557fca9184)
       at android.hardware.Camera._getNumberOfCameras(Native method)
       at android.hardware.Camera.getNumberOfCameras(Camera.java:313)
       at android.hardware.Camera.getNumberOfCameras(Camera.java:292)
       at ti.modules.titanium.media.MediaModule.getIsCameraSupported(MediaModule.java:1728)
       at ti.modules.titanium.media.MediaModule.launchNativeCamera(MediaModule.java:360)
       at ti.modules.titanium.media.MediaModule.showCamera(MediaModule.java:709)
       at org.appcelerator.kroll.runtime.v8.V8Object.nativeFireEvent(Native method)
       at org.appcelerator.kroll.runtime.v8.V8Object.fireEvent(V8Object.java:63)
       at org.appcelerator.kroll.KrollProxy.doFireEvent(KrollProxy.java:985)
       at org.appcelerator.kroll.KrollProxy.handleMessage(KrollProxy.java:1219)
       at org.appcelerator.titanium.proxy.TiViewProxy.handleMessage(TiViewProxy.java:258)
       at android.os.Handler.dispatchMessage(Handler.java:103)
       at android.os.Looper.loopOnce(Looper.java:249)
       at android.os.Looper.loop(Looper.java:337)
       at android.app.ActivityThread.main(ActivityThread.java:9410)
       at java.lang.reflect.Method.invoke(Native method)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:614)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1005)
        
```