### PR TITLE
feat: add script message handler support to Android WebView

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/WebViewProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/WebViewProxy.java
@@ -170,7 +170,7 @@ public class WebViewProxy extends ViewProxy implements Handler.Callback, OnLifec
 	}
 
 	@Kroll.method
-	public void addScriptMessageHandler(String name, @Kroll.argument(optional = true) boolean unusedParam)
+	public void addScriptMessageHandler(String name)
 	{
 		if (jsInterface == null) {
 			jsInterface = new JSInterface(this);

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/WebViewProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/WebViewProxy.java
@@ -740,7 +740,7 @@ public class WebViewProxy extends ViewProxy implements Handler.Callback, OnLifec
 		// Store references to add later the web-view is created.
 		private boolean isInterfaceAdded = false;
 		private WeakReference<WebViewProxy> proxy;
-		private final String TI_BRIDGE_INTERFACE = "tiBridge";
+		private final String JS_INTERFACE_NAME = "tisdk";
 		private final Set<String> scriptMessageHandlers = new HashSet<>();
 
 		public JSInterface(WebViewProxy proxy)
@@ -756,7 +756,7 @@ public class WebViewProxy extends ViewProxy implements Handler.Callback, OnLifec
 			}
 
 			WebView webView = tiUIWebView.getWebView();
-			webView.addJavascriptInterface(this, TI_BRIDGE_INTERFACE);
+			webView.addJavascriptInterface(this, JS_INTERFACE_NAME);
 			isInterfaceAdded = true;
 		}
 
@@ -780,7 +780,7 @@ public class WebViewProxy extends ViewProxy implements Handler.Callback, OnLifec
 
 			// Remove interface if no handlers available.
 			if (scriptMessageHandlers.isEmpty() && isInterfaceAdded) {
-				((TiUIWebView) view).getWebView().removeJavascriptInterface(TI_BRIDGE_INTERFACE);
+				((TiUIWebView) view).getWebView().removeJavascriptInterface(JS_INTERFACE_NAME);
 				isInterfaceAdded = false;
 			}
 		}
