### PR TITLE
feat: added trace log option for tests

### DIFF
--- a/build/lib/test/index.js
+++ b/build/lib/test/index.js
@@ -16,7 +16,10 @@ const LOCAL_TESTS = path.join(ROOT_DIR, 'tests');
  * @param {string} [program.deviceId] Titanium device id target to run the tests on
  * @param {string} [program.deployType] 'development' || 'test'
  * @param {string} [program.deviceFamily] 'ipad' || 'iphone'
+ * @param {string} [program.junitPrefix] A prefix for the junit filename
  * @param {string} [program.onlyFailedTests] boolean
+ * @param {string} [program.sdkVersion] The SDK version to use
+ * @param {string} [program.logLevel] The log level
  * @returns {Promise<object>} returns an object whose keys are platform names
  */
 export async function runTests(platforms, program) {
@@ -26,7 +29,7 @@ export async function runTests(platforms, program) {
 		fs.emptyDir(path.join(snapshotDir, '..', 'generated')),
 		fs.emptyDir(path.join(snapshotDir, '..', 'diffs'))
 	]);
-	return test(platforms, program.target, program.deviceId, program.deployType, program.deviceFamily, program.junitPrefix, snapshotDir, program.onlyFailedTests, program.sdkVersion);
+	return test(platforms, program.target, program.deviceId, program.deployType, program.deviceFamily, program.junitPrefix, snapshotDir, program.onlyFailedTests, program.sdkVersion, program.logLevel);
 }
 
 /**

--- a/build/lib/test/test.js
+++ b/build/lib/test/test.js
@@ -62,9 +62,10 @@ let showFailedOnly = false;
  * @param {string} [snapshotDir='../../../tests/Resources'] directory to place generated snapshot images
  * @param {string} [failedOnly] Show only failed tests
  * @param {string} [sdkVersion] The SDK version to use
+ * @param {string} [logLevel] The log level
  * @returns {Promise<object>}
  */
