### PR TITLE
feat(android): parity for `screenshotcaptured`  event

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
@@ -114,8 +114,9 @@ public abstract class TiBaseActivity extends AppCompatActivity implements TiActi
 			@Override
 			public void onScreenCaptured()
 			{
-				getTiApp().fireAppEvent("screenshotcaptured", new KrollDict());
-				getWindowProxy().fireEvent("screenshotcaptured", new KrollDict());
+				KrollDict kd = new KrollDict();
+				kd.put("source", getWindowProxy());
+				getTiApp().fireAppEvent("screenshotcaptured", kd);
 			}
 		};
 

--- a/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
@@ -116,6 +116,7 @@ public abstract class TiBaseActivity extends AppCompatActivity implements TiActi
 			public void onScreenCaptured()
 			{
 				getTiApp().fireAppEvent("screenshotcaptured", new KrollDict());
+				getWindowProxy().fireEvent("screenshotcaptured", new KrollDict());
 			}
 		};
 

--- a/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
@@ -46,6 +46,7 @@ import org.appcelerator.titanium.view.TiCompositeLayout;
 import org.appcelerator.titanium.view.TiCompositeLayout.LayoutArrangement;
 import org.appcelerator.titanium.view.TiInsetsProvider;
 
+import android.Manifest;
 import android.app.Activity;
 
 import androidx.appcompat.app.ActionBar;
@@ -69,6 +70,7 @@ import android.os.RemoteException;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatDelegate;
 import androidx.appcompat.widget.Toolbar;
+import androidx.core.content.ContextCompat;
 
 import android.text.Spannable;
 import android.text.SpannableStringBuilder;
@@ -107,6 +109,16 @@ public abstract class TiBaseActivity extends AppCompatActivity implements TiActi
 	private TiActivitySafeAreaMonitor safeAreaMonitor;
 	private Context baseContext;
 	public boolean keyboardVisible = false;