@@ -816,7 +816,7 @@ public class WebViewProxy extends ViewProxy implements Handler.Callback, OnLifec
 
 			if (view != null && isInterfaceAdded) {
 				WebView webView = ((TiUIWebView) view).getWebView();
-				webView.removeJavascriptInterface(TI_BRIDGE_INTERFACE);
+				webView.removeJavascriptInterface(JS_INTERFACE_NAME);
 			}
 
 			if (this.proxy != null) {

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/WebViewProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/WebViewProxy.java
@@ -241,6 +241,7 @@ public class WebViewProxy extends ViewProxy implements Handler.Callback, OnLifec
 					getWebView().stopLoading();
 					return true;
 				case MSG_RELEASE:
+					destroyJSInterface();
 					TiUIWebView webView = (TiUIWebView) peekView();
 					if (webView != null) {
 						webView.destroyWebViewBinding();
@@ -664,10 +665,7 @@ public class WebViewProxy extends ViewProxy implements Handler.Callback, OnLifec
 	@Override
 	public void onDestroy(Activity activity)
 	{
-		if (jsInterface != null) {
-			jsInterface.destroy();
-			jsInterface = null;
-		}
+		destroyJSInterface();
 
 		TiUIWebView webView = (TiUIWebView) peekView();
 		if (webView == null) {
@@ -692,6 +690,14 @@ public class WebViewProxy extends ViewProxy implements Handler.Callback, OnLifec
 	public String getApiName()
 	{
 		return "Ti.UI.WebView";
+	}
+
+	private void destroyJSInterface()
+	{
+		if (jsInterface != null) {
+			jsInterface.destroy();
+			jsInterface = null;
+		}
 	}
 
 	private static class EvalJSRunnable implements Runnable

--- a/apidoc/Titanium/UI/WebView.yml
+++ b/apidoc/Titanium/UI/WebView.yml
@@ -31,7 +31,7 @@ description: |
 
     Scripts downloaded from remote web servers cannot access the Titanium namespace.
 
-    To read data from the remote web page, wait until the content is loaded, then use the
+    To interact with remote content, wait until the content is loaded, then use the
     [evalJS](Titanium.UI.WebView.evalJS) method to execute a JavaScript expression
     inside the web view and retrieve the value of an expression.
 
@@ -419,24 +419,23 @@ methods:
   - name: addScriptMessageHandler
     summary: Adds a script message handler.
     description: |
-        Adding a script message handler with name 'name' causes the JavaScript function postMessage(param)
-        to be defined in all frames in the web view. You use the same 'name' in your webview's html.
+        Adds a script message handler in all frames of the web-view.
+        On iOS, if the second argument is false or not passed, the JS function on the web-page should be executed as: 
+        `window.webkit.messageHandlers.yourHandlerName.postMessage(body)`
+        On Android, the second argument is always omitted and the JS function has to executed as: 
+        `window.tiBridge.emit('yourHandlerName', JSON.stringify(body));`
+        This is done to keep backward compatibility for iOS apps, and to enable Android apps to always use the unified `tiBridge` based pattern.
         Important: Call this method before setting the URL, or reload the URL if added later.
         JS code usages on your web page script:
         ```
         <script type="text/javascript">
-            // For iOS, the script-message handler is added to the `window.webkit.messageHandlers` object.
-            window.webkit.messageHandlers.yourHandlerName.postMessage({
-                message: 'This is an example string.'
-            });
-
-            // For Android, it's added directly to the `window` object, and only accepts the string type argument.
-            window.yourHandlerName.postMessage(JSON.stringify({
-              name: 'yourHandlerName', // Must to be passed so the app can differentiate multiple script message handlers.
-              body: {
-                message: 'This is an example string.'
-              },
-            }));
+            // For iOS with second argument as `false`:
+            const body = { message: 'Hello Titanium!'};
+            window.webkit.messageHandlers.yourHandlerName.postMessage(body);
+            
+            // For Android, or for iOS with second argument as true:
+            const body = { message: 'Hello Titanium!'};
+            window.tiBridge.emit('yourHandlerName', JSON.stringify(body));
         </script>
         ```
         Titanium app code usages:
@@ -444,7 +443,7 @@ methods:
         webView.addScriptMessageHandler('yourHandlerName');
         webView.addEventListener('message', (e) => {
             if (e.name === 'yourHandlerName') {
-                console.log(e.body.message);
+                console.log(e.body);
             }
         });
         webView.url = 'some-remote-url';
@@ -454,9 +453,14 @@ methods:
     parameters:
       - name: handlerName
         summary: |
-            The name of the message handler and should not be '_Ti_',
-            as titanium is using it for internal usage.
+            The name of the message handler, other than the reserved '_Ti_', or '_Ti_Cookie_'.
         type: String
+      - name: enableParity
+        summary: |
+            Injects script to enable web pages to call a unified expression `window.tiBridge.emit('handlerName', JSON.stringify(body));` for both Android and iOS.
+        type: Boolean
+        optional: true
+        default: false
 
   - name: removeScriptMessageHandler
     summary: Removes a script message handler.

--- a/apidoc/Titanium/UI/WebView.yml
+++ b/apidoc/Titanium/UI/WebView.yml
@@ -431,7 +431,7 @@ methods:
         <script type="text/javascript">
             // For iOS with second argument as `false`:
             const body = { message: 'Hello Titanium!'};
-            window.webkit.messageHandlers.yourHandlerName.postMessage(body);
+            window.webkit?.messageHandlers.yourHandlerName.postMessage(body);
             
             // For Android, or for iOS with second argument as true:
             const body = { message: 'Hello Titanium!'};

--- a/apidoc/Titanium/UI/WebView.yml
+++ b/apidoc/Titanium/UI/WebView.yml
@@ -421,7 +421,7 @@ methods:
     description: |
         Adding a script message handler with name 'name' causes the JavaScript function postMessage(param)
         to be defined in all frames in the web view. You use the same 'name' in your webview's html.
-        There are platform specific differences on native WebView.
+        Important: Call this method before setting the URL, or reload the URL if added later.
         JS code usages on your web page script:
         ```
         <script type="text/javascript">
@@ -447,6 +447,7 @@ methods:
                 console.log(e.body.message);
             }
         });
+        webView.url = 'some-remote-url';
         ```
     platforms: [android, iphone, ipad, macos]
     since: {android: "13.1.0", iphone: "8.0.0", ipad: "8.0.0", macos: "9.2.0"}

--- a/apidoc/Titanium/UI/WebView.yml
+++ b/apidoc/Titanium/UI/WebView.yml
@@ -420,21 +420,26 @@ methods:
     summary: Adds a script message handler.
     description: |
         Adds a script message handler in all frames of the web-view.
-        On iOS, if the second argument is false or not passed, the JS function on the web-page should be executed as: 
-        `window.webkit.messageHandlers.yourHandlerName.postMessage(body)`
-        On Android, the second argument is always omitted and the JS function has to executed as: 
+        The JS function on the web app has to executed as for any platform: 
         `window.tisdk.emit('yourHandlerName', JSON.stringify(body));`
-        This is done to keep backward compatibility for iOS apps, and to enable Android apps to always use the unified `tisdk` based pattern.
+        Additionally, for iOS, the previous syntax can still be used:
+        `window.webkit.messageHandlers.yourHandlerName.postMessage(body)`
         Important: Call this method before setting the URL, or reload the URL if added later.
         JS code usages on your web page script:
         ```
         <script type="text/javascript">
-            // For iOS with second argument as `false`:
             const body = { message: 'Hello Titanium!'};
-            window.webkit?.messageHandlers.yourHandlerName.postMessage(body);
+
+            // For both Android/iOS.
+            if (window.tisdk) {
+              window.tisdk.emit('yourHandlerName', JSON.stringify(body));
+              return;
+            }
             
-            // For Android, or for iOS with second argument as true:
-            window.tisdk.emit('yourHandlerName', JSON.stringify(body));
+            // iOS only: to keep the backward compatibility with the old syntax.
+            if (window.webkit?.messageHandlers?.yourHandlerName) {
+              window.webkit.messageHandlers.yourHandlerName.postMessage(body);
+            }
         </script>
         ```
         Titanium app code usages:
@@ -442,7 +447,7 @@ methods:
         webView.addScriptMessageHandler('yourHandlerName');
         webView.addEventListener('message', (e) => {
             if (e.name === 'yourHandlerName') {
-                console.log(e.body);
+                console.log(e.body.message);
             }
         });
         webView.url = 'some-remote-url';
@@ -454,12 +459,6 @@ methods:
         summary: |
             The name of the message handler, other than the reserved '_Ti_', or '_Ti_Cookie_'.
         type: String
-      - name: enableParity
-        summary: |
-            Injects script to enable web pages to call a unified expression `window.tisdk.emit('handlerName', JSON.stringify(body));` for both Android and iOS.
-        type: Boolean
-        optional: true
-        default: false
 
   - name: removeScriptMessageHandler
     summary: Removes a script message handler.

--- a/apidoc/Titanium/UI/WebView.yml
+++ b/apidoc/Titanium/UI/WebView.yml
@@ -35,7 +35,7 @@ description: |
     [evalJS](Titanium.UI.WebView.evalJS) method to execute a JavaScript expression
     inside the web view and retrieve the value of an expression.
 
-    To trigger a message from the remote web page, refer <Titanium.UI.WebView.addScriptMessageHandler> usages.
+    To trigger a message from the remote web page, refer to <Titanium.UI.WebView.addScriptMessageHandler>.
 
     You can inject the local `Ti.App.fireEvent` bindings yourself by adding a script element using
     evalJS.
@@ -419,29 +419,32 @@ methods:
   - name: addScriptMessageHandler
     summary: Adds a script message handler.
     description: |
-        Adds a script message handler in all frames of the web-view.
-        The JS function on the web app has to executed as for any platform: 
-        `window.tisdk.emit('yourHandlerName', JSON.stringify(body));`
-        Additionally, for iOS, the previous syntax can still be used:
+        Adds a script message handler that enables communication between the web content and your Titanium application in all frames of the web view.
+
+        **New, cross-platform API:**
+        Use `window.tisdk.emit('yourHandlerName', JSON.stringify(body));` to send messages from web content. This API is available on all platforms and should be preferred for new development.
+
+        **Legacy iOS-only API:**
+        For backwards compatibility or when targeting SDK 13.0.0 or older, you can also use the legacy iOS-specific API:
         `window.webkit.messageHandlers.yourHandlerName.postMessage(body)`
-        Important: Call this method before setting the URL, or reload the URL if added later.
-        JS code usages on your web page script:
+        This method works only on iOS and will not be available on other platforms.
+
+        **Important:**
+        Always call `addScriptMessageHandler` before loading the page (setting the URL), or reload the URL after adding the handler to ensure your web content can communicate as expected.
+
+        JS code usage examples for your webpage:
         ```
         <script type="text/javascript">
             const body = { message: 'Hello Titanium!'};
 
-            // For both Android/iOS.
-            if (window.tisdk) {
-              window.tisdk.emit('yourHandlerName', JSON.stringify(body));
-              return;
-            }
-            
-            // iOS only: to keep the backward compatibility with the old syntax.
-            if (window.webkit?.messageHandlers?.yourHandlerName) {
-              window.webkit.messageHandlers.yourHandlerName.postMessage(body);
-            }
+            // Preferred API for all platforms in SDK 13.1.0 and later.
+            window.tisdk.emit('yourHandlerName', JSON.stringify(body));
+
+            // Legacy iOS-only API for SDK 13.0.0 and older.
+            window.webkit.messageHandlers.yourHandlerName.postMessage(body);
         </script>
         ```
+
         Titanium app code usages:
         ```js
         webView.addScriptMessageHandler('yourHandlerName');
@@ -450,7 +453,7 @@ methods:
                 console.log(e.body.message);
             }
         });
-        webView.url = 'some-remote-url';
+        webView.url = 'https://some-remote-url.org';
         ```
     platforms: [android, iphone, ipad, macos]
     since: {android: "13.1.0", iphone: "8.0.0", ipad: "8.0.0", macos: "9.2.0"}

--- a/apidoc/Titanium/UI/WebView.yml
+++ b/apidoc/Titanium/UI/WebView.yml
@@ -31,9 +31,11 @@ description: |
 
     Scripts downloaded from remote web servers cannot access the Titanium namespace.
 
-    To interact with remote content, wait until the content is loaded, then use the
+    To read data from the remote web page, wait until the content is loaded, then use the
     [evalJS](Titanium.UI.WebView.evalJS) method to execute a JavaScript expression
     inside the web view and retrieve the value of an expression.
+
+    To trigger a message from the remote web page, refer <Titanium.UI.WebView.addScriptMessageHandler> usages.
 
     You can inject the local `Ti.App.fireEvent` bindings yourself by adding a script element using
     evalJS.
@@ -50,8 +52,6 @@ description: |
     );
     ```
     The `binding.min.js` is available in the [repository](https://github.com/tidev/titanium-sdk/tree/master/android/modules/ui/assets/Resources/ti.internal/webview).
-
-    For iOS check the example in <Titanium.UI.WebView.addScriptMessageHandler>.
 
     #### Local JavaScript Files
 
@@ -419,28 +419,37 @@ methods:
   - name: addScriptMessageHandler
     summary: Adds a script message handler.
     description: |
-        Adding a script message handler with name 'name' causes the JavaScript function
-        window.webkit.messageHandlers.name.postMessage(messageBody) to be defined in all
-        frames in the web view. You use the same 'name' in your webview's html.
-        Example JS code for the webview page:
+        Adding a script message handler with name 'name' causes the JavaScript function postMessage(param)
+        to be defined in all frames in the web view. You use the same 'name' in your webview's html.
+        There are platform specific differences on native WebView.
+        JS code usages on your web page script:
         ```
         <script type="text/javascript">
+            // For iOS, the script-message handler is added to the `window.webkit.messageHandlers` object.
             window.webkit.messageHandlers.yourHandlerName.postMessage({
                 message: 'This is an example string.'
             });
+
+            // For Android, it's added directly to the `window` object, and only accepts the string type argument.
+            window.yourHandlerName.postMessage(JSON.stringify({
+              name: 'yourHandlerName', // Must to be passed so the app can differentiate multiple script message handlers.
+              body: {
+                message: 'This is an example string.'
+              },
+            }));
         </script>
         ```
-        Connection to the webview:
+        Titanium app code usages:
         ```js
         webView.addScriptMessageHandler('yourHandlerName');
-        webView.addEventListener('message', ({ name }) => {
-            if (name === 'yourHandlerName') {
+        webView.addEventListener('message', (e) => {
+            if (e.name === 'yourHandlerName') {
                 console.log(e.body.message);
             }
         });
         ```
-    platforms: [iphone, ipad, macos]
-    since: {iphone: "8.0.0", ipad: "8.0.0", macos: "9.2.0"}
+    platforms: [android, iphone, ipad, macos]
+    since: {android: "13.1.0", iphone: "8.0.0", ipad: "8.0.0", macos: "9.2.0"}
     parameters:
       - name: handlerName
         summary: |
@@ -450,8 +459,8 @@ methods:
 
   - name: removeScriptMessageHandler
     summary: Removes a script message handler.
-    platforms: [iphone, ipad, macos]
-    since: {iphone: "8.0.0", ipad: "8.0.0", macos: "9.2.0"}
+    platforms: [android, iphone, ipad, macos]
+    since: {android: "13.1.0", iphone: "8.0.0", ipad: "8.0.0", macos: "9.2.0"}
     parameters:
       - name: name
         summary: The name of the message handler.
@@ -652,8 +661,8 @@ events:
     description: |
         This event get fired when you have added a message handler using <Titanium.UI.WebView.addScriptMessageHandler>
         and the webpage sends a message to it.
-    platforms: [iphone, ipad, macos]
-    since: {iphone: "8.0.0", ipad: "8.0.0", macos: "9.2.0"}
+    platforms: [android, iphone, ipad, macos]
+    since: {android: "13.1.0", iphone: "8.0.0", ipad: "8.0.0", macos: "9.2.0"}
     properties:
       - name: url
         summary: URL of the web document being loaded.

--- a/apidoc/Titanium/UI/WebView.yml
+++ b/apidoc/Titanium/UI/WebView.yml
@@ -434,7 +434,6 @@ methods:
             window.webkit?.messageHandlers.yourHandlerName.postMessage(body);
             
             // For Android, or for iOS with second argument as true:
-            const body = { message: 'Hello Titanium!'};
             window.tisdk.emit('yourHandlerName', JSON.stringify(body));
         </script>
         ```

--- a/apidoc/Titanium/UI/WebView.yml
+++ b/apidoc/Titanium/UI/WebView.yml
@@ -423,8 +423,8 @@ methods:
         On iOS, if the second argument is false or not passed, the JS function on the web-page should be executed as: 
         `window.webkit.messageHandlers.yourHandlerName.postMessage(body)`
         On Android, the second argument is always omitted and the JS function has to executed as: 
-        `window.tiBridge.emit('yourHandlerName', JSON.stringify(body));`
-        This is done to keep backward compatibility for iOS apps, and to enable Android apps to always use the unified `tiBridge` based pattern.
+        `window.tisdk.emit('yourHandlerName', JSON.stringify(body));`
+        This is done to keep backward compatibility for iOS apps, and to enable Android apps to always use the unified `tisdk` based pattern.
         Important: Call this method before setting the URL, or reload the URL if added later.
         JS code usages on your web page script:
         ```
@@ -435,7 +435,7 @@ methods:
             
             // For Android, or for iOS with second argument as true:
             const body = { message: 'Hello Titanium!'};
-            window.tiBridge.emit('yourHandlerName', JSON.stringify(body));
+            window.tisdk.emit('yourHandlerName', JSON.stringify(body));
         </script>
         ```
         Titanium app code usages:
@@ -457,7 +457,7 @@ methods:
         type: String
       - name: enableParity
         summary: |
-            Injects script to enable web pages to call a unified expression `window.tiBridge.emit('handlerName', JSON.stringify(body));` for both Android and iOS.
+            Injects script to enable web pages to call a unified expression `window.tisdk.emit('handlerName', JSON.stringify(body));` for both Android and iOS.
         type: Boolean
         optional: true
         default: false

--- a/iphone/Classes/TiUIWebView.h
+++ b/iphone/Classes/TiUIWebView.h
@@ -40,7 +40,7 @@
 - (void)viewDidClose;
 - (void)reload;
 - (WKWebView *)webView;
-
+- (WKUserScript *)userScriptForMessageHandlerParity:(NSString *)handlerName;
 - (void)fireEvent:(id)listener withObject:(id)obj remove:(BOOL)yn thisObject:(id)thisObject_;
 
 @end

--- a/iphone/Classes/TiUIWebView.h
+++ b/iphone/Classes/TiUIWebView.h
@@ -40,7 +40,7 @@
 - (void)viewDidClose;
 - (void)reload;
 - (WKWebView *)webView;
-- (WKUserScript *)userScriptForMessageHandlerParity:(NSString *)handlerName;
+- (WKUserScript *)userScriptForMessageHandlerParity;
 - (void)fireEvent:(id)listener withObject:(id)obj remove:(BOOL)yn thisObject:(id)thisObject_;
 
 @end

--- a/iphone/Classes/TiUIWebView.m
+++ b/iphone/Classes/TiUIWebView.m
@@ -534,6 +534,21 @@ static NSString *const baseInjectScript = @"Ti._hexish=function(a){var r='';var 
                               forMainFrameOnly:YES] autorelease];
 }
 
+- (WKUserScript *)userScriptForMessageHandlerParity:(NSString *)handlerName
+{
+  NSString *script = @"(function(name){ \
+    window.tiBridge={ \
+      emit:function(name, payload){ \
+        window.webkit.messageHandlers[name].postMessage(JSON.parse(payload)); \
+      } \
+     }; \
+    })('%@'); \
+    ";
+
+  NSString *sourceString = [NSString stringWithFormat:script, handlerName];
+  return [[[WKUserScript alloc] initWithSource:sourceString injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:NO] autorelease];
+}
+
 - (WKUserScript *)userScriptTitaniumJSEvaluationFromString:(NSString *)string
 {
   return [[[WKUserScript alloc] initWithSource:string

--- a/iphone/Classes/TiUIWebView.m
+++ b/iphone/Classes/TiUIWebView.m
@@ -537,7 +537,7 @@ static NSString *const baseInjectScript = @"Ti._hexish=function(a){var r='';var 
 - (WKUserScript *)userScriptForMessageHandlerParity:(NSString *)handlerName
 {
   NSString *script = @"(function(name){ \
-    window.tiBridge={ \
+    window.tisdk={ \
       emit:function(name, payload){ \
         window.webkit.messageHandlers[name].postMessage(JSON.parse(payload)); \
       } \

--- a/iphone/Classes/TiUIWebView.m
+++ b/iphone/Classes/TiUIWebView.m
@@ -534,19 +534,16 @@ static NSString *const baseInjectScript = @"Ti._hexish=function(a){var r='';var 
                               forMainFrameOnly:YES] autorelease];
 }
 
-- (WKUserScript *)userScriptForMessageHandlerParity:(NSString *)handlerName
+- (WKUserScript *)userScriptForMessageHandlerParity
 {
-  NSString *script = @"(function(name){ \
-    window.tisdk={ \
-      emit:function(name, payload){ \
-        window.webkit.messageHandlers[name].postMessage(JSON.parse(payload)); \
+  NSString *tisdkScript = @"window.tisdk={ \
+      emit:function(handlerName, payload){ \
+        window.webkit.messageHandlers[handlerName].postMessage(JSON.parse(payload)); \
       } \
      }; \
-    })('%@'); \
     ";
 
-  NSString *sourceString = [NSString stringWithFormat:script, handlerName];
-  return [[[WKUserScript alloc] initWithSource:sourceString injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:NO] autorelease];
+  return [[[WKUserScript alloc] initWithSource:tisdkScript injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:NO] autorelease];
 }
 
 - (WKUserScript *)userScriptTitaniumJSEvaluationFromString:(NSString *)string

--- a/iphone/Classes/TiUIWebViewProxy.h
+++ b/iphone/Classes/TiUIWebViewProxy.h
@@ -19,7 +19,6 @@
 - (void)refreshHTMLContent;
 - (void)setPageToken:(NSString *)pageToken;
 
-@property (nonatomic, assign) BOOL hasAddedTisdkScript;
 @end
 
 #endif

--- a/iphone/Classes/TiUIWebViewProxy.h
+++ b/iphone/Classes/TiUIWebViewProxy.h
@@ -18,6 +18,8 @@
 
 - (void)refreshHTMLContent;
 - (void)setPageToken:(NSString *)pageToken;
+
+@property (nonatomic, assign) BOOL hasAddedTisdkScript;
 @end
 
 #endif

--- a/iphone/Classes/TiUIWebViewProxy.m
+++ b/iphone/Classes/TiUIWebViewProxy.m
@@ -384,12 +384,25 @@ static NSArray *webViewKeySequence;
   [controller removeAllUserScripts];
 }
 
-- (void)addScriptMessageHandler:(id)value
+- (void)addScriptMessageHandler:(id)args
 {
-  ENSURE_SINGLE_ARG(value, NSString);
+  NSString *handlerName = nil;
+  ENSURE_ARG_AT_INDEX(handlerName, args, 0, NSString);
+
+  BOOL enableParity = NO;
+  if ([args count] > 1) {
+    enableParity = [TiUtils boolValue:[args objectAtIndex:1] def:NO];
+  }
 
   WKUserContentController *controller = [[[self wkWebView] configuration] userContentController];
-  [controller addScriptMessageHandler:[self webView] name:value];
+
+  // Enable web pages to use unified API for both Android and iOS as:
+  // window.tiBridge.emit('handlerName', JSON.strinigify(body));
+  if (enableParity) {
+    [controller addUserScript:[[self webView] userScriptForMessageHandlerParity:handlerName]];
+  }
+
+  [controller addScriptMessageHandler:[self webView] name:handlerName];
 }
 
 - (void)removeScriptMessageHandler:(id)value

--- a/iphone/Classes/TiUIWebViewProxy.m
+++ b/iphone/Classes/TiUIWebViewProxy.m
@@ -384,25 +384,17 @@ static NSArray *webViewKeySequence;
   [controller removeAllUserScripts];
 }
 
