### PR TITLE
feat(ios): add parity for “backgroundSelectedColor” API

### DIFF
--- a/apidoc/Titanium/UI/View.yml
+++ b/apidoc/Titanium/UI/View.yml
@@ -1365,7 +1365,8 @@ properties:
 
         Defaults to background color of this view.
     type: [String, Titanium.UI.Color]
-    platforms: [android]
+    since: {android: "0.9", iphone: "13.1.0", ipad: "13.1.0", "macos": "13.1.0"}
+    platforms: [android, iphone, ipad, macos]
 
   - name: backgroundSelectedImage
     summary: Selected background image url for the view, specified as a local file path or URL.
@@ -1483,10 +1484,14 @@ properties:
     since: "9.3.0"
 
   - name: focusable
-    summary: Whether view should be focusable while navigating with the trackball.
+    summary: Enables the view to receive focus and selected background feedback when interacted with.
+    description: |
+        On Android this controls whether the view participates in focus navigation such as with a D-Pad or trackball.
+        On all platform, this property is required to use the `backgroundSelectedColor` property.
     type: Boolean
     default: false
-    platforms: [android]
+    since: {android: "0.9", iphone: "13.1.0", ipad: "13.1.0", "macos": "13.1.0"}
+    platforms: [android, iphone, ipad, macos]
 
   - name: height
     summary: View height, in platform-specific units.
@@ -1861,17 +1866,19 @@ properties:
         Touch feedback is only applied to a view's background. It is never applied to the view's foreground content
         such as a <Titanium.UI.ImageView>'s image.
 
-        On Android this maps to the native ripple effect. On iOS the view background briefly switches to the feedback
-        color for the duration of the touch.
+        For Titanium versions older than 9.1.0, touch feedback only works if you set the
+        <Titanium.UI.View.backgroundColor> property to a non-transparent color.
     type: Boolean
     default: false
-    since: {android: "6.1.0", iphone: "13.1.0", ipad: "13.1.0", macos: "13.1.0"}
+    platforms: [android]
+    since: "6.1.0"
 
   - name: touchFeedbackColor
     summary: Optional touch feedback ripple color. This has no effect unless `touchFeedback` is true.
-    description: Defaults to the native highlight color on each platform.
+    description: Defaults to provided theme color.
     type: String
-    since: {android: "6.1.0", iphone: "13.1.0", ipad: "13.1.0", macos: "13.1.0"}
+    platforms: [android]
+    since: "6.1.0"
 
   - name: transform
     summary: Transformation matrix to apply to the view.

--- a/apidoc/Titanium/UI/View.yml
+++ b/apidoc/Titanium/UI/View.yml
@@ -1861,19 +1861,19 @@ properties:
         Touch feedback is only applied to a view's background. It is never applied to the view's foreground content
         such as a <Titanium.UI.ImageView>'s image.
 
-        For Titanium versions older than 9.1.0, touch feedback only works if you set the
-        <Titanium.UI.View.backgroundColor> property to a non-transparent color.
+        On Android this maps to the native ripple effect. On iOS the view background briefly switches to the feedback
+        color for the duration of the touch.
     type: Boolean
     default: false
-    platforms: [android]
-    since: "6.1.0"
+    platforms: [android, iphone, ipad]
+    since: {android: "6.1.0", iphone: "13.1.0", ipad: "13.1.0", macos: "13.1.0"}
 
   - name: touchFeedbackColor
     summary: Optional touch feedback ripple color. This has no effect unless `touchFeedback` is true.
-    description: Defaults to provided theme color.
+    description: Defaults to the native highlight color on each platform.
     type: String
-    platforms: [android]
-    since: "6.1.0"
+    platforms: [android, iphone, ipad]
+    since: {android: "6.1.0", iphone: "13.1.0", ipad: "13.1.0", macos: "13.1.0"}
 
   - name: transform
     summary: Transformation matrix to apply to the view.

--- a/apidoc/Titanium/UI/View.yml
+++ b/apidoc/Titanium/UI/View.yml
@@ -1865,14 +1865,12 @@ properties:
         color for the duration of the touch.
     type: Boolean
     default: false
-    platforms: [android, iphone, ipad]
     since: {android: "6.1.0", iphone: "13.1.0", ipad: "13.1.0", macos: "13.1.0"}
 
   - name: touchFeedbackColor
     summary: Optional touch feedback ripple color. This has no effect unless `touchFeedback` is true.
     description: Defaults to the native highlight color on each platform.
     type: String
