### PR TITLE
chore: fixed some typos in sources

### DIFF
--- a/iphone/Classes/ContactsModule.h
+++ b/iphone/Classes/ContactsModule.h
@@ -28,7 +28,7 @@
 - (CNContactStore *)contactStore;
 + (NSArray *)contactKeysWithImage;
 + (NSArray *)contactKeysWithoutImage;
-- (void)save:(id)unusued;
+- (void)save:(id)unused;
 - (void)revert:(id)unused;
 - (void)showContacts:(id)args;
 - (NSArray *)getPeopleWithName:(id)arg;

--- a/iphone/Classes/TiDOMNamedNodeMapProxy.h
+++ b/iphone/Classes/TiDOMNamedNodeMapProxy.h
@@ -8,7 +8,7 @@
 /**
  * This supports the NamedNodeMap for the property "attributes"
  * defined by Interface Node.
- * The support for NamedNodeMap for the properties "entites" and "notations"
+ * The support for NamedNodeMap for the properties "entities" and "notations"
  * defined by Interface DocumentType is not yet implemented.
  */
 #if defined(USE_TI_XML) || defined(USE_TI_NETWORK)

--- a/iphone/Classes/TiMediaMusicPlayer.h
+++ b/iphone/Classes/TiMediaMusicPlayer.h
@@ -23,7 +23,7 @@
 - (void)stop:(id)unused;
 
 - (void)seekForward:(id)unused;
-- (void)seekBackward:(id)unusued;
+- (void)seekBackward:(id)unused;
 - (void)stopSeeking:(id)unused;
 
 - (void)skipToNext:(id)unused;

--- a/iphone/Classes/TiMediaMusicPlayer.m
+++ b/iphone/Classes/TiMediaMusicPlayer.m
@@ -129,7 +129,7 @@
   [player beginSeekingForward];
 }
 
-- (void)seekBackward:(id)unusued
+- (void)seekBackward:(id)unused
 {
   [player beginSeekingBackward];
 }

--- a/iphone/Classes/TiNetworkSocketTCPProxy.h
+++ b/iphone/Classes/TiNetworkSocketTCPProxy.h
@@ -7,7 +7,7 @@
 
 // TODO: Migrate to GCD sockets (GCDAsyncSocket). This will resolve a number of really ugly issues:
 // * Lower thread counts
-// * Explicit synchronization (no more conditions, flags, or race conditons!)
+// * Explicit synchronization (no more conditions, flags, or race conditions!)
 // * Maybe even synchronize with the context itself (when TIMOB-6990 complete)
 
 #if defined(USE_TI_NETWORKSOCKET) || (defined(USE_TI_NETWORK))

--- a/iphone/Classes/TiPlatformDisplayCaps.h
+++ b/iphone/Classes/TiPlatformDisplayCaps.h
@@ -11,7 +11,7 @@
 
 @protocol TiPlatformDisplayCapsExports <JSExport>
 
-// Properties (and accesors)
+// Properties (and accessors)
 READONLY_PROPERTY(NSString *, density, Density);
 READONLY_PROPERTY(NSNumber *, dpi, Dpi);
 READONLY_PROPERTY(NSNumber *, logicalDensityFactor, LogicalDensityFactor);

--- a/iphone/Classes/TiUIButton.m
+++ b/iphone/Classes/TiUIButton.m
@@ -81,7 +81,7 @@
 #endif
   {
     if ([thisView respondsToSelector:@selector(setHighlighted:)]) {
-      [(id)thisView setHighlighted:isHiglighted];
+      [(id)thisView setHighlighted:isHighlighted];
     }
   }
 }

--- a/iphone/Classes/TiUIButton.m
+++ b/iphone/Classes/TiUIButton.m
@@ -72,7 +72,7 @@
   return YES;
 }
 
-- (void)setHighlighting:(BOOL)isHiglighted
+- (void)setHighlighting:(BOOL)isHighlighted
 {
 #ifndef TI_USE_AUTOLAYOUT
   for (TiUIView *thisView in [viewGroupWrapper subviews])

--- a/iphone/Classes/TiUIDashboardViewProxy.m
+++ b/iphone/Classes/TiUIDashboardViewProxy.m
@@ -49,7 +49,7 @@ NSArray *dashboardKeySequence;
   [self makeViewPerformSelector:@selector(stopEditing) withObject:nil createIfNeeded:YES waitUntilDone:NO];
 }
 