-- (void)addScriptMessageHandler:(id)args
+- (void)addScriptMessageHandler:(id)value
 {
-  NSString *handlerName = nil;
-  ENSURE_ARG_AT_INDEX(handlerName, args, 0, NSString);
-
-  BOOL enableParity = NO;
-  if ([args count] > 1) {
-    enableParity = [TiUtils boolValue:[args objectAtIndex:1] def:NO];
-  }
+  ENSURE_SINGLE_ARG(value, NSString);
 
   WKUserContentController *controller = [[[self wkWebView] configuration] userContentController];
 
   // Enable web pages to use unified API for both Android and iOS as:
   // window.tisdk.emit('handlerName', JSON.stringify(body));
-  if (enableParity) {
-    [controller addUserScript:[[self webView] userScriptForMessageHandlerParity:handlerName]];
-  }
+  [controller addUserScript:[[self webView] userScriptForMessageHandlerParity]];
 
-  [controller addScriptMessageHandler:[self webView] name:handlerName];
+  [controller addScriptMessageHandler:[self webView] name:value];
 }
 
 - (void)removeScriptMessageHandler:(id)value

--- a/iphone/Classes/TiUIWebViewProxy.m
+++ b/iphone/Classes/TiUIWebViewProxy.m
@@ -14,7 +14,9 @@
 #import "TiNetworkCookieProxy.h"
 #import "TiUIWebView.h"
 