-    platforms: [android, iphone, ipad]
     since: {android: "6.1.0", iphone: "13.1.0", ipad: "13.1.0", macos: "13.1.0"}
 
   - name: transform

--- a/apidoc/Titanium/UI/View.yml
+++ b/apidoc/Titanium/UI/View.yml
@@ -1360,10 +1360,7 @@ properties:
     summary: Selected background color of the view, as a color name or hex triplet.
     description: |
         For information about color values, see the "Colors" section of <Titanium.UI>.
-
-        `focusable` must be true for normal views.
-
-        Defaults to background color of this view.
+        Defaults to transparent, so the background color of this view will be used.
     type: [String, Titanium.UI.Color]
     since: {android: "0.9", iphone: "13.1.0", ipad: "13.1.0", "macos": "13.1.0"}
     platforms: [android, iphone, ipad, macos]
@@ -1484,14 +1481,10 @@ properties:
     since: "9.3.0"
 
   - name: focusable
-    summary: Enables the view to receive focus and selected background feedback when interacted with.
-    description: |
-        On Android this controls whether the view participates in focus navigation such as with a D-Pad or trackball.
-        On all platform, this property is required to use the `backgroundSelectedColor` property.
+    summary: Whether view should be focusable while navigating with the trackball.
     type: Boolean
     default: false
