### PR TITLE
chore(ios): removed old iTunes references in apidoc

### DIFF
--- a/apidoc/Titanium/App/iOS/iOS.yml
+++ b/apidoc/Titanium/App/iOS/iOS.yml
@@ -744,7 +744,7 @@ properties:
 
   - name: UTTYPE_APPLE_PROTECTED_MPEG4_AUDIO
     summary: |
-        Uniform type identifier for protected MPEG-4 audio (iTunes music store format).
+        Uniform type identifier for Apple-protected MPEG-4 audio.
     type: String
     permission: read-only
     since: 5.0.0

--- a/apidoc/Titanium/Database/Database.yml
+++ b/apidoc/Titanium/Database/Database.yml
@@ -33,7 +33,7 @@ methods:
       Files stored in the `Private Documents` directory on iOS5 will be
       automatically backed up to iCloud and removed from the device in low
       storage situations. See
-      [How do I prevent files from being backed up to iCloud and iTunes?](https://developer.apple.com/library/ios/qa/qa1719/_index.html)
+      [How do I prevent files from being backed up to iCloud?](https://developer.apple.com/library/ios/qa/qa1719/_index.html)
       for details. To prevent this for database files, use the <Titanium.Database.DB.file> 
       object with the <Titanium.Filesystem.File.remoteBackup> property. 
 

--- a/apidoc/Titanium/Filesystem/File.yml
+++ b/apidoc/Titanium/Filesystem/File.yml
@@ -440,7 +440,7 @@ properties:
         versions 5.0.1 and later, but is safe to set on earlier versions.
 
         Note that setting this property to `false` will also prevent the
-        file identified by this object from being backed up to iTunes.
+        file identified by this object from being backed up to iCloud.
     default: true
     type: Boolean
     platforms: [iphone,ipad, macos]

--- a/apidoc/Titanium/Media/Item.yml
+++ b/apidoc/Titanium/Media/Item.yml
@@ -67,8 +67,7 @@ properties:
 
   - name: beatsPerMinute
     summary: |
-        The number of musical beats per minute for the media item, corresponding 
-        to the "BPM" field in the Info tab in the "Get Info" dialog in iTunes.
+        The number of musical beats per minute for the media item.
     type: Number
     permission: read-only
     since: "6.1.0"
@@ -81,8 +80,7 @@ properties:
 
   - name: comments
     summary: |
-        Textual information about the media item, corresponding to the "Comments" 
-        field in in the Info tab in the Get Info dialog in iTunes.
+        Textual information about the media item.
     type: String
     permission: read-only
     since: "6.1.0"
@@ -222,8 +220,7 @@ properties:
 
   - name: userGrouping
     summary: |
-        Corresponds to the "Grouping" field in the Info tab in the "Get Info" 
-        dialog in iTunes.
+        Grouping information for the media item.
     type: String
     permission: read-only
     since: "6.1.0"

--- a/apidoc/Titanium/Network/Network.yml
+++ b/apidoc/Titanium/Network/Network.yml
@@ -109,7 +109,7 @@ description: |
 
     **Test IPV6 DNS64/NAT64**
 
-    If you submit your application to the iTunes Store, you should setup an IPv6 DNS64/NAT64
+    If you submit your application to the App Store, you should setup an IPv6 DNS64/NAT64
     network to test your application to verify it is compatible with IPv6.
 
     If you are running macOS 10.11 or greater, you can use your computer to setup a local IPv6 Wi-Fi

--- a/apidoc/Titanium/UI/iOS/CoverFlowView.yml
+++ b/apidoc/Titanium/UI/iOS/CoverFlowView.yml
@@ -2,7 +2,7 @@
 name: Titanium.UI.iOS.CoverFlowView
 summary: |
     The cover flow view is a container showing animated three-dimensional images in a style 
-    consistent with the cover flow presentation style used for iPod, iTunes, and file browsing.
+    consistent with the former cover flow presentation style used for iPod, iTunes, and Finder.
 description: |
     The cover flow view is created by the <Titanium.UI.iOS.createCoverFlowView> method or 
     **`<CoverFlowView>`** element in an Alloy application.


### PR DESCRIPTION
**Description:**

- removed old references to _iTunes_ in the API documentation (e.g. iTunes Store &rarr; App Store, iTunes &rarr; iCloud)
- only at `CoverFlowView` is it still listed for historical reasons 😄 