### PR TITLE
fix: overwrite modules on local SDK build install

### DIFF
--- a/build/lib/utils.js
+++ b/build/lib/utils.js
@@ -365,7 +365,7 @@ export async function installSDK(versionTag, symlinkIfPossible = false) {
 			return fs.ensureSymlink(path.join(zipDir, 'mobilesdk', osName, versionTag), destDir);
 		}
 		await fs.copy(path.join(zipDir, 'mobilesdk'), path.join(dest, 'mobilesdk'), { dereference: true });
-		return fs.copy(path.join(zipDir, 'modules'), path.join(dest, 'modules'));
+		return fs.copy(path.join(zipDir, 'modules'), path.join(dest, 'modules'), { dereference: true, overwrite: true });
 	}
 
 	// try the zip


### PR DESCRIPTION
When running `npm run cleanbuild:local`, the command fails with:

```
BUILD SUCCESSFUL in 802ms
3 actionable tasks: 3 executed
Packaging iOS platform...
Packaging version (13.1.0) complete
Installing /Users/chris/other/titanium-sdk/dist/mobilesdk-13.1.0-osx...
Error: Cannot copy 'A' to a subdirectory of itself, 'A'.
    at /Users/chris/other/titanium-sdk/node_modules/fs-extra/lib/copy/copy.js:210:21
    at FSReqCallback.oncomplete (node:fs:187:23)
```

It's blowing up when it tries to copy the modules to the `~/Library/Application-Support/Titanium/modules` directory and the destination already exists. By adding the `overwrite` flag, it works and copies the files without removing exist modules.