### PR TITLE
chore: rename master to main in files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
     - master
+    - main
     - "[0-9]+_[0-9]+_X"
     - actions_tests
   pull_request:

--- a/.github/workflows/regen-builds.yml
+++ b/.github/workflows/regen-builds.yml
@@ -5,6 +5,7 @@ on:
     types: [completed]
     branches:
     - master
+    - main
     - "[0-9]+_[0-9]+_X"
 
 jobs:

--- a/.github/workflows/regen-docs.yml
+++ b/.github/workflows/regen-docs.yml
@@ -3,8 +3,10 @@ on:
   workflow_dispatch:
   pull_request:
     types: [ closed ]
-    branches: [ master ]
     paths: [ 'apidoc/**' ]
+    branches:
+    - master
+    - main
 
 jobs:
   regen:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       branch:
         description: The branch to release from
         required: true
-        default: master
+        default: main
       release-type:
         description: The type of release to perform
         required: true

--- a/README.md
+++ b/README.md
@@ -2,9 +2,13 @@
 
 <h1 align="center">Titanium SDK</h1>
 
-<p align="center">  <a href="https://bsky.app/profile/titaniumsdk.com">
-    <img src="https://img.shields.io/badge/Bluesky-0285FF?logo=bluesky&logoColor=fff" alt="Follow @titaniumsdk.com on Bluesky" />
-  </a><a href="https://github.com/tidev/titanium-sdk/actions/workflows/build.yml?query=branch%3Amaster" target="_blank"><img src="https://github.com/tidev/titanium-sdk/actions/workflows/build.yml/badge.svg?branch=master" /></a></p>
+<p align="center">
+  <a href="https://bsky.app/profile/titaniumsdk.com" target="_blank"><img
+    src="https://img.shields.io/badge/Bluesky-0285FF?logo=bluesky&logoColor=fff" alt="Follow @titaniumsdk.com on Bluesky"
+  /></a>
+  <a href="https://github.com/tidev/titanium-sdk/actions/workflows/build.yml?query=branch%3Amain" target="_blank"
+    ><img src="https://github.com/tidev/titanium-sdk/actions/workflows/build.yml/badge.svg?branch=main"
+  /></a></p>
 
 Welcome to the Titanium SDK open source project. Titanium SDK provides a mature platform for developers to build
 completely native cross-platform mobile applications using JavaScript.

--- a/android/kroll-apt/README.md
+++ b/android/kroll-apt/README.md
@@ -15,9 +15,9 @@ Implementation
 --------------
 The majority of the code lives in two places:
 
