### PR TITLE
fix(ios): fixed test:iphone:trace

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "test:ios:trace": "npm run test:iphone:trace",
     "test:iphone": "npm run cleanbuild:ios -- --skip-zip --no-docs --symlink && npm run test:integration -- ios -F iphone --sdk-version $npm_package_version",
     "test:iphone:onlyFailed": "npm run cleanbuild:ios -- --skip-zip --no-docs --symlink && npm run test:integration -- ios -F iphone --sdk-version $npm_package_version --only-failed",
-    "test:iphone:trace": "npm run cleanbuild:ios -- --skip-zip --no-docs --symlink && npm run test:integration: -- ios -F iphone --sdk-version $npm_package_version --log-level trace",
+    "test:iphone:trace": "npm run cleanbuild:ios -- --skip-zip --no-docs --symlink && npm run test:integration -- ios -F iphone --sdk-version $npm_package_version --log-level trace",
     "test:ipad": "npm run cleanbuild:ios -- --skip-zip --no-docs --symlink && npm run test:integration -- ios -F ipad --sdk-version $npm_package_version",
     "test:ipad:onlyFailed": "npm run cleanbuild:ios -- --skip-zip --no-docs --symlink && npm run test:integration -- ios -F ipad --sdk-version $npm_package_version --only-failed",
     "test:ipad:trace": "npm run cleanbuild:ios -- --skip-zip --no-docs --symlink && npm run test:integration -- ios -F ipad --sdk-version $npm_package_version --log-level trace",


### PR DESCRIPTION
**Description:**

- fixed a single-char typo in the run script `test:iphone:trace`, recently added by #14318 :see_no_evil: