### PR TITLE
feat(ios): opt-out new tab bar under iPadOS 18+

### DIFF
--- a/apidoc/Titanium/UI/TabGroup.yml
+++ b/apidoc/Titanium/UI/TabGroup.yml
@@ -415,6 +415,19 @@ properties:
     default: True if tab group is opened on top of the root activity. False otherwise.
     type: Boolean
 
+  - name: optOutTopTabBar
+    summary: Opt-out floating tab bar.
+    description: |
+        A new floating tab bar was introduced in iPadOS 18.
+        It is displayed without tab icons and at the top of the screen.
+        This property forces the tab bar to be displayed in the old style with icons and at the bottom of the screen (as on iPhone).
+    type: Boolean
+    default: false
+    availability: creation
+    osver: {ios: {min: "18.0"}}
+    platforms: [ipad]
+    since: 13.1.0
+
   - name: swipeable
     summary: |
         Boolean value indicating if tab navigation can be done by swipes, in addition to tab clicks.

--- a/apidoc/Titanium/UI/TabGroup.yml
+++ b/apidoc/Titanium/UI/TabGroup.yml
@@ -415,8 +415,8 @@ properties:
     default: True if tab group is opened on top of the root activity. False otherwise.
     type: Boolean
 
-  - name: optOutTopTabBar
-    summary: Opt-out floating tab bar.
+  - name: forceBottomPosition
+    summary: Force tab bar to bottom position.
     description: |
         A new floating tab bar was introduced in iPadOS 18.
         It is displayed without tab icons and at the top of the screen.

--- a/iphone/Classes/TiUITabGroup.m
+++ b/iphone/Classes/TiUITabGroup.m
@@ -50,10 +50,10 @@ DEFINE_EXCEPTIONS
       controller.tabBar.scrollEdgeAppearance = appearance;
     }
 
-    // opt-out new iPadOS 18+ floating tab bar
+    // force tab bar to bottom position (as before iPadOS 18 and on iPhone)
     if ([TiUtils isIOSVersionOrGreater:@"18.0"] && [TiUtils isIPad]) {
-      BOOL optOutTopTabBar = [TiUtils boolValue:[self.proxy valueForUndefinedKey:@"optOutTopTabBar"] def:NO];
-      if (optOutTopTabBar) {
+      BOOL forceBottomPosition = [TiUtils boolValue:[self.proxy valueForUndefinedKey:@"forceBottomPosition"] def:NO];
+      if (forceBottomPosition) {
         controller.traitOverrides.horizontalSizeClass = UIUserInterfaceSizeClassCompact;
       }
     }

--- a/iphone/Classes/TiUITabGroup.m
+++ b/iphone/Classes/TiUITabGroup.m
@@ -49,6 +49,14 @@ DEFINE_EXCEPTIONS
       appearance.backgroundColor = UIColor.clearColor;
       controller.tabBar.scrollEdgeAppearance = appearance;
     }
+
+    // opt-out new iPadOS 18+ floating tab bar
+    if ([TiUtils isIOSVersionOrGreater:@"18.0"] && [TiUtils isIPad]) {
+      BOOL optOutTopTabBar = [TiUtils boolValue:[self.proxy valueForUndefinedKey:@"optOutTopTabBar"] def:NO];
+      if (optOutTopTabBar) {
+        controller.traitOverrides.horizontalSizeClass = UIUserInterfaceSizeClassCompact;
+      }
+    }
   }
   return controller;
 }


### PR DESCRIPTION
Fixes https://github.com/tidev/titanium-sdk/issues/14123.

**Introduction:**
A new floating tab bar was introduced in iPadOS 18 which is displayed without tab icons and at the top of the screen.
This breaked many custom UI and CD/CI, see also [issue](https://github.com/tidev/titanium-sdk/issues/14123) above or recently in [Slack](https://tidev.slack.com/archives/C03CVQX2A/p1760476874190939).

**Description:**
- added property `forceBottomPosition` to `TagGroup` for iPad
  - forcing the tab bar to be displayed in the old style
  - works also under iPadOS 26 &ndash; is indeed a “floating” tab bar, but with icons and at the bottom of the screen (as on iPhone)
- updated apidoc

**Screenshots:**

iPadOS 18:
| `forceBottomPosition = false` (default) | `forceBottomPosition = true` |
| ------------- | ------------- |
| <img width="400" alt="Simulator Screenshot - iPad Air 11-inch (M3) - iPadOS 18" src="https://github.com/user-attachments/assets/6b917f95-8950-495a-a176-47c2f3349887" /> | <img width="400" alt="Simulator Screenshot - iPad Air 11-inch (M3) - iPadOS 18" src="https://github.com/user-attachments/assets/8ce096c7-68a0-4c76-94cd-2b71e593068c" /> | 

iPadOS 26:
| `forceBottomPosition = false` (default) | `forceBottomPosition = true` |
| ------------- | ------------- |
| <img width="400"  alt="Simulator Screenshot - iPad Air 11-inch (M3) - iPadOS 26" src="https://github.com/user-attachments/assets/e0ec16cb-a2d2-437a-a1b4-00cd7c457e19" /> | <img width="400" alt="Simulator Screenshot - iPad Air 11-inch (M3) - iPadOS 26" src="https://github.com/user-attachments/assets/e49b1852-df20-4d6e-9aa6-5ea83c8a5168" /> | 

**Usage:**

```
const tabGroup = Ti.UI.createTabGroup({
    tabs: [tab1, tab2],
    forceBottomPosition: true
});
```