-1. [KrollBindingGenerator.java](http://github.com/tidev/titanium_mobile/blob/master/android/kroll-apt/src/org/appcelerator/kroll/annotations/generator/KrollBindingGenerator.java)
+1. [KrollBindingGenerator.java](http://github.com/tidev/titanium_mobile/blob/main/android/kroll-apt/src/org/appcelerator/kroll/annotations/generator/KrollBindingGenerator.java)
     - This is the main class that implements AnnotationProcessor, builds/manages the JSON model, and invokes Freemarker for each proxy/module.
-2. [ProxyBinding.fm](http://github.com/tidev/titanium_mobile/blob/master/android/kroll-apt/src/org/appcelerator/kroll/annotations/generator/ProxyBinding.fm)
+2. [ProxyBinding.fm](http://github.com/tidev/titanium_mobile/blob/main/android/kroll-apt/src/org/appcelerator/kroll/annotations/generator/ProxyBinding.fm)
     - This is a [Freemarker](http://freemarker.sourceforge.net/docs/index.html) template that reads from the JSON model and generates a binding class that binds all of a proxy's methods and properties
 
 Running the Annotation processor

--- a/android/runtime/v8/src/native/NativeObject.h
+++ b/android/runtime/v8/src/native/NativeObject.h
@@ -23,7 +23,7 @@ class ProxyFactory;
 // used to store "user data" in the JavaScript object for use
 // inside method and property callbacks.
 
-// https://github.com/nodejs/node/blob/master/src/node_object_wrap.h
+// https://github.com/nodejs/node/blob/main/src/node_object_wrap.h
 class NativeObject
 {
  public:

--- a/android/runtime/v8/src/native/modules/ScriptsModule.cpp
+++ b/android/runtime/v8/src/native/modules/ScriptsModule.cpp
@@ -196,7 +196,7 @@ template<WrappedScript::EvalInputFlags input_flag, WrappedScript::EvalContextFla
 	WrappedScript::EvalOutputFlags output_flag>
 void WrappedScript::EvalMachine(const FunctionCallbackInfo<Value>& args)
 {
-	// TODO: This needs a major overhaul/update. We're way behind node's impl here: https://github.com/nodejs/node/blob/master/src/node_contextify.cc
+	// TODO: This needs a major overhaul/update. We're way behind node's impl here: https://github.com/nodejs/node/blob/main/src/node_contextify.cc
 	// Additionally, we don't actually use anything other than "this" context, as far as I know.
 	Isolate* isolate = args.GetIsolate();
 	Local<Context> currentContext = isolate->GetCurrentContext();

--- a/apidoc/Titanium/UI/WebView.yml
+++ b/apidoc/Titanium/UI/WebView.yml
@@ -49,7 +49,7 @@ description: |
       '})()'
     );
     ```
-    The `binding.min.js` is available in the [repository](https://github.com/tidev/titanium-sdk/tree/master/android/modules/ui/assets/Resources/ti.internal/webview).
+    The `binding.min.js` is available in the [repository](https://github.com/tidev/titanium-sdk/tree/main/android/modules/ui/assets/Resources/ti.internal/webview).
 
     For iOS check the example in <Titanium.UI.WebView.addScriptMessageHandler>.
 

--- a/cli/lib/webpack/log-update.js
+++ b/cli/lib/webpack/log-update.js
@@ -7,7 +7,7 @@
 import ansiEscapes from 'ansi-escapes';
 import wrapAnsi from 'wrap-ansi';
 
-// Based on https://github.com/sindresorhus/log-update/blob/master/index.js
+// Based on https://github.com/sindresorhus/log-update/blob/main/index.js
 
 const originalWrite = Symbol('webpackbarWrite');
 

--- a/common/Resources/ti.internal/extensions/node/internal/assert.js
+++ b/common/Resources/ti.internal/extensions/node/internal/assert.js
@@ -21,7 +21,7 @@
 /**
  * Node's lib/internal/assert.js modified for Axway Titanium
  *
- * @see https://github.com/nodejs/node/blob/master/lib/internal/assert.js
+ * @see https://github.com/nodejs/node/blob/main/lib/internal/assert.js
  */
 
 import { codes } from './errors';

--- a/common/Resources/ti.internal/extensions/node/internal/errors.js
+++ b/common/Resources/ti.internal/extensions/node/internal/errors.js
@@ -24,7 +24,7 @@
  * Only a few selected errors are exported manually here. Most of the functionality
  * is still missing and may be added as we move forward with Node compatibility.
  *
- * @see https://github.com/nodejs/node/blob/master/lib/internal/errors.js
+ * @see https://github.com/nodejs/node/blob/main/lib/internal/errors.js
  */
 
 import assert from './assert';

--- a/common/Resources/ti.internal/extensions/node/internal/util.js
+++ b/common/Resources/ti.internal/extensions/node/internal/util.js
@@ -21,7 +21,7 @@
 /**
  * Node's lib/internal/util.js modified for Axway Titanium
  *
- * @see https://github.com/nodejs/node/blob/master/lib/internal/util.js
+ * @see https://github.com/nodejs/node/blob/main/lib/internal/util.js
  */
 
 import { isNativeError } from './util/types';

--- a/common/Resources/ti.internal/extensions/node/internal/util/inspect.js
+++ b/common/Resources/ti.internal/extensions/node/internal/util/inspect.js
@@ -21,7 +21,7 @@
 /**
  * Node's lib/internal/util/inspec.js modified for Axway Titanium
  *
- * @see https://github.com/nodejs/node/blob/master/lib/internal/util/inspect.js
+ * @see https://github.com/nodejs/node/blob/main/lib/internal/util/inspect.js
  */
 
 import {

--- a/common/Resources/ti.internal/extensions/node/internal/util/types.js
+++ b/common/Resources/ti.internal/extensions/node/internal/util/types.js
@@ -21,7 +21,7 @@
 /**
  * Node's lib/internal/util/types.js modified for Axway Titanium
  *
- * @see https://github.com/nodejs/node/blob/master/lib/internal/util/types.js
+ * @see https://github.com/nodejs/node/blob/main/lib/internal/util/types.js
  */
 
 import { isBuffer, uncurryThis } from '../util';

--- a/common/Resources/ti.internal/extensions/node/string_decoder.js
+++ b/common/Resources/ti.internal/extensions/node/string_decoder.js
@@ -191,7 +191,7 @@ class Utf8StringDecoder extends MultiByteStringDecoderImpl {
 		// iOS apparently just returns undefined in that special case and
 		// Android differs here because we don't work backwards from the last char
 		// Can we cheat here and...
-		// see https://github.com/nodejs/string_decoder/blob/master/lib/string_decoder.js#L173-L198
+		// see https://github.com/nodejs/string_decoder/blob/main/lib/string_decoder.js#L173-L198
 		// - if we see a multi-byte character start, validate the next characters are continuation chars
 		// - if they're not replace the sequence with '\ufffd', treat like that multi-byte character was "completed"
 

--- a/maintainer-docs/releasing-the-sdk.md
+++ b/maintainer-docs/releasing-the-sdk.md
@@ -30,18 +30,18 @@ It should then be PR'd to the correct branch.
 
 If this is a patch release, you do not need to perform this step.
 
-For all other releases you should create a branch for this minor version of the SDK following the `1_2_X` format and bump the version of the master branch to the next version.
+For all other releases you should create a branch for this minor version of the SDK following the `1_2_X` format and bump the version of the main branch to the next version.
 
 The following steps are written from the perspective of a `11.0.0.GA` release.
 
-1. Create the maintenance branch from `master` in the [GitHub UI](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-and-deleting-branches-within-your-repository#creating-a-branch) or in the terminal
+1. Create the maintenance branch from `main` in the [GitHub UI](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-and-deleting-branches-within-your-repository#creating-a-branch) or in the terminal
    * If using the terminal ensure you push to the correct remote
-2. Bump the version on the `master` branch to the new minor version. If you are not an administrator on the repository, you should PR this change.
-   1. `git checkout master`
+2. Bump the version on the `main` branch to the new minor version. If you are not an administrator on the repository, you should PR this change.
+   1. `git checkout main`
    2. `npm --no-git-tag-version version minor`
    3. `git add package.json package-lock.json`
    4. `git commit -m "chore(release): bump version to 10.3.0`
-   5. `git push origin master`
+   5. `git push origin main`
 
 ## Running the release job
 

--- a/tests/Resources/assert.test.js
+++ b/tests/Resources/assert.test.js
@@ -11,8 +11,8 @@ const should = require('./utilities/assertions'); // eslint-disable-line no-unus
 let assert;
 
 // possible test cases:
-// https://github.com/nodejs/node/blob/master/test/parallel/test-assert-deep.js
-// https://github.com/nodejs/node/blob/master/test/parallel/test-assert.js
+// https://github.com/nodejs/node/blob/main/test/parallel/test-assert-deep.js
+// https://github.com/nodejs/node/blob/main/test/parallel/test-assert.js
 
 describe('assert', function () {
 	it('should be required as core module', function () {

--- a/tests/Resources/ti.media.videoplayer.test.js
+++ b/tests/Resources/ti.media.videoplayer.test.js
@@ -208,7 +208,7 @@ describe.androidARM64Broken('Titanium.Media.VideoPlayer', () => {
 				this.timeout(10000);
 
 				player = Ti.Media.createVideoPlayer({
-					url: 'https://raw.githubusercontent.com/appcelerator/titanium_mobile/master/tests/remote/mov_bbb.mp4',
+					url: 'https://raw.githubusercontent.com/tidev/titanium-sdk/main/tests/remote/mov_bbb.mp4',
 					autoplay: true,
 					showsControls: false,
 					height: 200
@@ -396,7 +396,7 @@ describe.androidARM64Broken('Titanium.Media.VideoPlayer', () => {
 			});
 
 			player = Ti.Media.createVideoPlayer({
-				url: 'https://raw.githubusercontent.com/appcelerator/titanium_mobile/master/tests/remote/mov_bbb.mp4',
+				url: 'https://raw.githubusercontent.com/tidev/titanium-sdk/main/tests/remote/mov_bbb.mp4',
 				autoplay: true,
 				backgroundColor: 'blue',
 				height: 300,
@@ -427,7 +427,7 @@ describe.androidARM64Broken('Titanium.Media.VideoPlayer', () => {
 		this.timeout(10000);
 		const videoWindow = Ti.UI.createWindow();
 		player = Ti.Media.createVideoPlayer({
-			url: 'https://raw.githubusercontent.com/appcelerator/titanium_mobile/master/tests/remote/mov_bbb.mp4',
+			url: 'https://raw.githubusercontent.com/tidev/titanium-sdk/main/tests/remote/mov_bbb.mp4',
 			top: 2,
 			autoplay: true,
 			backgroundColor: 'blue',

--- a/tests/Resources/ti.network.httpclient.test.js
+++ b/tests/Resources/ti.network.httpclient.test.js
@@ -85,7 +85,7 @@ describe('Titanium.Network.HTTPClient', function () {
 			}
 		};
 
-		xhr.open('GET', 'https://raw.githubusercontent.com/appcelerator/titanium_mobile/master/tests/Resources/large.jpg');
+		xhr.open('GET', 'https://raw.githubusercontent.com/tidev/titanium-sdk/main/tests/Resources/large.jpg');
 		xhr.send();
 	});
 
@@ -151,7 +151,7 @@ describe('Titanium.Network.HTTPClient', function () {
 			}
 		};
 
-		xhr.open('GET', 'https://httpbin.org/redirect-to?url=https%3A%2F%2Fraw.githubusercontent.com%2Ftidev%2Ftitanium-sdk%2Fmaster%2Ftests%2FResources%2Flarge.jpg');
+		xhr.open('GET', 'https://httpbin.org/redirect-to?url=https%3A%2F%2Fraw.githubusercontent.com%2Ftidev%2Ftitanium-sdk%main%2Ftests%2FResources%2Flarge.jpg');
 		xhr.send();
 	});
 
@@ -480,7 +480,7 @@ describe('Titanium.Network.HTTPClient', function () {
 			}
 		};
 
-		xhr.open('GET', 'https://raw.githubusercontent.com/appcelerator/titanium_mobile/master/tests/remote/test-pdf.pdf');
+		xhr.open('GET', 'https://raw.githubusercontent.com/tidev/titanium-sdk/main/tests/remote/test-pdf.pdf');
 		xhr.send();
 	});
 
@@ -653,7 +653,7 @@ describe('Titanium.Network.HTTPClient', function () {
 			}
 		};
 
-		xhr.open('GET', 'https://raw.githubusercontent.com/appcelerator/titanium_mobile/master/tests/Resources/large.jpg');
+		xhr.open('GET', 'https://raw.githubusercontent.com/tidev/titanium-sdk/main/tests/Resources/large.jpg');
 		xhr.send();
 	});
 

--- a/tests/Resources/util.test.js
+++ b/tests/Resources/util.test.js
@@ -21,7 +21,7 @@ describe('util', () => {
 		util.should.be.an.Object();
 	});
 
-	// For copious tests, see https://github.com/nodejs/node/blob/master/test/parallel/test-util-format.js
+	// For copious tests, see https://github.com/nodejs/node/blob/main/test/parallel/test-util-format.js
 	describe('#format()', () => {
 		it('is a function', () => {
 			util.format.should.be.a.Function();


### PR DESCRIPTION
We should have done this years ago.

All local clones will need to run the following:

```
git branch -m master main
git fetch origin
git branch -u origin/main main
git remote set-head origin -a
```

If you have a fork, rename `origin` with the name of the remote. For example, I call mine `upstream`.