-    since: {android: "0.9", iphone: "13.1.0", ipad: "13.1.0", "macos": "13.1.0"}
-    platforms: [android, iphone, ipad, macos]
+    platforms: [android]
 
   - name: height
     summary: View height, in platform-specific units.

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiUIView.h
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiUIView.h
@@ -69,11 +69,11 @@ void ModifyScrollViewForKeyboardHeightAndContentHeightWithResponderRect(UIScroll
   id transformMatrix;
   BOOL childrenInitialized;
   BOOL touchEnabled;
-  BOOL touchFeedback;
-  BOOL touchFeedbackHasStoredBackground;
-  NSUInteger touchFeedbackTouchCount;
-  TiColor *touchFeedbackColor;
-  UIColor *touchFeedbackPreviousBackgroundColor;
+  BOOL focusable;
+  BOOL focusableHasStoredBackground;
+  NSUInteger focusableTouchCount;
+  TiColor *backgroundSelectedColor;
+  UIColor *focusablePreviousBackgroundColor;
 
   unsigned int animationDelayGuard;
   unsigned int animationDelayGuardForLayout;

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiUIView.h
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiUIView.h
@@ -69,11 +69,10 @@ void ModifyScrollViewForKeyboardHeightAndContentHeightWithResponderRect(UIScroll
   id transformMatrix;
   BOOL childrenInitialized;
   BOOL touchEnabled;
-  BOOL focusable;
-  BOOL focusableHasStoredBackground;
-  NSUInteger focusableTouchCount;
+  BOOL hasStoredBackgroundForSelectionHighlight;
+  NSUInteger backgroundSelectedHighlightTouchCount;
   TiColor *backgroundSelectedColor;
-  UIColor *focusablePreviousBackgroundColor;
+  UIColor *backgroundSelectedPreviousBackgroundColor;
 
   unsigned int animationDelayGuard;
   unsigned int animationDelayGuardForLayout;

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiUIView.h
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiUIView.h
@@ -13,6 +13,7 @@
 #endif
 // By declaring a scrollView protocol, TiUITextWidget can access
 @class TiUIView;
+@class TiColor;
 
 /**
  The protocol for scrolling.
@@ -68,6 +69,11 @@ void ModifyScrollViewForKeyboardHeightAndContentHeightWithResponderRect(UIScroll
   id transformMatrix;
   BOOL childrenInitialized;
   BOOL touchEnabled;
+  BOOL touchFeedback;
+  BOOL touchFeedbackHasStoredBackground;
+  NSUInteger touchFeedbackTouchCount;
+  TiColor *touchFeedbackColor;
+  UIColor *touchFeedbackPreviousBackgroundColor;
 
   unsigned int animationDelayGuard;
   unsigned int animationDelayGuardForLayout;

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiUIView.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiUIView.m
@@ -187,8 +187,8 @@ DEFINE_EXCEPTIONS
   [upSwipeRecognizer release];
   [downSwipeRecognizer release];
   [longPressRecognizer release];
-  RELEASE_TO_NIL(touchFeedbackColor);
-  RELEASE_TO_NIL(touchFeedbackPreviousBackgroundColor);
+  RELEASE_TO_NIL(backgroundSelectedColor);
+  RELEASE_TO_NIL(focusablePreviousBackgroundColor);
   proxy = nil;
   touchDelegate = nil;
   [super dealloc];
@@ -222,9 +222,9 @@ DEFINE_EXCEPTIONS
 {
   self = [super init];
   if (self != nil) {
-    touchFeedback = NO;
-    touchFeedbackHasStoredBackground = NO;
-    touchFeedbackTouchCount = 0;
+    focusable = NO;
+    focusableHasStoredBackground = NO;
+    focusableTouchCount = 0;
   }
   return self;
 }
@@ -288,20 +288,20 @@ DEFINE_EXCEPTIONS
   }
 }
 
-#pragma mark Touch Feedback
+#pragma mark Focusable Highlight
 
-- (UIColor *)resolvedTouchFeedbackColor
+- (UIColor *)resolvedBackgroundSelectedColor
 {
-  if (touchFeedbackColor != nil) {
-    return [touchFeedbackColor _color];
+  if (backgroundSelectedColor != nil) {
+    return [backgroundSelectedColor _color];
   }
 
   return [[UIColor labelColor] colorWithAlphaComponent:0.12f];
 }
 
-- (void)refreshTouchFeedbackHighlight
+- (void)refreshBackgroundSelectedHighlight
 {
-  UIColor *color = [self resolvedTouchFeedbackColor];
+  UIColor *color = [self resolvedBackgroundSelectedColor];
   if (color == nil) {
     return;
   }
@@ -309,60 +309,60 @@ DEFINE_EXCEPTIONS
   [super setBackgroundColor:color];
 }
 
-- (void)applyTouchFeedbackHighlightWithAdditionalTouches:(NSUInteger)touchCount
+- (void)applyBackgroundSelectedHighlightWithAdditionalTouches:(NSUInteger)touchCount
 {
-  if (touchCount == 0 && !touchFeedbackHasStoredBackground) {
+  if (touchCount == 0 && !focusableHasStoredBackground) {
     return;
   }
 
-  if (!touchFeedbackHasStoredBackground) {
-    touchFeedbackHasStoredBackground = YES;
-    RELEASE_TO_NIL(touchFeedbackPreviousBackgroundColor);
+  if (!focusableHasStoredBackground) {
+    focusableHasStoredBackground = YES;
+    RELEASE_TO_NIL(focusablePreviousBackgroundColor);
 
     UIColor *currentColor = self.backgroundColor;
     if (currentColor != nil) {
-      touchFeedbackPreviousBackgroundColor = [currentColor retain];
+      focusablePreviousBackgroundColor = [currentColor retain];
     }
   }
 
-  [self refreshTouchFeedbackHighlight];
+  [self refreshBackgroundSelectedHighlight];
 
   if (touchCount > 0) {
-    touchFeedbackTouchCount += touchCount;
+    focusableTouchCount += touchCount;
   }
 }
 
-- (void)restoreTouchFeedbackHighlight
+- (void)restoreBackgroundSelectedHighlight
 {
-  if (!touchFeedbackHasStoredBackground) {
+  if (!focusableHasStoredBackground) {
     return;
   }
 
-  if (touchFeedbackPreviousBackgroundColor != nil) {
-    [super setBackgroundColor:touchFeedbackPreviousBackgroundColor];
+  if (focusablePreviousBackgroundColor != nil) {
+    [super setBackgroundColor:focusablePreviousBackgroundColor];
   } else {
     [super setBackgroundColor:nil];
   }
 
-  RELEASE_TO_NIL(touchFeedbackPreviousBackgroundColor);
-  touchFeedbackHasStoredBackground = NO;
-  touchFeedbackTouchCount = 0;
+  RELEASE_TO_NIL(focusablePreviousBackgroundColor);
+  focusableHasStoredBackground = NO;
+  focusableTouchCount = 0;
 }
 
-- (void)decrementTouchFeedbackTouches:(NSUInteger)touchCount
+- (void)decrementBackgroundSelectedTouches:(NSUInteger)touchCount
 {
   if (touchCount == 0) {
     return;
   }
 
-  if (touchFeedbackTouchCount <= touchCount) {
-    touchFeedbackTouchCount = 0;
+  if (focusableTouchCount <= touchCount) {
+    focusableTouchCount = 0;
   } else {
-    touchFeedbackTouchCount -= touchCount;
+    focusableTouchCount -= touchCount;
   }
 
-  if (touchFeedbackTouchCount == 0) {
-    [self restoreTouchFeedbackHighlight];
+  if (focusableTouchCount == 0) {
+    [self restoreBackgroundSelectedHighlight];
   }
 }
 
@@ -455,8 +455,8 @@ DEFINE_EXCEPTIONS
     }
   }
 
-  if (touchFeedbackHasStoredBackground) {
-    [self refreshTouchFeedbackHighlight];
+  if (focusableHasStoredBackground) {
+    [self refreshBackgroundSelectedHighlight];
   }
 }
 
@@ -691,13 +691,13 @@ DEFINE_EXCEPTIONS
     super.backgroundColor = [ticolor _color];
   }
 
-  if (touchFeedbackHasStoredBackground) {
-    RELEASE_TO_NIL(touchFeedbackPreviousBackgroundColor);
+  if (focusableHasStoredBackground) {
+    RELEASE_TO_NIL(focusablePreviousBackgroundColor);
     UIColor *currentColor = self.backgroundColor;
     if (currentColor != nil) {
-      touchFeedbackPreviousBackgroundColor = [currentColor retain];
+      focusablePreviousBackgroundColor = [currentColor retain];
     }
-    [self refreshTouchFeedbackHighlight];
+    [self refreshBackgroundSelectedHighlight];
   }
 }
 
@@ -1023,29 +1023,29 @@ DEFINE_EXCEPTIONS
   changedInteraction = YES;
 }
 
-- (void)setTouchFeedback_:(id)value
+- (void)setFocusable_:(id)value
 {
   BOOL newValue = [TiUtils boolValue:value def:NO];
 
-  if (touchFeedback == newValue) {
+  if (focusable == newValue) {
     return;
   }
 
-  touchFeedback = newValue;
+  focusable = newValue;
 
-  if (!touchFeedback) {
-    touchFeedbackTouchCount = 0;
-    [self restoreTouchFeedbackHighlight];
+  if (!focusable) {
+    focusableTouchCount = 0;
+    [self restoreBackgroundSelectedHighlight];
   }
 }
 
-- (void)setTouchFeedbackColor_:(id)value
+- (void)setBackgroundSelectedColor_:(id)value
 {
   if (value == nil || value == [NSNull null]) {
-    if (touchFeedbackColor != nil) {
-      RELEASE_TO_NIL(touchFeedbackColor);
-      if (touchFeedbackHasStoredBackground) {
-        [self refreshTouchFeedbackHighlight];
+    if (backgroundSelectedColor != nil) {
+      RELEASE_TO_NIL(backgroundSelectedColor);
+      if (focusableHasStoredBackground) {
+        [self refreshBackgroundSelectedHighlight];
       }
     }
     return;
@@ -1056,19 +1056,19 @@ DEFINE_EXCEPTIONS
     return;
   }
 
-  if (touchFeedbackColor != nil) {
-    UIColor *existingColor = [touchFeedbackColor _color];
+  if (backgroundSelectedColor != nil) {
+    UIColor *existingColor = [backgroundSelectedColor _color];
     UIColor *newColor = [color _color];
     if (existingColor != nil && newColor != nil && CGColorEqualToColor(existingColor.CGColor, newColor.CGColor)) {
       return;
     }
   }
 
-  RELEASE_TO_NIL(touchFeedbackColor);
-  touchFeedbackColor = [color retain];
+  RELEASE_TO_NIL(backgroundSelectedColor);
+  backgroundSelectedColor = [color retain];
 
-  if (touchFeedbackHasStoredBackground) {
-    [self refreshTouchFeedbackHighlight];
+  if (focusableHasStoredBackground) {
+    [self refreshBackgroundSelectedHighlight];
   }
 }
 
@@ -1719,8 +1719,8 @@ DEFINE_EXCEPTIONS
 
 - (void)touchesBegan:(NSSet *)touches withEvent:(UIEvent *)event
 {
-  if (touchFeedback) {
-    [self applyTouchFeedbackHighlightWithAdditionalTouches:[touches count]];
+  if (focusable) {
+    [self applyBackgroundSelectedHighlightWithAdditionalTouches:[touches count]];
   }
 
   if ([[event touchesForView:self] count] > 0 || [self touchedContentViewWithEvent:event]) {
@@ -1762,8 +1762,8 @@ DEFINE_EXCEPTIONS
 
 - (void)touchesEnded:(NSSet *)touches withEvent:(UIEvent *)event
 {
-  if (touchFeedback) {
-    [self decrementTouchFeedbackTouches:[touches count]];
+  if (focusable) {
+    [self decrementBackgroundSelectedTouches:[touches count]];
   }
 
   if ([[event touchesForView:self] count] > 0 || [self touchedContentViewWithEvent:event]) {
@@ -1800,9 +1800,9 @@ DEFINE_EXCEPTIONS
 
 - (void)touchesCancelled:(NSSet *)touches withEvent:(UIEvent *)event
 {
-  if (touchFeedback) {
-    touchFeedbackTouchCount = 0;
-    [self restoreTouchFeedbackHighlight];
+  if (focusable) {
+    focusableTouchCount = 0;
+    [self restoreBackgroundSelectedHighlight];
   }
 
   if ([[event touchesForView:self] count] > 0 || [self touchedContentViewWithEvent:event]) {

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiViewProxy.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiViewProxy.m
@@ -1396,7 +1396,7 @@ LAYOUTFLAGS_SETTER(setHorizontalWrap, horizontalWrap, horizontalWrap, [self will
               defaultValue:NUMBOOL(YES)];
   [self initializeProperty:@"visible" defaultValue:NUMBOOL(YES)];
   [self initializeProperty:@"touchEnabled" defaultValue:NUMBOOL(YES)];
-  [self initializeProperty:@"touchFeedbsck" defaultValue:NUMBOOL(FALSE)];
+  [self initializeProperty:@"focusable" defaultValue:NUMBOOL(FALSE)];
 
   if (properties != nil) {
     NSString *objectId = [properties objectForKey:@"id"];

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiViewProxy.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiViewProxy.m
@@ -1396,7 +1396,7 @@ LAYOUTFLAGS_SETTER(setHorizontalWrap, horizontalWrap, horizontalWrap, [self will
               defaultValue:NUMBOOL(YES)];
   [self initializeProperty:@"visible" defaultValue:NUMBOOL(YES)];
   [self initializeProperty:@"touchEnabled" defaultValue:NUMBOOL(YES)];
-  [self initializeProperty:@"focusable" defaultValue:NUMBOOL(FALSE)];
+  [self initializeProperty:@"focusable" defaultValue:NUMBOOL(NO)];
 
   if (properties != nil) {
     NSString *objectId = [properties objectForKey:@"id"];

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiViewProxy.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiViewProxy.m
@@ -1396,7 +1396,6 @@ LAYOUTFLAGS_SETTER(setHorizontalWrap, horizontalWrap, horizontalWrap, [self will
               defaultValue:NUMBOOL(YES)];
   [self initializeProperty:@"visible" defaultValue:NUMBOOL(YES)];
   [self initializeProperty:@"touchEnabled" defaultValue:NUMBOOL(YES)];
-  [self initializeProperty:@"focusable" defaultValue:NUMBOOL(NO)];
 
   if (properties != nil) {
     NSString *objectId = [properties objectForKey:@"id"];

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiViewProxy.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiViewProxy.m
@@ -1396,6 +1396,7 @@ LAYOUTFLAGS_SETTER(setHorizontalWrap, horizontalWrap, horizontalWrap, [self will
               defaultValue:NUMBOOL(YES)];
   [self initializeProperty:@"visible" defaultValue:NUMBOOL(YES)];
   [self initializeProperty:@"touchEnabled" defaultValue:NUMBOOL(YES)];
+  [self initializeProperty:@"touchFeedbsck" defaultValue:NUMBOOL(FALSE)];
 
   if (properties != nil) {
     NSString *objectId = [properties objectForKey:@"id"];


### PR DESCRIPTION
This pull request adds support for selected background color states in `Ti.UI.View` instances, aligning its behavior with Android and expanding platform coverage. Advantages compared to existing approaches:

- Increased performance: No additional tap gesture recognizer / event listeners necessary, no need to cross the JS bridge
- Parity: 1:1 compatibility with existing Android API

Test case:
```js
const win = Ti.UI.createWindow({
    backgroundColor: '#fff'
});

const view = Ti.UI.createView({
    width: 200,
    height: 50,
    backgroundColor: 'green',
    backgroundSelectedColor: 'red'
});

win.add(view);
win.open();
```

https://github.com/user-attachments/assets/5a2fcb1d-d006-4ff1-b720-4edf4632ef89