+	final Activity.ScreenCaptureCallback screenCaptureCallback =
+		new Activity.ScreenCaptureCallback()
+		{
+			@Override
+			public void onScreenCaptured()
+			{
+				getTiApp().fireAppEvent("screenshotcaptured", new KrollDict());
+			}
+		};
+
 	/**
 	 * Callback to be invoked when the TiBaseActivity.onRequestPermissionsResult() has been called,
 	 * providing the results of a requestPermissions() call. Instances of this interface are to
@@ -1560,6 +1572,11 @@ public abstract class TiBaseActivity extends AppCompatActivity implements TiActi
 		}
 
 		applyNightMode();
+
+		if (Build.VERSION.SDK_INT >= 34 && TiApplication.getInstance().checkCallingOrSelfPermission(
+			Manifest.permission.DETECT_SCREEN_CAPTURE) == PackageManager.PERMISSION_GRANTED) {
+			registerScreenCaptureCallback(ContextCompat.getMainExecutor(this), screenCaptureCallback);
+		}
 	}
 
 	@Override
@@ -1586,6 +1603,8 @@ public abstract class TiBaseActivity extends AppCompatActivity implements TiActi
 				}
 			}
 		}
+
+		unregisterScreenCaptureCallback(screenCaptureCallback);
 	}
 
 	@Override

--- a/apidoc/Titanium/App/App.yml
+++ b/apidoc/Titanium/App/App.yml
@@ -263,11 +263,11 @@ events:
 
   - name: screenshotcaptured
     summary: Fired after the user takes a screenshot, e.g. by pressing both the home and lock screen buttons.
-    descition: |
+    description: |
         Android is only available on devices with Android 14+ and you'll have to add the following permission
         to your tiapp.xml: `<uses-permission android:name="android.permission.DETECT_SCREEN_CAPTURE"/>`
     platforms: [android, iphone, ipad, macos]
-    since: {android: "13.1.0", iphone: "13.1.0", ipad: "13.1.0", macos: "13.1.0"}
+    since: 13.1.0
 
   - name: uncaughtException
     summary: Fired when an uncaught JavaScript exception occurs.

--- a/apidoc/Titanium/App/App.yml
+++ b/apidoc/Titanium/App/App.yml
@@ -268,6 +268,7 @@ events:
         to your tiapp.xml: `<uses-permission android:name="android.permission.DETECT_SCREEN_CAPTURE"/>`
     platforms: [android, iphone, ipad, macos]
     since: 13.1.0
+    osver: {android: {min: "14.0"}}
 
   - name: uncaughtException
     summary: Fired when an uncaught JavaScript exception occurs.

--- a/apidoc/Titanium/App/App.yml
+++ b/apidoc/Titanium/App/App.yml
@@ -261,6 +261,14 @@ events:
     platforms: [iphone, android]
     since: {android: "3.3.0"}
 
+  - name: screenshotcaptured
+    summary: Fired after the user takes a screenshot, e.g. by pressing both the home and lock screen buttons.
+    descition: |
+        Android is only available on devices with Android 14+ and you'll have to add the following permission
+        to your tiapp.xml: `<uses-permission android:name="android.permission.DETECT_SCREEN_CAPTURE"/>`
+    platforms: [android, iphone, ipad, macos]
+    since: {android: "13.1.0", iphone: "13.1.0", ipad: "13.1.0", macos: "13.1.0"}
+
   - name: uncaughtException
     summary: Fired when an uncaught JavaScript exception occurs.
     description: |

--- a/apidoc/Titanium/App/App.yml
+++ b/apidoc/Titanium/App/App.yml
@@ -269,6 +269,11 @@ events:
     platforms: [android, iphone, ipad, macos]
     since: 13.1.0
     osver: {android: {min: "14.0"}}
+    properties:
+      - name: source
+        summary: The current window the screenshot was taken from.
+        platforms: [android]
+        type: String
 
   - name: uncaughtException
     summary: Fired when an uncaught JavaScript exception occurs.

--- a/apidoc/Titanium/App/iOS/iOS.yml
+++ b/apidoc/Titanium/App/iOS/iOS.yml
@@ -1383,11 +1383,12 @@ events:
 
   - name: screenshotcaptured
     summary: Fired after the user takes a screenshot, e.g. by pressing both the home and lock screen buttons.
-    descition: |
-        Android is only available on devices with Android 14+ and you'll have to add the following permission
-        to your tiapp.xml: `<uses-permission android:name="android.permission.DETECT_SCREEN_CAPTURE"/>`
-    platforms: [android, iphone, ipad, macos]
-    since: {android: "13.1.0", iphone: "9.1.0", ipad: "9.1.0", macos: "9.2.0"}
+    platforms: [iphone, ipad, macos]
+    since: "9.1.0"
+    deprecated:
+        since: "13.1.0"
+        notes: Use [Titanium.App.screenshotcaptured](Titanium.App.screenshotcaptured) instead.
+
 
 ---
 name: NotificationParams

--- a/apidoc/Titanium/App/iOS/iOS.yml
+++ b/apidoc/Titanium/App/iOS/iOS.yml
@@ -1383,8 +1383,11 @@ events:
 
   - name: screenshotcaptured
     summary: Fired after the user takes a screenshot, e.g. by pressing both the home and lock screen buttons.
-    platforms: [iphone, ipad, macos]
-    since: "9.1.0"
+    descition: |
+        Android is only available on devices with Android 14+ and you'll have to add the following permission
+        to your tiapp.xml: `<uses-permission android:name="android.permission.DETECT_SCREEN_CAPTURE"/>`
+    platforms: [android, iphone, ipad, macos]
+    since: {android: "13.1.0", iphone: "9.1.0", ipad: "9.1.0", macos: "9.2.0"}
 
 ---
 name: NotificationParams

--- a/apidoc/Titanium/UI/Window.yml
+++ b/apidoc/Titanium/UI/Window.yml
@@ -546,7 +546,7 @@ methods:
         since: "12.7.0"
         removed: "13.0.0"
         notes: Deprecated in favor of <Titanium.UI.Window.tabBarHidden> property.
-     
+
   - name: open
     summary: Opens the window.
     parameters:
@@ -606,7 +606,7 @@ methods:
         since: "12.7.0"
         removed: "13.0.0"
         notes: Deprecated in favor of <Titanium.UI.Window.tabBarHidden> property.
-        
+
   - name: showToolbar
     summary: Makes the bottom toolbar visible.
     description: |
@@ -740,6 +740,14 @@ events:
     description: |
         The listener for this event must be defined before this window
         is opened.
+
+  - name: screenshotcaptured
+    summary: Fired after the user takes a screenshot of this window, e.g. by pressing both the home and lock screen buttons.
+    description: |
+        Android is only available on devices with Android 14+ and you'll have to add the following permission
+        to your tiapp.xml: `<uses-permission android:name="android.permission.DETECT_SCREEN_CAPTURE"/>`
+    platforms: [android, iphone, ipad, macos]
+    since: 13.1.0
 
 properties:
   - name: activity

--- a/apidoc/Titanium/UI/Window.yml
+++ b/apidoc/Titanium/UI/Window.yml
@@ -741,14 +741,6 @@ events:
         The listener for this event must be defined before this window
         is opened.
 
-  - name: screenshotcaptured
-    summary: Fired after the user takes a screenshot of this window, e.g. by pressing both the home and lock screen buttons.
-    description: |
-        Android is only available on devices with Android 14+ and you'll have to add the following permission
-        to your tiapp.xml: `<uses-permission android:name="android.permission.DETECT_SCREEN_CAPTURE"/>`
-    platforms: [android]
-    since: 13.1.0
-
 properties:
   - name: activity
     summary: |

--- a/apidoc/Titanium/UI/Window.yml
+++ b/apidoc/Titanium/UI/Window.yml
@@ -746,7 +746,7 @@ events:
     description: |
         Android is only available on devices with Android 14+ and you'll have to add the following permission
         to your tiapp.xml: `<uses-permission android:name="android.permission.DETECT_SCREEN_CAPTURE"/>`
-    platforms: [android, iphone, ipad, macos]
+    platforms: [android]
     since: 13.1.0
 
 properties:

--- a/iphone/Classes/AppModule.m
+++ b/iphone/Classes/AppModule.m
@@ -306,6 +306,13 @@ extern NSString *const TI_APPLICATION_GUID;
   [self fireEvent:@"keyboardframechanged" withObject:event];
 }
 
+- (void)didTakeScreenshot:(NSNotification *)info
+{
+  if ([self _hasListeners:@"screenshotcaptured"]) {
+    [self fireEvent:@"screenshotcaptured" withObject:nil];
+  }
+}
+
 - (void)timeChanged:(NSNotification *)notiication
 {
   if ([self _hasListeners:@"significanttimechange"]) {
@@ -378,7 +385,7 @@ extern NSString *const TI_APPLICATION_GUID;
 
   [nc addObserver:self selector:@selector(keyboardFrameChanged:) name:UIKeyboardWillChangeFrameNotification object:nil];
   [nc addObserver:self selector:@selector(timeChanged:) name:UIApplicationSignificantTimeChangeNotification object:nil];
-
+  [nc addObserver:self selector:@selector(didTakeScreenshot:) name:UIApplicationUserDidTakeScreenshotNotification object:nil];
 #ifdef __IPHONE_16_4
   // Ensure that the JSContext is debuggable during development
   if (@available(iOS 16.4, *)) {

--- a/iphone/Classes/TiAppiOSProxy.m
+++ b/iphone/Classes/TiAppiOSProxy.m
@@ -217,6 +217,7 @@
 
 - (void)didTakeScreenshot:(NSNotification *)info
 {
+  DEPRECATED_REPLACED(@"App.iOS.screenshotcaptured", @"9.1.0", @"App.screenshotcaptured");
   [self fireEvent:@"screenshotcaptured"];
 }
 

--- a/iphone/Classes/TiAppiOSProxy.m
+++ b/iphone/Classes/TiAppiOSProxy.m
@@ -217,7 +217,7 @@
 
 - (void)didTakeScreenshot:(NSNotification *)info
 {
-  DEPRECATED_REPLACED(@"App.iOS.screenshotcaptured", @"9.1.0", @"App.screenshotcaptured");
+  DEPRECATED_REPLACED(@"App.iOS.screenshotcaptured", @"13.1.0", @"App.screenshotcaptured");
   [self fireEvent:@"screenshotcaptured"];
 }
 


### PR DESCRIPTION
Android parity for `screenshotcaptured` using Android 14 `registerScreenCaptureCallback`:  https://developer.android.com/about/versions/14/features/screenshot-detection#java 

**Changes:**
* add Android parity for `screenshotcaptured` event
* move `Ti.App.iOS.screenshotcaptured` to `Ti.App.screenshotcaptured`
* add deprecation message for `Ti.App.iOS.screenshotcaptured`

**Test:**
```js
var win = Ti.UI.createWindow({
	id: "win1",
	backgroundColor: "#fff"
});
var btn = Ti.UI.createButton({
	top: 140,
	title: "open"
})
btn.addEventListener("click", function() {
	var win2 = Ti.UI.createWindow({
		backgroundColor: "#fff",
		id: "win2"
	})
	var lbl2 = Ti.UI.createLabel({
		color: "#000",
		text: "app even is still fired. Close window and check the log"
	});
	win2.open();
	win2.add(lbl2);
})
var lbl = Ti.UI.createLabel({
	color: "#000",
	text: ""
});
win.add([btn, lbl]);
win.open();

// iOS parity
Ti.App.addEventListener("screenshotcaptured", function(e) {
	console.log("Ti.App event: " + JSON.stringify(e));
	lbl.text += "Ti.App event: " + e.source.id + "\n";
})
if (OS_IOS) {
	Ti.App.iOS.addEventListener("screenshotcaptured", function(e) {
		console.log("Old Ti.App.iOS event: " + JSON.stringify(e));
		lbl.text += "Old Ti.App.iOS event\n";
	})
}

```
* and add `<uses-permission android:name="android.permission.DETECT_SCREEN_CAPTURE"/>` to your tiapp.xml
* Run the app and take a screenshot. 
* log and label will show that the event is fired
* click the open button to open a new window
* take a screenshot
* the app event is fired