-// TODO: Remove when deprication is done.
+// TODO: Remove when deprecation is done.
 - (void)fireEvent:(NSString *)type withObject:(id)obj withSource:(id)source propagate:(BOOL)propagate reportSuccess:(BOOL)report errorCode:(int)code message:(NSString *)message;
 {
   if ([type isEqual:@"click"]) {

--- a/iphone/Classes/TiUILabel.m
+++ b/iphone/Classes/TiUILabel.m
@@ -78,7 +78,7 @@
 {
   /*
      Why both? sizeThatFits returns the width with line break mode tail truncation and we like to
-     have atleast enough space to display one word. On the otherhand font measurement is unsuitable for
+     have atleast enough space to display one word. On the other hand font measurement is unsuitable for
      attributed strings till we move to the new measurement API. Hence take both and return MAX.
      */
   CGFloat sizeThatFitsResult = [[self label] sizeThatFits:CGSizeMake(suggestedWidth, 0)].width;
@@ -151,7 +151,7 @@
 }
 
 #ifndef TI_USE_AUTOLAYOUT
-// FIXME: This isn't quite true.  But the brilliant soluton wasn't so brilliant, because it screwed with layout in unpredictable ways.
+// FIXME: This isn't quite true.  But the brilliant solution wasn't so brilliant, because it screwed with layout in unpredictable ways.
 //	Sadly, there was a brilliant solution for fixing the blurring here, but it turns out there's a
 //	quicker fix: Make sure the label itself has an even height and width. Everything else is irrelevant.
 - (void)setCenter:(CGPoint)newCenter

--- a/iphone/Classes/TiUIListItem.m
+++ b/iphone/Classes/TiUIListItem.m
@@ -559,17 +559,17 @@
   }
   [self setBackgroundSelectedGradient_:selectedBackgroundGradientValue];
 
-  id selectedbackgroundColorValue = [properties objectForKey:@"backgroundSelectedColor"];
-  if (IS_NULL_OR_NIL(selectedbackgroundColorValue)) {
-    selectedbackgroundColorValue = [_proxy valueForKey:@"backgroundSelectedColor"];
+  id selectedBackgroundColorValue = [properties objectForKey:@"backgroundSelectedColor"];
+  if (IS_NULL_OR_NIL(selectedBackgroundColorValue)) {
+    selectedBackgroundColorValue = [_proxy valueForKey:@"backgroundSelectedColor"];
   }
-  if (IS_NULL_OR_NIL(selectedbackgroundColorValue)) {
-    selectedbackgroundColorValue = [properties valueForKey:@"selectedBackgroundColor"];
+  if (IS_NULL_OR_NIL(selectedBackgroundColorValue)) {
+    selectedBackgroundColorValue = [properties valueForKey:@"selectedBackgroundColor"];
 
-    if (IS_NULL_OR_NIL(selectedbackgroundColorValue)) {
-      selectedbackgroundColorValue = [_proxy valueForKey:@"selectedBackgroundColor"];
+    if (IS_NULL_OR_NIL(selectedBackgroundColorValue)) {
+      selectedBackgroundColorValue = [_proxy valueForKey:@"selectedBackgroundColor"];
     }
-    if (!IS_NULL_OR_NIL(selectedbackgroundColorValue)) {
+    if (!IS_NULL_OR_NIL(selectedBackgroundColorValue)) {
       DEPRECATED_REPLACED(@"selectedBackgroundColor", @"10.0.0", @"backgroundSelectedColor");
     }
   }
@@ -581,15 +581,15 @@
   if (IS_NULL_OR_NIL(selectedBackgroundImageValue)) {
     selectedBackgroundImageValue = [properties valueForKey:@"selectedBackgroundImage"];
 
-    if (IS_NULL_OR_NIL(selectedbackgroundColorValue)) {
-      selectedbackgroundColorValue = [_proxy valueForKey:@"selectedBackgroundImage"];
+    if (IS_NULL_OR_NIL(selectedBackgroundColorValue)) {
+      selectedBackgroundColorValue = [_proxy valueForKey:@"selectedBackgroundImage"];
     }
     if (!IS_NULL_OR_NIL(selectedBackgroundImageValue)) {
       DEPRECATED_REPLACED(@"selectedBackgroundImage", @"10.0.0", @"backgroundSelectedImage");
     }
   }
 
-  [self applyBackgroundWithSelectedColor:selectedbackgroundColorValue selectedImage:selectedBackgroundImageValue];
+  [self applyBackgroundWithSelectedColor:selectedBackgroundColorValue selectedImage:selectedBackgroundImageValue];
   [_resetKeys enumerateObjectsUsingBlock:^(NSString *keyPath, BOOL *stop) {
     id value = [_initialValues objectForKey:keyPath];
     [self setValue:(value != [NSNull null] ? value : nil) forKeyPath:keyPath];

--- a/iphone/Classes/TiUIListView.m
+++ b/iphone/Classes/TiUIListView.m
@@ -54,7 +54,7 @@ static TiViewProxy *FindViewProxyWithBindIdContainingPoint(UIView *view, CGPoint
   NSMutableArray<NSNumber *> *filteredIndices;
 
   UIView *_pullViewWrapper;
-  CGFloat pullThreshhold;
+  CGFloat pullThreshold;
 
   BOOL pullActive;
   CGPoint tapPoint;
@@ -346,7 +346,7 @@ static TiViewProxy *FindViewProxyWithBindIdContainingPoint(UIView *view, CGPoint
           [[self tableView] setTableFooterView:footerView];
           [((TiUIListViewProxy *)[self proxy]) contentsWillChange];
         } else if (sender == _pullViewProxy) {
-          pullThreshhold = ([_pullViewProxy view].frame.origin.y - _pullViewWrapper.bounds.size.height);
+          pullThreshold = ([_pullViewProxy view].frame.origin.y - _pullViewWrapper.bounds.size.height);
         }
       },
       NO);
@@ -1991,10 +1991,10 @@ static TiViewProxy *FindViewProxyWithBindIdContainingPoint(UIView *view, CGPoint
 
   if ([self.proxy _hasListeners:@"pull"]) {
     if ((_pullViewProxy != nil) && ([scrollView isTracking])) {
-      if ((scrollView.contentOffset.y < pullThreshhold) && !pullActive) {
+      if ((scrollView.contentOffset.y < pullThreshold) && !pullActive) {
         pullActive = YES;
         [self.proxy fireEvent:@"pull" withObject:[NSDictionary dictionaryWithObjectsAndKeys:NUMBOOL(pullActive), @"active", nil] withSource:self.proxy propagate:NO reportSuccess:NO errorCode:0 message:nil];
-      } else if ((scrollView.contentOffset.y > pullThreshhold) && (pullActive)) {
+      } else if ((scrollView.contentOffset.y > pullThreshold) && (pullActive)) {
         pullActive = NO;
         [self.proxy fireEvent:@"pull" withObject:[NSDictionary dictionaryWithObjectsAndKeys:NUMBOOL(pullActive), @"active", nil] withSource:self.proxy propagate:NO reportSuccess:NO errorCode:0 message:nil];
       }

--- a/iphone/Classes/TiUIListViewProxy.m
+++ b/iphone/Classes/TiUIListViewProxy.m
@@ -309,7 +309,7 @@
         section.sectionIndex = insertIndex;
         [indexSet addIndex:insertIndex];
       } else {
-        DebugLog(@"[WARN] ListView: Attempt to append exising section");
+        DebugLog(@"[WARN] ListView: Attempt to append existing section");
       }
     }];
     if ([indexSet count] > 0) {
@@ -373,7 +373,7 @@
         [indexSet addIndex:index];
         ++index;
       } else {
-        DebugLog(@"[WARN] ListView: Attempt to insert exising section");
+        DebugLog(@"[WARN] ListView: Attempt to insert existing section");
       }
     }];
     [_sections enumerateObjectsUsingBlock:^(TiUIListSectionProxy *section, NSUInteger idx, BOOL *stop) {
@@ -395,7 +395,7 @@
   [self rememberProxy:section];
   [self dispatchUpdateAction:^(UITableView *tableView) {
     if ([_sections containsObject:section]) {
-      DebugLog(@"[WARN] ListView: Attempt to insert exising section");
+      DebugLog(@"[WARN] ListView: Attempt to insert existing section");
       return;
     }
     if ([_sections count] <= replaceIndex) {

--- a/iphone/Classes/TiUIScrollableViewProxy.m
+++ b/iphone/Classes/TiUIScrollableViewProxy.m
@@ -142,7 +142,7 @@
   [self _addView:args atIndex:viewProxies ? [viewProxies count] : 0];
 }
 
-// Private, used to have only one method repsonsible for adding views
+// Private, used to have only one method responsible for adding views
 - (void)_addView:(TiViewProxy *)proxy atIndex:(NSUInteger)index
 {
   [self lockViewsForWriting];

--- a/iphone/Classes/TiUITableViewRowProxy.m
+++ b/iphone/Classes/TiUITableViewRowProxy.m
@@ -866,7 +866,7 @@ TiProxy *DeepScanForProxyOfViewContainingPoint(UIView *targetView, CGPoint point
   return dict;
 }
 
-// TODO: Remove when deprication is done.
+// TODO: Remove when deprecation is done.
 - (void)fireEvent:(NSString *)type withObject:(id)obj withSource:(id)source propagate:(BOOL)propagate reportSuccess:(BOOL)report errorCode:(int)code message:(NSString *)message;
 {
   // merge in any row level properties for the event

--- a/iphone/Classes/TiUIiOSDocumentViewerProxy.m
+++ b/iphone/Classes/TiUIiOSDocumentViewerProxy.m
@@ -120,7 +120,7 @@
 
 #pragma mark Utilities
 
-// Workaround for an issue occuring on iOS 11.2+ that causes
+// Workaround for an issue occurring on iOS 11.2+ that causes
 // files from the resources-directory (app-bundle) to not be
 // recognized properly. This method works around this by creating
 // a temporary file.


### PR DESCRIPTION
**Description:**

- fixed typos in sources:
  - parameter name `unusued` &rarr; `unused`
  - parameter name `isHiglighted` &rarr; `isHighlighted`
  - variable `pullThreshhold` &rarr;`pullThreshold`
  - camel-case in variable `selectedbackgroundColorValue` &rarr; `selectedBackgroundColorValue`
- fixed typos in a debug messages
- fixed typos in comments

**Note:** This change does not break the API.