-@implementation TiUIWebViewProxy
+@implementation TiUIWebViewProxy {
+  BOOL _hasAddedTisdkScript;
+}
 
 static NSArray *webViewKeySequence;
 
@@ -31,6 +33,7 @@ static NSArray *webViewKeySequence;
 - (id)_initWithPageContext:(id<TiEvaluator>)context
 {
   if (self = [super _initWithPageContext:context]) {
+    _hasAddedTisdkScript = NO;
   }
 
   return self;
@@ -382,6 +385,7 @@ static NSArray *webViewKeySequence;
 {
   WKUserContentController *controller = [[[self wkWebView] configuration] userContentController];
   [controller removeAllUserScripts];
+  _hasAddedTisdkScript = NO;
 }
 
 - (void)addScriptMessageHandler:(id)value
@@ -392,7 +396,10 @@ static NSArray *webViewKeySequence;
 
   // Enable web pages to use unified API for both Android and iOS as:
   // window.tisdk.emit('handlerName', JSON.stringify(body));
-  [controller addUserScript:[[self webView] userScriptForMessageHandlerParity]];
+  if (!_hasAddedTisdkScript) {
+    [controller addUserScript:[[self webView] userScriptForMessageHandlerParity]];
+    _hasAddedTisdkScript = YES;
+  }
 
   [controller addScriptMessageHandler:[self webView] name:value];
 }

