### PR TITLE
feat(android): enable accessibility support for `Ti.UI.Window`

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/TiApplicationLifecycle.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiApplicationLifecycle.java
@@ -9,6 +9,7 @@ package org.appcelerator.titanium;
 import android.app.Activity;
 import android.app.Application;
 import android.os.Bundle;
+import android.view.View;
 
 import org.appcelerator.kroll.KrollModule;
 
@@ -24,6 +25,25 @@ public class TiApplicationLifecycle implements Application.ActivityLifecycleCall
 	@Override
 	public void onActivityCreated(Activity activity, Bundle savedInstanceState)
 	{
+		// Apply accessibility on the root view of this activity.
+		View view = activity.getWindow() != null ? activity.getWindow().getDecorView() : null;
+		if (view != null) {
+			boolean accessibilityHidden = false;
+
+			if (activity.getIntent() != null) {
+				accessibilityHidden = activity.getIntent().getBooleanExtra(TiC.PROPERTY_ACCESSIBILITY_HIDDEN, false);
+			} else if (savedInstanceState != null) {
+				// If activity is re-created by OS in any circumstances.
+				accessibilityHidden = savedInstanceState.getBoolean(TiC.PROPERTY_ACCESSIBILITY_HIDDEN, false);
+			}
+
+			if (accessibilityHidden) {
+				view.setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS);
+			} else {
+				view.setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_AUTO);
+			}
+		}
+
 		// Reset "wasPaused" state when creating the 1st activity in a UI task.
 		// Needed to detect if the app is resuming after being paused.
 		if (this.existingActivityCount <= 0) {

--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/TiWindowProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/TiWindowProxy.java
@@ -525,6 +525,9 @@ public abstract class TiWindowProxy extends TiViewProxy
 
 	protected void fillIntent(Activity activity, Intent intent)
 	{
+		boolean accessibilityHidden = TiConvert.toBoolean(getProperty(TiC.PROPERTY_ACCESSIBILITY_HIDDEN), false);
+		intent.putExtra(TiC.PROPERTY_ACCESSIBILITY_HIDDEN, accessibilityHidden);
+
 		int windowFlags = 0;
 		if (hasProperty(TiC.PROPERTY_WINDOW_FLAGS)) {
 			windowFlags = TiConvert.toInt(getProperty(TiC.PROPERTY_WINDOW_FLAGS), 0);


### PR DESCRIPTION
This PR comes in as a workaround to this ongoing [Google Android Maps crash outage](https://issuetracker.google.com/issues/457601635) since last week where the apps are crashing while using `liteMode` enabled maps.

Some apps have found the workaround by disabling the accessibility on the map container itself, but it does not work for all since the MapView may create the SurfaceView internally for optimised rendering.

Debugging the stack-trace leads to that some views are still being queried for accessibility before the crash, so we want to try disable the accessibility for the entire activity where the MapView draw its content and see if it works. Unfortunately, there're no other known workarounds as of now, so any other ideas will be appreciated.

Changes in this PR:
- Enable the `accessibilityHidden` property on a `Ti.UI.Window` itself (the current one does not work) which is usually supposed to apply the accessibility value on its `Activity` level.
- This property is required to be applied before inflating any view so it properly takes effect on the entire Activity, which is why I have implemented it using Application level activity callbacks.