### PR TITLE
fix: show error if build command's config fails

### DIFF
--- a/cli/commands/build.js
+++ b/cli/commands/build.js
@@ -237,6 +237,10 @@ export function config(logger, config, cli) {
 				callback(null, conf);
 			});
 		})(function (err, result) {
+			if (err) {
+				console.error(err);
+				process.exit(1);
+			}
 			finished(result);
 		});
 	};


### PR DESCRIPTION
I don't know what I was thinking over 10 years ago when I thought it was a good idea to not bubble up errors from a command's `config()` function. We recently saw a bug where something was blowing up in `config()`, but the CLI continued on and eventually the command failed with an error that was unrelated to the actual problem. This PR surfaces the error and causes the CLI to exit with code 1.