--- a/iphone/Classes/TiUIWebViewProxy.m
+++ b/iphone/Classes/TiUIWebViewProxy.m
@@ -397,7 +397,7 @@ static NSArray *webViewKeySequence;
   WKUserContentController *controller = [[[self wkWebView] configuration] userContentController];
 
   // Enable web pages to use unified API for both Android and iOS as:
-  // window.tiBridge.emit('handlerName', JSON.strinigify(body));
+  // window.tisdk.emit('handlerName', JSON.stringify(body));
   if (enableParity) {
     [controller addUserScript:[[self webView] userScriptForMessageHandlerParity:handlerName]];
   }

--- a/iphone/Classes/TiUIWebViewProxy.m
+++ b/iphone/Classes/TiUIWebViewProxy.m
@@ -14,6 +14,10 @@
 #import "TiNetworkCookieProxy.h"
 #import "TiUIWebView.h"
 
+@interface TiUIWebViewProxy ()
+@property (nonatomic, assign) BOOL hasAddedTisdkScript;
+@end
+
 @implementation TiUIWebViewProxy
 
 static NSArray *webViewKeySequence;

--- a/iphone/Classes/TiUIWebViewProxy.m
+++ b/iphone/Classes/TiUIWebViewProxy.m
@@ -14,9 +14,7 @@
 #import "TiNetworkCookieProxy.h"
 #import "TiUIWebView.h"
 