-export async function test(platforms, target, deviceId, deployType, deviceFamily, junitPrefix, snapshotDir = path.join(__dirname, '../../../tests/Resources'), failedOnly, sdkVersion) {
+export async function test(platforms, target, deviceId, deployType, deviceFamily, junitPrefix, snapshotDir = path.join(__dirname, '../../../tests/Resources'), failedOnly, sdkVersion, logLevel) {
 	showFailedOnly = failedOnly;
 	const snapshotPromises = []; // place to stick commands we've fired off to pull snapshot images
 
@@ -81,7 +82,7 @@ export async function test(platforms, target, deviceId, deployType, deviceFamily
 	try {
 		const results = {};
 		for (const platform of platforms) {
-			const result = await runBuild(platform, target, deviceId, deployType, deviceFamily, snapshotDir, snapshotPromises, sdkVersion);
+			const result = await runBuild(platform, target, deviceId, deployType, deviceFamily, snapshotDir, snapshotPromises, sdkVersion, logLevel);
 			const prefix = generateJUnitPrefix(platform, target, junitPrefix || deviceFamily);
 			results[prefix] = result;
 			await outputJUnitXML(result, prefix);
@@ -381,9 +382,10 @@ async function addTiAppProperties() {
  * @param {string} snapshotDir directory to place generated images
  * @param {Promise[]} snapshotPromises array to hold promises for grabbing generated images
  * @param {string} [sdkVersion] The SDK version to use
+ * @param {string} [logLevel] The log level
  * @returns {Promise<object>}
  */
-async function runBuild(platform, target, deviceId, deployType, deviceFamily, snapshotDir, snapshotPromises, sdkVersion) {
+async function runBuild(platform, target, deviceId, deployType, deviceFamily, snapshotDir, snapshotPromises, sdkVersion, logLevel) {
 
 	if (target === undefined) {
 		switch (platform) {
@@ -402,7 +404,7 @@ async function runBuild(platform, target, deviceId, deployType, deviceFamily, sn
 		'--platform', platform,
 		'--target', target,
 		'--sdk', sdkVersion,
-		'--log-level', 'info'
+		'--log-level', logLevel
 	];
 
 	if (deployType) {

--- a/build/scons-test.js
+++ b/build/scons-test.js
@@ -10,10 +10,11 @@ program
 	.option('-C, --device-id [id]', 'Titanium device id to run the unit tests on. Only valid when there is a target provided')
 	.option('-T, --target [target]', 'Titanium platform target to run the unit tests on. Only valid when there is a single platform provided')
 	.option('-v, --sdk-version [version]', 'Override the SDK version we report', process.env.PRODUCT_VERSION || version)
+	.option('-l, --log-level <level>', 'Override the log level', 'info')
 	.option('-D, --deploy-type <type>', 'Override the deploy type used to build the project', /^(development|test)$/)
 	.option('-F, --device-family <value>', 'Override the device family used to build the project', /^(iphone|ipad)$/)
-	.option('-J --junit-prefix <value>', 'A prefix to add to junit tests to help distinguish them. Useful if targeting same platform and target', '')
-	.option('-O --only-failed', 'Show only failed tests', '')
+	.option('-J, --junit-prefix <value>', 'A prefix to add to junit tests to help distinguish them. Useful if targeting same platform and target', '')
+	.option('-O, --only-failed', 'Show only failed tests', '')
 	.parse(process.argv);
 
 async function main(program) {

--- a/package.json
+++ b/package.json
@@ -61,15 +61,22 @@
     "postinstall": "husky install",
     "test": "npm run ios-sanity-check && npm run lint",
     "test:android": "npm run cleanbuild:android -- --skip-zip --no-docs --symlink && npm run test:integration -- android --sdk-version $npm_package_version",
-    "test:android:onlyFailed": "npm run cleanbuild:android -- --skip-zip --no-docs --symlink && npm run test:integration:onlyFailed -- android --sdk-version $npm_package_version",
+    "test:android:onlyFailed": "npm run cleanbuild:android -- --skip-zip --no-docs --symlink && npm run test:integration -- android --sdk-version $npm_package_version --only-failed",
+    "test:android:trace": "npm run cleanbuild:android -- --skip-zip --no-docs --symlink && npm run test:integration -- android --sdk-version $npm_package_version --log-level trace",
     "test:cli": "JUNIT_REPORT_PATH=junit.cli.report.xml nyc mocha **/cli/tests/test-*.js build/**/test-*.js",
     "test:ios": "npm run test:iphone",
+    "test:ios:onlyFailed": "npm run test:iphone:onlyFailed",
+    "test:ios:trace": "npm run test:iphone:trace",
     "test:iphone": "npm run cleanbuild:ios -- --skip-zip --no-docs --symlink && npm run test:integration -- ios -F iphone --sdk-version $npm_package_version",
-    "test:iphone:onlyFailed": "npm run cleanbuild:ios -- --skip-zip --no-docs --symlink && npm run test:integration:onlyFailed -- ios -F iphone --sdk-version $npm_package_version",
+    "test:iphone:onlyFailed": "npm run cleanbuild:ios -- --skip-zip --no-docs --symlink && npm run test:integration -- ios -F iphone --sdk-version $npm_package_version --only-failed",
+    "test:iphone:trace": "npm run cleanbuild:ios -- --skip-zip --no-docs --symlink && npm run test:integration: -- ios -F iphone --sdk-version $npm_package_version --log-level trace",
     "test:ipad": "npm run cleanbuild:ios -- --skip-zip --no-docs --symlink && npm run test:integration -- ios -F ipad --sdk-version $npm_package_version",
+    "test:ipad:onlyFailed": "npm run cleanbuild:ios -- --skip-zip --no-docs --symlink && npm run test:integration -- ios -F ipad --sdk-version $npm_package_version --only-failed",
+    "test:ipad:trace": "npm run cleanbuild:ios -- --skip-zip --no-docs --symlink && npm run test:integration -- ios -F ipad --sdk-version $npm_package_version --log-level trace",
     "test:mac": "npm run cleanbuild:ios -- --skip-zip --no-docs --symlink && npm run test:integration -- ios -T macos --sdk-version $npm_package_version",
-    "test:integration": "node ./build/scons test",
-    "test:integration:onlyFailed": "node ./build/scons test --only-failed"
+    "test:mac:onlyFailed": "npm run cleanbuild:ios -- --skip-zip --no-docs --symlink && npm run test:integration -- ios -T macos --sdk-version $npm_package_version --only-failed",
+    "test:mac:trace": "npm run cleanbuild:ios -- --skip-zip --no-docs --symlink && npm run test:integration -- ios -T macos --sdk-version $npm_package_version --log-level trace",
+    "test:integration": "node ./build/scons test"
   },
   "commitlint": {
     "extends": [


### PR DESCRIPTION
**Introduction:**

Due to the current issues with errors and warnings at the `trace` log level, it is difficult to investigate problems when building the unit tests/mocha test app.
In this context, the log level is currently fixed at `info` in https://github.com/tidev/titanium-sdk/blob/214b762441e5bfa235b0f31fde94f857286ea61a/build/lib/test/test.js#L405

**Description:**

- added log-level option for scons tests (default: `info`)
- BTW added some missing doc comments
- added scripts:
  - `test:android:trace`
  - `test:iphone:trace` (plus "alias" `test:ios:trace`)
  - `test:ipad:trace`
  - `test:mac:trace`

**Bonus:**

- removed script `test:integration:onlyFailed` which couldn't run alone
  - used by`test:android:onlyFailed` and `test:iphone:onlyFailed`
- added scripts for completeness:
  - `test:ios:onlyFailed`
  - `test:ipad:onlyFailed`
  - `test:mac:onlyFailed`