-@implementation TiUIWebViewProxy {
-  BOOL _hasAddedTisdkScript;
-}
+@implementation TiUIWebViewProxy
 
 static NSArray *webViewKeySequence;
 
@@ -33,7 +31,7 @@ static NSArray *webViewKeySequence;
 - (id)_initWithPageContext:(id<TiEvaluator>)context
 {
   if (self = [super _initWithPageContext:context]) {
-    _hasAddedTisdkScript = NO;
+    self.hasAddedTisdkScript = NO;
   }
 
   return self;
@@ -385,7 +383,7 @@ static NSArray *webViewKeySequence;
 {
   WKUserContentController *controller = [[[self wkWebView] configuration] userContentController];
   [controller removeAllUserScripts];
-  _hasAddedTisdkScript = NO;
+  self.hasAddedTisdkScript = NO;
 }
 
 - (void)addScriptMessageHandler:(id)value
@@ -396,9 +394,9 @@ static NSArray *webViewKeySequence;
 
   // Enable web pages to use unified API for both Android and iOS as:
   // window.tisdk.emit('handlerName', JSON.stringify(body));
-  if (!_hasAddedTisdkScript) {
+  if (!self.hasAddedTisdkScript) {
     [controller addUserScript:[[self webView] userScriptForMessageHandlerParity]];
-    _hasAddedTisdkScript = YES;
+    self.hasAddedTisdkScript = YES;
   }
 
   [controller addScriptMessageHandler:[self webView] name:value];


### PR DESCRIPTION
This PR implements the `addScriptMessageHandler` and the `removeScriptMessageHandler` methods for Android platform, bringing parity with the iOS.

**Titanium App:**
```
const HANDLER_NAME = 'yourHandlerName';
const window = Ti.UI.createWindow();
const webView = Ti.UI.createWebView({ url: 'some-remote-url' });

webView.addScriptMessageHandler(HANDLER_NAME, true);
webView.addEventListener('message', (e) => {
	if (e.name === HANDLER_NAME) {
		alert(e.body.message);
	}
});

window.add(webView);
window.open();

```

**Web page:**
```
<script type="text/javascript">
  const body = { message: 'Hello Titanium!'};

  // For both Android/iOS.
  if (window.tisdk) {
    window.tisdk.emit('yourHandlerName', JSON.stringify(body));
    return;
  }
  
  // iOS only: to keep the backward compatibility with the old syntax.
  if (window.webkit?.messageHandlers?.yourHandlerName) {
    window.webkit.messageHandlers.yourHandlerName.postMessage(body);
  }
</script>
```