### PR TITLE
chore: fixed further typos and wording

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,7 +138,7 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: mobilesdk-${{ env.vtag }}-linux
-    - name: Download MacOS artifact
+    - name: Download macOS artifact
       uses: actions/download-artifact@v4
       with:
         name: mobilesdk-${{ env.vtag }}-osx

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-export ANDROID_SDK_ROOT="$HOME/Library/android_sdk"
-export PATH="$PATH:$ANDROID_SDK_ROOT/platform-tools:$ANDROID_SDK_ROOT/tools"
-
 npx --no-install lint-staged

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,4 @@
+export ANDROID_SDK_ROOT="$HOME/Library/android_sdk"
+export PATH="$PATH:$ANDROID_SDK_ROOT/platform-tools:$ANDROID_SDK_ROOT/tools"
+
 npx --no-install lint-staged

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -127,8 +127,8 @@ The following APIs were removed in 9.0.0:
 | `Ti.UI.View#finishLayout()` | Use the `#applyProperties()` method to batch-update layout properties. |
 | `Ti.UI.View#startLayout()` | Use the `#applyProperties()` method to batch-update layout properties. |
 | `Ti.UI.View#updateLayout()` | Use the `#applyProperties()` method to batch-update layout properties. |
-| `Ti.UI.WebView.error.message` | Use the `error` property instead. Removed on ios in 8.0.0. Removed on android in 9.0.0. |
-| `Ti.UI.WebView.error.errorCode` | Use the `code` property instead. Removed on ios in 8.0.0. Removed on android in 9.0.0. |
+| `Ti.UI.WebView.error.message` | Use the `error` property instead. Removed on iOS in 8.0.0. Removed on Android in 9.0.0. |
+| `Ti.UI.WebView.error.errorCode` | Use the `code` property instead. Removed on iOS in 8.0.0. Removed on Android in 9.0.0. |
 | `Ti.UI.WebView.onStopBlacklistedUrl` | Use the cross-platform `blacklisturl` event instead. |
 | `Ti.UI.Window.android:back` | Use the `Ti.UI.Window.androidback` event instead. |
 | `Ti.UI.Window.android:camera` | Use the `Ti.UI.Window.androidcamera` event instead. |

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ npm run test:ipad
 
 The test suite generates a single Titanium SDK project targeting the specified platform(s), builds the project for emulator, launches the app on the emulator and then runs a series of tests defined via ti-mocha and should.js.
 
-The tests spit out their results to the console log, and the test scripts listen to the logs to gather the results. We then generate an overview on the console as well as a junit report xml file (to be consume by CI build systems like Jenkins).
+The tests spit out their results to the console log, and the test scripts listen to the logs to gather the results. We then generate an overview on the console as well as a junit report XML file (to be consume by CI build systems like Jenkins).
 
 #### How to modify the tests locally and in your PRs
 

--- a/STARTUP.md
+++ b/STARTUP.md
@@ -15,7 +15,7 @@ At SDK build time, `./android/titanium/prebuild.js` script is run which takes JS
 - then call...
 
 `V8Runtime#nativeInit()`
- - from java down to JNI
+ - from Java down to JNI
  - sets up platform, isolate, debugger, then calls...
 `V8Runtime#bootstrap()`
 - sets up `EventEmitter` in C code
@@ -40,7 +40,7 @@ back to `V8Runtime#bootstrap()`
 - set up `global.global`
 - set default `global.__dirname` and `__filename`
 
-back to java `V8Runtime#initRuntime()`
+back to Java `V8Runtime#initRuntime()`
 - start debugger
 - load external native modules
 

--- a/android/.clang-format
+++ b/android/.clang-format
@@ -21,7 +21,7 @@ SpacesInParentheses: false
 TabWidth: 4
 UseTab: ForContinuationAndIndentation
 SpaceAfterCStyleCast: true
-# Spaces inside {} for array literals, i.e. "new Object[] { args }"
+# Spaces inside {} for array literals, e.g. "new Object[] { args }"
 Cpp11BracedListStyle: false
 ReflowComments: false
 JavaImportGroups: ['java', 'javax', 'org', 'android', 'com']

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -55,7 +55,7 @@ tasks.register('checkstyleChanged', Checkstyle) {
 	include getChangedFiles()
 }
 
-// Used to strip the src dir prefixes from the changed java files
+// Used to strip the src dir prefixes from the changed Java files
 def getChangedFiles() {
 	if (!project.hasProperty('changedFiles')) {
 		return new ArrayList<>()

--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -97,7 +97,7 @@ class AndroidBuilder extends Builder {
 		// we hook into the pre-validate event so that we can stop the build before
 		// prompting if we know the build is going to fail.
 		//
-		// this is also where we can detect android and jdk environments before
+		// this is also where we can detect Android and JDK environments before
 		// prompting occurs. because detection is expensive we also do it here instead
 		// of during config() because there's no sense detecting if config() is being
 		// called because of the help command.
@@ -110,13 +110,13 @@ class AndroidBuilder extends Builder {
 
 			async.series([
 				function (next) {
-					// detect android environment
+					// detect Android environment
 					androidDetect(config, { packageJson: _t.packageJson }, function (androidInfo) {
 						_t.androidInfo = androidInfo;
 						assertIssue(logger, androidInfo.issues, 'ANDROID_JDK_NOT_FOUND');
 						assertIssue(logger, androidInfo.issues, 'ANDROID_JDK_PATH_CONTAINS_AMPERSANDS');
 
-						// if --android-sdk was not specified, then we simply try to set a default android sdk
+						// if --android-sdk was not specified, then we simply try to set a default Android SDK
 						if (!cli.argv['android-sdk']) {
 							let androidSdkPath = config.android && config.android.sdkPath;
 							if (!androidSdkPath && androidInfo.sdk) {
@@ -130,7 +130,7 @@ class AndroidBuilder extends Builder {
 				},
 
 				function (next) {
-					// detect java development kit
+					// detect JDK
 					appc.jdk.detect(config, null, function (jdkInfo) {
 						assertIssue(logger, jdkInfo.issues, 'JDK_NOT_INSTALLED');
 						assertIssue(logger, jdkInfo.issues, 'JDK_MISSING_PROGRAMS');
@@ -252,7 +252,7 @@ class AndroidBuilder extends Builder {
 								}));
 							},
 							validate: function (value, callback) {
-								// if there's a value, then they entered something, otherwise let the cli prompt
+								// if there's a value, then they entered something, otherwise let the CLI prompt
 								if (value) {
 									const selectedAlias = value.toLowerCase(),
 										alias = _t.keystoreAlias = _t.keystoreAliases.filter(function (a) { return a.name && a.name.toLowerCase() === selectedAlias; }).shift();
@@ -300,19 +300,19 @@ class AndroidBuilder extends Builder {
 								} else if (_t.androidInfo.sdk && _t.androidInfo.sdk.path === afs.resolvePath(value)) {
 									callback(null, value);
 								} else {
-									// attempt to find android sdk
+									// attempt to find Android SDK
 									android.findSDK(value, config, loadPackageJson(__dirname), function () {
 
-										// NOTE: ignore errors when finding sdk, let gradle validate the sdk
+										// NOTE: ignore errors when finding SDK, let gradle validate the SDK
 
 										function next() {
-											// set the android sdk in the config just in case a plugin or something needs it
+											// set the Android SDK in the config just in case a plugin or something needs it
 											config.set('android.sdkPath', value);
 
 											// path looks good, do a full scan again
 											androidDetect(config, { packageJson: _t.packageJson, bypassCache: true }, function (androidInfo) {
 
-												// assume sdk is valid, let gradle validate the sdk
+												// assume SDK is valid, let gradle validate the SDK
 												if (!androidInfo.sdk) {
 													androidInfo.sdk = { path: value };
 												}
@@ -322,8 +322,8 @@ class AndroidBuilder extends Builder {
 											});
 										}
 
-										// new android sdk path looks good
-										// if we found an android sdk in the pre-validate hook, then we need to kill the other sdk's adb server
+										// new Android SDK path looks good
+										// if we found an Android SDK in the pre-validate hook, then we need to kill the other SDK's adb server
 										if (_t.androidInfo.sdk) {
 											new ADB(config).stopServer(next);
 										} else {
@@ -335,7 +335,7 @@ class AndroidBuilder extends Builder {
 						},
 						'avd-abi': {
 							abbr: 'B',
-							desc: 'the abi for the Android emulator; deprecated, use --device-id',
+							desc: 'the ABI for the Android emulator; deprecated, use --device-id',
 							hint: 'abi'
 						},
 						'avd-id': {
@@ -499,7 +499,7 @@ class AndroidBuilder extends Builder {
 														cli.argv['device-id'] = avds[0];
 														return callback();
 													} else if (!cli.argv['avd-abi']) {
-														// we have more than one matching avd, but no abi to filter by so we have to error
+														// we have more than one matching avd, but no ABI to filter by so we have to error
 														logger.error(`Found ${
 															avds.length
 														} avd${avds.length === 1 ? '' : 's'} with id "${
@@ -523,7 +523,7 @@ class AndroidBuilder extends Builder {
 															});
 														}
 														if (avds.length === 0) {
-															logger.error(`No emulators found with id "${cli.argv['avd-id']}", skin "${cli.argv['avd-skin']}", and abi "${cli.argv['avd-abi']}"\n`);
+															logger.error(`No emulators found with id "${cli.argv['avd-id']}", skin "${cli.argv['avd-skin']}", and ABI "${cli.argv['avd-abi']}"\n`);
 														} else {
 															// there is one or more avds, but we'll just return the first one
 															cli.argv['device-id'] = avds[0];
@@ -980,7 +980,7 @@ class AndroidBuilder extends Builder {
 				logger.error('The app id must consist only of letters, numbers, dashes, and underscores.');
 				logger.error('Note: Android does not allow dashes.');
 				logger.error('The first character must be a letter or underscore.');
-				logger.error('Usually the app id is your company\'s reversed Internet domain name. (i.e. com.example.myapp)\n');
+				logger.error('Usually the app id is your company\'s reversed Internet domain name. (e.g. com.example.myapp)\n');
 				process.exit(1);
 			}
 
@@ -989,7 +989,7 @@ class AndroidBuilder extends Builder {
 				logger.error('The app id must consist of letters, numbers, and underscores.');
 				logger.error('The first character must be a letter or underscore.');
 				logger.error('The first character after a period must not be a number.');
-				logger.error('Usually the app id is your company\'s reversed Internet domain name. (i.e. com.example.myapp)\n');
+				logger.error('Usually the app id is your company\'s reversed Internet domain name. (e.g. com.example.myapp)\n');
 				process.exit(1);
 			}
 
@@ -1033,7 +1033,7 @@ class AndroidBuilder extends Builder {
 			process.exit(1);
 		}
 
-		// map sdk versions to sdk targets instead of by id
+		// map SDK versions to SDK targets instead of by id
 		const targetSDKMap = {
 			// placeholder for gradle to use
 			[this.compileSdkVersion]: {
@@ -1080,7 +1080,7 @@ class AndroidBuilder extends Builder {
 			process.exit(1);
 		}
 
-		// validate the sdk levels
+		// validate the SDK levels
 		const usesSDK = this.customAndroidManifest ? this.customAndroidManifest.getUsesSdk() : null;
 
 		this.minSDK = this.minSupportedApiLevel;
@@ -1111,7 +1111,7 @@ class AndroidBuilder extends Builder {
 			usesSDK.maxSdkVersion    && (this.maxSDK    = usesSDK.maxSdkVersion);
 		}
 
-		// we need to translate the sdk to a real api level (i.e. L => 20, MNC => 22) so that
+		// we need to translate the SDK to a real API level (e.g. L => 20, MNC => 22) so that
 		// we can validate them
 		function getRealAPILevel(ver) {
 			return (ver && targetSDKMap[ver] && targetSDKMap[ver].sdk) || ver;
@@ -1120,7 +1120,7 @@ class AndroidBuilder extends Builder {
 		this.realTargetSDK = getRealAPILevel(this.targetSDK);
 		this.realMaxSDK    = getRealAPILevel(this.maxSDK);
 
-		// min sdk is too old
+		// min SDK is too old
 		if (this.minSDK && this.realMinSDK < this.minSupportedApiLevel) {
 			logger.error(`The minimum supported SDK API version must be ${
 				this.minSupportedApiLevel
@@ -1156,7 +1156,7 @@ class AndroidBuilder extends Builder {
 		}
 
 		if (this.targetSDK) {
-			// target sdk is too old
+			// target SDK is too old
 			if (this.realTargetSDK < this.minTargetApiLevel) {
 				logger.error(`The target SDK API ${
 					this.targetSDK
@@ -1192,7 +1192,7 @@ class AndroidBuilder extends Builder {
 				process.exit(1);
 			}
 
-			// target sdk < min sdk
+			// target SDK < min SDK
 			if (this.realTargetSDK < this.realMinSDK) {
 				logger.error(`The target SDK API must be greater than or equal to the minimum SDK ${
 					this.minSDK
@@ -1211,7 +1211,7 @@ class AndroidBuilder extends Builder {
 			this.realTargetSDK = this.targetSDK;
 		}
 
-		// check that we have this target sdk installed
+		// check that we have this target SDK installed
 		this.androidTargetSDK = targetSDKMap[this.targetSDK];
 
 		if (!this.androidTargetSDK) {
@@ -1784,7 +1784,7 @@ class AndroidBuilder extends Builder {
 			this.logger.info('Profiler disabled');
 		}
 
-		this.logger.info(`Transpile javascript: ${(this.transpile ? 'true' : 'false').cyan}`);
+		this.logger.info(`Transpile JavaScript: ${(this.transpile ? 'true' : 'false').cyan}`);
 		this.logger.info(`Generate source maps: ${(this.sourceMaps ? 'true' : 'false').cyan}`);
 	}
 
@@ -1854,7 +1854,7 @@ class AndroidBuilder extends Builder {
 			return true;
 		}
 
-		// if encryptJS changed, then we need to recompile the java files
+		// if encryptJS changed, then we need to recompile the Java files
 		if (this.encryptJS !== manifest.encryptJS) {
 			this.logger.info('Forcing rebuild: JavaScript encryption flag changed');
 			this.logger.info(`  Was: ${manifest.encryptJS}`);
@@ -1862,7 +1862,7 @@ class AndroidBuilder extends Builder {
 			return true;
 		}
 
-		// check if the titanium sdk paths are different
+		// check if the Titanium SDK paths are different
 		if (this.platformPath !== manifest.platformPath) {
 			this.logger.info('Forcing rebuild: Titanium SDK path changed since last build');
 			this.logger.info(`  Was: ${manifest.platformPath}`);
@@ -2535,7 +2535,7 @@ class AndroidBuilder extends Builder {
 		combined = gather.mergeMaps(allModulesResults);
 
 		// Ok, so we have a Map<string, FileInfo> for the full set of unique relative paths
-		// now categorize (i.e. lump into buckets of js/css/html/assets/generic resources)
+		// now categorize (e.g. lump into buckets of js/css/html/assets/generic resources)
 		const categorizer = new gather.Categorizer({
 			tiappIcon: this.tiapp.icon,
 			jsFilesNotToProcess: Object.keys(this.htmlJsFiles),
@@ -2677,7 +2677,7 @@ class AndroidBuilder extends Builder {
 		});
 		await task.run();
 		if (this.useWebpack) {
-			// Merge Ti symbols from Webpack with the ones from legacy js processing
+			// Merge Ti symbols from Webpack with the ones from legacy JS processing
 			Object.keys(task.data.tiSymbols).forEach(file => {
 				const existingSymbols = this.tiSymbols[file] || [];
 				const additionalSymbols = task.data.tiSymbols[file];
@@ -2714,7 +2714,7 @@ class AndroidBuilder extends Builder {
 	}
 
 	/**
-	 * @param {string[]} jsBootstrapFiles list of bootstrap js files to add to listing we generate
+	 * @param {string[]} jsBootstrapFiles list of bootstrap JS files to add to listing we generate
 	 * @returns {Promise<void>}
 	 */
 	async writeBootstrapJson(jsBootstrapFiles) {
@@ -2874,7 +2874,7 @@ class AndroidBuilder extends Builder {
 			throw new Error('Could not load encryption library!');
 		}
 
-		this.logger.info('Encrypting javascript assets...');
+		this.logger.info('Encrypting JavaScript assets...');
 
 		// NOTE: maintain 'build.android.titaniumprep' hook for remote encryption policy.
 		const hook = this.cli.createHook('build.android.titaniumprep', this, async function (exe, args, opts, next) {

--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -462,7 +462,7 @@ class AndroidBuilder extends Builder {
 											name = 'titanium_' + cli.argv['avd-id'] + '_';
 
 										if (avds.length) {
-											// try finding the first avd that starts with the avd id
+											// try finding the first AVD that starts with the AVD id
 											avds = avds.filter(function (avd) {
 												return avd.indexOf(name) === 0;
 											});
@@ -470,7 +470,7 @@ class AndroidBuilder extends Builder {
 												cli.argv['device-id'] = avds[0];
 												return callback();
 											} else if (avds.length > 1) {
-												// next try using the avd skin
+												// next try using the AVD skin
 												if (!cli.argv['avd-skin']) {
 													// we have more than one match
 													logger.error(`Found ${avds.length} avd${avds.length === 1 ? '' : 's'} with id "${cli.argv['avd-id']}"`);
@@ -499,7 +499,7 @@ class AndroidBuilder extends Builder {
 														cli.argv['device-id'] = avds[0];
 														return callback();
 													} else if (!cli.argv['avd-abi']) {
-														// we have more than one matching avd, but no ABI to filter by so we have to error
+														// we have more than one matching AVD, but no ABI to filter by so we have to error
 														logger.error(`Found ${
 															avds.length
 														} avd${avds.length === 1 ? '' : 's'} with id "${
@@ -525,7 +525,7 @@ class AndroidBuilder extends Builder {
 														if (avds.length === 0) {
 															logger.error(`No emulators found with id "${cli.argv['avd-id']}", skin "${cli.argv['avd-skin']}", and ABI "${cli.argv['avd-abi']}"\n`);
 														} else {
-															// there is one or more avds, but we'll just return the first one
+															// there is one or more AVDs, but we'll just return the first one
 															cli.argv['device-id'] = avds[0];
 															return callback();
 														}
@@ -536,7 +536,7 @@ class AndroidBuilder extends Builder {
 
 											logger.warn(`${'--avd-*'.cyan} options have been ${'deprecated'.red}, please use ${'--device-id'.cyan}\n`);
 
-											// print list of available avds
+											// print list of available AVDs
 											if (results.length && !cli.argv.prompt) {
 												logger.log('Available Emulators:');
 												results.forEach(function (emu) {

--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -2545,7 +2545,7 @@ class AndroidBuilder extends Builder {
 	}
 
 	/**
-	 * Optionally mifies the input css files and copies them to the app
+	 * Optionally minifies the input CSS files and copies them to the app
 	 * @param {Map<string,object>} files map from filename to file info
 	 * @returns {Promise<void>}
 	 */

--- a/android/cli/commands/_buildModule.js
+++ b/android/cli/commands/_buildModule.js
@@ -211,7 +211,7 @@ export class AndroidModuleBuilder extends Builder {
 
 			this.manifest = this.cli.manifest;
 
-			// detect android environment
+			// detect Android environment
 			androidDetect(config, { packageJson: this.packageJson }, function (androidInfo) {
 				this.androidInfo = androidInfo;
 
@@ -232,7 +232,7 @@ export class AndroidModuleBuilder extends Builder {
 				// check the Android SDK we require to build exists
 				this.androidCompileSDK = targetSDKMap[this.compileSdkVersion];
 
-				// if no target sdk, then default to most recent supported/installed
+				// if no target SDK, then default to most recent supported/installed
 				if (!this.targetSDK) {
 					this.targetSDK = this.maxSupportedApiLevel;
 				}
@@ -280,7 +280,7 @@ export class AndroidModuleBuilder extends Builder {
 					this.javacMaxMemory = cli.timodule.properties['android.javac.maxMemory'].value;
 				}
 
-				// detect java development kit
+				// detect JDK
 				appc.jdk.detect(config, null, function (jdkInfo) {
 					if (!jdkInfo.version) {
 						logger.error('Unable to locate the Java Development Kit\n');
@@ -957,7 +957,7 @@ export class AndroidModuleBuilder extends Builder {
 	}
 }
 
-// create the builder instance and expose the public api
+// create the builder instance and expose the public API
 const moduleBuilder = new AndroidModuleBuilder();
 export const config = moduleBuilder.config.bind(moduleBuilder);
 export const validate = moduleBuilder.validate.bind(moduleBuilder);

--- a/android/cli/lib/detect.js
+++ b/android/cli/lib/detect.js
@@ -28,7 +28,7 @@ export { detect };
  * Detects connected Android emulators.
  * @param {Object} config - The CLI config object
  * @param {Object} [opts] - Detection options
- * @param {String} [opts.type] - The type of emulator to load (avd, genymotion); defaults to all
+ * @param {String} [opts.type] - The type of emulator to load (AVD, genymotion); defaults to all
  * @param {Function} finished - Callback when detection is finished
  */
 export function detectEmulators(config, opts, finished) {

--- a/android/cli/lib/info.js
+++ b/android/cli/lib/info.js
@@ -19,7 +19,7 @@ export function detect(types, config, next) {
 	}(__dirname)));
 
 	import('./detect.js').then(({ default: mod }) => {
-		// detect android environment
+		// detect Android environment
 		mod.detect(config, null, function (result) {
 			// detect devices
 			mod.detectDevices(config, function (err, devices) {

--- a/android/cli/lib/process-drawables-task.js
+++ b/android/cli/lib/process-drawables-task.js
@@ -37,7 +37,7 @@ export class ProcessDrawablesTask extends CopyResourcesTask {
 			if (parts.length > 3) {
 				warningMessages.push('- Files cannot be put into subdirectories.');
 				// retain subdirs under the res-<dpi> folder to be mangled into the destination filename
-				// i.e. take images/res-mdpi/logos/app.png and store logos/app, which below will become logos_app.png
+				// e.g. take images/res-mdpi/logos/app.png and store logos/app, which below will become logos_app.png
 				base = parts.slice(2, parts.length - 1).join(path.sep) + path.sep + base;
 			}
 			const destFilename = `${base}.${info.ext}`;

--- a/android/debugger.md
+++ b/android/debugger.md
@@ -32,9 +32,9 @@ Studio implements process termination and process suspension by calling those me
 
 ## Java
 
-On the java side, we begin in V8Runtime again and set up a JSDebugger instance if debugging is enabled. We pass that instance down to C++ V8Runtime to use as part of JSDebugger::Init.
+On the Java side, we begin in V8Runtime again and set up a JSDebugger instance if debugging is enabled. We pass that instance down to C++ V8Runtime to use as part of JSDebugger::Init.
 
-Once the runtime is initialized, we then ask the java JSDebugger to "start()". This implementations spins up a new Thread to listen for debugger connections on the specified port via a ServerSocket.
+Once the runtime is initialized, we then ask the Java JSDebugger to "start()". This implementations spins up a new Thread to listen for debugger connections on the specified port via a ServerSocket.
 
 Once we receive a connection we spin up two additional threads to handle the incoming and outgoing messages between V8 and the debugger.
 

--- a/android/gradlew.bat
+++ b/android/gradlew.bat
@@ -23,7 +23,7 @@
 @rem
 @rem ##########################################################################
 
-@rem Set local scope for the variables with windows NT shell
+@rem Set local scope for the variables with Windows NT shell
 if "%OS%"=="Windows_NT" setlocal
 
 set DIRNAME=%~dp0
@@ -77,7 +77,7 @@ set CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
 "%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %*
 
 :end
-@rem End local scope for the variables with windows NT shell
+@rem End local scope for the variables with Windows NT shell
 if %ERRORLEVEL% equ 0 goto mainEnd
 
 :fail

--- a/android/kroll-apt/README.md
+++ b/android/kroll-apt/README.md
@@ -27,7 +27,7 @@ There are two ways to use this annotation processor:
 1. via javac
     - Example of building a simple proxy: ($TI_MOBILE represents the titanium_mobile repository)
     <code><pre>javac org/test/Test.java -classpath $TI_MOBILE/android/kroll-apt/bin:$TI_MOBILE/android/titanium/bin:$TI_MOBILE/android/kroll-apt/lib/freemarker.jar:$TI_MOBILE/android/kroll-apt/lib/json_simple-1.1.jar -processor org.appcelerator.kroll.annotations.generator.KrollBindingGenerator -Akroll.jsonFile=test.json -s .apt_generated</pre></code>
-    - This process is a little tricky when building titanium itself, because there are circular class dependencies between the @Kroll annotation and certain classes that are annotated in the "titanium" project. See the top level build.xml to see how this is worked around with a two-stage compile.
+    - This process is a little tricky when building Titanium itself, because there are circular class dependencies between the @Kroll annotation and certain classes that are annotated in the "titanium" project. See the top level build.xml to see how this is worked around with a two-stage compile.
 2. via Eclipse's built in Annotation processing support, using the processor as an Eclipse plugin (see details below)
 
 Using the annotation processor in Eclipse
@@ -42,7 +42,7 @@ You will need to make sure you have the Eclipse PDE plugins installed. If you ha
 - Copy this jar into your Eclipse installation's "plugins" folder
 - Restart Eclipse
 - Perform a "clean" build on your entire workspace
-- At this point, if you disable the ".* resources" filter in the Package Explorer view, you should see .apt_generated folders under each titanium project with Generated bindings for each proxy / module. If you are getting compile errors, jump down to Common Problems
+- At this point, if you disable the ".* resources" filter in the Package Explorer view, you should see .apt_generated folders under each Titanium project with Generated bindings for each proxy / module. If you are getting compile errors, jump down to Common Problems
 
 __Developing and debugging the annotation processor in Eclipse__
 

--- a/android/kroll-apt/build.gradle
+++ b/android/kroll-apt/build.gradle
@@ -28,7 +28,7 @@ tasks.register('checkstyleChanged', Checkstyle) {
 	include getChangedFiles()
 }
 
-// Used to strip the src dir prefixes from the changed java files
+// Used to strip the src dir prefixes from the changed Java files
 def getChangedFiles() {
 	if (!project.hasProperty('changedFiles')) {
 		return new ArrayList<>()

--- a/android/kroll-apt/src/main/java/org/appcelerator/kroll/annotations/Kroll.java
+++ b/android/kroll-apt/src/main/java/org/appcelerator/kroll/annotations/Kroll.java
@@ -23,7 +23,7 @@ import java.lang.annotation.Target;
  * 		{@link constant @Kroll.constant}, {@link property @Kroll.property}, {@link getProperty @Kroll.getProperty}, {@link setProperty @Kroll.setProperty}
  * </li>
  * <li>For injecting values into your proxy/module, see: {@link inject @Kroll.inject}</li>
- * <li>For binding a proxy or a proxy method into it's own top level object (i.e. "Titanium" or "setTimeout"), see: {@link topLevel @Kroll.topLevel}</li>
+ * <li>For binding a proxy or a proxy method into it's own top level object (e.g. "Titanium" or "setTimeout"), see: {@link topLevel @Kroll.topLevel}</li>
  * </ul>
  * @author Marshall Culpepper
  */
@@ -244,7 +244,7 @@ public @interface Kroll {
 		boolean set() default true;
 		/**
 		 * The name of this property in the API.<br>
-		 * @default The property's name in java source
+		 * @default The property's name in Java source
 		 */
 		String name() default DEFAULT_NAME;
 	}

--- a/android/kroll-apt/src/main/java/org/appcelerator/kroll/annotations/generator/KrollJSONGenerator.java
+++ b/android/kroll-apt/src/main/java/org/appcelerator/kroll/annotations/generator/KrollJSONGenerator.java
@@ -202,7 +202,7 @@ public class KrollJSONGenerator extends AbstractProcessor
 				// using the FileObject API fails to read the file, we'll use the pure file API
 				String jsonPath = bindingsFile.toUri().toString();
 				if (System.getProperty("os.name").contains("Windows")) {
-					// the file URI in windows needs to be massaged (remove file:\)
+					// the file URI in Windows needs to be massaged (remove file:\)
 					jsonPath = jsonPath.substring(6);
 				}
 				if (jsonPath.startsWith("file:/")) {

--- a/android/modules/android/src/java/ti/modules/titanium/android/TiJSService.java
+++ b/android/modules/android/src/java/ti/modules/titanium/android/TiJSService.java
@@ -33,7 +33,7 @@ public class TiJSService extends TiBaseService
 			if (intent != null && intent.getDataString() != null) {
 				url = intent.getDataString();
 			} else {
-				throw new IllegalStateException("Service url required.");
+				throw new IllegalStateException("Service URL required.");
 			}
 		}
 	}

--- a/android/modules/android/src/java/ti/modules/titanium/android/notificationmanager/NotificationProxy.java
+++ b/android/modules/android/src/java/ti/modules/titanium/android/notificationmanager/NotificationProxy.java
@@ -229,7 +229,7 @@ public class NotificationProxy extends KrollProxy
 	public void setTickerText(String tickerText)
 	{
 		notificationBuilder.setTicker(tickerText);
-		//set the javascript object
+		//set the JavaScript object
 		setProperty(TiC.PROPERTY_TICKER_TEXT, tickerText);
 	}
 

--- a/android/modules/calendar/src/java/ti/modules/titanium/calendar/EventProxy.java
+++ b/android/modules/calendar/src/java/ti/modules/titanium/calendar/EventProxy.java
@@ -26,7 +26,7 @@ import android.net.Uri;
 import android.provider.CalendarContract.Events;
 import android.provider.CalendarContract.Instances;
 
-// Columns and value constants taken from android.provider.Calendar in the android source base
+// Columns and value constants taken from android.provider.Calendar in the Android source base
 @Kroll.proxy(parentModule = CalendarModule.class, propertyAccessors = { TiC.PROPERTY_RECURRENCE_RULES })
 public class EventProxy extends KrollProxy
 {
@@ -510,7 +510,7 @@ public class EventProxy extends KrollProxy
 		results.close();
 
 		if (count == 1) {
-			// android won't let us update, so we have to delete+insert
+			// Android won't let us update, so we have to delete+insert
 			contentResolver.delete(extPropsUri, "name = ? and event_id = ?", new String[] { name, getId() });
 		}
 

--- a/android/modules/contacts/src/java/ti/modules/titanium/contacts/CommonContactsApi.java
+++ b/android/modules/contacts/src/java/ti/modules/titanium/contacts/CommonContactsApi.java
@@ -37,14 +37,14 @@ public abstract class CommonContactsApi
 			useNew = true;
 
 		} catch (ClassNotFoundException e) {
-			Log.e(TAG, "Unable to load contacts api: " + e.getMessage(), e);
+			Log.e(TAG, "Unable to load Contacts API: " + e.getMessage(), e);
 			useNew = false;
 		}
 
 		if (useNew) {
 			ContactsApiLevel5 c = new ContactsApiLevel5();
 			if (!c.loadedOk) {
-				Log.e(TAG, "ContactsApiLevel5 did not load successfully.");
+				Log.e(TAG, "Contacts API Level 5 did not load successfully.");
 				return null;
 
 			} else {
@@ -102,7 +102,7 @@ public abstract class CommonContactsApi
 		return proxies;
 	}
 
-	// Happily, these codes are common across api level
+	// Happily, these codes are common across API level
 	protected static String getEmailTextType(int type)
 	{
 		String key = "other";

--- a/android/modules/contacts/src/java/ti/modules/titanium/contacts/CommonContactsApi.java
+++ b/android/modules/contacts/src/java/ti/modules/titanium/contacts/CommonContactsApi.java
@@ -44,7 +44,7 @@ public abstract class CommonContactsApi
 		if (useNew) {
 			ContactsApiLevel5 c = new ContactsApiLevel5();
 			if (!c.loadedOk) {
-				Log.e(TAG, "Contacts API Level 5 did not load successfully.");
+				Log.e(TAG, "ContactsApiLevel5 did not load successfully.");
 				return null;
 
 			} else {

--- a/android/modules/database/src/java/ti/modules/titanium/database/DatabaseModule.java
+++ b/android/modules/database/src/java/ti/modules/titanium/database/DatabaseModule.java
@@ -143,7 +143,7 @@ public class DatabaseModule extends KrollModule
 
 		// Fetch a path to the source database file. This is the file to be copied/installed.
 		// Throw an exception if the source database was not found.
-		Log.d(TAG, "db url is = " + url, Log.DEBUG_MODE);
+		Log.d(TAG, "database URL is = " + url, Log.DEBUG_MODE);
 		String resolveUrl = url;
 		if (invocation != null) {
 			TiUrl tiUrl = TiUrl.createProxyUrl(invocation.getSourceUrl());
@@ -177,7 +177,7 @@ public class DatabaseModule extends KrollModule
 
 		// Set up the destination path that the source database file will be copied to.
 		File dbPath = ctx.getDatabasePath(name);
-		Log.d(TAG, "db path is = " + dbPath, Log.DEBUG_MODE);
+		Log.d(TAG, "database path is = " + dbPath, Log.DEBUG_MODE);
 
 		// Create the destination directory tree if it doesn't exist.
 		dbPath.getParentFile().mkdirs();

--- a/android/modules/media/src/java/android/widget/TiVideoView8.java
+++ b/android/modules/media/src/java/android/widget/TiVideoView8.java
@@ -21,7 +21,7 @@
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  *
- * This is the api level 8 VideoView.java with Titanium-specific modifications.
+ * This is the API level 8 VideoView.java with Titanium-specific modifications.
  */
 
 package android.widget;

--- a/android/modules/media/src/java/android/widget/TiVideoView8.java
+++ b/android/modules/media/src/java/android/widget/TiVideoView8.java
@@ -724,7 +724,7 @@ public class TiVideoView8 extends SurfaceView implements MediaPlayerControl
 			// TITANIUM
 			if (mPlaybackListener != null) {
 				mPlaybackListener.onStartPlayback();
-				// Fired after a stop or play is called after a after url change.
+				// Fired after a stop or play is called after a after URL change.
 				if (oldState == STATE_PREPARED || oldState == STATE_PREPARING) {
 					mPlaybackListener.onPlayingPlayback();
 				}

--- a/android/modules/media/src/java/ti/modules/titanium/media/TiCameraActivity.java
+++ b/android/modules/media/src/java/ti/modules/titanium/media/TiCameraActivity.java
@@ -617,7 +617,7 @@ public class TiCameraActivity extends TiBaseActivity implements SurfaceHolder.Ca
 	public void finish()
 	{
 		// For API 10 and above, the whole activity gets destroyed during an orientation change. We only want to set
-		// overlayProxy to null when we call finish, i.e. when we hide the camera or take a picture. By doing this, the
+		// overlayProxy to null when we call finish, e.g. when we hide the camera or take a picture. By doing this, the
 		// overlay proxy will be available during the recreation of the activity during an orientation change.
 		overlayProxy = null;
 		super.finish();

--- a/android/modules/media/src/java/ti/modules/titanium/media/TiUIVideoView.java
+++ b/android/modules/media/src/java/ti/modules/titanium/media/TiUIVideoView.java
@@ -265,7 +265,7 @@ public class TiUIVideoView
 			// Url not loaded yet. Do that first.
 			Object urlObj = proxy.getProperty(TiC.PROPERTY_URL);
 			if (urlObj == null) {
-				Log.w(TAG, "play() ignored, no url set.");
+				Log.w(TAG, "play() ignored, no URL set.");
 				return;
 			}
 			getPlayerProxy().fireLoadState(MediaModule.VIDEO_LOAD_STATE_UNKNOWN);

--- a/android/modules/network/src/java/ti/modules/titanium/network/TiHTTPClient.java
+++ b/android/modules/network/src/java/ti/modules/titanium/network/TiHTTPClient.java
@@ -985,7 +985,7 @@ public class TiHTTPClient
 	{
 		try {
 			// TiResourceFile cannot use the FileBody approach directly, because it requires
-			// a java File object, which you can't get from packaged resources. So
+			// a Java File object, which you can't get from packaged resources. So
 			// TiResourceFile uses the approach we use for blobs, which is write out the
 			// contents to a temp file, then use that for the FileBody.
 			if (value instanceof TiBaseFile && !(value instanceof TiResourceFile)) {

--- a/android/modules/network/src/java/ti/modules/titanium/network/TiHTTPClient.java
+++ b/android/modules/network/src/java/ti/modules/titanium/network/TiHTTPClient.java
@@ -196,7 +196,7 @@ public class TiHTTPClient
 				}
 			}
 
-			// Check for new url that is redirected
+			// Check for new URL that is redirected
 			URL currentLocation = connection.getURL();
 			if (autoRedirect && !mURL.sameFile(currentLocation)) {
 				redirectedLocation = currentLocation.toString();
@@ -872,9 +872,9 @@ public class TiHTTPClient
 			throw new IllegalArgumentException("URL cannot be null");
 		}
 
-		// if the url is not prepended with either http or
+		// if the URL is not prepended with either http or
 		// https, then default to http and prepend the protocol
-		// to the url
+		// to the URL
 		String lowerCaseUrl = url.toLowerCase();
 		if (!lowerCaseUrl.startsWith("http://") && !lowerCaseUrl.startsWith("https://")) {
 			url = "http://" + url;
@@ -887,7 +887,7 @@ public class TiHTTPClient
 			this.uri = Uri.parse(url);
 		}
 
-		// If the original url does not contain any
+		// If the original URL does not contain any
 		// escaped query string (i.e., does not look
 		// pre-encoded), go ahead and reset it to the
 		// clean uri. Else keep it as is so the user's
@@ -925,7 +925,7 @@ public class TiHTTPClient
 				port = javaUrl.getPort();
 
 			} catch (MalformedURLException e) {
-				Log.e(TAG, "Error attempting to derive Java url from uri: " + e.getMessage(), e);
+				Log.e(TAG, "Error attempting to derive Java URL from uri: " + e.getMessage(), e);
 			}
 
 		} else {

--- a/android/modules/platform/src/java/ti/modules/titanium/platform/PlatformModule.java
+++ b/android/modules/platform/src/java/ti/modules/titanium/platform/PlatformModule.java
@@ -606,7 +606,7 @@ public class PlatformModule extends KrollModule
 	}
 
 	/**
-	 * Creates an ACTION_VIEW (or similar) intent for the give url to be used to start an activity.
+	 * Creates an ACTION_VIEW (or similar) intent for the give URL to be used to start an activity.
 	 * This method is intended to be used by this class' canOpenURL() and openURL() methods.
 	 * @param url
 	 * The URL to create an intent for such as "http:", "mailto:", "geo:", "file:", etc.

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TabProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TabProxy.java
@@ -181,7 +181,7 @@ public class TabProxy extends TiViewProxy
 	{
 		// Windows are lazily opened when the tab is first focused.
 		if (window != null && !windowOpened) {
-			// Need to handle the url window in the JS side.
+			// Need to handle the URL window in the JS side.
 			window.callPropertySync(TiC.PROPERTY_LOAD_URL, null);
 			windowOpened = true;
 			window.fireEvent(TiC.EVENT_OPEN, null, false);

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/WebViewProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/WebViewProxy.java
@@ -551,7 +551,7 @@ public class WebViewProxy extends ViewProxy implements Handler.Callback, OnLifec
 	{
 		setProperty(TiC.PROPERTY_ZOOM_LEVEL, value);
 
-		// If the web view has not been created yet, don't set html here. It will be set in processProperties() when the
+		// If the web view has not been created yet, don't set HTML here. It will be set in processProperties() when the
 		// view is created.
 		TiUIView v = peekView();
 		if (v != null) {

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/WindowProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/WindowProxy.java
@@ -366,7 +366,7 @@ public class WindowProxy extends TiWindowProxy implements TiActivityWindow
 		}
 		activity.getActivityProxy().getDecorView().add(this);
 
-		// Need to handle the cached activity proxy properties and url window in the JS side.
+		// Need to handle the cached activity proxy properties and URL window in the JS side.
 		callPropertySync(PROPERTY_POST_WINDOW_CREATED, null);
 	}
 

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUILabel.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUILabel.java
@@ -169,7 +169,7 @@ public class TiUILabel extends TiUIView
 				MaterialTextView textView = (MaterialTextView) this;
 				Object text = textView.getText();
 
-				//For html texts, we will manually detect url clicks.
+				// For HTML texts, we will manually detect url clicks.
 				if (text instanceof SpannedString) {
 					SpannedString spanned = (SpannedString) text;
 					Spannable buffer = Factory.getInstance().newSpannable(spanned.subSequence(0, spanned.length()));

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIScrollView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIScrollView.java
@@ -835,7 +835,7 @@ public class TiUIScrollView extends TiUIView
 			}
 		}
 
-		// android only property
+		// Android only property
 		if (d.containsKey(TiC.PROPERTY_SCROLL_TYPE)) {
 			Object scrollType = d.get(TiC.PROPERTY_SCROLL_TYPE);
 			if (scrollType.equals(TiC.LAYOUT_VERTICAL)) {

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
@@ -403,7 +403,7 @@ public class TiUIWebView extends TiUIView
 			}
 		}
 
-		// set user-agent befoe loading url to avoid immediate reload
+		// set user-agent before loading URL to avoid immediate reload
 		if (d.containsKey(TiC.PROPERTY_USER_AGENT)) {
 			((WebViewProxy) getProxy()).setUserAgent(d.getString(TiC.PROPERTY_USER_AGENT));
 		}
@@ -583,7 +583,7 @@ public class TiUIWebView extends TiUIView
 		// The scheme is processed by `resolveUrl()`.
 		final Uri finalUri = Uri.parse(getProxy().resolveUrl(null, url));
 
-		// Reconstruct URL, ommiting any query parameters.
+		// Reconstruct URL, omitting any query parameters.
 		final String finalUrl = finalUri.toString().replace(query, "");
 
 		if (TiFileFactory.isLocalScheme(finalUrl) && mightBeHtml(finalUrl)) {
@@ -642,7 +642,7 @@ public class TiUIWebView extends TiUIView
 		}
 
 		Log.d(TAG, "WebView will load " + url + " directly without code injection.", Log.DEBUG_MODE);
-		// iOS parity: for whatever reason, when a remote url is used, the iOS implementation
+		// iOS parity: for whatever reason, when a remote URL is used, the iOS implementation
 		// explicitly sets the native webview's setScalesPageToFit to YES if the
 		// Ti scalesPageToFit property has _not_ been set.
 		if (!proxy.hasProperty(TiC.PROPERTY_SCALES_PAGE_TO_FIT)) {
@@ -790,7 +790,7 @@ public class TiUIWebView extends TiUIView
 			return;
 		}
 
-		// iOS parity: for whatever reason, when html is set directly, the iOS implementation
+		// iOS parity: for whatever reason, when HTML is set directly, the iOS implementation
 		// explicitly sets the native webview's setScalesPageToFit to NO if the
 		// Ti scalesPageToFit property has _not_ been set.
 		if (this.proxy != null) {
@@ -807,7 +807,7 @@ public class TiUIWebView extends TiUIView
 			}
 		}
 
-		// Set flag to indicate that it's local html (used to determine whether we want to inject binding code)
+		// Set flag to indicate that it's local HTML (used to determine whether we want to inject binding code)
 		isLocalHTML = true;
 
 		if (html.contains(TiWebViewBinding.SCRIPT_INJECTION_ID)) {
@@ -1007,7 +1007,7 @@ public class TiUIWebView extends TiUIView
 					setHtml(TiConvert.toString(getProxy().getProperty(TiC.PROPERTY_HTML)),
 							(HashMap<String, Object>) reloadData);
 				} else {
-					Log.d(TAG, "reloadMethod points to html but reloadData is of wrong type. Calling default",
+					Log.d(TAG, "reloadMethod points to HTML but reloadData is of wrong type. Calling default",
 						  Log.DEBUG_MODE);
 					getWebView().reload();
 				}
@@ -1017,7 +1017,7 @@ public class TiUIWebView extends TiUIView
 				if (reloadData != null && reloadData instanceof String) {
 					setUrl((String) reloadData);
 				} else {
-					Log.d(TAG, "reloadMethod points to url but reloadData is null or of wrong type. Calling default",
+					Log.d(TAG, "reloadMethod points to URL but reloadData is null or of wrong type. Calling default",
 						  Log.DEBUG_MODE);
 					getWebView().reload();
 				}

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiWebViewBinding.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiWebViewBinding.java
@@ -154,7 +154,7 @@ public class TiWebViewBinding
 
 	synchronized public String getJSValue(String expression)
 	{
-		// Don't try to evaluate js code again if the binding has already been destroyed
+		// Don't try to evaluate JS code again if the binding has already been destroyed
 		if (!destroyed && interfacesAdded) {
 			String code = "_TiReturn.setValue((function(){try{return " + expression
 						  + "+\"\";}catch(ti_eval_err){return '';}})());";

--- a/android/modules/xml/src/java/ti/modules/titanium/xml/AttrProxy.java
+++ b/android/modules/xml/src/java/ti/modules/titanium/xml/AttrProxy.java
@@ -43,7 +43,7 @@ public class AttrProxy extends NodeProxy
 	public boolean getSpecified()
 	{
 		// Harmony will return false even when ownerElement is null, whereas
-		// spec says: "If the ownerElement attribute is null (i.e. because it
+		// spec says: "If the ownerElement attribute is null (e.g. because it
 		// was just created or was set to null by the various removal and cloning
 		// operations) specified is true."
 		if (attr.getOwnerElement() == null) {

--- a/android/runtime/common/src/java/org/appcelerator/kroll/KrollObject.java
+++ b/android/runtime/common/src/java/org/appcelerator/kroll/KrollObject.java
@@ -60,7 +60,7 @@ public abstract class KrollObject implements Handler.Callback
 	/**
 	 * Sets whether the passed in event has a corresponding eventListener associated with it on JS side.
 	 * @param event  the event to be set.
-	 * @param hasListeners  If this is true, then the passed in event has a javascript event listener, false otherwise.
+	 * @param hasListeners  If this is true, then the passed in event has a JavaScript event listener, false otherwise.
 	 */
 	public void setHasListenersForEventType(String event, boolean hasListeners)
 	{

--- a/android/runtime/v8/src/java/org/appcelerator/kroll/runtime/v8/JSDebugger.java
+++ b/android/runtime/v8/src/java/org/appcelerator/kroll/runtime/v8/JSDebugger.java
@@ -26,7 +26,7 @@ public final class JSDebugger
 	// The port to listen to for debugger connections
 	private final int port;
 
-	// The sdk version we report in embedding host header for handshake message to debugger.
+	// The SDK version we report in embedding host header for handshake message to debugger.
 	private final String sdkVersion;
 
 	// The lock used to wait for debugger to connect

--- a/android/runtime/v8/src/native/JavaObject.cpp
+++ b/android/runtime/v8/src/native/JavaObject.cpp
@@ -76,7 +76,7 @@ jobject JavaObject::getJavaObject()
 		jobject ref = ReferenceTable::getReference(refTableKey_);
 		if (ref == NULL) {
 			// Sanity check. Did we get into a state where it was weak on Java, got GC'd but the C++ proxy didn't get deleted yet?
-			LOGW(TAG, "Could not obtain reference, java object has already been collected! (Key: %d)", refTableKey_);
+			LOGW(TAG, "Could not obtain reference, Java object has already been collected! (Key: %d)", refTableKey_);
 			refTableKey_ = 0;
 			javaObject_ = NULL;
 		}
@@ -162,7 +162,7 @@ void JavaObject::MakeJavaStrong()
 		jobject stored = ReferenceTable::clearReference(refTableKey_);
 		if (stored == NULL) {
 			// Sanity check. Did we get into a state where it was weak on Java, got GC'd but the C++ proxy didn't get deleted yet?
-			LOGW(TAG, "Could not move weak reference to strong, java object has already been collected! (Key: %d)", refTableKey_);
+			LOGW(TAG, "Could not move weak reference to strong, Java object has already been collected! (Key: %d)", refTableKey_);
 			refTableKey_ = 0;
 			javaObject_ = NULL;
 		} else {
@@ -173,7 +173,7 @@ void JavaObject::MakeJavaStrong()
 		ASSERT(javaObject_ != NULL);
 		ASSERT(refTableKey_ == 0); // make sure we haven't already stored something
 		refTableKey_ = ReferenceTable::createReference(javaObject_); // make strong ref on Java side
-		javaObject_ = NULL; // toss out the java object copy here, it's in ReferenceTable's HashMap
+		javaObject_ = NULL; // toss out the Java object copy here, it's in ReferenceTable's HashMap
 	}
 	// When we're done we should always have a reference key, but no object
 	ASSERT(refTableKey_ != 0);

--- a/android/runtime/v8/src/native/JavaObject.h
+++ b/android/runtime/v8/src/native/JavaObject.h
@@ -50,7 +50,7 @@ public:
 
 	/**
 	 * Determines if we are 'detached'. In real terms this means we either:
-	 * - Are wrapping no java object (so javaObject_ == NULL && refTableKey_ == 0)
+	 * - Are wrapping no Java object (so javaObject_ == NULL && refTableKey_ == 0)
 	 * - OR we've been informed by V8 that the JS object is GC-able and we've made the Java reference a weak one
 	 *
 	 * This is useful to know if we're being asked to release the proxy, then we can truly kill it if this is true. Otherwise we should wait until V8 and the JVM want it dead.
@@ -82,7 +82,7 @@ private:
 	jobject javaObject_;
 
 	/**
-	 * If we're not using global references, this will hold the key to look up the java object in our ReferenceTable. Otherwise it is 0.
+	 * If we're not using global references, this will hold the key to look up the Java object in our ReferenceTable. Otherwise it is 0.
 	 */
 	jlong refTableKey_;
 

--- a/android/runtime/v8/src/native/KrollBindings.cpp
+++ b/android/runtime/v8/src/native/KrollBindings.cpp
@@ -297,8 +297,8 @@ void KrollBindings::dispose(v8::Isolate* isolate)
 }
 
 /*
- * Stores a java KrollSourceCodeProvider instance and the id of its getSourceCode method
- * for an external CommonJS module that is stored in a java external module.
+ * Stores a Java KrollSourceCodeProvider instance and the id of its getSourceCode method
+ * for an external CommonJS module that is stored in a Java external module.
  */
 void KrollBindings::addExternalCommonJsModule(const char *name, jobject sourceProvider, jmethodID sourceRetrievalMethod)
 {

--- a/android/runtime/v8/src/native/KrollBindings.h
+++ b/android/runtime/v8/src/native/KrollBindings.h
@@ -79,7 +79,7 @@ public:
 
 	/**
 	 * The JS callback. Used when we call kroll.externalBinding('name') in JS code.
-	 * This looks up 'external' bindings specifically (i.e. it won't look at the natives/titanium proxies)
+	 * This looks up 'external' bindings specifically (e.g. it won't look at the natives/titanium proxies)
 	 *
 	 * @param args Function arguments
 	 */

--- a/android/runtime/v8/src/native/Proxy.cpp
+++ b/android/runtime/v8/src/native/Proxy.cpp
@@ -97,14 +97,14 @@ static Local<Value> getPropertyForProxy(Isolate* isolate, Local<Name> property, 
 	return value.FromMaybe(Undefined(isolate).As<Value>());
 }
 
-// This variant is used when accessing a property in standard JS fashion (i.e. obj.text or obj['text'])
+// This variant is used when accessing a property in standard JS fashion (e.g. obj.text or obj['text'])
 void Proxy::getProperty(Local<Name> property, const PropertyCallbackInfo<Value>& args)
 {
 	Isolate* isolate = args.GetIsolate();
 	args.GetReturnValue().Set(getPropertyForProxy(isolate, property, args.Holder()));
 }
 
-// This variant is used when accessing a property through a getter method (i.e. obj.getText())
+// This variant is used when accessing a property through a getter method (e.g. obj.getText())
 void Proxy::getProperty(const FunctionCallbackInfo<Value>& args)
 {
 	Isolate* isolate = args.GetIsolate();
@@ -198,7 +198,7 @@ static void onPropertyChangedForProxy(Isolate* isolate, Local<String> property, 
 	setPropertyOnProxy(isolate, property, value, proxyObject);
 }
 
-// This variant is used when accessing a property in a standard way and setting a value (i.e. obj.text = 'whatever')
+// This variant is used when accessing a property in a standard way and setting a value (e.g. obj.text = 'whatever')
 void Proxy::onPropertyChanged(Local<Name> property, Local<Value> value, const v8::PropertyCallbackInfo<void>& info)
 {
 	Isolate* isolate = info.GetIsolate();
@@ -206,7 +206,7 @@ void Proxy::onPropertyChanged(Local<Name> property, Local<Value> value, const v8
 	onPropertyChangedForProxy(isolate, property->ToString(context).ToLocalChecked(), value, info.Holder());
 }
 
-// This variant is used when accessing a property through a getter method (i.e. setText('whatever'))
+// This variant is used when accessing a property through a getter method (e.g. setText('whatever'))
 void Proxy::onPropertyChanged(const v8::FunctionCallbackInfo<v8::Value>& args)
 {
 	Isolate* isolate = args.GetIsolate();
@@ -387,7 +387,7 @@ Local<FunctionTemplate> Proxy::inheritProxyTemplate(Isolate* isolate,
 {
 	EscapableHandleScope scope(isolate);
 
-	// Wrap the java class in an External and we can access it via FunctionCallbackInfo.Data() in #proxyConstructor
+	// Wrap the Java class in an External and we can access it via FunctionCallbackInfo.Data() in #proxyConstructor
 	Local<FunctionTemplate> inheritedTemplate = FunctionTemplate::New(isolate, proxyConstructor, External::New(isolate, javaClass));
 
 	inheritedTemplate->InstanceTemplate()->SetInternalFieldCount(kInternalFieldCount);
@@ -418,13 +418,13 @@ void Proxy::proxyConstructor(const v8::FunctionCallbackInfo<v8::Value>& args)
 	// every instance gets a special "_properties" object for us to use internally for get/setProperty
 	jsProxy->DefineOwnProperty(context, propertiesSymbol.Get(isolate), Object::New(isolate), static_cast<PropertyAttribute>(DontEnum));
 
-	// Now we hook up a java Object from the JVM...
+	// Now we hook up a Java Object from the JVM...
 	jobject javaProxy = Proxy::unwrapJavaProxy(args); // do we already have one that got passed in?
 	bool deleteRef = false;
 	if (!javaProxy) {
 		if (args.Data().IsEmpty() || !args.Data()->IsExternal()) {
 			String::Utf8Value jsClassName(isolate, jsProxy->GetConstructorName());
-			LOGE(TAG, "No JNI Java Class reference set for proxy java proxy type %s", *jsClassName);
+			LOGE(TAG, "No JNI Java Class reference set for proxy Java proxy type %s", *jsClassName);
 			return;
 		}
 

--- a/android/runtime/v8/src/native/Proxy.h
+++ b/android/runtime/v8/src/native/Proxy.h
@@ -18,7 +18,7 @@ class Proxy : public JavaObject
 public:
 	enum {
 		kJavaObject = 0,
-		kInternalFieldCount // Just one internal field on proxies, and it wraps the java object
+		kInternalFieldCount // Just one internal field on proxies, and it wraps the Java object
 	};
 
 	static v8::Persistent<v8::FunctionTemplate> baseProxyTemplate;
@@ -110,7 +110,7 @@ public:
 	static void onEventFired(const v8::FunctionCallbackInfo<v8::Value>& args);
 
 	// This provides Javascript a way to extend one of our native / wrapped
-	// templates without needing to know about the internal java class.
+	// templates without needing to know about the internal Java class.
 	//
 	// An example of what this might look like from JS:
 	// var MyProxy = Ti.UI.View.inherit(function MyView(options) {
@@ -153,12 +153,12 @@ private:
 	/**
 	 * This is the callback used when we need to construct a native Proxy for a JS object.
 	 * Here we typically:
-	 * - wrap the js object in a Proxy instance
+	 * - wrap the JS object in a Proxy instance
 	 * - define an own property "_properties" used for #getProperty and #setProperty callbacks
 	 * - Grab the Java class inside an External from the Data() value.
 	 * This got set back in #inheritProxyTemplate when we generate the FunctionTemplate
 	 * - attach the Java Proxy instantiated to this native Proxy.
-	 * - Deal with argunents passed
+	 * - Deal with arguments passed
 	 *
 	 * @param args The constructor arguments.
 	 */

--- a/android/runtime/v8/src/native/ProxyFactory.h
+++ b/android/runtime/v8/src/native/ProxyFactory.h
@@ -48,7 +48,7 @@ public:
 
 	/**
 	 * Given a jclass, get the name of the class and return it as a Local<Value>
-	 * (using typical java.lang.Names, rather than jni slash separated names)
+	 * (using typical java.lang.Names, rather than JNI slash separated names)
 	 * @param javaClass
 	 */
 	static v8::Local<v8::Value> getJavaClassName(v8::Isolate* isolate, jclass javaClass);

--- a/android/runtime/v8/src/native/TypeConverter.cpp
+++ b/android/runtime/v8/src/native/TypeConverter.cpp
@@ -782,7 +782,7 @@ Local<Array> TypeConverter::javaArrayToJsArray(Isolate* isolate, JNIEnv *env, jo
 	return jsArray;
 }
 
-// converts js value to java object and recursively converts sub objects if this
+// converts JS value to Java object and recursively converts sub objects if this
 // object is a container type
 jobject TypeConverter::jsValueToJavaObject(Isolate* isolate, Local<Value> jsValue, bool *isNew)
 {
@@ -835,7 +835,7 @@ jobject TypeConverter::jsValueToJavaObject(Isolate* isolate, JNIEnv *env, Local<
 		} else {
 
 			Local<Context> context = isolate->GetCurrentContext();
-			// Unwrap hyperloop JS wrappers to get native java proxy
+			// Unwrap hyperloop JS wrappers to get native Java proxy
 			Local<String> nativeString = STRING_NEW(isolate, "$native");
 			if (jsObject->HasOwnProperty(context, nativeString).FromMaybe(false)) {
 
@@ -897,7 +897,7 @@ jobject TypeConverter::jsValueToJavaObject(Isolate* isolate, JNIEnv *env, Local<
 	return NULL;
 }
 
-// converts js object to kroll dict and recursively converts sub objects if this
+// converts JS object to kroll dict and recursively converts sub objects if this
 // object is a container type
 jobject TypeConverter::jsObjectToJavaKrollDict(Isolate* isolate, Local<Value> jsValue, bool *isNew)
 {
@@ -951,7 +951,7 @@ jobject TypeConverter::jsObjectToJavaKrollDict(Isolate* isolate, JNIEnv *env, Lo
 }
 
 
-// converts js value to java error
+// converts JS value to Java error
 jobject TypeConverter::jsValueToJavaError(Isolate* isolate, Local<Value> jsValue, bool* isNew)
 {
 	JNIEnv *env = JNIScope::getEnv();
@@ -966,7 +966,7 @@ jobject TypeConverter::jsValueToJavaError(Isolate* isolate, JNIEnv *env, Local<V
 	if (jsValue->IsObject()) {
 		Local<Object> jsObject = jsValue.As<Object>();
 
-		// If it's a java object, we just return null for now.
+		// If it's a Java object, we just return null for now.
 		if (!JavaObject::isJavaObject(jsObject)) {
 
 			Local<Context> context = isolate->GetCurrentContext();
@@ -996,7 +996,7 @@ jobject TypeConverter::jsValueToJavaError(Isolate* isolate, JNIEnv *env, Local<V
 	return NULL;
 }
 
-// converts java hashmap to js value and recursively converts sub objects if this
+// converts Java hashmap to JS value and recursively converts sub objects if this
 // object is a container type. If javaObject is NULL, an empty object is created.
 Local<Object> TypeConverter::javaHashMapToJsValue(Isolate* isolate, JNIEnv *env, jobject javaObject)
 {
@@ -1034,7 +1034,7 @@ Local<Object> TypeConverter::javaHashMapToJsValue(Isolate* isolate, JNIEnv *env,
 	return jsObject;
 }
 
-// converts java object to js value and recursively converts sub objects if this
+// converts Java object to JS value and recursively converts sub objects if this
 // object is a container type
 Local<Value> TypeConverter::javaObjectToJsValue(Isolate* isolate, jobject javaObject)
 {
@@ -1173,8 +1173,8 @@ jobjectArray TypeConverter::jsObjectIndexPropsToJavaArray(Isolate* isolate, JNIE
 
 /****************************** private methods ******************************/
 
-// used mainly by the array conversion methods when converting java numeric types
-// arrays to to the generic js number type
+// used mainly by the array conversion methods when converting Java numeric types
+// arrays to to the generic JS number type
 Local<Array> TypeConverter::javaDoubleArrayToJsNumberArray(Isolate* isolate, jdoubleArray javaDoubleArray)
 {
 	JNIEnv *env = JNIScope::getEnv();
@@ -1294,7 +1294,7 @@ Local<Object> TypeConverter::javaThrowableToJSError(v8::Isolate* isolate, JNIEnv
 	// We use .As<Object> on Error because an Error is an Object.
 	Local<Object> error = Exception::Error(message.As<String>()).As<Object>();
 
-	// Now loop through the java stack and generate a JS String from the result and assign to Local<String> stack
+	// Now loop through the Java stack and generate a JS String from the result and assign to Local<String> stack
 	std::stringstream stackStream;
 	jobjectArray frames = (jobjectArray) env->CallObjectMethod(javaException, JNIUtil::throwableGetStackTraceMethod);
 	jsize frames_length = env->GetArrayLength(frames);

--- a/android/runtime/v8/src/native/V8Runtime.cpp
+++ b/android/runtime/v8/src/native/V8Runtime.cpp
@@ -404,7 +404,7 @@ JNIEXPORT jboolean JNICALL Java_org_appcelerator_kroll_runtime_v8_V8Runtime_nati
 }
 
 /*
- * Called by V8Runtime.java, this passes a KrollSourceCodeProvider java class instance
+ * Called by V8Runtime.java, this passes a KrollSourceCodeProvider Java class instance
  * to KrollBindings, where it's stored and later used to retrieve an external CommonJS module's
  * Javascript code when require(moduleName) occurs in Javascript.
  * "External" CommonJS modules are CommonJS modules stored in external modules.

--- a/android/runtime/v8/src/native/V8Util.cpp
+++ b/android/runtime/v8/src/native/V8Util.cpp
@@ -173,14 +173,14 @@ void V8Util::openJSErrorDialog(Isolate* isolate, TryCatch &tryCatch)
 	Local<Value> jsStack;
 	Local<Value> javaStack;
 
-	// obtain javascript and java stack traces
+	// obtain JavaScript and Java stack traces
 	if (exception->IsObject()) {
 		Local<Object> error = exception.As<Object>();
 		jsStack = error->Get(context, STRING_NEW(isolate, "stack")).FromMaybe(Undefined(isolate).As<Value>());
 		javaStack = error->Get(context, STRING_NEW(isolate, "nativeStack")).FromMaybe(Undefined(isolate).As<Value>());
 	}
 
-	// javascript stack trace not provided? obtain current javascript stack trace
+	// JavaScript stack trace not provided? obtain current JavaScript stack trace
 	if (jsStack.IsEmpty() || jsStack->IsNullOrUndefined()) {
 		Local<StackTrace> frames = message->GetStackTrace();
 		if (frames.IsEmpty() || !frames->GetFrameCount()) {

--- a/android/runtime/v8/src/native/modules/ScriptsModule.cpp
+++ b/android/runtime/v8/src/native/modules/ScriptsModule.cpp
@@ -262,7 +262,7 @@ void WrappedScript::EvalMachine(const FunctionCallbackInfo<Value>& args)
 	}
 
 	// Explicitly set up var to track context we should use for compile/run of script.
-	// When "thisContext", use the current context from the isolate. Otherwise use the context we set in the persistent above
+	// When "thisContext", use the current context from the isolate. Otherwise use the context we set in the `Persistent` above
 	Local<Context> contextToUse = (context_flag == thisContext) ? currentContext : context.Get(isolate);
 
 	// New and user context share code. DRY it up.

--- a/android/runtime/v8/src/native/modules/ScriptsModule.cpp
+++ b/android/runtime/v8/src/native/modules/ScriptsModule.cpp
@@ -262,7 +262,7 @@ void WrappedScript::EvalMachine(const FunctionCallbackInfo<Value>& args)
 	}
 
 	// Explicitly set up var to track context we should use for compile/run of script.
-	// When "thisContext", use teh current context from the isolate. Otherwise use the context we set in the Persistent above
+	// When "thisContext", use the current context from the isolate. Otherwise use the context we set in the persistent above
 	Local<Context> contextToUse = (context_flag == thisContext) ? currentContext : context.Get(isolate);
 
 	// New and user context share code. DRY it up.

--- a/android/templates/module/generated/build.gradle
+++ b/android/templates/module/generated/build.gradle
@@ -117,7 +117,7 @@ android {
 			res.srcDirs = [
 				"${projectDir}/../../platform/android/res"
 			]
-			// These files are added as JAR resources. Can be accessed in java via Class.getResourceAsStream() method.
+			// These files are added as JAR resources. Can be accessed in Java via Class.getResourceAsStream() method.
 			resources {
 				srcDirs = [
 					"${projectDir}/../../assets",

--- a/android/templates/module/java/template/android/.clang-format
+++ b/android/templates/module/java/template/android/.clang-format
@@ -21,6 +21,6 @@ SpacesInParentheses: false
 TabWidth: 4
 UseTab: ForContinuationAndIndentation
 SpaceAfterCStyleCast: true
-# Spaces inside {} for array literals, i.e. "new Object[] { args }"
+# Spaces inside {} for array literals, e.g. "new Object[] { args }"
 Cpp11BracedListStyle: false
 ReflowComments: false

--- a/android/titanium/build.gradle
+++ b/android/titanium/build.gradle
@@ -243,7 +243,7 @@ tasks.withType(Checkstyle).configureEach {
 	source android.sourceSets.main.java.srcDirs
 }
 
-// Used to strip the src dir prefixes from the changed java files
+// Used to strip the src dir prefixes from the changed Java files
 def getChangedFiles() {
 	if (!project.hasProperty('changedFiles')) {
 		return new ArrayList<>()

--- a/android/titanium/src/java/org/appcelerator/kroll/KrollProxy.java
+++ b/android/titanium/src/java/org/appcelerator/kroll/KrollProxy.java
@@ -932,7 +932,7 @@ public class KrollProxy implements Handler.Callback, KrollProxySupport, OnLifecy
 					} else {
 						String warningMessage
 							= "DEPRECATION WARNING: Events with 'code' and 'success' should have success be true"
-							+ " if and only if code is nonzero. For java modules, consider the putCodeAndMessage()"
+							+ " if and only if code is nonzero. For Java modules, consider the putCodeAndMessage()"
 							+ " method to do this for you. The capability to use other types will be removed in a"
 							+ " future version.";
 						Log.w(TAG, warningMessage, Log.DEBUG_MODE);
@@ -940,13 +940,13 @@ public class KrollProxy implements Handler.Callback, KrollProxySupport, OnLifecy
 				} else if (successValue) {
 					String warningMessage
 						= "DEPRECATION WARNING: Events with 'success' of true should have an integer 'code' property"
-						+ " that is 0. For java modules, consider the putCodeAndMessage() method to do this for you."
+						+ " that is 0. For Java modules, consider the putCodeAndMessage() method to do this for you."
 						+ " The capability to use other types will be removed in a future version.";
 					Log.w(TAG, warningMessage, Log.DEBUG_MODE);
 				} else {
 					String warningMessage
 						= "DEPRECATION WARNING: Events with 'success' of false should have an integer 'code' property"
-						+ " that is nonzero. For java modules, consider the putCodeAndMessage() method to do this for"
+						+ " that is nonzero. For Java modules, consider the putCodeAndMessage() method to do this for"
 						+ " you. The capability to use other types will be removed in a future version.";
 					Log.w(TAG, warningMessage, Log.DEBUG_MODE);
 				}
@@ -963,7 +963,7 @@ public class KrollProxy implements Handler.Callback, KrollProxySupport, OnLifecy
 				krollData.remove(TiC.EVENT_PROPERTY_ERROR);
 			} else if (hashValue != null) {
 				String warningMessage
-					= "DEPRECATION WARNING: The 'error' event property is reserved to be a string. For java modules,"
+					= "DEPRECATION WARNING: The 'error' event property is reserved to be a string. For Java modules,"
 					+ " consider the putCodeAndMessage() method to do this for you. The capability to use other types"
 					+ " will be removed in a future version.";
 				Log.w(TAG, warningMessage, Log.DEBUG_MODE);
@@ -1359,7 +1359,7 @@ public class KrollProxy implements Handler.Callback, KrollProxySupport, OnLifecy
 					eventListeners.remove(eventName);
 				}
 				if (eventListeners.isEmpty()) {
-					// If we don't have any java listeners, we set the property to false
+					// If we don't have any Java listeners, we set the property to false
 					setProperty(PROPERTY_HAS_JAVA_LISTENER, false);
 				}
 			}

--- a/android/titanium/src/java/org/appcelerator/titanium/TiApplication.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiApplication.java
@@ -357,16 +357,16 @@ public abstract class TiApplication extends Application implements KrollApplicat
 		super.onCreate();
 		Log.d(TAG, "Application onCreate", Log.DEBUG_MODE);
 
-		// Reference to android run-time exception handler to delegate exceptions properly.
+		// Reference to Android run-time exception handler to delegate exceptions properly.
 		nativeExceptionHandler = Thread.getDefaultUncaughtExceptionHandler();
 
-		// handle uncaught java exceptions
+		// handle uncaught Java exceptions
 		Thread.setDefaultUncaughtExceptionHandler(new UncaughtExceptionHandler() {
 			@Override
 			public void uncaughtException(Thread t, Throwable e)
 			{
 
-				// obtain java stack trace
+				// obtain Java stack trace
 				String javaStack = null;
 				StackTraceElement[] frames = e.getCause() != null ? e.getCause().getStackTrace() : e.getStackTrace();
 				if (frames != null && frames.length > 0) {

--- a/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
@@ -143,7 +143,7 @@ public abstract class TiBaseActivity extends AppCompatActivity implements TiActi
 
 	public static boolean canFinishRoot = true;
 
-	private boolean overridenLayout;
+	private boolean overriddenLayout;
 
 	public static class DialogWrapper
 	{
@@ -641,21 +641,21 @@ public abstract class TiBaseActivity extends AppCompatActivity implements TiActi
 	@Override
 	public void setContentView(View view)
 	{
-		overridenLayout = true;
+		overriddenLayout = true;
 		super.setContentView(view);
 	}
 
 	@Override
 	public void setContentView(int layoutResID)
 	{
-		overridenLayout = true;
+		overriddenLayout = true;
 		super.setContentView(layoutResID);
 	}
 
 	@Override
 	public void setContentView(View view, LayoutParams params)
 	{
-		overridenLayout = true;
+		overriddenLayout = true;
 		super.setContentView(view, params);
 	}
 
@@ -669,7 +669,7 @@ public abstract class TiBaseActivity extends AppCompatActivity implements TiActi
 	@Override
 	/**
 	 * When the activity is created, this method adds it to the activity stack and
-	 * fires a javascript 'create' event.
+	 * fires a JavaScript 'create' event.
 	 * @param savedInstanceState Bundle of saved data.
 	 */
 	protected void onCreate(Bundle savedInstanceState)
@@ -846,7 +846,7 @@ public abstract class TiBaseActivity extends AppCompatActivity implements TiActi
 		tiApp.setCurrentActivity(this, tempCurrentActivity);
 
 		// If user changed the layout during app.js load, keep that
-		if (!overridenLayout) {
+		if (!overriddenLayout) {
 			super.setContentView(layout);
 		}
 
@@ -1461,7 +1461,7 @@ public abstract class TiBaseActivity extends AppCompatActivity implements TiActi
 
 	@Override
 	/**
-	 * When this activity pauses, this method sets the current activity to null, fires a javascript 'pause' event,
+	 * When this activity pauses, this method sets the current activity to null, fires a JavaScript 'pause' event,
 	 * and if the activity is finishing, remove all dialogs associated with it.
 	 */
 	protected void onPause()
@@ -1504,7 +1504,7 @@ public abstract class TiBaseActivity extends AppCompatActivity implements TiActi
 
 	@Override
 	/**
-	 * When the activity resumes, this method updates the current activity to this and fires a javascript
+	 * When the activity resumes, this method updates the current activity to this and fires a JavaScript
 	 * 'resume' event.
 	 */
 	protected void onResume()
@@ -1544,7 +1544,7 @@ public abstract class TiBaseActivity extends AppCompatActivity implements TiActi
 	@Override
 	/**
 	 * When this activity starts, this method updates the current activity to this if necessary and
-	 * fire javascript 'start' and 'focus' events. Focus events will only fire if
+	 * fire JavaScript 'start' and 'focus' events. Focus events will only fire if
 	 * the activity is not a tab activity.
 	 */
 	protected void onStart()
@@ -1587,7 +1587,7 @@ public abstract class TiBaseActivity extends AppCompatActivity implements TiActi
 
 	@Override
 	/**
-	 * When this activity stops, this method fires the javascript 'blur' and 'stop' events. Blur events will only fire
+	 * When this activity stops, this method fires the JavaScript 'blur' and 'stop' events. Blur events will only fire
 	 * if the activity is not a tab activity.
 	 */
 	protected void onStop()
@@ -1633,7 +1633,7 @@ public abstract class TiBaseActivity extends AppCompatActivity implements TiActi
 	@Override
 	/**
 	 * When a key, touch, or trackball event is dispatched to the activity, this method fires the
-	 * javascript 'userinteraction' event.
+	 * JavaScript 'userinteraction' event.
 	 */
 	public void onUserInteraction()
 	{
@@ -1645,7 +1645,7 @@ public abstract class TiBaseActivity extends AppCompatActivity implements TiActi
 	@Override
 	/**
 	 * When the activity is about to go into the background as a result of user choice, this method fires the
-	 * javascript 'userleavehint' event.
+	 * JavaScript 'userleavehint' event.
 	 */
 	protected void onUserLeaveHint()
 	{
@@ -1661,7 +1661,7 @@ public abstract class TiBaseActivity extends AppCompatActivity implements TiActi
 	@Override
 	/**
 	 * When this activity is destroyed, this method removes it from the activity stack, performs
-	 * clean up, and fires javascript 'destroy' event.
+	 * clean up, and fires JavaScript 'destroy' event.
 	 */
 	protected void onDestroy()
 	{

--- a/android/titanium/src/java/org/appcelerator/titanium/TiExceptionHandler.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiExceptionHandler.java
@@ -117,7 +117,7 @@ public class TiExceptionHandler implements Handler.Callback, KrollExceptionHandl
 		if (javaStack != null) {
 			output += javaStack;
 
-			// no java stack, attempt to obtain last ten stack entries
+			// no Java stack, attempt to obtain last ten stack entries
 			// omitting our error handling entries
 		} else {
 			StackTraceElement[] trace = new Error().getStackTrace();

--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/TiWindowProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/TiWindowProxy.java
@@ -480,7 +480,7 @@ public abstract class TiWindowProxy extends TiViewProxy
 			paddingBottom = bottomDimension.getAsDefault(contentView);
 		}
 
-		// Return the result via a titanium "ViewPadding" dictionary.
+		// Return the result via a Titanium "ViewPadding" dictionary.
 		KrollDict dictionary = new KrollDict();
 		dictionary.put(TiC.PROPERTY_LEFT, paddingLeft);
 		dictionary.put(TiC.PROPERTY_TOP, paddingTop);

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiAnimationBuilder.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiAnimationBuilder.java
@@ -961,7 +961,7 @@ public class TiAnimationBuilder
 			}
 
 			if (applyOpacity && (autoreverse == null || !autoreverse.booleanValue())) {
-				// There is an android bug where animations still occur after
+				// There is an Android bug where animations still occur after
 				// this method. We clear it from the view to
 				// correct this.
 				view.clearAnimation();

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiConvert.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiConvert.java
@@ -683,10 +683,10 @@ public class TiConvert
 	}
 
 	/**
-	 * Returns a url string by appending the
+	 * Returns a URL string by appending the
 	 * String representation of 'uri' to file:///android_asset/Resources/
-	 * @param uri the uri, cannot be null.
-	 * @return url string.
+	 * @param uri the URI, cannot be null.
+	 * @return URL string.
 	 */
 	public static String toURL(Uri uri)
 	{

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiFileHelper.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiFileHelper.java
@@ -230,7 +230,7 @@ public class TiFileHelper
 	/**
 	 * This is a wrapper method.
 	 * Refer to {@link #loadDrawable(String, boolean, boolean)} for more details.
-	 * @param path  url of the Drawable
+	 * @param path  URL of the Drawable
 	 * @param report  this is not being used.
 	 * @return a Drawable instance.
 	 */

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiFileHelper.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiFileHelper.java
@@ -134,7 +134,7 @@ public class TiFileHelper
 			if (isTitaniumResource(path)) {
 				String[] parts = path.split(":");
 				if (parts.length != 3) {
-					Log.w(TAG, "Malformed titanium resource url, resource not loaded: " + path);
+					Log.w(TAG, "Malformed Titanium resource url, resource not loaded: " + path);
 					return null;
 				}
 				@SuppressWarnings("unused")
@@ -336,7 +336,7 @@ public class TiFileHelper
 
 			String[] parts = s.split(":");
 			if (parts.length != 2) {
-				Log.w(TAG, "Malformed titanium resource url, resource not loaded: " + s);
+				Log.w(TAG, "Malformed Titanium resource url, resource not loaded: " + s);
 				return null;
 			}
 			String section = parts[0];
@@ -372,7 +372,7 @@ public class TiFileHelper
 			}
 
 		} else {
-			Log.w(TAG, "Ignoring non titanium resource string id: " + s);
+			Log.w(TAG, "Ignoring non Titanium resource string id: " + s);
 		}
 
 		return d;

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiMenuSupport.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiMenuSupport.java
@@ -53,7 +53,7 @@ public class TiMenuSupport
 	public boolean onOptionsItemSelected(MenuItem item)
 	{
 		// menuProxy could be null in the case
-		// where developer has targeted sdk 11 or higher,
+		// where developer has targeted SDK 11 or higher,
 		// not specified any menu/action bar, has a
 		// heavyweight window and the user clicks the
 		// auto-generated ActionBar.

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiResponseCache.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiResponseCache.java
@@ -179,7 +179,7 @@ public class TiResponseCache extends ResponseCache
 
 	/**
 	 * Check whether the content from uri has been cached. This method is optimized for
-	 * TiResponseCache. For other kinds of ResponseCache, eg. HttpResponseCache, it only
+	 * TiResponseCache. For other kinds of ResponseCache, e.g. HttpResponseCache, it only
 	 * checks whether the system's default response cache is set.
 	 * @param uri The uri to check if cached content exists for.
 	 * @return true if the content from uri is cached; false otherwise.
@@ -566,7 +566,7 @@ public class TiResponseCache extends ResponseCache
 			return null;
 		}
 
-		// Work around an android bug which gives us the wrong URI
+		// Work around an Android bug which gives us the wrong URI
 		try {
 			uri = conn.getURL().toURI();
 		} catch (URISyntaxException e) {

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiResponseCache.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiResponseCache.java
@@ -178,11 +178,11 @@ public class TiResponseCache extends ResponseCache
 	}
 
 	/**
-	 * Check whether the content from uri has been cached. This method is optimized for
+	 * Check whether the content from URI has been cached. This method is optimized for
 	 * TiResponseCache. For other kinds of ResponseCache, e.g. HttpResponseCache, it only
 	 * checks whether the system's default response cache is set.
-	 * @param uri The uri to check if cached content exists for.
-	 * @return true if the content from uri is cached; false otherwise.
+	 * @param uri The URI to check if cached content exists for.
+	 * @return true if the content from URI is cached; false otherwise.
 	 */
 	public static boolean peek(URI uri)
 	{

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiUIHelper.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiUIHelper.java
@@ -997,8 +997,8 @@ public class TiUIHelper
 	}
 
 	/**
-	 * Creates and returns a bitmap from its url.
-	 * @param url the bitmap url.
+	 * Creates and returns a bitmap from its URL.
+	 * @param url the bitmap URL.
 	 * @return a new bitmap instance
 	 */
 	public static Bitmap getResourceBitmap(String url)

--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiDrawableReference.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiDrawableReference.java
@@ -199,9 +199,9 @@ public class TiDrawableReference
 	}
 
 	/**
-	 * Resolves the url, then creates and returns a TiDrawableReference instance.
+	 * Resolves the URL, then creates and returns a TiDrawableReference instance.
 	 * @param proxy the activity proxy.
-	 * @param url the url to resolve.
+	 * @param url the URL to resolve.
 	 * @return A ready instance of TiDrawableReference.
 	 */
 	public static TiDrawableReference fromUrl(KrollProxy proxy, String url)
@@ -222,7 +222,7 @@ public class TiDrawableReference
 	/**
 	 * Creates and returns a TiDrawableReference with type DrawableReferenceType.URL.
 	 * @param activity the referenced activity.
-	 * @param url the resource's url.
+	 * @param url the resource's URL.
 	 * @return A ready instance of TiDrawableReference.
 	 */
 	public static TiDrawableReference fromUrl(Activity activity, String url)
@@ -855,7 +855,7 @@ public class TiDrawableReference
 				stream = TiFileHelper.getInstance().openInputStream(url, false);
 
 			} catch (IOException e) {
-				Log.e(TAG, "Problem opening stream with url " + url + ": " + e.getMessage());
+				Log.e(TAG, "Problem opening stream with URL " + url + ": " + e.getMessage());
 			}
 
 		} else if (isTypeFile() && file != null) {

--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiUIView.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiUIView.java
@@ -500,7 +500,7 @@ public abstract class TiUIView implements KrollProxyListener, OnFocusChangeListe
 
 		animBuilder.applyOptions(options);
 
-		// When using property Animators, we can only use absolute values to specify the anchor point, eg. "50px".
+		// When using property Animators, we can only use absolute values to specify the anchor point, e.g. "50px".
 		// Therefore, we must start the transformation after the layout pass when we get the height and width of the view.
 		if (animBuilder.isUsingPropertyAnimators()) {
 			startTransformAfterLayout(outerView);
@@ -2145,7 +2145,7 @@ public abstract class TiUIView implements KrollProxyListener, OnFocusChangeListe
 	}
 
 	/**
-	 * Can be overriden by inheriting views for special click handling.  For example,
+	 * Can be overridden by inheriting views for special click handling.  For example,
 	 * the Facebook module's login button view needs special click handling.
 	 */
 	protected void setOnClickListener(View view)

--- a/apidoc/Global/Console/Console.yml
+++ b/apidoc/Global/Console/Console.yml
@@ -3,7 +3,7 @@ name: Global.Console
 summary: Console logging facilities.
 description: |
     The toplevel `console` support is intended to supplement <Titanium.API>
-    and make it easier for developers to port existing javascript code
+    and make it easier for developers to port existing JavaScript code
     (especially CommonJS modules) to Titanium.
     
     Note that `console` does not currently implement the complete

--- a/apidoc/Global/Global.yml
+++ b/apidoc/Global/Global.yml
@@ -11,7 +11,7 @@ description: |
 
     #### console
 
-    Titanium provides [console](Global.Console) support familiar to many javascript developers
+    Titanium provides [console](Global.Console) support familiar to many JavaScript developers
     for logging at the toplevel, in addition to the [Titanium](Titanium.API) logging facilities.
 
     #### Timers

--- a/apidoc/Global/Intl/DateTimeFormat.yml
+++ b/apidoc/Global/Intl/DateTimeFormat.yml
@@ -89,7 +89,7 @@ methods:
         summary: The localized date and/or time string.
 
   - name: formatToParts
-    summary: Formats given date to an array of components describing what the formmated string would produce.
+    summary: Formats given date to an array of components describing what the formatted string would produce.
     description: |
       Returns an array of objects providing the "type" and "value" of each component the formatted
       string would produce. Can be used to detect month/day/year ordering for the current locale,

--- a/apidoc/Global/Intl/Intl.yml
+++ b/apidoc/Global/Intl/Intl.yml
@@ -24,7 +24,7 @@ methods:
       ```
     parameters:
       - name: locales
-        summary: A string or array of strings providing BCP 47 locale identifiers to fetch the canoncial names of.
+        summary: A string or array of strings providing BCP 47 locale identifiers to fetch the canonical names of.
         type: [String, Array<String>]
         optional: true
         default: undefined

--- a/apidoc/Global/Intl/NumberFormat.yml
+++ b/apidoc/Global/Intl/NumberFormat.yml
@@ -132,10 +132,10 @@ methods:
         summary: The localized numeric string.
 
   - name: formatToParts
-    summary: Formats given number to an array of components describing what the formmated string would produce.
+    summary: Formats given number to an array of components describing what the formatted string would produce.
     description: |
       Returns an array of objects providing the "type" and "value" of each component the formatted
-      string would produce. Can be used to fetch localized separator chracters, currency characters,
+      string would produce. Can be used to fetch localized separator characters, currency characters,
       currency symbol positions, etc.
 
       For more detail, see the MDN website about

--- a/apidoc/NodeJS/assert.yml
+++ b/apidoc/NodeJS/assert.yml
@@ -137,7 +137,7 @@ methods:
         optional: true
         default: 'Failed'
 
-# TODO: Support the deprected fail invocation format?
+# TODO: Support the deprecated fail invocation format?
 # assert.fail(actual, expected[, message[, operator[, stackStartFn]]])
 
   - name: ifError
@@ -159,7 +159,7 @@ methods:
   #   parameters:
   #     - name: string
   #       type: String
-  #       summary: The strign to match
+  #       summary: The string to match
   #     - name: regexp
   #       type: RegExp
   #       summary: The regular expression to match against

--- a/apidoc/NodeJS/fs.yml
+++ b/apidoc/NodeJS/fs.yml
@@ -16,7 +16,7 @@ description: |
     const fs = require('fs');
     ```
     
-    All file system operations have synchronous and asynchronouse callback forms.
+    All file system operations have synchronous and asynchronous callback forms.
 
     **NOTE:** The Titanium shim for this module does not support the new Promises API yet, nor does it support some of the newer (and a subset of older) APIs.
 
@@ -1262,7 +1262,7 @@ properties:
   - name: O_NONBLOCK
     type: Number
     value: 4
-    summary: Flag indicating to open the file in nonblocking mode when possible.
+    summary: Flag indicating to open the file in non-blocking mode when possible.
 
   - name: S_IRWXU
     type: Number

--- a/apidoc/NodeJS/path.yml
+++ b/apidoc/NodeJS/path.yml
@@ -191,17 +191,17 @@ properties:
     type: String
 
   - name: root
-    summary: Root filesystem path, i.e. `'/'` or `'C:\\'`. Ignored if `pathObject.dir` is provided
+    summary: Root filesystem path, e.g. `'/'` or `'C:\\'`. Ignored if `pathObject.dir` is provided
     type: String
 
   - name: base
-    summary: file basename, i.e. `'file.txt'`
+    summary: file basename, e.g. `'file.txt'`
     type: String
 
   - name: name
-    summary: file basename without the extension, i.e. `'file'`. Ignored if `pathObject.base` exists
+    summary: file basename without the extension, e.g. `'file'`. Ignored if `pathObject.base` exists
     type: String
 
   - name: ext
-    summary: file extension, i.e. `'.txt'`. Ignored if `pathObject.base` exists
+    summary: file extension, e.g. `'.txt'`. Ignored if `pathObject.base` exists
     type: String

--- a/apidoc/NodeJS/process.yml
+++ b/apidoc/NodeJS/process.yml
@@ -61,7 +61,7 @@ properties:
   - name: env
     type: Object
     summary: |
-        This is an object whose keys are environment variable names and whose values are the related environmnet variable values.
+        This is an object whose keys are environment variable names and whose values are the related environment variable values.
 
         In Titanium, we will pass along environment variables from the system/CLI to the app for `'development'` builds,
         *but will not do so for `'production'` builds!*

--- a/apidoc/Titanium/Android/Android.yml
+++ b/apidoc/Titanium/Android/Android.yml
@@ -267,7 +267,7 @@ methods:
         type: Titanium.Android.BroadcastReceiver
       - name: actions
         summary: |
-            The actions that the broadcast reciever will handle
+            The actions that the broadcast receiver will handle
         type: Array<String>
     since: "3.1.0"
 
@@ -372,7 +372,7 @@ properties:
     permission: read-only
 
   - name: ACTION_BATTERY_OKAY
-    summary: Inidicates the battery is now okay after being low.
+    summary: Indicates the battery is now okay after being low.
     description: |
         Pass to the <Titanium.Android.registerBroadcastReceiver> method to listen to the system broadcast.
 
@@ -1850,7 +1850,7 @@ properties:
         This constant is passed to the <Titanium.Android.Service.foregroundNotify> method.
 
         To use this constant, you must also set your `<service/>` element to the
-        `foregroundServieType` attribute value as shown below.
+        `foregroundServiceType` attribute value as shown below.
 
         ``` xml
         <ti:app>
@@ -1875,7 +1875,7 @@ properties:
         This constant is passed to the <Titanium.Android.Service.foregroundNotify> method.
 
         To use this constant, you must also set your `<service/>` element to the
-        `foregroundServieType` attribute value as shown below.
+        `foregroundServiceType` attribute value as shown below.
 
         ``` xml
         <ti:app>
@@ -1900,7 +1900,7 @@ properties:
         This constant is passed to the <Titanium.Android.Service.foregroundNotify> method.
 
         To use this constant, you must also set your `<service/>` element to the
-        `foregroundServieType` attribute value as shown below.
+        `foregroundServiceType` attribute value as shown below.
 
         ``` xml
         <ti:app>
@@ -1925,7 +1925,7 @@ properties:
         This constant is passed to the <Titanium.Android.Service.foregroundNotify> method.
 
         To use this constant, you must also set your `<service/>` element to the
-        `foregroundServieType` attribute value as shown below.
+        `foregroundServiceType` attribute value as shown below.
 
         ``` xml
         <ti:app>
@@ -1951,7 +1951,7 @@ properties:
         This constant is passed to the <Titanium.Android.Service.foregroundNotify> method.
 
         To use this constant, you must also set your `<service/>` element to the
-        `foregroundServieType` attribute value as shown below.
+        `foregroundServiceType` attribute value as shown below.
 
         ``` xml
         <ti:app>
@@ -1975,7 +1975,7 @@ properties:
         This constant is passed to the <Titanium.Android.Service.foregroundNotify> method.
 
         To use this constant, you must also set your `<service/>` element to the
-        `foregroundServieType` attribute value as shown below.
+        `foregroundServiceType` attribute value as shown below.
 
         ``` xml
         <ti:app>
@@ -1999,7 +1999,7 @@ properties:
         This constant is passed to the <Titanium.Android.Service.foregroundNotify> method.
 
         To use this constant, you must also set your `<service/>` element to the
-        `foregroundServieType` attribute value as shown below.
+        `foregroundServiceType` attribute value as shown below.
 
         ``` xml
         <ti:app>
@@ -2141,7 +2141,7 @@ properties:
     since: "3.6.0"
 
   - name: VISIBILITY_PUBLIC
-    summary: Shows the notification's full content on the lockscreen. This is the system default if visibility is left unspecified.
+    summary: Shows the notification's full content on the lock screen. This is the system default if visibility is left unspecified.
     description: |
         Use with the <Titanium.Android.Notification.visibility> property.
 
@@ -2151,7 +2151,7 @@ properties:
     since: "3.6.0"
 
   - name: VISIBILITY_SECRET
-    summary: Shows the most minimal information of the notification on the lockscreen.
+    summary: Shows the most minimal information of the notification on the lock screen.
     description: |
         Use with the <Titanium.Android.Notification.visibility> property.
 
@@ -2161,9 +2161,9 @@ properties:
     since: "3.6.0"
 
   - name: TILE_STATE_UNAVAILABLE
-    summary: QuickSettings tile is unavailble.
+    summary: QuickSettings tile is unavailable.
     description: |
-        For some reason the Tile is not avaialable to the user and will have no click action.
+        For some reason the Tile is not available to the user and will have no click action.
     type: Number
     permission: read-only
     since: "7.0.0"

--- a/apidoc/Titanium/Android/MenuItem.yml
+++ b/apidoc/Titanium/Android/MenuItem.yml
@@ -172,7 +172,7 @@ properties:
     default: null
 
   - name: accessibilityLabel
-    summary: A succint label identifying the view for the device's accessibility service.
+    summary: A succinct label identifying the view for the device's accessibility service.
     description: |
         Value of this property is concatenated together with
         <Titanium.Android.MenuItem.accessibilityValue> and <Titanium.Android.MenuItem.accessibilityHint> in the order: `accessibilityLabel`,
@@ -337,7 +337,7 @@ properties:
         the text is displayed depends on the device's orientation _when the application
         launches_. (This is true of both Titanium applications and native Android
         applications.) For this reason, using `SHOW_AS_ACTION_WITH_TEXT` is not recommended
-        for applications that support both orientions.
+        for applications that support both orientations.
 
         If you want to guarantee that text and icon are always visible, you can create a
         button with the text and image, and specify it as the item's `actionView`.

--- a/apidoc/Titanium/Android/Notification.yml
+++ b/apidoc/Titanium/Android/Notification.yml
@@ -71,7 +71,7 @@ examples:
             action: Ti.Android.ACTION_MAIN,
             // Substitute the correct class name for your application
             className: 'com.appcelerator.notificationsample.NotificationsampleActivity',
-            // Substitue the correct package name for your application
+            // Substitute the correct package name for your application
             packageName: 'com.appcelerator.notificationsample'
         });
         intent.flags |= Ti.Android.FLAG_ACTIVITY_NEW_TASK;
@@ -339,7 +339,7 @@ properties:
     summary: Accent color used behind icon.
     description: |
         Accent color of the circle used behind icon. The Icon will be stenciled in white on top of a
-        cicle of the color set. For information about color values, see the "Colors" section of <Titanium.UI>.
+        circle of the color set. For information about color values, see the "Colors" section of <Titanium.UI>.
 
         See Android Reference for the [color](https://developer.android.com/reference/android/app/Notification.html#color) property.
     type: String
@@ -459,7 +459,7 @@ properties:
     type: String
 
   - name: visibility
-    summary: Allows user to conceal private information of the notification on the lockscreen.
+    summary: Allows user to conceal private information of the notification on the lock screen.
     description: |
          This property only works on devices running Android 5.0 (API 21) and greater.
     type: Number

--- a/apidoc/Titanium/Android/NotificationChannel.yml
+++ b/apidoc/Titanium/Android/NotificationChannel.yml
@@ -72,7 +72,7 @@ properties:
     type: Number
 
   - name: lockscreenVisibility
-    summary: Whether or not notifications posted to this channel are shown on the lockscreen in full or redacted form.
+    summary: Whether or not notifications posted to this channel are shown on the lock screen in full or redacted form.
     type: Number
     constants: [Titanium.Android.VISIBILITY_*]
 

--- a/apidoc/Titanium/Android/QuickSettingsService.yml
+++ b/apidoc/Titanium/Android/QuickSettingsService.yml
@@ -6,7 +6,7 @@ description: |
     and event handling of the tile. Usage is similar to default <Titanium.Android.Service> but with the
     addition of some specific attributes and methods. This service is not started from within the application 
     with the help of an Intent, but instead whenever the custom tile is added in the quick settings menu by the
-    user. Applications can have multiple tiles in the quick settigs menu, but a <Titanium.Android.QuickSettingsService>
+    user. Applications can have multiple tiles in the quick settings menu, but a <Titanium.Android.QuickSettingsService>
     corresponds to a single one - you need separate service file for every tile.
 
     To create a service file:
@@ -148,7 +148,7 @@ methods:
         summary: Dictionary containing the options for the dialog.
 
   - name: startActivityAndCollapse
-    summary: Colapses the quick settings menu and starts an activity for the passed Intent.
+    summary: Collapses the quick settings menu and starts an activity for the passed Intent.
     parameters:
       - name: intent
         summary: Intent to be fired.
@@ -175,15 +175,15 @@ events:
   - name: tileadded
     summary: The Tile has been added in the quick menu.
     description: |
-      Dispatched wheneved the user has moved the Tile for this service in the quick settings menu.
+      Dispatched whenever the user has moved the Tile for this service in the quick settings menu.
 
   - name: tileremoved
     summary: The Tile has been removed from the quick menu.
     description: |
-      Dispatched wheneved the user has removed the Tile for this service from the quick settings menu.
+      Dispatched whenever the user has removed the Tile for this service from the quick settings menu.
 
   - name: tiledialogoptionselected
-    summary: An item from the signle choice menu has been selected.
+    summary: An item from the single choice menu has been selected.
     properties:
       - name: itemIndex
         summary: Index of the selected item from the single choice menu in the dialog.

--- a/apidoc/Titanium/Android/RemoteViews.yml
+++ b/apidoc/Titanium/Android/RemoteViews.yml
@@ -16,7 +16,7 @@ description: |
 
     Because the remote view hierarchy belongs to another process, you cannot call methods on it
     directly, but you can call methods on the `RemoteViews` object to update views in the
-    heirarchy by ID. To reference a view inside the layout, use the
+    hierarchy by ID. To reference a view inside the layout, use the
     <Titanium.App.Android.R> object to reference the view's ID. For example, if you have a 
     view with the ID `notify_imageview`, you can refer to it using:
         

--- a/apidoc/Titanium/Android/Service.yml
+++ b/apidoc/Titanium/Android/Service.yml
@@ -313,7 +313,7 @@ events:
     summary: Fired when the task that comes from the service's application has been removed.
     description: |
          This event is fired if the service is currently running and the user has removed a task
-         that comes from the service's application, eg. the user swipes the application away from
+         that comes from the service's application, e.g. the user swipes the application away from
          the recent applications list. It only works for unbound service which is
          started using <Titanium.Android.startService>.
 

--- a/apidoc/Titanium/App/App.yml
+++ b/apidoc/Titanium/App/App.yml
@@ -319,7 +319,7 @@ events:
           notes: Use `column` property for cross-platform parity.
         platforms: [android]
       - name: javascriptStack
-        summary: The javascript stack trace of the exception. (Deprecated since 9.0.0. Use `stack` instead.)
+        summary: The JavaScript stack trace of the exception. (Deprecated since 9.0.0. Use `stack` instead.)
         type: String
         since: "8.0.0"
         deprecated:
@@ -327,7 +327,7 @@ events:
           notes: Use `stack` property for cross-platform parity.
         platforms: [android]
       - name: javaStack
-        summary: The java stack trace of the exception. (Deprecated since 9.0.0. Use `nativeStack` instead.)
+        summary: The Java stack trace of the exception. (Deprecated since 9.0.0. Use `nativeStack` instead.)
         type: String
         since: "8.0.0"
         deprecated:
@@ -335,7 +335,7 @@ events:
           notes: Use `nativeStack` property for cross-platform parity.
         platforms: [android]
       - name: stack
-        summary: The javascript stack trace of the exception.
+        summary: The JavaScript stack trace of the exception.
         type: String
         since: "9.0.0"
       - name: nativeStack

--- a/apidoc/Titanium/App/App.yml
+++ b/apidoc/Titanium/App/App.yml
@@ -49,7 +49,7 @@ description: |
     or moves to the background state and fires the `paused` event.
 
     Alert-based interruptions result in temporary loss of control by your app and results in `pause`
-    event being fired. Your app continues to run in the foreground, but it does not recieve
+    event being fired. Your app continues to run in the foreground, but it does not receive
     touch events from the system. (It does continue to receive notifications and other types
     of events, such as accelerometer events.) When your app is moved back to the
     active state, the `resumed` event is fired.
@@ -132,7 +132,7 @@ description: |
 
     When you add an event listener on a Titanium module (such as `Ti.App` or
     [Ti.Geolocation](Titanium.Geolocation)), the event listener function is referenced from
-    the global context. This means the event listener function and any objecst it references
+    the global context. This means the event listener function and any object it references
     can't be garbage collected until the event listener is removed.
 
     This can lead to memory leaks if application-level event listeners are added and not
@@ -279,7 +279,7 @@ events:
     summary: Fired when an uncaught JavaScript exception occurs.
     description: |
         This event will occur in both production and development builds, allowing you to warn the
-        user that an error has occured, and log more information to help you fix any bugs.
+        user that an error has occurred, and log more information to help you fix any bugs.
     properties:
       - name: message
         summary: The error message.
@@ -343,7 +343,7 @@ events:
         type: String
         since: "9.0.0"
       - name: column
-        summary: The column offset on the line where the error occured.
+        summary: The column offset on the line where the error occurred.
         type: Number
         since: {android: "9.0.0",  iphone: "4.1.0", ipad: "4.1.0", macos: "9.2.0"}
     platforms: [android, iphone, ipad, macos]
@@ -399,7 +399,7 @@ events:
         the duration of the animation for the presentation and dismissal of the soft keyboard.
 
         Note that the keyboard `height` and `width` properties will not be accurate when the keyboard
-        is being dissmissed.
+        is being dismissed.
 
         For Android it will only work using Android 11 and up. The return values are empty but you can use
         `keyboardVisible` to check if the keyboard is visible or not.
@@ -419,8 +419,8 @@ events:
     description: |
         Examples of significant time changes include the arrival of midnight, an update to the time by a carrier,
         and the change to daylight savings time. If your application is currently in `paused` state, this message
-        will be is queued until your application returns to the foreground, at which point it is delievered. If multiple
-        changes occur, only the most recent one is delievered.
+        will be is queued until your application returns to the foreground, at which point it is delivered. If multiple
+        changes occur, only the most recent one is delivered.
     platforms: [iphone, ipad, macos]
     since: {iphone: "3.1.0", ipad: "3.1.0", macos: "9.2.0"}
 
@@ -502,7 +502,7 @@ properties:
     permission: read-only
 
   - name: currentService
-    summary: A reference to the currnet background service running when the application is placed in the background.
+    summary: A reference to the current background service running when the application is placed in the background.
     type: Titanium.App.iOS.BackgroundService
     permission: read-only
     platforms: [iphone, ipad, macos]
@@ -634,11 +634,11 @@ properties:
     platforms: [android, iphone, ipad, macos]
 
   - name: trackUserInteraction
-    summary: Indicates whether or not the user interaction shoud be tracked.
+    summary: Indicates whether or not the user interaction should be tracked.
     description: |
         Use the <Titanium.App.userinteraction> event to get notified about user interaction.
         For Android, user-interactions are controlled by the event and do not require this
-        property to be set explicitely. For iOS, this is done to prevent additional overhead.
+        property to be set explicitly. For iOS, this is done to prevent additional overhead.
     type: Boolean
     accessors: false
     platforms: [iphone, ipad, macos]

--- a/apidoc/Titanium/App/iOS/ActivityAttributes.yml
+++ b/apidoc/Titanium/App/iOS/ActivityAttributes.yml
@@ -3,7 +3,7 @@ name: Titanium.App.iOS.ActivityAttributes
 summary: |
     Use this module to communicate with the native iOS 16+ Dynamic Island APIs.
 description: |
-    To properly use these APIs, you need to habe your Widget Extension ready.
+    To properly use these APIs, you need to have your Widget Extension ready.
     You can follow this [sample repository](https://github.com/hansemannn/titanium-widget-kit-sample-app) for an extended example.
 since: "12.0.0"
 platforms: [iphone, ipad]

--- a/apidoc/Titanium/App/iOS/SearchableIndex.yml
+++ b/apidoc/Titanium/App/iOS/SearchableIndex.yml
@@ -41,7 +41,7 @@ methods:
         type: Callback<Dictionary>
     platforms: [iphone, ipad, macos]
 
-  - name: deleteAllSearchableItemByDomainIdenifiers
+  - name: deleteAllSearchableItemByDomainIdentifiers
     summary: |
         Removes search items based on an array of domain identifiers.
     parameters:

--- a/apidoc/Titanium/App/iOS/SearchableItem.yml
+++ b/apidoc/Titanium/App/iOS/SearchableItem.yml
@@ -61,7 +61,7 @@ examples:
         });
 
         var item = Ti.App.iOS.createSearchableItem({
-            uniqueIndentifier:"my-id",
+            uniqueIdentifier:"my-id",
             domainIdentifier:"com.mydomain",
             attributeSet:itemAttr
         });

--- a/apidoc/Titanium/App/iOS/UserActivity.yml
+++ b/apidoc/Titanium/App/iOS/UserActivity.yml
@@ -105,7 +105,7 @@ properties:
 
   - name: needsSave
     summary: |
-        Set to true everytime you have updated the user activity and need the changes to be saved before handing it off to another device.
+        Set to true every time you have updated the user activity and need the changes to be saved before handing it off to another device.
     type: Boolean
 
   - name: requiredUserInfoKeys
@@ -172,7 +172,7 @@ methods:
     summary: |
         Deletes user activities created by your app that have the specified persistent identifiers.
     description: |
-        The <Titanium.App.iOS.UserActivity.useractivitydeleted> event is fired after deteting the 
+        The <Titanium.App.iOS.UserActivity.useractivitydeleted> event is fired after deleting the 
         user activities. Listen and wait for this event to fired to ensure that the system deletes 
         the activities (or marks them for deletion).
     parameters:
@@ -184,7 +184,7 @@ methods:
   - name: deleteAllSavedUserActivities
     summary: Deletes all user activities created by your app.
     description: |
-        The <Titanium.App.iOS.UserActivity.useractivitydeleted> event is fired after deteting the 
+        The <Titanium.App.iOS.UserActivity.useractivitydeleted> event is fired after deleting the 
         user activities. Listen and wait for this event to fired to ensure that the system deletes 
         the activities (or marks them for deletion).
     since: "7.4.0"
@@ -194,7 +194,7 @@ events:
     summary: |
         Fired if the activity context needs to be saved before being continued on another device.
 
-        To fire the event, set the UserActiviy object's `needsSave ` property to `true`.
+        To fire the event, set the UserActivity object's `needsSave ` property to `true`.
 
         The receiver should update the activity with current activity state.
 
@@ -217,7 +217,7 @@ events:
         type: Dictionary
     deprecated:
         since: "5.2.0"
-        notes: Set the property `needsSave` to true everytime you update current activity state instead.
+        notes: Set the property `needsSave` to true every time you update current activity state instead.
 
   - name: useractivitywascontinued
     summary: |

--- a/apidoc/Titanium/App/iOS/UserNotificationCenter.yml
+++ b/apidoc/Titanium/App/iOS/UserNotificationCenter.yml
@@ -167,7 +167,7 @@ summary: |
 platforms: [iphone, ipad, macos]
 
 properties:
-  - name: showInForground
+  - name: showInForeground
     summary: Show notification if app is in foreground
     description: |
         Boolean if a notification banner is shown if the app is in foreground.
@@ -190,7 +190,7 @@ properties:
     constants: Titanium.App.iOS.USER_NOTIFICATION_TYPE_*
 
   - name: categories
-    summary: Set of categories of user notification actions required by the applicaiton to use.
+    summary: Set of categories of user notification actions required by the application to use.
     type: Array<Titanium.App.iOS.UserNotificationCategory>
     description: |
         Only available in iOS < 10. iOS 10 and later returns notification settings more detailed,
@@ -217,7 +217,7 @@ properties:
     constants: [Titanium.App.iOS.USER_NOTIFICATION_SETTING_*]
 
   - name: notificationCenterSetting
-    summary: The current notication-center settings.
+    summary: The current notification-center settings.
     type: Number
     constants: [Titanium.App.iOS.USER_NOTIFICATION_SETTING_*]
 

--- a/apidoc/Titanium/App/iOS/iOS.yml
+++ b/apidoc/Titanium/App/iOS/iOS.yml
@@ -53,7 +53,7 @@ description: |
 
     ### Handoff User Activities
 
-    Handoff allows you to create and transfer user activies from one device to another. For example, you can start editing
+    Handoff allows you to create and transfer user activities from one device to another. For example, you can start editing
     a document on your phone, then transfer the activity to your iPad to continue editing the document.
 
     To make an activity shareable, use the <Titanium.App.iOS.UserActivity> API to create the activity.
@@ -164,7 +164,7 @@ methods:
       - name: handlerID
         summary: |
             Unique string identifier for the event (`backgroundfetch`, `silentpush` or `backgroundtransfer`)
-            that initiated the background opertation mode.
+            that initiated the background operation mode.
         type: String
     since: "3.2.0"
 
@@ -175,7 +175,7 @@ methods:
             Use [Titanium.WatchSession](Titanium.WatchSession) instead, which is supported on iOS 9 and later.
     summary: Marks the end of an `openParentApplication:reply` execution by a WatchKit extension.
     description: |
-        This method must be called after your Titaium application has finished processing the `watchkitextensionrequest` event. Optional
+        This method must be called after your Titanium application has finished processing the `watchkitextensionrequest` event. Optional
         information can be provided in the userInfo argument will be provided back to the WatchKit extension as part of the reply method.
         If no userInfo is provide nil will be sent to the WatchKit extension to during the reply callback.
 
@@ -1211,13 +1211,13 @@ events:
       - name: message
         summary: |
             A string containing the localized description of the error.
-            This property does not exhist if errorCode is 0, which means there is no error.
+            This property does not exist if errorCode is 0, which means there is no error.
         type: String
 
       - name: responseText
         summary: |
             The response text for [task](Modules.URLSession.task) and [uploadTask](Modules.URLSession.uploadTask).
-            This property does not exhist for download task. For download task response,
+            This property does not exist for download task. For download task response,
             use [downloadcompleted](Titanium.App.iOS.downloadcompleted) event.
         type: String
         since: "7.2.0"
@@ -1325,7 +1325,7 @@ events:
         type: String
       - name: searchableItemActivityIdentifier
         summary: |
-            With field will contain the searchable Unique Identifier if the continueactivity is fired from a Core Spotlight searh result.
+            With field will contain the searchable Unique Identifier if the continueactivity is fired from a Core Spotlight search result.
         type: String
       - name: title
         summary: |

--- a/apidoc/Titanium/App/iOS/iOS.yml
+++ b/apidoc/Titanium/App/iOS/iOS.yml
@@ -1239,7 +1239,7 @@ events:
         is automatically relaunched in the background, and the app fires the [backgroundtransfer](Titanium.App.iOS.backgroundtransfer) event.
         This event should contain the identifier of the session that caused your app to be launched.
         Your app should then store that `handlerID` before creating a background session configuration object
-        with the same identifier, and creating a url session object with that configuration.
+        with the same identifier, and creating a URL session object with that configuration.
         The newly created session is automatically reassociated with ongoing background activity.
 
         When your app later receives a `sessioneventscompleted` event, this indicates that
@@ -1546,7 +1546,7 @@ properties:
     summary: The application or service that triggered the handled URL.
     type: String
   - name: url
-    summary: The url that was triggered by the application or service.
+    summary: The URL that was triggered by the application or service.
     type: String
 
 ---
@@ -1568,5 +1568,5 @@ properties:
     constants: Titanium.App.iOS.USER_NOTIFICATION_TYPE_*
 
   - name: categories
-    summary: Set of categories of user notification actions required by the applicaiton to use.
+    summary: Set of categories of user notification actions required by the application to use.
     type: Array<Titanium.App.iOS.UserNotificationCategory>

--- a/apidoc/Titanium/App/iOS/iOS.yml
+++ b/apidoc/Titanium/App/iOS/iOS.yml
@@ -656,7 +656,7 @@ properties:
 
   - name: UTTYPE_APPLE_ICNS
     summary: |
-        Uniform type identifier for Mac OS icon images.
+        Uniform type identifier for macOS icon images.
     type: String
     permission: read-only
     value: "com.apple.icns"

--- a/apidoc/Titanium/Blob.yml
+++ b/apidoc/Titanium/Blob.yml
@@ -69,7 +69,7 @@ properties:
         **NOTE 1**: On SDK versions prior to 9.1.0, Ti.Blob images may have reported in points, not pixels.
         This would occur for images with a higher density/scale returned by <Titanium.UI.View.toImage> or images with `@dx` density suffixes.
         You may multiply by <Titanium.Platform.DisplayCaps.logicalDensityFactor> to try and determine the pixels, but this value may be off for some pixel/density combinations.
-        (i.e. a `10px` image would report as `3` on a `3x` density screen, so multiplying would give you `9` pixels, which is still incorrect)
+        (e.g. a `10px` image would report as `3` on a `3x` density screen, so multiplying would give you `9` pixels, which is still incorrect)
 
         **NOTE 2**: This represents the height the platform decodes the image to in memory. iOS will automatically
         rotate a JPEG based on its EXIF orientation when loaded into memory, but Android does not and instead
@@ -100,7 +100,7 @@ properties:
         **NOTE 1**: On SDK versions prior to 9.1.0, Ti.Blob images may have reported in points, not pixels.
         This would occur for images with a higher density/scale returned by <Titanium.UI.View.toImage> or images with `@dx` density suffixes.
         You may multiply by <Titanium.Platform.DisplayCaps.logicalDensityFactor> to try and determine the pixels, but this value may be off for some pixel/density combinations.
-        (i.e. a `10px` image would report as `3` on a `3x` density screen, so multiplying would give you `9` pixels, which is still incorrect)
+        (e.g. a `10px` image would report as `3` on a `3x` density screen, so multiplying would give you `9` pixels, which is still incorrect)
 
         **NOTE 2**: This represents the width the platform decodes the image to in memory. iOS will automatically
         rotate a JPEG based on its EXIF orientation when loaded into memory, but Android does not and instead

--- a/apidoc/Titanium/Buffer.yml
+++ b/apidoc/Titanium/Buffer.yml
@@ -125,7 +125,7 @@ methods:
         summary: The number of bytes copied.
     summary: Copies data from `sourceBuffer` into the current buffer at `offset`.
     description: |
-        Does not expand this buffer if there is not enough room  to accomodate the data
+        Does not expand this buffer if there is not enough room to accommodate the data
         from `sourceBuffer`.
 
         If `sourceOffset` and `sourceLength` are specified, bytes are copied from
@@ -162,7 +162,7 @@ methods:
         type: Titanium.Buffer
     summary: Creates a complete or partial copy of this buffer.
     description: |
-        If called with no arguments, retuns a complete copy of the current buffer.
+        If called with no arguments, returns a complete copy of the current buffer.
 
         If `offset` and `length` are specified, creates a new buffer from the original
         buffer contents starting at `offset` and ending at `offset`+`length`-1.

--- a/apidoc/Titanium/Calendar/Calendar.yml
+++ b/apidoc/Titanium/Calendar/Calendar.yml
@@ -358,7 +358,7 @@ properties:
     platforms: [iphone, ipad, macos]
 
   - name: RECURRENCEFREQUENCY_DAILY
-    summary: Indicates a daily recurrence rule for a events reccurance frequency.
+    summary: Indicates a daily recurrence rule for a events recurrence frequency.
     description:  |
         Used with the <Titanium.Calendar.RecurrenceRule.frequency> property.
 
@@ -373,7 +373,7 @@ properties:
     since: {iphone: "3.1.0", ipad: "3.1.0", android: "7.1.0"}
 
   - name: RECURRENCEFREQUENCY_WEEKLY
-    summary: Indicates a weekly recurrence rule for a events reccurance frequency.
+    summary: Indicates a weekly recurrence rule for a events recurrence frequency.
     description:  |
         Used with the <Titanium.Calendar.RecurrenceRule.frequency> property.
 
@@ -388,7 +388,7 @@ properties:
     since: {iphone: "3.1.0", ipad: "3.1.0", android: "7.1.0"}
 
   - name: RECURRENCEFREQUENCY_MONTHLY
-    summary: Indicates a monthly recurrence rule for a events reccurance frequency.
+    summary: Indicates a monthly recurrence rule for a events recurrence frequency.
     description:  |
         Used with the <Titanium.Calendar.RecurrenceRule.frequency> property.
 
@@ -403,7 +403,7 @@ properties:
     since: {iphone: "3.1.0", ipad: "3.1.0", android: "7.1.0"}
 
   - name: RECURRENCEFREQUENCY_YEARLY
-    summary: Indicates a yearly recurrence rule for a events reccurance frequency.
+    summary: Indicates a yearly recurrence rule for a events recurrence frequency.
     description:  |
         Used with the <Titanium.Calendar.RecurrenceRule.frequency> property.
 
@@ -739,7 +739,7 @@ properties:
     summary: |
         All calendars selected within the native calendar app, which may be a subset of `allCalendars`.
     description: |
-        The native calendar application may know via the registered webservices, such as Gooogle or
+        The native calendar application may know via the registered web services, such as Google or
         Facebook accounts about calendars that it has access to but have not been selected to be
         displayed in the native calendar app.
     type: Array<Titanium.Calendar.Calendar>

--- a/apidoc/Titanium/Codec/Codec.yml
+++ b/apidoc/Titanium/Codec/Codec.yml
@@ -287,7 +287,7 @@ methods:
         *   If `sourcePosition` is included, a substring of the source string starting at the
             specified position is encoded.
 
-        *   If `sourceLength` is included, at most the specified numer of characters
+        *   If `sourceLength` is included, at most the specified number of characters
             are encoded.
 
         Throws an exception if `charset` is not a valid character set,

--- a/apidoc/Titanium/Contacts/Contacts.yml
+++ b/apidoc/Titanium/Contacts/Contacts.yml
@@ -201,7 +201,7 @@ properties:
     summary: A boolean value that indicates whether to fetch the notes stored in contacts or not.
     description:  |
         This  property need to be set before calling contacts APIs.
-        From iOS 13 or later if your app fetch note field from contact, the app must have to set key 'com.apple.developer.contacts.notes' to 'true' in entitelements section of tiapp.xml.
+        From iOS 13 or later if your app fetch note field from contact, the app must have to set key 'com.apple.developer.contacts.notes' to 'true' in entitlements section of tiapp.xml.
 
         ``` xml
         <key>com.apple.developer.contacts.notes</key>

--- a/apidoc/Titanium/Contacts/Group.yml
+++ b/apidoc/Titanium/Contacts/Group.yml
@@ -14,7 +14,7 @@ methods:
     parameters:
       - name: person
         summary: |
-            Person to add. For >= iOS9, it is not required to
+            Person to add. For >= iOS 9, it is not required to
             call <Titanium.Contacts.save> after calling this method.
         type: Titanium.Contacts.Person
         
@@ -25,7 +25,7 @@ methods:
     
   - name: remove
     summary: |
-        Removes a person from this group. For >= iOS9, it is not
+        Removes a person from this group. For >= iOS 9, it is not
         required to call <Titanium.Contacts.save> after calling this method.
     parameters:
       - name: person

--- a/apidoc/Titanium/Contacts/Person.yml
+++ b/apidoc/Titanium/Contacts/Person.yml
@@ -137,7 +137,7 @@ properties:
     since: {iphone: "5.0.0", ipad: "5.0.0", macos: "9.2.0"}
 
   - name: image
-    summary: Image for the person. Single value. Read-only for >= iOS9
+    summary: Image for the person. Single value. Read-only for >= iOS 9
     description: Set to `null` to remove the image. 
     type: Titanium.Blob
     

--- a/apidoc/Titanium/Database/Database.yml
+++ b/apidoc/Titanium/Database/Database.yml
@@ -30,7 +30,7 @@ methods:
       rather than copying the file from the path provided in the first
       argument.
 
-      Files stored in the `Private Documents` directory on iOS5 will be
+      Files stored in the `Private Documents` directory on iOS 5 will be
       automatically backed up to iCloud and removed from the device in low
       storage situations. See
       [How do I prevent files from being backed up to iCloud?](https://developer.apple.com/library/ios/qa/qa1719/_index.html)

--- a/apidoc/Titanium/Database/Database.yml
+++ b/apidoc/Titanium/Database/Database.yml
@@ -136,7 +136,7 @@ methods:
     examples:
     - title: Open a Database from Internal Storage (iOS)
       example: |
-        A database, with a persistant name of `mydb1Installed` and located in the
+        A database, with a persistent name of `mydb1Installed` and located in the
         default database location on internal storage, is opened.
 
         ``` js
@@ -157,7 +157,7 @@ methods:
         * `/Applications/<apple app id>/Library/Application Support/database/mydb1Installed.sql` (earlier versions)
     - title: Open a Database on Internal Storage (Android)
       example: |
-        A database, with a persistant name of `mydb1Installed` and located in the
+        A database, with a persistent name of `mydb1Installed` and located in the
         default database location on internal storage, is opened.
 
         ``` js

--- a/apidoc/Titanium/Filesystem/File.yml
+++ b/apidoc/Titanium/Filesystem/File.yml
@@ -412,7 +412,7 @@ properties:
     description: |
         iOS platform-note: Prior to Titanium SDK 7.0.0, this method returned the
         path of the parent directory as a String. Since Titanium SDK 7.0.0 it
-        returnes a <Titanium.Filesystem.File> reference for parity wih Android and Windows.
+        returns a <Titanium.Filesystem.File> reference for parity wih Android and Windows.
     type: Titanium.Filesystem.File
     permission: read-only
     platforms: [android]

--- a/apidoc/Titanium/Filesystem/Filesystem.yml
+++ b/apidoc/Titanium/Filesystem/Filesystem.yml
@@ -61,7 +61,7 @@ methods:
         `Resources` directory, **not** to the current context. This is a known issue
         that will be addressed in a future release.
 
-        On iOS9, if app thinning is enabled, and the file of interest is an image file
+        On iOS 9, if app thinning is enabled, and the file of interest is an image file
         that was bundled with the app (not downloaded during runtime), this will not return
         the image file since it is already allocated inside the assets catalog. Please
         use [getAsset](Titanium.Filesystem.getAsset) instead for this case.

--- a/apidoc/Titanium/Geolocation/Android/Android.yml
+++ b/apidoc/Titanium/Geolocation/Android/Android.yml
@@ -29,7 +29,7 @@ description: |
     using location updates, you should remove any registered event listeners.
 
     In manual mode, the application is responsible for dynamically updating the settings
-    to acheive its required accuracy while limiting battery usage. For example, an
+    to achieve its required accuracy while limiting battery usage. For example, an
     application might do any of the following:
 
     *   If the application isn't getting updates frequently enough, it can adjust its

--- a/apidoc/Titanium/Geolocation/Geolocation.yml
+++ b/apidoc/Titanium/Geolocation/Geolocation.yml
@@ -93,7 +93,7 @@ description: |
 
     On Android, two different location service modes are supported: *simple*, and *manual*.
 
-    *   *Simple mode* provides a compromise mode that provides adaquate support for
+    *   *Simple mode* provides a compromise mode that provides adequate support for
         undemanding location applications without requiring developers to
         write a lot of Android-specific code. To use simple mode:
 
@@ -277,7 +277,7 @@ methods:
         their permissions from "When in Use" to "Always". In order to get the best usability for iOS 11 and later, request "When in Use" first
         and upgrade your location-permissions by requesting "Always" permissions later if required. If this permission-flow is not used, iOS
         will still ask the user to select between "When in Use", "Always", and "Don't Allow" (primary action) on iOS 11 when asking for "Always"
-        permissions, which can lead to a higher frequence of denied permissions, so be careful requesting location permissions.
+        permissions, which can lead to a higher frequency of denied permissions, so be careful requesting location permissions.
         The iOS 11 related upgrade-flow is available in Titanium SDK 6.3.0 and later.
 
         Finally, iOS 11 and later will require you to *always* include the `NSLocationWhenInUseUsageDescription` permission and Titanium will throw a
@@ -598,7 +598,7 @@ properties:
   - name: AUTHORIZATION_RESTRICTED
     summary: |
         A [locationServicesAuthorization](Titanium.Geolocation.locationServicesAuthorization) value
-        indicating that the application is not authorized to use location servies *and*
+        indicating that the application is not authorized to use location services *and*
         the user cannot change this application's status.
     type: Number
     permission: read-only
@@ -748,7 +748,7 @@ properties:
         `ACCURACY_NEAREST_TEN_METERS`, `ACCURACY_HUNDRED_METERS`, `ACCURACY_KILOMETER`, or
         `ACCURACY_THREE_KILOMETERS`.
 
-        For finer-grained control on Android, use *manual mode*, instead of specifing an accuracy.
+        For finer-grained control on Android, use *manual mode*, instead of specifying an accuracy.
         This mode requires more active management on the part of the application, but it
         is recommended to maximize accuracy and battery life.
         See <Titanium.Geolocation.Android> for details on using manual mode.

--- a/apidoc/Titanium/Locale/Locale.yml
+++ b/apidoc/Titanium/Locale/Locale.yml
@@ -109,7 +109,7 @@ methods:
         Returns a string, localized according to the current system locale using the appropriate 
         `/i18n/LANG/strings.xml` localization file.
     description: |
-        This method is functionaly identical to its alias <Global.L>. For example, 
+        This method is functionally identical to its alias <Global.L>. For example, 
         `Ti.Locale.getString('thisKey', 'missing key')` produces the same result as 
         `L('thisKey', 'missing key')`.
         

--- a/apidoc/Titanium/Media/AudioPlayer.yml
+++ b/apidoc/Titanium/Media/AudioPlayer.yml
@@ -285,7 +285,7 @@ events:
 
       - name: code
         summary: |
-            Error code. Different between android and iOS.
+            Error code. Different between Android and iOS.
         type: Number
     since: "4.1.0"
 

--- a/apidoc/Titanium/Media/Media.yml
+++ b/apidoc/Titanium/Media/Media.yml
@@ -1741,7 +1741,7 @@ properties:
         Returns an object of possible `targetImageWidth` and `targetImageHeight` values. The output
         contains a `cameraType` (front or back) and object of width/height values. You have to set
         `targetImageWidth` and `targetImageHeight` if you want to change the camera image output size.
-        Note: depeneding on your phone and camera the values won't be used or can be different.
+        Note: depending on your phone and camera the values won't be used or can be different.
     type: Object
     platforms: [android]
     permission: read-only

--- a/apidoc/Titanium/Media/Media.yml
+++ b/apidoc/Titanium/Media/Media.yml
@@ -743,14 +743,14 @@ properties:
     since: "3.4.2"
 
   - name: AUDIO_SESSION_PORT_BLUETOOTHLE
-    summary: Constant for output on a Bluetooth Low Energy device. This is an output port. This is available on iOS7 and later.
+    summary: Constant for output on a Bluetooth Low Energy device. This is an output port. This is available on iOS 7 and later.
     type: String
     permission: read-only
     platforms: [iphone, ipad, macos]
     since: "3.4.2"
 
   - name: AUDIO_SESSION_PORT_CARAUDIO
-    summary: Constant for Input or output via Car Audio. This can be both an input and output port. This is available on iOS7 and later.
+    summary: Constant for Input or output via Car Audio. This can be both an input and output port. This is available on iOS 7 and later.
     type: String
     permission: read-only
     platforms: [iphone, ipad, macos]
@@ -873,28 +873,28 @@ properties:
     since:
         android: "3.2.0"
   - name: CAMERA_AUTHORIZATION_AUTHORIZED
-    summary: Constant specifying that app is authorized to use camera. This is available on iOS7 and later.
+    summary: Constant specifying that app is authorized to use camera. This is available on iOS 7 and later.
     type: Number
     permission: read-only
     exclude-platforms: [android]
     since: "4.0.0"
 
   - name: CAMERA_AUTHORIZATION_DENIED
-    summary: Constant specifying that app is denied usage of camera. This is available on iOS7 and later.
+    summary: Constant specifying that app is denied usage of camera. This is available on iOS 7 and later.
     type: Number
     permission: read-only
     exclude-platforms: [android]
     since: "4.0.0"
 
   - name: CAMERA_AUTHORIZATION_RESTRICTED
-    summary: Constant specifying that app is restricted from using camera. This is available on iOS7 and later.
+    summary: Constant specifying that app is restricted from using camera. This is available on iOS 7 and later.
     type: Number
     permission: read-only
     exclude-platforms: [android]
     since: "4.0.0"
 
   - name: CAMERA_AUTHORIZATION_UNKNOWN
-    summary: Constant specifying that app is not yet authorized to use camera. This is available on iOS7 and later.
+    summary: Constant specifying that app is not yet authorized to use camera. This is available on iOS 7 and later.
     type: Number
     permission: read-only
     exclude-platforms: [android]
@@ -908,7 +908,7 @@ properties:
   - name: IMAGE_SCALING_AUTO
     summary: Scales the image depending on how the view container is sized.
     description: |
-        If a [width](Titanium.UI.View.width) and [height](Titanium.UI.View.height) are both conigured on the
+        If a [width](Titanium.UI.View.width) and [height](Titanium.UI.View.height) are both configured on the
         image view, then it will use [IMAGE_SCALING_FILL](Titanium.Media.IMAGE_SCALING_FILL)
         to stretch the image disproportionally to fill the view. Otherwise it will use
         [IMAGE_SCALING_ASPECT_FIT](Titanium.Media.IMAGE_SCALING_ASPECT_FIT) to letterbox/pillarbox the image.
@@ -1476,7 +1476,7 @@ properties:
     since: {android: "6.2.0", iphone: "0.9.0", ipad: "0.9.0"}
 
   - name: VIDEO_REPEAT_MODE_ONE
-    summary: Constant for repeating one video (i.e., the one video will repeat constantly) during playback.
+    summary: Constant for repeating one video (e.g., the one video will repeat constantly) during playback.
     type: Number
     permission: read-only
     platforms: [android, iphone, ipad, macos]

--- a/apidoc/Titanium/Network/BonjourService.yml
+++ b/apidoc/Titanium/Network/BonjourService.yml
@@ -208,7 +208,7 @@ examples:
         bonjourSocket.accept({ timeout: 10000 });
 
         // Publish the service
-        localService.publish(bonjourSocket, fnction (err, bool) {
+        localService.publish(bonjourSocket, function (err, bool) {
           // Now you can find the service on your network (including using a Ti.Network.BonjourBrowser)
         });
         ```

--- a/apidoc/Titanium/Network/Cookie.yml
+++ b/apidoc/Titanium/Network/Cookie.yml
@@ -445,7 +445,7 @@ methods:
     summary: Returns true if the cookie is valid.
     description: |
         This method checks if the cookie is valid. For a cookie to be valid the minimum
-        properties requiered are `name`, `value`, `path` and either `domain` or `originalUrl` (iOS only)
+        properties required are `name`, `value`, `path` and either `domain` or `originalUrl` (iOS only)
     platforms: [android, iphone, ipad, macos]
     since: {android: "6.2.0", iphone: "3.3.0", ipad: "3.3.0"}
     returns:

--- a/apidoc/Titanium/Network/Cookie.yml
+++ b/apidoc/Titanium/Network/Cookie.yml
@@ -492,7 +492,7 @@ properties:
     availability: creation
 
   - name: originalUrl
-    summary: The origual url attribute of the cookie.
+    summary: The original URL attribute of the cookie.
     type: String
     platforms: [iphone, ipad, macos]
     since: "3.3.0"

--- a/apidoc/Titanium/Network/HTTPClient.yml
+++ b/apidoc/Titanium/Network/HTTPClient.yml
@@ -118,7 +118,7 @@ description: |
       </dict>
     </dict>
     ```
-    Titanium will not fallback with a lower TLS version if the `tlsVersion` property in android or `NSExceptionMinimumTLSVersion` in iOS, is set.
+    Titanium will not fallback with a lower TLS version if the `tlsVersion` property in Android or `NSExceptionMinimumTLSVersion` in iOS, is set.
     Setting the TLS version saves time from re-attempting connections with lower TLS versions and
     provides added security by denying attempts to use lower TLS versions.
 

--- a/apidoc/Titanium/Network/HTTPClient.yml
+++ b/apidoc/Titanium/Network/HTTPClient.yml
@@ -285,7 +285,7 @@ properties:
   - name: DONE
     summary: Ready state constant indicating that the request is complete.
     description: |
-        In this ready state, either the data has been transferred, or an error has occured.
+        In this ready state, either the data has been transferred, or an error has occurred.
 
         See also [readyState](Titanium.Network.HTTPClient.readyState).
     type: Number
@@ -607,7 +607,7 @@ properties:
 
         If `cache` is `false`, any request on this HTTP client will result in a new HTTP request.
 
-        This propery must be set before `open` is called.
+        This property must be set before `open` is called.
     type: Boolean
     since: "2.0.0"
     default: false

--- a/apidoc/Titanium/Network/Network.yml
+++ b/apidoc/Titanium/Network/Network.yml
@@ -477,7 +477,7 @@ properties:
     platforms: [iphone, ipad, macos]
 
   - name: NOTIFICATION_TYPE_NEWSSTAND
-    summary: Constant value for a Newsstand style push notification. Only available on iOS5 and later
+    summary: Constant value for a Newsstand style push notification. Only available on iOS 5 and later
     type: Number
     permission: read-only
     platforms: [iphone, ipad, macos]

--- a/apidoc/Titanium/Network/Socket/TCP.yml
+++ b/apidoc/Titanium/Network/Socket/TCP.yml
@@ -235,7 +235,7 @@ methods:
         or [LISTENING](Titanium.Network.Socket.LISTENING) state.
         Throws an exception if a valid host and port has not been set on this socket.
 
-        Nonblocking; connection attempts are asynchronous.
+        Non-blocking; connection attempts are asynchronous.
 
   - name: listen
     summary: Attempts to start listening on the socket's host/port.
@@ -243,7 +243,7 @@ methods:
         The `listen` call will attempt to listen on the specified host and/or port
         property for the socket if they are set.
 
-        Nonblocking; may return before the socket is fully open and listening.
+        Non-blocking; may return before the socket is fully open and listening.
 
         If the socket is already in a [LISTENING](Titanium.Network.Socket.LISTENING) or
         [CONNECTED](Titanium.Network.Socket.CONNECTED) state, `listen` throws an exception
@@ -256,7 +256,7 @@ methods:
   - name: accept
     summary: Tells a [LISTENING](Titanium.Network.Socket.LISTENING) socket to accept a connection request at the top of a listener's request queue when one becomes available.
     description: |
-        Nonblocking; if there are no connections in the queue, sets a flag so that
+        Non-blocking; if there are no connections in the queue, sets a flag so that
         the socket accepts the next incoming connection immediately.
 
         Takes an argument, an <AcceptDict> object which assigns options to the new

--- a/apidoc/Titanium/Network/TCPSocket.yml
+++ b/apidoc/Titanium/Network/TCPSocket.yml
@@ -16,7 +16,7 @@ methods:
   - name: close
     summary: close the socket
   - name: connect
-    summary: connect the scocket to a TCP server
+    summary: connect the socket to a TCP server
   - name: listen
     summary: set up the socket to receive connections
   - name: write
@@ -39,7 +39,7 @@ events:
         summary: a blob representing the data read, can be interpreted via toString
         type: Titanium.Blob
   - name: readError
-    summary: an error occured when reading
+    summary: an error occurred when reading
     properties:
       - name: success
         summary: Indicates a successful operation. Returns `false`.
@@ -56,7 +56,7 @@ events:
             is used. Otherwise, this value will be -1.
         type: Number
   - name: writeError
-    summary: an error occured when writing
+    summary: an error occurred when writing
     properties:
       - name: success
         summary: Indicates a successful operation. Returns `false`.

--- a/apidoc/Titanium/Platform/Platform.yml
+++ b/apidoc/Titanium/Platform/Platform.yml
@@ -359,7 +359,7 @@ properties:
 
   - name: osname
     summary: |
-        Short name of the system's Operating System. Returns `android` for the Android platfrom,
+        Short name of the system's Operating System. Returns `android` for the Android platform,
         `iphone` for the iPhone or iPod Touch, `ipad` for the iPad, `windowsphone` for Windows Phone, and `windowsstore` for Windows Store
         platform.
     type: String

--- a/apidoc/Titanium/Platform/Platform.yml
+++ b/apidoc/Titanium/Platform/Platform.yml
@@ -64,7 +64,7 @@ methods:
     since: {android: "8.1.0", iphone: "0.8", ipad: "0.8"}
     parameters:
       - name: url
-        summary: The url to check.
+        summary: The URL to check.
         type: String
 
   - name: cpus
@@ -117,7 +117,7 @@ methods:
         type: Boolean
     parameters:
       - name: url
-        summary: The url to open.
+        summary: The URL to open.
         type: String
       - name: options
         summary: |

--- a/apidoc/Titanium/Platform/Platform.yml
+++ b/apidoc/Titanium/Platform/Platform.yml
@@ -69,7 +69,7 @@ methods:
 
   - name: cpus
     summary: |
-        Returns an array of basic cpu information for all logical processors
+        Returns an array of basic CPU information for all logical processors
     description: |
         This is intended to provide an implementation similar to Node's `os.cpus()`.
     returns:
@@ -471,7 +471,7 @@ properties:
 
 ---
 name: CPUTimes
-summary: Simple object holding the data for a logical cpu execution times.
+summary: Simple object holding the data for a logical CPU execution times.
 properties:
 
   - name: user

--- a/apidoc/Titanium/Proxy.yml
+++ b/apidoc/Titanium/Proxy.yml
@@ -4,8 +4,8 @@ summary: The base for all Titanium objects.
 description: |
     On platforms that use native code (Android and iOS), the `Proxy` type represents a
     JavaScript wrapper or _proxy_ around a native object. Setting or getting a property
-    on a proxy object results in a method invokation on the native object. Likewise,
-    calling a method on the proxy object results in a method invokation on the native
+    on a proxy object results in a method invocation on the native object. Likewise,
+    calling a method on the proxy object results in a method invocation on the native
     object.
 
     Some Titanium objects are _createable_: new instances of these objects can be created using

--- a/apidoc/Titanium/Stream/Stream.yml
+++ b/apidoc/Titanium/Stream/Stream.yml
@@ -84,7 +84,7 @@ methods:
         `Buffer` or `Blob` is provided as the `source` property in `params`.
 
 
-        `Blob` obects are read only. Throws an exception if `MODE_WRITE` or `MODE_APPEND` is
+        `Blob` objects are read only. Throws an exception if `MODE_WRITE` or `MODE_APPEND` is
         specified along with a blob object.
     parameters:
 

--- a/apidoc/Titanium/UI/AlertDialog.yml
+++ b/apidoc/Titanium/UI/AlertDialog.yml
@@ -493,7 +493,7 @@ properties:
   - name: tintColor
     summary: The tint-color of the dialog.
     description: |
-        This property is a direct correspondant of the `tintColor` property of
+        This property is a direct correspondent of the `tintColor` property of
         UIView on iOS. For a dialog, it will tint the color of it's buttons.
         For information about color values, see the "Colors" section of <Titanium.UI>.
     type: [ String, Titanium.UI.Color ]

--- a/apidoc/Titanium/UI/AnimatedOptions.yml
+++ b/apidoc/Titanium/UI/AnimatedOptions.yml
@@ -14,7 +14,7 @@ properties:
 ---
 name: AnimatedWithDurationOptions
 extends: AnimatedOptions
-summary: A JavaScript object holding `animated` and `duration` properties. Used on iOS For [TablewView](Titanium.UI.TableView) and [ListView](Titanium.UI.ListView) content offset transitions.
+summary: A JavaScript object holding `animated` and `duration` properties. Used on iOS For [TableView](Titanium.UI.TableView) and [ListView](Titanium.UI.ListView) content offset transitions.
 properties:
   - name: duration
     type: Number

--- a/apidoc/Titanium/UI/Animation.yml
+++ b/apidoc/Titanium/UI/Animation.yml
@@ -204,7 +204,7 @@ properties:
     type: Number
 
   - name: transform
-    summary: Animate the view from its current tranform to the specified transform.
+    summary: Animate the view from its current transform to the specified transform.
     description: |
         Over the course of the animation, the view interpolates from its current transform to the
         specified transform.
@@ -217,7 +217,7 @@ properties:
     description: |
         The new view being transitioned to **should NOT** be a child of another view or
         of the animating view. The animation replaces the current view from the
-        view heirarchy and adds the new view to it.
+        view hierarchy and adds the new view to it.
     type: Number
     constants: Titanium.UI.iOS.AnimationStyle.*
     platforms: [iphone, ipad, macos]
@@ -230,7 +230,7 @@ properties:
 
         The new view being transitioned to **should NOT** be a child of another view or
         of the animating view. The animation replaces the current view from the
-        view heirarchy and adds the new view to it.
+        view hierarchy and adds the new view to it.
     type: Titanium.UI.View
     platforms: [iphone, ipad, macos]
 

--- a/apidoc/Titanium/UI/Attribute.yml
+++ b/apidoc/Titanium/UI/Attribute.yml
@@ -191,7 +191,7 @@ properties:
       regardless of the font size or size of any attached graphic. This value must be nonnegative float value 
       or dimension string (e.g. '10px').
       E.g. If you have set minimum height 30 and font size 10. It will make line height 30 which have 
-      smaller text size and more vertical sapcing between text. 
+      smaller text size and more vertical spacing between text. 
     type: [Number,String]
 
   - name: lineSpacing

--- a/apidoc/Titanium/UI/Attribute.yml
+++ b/apidoc/Titanium/UI/Attribute.yml
@@ -91,7 +91,7 @@ properties:
         }
         ```
 
-        On IOS, if you use the <Titanium.UI.ATTRIBUTE_PARAGRAPH_STYLE>, the `value` must be ParagraphAttribute. 
+        On iOS, if you use the <Titanium.UI.ATTRIBUTE_PARAGRAPH_STYLE>, the `value` must be ParagraphAttribute. 
         E.g:
         ``` js
         {

--- a/apidoc/Titanium/UI/Button.yml
+++ b/apidoc/Titanium/UI/Button.yml
@@ -30,7 +30,7 @@ description: |
     The Material style introduced in Titanium SDK 10.0.0 will change the default look of the buttons.
     You can change button styles with a custom theme as follows:
     ``` xml
-    <!-- Assign this custom theme to "tiapp.xml" file's android manifest application element. -->
+    <!-- Assign this custom theme to "tiapp.xml" file's Android manifest application element. -->
     <style name="Theme.MyTheme" parent="Theme.Titanium.Light">
         <item name="textAppearanceButton">@style/TextAppearance.MyButton</item>
         <item name="android:buttonStyle">@style/Widget.MyButton</item>

--- a/apidoc/Titanium/UI/Button.yml
+++ b/apidoc/Titanium/UI/Button.yml
@@ -150,7 +150,7 @@ properties:
         The underlying attributed string drawn by the label. If set, avoid setting common attributes
         in the label, such as `color` and `font`, as unexpected behaviors may result.
 
-        iOS Note: This property can also be used to supress the underline style when accessibility
+        iOS note: This property can also be used to suppress the underline style when accessibility
         is enabled. To do so, set the `type` to <Titanium.UI.ATTRIBUTE_UNDERLINES_STYLE> and the
         `value` to <Titanium.UI.ATTRIBUTE_UNDERLINE_STYLE_NONE>.
     type: Titanium.UI.AttributedString
@@ -257,7 +257,7 @@ properties:
         [tintColor](Titanium.UI.Button.tintColor) property. If set `false`, the image is displayed as-is.
 
         On Android, you can set this to a numeric resource drawable ID via `Ti.App.Android.R.drawable.*`
-        which lets you use native vector drawbles that are commonly used as icons.
+        which lets you use native vector drawables that are commonly used as icons.
     type: [String, Number, Titanium.Blob]
 
   - name: imageIsMask

--- a/apidoc/Titanium/UI/ButtonBar.yml
+++ b/apidoc/Titanium/UI/ButtonBar.yml
@@ -13,7 +13,7 @@ description: |
     Use the <Titanium.UI.createButtonBar> method or **`<ButtonBar>`** Alloy element to create a button bar.
 
     The [TabbedBar](Titanium.UI.iOS.TabbedBar) control is a button bar where the
-    last selected button mantains a pressed or selected state. The following discussion
+    last selected button maintains a pressed or selected state. The following discussion
     applies to both button bar and tabbed bar.
 extends: Titanium.UI.View
 since: {android: "10.0.0", iphone: "0.8", ipad: "0.8", macos: "9.2.0"}

--- a/apidoc/Titanium/UI/Label.yml
+++ b/apidoc/Titanium/UI/Label.yml
@@ -142,7 +142,7 @@ properties:
   - name: html
     summary: Pass a HTML-based string and it will be formatted accordingly.
     description: |
-        Note that complex html structures like images are not supported.
+        Note that complex HTML structures like images are not supported.
         Use a <Titanium.UI.WebView> for those cases.
     platforms: [android, iphone, ipad, macos]
     since: { android: "0.8.0", iphone: "12.3.0", ipad: "12.3.0", macos: "12.3.0" }

--- a/apidoc/Titanium/UI/Label.yml
+++ b/apidoc/Titanium/UI/Label.yml
@@ -176,7 +176,7 @@ properties:
     since: "4.1.0"
 
   - name: lineCount
-    summary: Returns the amount of lines the content is acually using. Is equal or lower than `maxLines`.
+    summary: Returns the amount of lines the content is actually using. Is equal or lower than `maxLines`.
     type: Number
     permission: read-only
     since: "12.3.0"
@@ -250,7 +250,7 @@ properties:
     type: String
 
   - name: textTransform
-    summary: Property that specifies how to capitialize the text. Can be `lowercase`, `uppercase` or `none` (default)
+    summary: Property that specifies how to capitalize the text. Can be `lowercase`, `uppercase` or `none` (default)
     type: String
     default: "none"
     since: "12.7.0"
@@ -304,7 +304,7 @@ events:
         The URL is set using the [ATTRIBUTE_LINK](Titanium.UI.ATTRIBUTE_LINK) property on the [attributedString](Titanium.UI.Label.attributedString).
 
         On Android, this event also fires if the `html` property is used instead of the `attributedString` property. This event will
-        also override the default behavior of openning the link in its default application.
+        also override the default behavior of opening the link in its default application.
 
         On iOS, this is only valid on version 7 and above. In previous versions of the the Titanium SDK this event required a `longpress`
         gesture to be performed. Beginning with Titanium SDK 4.0.0, only a `singletap` gesture is required to invoke this event.

--- a/apidoc/Titanium/UI/ListItem.yml
+++ b/apidoc/Titanium/UI/ListItem.yml
@@ -682,13 +682,13 @@ description: |
     But please note that the trigger to activate these edit actions can defer based on the API you're integrating the edit actions:
 
     *List Views*:
-    By default when a ListItem has [canEdit](Titanium.UI.ListItem.canEdit) set to `true`, a left swipe on the the row presens the localized 'Delete' button.
+    By default when a ListItem has [canEdit](Titanium.UI.ListItem.canEdit) set to `true`, a left swipe on the the row presents the localized 'Delete' button.
     This object lets developers define custom titles for editing actions supported on the row.
     This object is used in conjunction with the [editActions](Titanium.UI.ListItem.editActions) property and
     [editaction](Titanium.UI.ListView.editaction) event.
     
     *Table Views*:
-    By default when a TableViewRow has [editable](Titanium.UI.TableViewRow.editable) set to `true`, a left swipe on the the row presens the localized 'Delete' button.
+    By default when a TableViewRow has [editable](Titanium.UI.TableViewRow.editable) set to `true`, a left swipe on the the row presents the localized 'Delete' button.
     This object lets developers define custom titles for editing actions supported on the row.
     This object is used in conjunction with the [editActions](Titanium.UI.TableViewRow.editActions) property and
     [editaction](Titanium.UI.TableView.editaction) event. For table views, this property was added in Titanium SDK 12.4.0.

--- a/apidoc/Titanium/UI/ListView.yml
+++ b/apidoc/Titanium/UI/ListView.yml
@@ -165,7 +165,7 @@ description: |
         - [canEdit](Titanium.UI.ListItem.canEdit) - When this is set to true, it allows the item to be deleted
           from the ListView through a user initiated action. The item can only be deleted when the ListView is
           in editing mode. The ListView can enter 'editing' mode either by explicitly setting the [editing](Titanium.UI.ListView.editing)
-          property to true, or by swiping accross an item whose `canEdit` property is set to true. When the user
+          property to true, or by swiping across an item whose `canEdit` property is set to true. When the user
           deletes the item, a [delete](Titanium.UI.ListView.delete) event is fired.
 
         - [editActions](Titanium.UI.ListItem.editActions) - When [canEdit](Titanium.UI.ListItem.canEdit) is set to true, the default behavior
@@ -193,7 +193,7 @@ description: |
           be deleted or reordered.
 
         - [requiresEditingToMove](Titanium.UI.ListView.requiresEditingToMove) - Determines if the ListView
-          should be able to drag-and-drop without explicitely enabling editing support (like drag bars).
+          should be able to drag-and-drop without explicitly enabling editing support (like drag bars).
 
         - [pruneSectionsOnEdit](Titanium.UI.ListView.pruneSectionsOnEdit) - When this property is set to true and the
           user action results in a section having no other items, the section is deleted from the List View. Please note
@@ -639,7 +639,7 @@ events:
         This event will fire while the list view is scrolling and the user releases the finger.
         On iOS no event is fired when the finger is not released. Use  `direction` to determine the scroll direction,
         `velocity` to determine scroll speed, targetContentOffset to determine where the scrolling will end (in dpi).
-        When `direction` is `down`, `velocity` is negative and viceversa. On Android `velocity` and `targetContentOffset` is 0.
+        When `direction` is `down`, `velocity` is negative and vice versa. On Android `velocity` and `targetContentOffset` is 0.
 
     platforms: [android, iphone, ipad, macos]
     since:
@@ -1851,7 +1851,7 @@ summary: |
 description: |
     Not all properties apply to all methods.
     `animationStyle` does not apply to the `scrollToItem` method.
-    `positon` only applies to the `scrollToItem` method.
+    `position` only applies to the `scrollToItem` method.
     Since Release 3.3.0 of the Titanium SDK, Android supports the `animated` property and is applicable only to `scrollToItem`
 platforms: [iphone, ipad, android, macos]
 since: {android: "10.1.0", iphone: "3.1.0", ipad: "3.1.0", macos: "9.2.0"}

--- a/apidoc/Titanium/UI/Notification.yml
+++ b/apidoc/Titanium/UI/Notification.yml
@@ -81,7 +81,7 @@ properties:
     type: Number
     default: 0
   - name: verticalMargin
-    summary: Vertical placement of the notifcation, *as a fraction of the screen height*.
+    summary: Vertical placement of the notification, *as a fraction of the screen height*.
     description: Useful values range from -0.5 (top) to 0.5 (bottom). A value
         of zero indicates default placement.
     type: Number

--- a/apidoc/Titanium/UI/OptionDialog.yml
+++ b/apidoc/Titanium/UI/OptionDialog.yml
@@ -107,7 +107,7 @@ events:
         type: Number
         platforms: [iphone, ipad, macos]
 
-# FIXME: I think Android does support AnimatedOptions for show/hide (separately, versus how ios only really takes show and uses the animated value for hide), defaulting to false
+# FIXME: I think Android does support AnimatedOptions for show/hide (separately, versus how iOS only really takes show and uses the animated value for hide), defaulting to false
 methods:
   - name: show
     summary: Shows this dialog.
@@ -206,7 +206,7 @@ properties:
     description: |
         This property is useful to ensure that the option dialog will display contents properly
         on the iPAD idiom without ghosting when scrolling. This property is only respected on the
-        iPAD idiom on iOS7 and above.
+        iPAD idiom on iOS 7 and above.
     type: Boolean
     default: false
     since: "3.2.0"

--- a/apidoc/Titanium/UI/OptionDialog.yml
+++ b/apidoc/Titanium/UI/OptionDialog.yml
@@ -300,7 +300,7 @@ examples:
             if (e.button === false && e.index === 0) {
               alert('Confirm option selected! e.index = ' + e.index);
             }
-            if (e.button === false && eventeindex === 1) {
+            if (e.button === false && e.index === 1) {
               alert('Cancel option selected! e.index = ' + e.index);
             }
             if (e.button === true && e.index === 0) {

--- a/apidoc/Titanium/UI/OptionDialog.yml
+++ b/apidoc/Titanium/UI/OptionDialog.yml
@@ -205,8 +205,8 @@ properties:
     summary: Boolean value indicating if the option dialog should have an opaque background.
     description: |
         This property is useful to ensure that the option dialog will display contents properly
-        on the iPAD idiom without ghosting when scrolling. This property is only respected on the
-        iPAD idiom on iOS 7 and above.
+        on the iPad idiom without ghosting when scrolling. This property is only respected on the
+        iPad idiom on iOS 7 and above.
     type: Boolean
     default: false
     since: "3.2.0"

--- a/apidoc/Titanium/UI/Picker.yml
+++ b/apidoc/Titanium/UI/Picker.yml
@@ -301,7 +301,7 @@ properties:
     summary: |
         Determines whether the Time pickers display in 24-hour or 12-hour clock format.
     description: |
-        Only applcable to pickers of type <Titanium.UI.PICKER_TYPE_TIME>.
+        Only applicable to pickers of type <Titanium.UI.PICKER_TYPE_TIME>.
 
         When this property is set `true`, a time picker is displayed with hours 0 through 23.
         When set `false`, hours will be 1 through 12 with am/pm controls.
@@ -447,7 +447,7 @@ properties:
     default: <Titanium.UI.PICKER_TYPE_PLAIN>
 
   - name: useSpinner
-    summary: Determines if a multicolumn spinner or single column drop-down picker should be used.
+    summary: Determines if a multi-column spinner or single column drop-down picker should be used.
     description: |
         This property is intended to be used by plain picker types. When set on date/time pickers,
         this property will override the [datePickerStyle](Titanium.UI.Picker.datePickerStyle) property.
@@ -466,7 +466,7 @@ properties:
     platforms: [android]
 
   - name: nativeSpinner
-    summary: Determines if a multicolumn spinner or single column drop-down picker should be used.
+    summary: Determines if a multi-column spinner or single column drop-down picker should be used.
     description: |
         This property is intended to be used by time picker types.
 

--- a/apidoc/Titanium/UI/ScrollableView.yml
+++ b/apidoc/Titanium/UI/ScrollableView.yml
@@ -259,7 +259,7 @@ properties:
     summary: Number of pages to cache (pre-render).
     description: |
         Pages are rendered in the range (currentPage +/- (cacheSize - 1)/2), *rounded down* for even
-        values (i.e. cacheSize=4 renders 3 pages into the cache.) Keep in mind that improved
+        values (e.g. cacheSize=4 renders 3 pages into the cache.) Keep in mind that improved
         performance (larger cache) will lead to faster performance, but greater memory usage.
     type: Number
     platforms: [android, iphone, ipad, macos]

--- a/apidoc/Titanium/UI/Slider.yml
+++ b/apidoc/Titanium/UI/Slider.yml
@@ -12,7 +12,7 @@ description: |
 
     #### Android Platform Implementation Notes
 
-    On Android, the user can also maniuplate the slider using the arrow keys. For this
+    On Android, the user can also manipulate the slider using the arrow keys. For this
     reason, placing other focusable UI elements to the left or right of
     the slider is not recommended.
 

--- a/apidoc/Titanium/UI/Tab.yml
+++ b/apidoc/Titanium/UI/Tab.yml
@@ -119,7 +119,7 @@ methods:
     summary: Sets the root window that appears in the tab.
     description: |
         You can only use this method to set the tab's root window before the TabGroup containing this tab
-        is openened, that is, once the TabGroup is displayed, you cannot change the root window
+        is opened, that is, once the TabGroup is displayed, you cannot change the root window
         that appears in the tab.
     parameters:
       - name: window
@@ -187,7 +187,7 @@ properties:
     summary: Badge value for this tab. `null` indicates no badge.
     description: |
         On the Android platform you will need to use a Theme with `parent="Theme.MaterialComponents.*"`
-        in order to use a badge. You have to pass a number as a string. Non-numberic characters will not be displayed.
+        in order to use a badge. You have to pass a number as a string. Non-numeric characters will not be displayed.
 
         On iOS, a badge will only be shown if the tab has been assigned an icon. Text only tabs do not support badges.
     type: String

--- a/apidoc/Titanium/UI/TabGroup.yml
+++ b/apidoc/Titanium/UI/TabGroup.yml
@@ -394,7 +394,7 @@ properties:
   - name: navTintColor
     summary: The tintColor to apply to the navigation bar (typically for the **More** tab).
     description: |
-        This property is a direct correspondant of the tintColor property of NavigationBar on iOS.
+        This property is a direct correspondent of the tintColor property of NavigationBar on iOS.
     type: [String, Titanium.UI.Color]
     since: "3.3.0"
     default: null
@@ -554,7 +554,7 @@ properties:
   - name: tabsTintColor
     summary: The tintColor to apply to the tabs.
     description: |
-        This property is a direct correspondant of the tintColor property of UITabBar on iOS. This effects the
+        This property is a direct correspondent of the tintColor property of UITabBar on iOS. This effects the
         title and icons rendered in the active tab. When not specified the active icons are tinted with a bright
         blue.
     type: [String, Titanium.UI.Color]

--- a/apidoc/Titanium/UI/TabGroup.yml
+++ b/apidoc/Titanium/UI/TabGroup.yml
@@ -363,7 +363,7 @@ properties:
   - name: translucent
     summary: Boolean value indicating if the nav bar (typically for the **More** tab), is translucent.
     platforms: [iphone, ipad, macos]
-    default: true on iOS7 and above, false otherwise.
+    default: true on iOS 7 and above, false otherwise.
     type: Boolean
     since: "3.3.0"
 

--- a/apidoc/Titanium/UI/TableView.yml
+++ b/apidoc/Titanium/UI/TableView.yml
@@ -22,7 +22,7 @@ description: |
     The simplest approach is to pass dictionaries of `TableViewRow` properties, such as
     [backgroundColor](Titanium.UI.TableViewRow.backgroundColor),
     [color](Titanium.UI.TableViewRow.color), and [title](Titanium.UI.TableViewRow.title), to the
-    [createTableView](Titanium.UI.createTableView) method, which causes the rows to be implictly
+    [createTableView](Titanium.UI.createTableView) method, which causes the rows to be implicitly
     created, added to a single [TableViewSection](Titanium.UI.TableViewSection), and then added to
     the `TableView`. Refer to the "Simple Table View with Basic Rows" example.
 
@@ -1400,7 +1400,7 @@ properties:
     type: Number
 
   - name: scrollable
-    summary: If `true`, the tableview can be scrolled.
+    summary: If `true`, the table view can be scrolled.
     type: Boolean
     default: true
     since: { android: 7.3.0, iphone: 0.8, ipad: 0.8 }

--- a/apidoc/Titanium/UI/TableViewRow.yml
+++ b/apidoc/Titanium/UI/TableViewRow.yml
@@ -282,7 +282,7 @@ properties:
         detailed information.
 
         On iOS, this is specifically used when clicking on the row navigates to the next table view
-        in a heirarchy of table views.
+        in a hierarchy of table views.
     type: Boolean
     default: false
 
@@ -415,7 +415,7 @@ properties:
     type: String
 
   - name: accessibilityLabel
-    summary: A succint label associated with the table row for the device's accessibility service.
+    summary: A succinct label associated with the table row for the device's accessibility service.
     description: |
         See <Titanium.UI.View.accessibilityLabel> description.
     since: "3.0.0"

--- a/apidoc/Titanium/UI/TextArea.yml
+++ b/apidoc/Titanium/UI/TextArea.yml
@@ -450,7 +450,7 @@ properties:
     since: 2.1.2
 
   - name: showUndoRedoActions
-    summary: Determinates if the undo and redo buttons on the left side of the keyboard should be displayed or not. Only valid on iOS9 and above. This property can only be set upon creation.
+    summary: Determinates if the undo and redo buttons on the left side of the keyboard should be displayed or not. Only valid on iOS 9 and above. This property can only be set upon creation.
     type: Boolean
     default: true
     platforms: [ipad, macos]
@@ -493,7 +493,7 @@ properties:
         This property is useful to track the current cursor position of the text area. On iOS this property
         can be used in lieu of the [selected](Titanium.UI.TextArea.selected) event.
 
-        This method will return null on android and undefined on iOS if the view has not yet been attached
+        This method will return null on Android and undefined on iOS if the view has not yet been attached
         to the window.
     type: textAreaSelectedParams
     permission: read-only
@@ -538,7 +538,7 @@ events:
     summary: Fired when user interacts with a URL in the text area. See [handleLinks](Titanium.UI.TextArea.handleLinks).
     description: |
         The URL is set using the [ATTRIBUTE_LINK](Titanium.UI.ATTRIBUTE_LINK) property on the [attributedString](Titanium.UI.TextArea.attributedString).
-        This event is fired even in handleLinks is set to false. Only valid on iOS7 and above.
+        This event is fired even in handleLinks is set to false. Only valid on iOS 7 and above.
     properties:
       - name: url
         summary: The URL that is associated with this event.

--- a/apidoc/Titanium/UI/TextArea.yml
+++ b/apidoc/Titanium/UI/TextArea.yml
@@ -356,7 +356,7 @@ properties:
   - name: html
     summary: Pass a HTML-based string and it will be formatted accordingly.
     description: |
-        Note that complex html structures like images are not supported.
+        Note that complex HTML structures like images are not supported.
         Use a <Titanium.UI.WebView> for those cases.
     platforms: [android, iphone, ipad, macos]
     since: "12.7.0"

--- a/apidoc/Titanium/UI/TextArea.yml
+++ b/apidoc/Titanium/UI/TextArea.yml
@@ -450,7 +450,7 @@ properties:
     since: 2.1.2
 
   - name: showUndoRedoActions
-    summary: Determinates if the undo and redo buttons on the left side of the keyboard should be displayed or not. Only valid on iOS 9 and above. This property can only be set upon creation.
+    summary: Determines if the undo and redo buttons on the left side of the keyboard should be displayed or not. Only valid on iOS 9 and above. This property can only be set upon creation.
     type: Boolean
     default: true
     platforms: [ipad, macos]

--- a/apidoc/Titanium/UI/TextField.yml
+++ b/apidoc/Titanium/UI/TextField.yml
@@ -306,7 +306,7 @@ properties:
     platforms: [iphone, ipad, android, macos]
     since: {iphone: "5.4.0", ipad: "5.4.0", android: "4.1.0"}
     description: |
-        Sets the color of the <Titanium.UI.TextField.hintText>. Please not that this can be overriden
+        Sets the color of the <Titanium.UI.TextField.hintText>. Please not that this can be overridden
         by the <Titanium.UI.TextField.attributedHintText> which provides an advanced configuration to
         style hint texts.
 
@@ -543,7 +543,7 @@ properties:
         can only be used when the text field has focus. Accessing this property when text field does not have
         focus will return an undefined value.
 
-        This method will return null on android and undefined on iOS if the view has not yet been attached
+        This method will return null on Android and undefined on iOS if the view has not yet been attached
         to the window.
     type: textFieldSelectedParams
     permission: read-only
@@ -551,7 +551,7 @@ properties:
     since: "3.3.0"
 
   - name: showUndoRedoActions
-    summary: Determinates if the undo and redo buttons on the left side of the keyboard should be displayed or not. Only valid on iOS9 and above.
+    summary: Determinates if the undo and redo buttons on the left side of the keyboard should be displayed or not. Only valid on iOS 9 and above.
     type: Boolean
     default: true
     platforms: [ipad, macos]

--- a/apidoc/Titanium/UI/TextField.yml
+++ b/apidoc/Titanium/UI/TextField.yml
@@ -551,7 +551,7 @@ properties:
     since: "3.3.0"
 
   - name: showUndoRedoActions
-    summary: Determinates if the undo and redo buttons on the left side of the keyboard should be displayed or not. Only valid on iOS 9 and above.
+    summary: Determines if the undo and redo buttons on the left side of the keyboard should be displayed or not. Only valid on iOS 9 and above.
     type: Boolean
     default: true
     platforms: [ipad, macos]

--- a/apidoc/Titanium/UI/Toolbar.yml
+++ b/apidoc/Titanium/UI/Toolbar.yml
@@ -149,7 +149,7 @@ methods:
     platforms: [android]
 
   - name: dismissPopupMenus
-    summary: Collapses expandend ActionViews and hides overflow menu
+    summary: Collapses expanded ActionViews and hides overflow menu
     platforms: [android]
 
   - name: getContentInsetEnd

--- a/apidoc/Titanium/UI/UI.yml
+++ b/apidoc/Titanium/UI/UI.yml
@@ -56,7 +56,7 @@ description:  |
     Prior to the release of Titanium SDK `9.0.0.GA` any variable declared in `app.js` or `alloy.js`
     was added to a global scope. This however is no longer the case since `9.0.0.GA`. However
     it is still possible to add variables to a global scope by adding `global.` in front of any
-    variabled declared in `app.js` or `alloy.js`. However you should be careful with adding variables
+    variable declared in `app.js` or `alloy.js`. However you should be careful with adding variables
     to global context because anything added to the global context will not be garbage-collected.
 
     In Alloy the recommended way to add global context is `Alloy.Globals`.
@@ -101,7 +101,7 @@ description:  |
     it is recommended to include it to provide compatibility with other platforms.
 
     iOS and Android also accept colors specified in the form, `rgb(R,G,B)` and `rgba(R,G,B,A)`, with the color
-    channels inside the parethesis represented by integer numbers between `0` and `255` and the
+    channels inside the parentheses represented by integer numbers between `0` and `255` and the
     alpha channel by a float number between `0` and `1.0` (transparent to opaque, respectively).
     For example, an opaque purple could be obtained using `'rgb(255,0,255)'` and a semi-opaque purple
     using `'rgba(255,0,255,0.3)'`. Note that although this format will work if the `rgb` or `rgba`
@@ -411,7 +411,7 @@ properties:
         Use with <Attribute.type> to specify the width of the stroke text.
     description: |
         Set <Attribute.value> to a float value specifying the size of stroke width as a percentage of the
-        font size. A positive value displays an outline of the charater, while a negative value
+        font size. A positive value displays an outline of the character, while a negative value
         fills the character.
 
         See <Attribute> for more information.
@@ -1494,7 +1494,7 @@ properties:
     summary: |
         Displays a <Titanium.UI.Picker> using the best visual style on the current platform for date/time selection.
     description: |
-        On Android and iOS, a picker with this style will be shown in compatct form,
+        On Android and iOS, a picker with this style will be shown in compact form,
         where the picker will be a read-only text field which opens a selection dialog when tapped on.
 
         Note: Prior to iOS 14, this property is only used on iOS Catalyst apps.
@@ -2682,7 +2682,7 @@ properties:
     permission: read-only
 
   - name: UPSIDE_PORTRAIT
-    summary: Orientation constant for inverted portait orientation.
+    summary: Orientation constant for inverted portrait orientation.
     description: |
         One of the group of orientation constants for the <Titanium.Gesture> module,
         <Titanium.UI.PORTRAIT>,

--- a/apidoc/Titanium/UI/UI.yml
+++ b/apidoc/Titanium/UI/UI.yml
@@ -2702,7 +2702,7 @@ properties:
     permission: read-only
 
   - name: URL_ERROR_BAD_URL
-    summary: Bad url error code reported via <Titanium.UI.WebView.error>.
+    summary: Bad URL error code reported via <Titanium.UI.WebView.error>.
     type: Number
     since: "3.0.0"
     permission: read-only
@@ -2757,7 +2757,7 @@ properties:
     permission: read-only
 
   - name: URL_ERROR_UNSUPPORTED_SCHEME
-    summary: Error code reported via <Titanium.UI.WebView.error> when a url contains an unsupported scheme.
+    summary: Error code reported via <Titanium.UI.WebView.error> when a URL contains an unsupported scheme.
     type: Number
     since: "3.0.0"
     permission: read-only

--- a/apidoc/Titanium/UI/UI.yml
+++ b/apidoc/Titanium/UI/UI.yml
@@ -213,7 +213,7 @@ methods:
     parameters:
       - name: convertFromValue
         summary: |
-            Measurement and optional unit to convert from, i.e. 160, "120dip".  Percentages are
+            Measurement and optional unit to convert from, e.g. 160, "120dip".  Percentages are
             not accepted.
         type: String
 
@@ -1607,7 +1607,7 @@ properties:
     since: "6.0.0"
 
   - name: TEXT_ELLIPSIZE_TRUNCATE_CHAR_WRAP
-    summary: Add ellipses before the first character that doesnt fit.
+    summary: Add ellipses before the first character that doesn't fit.
     description: |
         One of the group of constants for the <Titanium.UI.Label.ellipsize> property.
     type: Number

--- a/apidoc/Titanium/UI/View.yml
+++ b/apidoc/Titanium/UI/View.yml
@@ -177,7 +177,7 @@ description: |
     #### iOS: backgroundLeftCap and backgroundTopCap properties
 
     The [backgroundLeftCap](Titanium.UI.View.backgroundLeftCap) and [backgroundTopCap](Titanium.UI.View.backgroundTopCap) properties are
-    used to specify the portions of the [backgroundImage](Titanium.UI.View.backgroundImage) that must not be resized when the image is streched or shrunk.
+    used to specify the portions of the [backgroundImage](Titanium.UI.View.backgroundImage) that must not be resized when the image is stretched or shrunk.
 
     Given an image of width `w` and height `h`, the stretchable portion on the image is defined as a rectangle with the `top-left` point set to
     `(backgroundLeftCap , backgroundTopCap)` and the `bottom-right` point set to `(w - backgroundLeftCap , h - backgroundTopCap)`. The portions not covered by
@@ -876,7 +876,7 @@ methods:
         work as expected.
 
         For maximum portability, these views should be treated as if they do not support children.
-        Instead of adding children to these views, applications can positon other views as
+        Instead of adding children to these views, applications can position other views as
         siblings. For example, instead of adding a button as a child of a `WebView`, you can add
         the button to the web view's parent such that it appears on top of the web view.
 
@@ -897,7 +897,7 @@ methods:
         *   [TableView](Titanium.UI.TableView) is a specialized container for
             `TableViewSection` and `TableViewRow` objects. These objects must be
             added using the properties and methods that `TableView` provides
-            for adding and removing sectons and rows.
+            for adding and removing sections and rows.
 
             On some platforms, it is possible to add arbitrary child views to a table view
             using the `add` method. However, this is not guaranteed to work on all platforms,
@@ -1034,7 +1034,7 @@ methods:
         type: AnimatedOptions
         optional: true
         default: "{ animated: false }"
-        # FIXME: Support platfroms/osver/since on parameters!
+        # FIXME: Support platforms/osver/since on parameters!
 
   - name: stopAnimation
     summary: Stops a running animation.
@@ -1144,7 +1144,7 @@ properties:
     default: null
 
   - name: accessibilityLabel
-    summary: A succint label identifying the view for the device's accessibility service.
+    summary: A succinct label identifying the view for the device's accessibility service.
     description: |
         On iOS this is a direct analog of the `accessibilityLabel` property defined in the
         [UIAccessibility Protocol](https://developer.apple.com/documentation/uikit/accessibility/uiaccessibility).
@@ -1819,7 +1819,7 @@ properties:
   - name: tintColor
     summary: The view's tintColor
     description: |
-        This property is a direct correspondant of the tintColor property of UIView on iOS. If no value is specified,
+        This property is a direct correspondent of the tintColor property of UIView on iOS. If no value is specified,
         the tintColor of the View is inherited from its superview.
     type: [String, Titanium.UI.Color]
     since: "3.1.3"
@@ -2138,7 +2138,7 @@ summary: |
 
       * `view` (Titanium.UI.View): View to insert
       * `position` (Number): Position in the [children](Titanium.UI.View.children) array of
-        the view elment to replace.
+        the view element to replace.
 properties:
   - name: view
     type: Titanium.UI.View

--- a/apidoc/Titanium/UI/View.yml
+++ b/apidoc/Titanium/UI/View.yml
@@ -80,7 +80,7 @@ description: |
     *    Pixels on Android.
     *    DIPs on iOS.
 
-    On Android and iOS, the default unit can be overriden on a per-application level by setting the
+    On Android and iOS, the default unit can be overridden on a per-application level by setting the
     `ti.ui.defaultunit` property in `tiapp.xml`. For example, to use DIPs as the
     default on all platforms, set `defaultunit` to `dip`:
 
@@ -91,7 +91,7 @@ description: |
     The value for `ti.ui.defaultunit` can be any of the unit specifiers defined above, or
     `system` to specify that the platform's default unit should be used.
 
-    On IOS if you set the `ti.ui.defaultunit` property to anything other than `system` or `dip`, your
+    On iOS if you set the `ti.ui.defaultunit` property to anything other than `system` or `dip`, your
     application should detect and handle Retina displays manually.
 
     Font sizes on iOS are treated differently than other sizes: font sizes are always
@@ -1721,7 +1721,7 @@ properties:
         Preview context to present the "Peek and Pop" of a view. Use an configured instance
         of <Titanium.UI.iOS.PreviewContext> here.
 
-        Note: This property can only be used on devices running iOS9 or later and supporting 3D-Touch.
+        Note: This property can only be used on devices running iOS 9 or later and supporting 3D-Touch.
         It is ignored on older devices and can manually be checked using <Titanium.UI.iOS.forceTouchSupported>.
     platforms: [iphone]
     since: "5.1.0"

--- a/apidoc/Titanium/UI/View.yml
+++ b/apidoc/Titanium/UI/View.yml
@@ -1366,7 +1366,7 @@ properties:
     platforms: [android, iphone, ipad, macos]
 
   - name: backgroundSelectedImage
-    summary: Selected background image url for the view, specified as a local file path or URL.
+    summary: Selected background image URL for the view, specified as a local file path or URL.
     description: |
       For normal views, the selected background is only used if `focusable` is `true`.
 

--- a/apidoc/Titanium/UI/WebView.yml
+++ b/apidoc/Titanium/UI/WebView.yml
@@ -508,20 +508,20 @@ methods:
         summary: The height in mils (thousandths of an inch) of the PDF (Android only)
         type: Number
       - name: pageSize
-        summary: Predfined size. (Android only)
+        summary: Predefined size. (Android only)
         type: Number
         constants: Titanium.UI.WebView.PDF_PAGE_*
       - name: showMenu
-        summary:  Will show Androids printing menu. No sucess callback afterwards. (Android only)
+        summary:  Will show Androids printing menu. No success callback afterwards. (Android only)
         type: Boolean
       - name: firstPageOnly
         summary: Only print first page (Android only)
         type: Boolean
       - name: success
-        summary: Function to call upon pdf creation. (Android only)
+        summary: Function to call upon PDF creation. (Android only)
         type: Callback<DataCreationResultAndroid>
       - name: callback
-        summary: Function to call upon pdf creation. (iOS only)
+        summary: Function to call upon PDF creation. (iOS only)
         type: Callback<DataCreationResult>
 
   - name: createWebArchive
@@ -808,7 +808,7 @@ properties:
     since: {android: "6.1.0", iphone: "6.1.0", ipad: "6.1.0", macos: "9.2.0"}
 
   - name: enableJavascriptInterface
-    summary: Enable adding javascript interfaces internally to webview prior to JELLY_BEAN_MR1 (Android 4.2)
+    summary: Enable adding JavaScript interfaces internally to webview prior to JELLY_BEAN_MR1 (Android 4.2)
     description: |
         This property is introduced to prevent a security issue with older devices (< JELLY_BEAN_MR1)
     type: Boolean
@@ -833,7 +833,7 @@ properties:
         since: "8.0.0"
         notes: |
             This property in no more supported in Titanium SDK 8.0.0+. Use property <Titanium.UI.WebView.allowedURLSchemes>
-            in conjuction with <Titanium.UI.WebView.handleurl>. See the example section
+            in conjunction with <Titanium.UI.WebView.handleurl>. See the example section
             "Usage of allowedURLSchemes and handleurl in iOS".
 
   - name: configuration
@@ -1039,7 +1039,7 @@ properties:
     summary: A value indicating the render mode of the WebView
     description: |
         Set to Ti.UI.WebView.LAYER_TYPE_SOFTWARE (software rendering) if you use `Ti.Media.takeScreenshot()` or `toImage()` and the WebView contains local HTML files.
-        Otherwise the WebView might be empty in the screenshot/image. If you change the setting you will have to assing the HTML content again.
+        Otherwise the WebView might be empty in the screenshot/image. If you change the setting you will have to assign the HTML content again.
     type: Number
     constants: Titanium.UI.WebView.LAYER_TYPE_*
     default: <Titanium.UI.WebView.LAYER_TYPE_NONE>

--- a/apidoc/Titanium/UI/WebView.yml
+++ b/apidoc/Titanium/UI/WebView.yml
@@ -617,12 +617,12 @@ events:
   - name: onLoadResource
     summary: Fired when loading resource.
     description: |
-        Android only. Notify the host application that the WebView will load the resource specified by the given url.
+        Android only. Notify the host application that the WebView will load the resource specified by the given URL.
     platforms: [android]
     since: "3.6.0"
     properties:
       - name: url
-        summary: The url of the resource that will load.
+        summary: The URL of the resource that will load.
         type: String
 
   - name: sslerror
@@ -755,9 +755,9 @@ properties:
 
   - name: blacklistedURLs
     summary: |
-        An array of url strings to blacklist.
+        An array of URL strings to blacklist.
     description: |
-        An array of url strings to blacklist. This will stop the webview from going to urls listed in
+        An array of URL strings to blacklist. This will stop the webview from going to URLs listed in
         the blacklist. Note, this only applies in the links clicked inside the webview. The first website
         that is loaded will not be stopped even if it matches the blacklist.
     type: Array<String>
@@ -770,9 +770,9 @@ properties:
 
   - name: blockedURLs
     summary: |
-        An array of url strings to be blocked.
+        An array of URL strings to be blocked.
     description: |
-        An array of url strings to be blocked from loading. This will stop the webview from going to urls
+        An array of URL strings to be blocked from loading. This will stop the webview from going to URLs
         listed in this array. Note that this only applies to the links tapped on by the end-user.
         The first website that is loaded will not be stopped, even if it is listed in the blocklist.
     type: Array<String>
@@ -1326,7 +1326,7 @@ examples:
         ```
   - title: Usage of allowedURLSchemes and handleurl in iOS
     example: |
-        Create a web view and listen 'handleurl' event to open url from Titanium platform.
+        Create a web view and listen 'handleurl' event to open URL from Titanium platform.
 
         ``` js
         var webview = Ti.UI.createWebView({
@@ -1479,7 +1479,7 @@ summary: An object returned when the <Titanium.UI.WebView.onlink> callback is fi
 platforms: [iphone, ipad, android, macos]
 properties:
   - name: url
-    summary: The url of the link that should be navigated to.
+    summary: The URL of the link that should be navigated to.
     type: String
 
 ---

--- a/apidoc/Titanium/UI/WebView.yml
+++ b/apidoc/Titanium/UI/WebView.yml
@@ -1174,7 +1174,7 @@ properties:
 
   - name: allowsBackForwardNavigationGestures
     summary: |
-        A Boolean value indicating whether horizontal swipe gestures will trigger back-forward list navigations.
+        A Boolean value indicating whether horizontal swipe gestures will trigger back-forward list navigation.
     type: Boolean
     default: false
     platforms: [iphone, ipad, macos]

--- a/apidoc/Titanium/UI/Window.yml
+++ b/apidoc/Titanium/UI/Window.yml
@@ -792,7 +792,7 @@ properties:
     description: |
         The behavior of this API on iOS has changed from version 3.2.0. Previous versions
         of the SDK created a custom image view and inserted it as a child of the navigation bar.
-        The titanium sdk now uses the native call to set the background image of the navigation bar.
+        The Titanium SDK now uses the native call to set the background image of the navigation bar.
         You can set it to a 1px transparent png to use a combination of `barColor` and `hideShadow:true`.
     platforms: [iphone, ipad, macos]
     type: String
@@ -1538,7 +1538,7 @@ properties:
   - name: translucent
     summary: Boolean value indicating if the nav bar is translucent.
     platforms: [iphone, ipad, macos]
-    default: true on iOS7 and above, false otherwise.
+    default: true on iOS 7 and above, false otherwise.
     type: Boolean
 
   - name: windowFlags
@@ -1725,7 +1725,7 @@ properties:
     type: Number
     constants: [ Titanium.UI.Android.TRANSITION_CHANGE_*, Titanium.UI.Android.TRANSITION_NONE ]
     default: |
-        Defaults to android platform's [move](https://github.com/android/platform_frameworks_base/blob/lollipop-release/core/res/res/transition/move.xml) transition.
+        Defaults to Android platform's [move](https://github.com/android/platform_frameworks_base/blob/lollipop-release/core/res/res/transition/move.xml) transition.
     since: "5.2.0"
     availability: creation
     platforms: [android]
@@ -1741,7 +1741,7 @@ properties:
     type: Number
     constants: [ Titanium.UI.Android.TRANSITION_CHANGE_*, Titanium.UI.Android.TRANSITION_NONE ]
     default: |
-        Defaults to android platform's [move](https://github.com/android/platform_frameworks_base/blob/lollipop-release/core/res/res/transition/move.xml) transition.
+        Defaults to Android platform's [move](https://github.com/android/platform_frameworks_base/blob/lollipop-release/core/res/res/transition/move.xml) transition.
     since: "5.2.0"
     availability: creation
     platforms: [android]
@@ -1757,7 +1757,7 @@ properties:
     type: Number
     constants: [ Titanium.UI.Android.TRANSITION_CHANGE_*, Titanium.UI.Android.TRANSITION_NONE ]
     default: |
-        Defaults to android platform's [move](https://github.com/android/platform_frameworks_base/blob/lollipop-release/core/res/res/transition/move.xml) transition.
+        Defaults to Android platform's [move](https://github.com/android/platform_frameworks_base/blob/lollipop-release/core/res/res/transition/move.xml) transition.
     since: "5.2.0"
     availability: creation
     platforms: [android]
@@ -1773,7 +1773,7 @@ properties:
     type: Number
     constants: [ Titanium.UI.Android.TRANSITION_CHANGE_*, Titanium.UI.Android.TRANSITION_NONE ]
     default: |
-        Defaults to android platform's [move](https://github.com/android/platform_frameworks_base/blob/lollipop-release/core/res/res/transition/move.xml) transition.
+        Defaults to Android platform's [move](https://github.com/android/platform_frameworks_base/blob/lollipop-release/core/res/res/transition/move.xml) transition.
     since: "5.2.0"
     availability: creation
     platforms: [android]

--- a/apidoc/Titanium/UI/Window.yml
+++ b/apidoc/Titanium/UI/Window.yml
@@ -155,7 +155,7 @@ description: |
     and "Form sheet" style windows:
 
     * **Page sheet** style windows have a fixed width, equal to the width of the screen
-      in portait mode, and a height equal to the *current* height of the screen. This means
+      in portrait mode, and a height equal to the *current* height of the screen. This means
       that in portrait mode, the window covers the entire screen. In landscape mode,
       the window is centered on the screen horizontally.
 
@@ -269,7 +269,7 @@ description: |
     show the window, then set the newly created TransitionAnimation object to the window's
     <Titanium.UI.Window.transitionAnimation> property.
 
-    In the example below, the windows are closed by rotating them upside down while simulatenously
+    In the example below, the windows are closed by rotating them upside down while simultaneously
     making them transparent:
 
     `app/views/index.xml`:
@@ -462,7 +462,7 @@ description: |
     to use these transition animations, while in older version of Titanium that was required.
 
     See the official Android [Activity Transitions](https://developer.android.com/training/material/animations.html#Transitions)
-    documentation for more information and supported transitons.
+    documentation for more information and supported transitions.
 
     #### Android "root" Windows
 
@@ -1101,7 +1101,7 @@ properties:
   - name: navTintColor
     summary: The tintColor to apply to the navigation bar.
     description: |
-        This property is a direct correspondant of the tintColor property of NavigationBar on iOS.
+        This property is a direct correspondent of the tintColor property of NavigationBar on iOS.
     type: [String, Titanium.UI.Color]
     default: null
     platforms: [iphone, ipad, macos]
@@ -1182,7 +1182,7 @@ properties:
         #### Android Orientation Modes
 
         On Android, orientation behavior is dependent on the Android SDK level
-        of the device itself. Devices running Android 2.3 and above support "sensor portait
+        of the device itself. Devices running Android 2.3 and above support "sensor portrait
         mode" and "sensor landscape mode," in these modes, the device is locked into
         either a portrait or landscape orientation, but can switch between the normal and reverse
         orientations (for example, between PORTRAIT and UPSIDE_PORTRAIT).
@@ -1315,7 +1315,7 @@ properties:
             windowFlags: Ti.UI.Android.FLAG_TRANSLUCENT_NAVIGATION | Ti.UI.Android.FLAG_TRANSLUCENT_STATUS
         });
 
-        // Set up a safe-area view to be layed out between the system insets.
+        // Set up a safe-area view to be laid out between the system insets.
         // You should use this as a container for child views.
         var safeAreaView = Ti.UI.createView({
             backgroundColor: 'green'
@@ -1352,7 +1352,7 @@ properties:
     availability: creation
     deprecated:
         since: "6.2.0"
-        notes: Deprecated in AppCompat theme. The same behaviour can be achived by using Toolbar.
+        notes: Deprecated in AppCompat theme. The same behaviour can be achieved by using Toolbar.
 
   - name: statusBarStyle
     summary: The status bar style associated with this window.
@@ -1573,7 +1573,7 @@ properties:
   - name: windowSoftInputMode
     summary: |
         Determines whether a window's soft input area (ie software keyboard) is visible
-        as it receives focus and how the window behaves in order to accomodate it while keeping its
+        as it receives focus and how the window behaves in order to accommodate it while keeping its
         contents in view.
     description: |
         In order for this property to take effect on an emulator, its Android Virtual Device (AVD)
@@ -1581,7 +1581,7 @@ properties:
         recommended to test an application on a physical device to understand its true behavior.
 
         This property is capable of representing two settings from the soft input *visibility*
-        constatns and soft input *adjustment* constants
+        constants and soft input *adjustment* constants
         using the [bitwise OR](http://en.wikipedia.org/wiki/Bitwise_operation#OR) operation.
 
         Note that in JavaScript, bitwise OR is achieved using the single pipe operand. See the

--- a/apidoc/Titanium/UI/iOS/PreviewActionGroup.yml
+++ b/apidoc/Titanium/UI/iOS/PreviewActionGroup.yml
@@ -1,7 +1,7 @@
 ---
 name: Titanium.UI.iOS.PreviewActionGroup
 summary: |
-    A PreviewActionGroup provides options to configure a group of actions used by the iOS9 3D-Touch
+    A PreviewActionGroup provides options to configure a group of actions used by the iOS 9 3D-Touch
     feature "Peek and Pop".
 description: |
     The PreviewActionGroup is created by the <Titanium.UI.iOS.createPreviewActionGroup> method. You

--- a/apidoc/Titanium/WatchSession/WatchSession.yml
+++ b/apidoc/Titanium/WatchSession/WatchSession.yml
@@ -98,13 +98,13 @@ methods:
 
   - name: sendMessage
     summary: |
-        Sends a message to the apple watch.
+        Sends a message to the Apple Watch.
     description: |
-        Sends a message to the installed watchapp on the apple watch in the foreground. 
+        Sends a message to the installed watch app on the Apple Watch in the foreground. 
     parameters: 
       - name: message
         summary: | 
-            Message to send to apple watch. This property is required and the key of the dictionary 
+            Message to send to the Apple Watch. This property is required and the key of the dictionary 
             needs to be a String.
         type: Dictionary
         optional: false
@@ -120,33 +120,33 @@ methods:
 
   - name: updateApplicationContext
     summary: |
-        Sends an app context update to the apple watch.
+        Sends an app context update to the Apple Watch.
     description: |
-        Sends an app context update to the apple watch. If watchapp is in background during transfer,
-        watchapp will fire the <Titanium.WatchSession.receiveapplicationcontext> event immediately when 
+        Sends an app context update to the Apple Watch. If watch app is in background during transfer,
+        watch app will fire the <Titanium.WatchSession.receiveapplicationcontext> event immediately when 
         it becomes active. Only one app context is stored at any one time. Subsequent updates will simply 
         replace the earlier one sent.
     parameters: 
       - name: params    
-        summary: App context to be updated in apple watch.
+        summary: App context to be updated in the Apple Watch.
         type: Dictionary
 
   - name: transferUserInfo
     summary: |
-        Transfers an user info to the apple watch.
+        Transfers an user info to the Apple Watch.
     description: |
-        Transfers an user info object to the installed watchapp on the apple watch in the background.
+        Transfers an user info object to the installed watch app on the Apple Watch in the background.
         Subsequent transfers are queued. 
     parameters:
       - name: params
-        summary: userInfo to be transferred to apple watch.
+        summary: userInfo to be transferred to the Apple Watch.
         type: Dictionary
 
   - name: transferFile
     summary: |
-        Transfers a file to the apple watch.
+        Transfers a file to the Apple Watch.
     description: |
-        Transfers a file to the installed watchapp on the apple watch in the background. Subsequent
+        Transfers a file to the installed watch app on the Apple Watch in the background. Subsequent
         transfers are queued. 
     parameters: 
       - name: params
@@ -170,26 +170,26 @@ methods:
 
   - name: cancelAllUserInfoTransfers
     summary: |
-        Cancels all incomplete user info and complication transfers to the apple watch.
+        Cancels all incomplete user info and complication transfers to the Apple Watch.
     description: |
-        Cancels all incomplete user info and complication transfers to the apple watch.
+        Cancels all incomplete user info and complication transfers to the Apple Watch.
 
   - name: cancelAllFileTransfers
     summary: |
-        Cancels all incomplete file transfers to the apple watch.
+        Cancels all incomplete file transfers to the Apple Watch.
     description: |
-        Cancels all incomplete file transfers to the apple watch.
+        Cancels all incomplete file transfers to the Apple Watch.
 
   - name: cancelAllTransfers
     summary: |
-        Cancels all incomplete transfers to the apple watch.
+        Cancels all incomplete transfers to the Apple Watch.
     description: |
-        Cancels all incomplete transfers to the apple watch, including user info, complication and file.
+        Cancels all incomplete transfers to the Apple Watch, including user info, complication and file.
 
 events:
   - name: receivemessage
     summary: |
-        App received message from apple watch in foreground. Will be called on startup if the 
+        App received message from Apple Watch in foreground. Will be called on startup if the 
         incoming message caused the receiver to launch.
     properties:
       - name: message
@@ -198,7 +198,7 @@ events:
 
   - name: receiveapplicationcontext
     summary: |
-        App received app context from apple watch. Will be called on startup if an applicationContext is available.
+        App received app context from Apple Watch. Will be called on startup if an applicationContext is available.
     properties:
       - name: applicationContext
         summary: The application Context
@@ -206,7 +206,7 @@ events:
 
   - name: receiveuserinfo
     summary: |
-        App received user info from apple watch in background. Will be called on startup if the user info finished 
+        App received user info from Apple Watch in background. Will be called on startup if the user info finished 
         transferring when the receiver was not running.
     properties:
       - name: userInfo
@@ -215,7 +215,7 @@ events:
 
   - name: receivefile
     summary: |
-        App received file from apple watch in background.
+        App received file from Apple Watch in background.
     properties:
       - name: data
         summary: The downloaded data as a Titanium.Blob object.
@@ -238,20 +238,20 @@ events:
         The watch state has changed.
     properties:
       - name: isPaired
-        summary: If the device is paired with the apple watch.
+        summary: If the device is paired with the Apple Watch.
         type: Boolean
       - name: isReachable
-        summary: If apple watch is currently reachable.
+        summary: If the Apple Watch is currently reachable.
         type: Boolean
       - name: isWatchAppInstalled
-        summary: If the watch app is installed in the apple watch.
+        summary: If the watch app is installed in the Apple Watch.
         type: Boolean
       - name: isComplicationEnabled
-        summary: If the complication is enabled in the apple watch.
+        summary: If the complication is enabled in the Apple Watch.
         type: Boolean
       - name: isActivated
         summary: | 
-            If the apple watch is currently activated. Only available on iOS 9.3
+            If the Apple Watch is currently activated. Only available on iOS 9.3
             and later. See <Titanium.WatchSession.isActivated> for more infos.
         type: Boolean
       - name: activationState
@@ -266,20 +266,20 @@ events:
         The watch reachability state has changed.
     properties:
       - name: isPaired
-        summary: If the device is paired with the apple watch.
+        summary: If the device is paired with the Apple Watch.
         type: Boolean
       - name: isReachable
-        summary: If apple watch is currently reachable.
+        summary: If the Apple Watch is currently reachable.
         type: Boolean
       - name: isWatchAppInstalled
-        summary: If the watch app is installed in the apple watch.
+        summary: If the watch app is installed in the Apple Watch.
         type: Boolean
       - name: isComplicationEnabled
-        summary: If the complication is enabled in the apple watch.
+        summary: If the complication is enabled in the Apple Watch.
         type: Boolean
       - name: isActivated
         summary: | 
-            If the apple watch is currently activated. Only available on iOS 9.3
+            If the Apple Watch is currently activated. Only available on iOS 9.3
             and later. See <Titanium.WatchSession.isActivated> for more infos.
         type: Boolean
       - name: activationState
@@ -333,20 +333,20 @@ events:
         This will happen when the selected watch is being changed. 
     properties:
       - name: isPaired
-        summary: If the device is paired with the apple watch.
+        summary: If the device is paired with the Apple Watch.
         type: Boolean
       - name: isReachable
-        summary: If apple watch is currently reachable.
+        summary: If the Apple Watch is currently reachable.
         type: Boolean
       - name: isWatchAppInstalled
-        summary: If the watch app is installed in the apple watch.
+        summary: If the watch app is installed in the Apple Watch.
         type: Boolean
       - name: isComplicationEnabled
-        summary: If the complication is enabled in the apple watch.
+        summary: If the complication is enabled in the Apple Watch.
         type: Boolean
       - name: isActivated
         summary: | 
-            If the apple watch is currently activated. Only available on iOS 9.3
+            If the Apple Watch is currently activated. Only available on iOS 9.3
             and later. See <Titanium.WatchSession.isActivated> for more infos.
         type: Boolean
       - name: activationState
@@ -364,30 +364,30 @@ events:
         The session can be re-activated for the now selected watch using activateSession.
     properties:
       - name: isPaired
-        summary: If the device is paired with the apple watch.
+        summary: If the device is paired with the Apple Watch.
         type: Boolean
       - name: isReachable
-        summary: If apple watch is currently reachable.
+        summary: If the Apple Watch is currently reachable.
         type: Boolean
       - name: isWatchAppInstalled
-        summary: If the watch app is installed in the apple watch.
+        summary: If the watch app is installed in the Apple Watch.
         type: Boolean
       - name: isComplicationEnabled
-        summary: If the complication is enabled in the apple watch.
+        summary: If the complication is enabled in the Apple Watch.
         type: Boolean
       - name: isActivated
         summary: | 
-            If the apple watch is currently activated. Only available on iOS 9.3
+            If the Apple Watch is currently activated. Only available on iOS 9.3
             and later. See <Titanium.WatchSession.isActivated> for more infos.
         type: Boolean
       - name: hasContentPending
         summary: | 
-            If the apple watch has currently content pending. Only available on iOS 10.0
+            If the Apple Watch has currently content pending. Only available on iOS 10.0
             and later. See <Titanium.WatchSession.hasContentPending> for more infos.
         type: Boolean
       - name: remainingComplicationUserInfoTransfers
         summary: | 
-            If the apple watch has complication userInfo transfers left. Only available on iOS 10.0
+            If the Apple Watch has complication userInfo transfers left. Only available on iOS 10.0
             and later. See <Titanium.WatchSession.remainingComplicationUserInfoTransfers> for more infos.
         type: Boolean
       - name: activationState
@@ -406,20 +406,20 @@ events:
         with more details. 
     properties:
       - name: isPaired
-        summary: If the device is paired with the apple watch.
+        summary: If the device is paired with the Apple Watch.
         type: Boolean
       - name: isReachable
-        summary: If apple watch is currently reachable.
+        summary: If the Apple Watch is currently reachable.
         type: Boolean
       - name: isWatchAppInstalled
-        summary: If the watch app is installed in the apple watch.
+        summary: If the watch app is installed in the Apple Watch.
         type: Boolean
       - name: isComplicationEnabled
-        summary: If the complication is enabled in the apple watch.
+        summary: If the complication is enabled in the Apple Watch.
         type: Boolean
       - name: isActivated
         summary: | 
-            If the apple watch is currently activated. Only available on iOS 9.3
+            If the Apple Watch is currently activated. Only available on iOS 9.3
             and later. See <Titanium.WatchSession.isActivated> for more infos.
         type: Boolean
       - name: activationState
@@ -437,7 +437,7 @@ name: MessageReply
 summary: Reply message received from watch app.
 properties:
   - name: message 
-    summary: Reply message from watchapp.
+    summary: Reply message from watch app.
     description: Will be undefined if `success` is `false`.
     type: Dictionary
   - name: success

--- a/apidoc/Titanium/XML/CharacterData.yml
+++ b/apidoc/Titanium/XML/CharacterData.yml
@@ -5,7 +5,7 @@ summary: An interface extending <Titanium.XML.Node> with a set of
     attributes and methods for accessing character data in the DOM.
 
     Implements the [DOM Level 2 API](https://www.w3.org/TR/DOM-Level-2-Core/core.html#ID-FF21A306) on
-    Android and iOS. For reasons of compatibility with the javascript engine, text is represented by
+    Android and iOS. For reasons of compatibility with the JavaScript engine, text is represented by
     UTF-8 instead of UTF-16 on Android and iOS.
 createable: false
 since: {android: "0.9", iphone: "0.9", ipad: "0.9", macos: "9.2.0"}

--- a/apidoc/Titanium/XML/NamedNodeMap.yml
+++ b/apidoc/Titanium/XML/NamedNodeMap.yml
@@ -36,7 +36,7 @@ methods:
   - name: removeNamedItem
     summary: >
         Removes a node from the map specified by name. When this map
-        contains attributes attached to an element, if the removed attribtue is
+        contains attributes attached to an element, if the removed attribute is
         known to have a default, it is replaced with that value.
     returns:
         type: Titanium.XML.Node
@@ -87,7 +87,7 @@ methods:
     summary: >
         Removes a node from the map specified by local name and namespace URI.
         When this map contains attributes attached to an element, if the removed
-        attribtue is known to have a default, it is replaced with that value.
+        attribute is known to have a default, it is replaced with that value.
         Returns the node removed from the map, or `null` if there is no
         corresponding node.
     returns:

--- a/apidoc/Titanium/XML/ProcessingInstruction.yml
+++ b/apidoc/Titanium/XML/ProcessingInstruction.yml
@@ -11,7 +11,7 @@ properties:
   - name: data
     summary: >
         Retrieve the content of this processing instruction. This from the first non white space character
-        after the target to the character immediatly preceding the ?>. When setting a processing instruction,
+        after the target to the character immediately preceding the ?>. When setting a processing instruction,
         a DOMException may be thrown on an invalid instruction.
     type: String
   - name: target

--- a/changelog/config.js
+++ b/changelog/config.js
@@ -346,11 +346,11 @@ module.exports = {
 			const eosDate = new Date();
 			if (context.isMajor) {
 				eosDate.setMonth(eosDate.getMonth() + 12);
-				// if isMajor, subtract one from major, add '.x', i.e. 8.0.0 -> '7.x'
+				// if isMajor, subtract one from major, add '.x', e.g. 8.0.0 -> '7.x'
 				context.eosBranch = `${semver.major(context.version) - 1}.x`;
 			} else {
 				if (!context.isPatch) { // should be minor!
-					// if isMinor, subtract one from minor, add .x, i.e. 8.1.0 -> 8.0.x
+					// if isMinor, subtract one from minor, add .x, e.g. 8.1.0 -> 8.0.x
 					context.eosBranch = `${semver.major(context.version)}.${semver.minor(context.version) - 1}.x`;
 					context.patchBranch = `${semver.major(context.version)}.${semver.minor(context.version)}.x`;
 					context.majorBranch = `${semver.major(context.version)}.x`;

--- a/cli/commands/build.js
+++ b/cli/commands/build.js
@@ -210,7 +210,7 @@ export function config(logger, config, cli) {
 										tiFile = path.join(dir, tiXml);
 									}
 
-									// Found the xml file, break the loop
+									// Found the XML file, break the loop
 									if (fs.existsSync(tiFile)) {
 										isFound = true;
 										return true;

--- a/cli/commands/clean.js
+++ b/cli/commands/clean.js
@@ -143,7 +143,7 @@ export function config(logger, config, cli) {
 									tiFile = path.join(dir, tiXml);
 								}
 
-								// Found the xml file, break the loop
+								// Found the XML file, break the loop
 								if (fs.existsSync(tiFile)) {
 									isFound = true;
 									return true;

--- a/cli/commands/create.js
+++ b/cli/commands/create.js
@@ -190,7 +190,7 @@ export class CreateCommand {
 	}
 }
 
-// create the builder instance and expose the public api
+// create the builder instance and expose the public API
 const createCommand = new CreateCommand();
 export const config = createCommand.config.bind(createCommand);
 export const run = createCommand.run.bind(createCommand);

--- a/cli/lib/creator.js
+++ b/cli/lib/creator.js
@@ -153,7 +153,7 @@ export class Creator {
 				logger.error('The App ID must consist of letters, numbers, dashes, and underscores.');
 				logger.error('Note: Android does not allow dashes and iOS does not allow underscores.');
 				logger.error('The first character must be a letter or underscore.');
-				logger.error('Usually the App ID is your company\'s reversed Internet domain name. (i.e. com.example.myapp)\n');
+				logger.error('Usually the App ID is your company\'s reversed Internet domain name. (e.g. com.example.myapp)\n');
 				return callback(true);
 			}
 

--- a/cli/lib/creator.js
+++ b/cli/lib/creator.js
@@ -409,7 +409,7 @@ export class Creator {
 	 */
 	configOptionTemplate(order, defaultValue) {
 		return {
-			desc: 'the name of the project template, path to template dir, path to zip file, or url to zip file',
+			desc: 'the name of the project template, path to template dir, path to zip file, or URL to zip file',
 			default: defaultValue || 'default',
 			order: order,
 			required: true

--- a/cli/lib/gather.js
+++ b/cli/lib/gather.js
@@ -45,18 +45,18 @@ class FileInfo {
 
 export class Result {
 	constructor() {
-		this.appIcons = new Map(); // ios specific
-		this.cssFiles = new Map(); // css files to be processed (minified optionally)
-		this.jsFiles = new Map(); // js files to be processed (transpiled/sourcemapped/minified/etc)
+		this.appIcons = new Map(); // iOS specific
+		this.cssFiles = new Map(); // CSS files to be processed (minified optionally)
+		this.jsFiles = new Map(); // JS files to be processed (transpiled/sourcemapped/minified/etc)
 		this.launchImages = new Map(); // Used to create an asset catalog for launch images on iOS, used for splash screen(s) on Android
-		this.launchLogos = new Map(); // ios specific
+		this.launchLogos = new Map(); // iOS specific
 		this.imageAssets = new Map(); // used for asset catalogs and app thinning on iOS, used for drawables on Android
 		this.resourcesToCopy = new Map(); // "plain" files to copy to the app
-		this.htmlJsFiles = new Set(); // used internally to track js files we shouldn't process (basically move from jsFiles to resourcesToCopy bucket)
+		this.htmlJsFiles = new Set(); // used internally to track JS files we shouldn't process (basically move from jsFiles to resourcesToCopy bucket)
 	}
 
 	/**
-	 * If a js file is references by HTML, don't minify/transpile/etc, treat like any resource we just copy over as-is
+	 * If a JS file is references by HTML, don't minify/transpile/etc, treat like any resource we just copy over as-is
 	 */
 	dontProcessJsFilesReferencedFromHTML() {
 		for (const file of this.htmlJsFiles.keys()) {

--- a/cli/lib/module-copier.js
+++ b/cli/lib/module-copier.js
@@ -4,7 +4,7 @@ import path from 'node:path';
 
 /**
  * Reads of the node_modules on disk, and then produces a Set of paths to copy that match the
- * criteria. Will always ignore development dependencies, titanium native modules (denoted by
+ * criteria. Will always ignore development dependencies, Titanium native modules (denoted by
  * titanium.type in package.json being native-modules), and optionally peer and optional
  * dependencies
  *
@@ -98,7 +98,7 @@ async function getDirectoriesToCopy(tree, projectPath, includeOptional, includeP
 }
 
 /**
- * Filters the children property to exclude development dependencies, titanium native modules,
+ * Filters the children property to exclude development dependencies, Titanium native modules,
  * and optionally peer or optional dependencies.
  *
  * @param {Object} children The children property from a @npmcli/arborist Node

--- a/cli/lib/tasks/process-css-task.js
+++ b/cli/lib/tasks/process-css-task.js
@@ -8,7 +8,7 @@ const MAX_SIMULTANEOUS_FILES = 256;
 const limit = pLimit(MAX_SIMULTANEOUS_FILES);
 
 /**
- * Task that takes input CSS files and optionally minifes them before copying to destination.
+ * Task that takes input CSS files and optionally minifies them before copying to destination.
  */
 export class ProcessCSSTask extends IncrementalFileTask {
 
@@ -165,7 +165,7 @@ export class ProcessCSSTask extends IncrementalFileTask {
 	async handleDeletedFile(filePathAndName) {
 		this.logger.info(`DELETED ${filePathAndName}`);
 		// FIXME: If the file is deleted, how do we know the destination path to remove?
-		// Either we need to track the src -> dest map ourselevs, or appc-tasks needs to supply the last output state so we can find the matching file somehow
+		// Either we need to track the src -> dest map ourselves, or appc-tasks needs to supply the last output state so we can find the matching file somehow
 		// i.e. same sha/size?
 		const relativePathKey = this.resolveRelativePath(filePathAndName);
 		const info = this.files.get(relativePathKey);
@@ -226,7 +226,7 @@ export class ProcessCSSTask extends IncrementalFileTask {
 	/**
 	 * Loads data from the previous task run.
 	 *
-	 * @return {Boolean} True if the data was sucessfully loaded, false if not.
+	 * @return {Boolean} True if the data was successfully loaded, false if not.
 	 */
 	async loadTaskData() {
 		try {

--- a/cli/lib/tasks/process-js-task.js
+++ b/cli/lib/tasks/process-js-task.js
@@ -52,7 +52,7 @@ export class ProcessJsTask extends IncrementalFileTask {
 			deploytype: this.builder.deployType,
 			target: this.builder.target,
 			Ti: {
-				version: this.builder.titaniumSdkVersion, // use the shortened version number, i.e. 9.1.0
+				version: this.builder.titaniumSdkVersion, // use the shortened version number, e.g. 9.1.0
 				// TODO: Do these work?
 				// buildHash: ti.manifest.githash,
 				// buildDate: ti.manifest.timestamp,

--- a/cli/lib/webpack/service.js
+++ b/cli/lib/webpack/service.js
@@ -191,7 +191,7 @@ export class WebpackService extends EventEmitter {
 	}
 
 	/**
-	 * Prints the url to the web ui.
+	 * Prints the URL to the web UI.
 	 */
 	printWebUiUrl() {
 		const { host, port } = this.client;

--- a/common/Resources/ti.internal/extensions/node/_errors.js
+++ b/common/Resources/ti.internal/extensions/node/_errors.js
@@ -1,7 +1,7 @@
 /**
  * @param  {*} arg passed in argument value
  * @param  {string} name name of the argument
- * @param  {string} typename i.e. 'string', 'Function' (value is compared to typeof after lowercasing)
+ * @param  {string} typename e.g. 'string', 'Function' (value is compared to typeof after lowercasing)
  * @return {void}
  * @throws {TypeError}
  */

--- a/common/Resources/ti.internal/extensions/node/fs.js
+++ b/common/Resources/ti.internal/extensions/node/fs.js
@@ -828,7 +828,7 @@ fs.readFile = (path, options, callback) => {
 
 	const wasFileDescriptor = (typeof path === 'number');
 
-	let fileDescriptor = path; // may be overriden later
+	let fileDescriptor = path; // may be overridden later
 	/**
 	 * @param {Error} err possible Error
 	 * @param {Ti.Buffer} buffer Ti.Buffer instance
@@ -1240,7 +1240,7 @@ fs.writeFile = (file, data, options, callback) => {
 	// Turn into file descriptor
 	const wasFileDescriptor = typeof file === 'number';
 
-	let fileDescriptor = file; // may be overriden later
+	let fileDescriptor = file; // may be overridden later
 	const finish = (err) => {
 		if (err) {
 			callback(err);

--- a/common/Resources/ti.internal/extensions/node/path.js
+++ b/common/Resources/ti.internal/extensions/node/path.js
@@ -70,11 +70,11 @@ function dirname(separator, filepath) {
 	const foundIndex = filepath.lastIndexOf(separator, fromIndex);
 	// no separators
 	if (foundIndex === -1) {
-		// handle special case of root windows paths
+		// handle special case of root Windows paths
 		if (length >= 2 && separator === '\\' && filepath.charAt(1) === ':') {
 			const firstChar = filepath.charCodeAt(0);
 			if (isWindowsDeviceName(firstChar)) {
-				return filepath; // it's a root windows path
+				return filepath; // it's a root Windows path
 			}
 		}
 		return '.';

--- a/common/Resources/ti.internal/extensions/node/process.js
+++ b/common/Resources/ti.internal/extensions/node/process.js
@@ -53,7 +53,7 @@ function standardizeArch(original) {
 const process = new EventEmitter();
 process.abort = () => {}; // TODO: Do we have equivalent of forcibly killing the process? We have restart, but I think we just want a no-op stub here
 process.arch = standardizeArch(Ti.Platform.architecture);
-process.argv = []; // TODO: What makes sense here? path to titanium cli for first arg? path to ti.main/app.js for second?
+process.argv = []; // TODO: What makes sense here? path to Titanium CLI for first arg? path to ti.main/app.js for second?
 Object.defineProperty(process, 'argv0', {
 	value: '', // TODO: Path to .app on iOS?
 	writable: false,
@@ -91,7 +91,7 @@ Object.defineProperty(process, 'debugPort', {
 					}
 				}
 			} else if (Ti.Platform.osname === 'iphone' || Ti.Platform.osname === 'ipad') {
-				// iOS is 27753 as of ios < 11.3 for simulators
+				// iOS is 27753 as of iOS < 11.3 for simulators
 				// for 11.3+ it uses a unix socket
 				// for devices, it uses usbmuxd
 				value = 27753; // TODO: Can we only return this for simulator < 11.3?
@@ -167,7 +167,7 @@ Object.defineProperty(process, 'env', {
 	configurable: true
 });
 process.execArgv = [];
-process.execPath = ''; // FIXME: What makes sense here? Path to titanium CLI here?
+process.execPath = ''; // FIXME: What makes sense here? Path to Titanium CLI here?
 process.exit = () => {
 	throw new Error('process.exit is not supported');
 };
@@ -212,10 +212,10 @@ process.uptime = () => {
 };
 process.version = Ti.version;
 process.versions = {
-	modules: '', // TODO: Report module api version (for current platform!)
-	v8: '', // TODO: report android's v8 version (if on Android!)
-	jsc: '' // TODO: report javascriptcore version for iOS/WIndows?
-	// TODO: Report ios/Android/Windows platform versions?
+	modules: '', // TODO: Report module API version (for current platform!)
+	v8: '', // TODO: report Android's v8 version (if on Android!)
+	jsc: '' // TODO: report JavaScriptCore version for iOS/Windows?
+	// TODO: Report iOS/Android/Windows platform versions?
 };
 process[Symbol.toStringTag] = 'process';
 

--- a/common/Resources/ti.internal/extensions/node/slowbuffer.js
+++ b/common/Resources/ti.internal/extensions/node/slowbuffer.js
@@ -107,7 +107,7 @@ export default class SlowBuffer {
 		return SlowBuffer.fromTiBuffer(tiBuffer);
 	}
 
-	// This is a method we should get by extending Uint8Array, so really should only be overriden on a "SlowBuffer" that wraps Ti.Buffer
+	// This is a method we should get by extending Uint8Array, so really should only be overridden on a "SlowBuffer" that wraps Ti.Buffer
 	get buffer() {
 		// Get the slice of the array from byteOffset to length
 		return Uint8Array.from(this).buffer;
@@ -153,7 +153,7 @@ export default class SlowBuffer {
 		return setAdjustedIndex(this, index, value);
 	}
 
-	// This is a method we should get by extending Uint8Array, so really should only be overriden on a "SlowBuffer" that wraps Ti.Buffer
+	// This is a method we should get by extending Uint8Array, so really should only be overridden on a "SlowBuffer" that wraps Ti.Buffer
 	set(src, offset = 0) {
 		const numBytes = src.length;
 		// check src.length + offset doesn't go beyond our length!

--- a/common/Resources/ti.internal/extensions/ti/ui/semanticColor.js
+++ b/common/Resources/ti.internal/extensions/ti/ui/semanticColor.js
@@ -4,7 +4,7 @@
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
-/* globals OS_ANDROID,OS_IOS, OS_VERSION_MAJOR, OS_VERSION_MINOR */
+/* globals OS_ANDROID, OS_IOS, OS_VERSION_MAJOR, OS_VERSION_MINOR */
 import Color from '../../../../../lib/color';
 const isIOS13Plus = OS_IOS && (OS_VERSION_MAJOR >= 13);
 const isMacOS = Ti.Platform.name === 'Mac OS X';
@@ -28,7 +28,7 @@ Object.defineProperty(UI, 'SEMANTIC_COLOR_TYPE_DARK', {
 });
 Object.defineProperty(UI, 'semanticColorType', {
 	get: () => {
-		// TODO: Guard against ios < 13 and Android api < 29?
+		// TODO: Guard against iOS < 13 and Android API < 29?
 		// Assume "light" mode unless we explicitly know it's dark
 		if (Ti.UI.userInterfaceStyle === Ti.UI.USER_INTERFACE_STYLE_DARK) {
 			return UI.SEMANTIC_COLOR_TYPE_DARK;

--- a/common/Resources/ti.internal/kernel/android/invoker.js
+++ b/common/Resources/ti.internal/kernel/android/invoker.js
@@ -39,11 +39,11 @@
  * @param {object} wrapperAPI e.g. TitaniumWrapper
  * @param {object} realAPI e.g. Titanium
  * @param {string} apiName e.g. 'Titanium'
- * @param {object} invocationAPI details on the api we're wrapping
+ * @param {object} invocationAPI details on the API we're wrapping
  * @param {string} invocationAPI.namespace the namespace of the proxy where method hangs (w/o 'Ti.' prefix) e.g. 'Filesystem' or 'UI.Android'
  * @param {string} invocationAPI.api the method name e.g. 'openFile' or 'createSearchView'
  * @param {object} scopeVars holder for context specific values (basically just wraps sourceUrl)
- * @param {string} scopeVars.sourceUrl source URL of js file entry point
+ * @param {string} scopeVars.sourceUrl source URL of JS file entry point
  * @param {Module} [scopeVars.module] module
  */
 function genInvoker(wrapperAPI, realAPI, apiName, invocationAPI, scopeVars) {

--- a/common/Resources/ti.internal/kernel/android/nativemodule.js
+++ b/common/Resources/ti.internal/kernel/android/nativemodule.js
@@ -18,7 +18,7 @@ export default function NativeModuleBootstrap(global, kroll) {
 	}
 
 	/**
-	 * This should be an object with string keys (baked in module ids) -> string values (source of the baked in js code)
+	 * This should be an object with string keys (baked in module ids) -> string values (source of the baked in JS code)
 	 */
 	NativeModule._source = kroll.binding('natives');
 	NativeModule._cache = {};

--- a/common/Resources/ti.internal/kernel/android/proxy.js
+++ b/common/Resources/ti.internal/kernel/android/proxy.js
@@ -1,6 +1,6 @@
 /**
  * This hangs the Proxy type off Ti namespace. It also generates a hidden _properties object
- * that is used to store property values on the JS side for java Proxies.
+ * that is used to store property values on the JS side for Java Proxies.
  * Basically these get/set methods are fallbacks for when a Java proxy doesn't have a native method to handle getting/setting the property.
  * (see Proxy.h/ProxyBindingV8.cpp.fm for more info)
  * @param {object} tiBinding the underlying 'Titanium' native binding (see KrollBindings::initTitanium)

--- a/common/Resources/ti.internal/kernel/module.js
+++ b/common/Resources/ti.internal/kernel/module.js
@@ -75,7 +75,7 @@ function bootstrap (global, kroll) {
 		 * each invocation API in an external (3rd party) module
 		 * See invoker.js for more info
 		 * @param  {object} externalModule native module proxy
-		 * @param  {string} sourceUrl      the current js file url
+		 * @param  {string} sourceUrl      the current JS file url
 		 * @return {object}                wrapper around the externalModule
 		 */
 		createModuleWrapper (externalModule, sourceUrl) {
@@ -597,7 +597,7 @@ function bootstrap (global, kroll) {
 		// FIXME: I don't know why instanceof for Titanium.Service works here!
 		// On Android, it's an apiname of Ti.Android.Service
 		// On iOS, we don't yet pass in the value, but we do set Ti.App.currentService property beforehand!
-		// Can we remove the preload stuff in KrollBridge.m to pass along the service instance into this like we do on Andorid?
+		// Can we remove the preload stuff in KrollBridge.m to pass along the service instance into this like we do on Android?
 		module.isService = OS_ANDROID ? (activityOrService instanceof Titanium.Service) : Ti.App.currentService !== null;
 		if (OS_ANDROID) {
 			if (module.isService) {

--- a/common/Resources/ti.internal/kernel/titanium.js
+++ b/common/Resources/ti.internal/kernel/titanium.js
@@ -1,4 +1,4 @@
-/* globals OS_ANDROID,OS_IOS */
+/* globals OS_ANDROID, OS_IOS */
 import invoker from './android/invoker';
 import ProxyBootstrap from './android/proxy';
 

--- a/common/Resources/ti.kernel.js
+++ b/common/Resources/ti.kernel.js
@@ -1,7 +1,7 @@
 // This is the file each platform loads on boot *before* we launch ti.main.js to insert all our shims/extensions
 // and eventually load app.js
 // This is where any common setup cross-platform should take place
-// This is analagous to android's runtime/common/src/js directory before
+// This is analogous to Android's runtime/common/src/js directory before
 // On Android, this will get baked into the binary as raw char* to be loaded
 // On iOS, we'll simply evaluate/execute this before launching ti.main.js
 

--- a/common/Resources/ti.kernel.js
+++ b/common/Resources/ti.kernel.js
@@ -17,7 +17,7 @@
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
-/* globals OS_ANDROID,OS_IOS */
+/* globals OS_ANDROID, OS_IOS */
 // We must wrap and export a bootstrap function to be able to delay access to kroll/global
 // We're basically baking in the require wrapper function stuff in the code explicitly
 import ModuleBootstrap from './ti.internal/kernel/module';
@@ -83,10 +83,10 @@ function bootstrap(global, kroll) {
 		if (OS_ANDROID) {
 			kroll.ScopeVars = ScopeVars;
 			// external module bootstrap.js expects to call kroll.NativeModule.require directly to load in their own source
-			// and to refer to the baked in "bootstrap.js" for the SDK and "invoker.js" to hang lazy APIs/wrap api calls to pass in scope vars
+			// and to refer to the baked in "bootstrap.js" for the SDK and "invoker.js" to hang lazy APIs/wrap API calls to pass in scope vars
 			kroll.NativeModule = NativeModuleBootstrap(global, kroll);
 			// Android uses it's own EventEmitter impl, and it's baked right into the proxy class chain
-			// It assumes it can call back into java proxies to alert when listeners are added/removed
+			// It assumes it can call back into Java proxies to alert when listeners are added/removed
 			// FIXME: Get it to use the events.js impl in the node extension, and get iOS to bake that into it's proxies as well!
 			EventEmitterBootstrap(global, kroll);
 		} else if (OS_IOS) {

--- a/common/lib/color.js
+++ b/common/lib/color.js
@@ -3,10 +3,10 @@
  * It provides a common interface for handling colors and converting to necessary string forms.
  */
 
-const HEX_3_REGEX = /^#?([a-f\d])([a-f\d])([a-f\d])$/i; // i.e. #0F3
-const HEX_4_REGEX = /^#?([a-f\d])([a-f\d])([a-f\d])([a-f\d])$/i; // i.e. #0F38
-const HEX_6_REGEX = /^#?([a-f\d]){6}$/i; // i.e. #00FF33
-const HEX_8_REGEX = /^#?([a-f\d]){8}$/i; // i.e. #00FF3388
+const HEX_3_REGEX = /^#?([a-f\d])([a-f\d])([a-f\d])$/i; // e.g. #0F3
+const HEX_4_REGEX = /^#?([a-f\d])([a-f\d])([a-f\d])([a-f\d])$/i; // e.g. #0F38
+const HEX_6_REGEX = /^#?([a-f\d]){6}$/i; // e.g. #00FF33
+const HEX_8_REGEX = /^#?([a-f\d]){8}$/i; // e.g. #00FF3388
 
 /**
  * @param {number} integer in range of 0-255

--- a/dangerfile.cjs
+++ b/dangerfile.cjs
@@ -243,7 +243,7 @@ async function updateMilestone() {
 		// Typically this is because:
 		// - The milestone got out of date once we did some branch/version bumping
 		// - The milestone was set wrong
-		// - The milestone is for a future version on a maintenance branch (i.e. 8.1.1 on 8_1_X branch where we haven't released 8.1.0 yet)
+		// - The milestone is for a future version on a maintenance branch (e.g. 8.1.1 on 8_1_X branch where we haven't released 8.1.0 yet)
 		warn(`This PR has milestone set to ${github.pr.milestone.title}, but the version defined in package.json is ${packageJSON.version}
 Please either:
 - Update the milestone on the PR

--- a/iphone/Classes/AppModule.m
+++ b/iphone/Classes/AppModule.m
@@ -201,7 +201,7 @@ extern NSString *const TI_APPLICATION_GUID;
       }
       [eventObject setValue:type forKey:@"type"];
       // since this is cross context, we need to force into a JSON so the data can serialize
-      // we first force to string json, then we convert the string JSON back to a dictionary to
+      // we first force to string JSON, then we convert the string JSON back to a dictionary to
       // eliminate any native things like functions, native objects, etc.
       NSString *json_ = [TiUtils jsonStringify:eventObject];
       id jsonObject = [TiUtils jsonParse:json_ error:nil];
@@ -253,7 +253,7 @@ extern NSString *const TI_APPLICATION_GUID;
 {
   BOOL yn = [TiUtils boolValue:value];
   [UIDevice currentDevice].proximityMonitoringEnabled = yn;
-  WARN_IF_BACKGROUND_THREAD_OBJ; // NSNotificationCenter is not threadsafe!
+  WARN_IF_BACKGROUND_THREAD_OBJ; // NSNotificationCenter is not thread-safe!
   if (yn) {
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(proximityDetectionChanged:)
@@ -377,7 +377,7 @@ extern NSString *const TI_APPLICATION_GUID;
 
 - (void)startup
 {
-  WARN_IF_BACKGROUND_THREAD_OBJ; // NSNotificationCenter is not threadsafe!
+  WARN_IF_BACKGROUND_THREAD_OBJ; // NSNotificationCenter is not thread-safe!
   NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
   [nc addObserver:self selector:@selector(willShutdown:) name:kTiWillShutdownNotification object:nil];
   [nc addObserver:self selector:@selector(willShutdownContext:) name:kTiContextShutdownNotification object:nil];
@@ -404,7 +404,7 @@ extern NSString *const TI_APPLICATION_GUID;
 {
   // make sure we force any changes made on shutdown
   [[NSUserDefaults standardUserDefaults] synchronize];
-  WARN_IF_BACKGROUND_THREAD_OBJ; // NSNotificationCenter is not threadsafe!
+  WARN_IF_BACKGROUND_THREAD_OBJ; // NSNotificationCenter is not thread-safe!
   [[NSNotificationCenter defaultCenter] removeObserver:self];
   [super shutdown:sender];
 }

--- a/iphone/Classes/AsyncSocket.h
+++ b/iphone/Classes/AsyncSocket.h
@@ -376,7 +376,7 @@ typedef enum AsyncSocketError AsyncSocketError;
 // When a write is complete the onSocket:didWriteDataWithTag: delegate method is called.
 //
 // You may optionally set a timeout for any read/write operation. (To not timeout, use a negative time interval.)
-// If a read/write opertion times out, the corresponding "onSocket:shouldTimeout..." delegate method
+// If a read/write operation times out, the corresponding "onSocket:shouldTimeout..." delegate method
 // is called to optionally allow you to extend the timeout.
 // Upon a timeout, the "onSocket:willDisconnectWithError:" method is called, followed by "onSocketDidDisconnect".
 //

--- a/iphone/Classes/AsyncSocket.m
+++ b/iphone/Classes/AsyncSocket.m
@@ -2238,7 +2238,7 @@ Failed:
 }
 
 /**
- * Diconnects after all pending reads have completed.
+ * Disconnects after all pending reads have completed.
  **/
 - (void)disconnectAfterReading
 {

--- a/iphone/Classes/AsyncUdpSocket.h
+++ b/iphone/Classes/AsyncUdpSocket.h
@@ -325,7 +325,7 @@ typedef enum AsyncUdpSocketError AsyncUdpSocketError;
 
 /**
  * Called if an error occurs while trying to send a datagram.
- * This could be due to a timeout, or something more serious such as the data being too large to fit in a sigle packet.
+ * This could be due to a timeout, or something more serious such as the data being too large to fit in a single packet.
  **/
 - (void)onUdpSocket:(AsyncUdpSocket *)sock didNotSendDataWithTag:(long)tag dueToError:(NSError *)error;
 

--- a/iphone/Classes/AsyncUdpSocket.m
+++ b/iphone/Classes/AsyncUdpSocket.m
@@ -1011,7 +1011,7 @@ static void MyCFSocketCallback(CFSocketRef, CFSocketCallBackType, CFDataRef, con
 /**
  * Join multicast group
  *
- * Group should be a multicast IP address (eg. @"239.255.250.250" for IPv4).
+ * Group should be a multicast IP address (e.g. @"239.255.250.250" for IPv4).
  * Address is local interface for IPv4, but currently defaults under IPv6.
  **/
 - (BOOL)joinMulticastGroup:(NSString *)group error:(NSError **)errPtr

--- a/iphone/Classes/ContactsModule.m
+++ b/iphone/Classes/ContactsModule.m
@@ -448,7 +448,7 @@ static NSArray *contactKeysWithoutImage;
   }
   NSError *error = nil;
   CNMutableContact *newContact = [[CNMutableContact alloc] init];
-  // We dont set observer here because we dont want to be notified when props are being added to a newly created contact.
+  // We don't set observer here because we don't want to be notified when props are being added to a newly created contact.
   TiContactsPerson *newPerson = [[[TiContactsPerson alloc] _initWithPageContext:[self executionContext]
                                                                       contactId:newContact
                                                                          module:self] autorelease];
@@ -563,7 +563,7 @@ MAKE_SYSTEM_PROP(AUTHORIZATION_AUTHORIZED, CNAuthorizationStatusAuthorized);
     }
     if ([value isKindOfClass:[NSDateComponents class]]) {
       // this part of the code is supposed to work for birthday and alternateBirthday
-      // but iOS9 Beta is giving a null value for these properties in `value`, so only
+      // but iOS 9 Beta is giving a null value for these properties in `value`, so only
       // processing `anniversary` and `other` here.
       //			if ([contactProperty.key isEqualToString:CNContactNonGregorianBirthdayKey]) {
       //				NSDateComponents *dateComps = (NSDateComponents*)value;

--- a/iphone/Classes/FilesystemModule.m
+++ b/iphone/Classes/FilesystemModule.m
@@ -112,7 +112,7 @@
 
 - (bool)isExternalStoragePresent
 {
-  // IOS treats the camera connection kit as just that, and does not allow
+  // iOS treats the camera connection kit as just that, and does not allow
   // R/W access to it, which is just as well as it'd mess up cameras.
   return NO;
 }
@@ -143,7 +143,7 @@ GETTER_IMPL(NSString *, applicationSupportDirectory, ApplicationSupportDirectory
   NSString *home = NSHomeDirectory();
   return [NSString stringWithFormat:@"%@/Documents/", fileURLify(home)];
 #else
-  // TODO: Unify these. Appending /Documents to the home directory appears to give the same path as below code for ios sim (probably also device)
+  // TODO: Unify these. Appending /Documents to the home directory appears to give the same path as below code for iOS sim (probably also device)
   return [NSString stringWithFormat:@"%@/", fileURLify([NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) objectAtIndex:0])];
 #endif
 }

--- a/iphone/Classes/FilesystemModule.m
+++ b/iphone/Classes/FilesystemModule.m
@@ -37,7 +37,7 @@
   NSString *first = [[args objectAtIndex:0] toString];
   if ([first hasPrefix:@"file://"]) {
     NSURL *fileUrl = [NSURL URLWithString:first];
-    // Why not just crop? Because the url may have some things escaped that need to be unescaped.
+    // Why not just crop? Because the URL may have some things escaped that need to be unescaped.
     newpath = [fileUrl path];
   } else if ([first characterAtIndex:0] != '/') {
     NSURL *url = [NSURL URLWithString:[self resourcesDirectory]];

--- a/iphone/Classes/GDataXMLNode.h
+++ b/iphone/Classes/GDataXMLNode.h
@@ -150,7 +150,7 @@ typedef NSUInteger GDataXMLNodeKind;
 // This implementation of nodesForXPath registers namespaces only from the
 // document's root node.  _def_ns may be used as a prefix for the default
 // namespace, though there's no guarantee that the default namespace will
-// be consistenly the same namespace in server responses.
+// be consistently the same namespace in server responses.
 - (NSArray *)nodesForXPath:(NSString *)xpath error:(NSError **)error;
 
 // access to the underlying libxml node; be sure to release the cached values
@@ -219,7 +219,7 @@ typedef NSUInteger GDataXMLNodeKind;
 // This implementation of nodesForXPath registers namespaces only from the
 // document's root node.  _def_ns may be used as a prefix for the default
 // namespace, though there's no guarantee that the default namespace will
-// be consistenly the same namespace in server responses.
+// be consistently the same namespace in server responses.
 - (NSArray *)nodesForXPath:(NSString *)xpath error:(NSError **)error;
 
 - (NSString *)description;

--- a/iphone/Classes/GDataXMLNode.m
+++ b/iphone/Classes/GDataXMLNode.m
@@ -1268,7 +1268,7 @@ static xmlChar *SplitQNameReverse(const xmlChar *qname, xmlChar **prefix)
         xmlChar *childDesiredLocalName = expectedLocalName;
 
         if (currChildPtr->nsDef != NULL) {
-          // this child has its own namespace definitons; do a fresh resolve
+          // this child has its own namespace definitions; do a fresh resolve
           // of the namespace starting from the child, and see if it differs
           // from the resolve done starting from the parent.  If the resolve
           // finds a different namespace, then override the desired local
@@ -1499,7 +1499,7 @@ static xmlChar *SplitQNameReverse(const xmlChar *qname, xmlChar **prefix)
                fromXMLNode:(xmlNodePtr)node
 {
 
-  // utilty routine to remove a namespace pointer from an element's
+  // utility routine to remove a namespace pointer from an element's
   // namespace definition list.  This is just removing the nsPtr
   // from the singly-linked list, the node's namespace definitions.
   xmlNsPtr currNS = node->nsDef;

--- a/iphone/Classes/GeolocationModule.m
+++ b/iphone/Classes/GeolocationModule.m
@@ -224,7 +224,7 @@ extern NSString *const TI_APPLICATION_GUID;
     // activity Type by default
     activityType = CLActivityTypeOther;
 
-    // pauseLocationupdateAutomatically by default NO
+    // pauseLocationUpdateAutomatically by default NO
     pauseLocationUpdateAutomatically = NO;
 
     // Set the default based on if the user has defined a background location mode
@@ -275,7 +275,7 @@ extern NSString *const TI_APPLICATION_GUID;
         [locationManager requestWhenInUseAuthorization];
       } else {
         NSLog(@"[ERROR] If you are only using geolocation-services *when in use*, you only need to specify the %@ key in your tiapp.xml", kTiGeolocationUsageDescriptionWhenInUse);
-        NSLog(@"[ERROR] If you are *always*  using geolocation-servcies, you need to specify the following three keys in your tiapp.xml:\n  * %@\n  * %@\n  * %@", kTiGeolocationUsageDescriptionWhenInUse, kTiGeolocationUsageDescriptionAlways, kTiGeolocationUsageDescriptionAlwaysAndWhenInUse);
+        NSLog(@"[ERROR] If you are *always* using geolocation-services, you need to specify the following three keys in your tiapp.xml:\n  * %@\n  * %@\n  * %@", kTiGeolocationUsageDescriptionWhenInUse, kTiGeolocationUsageDescriptionAlways, kTiGeolocationUsageDescriptionAlwaysAndWhenInUse);
       }
     }
 
@@ -1071,7 +1071,7 @@ READWRITE_IMPL(bool, showCalibration, ShowCalibration);
 
   BOOL requestedStatusMatchesActualStatus = status == requestedAuthorizationStatus;
 
-  // The new callback for android parity used inside Ti.Geolocation.requestLocationPermissions()
+  // The new callback for Android parity used inside Ti.Geolocation.requestLocationPermissions()
   if (authorizationPromise != nil && status != kCLAuthorizationStatusNotDetermined) {
     int code = 0;
     NSString *errorStr = nil;

--- a/iphone/Classes/GestureModule.m
+++ b/iphone/Classes/GestureModule.m
@@ -42,7 +42,7 @@
 
 - (void)registerForShake
 {
-  WARN_IF_BACKGROUND_THREAD_OBJ; // NSNotificationCenter is not threadsafe!
+  WARN_IF_BACKGROUND_THREAD_OBJ; // NSNotificationCenter is not thread-safe!
   [[NSNotificationCenter defaultCenter] addObserver:self
                                            selector:@selector(shakeEvent:)
                                                name:kTiGestureShakeNotification
@@ -52,7 +52,7 @@
 - (void)registerForOrientation
 {
   [[UIDevice currentDevice] beginGeneratingDeviceOrientationNotifications];
-  WARN_IF_BACKGROUND_THREAD_OBJ; // NSNotificationCenter is not threadsafe!
+  WARN_IF_BACKGROUND_THREAD_OBJ; // NSNotificationCenter is not thread-safe!
   [[NSNotificationCenter defaultCenter] addObserver:self
                                            selector:@selector(rotateEvent:)
                                                name:UIDeviceOrientationDidChangeNotification
@@ -79,7 +79,7 @@
 
 - (void)unregisterForNotificationNamed:(NSString *)oldNotification
 {
-  WARN_IF_BACKGROUND_THREAD_OBJ; // NSNotificationCenter is not threadsafe!
+  WARN_IF_BACKGROUND_THREAD_OBJ; // NSNotificationCenter is not thread-safe!
   [[NSNotificationCenter defaultCenter] removeObserver:self name:oldNotification object:nil];
 }
 
@@ -108,7 +108,7 @@ GETTER_IMPL(bool, landscape, Landscape);
 
 - (bool)portrait
 {
-  return [TiUtils isOrientationPortait];
+  return [TiUtils isOrientationPortrait];
 }
 GETTER_IMPL(bool, portrait, Portrait);
 

--- a/iphone/Classes/KrollWrapper.h
+++ b/iphone/Classes/KrollWrapper.h
@@ -47,7 +47,7 @@
 // Unprotects a JSObject from being GC'd
 - (void)unprotectJsobject;
 
-// Replaces a value for a given key in it's underlaying JSContext
+// Replaces a value for a given key in it's underlying JSContext
 - (void)replaceValue:(id)value forKey:(NSString *)key notification:(BOOL)notify;
 
 // Executes an async JavaScript function and returns the resulting JSCore value if any

--- a/iphone/Classes/LocaleModule.m
+++ b/iphone/Classes/LocaleModule.m
@@ -52,7 +52,7 @@ GETTER_IMPL(NSString *, currentLocale, CurrentLocale);
   NSString *localeID = [NSLocale localeIdentifierFromComponents:[NSDictionary dictionaryWithObject:currencyCode forKey:NSLocaleCurrencyCode]];
   NSLocale *locale = [[[NSLocale alloc] initWithLocaleIdentifier:localeID] autorelease];
   NSString *currency = [locale objectForKey:NSLocaleCurrencySymbol];
-  // Many countries do $ and iOS (correctly) differentiates them when provided only with currecy code.  However
+  // Many countries do $ and iOS (correctly) differentiates them when provided only with currency code.  However
   // this doesn't match Android.  So, if the currency contains a $, that's all we return.
   if ([currency hasSuffix:@"$"]) {
     return @"$";

--- a/iphone/Classes/MediaModule.m
+++ b/iphone/Classes/MediaModule.m
@@ -450,11 +450,11 @@ MAKE_SYSTEM_PROP(VIDEO_REPEAT_MODE_ONE, VideoRepeatModeOne);
 - (void)_listenerAdded:(NSString *)type count:(int)count
 {
   if (count == 1 && [type isEqualToString:@"routechange"]) {
-    WARN_IF_BACKGROUND_THREAD_OBJ; // NSNotificationCenter is not threadsafe
+    WARN_IF_BACKGROUND_THREAD_OBJ; // NSNotificationCenter is not thread-safe
     [[TiMediaAudioSession sharedSession] startAudioSession]; // Have to start a session to get a listener
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(audioRouteChanged:) name:kTiMediaAudioSessionRouteChange object:[TiMediaAudioSession sharedSession]];
   } else if (count == 1 && [type isEqualToString:@"volume"]) {
-    WARN_IF_BACKGROUND_THREAD_OBJ; // NSNotificationCenter is not threadsafe!
+    WARN_IF_BACKGROUND_THREAD_OBJ; // NSNotificationCenter is not thread-safe!
     [[TiMediaAudioSession sharedSession] startAudioSession]; // Have to start a session to get a listener
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(audioVolumeChanged:) name:kTiMediaAudioSessionVolumeChange object:[TiMediaAudioSession sharedSession]];
   }
@@ -463,11 +463,11 @@ MAKE_SYSTEM_PROP(VIDEO_REPEAT_MODE_ONE, VideoRepeatModeOne);
 - (void)_listenerRemoved:(NSString *)type count:(int)count
 {
   if (count == 0 && [type isEqualToString:@"routechange"]) {
-    WARN_IF_BACKGROUND_THREAD_OBJ; // NSNotificationCenter is not threadsafe!
+    WARN_IF_BACKGROUND_THREAD_OBJ; // NSNotificationCenter is not thread-safe!
     [[TiMediaAudioSession sharedSession] stopAudioSession];
     [[NSNotificationCenter defaultCenter] removeObserver:self name:kTiMediaAudioSessionRouteChange object:[TiMediaAudioSession sharedSession]];
   } else if (count == 0 && [type isEqualToString:@"volume"]) {
-    WARN_IF_BACKGROUND_THREAD_OBJ; // NSNotificationCenter is not threadsafe!
+    WARN_IF_BACKGROUND_THREAD_OBJ; // NSNotificationCenter is not thread-safe!
     [[TiMediaAudioSession sharedSession] stopAudioSession];
     [[NSNotificationCenter defaultCenter] removeObserver:self name:kTiMediaAudioSessionVolumeChange object:[TiMediaAudioSession sharedSession]];
   }

--- a/iphone/Classes/NetworkModule.m
+++ b/iphone/Classes/NetworkModule.m
@@ -49,7 +49,7 @@ static NSOperationQueue *_operationQueue = nil;
   [super _configure];
   // default to unknown network type on startup until reachability has figured it out
   state = TiNetworkConnectionStateUnknown;
-  WARN_IF_BACKGROUND_THREAD_OBJ; // NSNotificationCenter is not threadsafe!
+  WARN_IF_BACKGROUND_THREAD_OBJ; // NSNotificationCenter is not thread-safe!
   [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(reachabilityChanged:) name:kReachabilityChangedNotification object:nil];
   // wait until done is important to get the right state
   TiThreadPerformOnMainThread(
@@ -66,7 +66,7 @@ static NSOperationQueue *_operationQueue = nil;
         [self stopReachability];
       },
       YES);
-  WARN_IF_BACKGROUND_THREAD_OBJ; // NSNotificationCenter is not threadsafe!
+  WARN_IF_BACKGROUND_THREAD_OBJ; // NSNotificationCenter is not thread-safe!
   [[NSNotificationCenter defaultCenter] removeObserver:self name:kReachabilityChangedNotification object:nil];
   RELEASE_TO_NIL(pushNotificationCallback);
   RELEASE_TO_NIL(pushNotificationError);
@@ -243,8 +243,8 @@ MAKE_SYSTEM_NUMBER(PROGRESS_UNKNOWN, NUMINT(-1));
 
   UIApplication *app = [UIApplication sharedApplication];
 
-  // for iOS8 or greater only
-  // Note adviced to register user notification settings in Ti.App.iOS first before register for remote notifications
+  // for iOS 8 or greater only
+  // Note advised to register user notification settings in Ti.App.iOS first before register for remote notifications
   [app registerForRemoteNotifications];
 
   if ([args objectForKey:@"types"] != nil) {

--- a/iphone/Classes/PlatformModule.m
+++ b/iphone/Classes/PlatformModule.m
@@ -342,7 +342,7 @@ GETTER_IMPL(NSNumber *, availableMemory, AvailableMemory);
     optionsDict = [options toDictionary];
   }
   // Ensure callback is actually a function. If not, make it nil so we don't fire it
-  // Since callback is optional, this may be a JSValue representing 'undefined' here wich is not nil
+  // Since callback is optional, this may be a JSValue representing 'undefined' here which is not nil
   // So we need this special guard
   if (![callback isFunction]) {
     callback = nil;

--- a/iphone/Classes/Reachability.h
+++ b/iphone/Classes/Reachability.h
@@ -3,7 +3,7 @@
  See LICENSE.txt for this sample’s licensing information
 
  Abstract:
- Basic demonstration of how to use the SystemConfiguration Reachablity APIs.
+ Basic demonstration of how to use the SystemConfiguration Reachability APIs.
  */
 
 // clang-format off

--- a/iphone/Classes/Reachability.m
+++ b/iphone/Classes/Reachability.m
@@ -3,7 +3,7 @@
  See LICENSE.txt for this sample’s licensing information
 
  Abstract:
- Basic demonstration of how to use the SystemConfiguration Reachablity APIs.
+ Basic demonstration of how to use the SystemConfiguration Reachability APIs.
  */
 // clang-format off
 

--- a/iphone/Classes/ThirdpartyNS.h
+++ b/iphone/Classes/ThirdpartyNS.h
@@ -63,7 +63,7 @@
 #define AsyncUdpSocketDelegate __TI_NS_SYMBOL(AsyncUdpSocketDelegate)
 #endif
 
-// Reachalility
+// Reachability
 #ifndef kInternetConnection
 #define kInternetConnection __TI_NS_SYMBOL(kInternetConnection)
 #endif

--- a/iphone/Classes/TiAction.h
+++ b/iphone/Classes/TiAction.h
@@ -7,7 +7,7 @@
 
 /**
  The generic action wrapper class for packaging something that you
- want to be executed but simplier than an NSOperation.
+ want to be executed but simpler than an NSOperation.
  @deprecated
  */
 @interface TiAction : NSObject {

--- a/iphone/Classes/TiApp+Addons.m
+++ b/iphone/Classes/TiApp+Addons.m
@@ -28,7 +28,7 @@
     // Generate unique key with timestamp.
     NSString *key = [NSString stringWithFormat:@"Fetch-%f", [[NSDate date] timeIntervalSince1970]];
 
-    // Store the completionhandler till we can come back and send appropriate message.
+    // Store the completion handler till we can come back and send appropriate message.
     if (pendingCompletionHandlers == nil) {
       pendingCompletionHandlers = [[NSMutableDictionary alloc] init];
     }
@@ -73,7 +73,7 @@
     // Generate unique key with timestamp.
     NSString *key = [NSString stringWithFormat:@"SilentPush-%f", [[NSDate date] timeIntervalSince1970]];
 
-    // Store the completionhandler till we can come back and send appropriate message.
+    // Store the completion handler till we can come back and send appropriate message.
     if (pendingCompletionHandlers == nil) {
       pendingCompletionHandlers = [[NSMutableDictionary alloc] init];
     }

--- a/iphone/Classes/TiAppiOSProxy.m
+++ b/iphone/Classes/TiAppiOSProxy.m
@@ -821,7 +821,7 @@
 
  @param userInfo User info dictionary to assign to the notification content
  @param content Notification content, can either be UNMutableNotificationContent or UILocalNotification
- @param notificationIdentifier The unique Identifier for a notification.
+ @param notificationIdentifier The unique identifier for a notification.
  */
 - (void)assignUserInfo:(NSDictionary *)userInfo toContent:(id)content ensureIdentifier:(NSString *)notificationIdentifier
 {

--- a/iphone/Classes/TiAppiOSProxy.m
+++ b/iphone/Classes/TiAppiOSProxy.m
@@ -794,7 +794,7 @@
     [content setThreadIdentifier:threadIdentifier];
   }
 
-  // Construct a new notiication request using our content and trigger (e.g. date or location)
+  // Construct a new notification request using our content and trigger (e.g. date or location)
   UNNotificationRequest *request = [UNNotificationRequest requestWithIdentifier:identifier
                                                                         content:content
                                                                         trigger:trigger];
@@ -821,7 +821,7 @@
 
  @param userInfo User info dictionary to assign to the notification content
  @param content Notification content, can either be UNMutableNotificationContent or UILocalNotification
- @param notificationIdentifier The unique idenitifer for a notification.
+ @param notificationIdentifier The unique Identifier for a notification.
  */
 - (void)assignUserInfo:(NSDictionary *)userInfo toContent:(id)content ensureIdentifier:(NSString *)notificationIdentifier
 {

--- a/iphone/Classes/TiAppiOSSearchableIndexProxy.h
+++ b/iphone/Classes/TiAppiOSSearchableIndexProxy.h
@@ -10,5 +10,9 @@
 
 @interface TiAppiOSSearchableIndexProxy : TiProxy {
 }
+/**
+ * @deprecated Use `deleteAllSearchableItemByDomainIdentifiers:` instead.
+ */
+- (void)deleteAllSearchableItemByDomainIdenifiers:(id)args __attribute__((deprecated));
 @end
 #endif

--- a/iphone/Classes/TiAppiOSSearchableIndexProxy.m
+++ b/iphone/Classes/TiAppiOSSearchableIndexProxy.m
@@ -83,6 +83,10 @@
 
 - (void)deleteAllSearchableItemByDomainIdenifiers:(id)args
 {
+  [self deleteAllSearchableItemByDomainIdentifiers:args];
+}
+- (void)deleteAllSearchableItemByDomainIdentifiers:(id)args
+{
   ENSURE_ARG_COUNT(args, 2);
   NSArray *domainIdentifiers = [args objectAtIndex:0];
   ENSURE_TYPE(domainIdentifiers, NSArray);
@@ -90,7 +94,7 @@
   KrollCallback *callback = [args objectAtIndex:1];
   ENSURE_TYPE(callback, KrollCallback);
 
-  ENSURE_UI_THREAD(deleteAllSearchableItemByDomainIdenifiers, args);
+  ENSURE_UI_THREAD(deleteAllSearchableItemByDomainIdentifiers, args);
 
   [[CSSearchableIndex defaultSearchableIndex] deleteSearchableItemsWithDomainIdentifiers:domainIdentifiers
                                                                        completionHandler:^(NSError *_Nullable error) {

--- a/iphone/Classes/TiAppiOSSearchableItemAttributeSetProxy.m
+++ b/iphone/Classes/TiAppiOSSearchableItemAttributeSetProxy.m
@@ -544,8 +544,8 @@
   _attributes.lyricist = value;
 }
 
-// The title for a collection of media. This is analagous to a record album,
-// or photo album whichs are collections of audio or images.
+// The title for a collection of media. This is analogous to a record album,
+// or photo album which are collections of audio or images.
 - (NSString *)album
 {
   return _attributes.album;
@@ -810,7 +810,7 @@
 
 // This attribute indicates where the item was obtained from.
 // Examples:
-//- downloaded file may refer to the site they were downloaded from,the refering URL, etc
+//- downloaded file may refer to the site they were downloaded from, the referring URL, etc
 //- files received by email may indicate who sent the file, the message subject, etc
 - (NSArray *)contentSources
 {
@@ -1344,7 +1344,7 @@
 
 - (void)setPostalCode:(id)value
 {
-  ENSURE_IOS_API(@"10", @"Ti.App.iOS.SearchableItemAttributSet.postalCode");
+  ENSURE_IOS_API(@"10", @"Ti.App.iOS.SearchableItemAttributeSet.postalCode");
   ENSURE_SINGLE_ARG(value, NSString);
   ENSURE_UI_THREAD(setPostalCode, value);
   [_attributes setPostalCode:[TiUtils stringValue:value]];

--- a/iphone/Classes/TiAppiOSUserNotificationActionProxy.m
+++ b/iphone/Classes/TiAppiOSUserNotificationActionProxy.m
@@ -45,7 +45,7 @@
       options |= UNNotificationActionOptionAuthenticationRequired;
     }
 
-    // Important: The UNNoticationAction class is creation-only, so the manual setters are only
+    // Important: The UNNotificationAction class is creation-only, so the manual setters are only
     // for the iOS < 10 UIUserNotificationAction
     if (behavior && [TiUtils intValue:behavior def:UIUserNotificationActionBehaviorDefault] == UIUserNotificationActionBehaviorTextInput) {
       _notificationAction = [[UNTextInputNotificationAction actionWithIdentifier:identifier

--- a/iphone/Classes/TiContactsGroup.m
+++ b/iphone/Classes/TiContactsGroup.m
@@ -186,7 +186,7 @@
                 location:CODELOCATION];
   }
 
-// Ignore static analylzer warning here
+// Ignore static analyzer warning here
 // This is to release the saverequest in TiContactsPerson.m line 965 in (CNSaveRequest*)getSaveRequestForAddition
 #ifndef __clang_analyzer__
   RELEASE_TO_NIL(saveRequest);
@@ -222,7 +222,7 @@
 #endif
 }
 
-// For iOS9 deleting contact
+// For iOS 9 deleting contact
 #ifndef __clang_analyzer__
 - (CNSaveRequest *)getSaveRequestForDeletion
 {

--- a/iphone/Classes/TiContactsPerson.m
+++ b/iphone/Classes/TiContactsPerson.m
@@ -70,7 +70,7 @@ static NSDictionary *iOS9propertyKeys;
     return nil;
   }
 
-  // iOS9 contacts framework by default returns partial contact.
+  // iOS 9 contacts framework by default returns partial contact.
   // For ex: Email is returned nil when phone is selected and vice-versa.
   // So check and add.
   NSMutableDictionary *dict = [[NSMutableDictionary alloc] init];
@@ -136,7 +136,7 @@ static NSDictionary *iOS9propertyKeys;
                               @"main", CNLabelPhoneNumberMain,
                               @"iPhone", CNLabelPhoneNumberiPhone,
                               @"homeFax", CNLabelPhoneNumberHomeFax,
-                              @"facebookProfile", [CNSocialProfileServiceFacebook lowercaseString], // Social Profile Labels, curiously the string constants in the system is in lower case, so small hack here until iOS9 Beta makes changes here.
+                              @"facebookProfile", [CNSocialProfileServiceFacebook lowercaseString], // Social Profile Labels, curiously the string constants in the system is in lower case, so small hack here until iOS 9 Beta makes changes here.
                               @"flickrProfile", [CNSocialProfileServiceFlickr lowercaseString],
                               @"gameCenterProfile", [CNSocialProfileServiceGameCenter lowercaseString],
                               @"linkedInProfile", [CNSocialProfileServiceLinkedIn lowercaseString],
@@ -364,7 +364,7 @@ static NSDictionary *iOS9propertyKeys;
   }
   id property = nil;
 
-  // Birthday property managed seperately
+  // Birthday property managed separately
   if ([key isEqualToString:@"birthday"] && [person isKeyAvailable:CNContactBirthdayKey] && person.birthday != nil) {
     NSDate *date = [[NSCalendar currentCalendar] dateFromComponents:person.birthday];
     return [TiUtils UTCDateForDate:date];
@@ -586,12 +586,12 @@ static NSDictionary *iOS9propertyKeys;
     RELEASE_TO_NIL(newObjects)
   }
   // Why we do this ?
-  // In >= iOS9 contacts are immutable as well. So when a change happens we should create an associated CNSaveRequest.
+  // In >= iOS 9 contacts are immutable as well. So when a change happens we should create an associated CNSaveRequest.
   // By observing on this object the observer can update its CNSaveRequest accordingly.
   [self checkAndNotifyObserver];
 }
 
-// For iOS9 deleting contact
+// For iOS 9 deleting contact
 #ifndef __clang_analyzer__
 - (CNSaveRequest *)getSaveRequestForDeletion
 {

--- a/iphone/Classes/TiDOMDocumentProxy.m
+++ b/iphone/Classes/TiDOMDocumentProxy.m
@@ -416,9 +416,9 @@
       [self throwException:@"document/documenttype nodes can not be imported" subreason:nil location:CODELOCATION];
       return nil;
     }
-    GDataXMLNode *resultElemet = [[self document] importNode:[theNodeToImport node] recursive:deep];
+    GDataXMLNode *resultElement = [[self document] importNode:[theNodeToImport node] recursive:deep];
     id context = ([self executionContext] == nil) ? [self pageContext] : [self executionContext];
-    return [self makeNode:resultElemet context:context];
+    return [self makeNode:resultElement context:context];
   }
   return nil;
 }

--- a/iphone/Classes/TiDatabaseProxy.m
+++ b/iphone/Classes/TiDatabaseProxy.m
@@ -33,7 +33,7 @@
 
 - (void)_destroy
 {
-  WARN_IF_BACKGROUND_THREAD_OBJ; // NSNotificationCenter is not threadsafe!
+  WARN_IF_BACKGROUND_THREAD_OBJ; // NSNotificationCenter is not thread-safe!
   [[NSNotificationCenter defaultCenter] removeObserver:self name:kTiShutdownNotification object:nil];
   [self shutdown:nil];
   [super _destroy];
@@ -41,7 +41,7 @@
 
 - (void)_configure
 {
-  WARN_IF_BACKGROUND_THREAD_OBJ; // NSNotificationCenter is not threadsafe!
+  WARN_IF_BACKGROUND_THREAD_OBJ; // NSNotificationCenter is not thread-safe!
   [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(shutdown:) name:kTiShutdownNotification object:nil];
   [super _configure];
 }
@@ -254,7 +254,7 @@
 - (TiDatabaseResultSetProxy *)execute:(NSString *)sql
 {
   NSArray *params = @[];
-  // Check for varargs for perepared statement params
+  // Check for varargs for prepared statement params
   NSArray *currentArgs = [JSContext currentArguments];
   if ([currentArgs count] > 1) {
     JSValue *possibleParams = [currentArgs objectAtIndex:1];

--- a/iphone/Classes/TiDatabaseResultSetProxy.m
+++ b/iphone/Classes/TiDatabaseResultSetProxy.m
@@ -202,7 +202,7 @@
     BOOL reset = NO;
     if (rowCount < 0) {
       // since we start off at one, we need to include ours by
-      // calling reset and then after calcuating the count we
+      // calling reset and then after calculating the count we
       // need to advance again (below)
       [results reset];
       reset = YES;

--- a/iphone/Classes/TiMediaAudioPlayerProxy.m
+++ b/iphone/Classes/TiMediaAudioPlayerProxy.m
@@ -377,7 +377,7 @@
 
 - (void)addNotificationObserver
 {
-  WARN_IF_BACKGROUND_THREAD; // NSNotificationCenter is not threadsafe!
+  WARN_IF_BACKGROUND_THREAD; // NSNotificationCenter is not thread-safe!
   NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
 
   // For playbackState property / playbackstate event

--- a/iphone/Classes/TiMediaMusicPlayer.m
+++ b/iphone/Classes/TiMediaMusicPlayer.m
@@ -17,7 +17,7 @@
 // Has to happen on main thread or notifications screw up
 - (void)initializePlayer
 {
-  WARN_IF_BACKGROUND_THREAD_OBJ; // NSNotificationCenter is not threadsafe!
+  WARN_IF_BACKGROUND_THREAD_OBJ; // NSNotificationCenter is not thread-safe!
   NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
   [nc addObserver:self selector:@selector(stateDidChange:) name:MPMusicPlayerControllerPlaybackStateDidChangeNotification object:player];
   [nc addObserver:self selector:@selector(playingDidChange:) name:MPMusicPlayerControllerNowPlayingItemDidChangeNotification object:player];
@@ -30,7 +30,7 @@
 {
   if (self = [super _initWithPageContext:context]) {
     player = player_;
-    WARN_IF_BACKGROUND_THREAD_OBJ; // NSNotificationCenter is not threadsafe!
+    WARN_IF_BACKGROUND_THREAD_OBJ; // NSNotificationCenter is not thread-safe!
     NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
     [nc addObserver:self selector:@selector(stateDidChange:) name:MPMusicPlayerControllerPlaybackStateDidChangeNotification object:player];
     [nc addObserver:self selector:@selector(playingDidChange:) name:MPMusicPlayerControllerNowPlayingItemDidChangeNotification object:player];
@@ -43,7 +43,7 @@
 
 - (void)dealloc
 {
-  WARN_IF_BACKGROUND_THREAD_OBJ; // NSNotificationCenter is not threadsafe!
+  WARN_IF_BACKGROUND_THREAD_OBJ; // NSNotificationCenter is not thread-safe!
   NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
   [nc removeObserver:self name:MPMusicPlayerControllerPlaybackStateDidChangeNotification object:player];
   [nc removeObserver:self name:MPMusicPlayerControllerNowPlayingItemDidChangeNotification object:player];

--- a/iphone/Classes/TiMediaVideoPlayer.m
+++ b/iphone/Classes/TiMediaVideoPlayer.m
@@ -112,7 +112,7 @@
 {
   // The view hierarchy of the movie player controller's view is subject to change,
   // and traversing it is dangerous. If we received a touch which isn't on a TiUIView,
-  // assume it falls into the movie player view hiearchy; this matches previous
+  // assume it falls into the movie player view hierarchy; this matches previous
   // behavior as well.
 
   UITouch *touch = [[event allTouches] anyObject];

--- a/iphone/Classes/TiMediaVideoPlayerProxy.m
+++ b/iphone/Classes/TiMediaVideoPlayerProxy.m
@@ -126,7 +126,7 @@ NSArray *moviePlayerKeys = nil;
 
   // we need this code below since the player can be realized before loading
   // properties in certain cases and when we go to create it again after setting
-  // url we will need to set the new controller to the already created view
+  // URL we will need to set the new controller to the already created view
   if ([self viewAttached]) {
     TiMediaVideoPlayer *vp = (TiMediaVideoPlayer *)[self view];
     [vp setMovie:movie];
@@ -140,7 +140,7 @@ NSArray *moviePlayerKeys = nil;
     if (url == nil) {
       [playerLock unlock];
       // this is OK - we just need to delay creation of the
-      // player until after the url is set
+      // player until after the URL is set
       return nil;
     }
     movie = [[AVPlayerViewController alloc] init];
@@ -741,7 +741,7 @@ NSArray *moviePlayerKeys = nil;
 
   if (url == nil) {
     [self throwException:TiExceptionInvalidType
-               subreason:@"Tried to play movie player without a valid url or media property"
+               subreason:@"Tried to play movie player without a valid URL or media property"
                 location:CODELOCATION];
   }
 

--- a/iphone/Classes/TiMediaVideoPlayerProxy.m
+++ b/iphone/Classes/TiMediaVideoPlayerProxy.m
@@ -83,7 +83,7 @@ NSArray *moviePlayerKeys = nil;
 
 - (void)addNotificationObserver
 {
-  WARN_IF_BACKGROUND_THREAD; // NSNotificationCenter is not threadsafe!
+  WARN_IF_BACKGROUND_THREAD; // NSNotificationCenter is not thread-safe!
   NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
 
   // For durationavailable event
@@ -366,7 +366,7 @@ NSArray *moviePlayerKeys = nil;
     AVPlayerItem *newVideoItem = [AVPlayerItem playerItemWithAsset:urlAsset];
     [[movie player] replaceCurrentItemWithPlayerItem:newVideoItem];
     [self removeNotificationObserver]; // Remove old observers
-    [self addNotificationObserver]; // Add new oberservers
+    [self addNotificationObserver]; // Add new observers
   } else {
     [self ensurePlayer];
   }

--- a/iphone/Classes/TiNetworkBonjourServiceProxy.h
+++ b/iphone/Classes/TiNetworkBonjourServiceProxy.h
@@ -24,7 +24,7 @@ PROPERTY(JSValue *, socket, Socket);
 PROPERTY(NSString *, type, Type);
 
 // Methods
-// FIXME: socketProxy can be TiNetworkSocketTCPProxy* once that proxy is moved to obj-c api
+// FIXME: socketProxy can be TiNetworkSocketTCPProxy* once that proxy is moved to obj-c API
 JSExportAs(publish,
            -(void)publish
            : (JSValue *)socketProxy withCallback

--- a/iphone/Classes/TiNetworkSocketTCPProxy.m
+++ b/iphone/Classes/TiNetworkSocketTCPProxy.m
@@ -643,7 +643,7 @@ TYPESAFE_SETTER(setError, error, KrollCallback)
   }
 }
 
-// Prevent that goofy race conditon where a socket isn't attached to a run loop before beginning the accepted socket run loop.
+// Prevent that goofy race condition where a socket isn't attached to a run loop before beginning the accepted socket run loop.
 - (void)onSocketReadyInRunLoop:(AsyncSocket *)sock
 {
   NSCondition *tempConditionRef = [readyCondition retain];

--- a/iphone/Classes/TiUIActivityIndicator.m
+++ b/iphone/Classes/TiUIActivityIndicator.m
@@ -254,7 +254,7 @@
     // Make the backgroundView as small as the biggest of the two
     [backgroundView addConstraints:TI_CONSTR(@"V:|-(>=0)-[messageLabel]-(>=0)-|", views)];
     [backgroundView addConstraints:TI_CONSTR(@"V:|-(>=0)-[indicatorView]-(>=0)-|", views)];
-    // Center both verically
+    // Center both vertically
     [backgroundView addConstraint:[NSLayoutConstraint constraintWithItem:messageLabel
                                                                attribute:NSLayoutAttributeCenterY
                                                                relatedBy:NSLayoutRelationEqual

--- a/iphone/Classes/TiUIAttributedStringProxy.m
+++ b/iphone/Classes/TiUIAttributedStringProxy.m
@@ -283,8 +283,8 @@
 
   for (NSString *key in _urls) {
     NSRange range = NSRangeFromString(key);
-    CGFloat tempLenght = range.location + range.length;
-    if (range.location <= tempIndx && tempLenght >= tempIndx) {
+    CGFloat tempLength = range.location + range.length;
+    if (range.location <= tempIndx && tempLength >= tempIndx) {
       return [_urls valueForKey:key];
     }
   }

--- a/iphone/Classes/TiUIButton.m
+++ b/iphone/Classes/TiUIButton.m
@@ -102,8 +102,8 @@
   } else {
     // If the bounds are smaller than the image size render it in an imageView and get the image of the view.
     // Should be pretty inexpensive since it happens rarely. TIMOB-9166
-    CGSize unstrechedSize = (backgroundImageUnstretchedCache != nil) ? [backgroundImageUnstretchedCache size] : CGSizeZero;
-    if (backgroundImageUnstretchedCache == nil || !CGSizeEqualToSize(unstrechedSize, bounds.size)) {
+    CGSize unstretchedSize = (backgroundImageUnstretchedCache != nil) ? [backgroundImageUnstretchedCache size] : CGSizeZero;
+    if (backgroundImageUnstretchedCache == nil || !CGSizeEqualToSize(unstretchedSize, bounds.size)) {
       UIImageView *theView = [[UIImageView alloc] initWithFrame:bounds];
       [theView setImage:backgroundImageCache];
       UIGraphicsBeginImageContextWithOptions(bounds.size, [theView.layer isOpaque], 0.0);

--- a/iphone/Classes/TiUICanvasView.m
+++ b/iphone/Classes/TiUICanvasView.m
@@ -17,7 +17,7 @@ enum {
   TiCanvasStrokeRect,
   TiCanvasStrokeStyle,
   TiCanvasLineWidth,
-  TiCanvasFillElipse,
+  TiCanvasFillEllipse,
   TiCanvasLineJoin,
   TiCanvasLineCap,
   TiCanvasLineTo,
@@ -174,7 +174,7 @@ enum {
     CGContextSetLineWidth(context, [TiUtils floatValue:[args objectAtIndex:0]]);
     break;
   }
-  case TiCanvasFillElipse: {
+  case TiCanvasFillEllipse: {
     CGContextFillEllipseInRect(context, [self rectFromArray:args]);
     break;
   }

--- a/iphone/Classes/TiUIImageView.h
+++ b/iphone/Classes/TiUIImageView.h
@@ -12,7 +12,7 @@
 //
 // this is a re-implementation (sort of) of the UIImageView object used for
 // displaying animated images.  The UIImageView object sucks and is very
-// problemmatic and we try and solve it here.
+// problematic and we try and solve it here.
 //
 
 @interface TiUIImageView : TiUIView <ImageLoaderDelegate, TiProxyDelegate> {

--- a/iphone/Classes/TiUIImageView.m
+++ b/iphone/Classes/TiUIImageView.m
@@ -480,7 +480,7 @@ DEFINE_EXCEPTIONS
       imageSize.height *= 2;
     }
 
-    // Skip the imageloader completely if this is obviously a file we can load off the fileystem.
+    // Skip the imageloader completely if this is obviously a file we can load off the filesystem.
     // why were we ever doing that in the first place...?
     if ([img isFileURL]) {
       UIImage *image = nil;

--- a/iphone/Classes/TiUILabel.m
+++ b/iphone/Classes/TiUILabel.m
@@ -78,7 +78,7 @@
 {
   /*
      Why both? sizeThatFits returns the width with line break mode tail truncation and we like to
-     have atleast enough space to display one word. On the other hand font measurement is unsuitable for
+     have at least enough space to display one word. On the other hand font measurement is unsuitable for
      attributed strings till we move to the new measurement API. Hence take both and return MAX.
      */
   CGFloat sizeThatFitsResult = [[self label] sizeThatFits:CGSizeMake(suggestedWidth, 0)].width;

--- a/iphone/Classes/TiUIListItem.m
+++ b/iphone/Classes/TiUIListItem.m
@@ -97,7 +97,7 @@
 
 #ifdef USE_TI_UIACTIVITYINDICATOR
   // TIMOB-17572: Attempt to resume activity indicator animation to reuse cell
-  // Use this workaroud until iOS is smart enough to retain the animation state itself
+  // Use this workaround until iOS is smart enough to retain the animation state itself
   if (self.subviews.firstObject != nil) {
     UIView *container = self.subviews.firstObject;
     [[container subviews] enumerateObjectsUsingBlock:^(__kindof UIView *_Nonnull obj, NSUInteger idx, BOOL *_Nonnull stop) {
@@ -141,7 +141,7 @@
   }
 }
 
-// TIMOB-17373. Workaround for separators disappearing on iOS7 and above
+// TIMOB-17373. Workaround for separators disappearing on iOS 7 and above
 - (void)ensureVisibleSelectorWithTableView:(UITableView *)tableView
 {
   if ([self selectedOrHighlighted]) {

--- a/iphone/Classes/TiUIListSectionProxy.h
+++ b/iphone/Classes/TiUIListSectionProxy.h
@@ -26,7 +26,7 @@
 @property (nonatomic, readwrite, assign) id<TiUIListViewDelegate> delegate;
 @property (nonatomic, readwrite, assign) NSUInteger sectionIndex;
 
-// Private API. Used by ListView directly. Not for public comsumption
+// Private API. Used by ListView directly. Not for public consumption
 - (NSDictionary *)itemAtIndex:(NSUInteger)index;
 - (void)deleteItemAtIndex:(NSUInteger)index;
 - (void)addItem:(NSDictionary *)item atIndex:(NSUInteger)index;

--- a/iphone/Classes/TiUINavBarButton.m
+++ b/iphone/Classes/TiUINavBarButton.m
@@ -39,7 +39,7 @@ DEFINE_EXCEPTIONS
 - (void)dealloc
 {
 #if NAVBAR_MEMORY_DEBUG == 1
-  NSLog(@"[DEBUG] Deallocing %X (%d)", self, [self retainCount]);
+  NSLog(@"[DEBUG] Deallocating %X (%d)", self, [self retainCount]);
 #endif
   RELEASE_TO_NIL(activityDelegate);
   [super dealloc];

--- a/iphone/Classes/TiUINavigationWindowProxy.m
+++ b/iphone/Classes/TiUINavigationWindowProxy.m
@@ -337,7 +337,7 @@
       [promise resolve:@[]];
     }
   } else {
-    // FIXME: forward/chain the underying promise from [window close:] done internally here rather than assume success
+    // FIXME: forward/chain the underlying promise from [window close:] done internally here rather than assume success
     [self closeWindow:window animated:NO];
     if (promise != nil) {
       [promise resolve:@[]];

--- a/iphone/Classes/TiUIOptionDialogProxy.m
+++ b/iphone/Classes/TiUIOptionDialogProxy.m
@@ -114,7 +114,7 @@
          ** This block commented out since it seems to have no effect on the alert controller.
          ** If you read the modalPresentationStyle after setting the value, it still shows UIModalPresentationPopover
          ** However not configuring the UIPopoverPresentationController seems to do the trick.
-         ** This hack in place to conserve current behavior. Should revisit when iOS7 is dropped so that
+         ** This hack in place to conserve current behavior. Should revisit when iOS 7 is dropped so that
          ** option dialogs are always presented in UIModalPresentationPopover
          if (isPopover) {
          alertController.modalPresentationStyle = UIModalPresentationCurrentContext;
@@ -122,7 +122,7 @@
          }
          */
   }
-  /*See Comment above. Remove if condition to see difference in behavior on iOS8*/
+  /* See Comment above. Remove if condition to see difference in behavior on iOS 8 */
   if (!isPopover) {
     UIPopoverPresentationController *presentationController = alertController.popoverPresentationController;
     presentationController.permittedArrowDirections = UIPopoverArrowDirectionAny;

--- a/iphone/Classes/TiUIPickerRowProxy.m
+++ b/iphone/Classes/TiUIPickerRowProxy.m
@@ -23,9 +23,9 @@
 
 - (UIView *)viewWithFrame:(CGRect)theFrame reusingView:(UIView *)theView
 {
-  // The picker on IOS seems to consist of 3 tableViews (or some derivative of it) each of which calls the
+  // The picker on iOS seems to consist of 3 tableViews (or some derivative of it) each of which calls the
   // delegate method. So we have a singleView from our proxy residing in 3 superViews.
-  // While older version of IOS somehow made this work, IOS7 seems to be completely broken.
+  // While older version of iOS somehow made this work, iOS 7 seems to be completely broken.
   // So what we are doing is creating a snapshot (toImage() -> UIImageView) and returning that.
   // Downside -> No touch events from pickerrow or its children
   // Upside -> It works and is performant. Accessibility is configured on the delegate

--- a/iphone/Classes/TiUIScrollViewProxy.m
+++ b/iphone/Classes/TiUIScrollViewProxy.m
@@ -58,7 +58,7 @@ static NSArray *scrollViewKeySequence;
 {
   [super windowWillOpen];
   // Since layout children is overridden in scrollview need to make sure that
-  // a full layout occurs atleast once if view is attached
+  // a full layout occurs at least once if view is attached
   if ([self viewAttached]) {
     [self contentsWillChange];
   }
@@ -445,7 +445,7 @@ static NSArray *scrollViewKeySequence;
   }
 }
 
-// listerner which tells when dragging ended in the scroll view.
+// listener which tells when dragging ended in the scroll view.
 - (void)scrollViewDidEndDragging:(UIScrollView *)scrollView willDecelerate:(BOOL)decelerate
 {
   CGPoint offset = [scrollView contentOffset];

--- a/iphone/Classes/TiUISearchBar.m
+++ b/iphone/Classes/TiUISearchBar.m
@@ -208,7 +208,7 @@
   // try to set the image with UIBarMetricsDefaultPrompt barMetrics
   //
   // Checking for the `prompt` property is not reliable, even if it's not set, the height
-  // of the searchbar determines wheather the barMetrics is `DefaultPrompt` or just `Default`
+  // of the searchbar determines whether the barMetrics is `DefaultPrompt` or just `Default`
   [searchBar setBackgroundImage:image forBarPosition:UIBarPositionAny barMetrics:UIBarMetricsDefaultPrompt];
 
   // check that the image has been set, otherwise try the other barMetrics

--- a/iphone/Classes/TiUISearchBarProxy.h
+++ b/iphone/Classes/TiUISearchBarProxy.h
@@ -22,7 +22,7 @@
 - (UISearchBar *)searchBar;
 
 //	showsCancelButton is related to the JS property ShowCancel,
-//	but is internal ONLY, and should NOT be used by javascript.
+//	but is internal ONLY, and should NOT be used by JavaScript.
 @property (nonatomic, readwrite, assign) BOOL showsCancelButton;
 
 #pragma mark - Titanium Internal Use

--- a/iphone/Classes/TiUISlider.m
+++ b/iphone/Classes/TiUISlider.m
@@ -304,7 +304,7 @@ USE_PROXY_FOR_VERIFY_AUTORESIZING
 {
   // APPLE BUG: Sometimes in a double-click our 'UIControlEventTouchUpInside' event is fired more than once.  This is
   // ALWAYS indicated by a sub-0.1s difference between the clicks, and results in an additional fire of the event.
-  // We have to track the PREVIOUS (not current) inverval and prevent these ugly misfires!
+  // We have to track the PREVIOUS (not current) interval and prevent these ugly misfires!
 
   NSDate *now = [[NSDate alloc] init];
   NSTimeInterval currentTimeInterval = [now timeIntervalSinceDate:lastTouchUp];

--- a/iphone/Classes/TiUISwitch.m
+++ b/iphone/Classes/TiUISwitch.m
@@ -101,7 +101,7 @@
 - (void)setValue_:(id)value
 {
   // need to check if we're in a reproxy when this is set
-  // so we don't artifically trigger a change event or
+  // so we don't artificially trigger a change event or
   // animate the change -- this happens on the tableview
   // reproxy as we scroll
   BOOL reproxying = [self.proxy inReproxy];

--- a/iphone/Classes/TiUITabGroup.m
+++ b/iphone/Classes/TiUITabGroup.m
@@ -162,7 +162,7 @@ DEFINE_EXCEPTIONS
       [self.proxy fireEvent:@"focus" withObject:event];
     }
   }
-  // TIMOB-15187. Dont fire focus of tabs if proxy does not have focus
+  // TIMOB-15187. Don't fire focus of tabs if proxy does not have focus
   if ([(TiUITabGroupProxy *)[self proxy] canFocusTabs]) {
     [focusedTabProxy handleDidFocus:event];
   }
@@ -259,7 +259,7 @@ DEFINE_EXCEPTIONS
     if (allowConfiguration) {
       [self setEditButton:navigationController];
     }
-    // However, under iOS4, we have to manage the appearance/disappearance of the edit button ourselves.
+    // However, under iOS 4, we have to manage the appearance/disappearance of the edit button ourselves.
     else {
       [self removeEditButton:navigationController];
     }

--- a/iphone/Classes/TiUITableView.h
+++ b/iphone/Classes/TiUITableView.h
@@ -17,7 +17,7 @@
 #endif
 @class TiGradientLayer;
 
-// Overloads hilighting to send touchbegin/touchend events
+// Overloads highlighting to send touchbegin/touchend events
 @interface TiUITableViewCell : UITableViewCell {
   TiUITableViewRowProxy *proxy;
   TiGradientLayer *gradientLayer;

--- a/iphone/Classes/TiUITableView.m
+++ b/iphone/Classes/TiUITableView.m
@@ -452,17 +452,17 @@
     if (TiDimensionIsDip(rowHeight)) {
       [tableview setRowHeight:rowHeight.value];
     } else {
-      // TIMOB-17373 rowHeight on iOS8 is -1. Bug??
+      // TIMOB-17373 rowHeight on iOS 8 is -1. Bug??
       [tableview setRowHeight:44];
     }
 
-    BOOL initBackGround = YES;
+    BOOL initBackground = YES;
     id bgInitValue = [[self proxy] valueForKey:@"backgroundColor"];
     if (style == UITableViewStyleGrouped) {
       // If the style is grouped do not call this method unless a backgroundColor is specified
-      initBackGround = (bgInitValue != nil);
+      initBackground = (bgInitValue != nil);
     }
-    if (initBackGround) {
+    if (initBackground) {
       [self setBackgroundColor:[TiUtils colorValue:bgInitValue] onTable:tableview];
     }
 
@@ -808,7 +808,7 @@
     [self appendRow:row];
     for (TiUITableViewRowProxy *moveRow in addRows) {
       [self appendRow:moveRow];
-      // Removing the temporarly saved proxy.
+      // Removing the temporarily saved proxy.
       [(TiUITableViewProxy *)[self proxy] forgetProxy:moveRow];
     }
     if (![self isSearchStarted]) {
@@ -1581,7 +1581,7 @@
   // called when text starts editing
   [self showSearchScreen:nil];
   searchActivated = YES;
-  // Dont reload here since user started editing but not yet started typing.
+  // Don't reload here since user started editing but not yet started typing.
   // Also if a previous search string exists this reload results in blank cells.
 }
 
@@ -1832,7 +1832,7 @@
     [searchField setDelegate:self];
     [self tableView];
     [self updateSearchView];
-    [self initSearhController];
+    [self initSearchController];
 
     if (searchHidden) {
       // This seems like inconsistent behavior, as much of our 'search hide' logic works out to
@@ -1855,7 +1855,7 @@
   self.tableView.sectionHeaderTopPadding = [TiUtils floatValue:value def:UITableViewAutomaticDimension];
 }
 
-- (void)initSearhController
+- (void)initSearchController
 {
   if (searchController == nil) {
     searchController = [[UISearchController alloc] initWithSearchResultsController:nil];
@@ -2131,7 +2131,7 @@
   TiUITableViewRowProxy *row = [self rowForIndexPath:index];
   [row triggerAttach];
 
-  // the classname for all rows that have the same substainal layout will be the same
+  // the classname for all rows that have the same substantial layout will be the same
   // we reuse them for speed
   UITableViewCell *cell = [ourTableView dequeueReusableCellWithIdentifier:row.tableClass];
 

--- a/iphone/Classes/TiUITableViewProxy.m
+++ b/iphone/Classes/TiUITableViewProxy.m
@@ -506,7 +506,7 @@ USE_VIEW_FOR_CONTENT_HEIGHT
     // No table, we have to do the data update ourselves.
     // If we don't handle it, the row gets dropped on the ground,
     // but if we create the tableview, there's this horrible issue where
-    // the uitableview isn't fully formed, it gets this message to do an action,
+    // the UITableView isn't fully formed, it gets this message to do an action,
     // and ends up throwing an exception because we're out of bounds.
     [section remove:row];
   }

--- a/iphone/Classes/TiUITableViewRowProxy.m
+++ b/iphone/Classes/TiUITableViewRowProxy.m
@@ -597,7 +597,7 @@ TiProxy *DeepScanForProxyOfViewContainingPoint(UIView *targetView, CGPoint point
   }
   RELEASE_TO_NIL(rowContainerView);
 
-  // ... But that's not enough. We need to detatch the views
+  // ... But that's not enough. We need to detach the views
   // for all children of the row, to clean up memory.
   for (TiViewProxy *child in [self children]) {
     [child detachView];

--- a/iphone/Classes/TiUITableViewSectionProxy.m
+++ b/iphone/Classes/TiUITableViewSectionProxy.m
@@ -105,7 +105,7 @@
 - (TiUITableViewRowProxy *)rowAtIndex:(NSUInteger)index
 {
   // Because rowAtIndex is used internally, with an int, it can't be used by the Javascript.
-  // The javascript passes in an NSArray pointer, not an index. And things blow up.
+  // The JavaScript passes in an NSArray pointer, not an index. And things blow up.
   return [rows objectAtIndex:index];
 }
 

--- a/iphone/Classes/TiUITextField.m
+++ b/iphone/Classes/TiUITextField.m
@@ -269,7 +269,7 @@
 
 - (void)dealloc
 {
-  WARN_IF_BACKGROUND_THREAD_OBJ; // NSNotificationCenter is not threadsafe!
+  WARN_IF_BACKGROUND_THREAD_OBJ; // NSNotificationCenter is not thread-safe!
   [[NSNotificationCenter defaultCenter] removeObserver:self name:UITextFieldTextDidChangeNotification object:nil];
   [super dealloc];
 }
@@ -289,7 +289,7 @@
     [(TiTextField *)textWidgetView setTouchHandler:self];
     [self addSubview:textWidgetView];
     self.clipsToBounds = YES;
-    WARN_IF_BACKGROUND_THREAD_OBJ; // NSNotificationCenter is not threadsafe!
+    WARN_IF_BACKGROUND_THREAD_OBJ; // NSNotificationCenter is not thread-safe!
     NSNotificationCenter *theNC = [NSNotificationCenter defaultCenter];
     [theNC addObserver:self selector:@selector(textFieldDidChange:) name:UITextFieldTextDidChangeNotification object:textWidgetView];
   }

--- a/iphone/Classes/TiUIToolbarProxy.m
+++ b/iphone/Classes/TiUIToolbarProxy.m
@@ -59,7 +59,7 @@ USE_VIEW_FOR_VERIFY_HEIGHT
         [self throwException:errorString subreason:nil location:CODELOCATION];
         /*
          *	Note that this theoretically could mean proxies are improperly remembered
-         *	if a later entry causes this exception to be thrown. However, the javascript
+         *	if a later entry causes this exception to be thrown. However, the JavaScript
          *	should NOT be using nonproxy objects and the onus is on the Javascript
          */
       }

--- a/iphone/Classes/TiUIWebView.m
+++ b/iphone/Classes/TiUIWebView.m
@@ -912,7 +912,7 @@ static NSString *const baseInjectScript = @"Ti._hexish=function(a){var r='';var 
   [self _cleanupLoadingIndicator];
   [(TiUIWebViewProxy *)[self proxy] refreshHTMLContent];
 
-  // TO DO: Once TIMOB-26915 done, remove this
+  // TODO: Once TIMOB-26915 done, remove this
   __block BOOL finishedEvaluation = NO;
   [_webView.configuration.websiteDataStore.httpCookieStore getAllCookies:^(NSArray<NSHTTPCookie *> *cookies) {
     for (NSHTTPCookie *cookie in cookies) {
@@ -1120,7 +1120,7 @@ static NSString *const baseInjectScript = @"Ti._hexish=function(a){var r='';var 
     BOOL valid = !ignoreNextRequest;
     if ([scheme hasPrefix:@"http"]) {
       // UIWebViewNavigationTypeOther means we are either in a META redirect
-      // or it is a js request from within the page
+      // or it is a JS request from within the page
       valid = valid && (navigationAction.navigationType != WKNavigationTypeOther);
     }
     if (valid) {

--- a/iphone/Classes/TiUIWebView.m
+++ b/iphone/Classes/TiUIWebView.m
@@ -758,7 +758,7 @@ static NSString *const baseInjectScript = @"Ti._hexish=function(a){var r='';var 
       html = [[[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding] autorelease];
     }
     if (html != nil) {
-      // Because local HTML may rely on JS that's stored in the app: schema, we must kee the url in the app: format.
+      // Because local HTML may rely on JS that's stored in the app: schema, we must kee the URL in the app: format.
       [[self webView] loadHTMLString:html baseURL:baseURL];
     } else {
       NSLog(@"[WARN] couldn't load URL: %@", url);
@@ -1092,7 +1092,7 @@ static NSString *const baseInjectScript = @"Ti._hexish=function(a){var r='';var 
 
   if ([allowedURLSchemes containsObject:navigationAction.request.URL.scheme]) {
     if ([[UIApplication sharedApplication] canOpenURL:navigationAction.request.URL]) {
-      // Event to return url to Titanium in order to handle OAuth and more
+      // Event to return URL to Titanium in order to handle OAuth and more
       if ([[self proxy] _hasListeners:@"handleurl"]) {
         TiThreadPerformOnMainThread(
             ^{

--- a/iphone/Classes/TiUIWebViewProxy.m
+++ b/iphone/Classes/TiUIWebViewProxy.m
@@ -568,7 +568,7 @@ static NSArray *webViewKeySequence;
 
   if (code == nil) {
     [self throwException:@"Missing JavaScript code"
-               subreason:@"The required first argument is missinf and should contain a valid JavaScript string."
+               subreason:@"The required first argument is missing and should contain a valid JavaScript string."
                 location:CODELOCATION];
     return nil;
   }
@@ -667,7 +667,7 @@ static NSArray *webViewKeySequence;
 // 3. We are using following to implement cookies-
 //  https://stackoverflow.com/questions/26573137
 //  https://github.com/haifengkao/YWebView
-// TO DO: If we can make parity using WKHTTPCookieStore, we should start using WKHTTPCookieStore APIs
+// TODO: If we can make parity using WKHTTPCookieStore, we should start using WKHTTPCookieStore APIs
 
 - (id<TiEvaluator>)evaluationContext
 {

--- a/iphone/Classes/TiUIiOSDocumentViewerProxy.m
+++ b/iphone/Classes/TiUIiOSDocumentViewerProxy.m
@@ -90,7 +90,7 @@
   ENSURE_TYPE(value, NSString);
   NSURL *url = [self _toURL:value proxy:self];
   // UIDocumentInteractionController is recommended to be a new instance for every different url
-  // instead of having titanium developer create a new instance every time a new document url is loaded
+  // instead of having Titanium developer create a new instance every time a new document url is loaded
   // we assume that setUrl is called to change doc, so we go ahead and release the controller and create
   // a new one when asked to present
   RELEASE_TO_NIL(controller);

--- a/iphone/Classes/TiUIiOSDocumentViewerProxy.m
+++ b/iphone/Classes/TiUIiOSDocumentViewerProxy.m
@@ -89,8 +89,8 @@
 {
   ENSURE_TYPE(value, NSString);
   NSURL *url = [self _toURL:value proxy:self];
-  // UIDocumentInteractionController is recommended to be a new instance for every different url
-  // instead of having Titanium developer create a new instance every time a new document url is loaded
+  // UIDocumentInteractionController is recommended to be a new instance for every different URL
+  // instead of having Titanium developer create a new instance every time a new document URL is loaded
   // we assume that setUrl is called to change doc, so we go ahead and release the controller and create
   // a new one when asked to present
   RELEASE_TO_NIL(controller);

--- a/iphone/Classes/TiUIiOSFeedbackGeneratorProxy.h
+++ b/iphone/Classes/TiUIiOSFeedbackGeneratorProxy.h
@@ -20,7 +20,7 @@ typedef NS_ENUM(NSInteger, TiUIiOSFeedbackGeneratorType) {
 
 /**
  * Provide support for the iOS 10 haptic engine on supported devices (currently iPhone 7
- * and iPhone 7 Plus). The developer can specify a feedback generator type to distungish
+ * and iPhone 7 Plus). The developer can specify a feedback generator type to distinguish
  * between a selection-, impact-, and notification-generator to receive different kind of
  * haptic feedbacks.
  */

--- a/iphone/Classes/TiUIiOSLivePhotoViewProxy.h
+++ b/iphone/Classes/TiUIiOSLivePhotoViewProxy.h
@@ -28,7 +28,7 @@
 - (void)setMuted:(id)value;
 
 /**
- *  Returns wheather or not the current playback is muted.
+ *  Returns whether or not the current playback is muted.
  */
 - (NSNumber *)muted;
 

--- a/iphone/Classes/TiUIiOSMenuPopupProxy.h
+++ b/iphone/Classes/TiUIiOSMenuPopupProxy.h
@@ -30,7 +30,7 @@
 - (void)setItems:(id)args;
 
 /*
- Determines if the menu is currenty visible.
+ Determines if the menu is currently visible.
  */
 - (NSNumber *)isVisible:(id)unused;
 

--- a/iphone/Classes/TiUIiOSPreviewContextProxy.h
+++ b/iphone/Classes/TiUIiOSPreviewContextProxy.h
@@ -33,7 +33,7 @@
 @property (nonatomic, assign) int contentHeight;
 
 /**
-    Connectes the collected preview data to the iOS delegates.
+    Connects the collected preview data to the iOS delegates.
  */
 - (void)connectToDelegate;
 

--- a/iphone/Classes/TiUIiOSPreviewContextProxy.h
+++ b/iphone/Classes/TiUIiOSPreviewContextProxy.h
@@ -33,7 +33,7 @@
 @property (nonatomic, assign) int contentHeight;
 
 /**
-    Connects the collected preview data to the iOS delegates.
+ * Connects the collected preview data to the iOS delegates.
  */
 - (void)connectToDelegate;
 

--- a/iphone/Classes/TiUIiOSProxy.h
+++ b/iphone/Classes/TiUIiOSProxy.h
@@ -169,7 +169,7 @@
 @property (nonatomic, readonly) NSNumber *TAB_GROUP_MINIMIZE_BEHAVIOR_ON_SCROLL_UP;
 
 /**
- * Checks the force touch capibility of the current device.
+ * Checks the force touch capability of the current device.
  */
 - (NSNumber *)forceTouchSupported;
 

--- a/iphone/Classes/TiUIiOSProxy.m
+++ b/iphone/Classes/TiUIiOSProxy.m
@@ -764,7 +764,7 @@ MAKE_SYSTEM_PROP(SHORTCUT_ICON_TYPE_AUDIO, UIApplicationShortcutIconTypeAudio);
 MAKE_SYSTEM_PROP(SHORTCUT_ICON_TYPE_UPDATE, UIApplicationShortcutIconTypeUpdate);
 #endif
 
-// Modal Transition and Presentatiom
+// Modal Transition and Presentation
 MAKE_SYSTEM_PROP(MODAL_TRANSITION_STYLE_COVER_VERTICAL, UIModalTransitionStyleCoverVertical);
 MAKE_SYSTEM_PROP(MODAL_TRANSITION_STYLE_FLIP_HORIZONTAL, UIModalTransitionStyleFlipHorizontal);
 MAKE_SYSTEM_PROP(MODAL_TRANSITION_STYLE_CROSS_DISSOLVE, UIModalTransitionStyleCrossDissolve);

--- a/iphone/Classes/TiUIiOSSplitWindow.h
+++ b/iphone/Classes/TiUIiOSSplitWindow.h
@@ -23,7 +23,7 @@
   float splitRatioLandscape;
 }
 
-#pragma mark - Titanim Internal Use Only
+#pragma mark - Titanium Internal Use Only
 - (void)setShowMasterInPortrait_:(id)value withObject:(id)animated;
 - (void)setMasterIsOverlayed_:(id)value withObject:(id)animated;
 - (void)initWrappers;

--- a/iphone/Classes/XMLModule.m
+++ b/iphone/Classes/XMLModule.m
@@ -46,7 +46,7 @@
 }
 
 /**
- IOS does not have a proper transformer like java. (javax.xml.transform.Transformer)
+ iOS does not have a proper transformer like java. (javax.xml.transform.Transformer)
  It is perfectly valid to have an element with a namespace and an attribute whose values match the namespace
  Eg:
  var doc = Ti.XML.parseString('<a/>');

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/AssetsModule.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/AssetsModule.m
@@ -61,7 +61,7 @@ typedef NS_ENUM(NSInteger, FileStatus) {
 + (NSData *)loadURL:(NSURL *)url
 {
   FileStatus status = FileStatusUnknown;
-  // This assumes it's a js or json file already!
+  // This assumes it's a JS or JSON file already!
   if (url.isFileURL) { // if it's a resource, check index.json listing for status
     status = [AssetsModule fileStatus:[TiHost resourceRelativePath:url]];
   }
@@ -92,13 +92,13 @@ typedef NS_ENUM(NSInteger, FileStatus) {
   // Calling [relativePath stringByStandardizingPath]; does not resolve '..' segments because the path isn't absolute!
   // so we hack around it here by making an URL that does point to absolute location...
   NSURL *url_ = [NSURL URLWithString:path relativeToURL:baseURL];
-  // "standardizing" it (i.e. removing '.' and '..' segments properly...
+  // "standardizing" it (e.g. removing '.' and '..' segments properly...
   return [AssetsModule loadURL:[url_ standardizedURL]];
 }
 
 + (FileStatus)fileStatus:(NSString *)path
 {
-  // if it's not a js or json file, status is unknown!
+  // if it's not a JS or JSON file, status is unknown!
   NSString *extension = path.pathExtension;
   if (![extension isEqual:@"js"] && ![extension isEqual:@"json"]) {
     return FileStatusUnknown;
@@ -111,7 +111,7 @@ typedef NS_ENUM(NSInteger, FileStatus) {
   if ([path isEqualToString:@"/_index_.json"]) { // we know it exists! we loaded it
     return FileStatusUnknown; // treat as "unknown" since we didn't record if we loaded in normal or encrypted...
   }
-  // Initial path is assuemd to be of form: "/ti.main.js", "/app.js" or "/ti.kernel.js"
+  // Initial path is assumed to be of form: "/ti.main.js", "/app.js" or "/ti.kernel.js"
   // Basically a path that looks absolute but is relative to Resources dir (app root)
   path = [@"Resources" stringByAppendingString:path];
   NSNumber *type = files[path];
@@ -167,7 +167,7 @@ typedef NS_ENUM(NSInteger, FileStatus) {
     }
     if (errorString != nil) {
       DebugLog(@"[ERROR] Could not load _index_.json require index, error was %@", errorString);
-      // Create an empty dictioary to avoid running this code over and over again.
+      // Create an empty dictionary to avoid running this code over and over again.
       props = [[NSDictionary dictionary] retain];
     }
   }

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/ImageLoader.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/ImageLoader.m
@@ -319,7 +319,7 @@ DEFINE_EXCEPTIONS
 - (id)init
 {
   if (self = [super init]) {
-    WARN_IF_BACKGROUND_THREAD_OBJ; // NSNotificationCenter is not threadsafe!
+    WARN_IF_BACKGROUND_THREAD_OBJ; // NSNotificationCenter is not thread-safe!
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(didReceiveMemoryWarning:)
                                                  name:UIApplicationDidReceiveMemoryWarningNotification
@@ -331,7 +331,7 @@ DEFINE_EXCEPTIONS
 
 - (void)dealloc
 {
-  WARN_IF_BACKGROUND_THREAD_OBJ; // NSNotificationCenter is not threadsafe!
+  WARN_IF_BACKGROUND_THREAD_OBJ; // NSNotificationCenter is not thread-safe!
   [[NSNotificationCenter defaultCenter] removeObserver:self
                                                   name:UIApplicationDidReceiveMemoryWarningNotification
                                                 object:nil];

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/KrollBridge.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/KrollBridge.m
@@ -47,7 +47,7 @@ CFMutableSetRef krollBridgeRegistry = nil;
 
 - (void)registerForMemoryWarning
 {
-  WARN_IF_BACKGROUND_THREAD_OBJ; // NSNotificationCenter is not threadsafe!
+  WARN_IF_BACKGROUND_THREAD_OBJ; // NSNotificationCenter is not thread-safe!
   [[NSNotificationCenter defaultCenter] addObserver:self
                                            selector:@selector(didReceiveMemoryWarning:)
                                                name:UIApplicationDidReceiveMemoryWarningNotification
@@ -56,7 +56,7 @@ CFMutableSetRef krollBridgeRegistry = nil;
 
 - (void)unregisterForMemoryWarning
 {
-  WARN_IF_BACKGROUND_THREAD_OBJ; // NSNotificationCenter is not threadsafe!
+  WARN_IF_BACKGROUND_THREAD_OBJ; // NSNotificationCenter is not thread-safe!
   [[NSNotificationCenter defaultCenter] removeObserver:self name:UIApplicationDidReceiveMemoryWarningNotification object:nil];
 }
 
@@ -300,7 +300,7 @@ CFMutableSetRef krollBridgeRegistry = nil;
     shutdownCondition = [condition retain];
     shutdown = YES;
     // fire a notification event to our listeners
-    WARN_IF_BACKGROUND_THREAD_OBJ; // NSNotificationCenter is not threadsafe!
+    WARN_IF_BACKGROUND_THREAD_OBJ; // NSNotificationCenter is not thread-safe!
     NSNotification *notification = [NSNotification notificationWithName:kTiContextShutdownNotification object:self];
     [[NSNotificationCenter defaultCenter] postNotification:notification];
 
@@ -403,18 +403,18 @@ CFMutableSetRef krollBridgeRegistry = nil;
         }
       }
     }
-    startURL = [url copy]; // should be the entry point of the background service js file
+    startURL = [url copy]; // should be the entry point of the background service JS file
   } else {
     startURL = [host startURL]; // should be ti.main.js
   }
 
-  // We need to run this before the entry js file, which means it has to be here.
+  // We need to run this before the entry JS file, which means it has to be here.
   TiBindingRunLoopAnnounceStart(kroll);
   if (!evaluationError) {
     [self evalFile:[startURL absoluteString] callback:self selector:@selector(booted)];
   } else {
     NSLog(@"[ERROR] Error loading/executing ti.kernel.js bootstrap code, refusing to launch app main file.");
-    // DO NOT POP AN ERROR DIALOG! The most likley scenario here is that the app is remotely encrypted
+    // DO NOT POP AN ERROR DIALOG! The most likely scenario here is that the app is remotely encrypted
     // and the decryption failed because the device is offline
     // If we pop a dialog here, it will block the "Security Violation" error dialog that would show in that case
   }
@@ -437,7 +437,7 @@ CFMutableSetRef krollBridgeRegistry = nil;
   if (!shutdown) {
     shutdown = YES;
     // fire a notification event to our listeners
-    WARN_IF_BACKGROUND_THREAD_OBJ; // NSNotificationCenter is not threadsafe!
+    WARN_IF_BACKGROUND_THREAD_OBJ; // NSNotificationCenter is not thread-safe!
     NSNotification *notification = [NSNotification notificationWithName:kTiContextShutdownNotification object:self];
     [[NSNotificationCenter defaultCenter] postNotification:notification];
   }

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/KrollModule.h
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/KrollModule.h
@@ -21,7 +21,7 @@
 }
 
 /**
- * @param moduleID is assumed to be the module name (classname with the "Module" suffix stripped off) - i.e. "UI", "App", "Media"
+ * @param moduleID is assumed to be the module name (classname with the "Module" suffix stripped off) - e.g. "UI", "App", "Media"
  * We will generate the full class name from the moduleID: "UI" => "UIModule", "com.appcelerator.urlSession" => "ComAppceleratorUrlSessionModule"
  * @return TiModule* or ObjcProxy* based on whether the module is an older style proxy module or a new Obj-C JSC API style (currently only 1st party in-SDK code)
  */

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/Mimetypes.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/Mimetypes.m
@@ -16,7 +16,7 @@ static NSDictionary *mimeTypeFromExtensionDict = nil;
 
 + (void)initialize
 {
-  // This dictionary contains info on mimetypes surrently missing on IOS platform.
+  // This dictionary contains info on mimetypes currently missing on iOS platform.
   // This should be updated on a case by case basis.
   if (mimeTypeFromExtensionDict == nil) {
     mimeTypeFromExtensionDict = [[NSDictionary alloc] initWithObjectsAndKeys:

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/Module.h
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/Module.h
@@ -6,7 +6,7 @@
 
 /*
  * Used to force a module name for native modules. This is used in the calculation of the expected proxy name for proxy factory method calls.
- * i.e. TiMapModule w/ a call to Map.createAnnotation => TiMapAnnotationProxy
+ * e.g. TiMapModule w/ a call to Map.createAnnotation => TiMapAnnotationProxy
  * w/ no name set, it will prepend "Ti" i.e. UIModule w/ a call to createWindow => TiUIWindowProxy
  * This logic is currently only used in TiModule.m
  */

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/NSData+Additions.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/NSData+Additions.m
@@ -76,7 +76,7 @@ NSString *stringWithHexString(NSString *hexString)
 // some commentary on the 128 bit issue:
 //
 // Assuming that one could build a machine that could recover a DES
-// key in a second (i.e., try 255 keys per second), it would take that
+// key in a second (e.g., try 255 keys per second), it would take that
 // machine approximately 149 thousand billion (149 trillion) years to
 // crack a 128-bit AES key. To put that into perspective, the universe
 // is believed to be fewer than 20 billion years old.

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/SBJSON.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/SBJSON.m
@@ -184,7 +184,7 @@ static char ctrl[0x24];
  If nil is returned and @p error is not NULL, @p *error can be interrogated to find the cause of the error.
 
  @param value any instance that can be represented as a JSON fragment
- @param allowScalar wether to return json fragments for scalar objects
+ @param allowScalar wether to return JSON fragments for scalar objects
  @param error used to return an error by reference (pass NULL if this is not desired)
  */
 - (NSString *)stringWithObject:(id)value allowScalar:(BOOL)allowScalar error:(NSError **)error
@@ -415,7 +415,7 @@ static char ctrl[0x24];
  Returns the object represented by the passed-in string or nil on error. The returned object can be
  a string, number, boolean, null, array or dictionary.
 
- @param repr the json string to parse
+ @param repr the JSON string to parse
  @param allowScalar whether to return objects for JSON fragments
  @param error used to return an error by reference (pass NULL if this is not desired)
  */
@@ -461,7 +461,7 @@ static char ctrl[0x24];
  Returns the object represented by the passed-in string or nil on error. The returned object can be
  a string, number, boolean, null, array or dictionary.
 
- @param repr the json string to parse
+ @param repr the JSON string to parse
  @param error used to return an error by reference (pass NULL if this is not desired)
  */
 - (id)fragmentWithString:(NSString *)repr error:(NSError **)error
@@ -473,7 +473,7 @@ static char ctrl[0x24];
  Returns the object represented by the passed-in string or nil on error. The returned object
  will be either a dictionary or an array.
 
- @param repr the json string to parse
+ @param repr the JSON string to parse
  @param error used to return an error by reference (pass NULL if this is not desired)
  */
 - (id)objectWithString:(NSString *)repr error:(NSError **)error

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiApp.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiApp.m
@@ -1117,7 +1117,7 @@ TI_INLINE void waitForMemoryPanicCleared(void); // WARNING: This must never be r
   [sessionId release];
   sessionId = [[TiUtils createUUID] retain];
 
-  // TIMOB-3432. Ensure url is cleared when resume event is fired.
+  // TIMOB-3432. Ensure URL is cleared when resume event is fired.
   [launchOptions removeObjectForKey:@"url"];
   [launchOptions removeObjectForKey:@"source"];
 

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiBindingEvent.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiBindingEvent.m
@@ -18,7 +18,7 @@ extern JSStringRef kTiStringLength;
 
 /** Event lifecycle, a documentation.
 
- The event structures are designed to be threadsafe, yet don't have a lock.
+ The event structures are designed to be thread-safe, yet don't have a lock.
  How is this so? The trick is the lifecycle and atomic transactions on pendingEvents:
 
  Creation:
@@ -32,7 +32,7 @@ extern JSStringRef kTiStringLength;
  EventProcess:
         Event is immutable during processing
         cancelBubble is mutable, but blindly set during processing, thus no race
-        Once done processing, the pendingEvents is atomically decrimented.
+        Once done processing, the pendingEvents is atomically decremented.
         Once pendingEvents reaches 0, we are certain that no other threads are using
         this event. During this time, the event is again mutable for purposes of
         propagation- caching and then fireEvent.

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiBindingTiValue.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiBindingTiValue.m
@@ -15,7 +15,7 @@
 
 /*
  *	Since JSStringRefs are not tied to any particular context, and are
- *	immutable, they are threadsafe and more importantly, ones that are in
+ *	immutable, they are thread-safe and more importantly, ones that are in
  *	constant use never need to garbage collected, but can be reused.
  */
 

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiBlob.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiBlob.m
@@ -413,7 +413,7 @@ GETTER_IMPL(NSUInteger, length, Length);
 
 - (TiBlob *)imageAsResized:(NSUInteger)width withHeight:(NSUInteger)height
 {
-  // How do we test that they didn't send us a "bad" value (i.e. negative, or double/float)? It'll get coerced here. Do we care?
+  // How do we test that they didn't send us a "bad" value (e.g. negative, or double/float)? It'll get coerced here. Do we care?
   if (isnan(width)) {
     THROW_INVALID_ARG(@"width argument must be an integer value");
   }

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiModule.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiModule.m
@@ -99,7 +99,7 @@
 
 - (void)registerForNotifications
 {
-  WARN_IF_BACKGROUND_THREAD_OBJ; // NSNotificationCenter is not threadsafe!
+  WARN_IF_BACKGROUND_THREAD_OBJ; // NSNotificationCenter is not thread-safe!
   [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(shutdown:) name:kTiShutdownNotification object:nil];
   [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(suspend:) name:kTiSuspendNotification object:nil];
   [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(paused:) name:kTiPausedNotification object:nil];
@@ -223,7 +223,7 @@
 {
   NSString *moduleId = [self moduleId];
   if (moduleId != nil) {
-    // if we have module js than we're a JS native module
+    // if we have module JS than we're a JS native module
     return [self moduleJS] != nil;
   }
   return NO;

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiProxy.h
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiProxy.h
@@ -27,7 +27,7 @@ extern NSString *const TiExceptionOSError;
 // This is when a normally allowed command is not allowed (Say, adding a row to a table when it already is added elsewhere)
 extern NSString *const TiExceptionInternalInconsistency;
 
-// Rare exceptions to indicate a bug in the titanium code (Eg, function that a subclass should have implemented)
+// Rare exceptions to indicate a bug in the Titanium code (e.g., function that a subclass should have implemented)
 extern NSString *const TiExceptionUnimplementedFunction;
 
 // Rare exception in the case of malloc failure

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiProxy.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiProxy.m
@@ -30,7 +30,7 @@ NSString *const TiExceptionOSError = @"The iOS reported an error";
 // Should be rare, but also useful if arguments are used improperly.
 NSString *const TiExceptionInternalInconsistency = @"Value was not the value expected";
 
-// Rare exceptions to indicate a bug in the titanium code (Eg, method that a subclass should have implemented)
+// Rare exceptions to indicate a bug in the Titanium code (e.g., method that a subclass should have implemented)
 NSString *const TiExceptionUnimplementedFunction = @"Subclass did not implement required method";
 
 NSString *const TiExceptionMemoryFailure = @"Memory allocation failed";
@@ -577,7 +577,7 @@ void TiClassSelectorFunction(TiBindingRunLoop runloop, void *payload)
   }
 
   if (![bridge usesProxy:self]) {
-    DeveloperLog(@"[DEBUG] Proxy %@ may be missing its javascript representation.", self);
+    DeveloperLog(@"[DEBUG] Proxy %@ may be missing its JavaScript representation.", self);
   }
 
   return [bridge krollObjectForProxy:self];
@@ -596,7 +596,7 @@ void TiClassSelectorFunction(TiBindingRunLoop runloop, void *payload)
   KrollBridge *ourBridge = (KrollBridge *)[context delegate];
 
   if (![ourBridge usesProxy:self]) {
-    DeveloperLog(@"[DEBUG] Proxy %@ may be missing its javascript representation.", self);
+    DeveloperLog(@"[DEBUG] Proxy %@ may be missing its JavaScript representation.", self);
   }
 
   return [ourBridge krollObjectForProxy:self];
@@ -639,7 +639,7 @@ void TiClassSelectorFunction(TiBindingRunLoop runloop, void *payload)
     return;
   }
   if (bridgeCount < 1) {
-    DeveloperLog(@"[DEBUG] Proxy %@ is missing its javascript representation needed to remember %@.", self, rememberedProxy);
+    DeveloperLog(@"[DEBUG] Proxy %@ is missing its JavaScript representation needed to remember %@.", self, rememberedProxy);
     return;
   }
 
@@ -1153,7 +1153,7 @@ DEFINE_EXCEPTIONS
 - (void)didReceiveMemoryWarning:(NSNotification *)notification
 {
   // FOR NOW, we're not dropping anything but we'll want to do before release
-  // subclasses need to call super if overriden
+  // subclasses need to call super if overridden
 }
 
 #pragma mark Dispatching Helper

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiRootViewController.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiRootViewController.m
@@ -92,7 +92,7 @@
   RELEASE_TO_NIL(modalWindows);
   RELEASE_TO_NIL(hostView);
 
-  WARN_IF_BACKGROUND_THREAD; // NSNotificationCenter is not threadsafe!
+  WARN_IF_BACKGROUND_THREAD; // NSNotificationCenter is not thread-safe!
   NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
   [nc removeObserver:self];
   [super dealloc];
@@ -1014,7 +1014,7 @@
     CGRect mainScreenBounds = [[UIScreen mainScreen] bounds];
     CGRect viewBounds = [[self view] bounds];
 
-    // Need to do this to force navigation bar to draw correctly on iOS7
+    // Need to do this to force navigation bar to draw correctly on iOS 7
     [[NSNotificationCenter defaultCenter] postNotificationName:kTiFrameAdjustNotification object:nil];
     if (statusBarFrame.size.height > 20) {
       if (viewBounds.size.height != (mainScreenBounds.size.height - statusBarFrame.size.height)) {

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiUIView.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiUIView.m
@@ -1141,9 +1141,9 @@ DEFINE_EXCEPTIONS
 
 - (CAShapeLayer *)shadowLayer
 {
-  // If there is single cborderRadius, use self.layer as shadwoLayer.
+  // If there is single borderRadius, use self.layer as shadowLayer.
   // Shadow animation does not work if shadowLayer is added on self.layer.superlayer
-  // But in this case, shadwoLayer is self.layer. So animation will work on shadow as well.
+  // But in this case, shadowLayer is self.layer. So animation will work on shadow as well.
   NSArray *array = [self cornerArrayFromRadius:[proxy valueForUndefinedKey:@"borderRadius"]];
   if ((!array || array.count <= 1) && _shadowLayer != self.layer) {
     self.layer.mask = nil;

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiUtils.h
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiUtils.h
@@ -549,8 +549,16 @@ typedef enum {
  Whether or not the current device orientation is portrait.
 
  @return _YES_ is the current device orientation is portrait, _NO_ otherwise.
+ @deprecated Use `isOrientationPortrait` instead.
  */
-+ (BOOL)isOrientationPortait;
++ (BOOL)isOrientationPortait __attribute__((deprecated));
+
+/**
+ Whether or not the current device orientation is portrait.
+
+ @return _YES_ is the current device orientation is portrait, _NO_ otherwise.
+ */
++ (BOOL)isOrientationPortrait;
 
 /**
  Whether or not the current device orientation is landscape.

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiUtils.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiUtils.m
@@ -2012,7 +2012,7 @@ If the new path starts with / and the base url is app://..., we have to massage 
 }
 
 // In pre-iOS 5, it looks like response headers were case-mangled.
-// (i.e. WWW-Authenticate became Www-Authenticate). So we have to take this
+// (e.g. WWW-Authenticate became Www-Authenticate). So we have to take this
 // mangling into mind; headers such as FooBar-XYZ may also have been mangled
 // to be case-correct. We can't be certain.
 //

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiUtils.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiUtils.m
@@ -684,7 +684,7 @@ static NSDictionary *sizeMap = nil;
   NSURL *urlAttempt = [self toURL:object proxy:proxy];
   UIImage *image = [[ImageLoader sharedLoader] loadImmediateImage:urlAttempt withSize:imageSize];
   return image;
-  // Note: If url is a nonimmediate image, this returns nil.
+  // Note: If URL is a nonimmediate image, this returns nil.
 }
 
 + (UIImage *)toImage:(id)object proxy:(TiProxy *)proxy
@@ -702,7 +702,7 @@ static NSDictionary *sizeMap = nil;
   NSURL *urlAttempt = [self toURL:object proxy:proxy];
   UIImage *image = [[ImageLoader sharedLoader] loadImmediateImage:urlAttempt];
   return image;
-  // Note: If url is a nonimmediate image, this returns nil.
+  // Note: If URL is a nonimmediate image, this returns nil.
 }
 
 + (UIImage *)adjustRotation:(UIImage *)image
@@ -899,7 +899,7 @@ sms:, tel:, mailto: are all done
 
 If the new path is HTTP:// etc, then punt and massage the code.
 
-If the new path starts with / and the base url is app://..., we have to massage the url.
+If the new path starts with / and the base URL is app://..., we have to massage the URL.
 
 
 */

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiUtils.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiUtils.m
@@ -1423,6 +1423,10 @@ If the new path starts with / and the base URL is app://..., we have to massage 
 
 + (BOOL)isOrientationPortait
 {
+  return [self isOrientationPortrait];
+}
++ (BOOL)isOrientationPortrait
+{
   return UIInterfaceOrientationIsPortrait([self orientation]);
 }
 

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiViewProxy.h
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiViewProxy.h
@@ -88,7 +88,7 @@ enum {
 
 /**
  The class represents a proxy that is attached to a view.
- The class is not intended to be overriden.
+ The class is not intended to be overridden.
  */
 @interface TiViewProxy : TiProxy <LayoutAutosizing> {
   @protected

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiViewProxy.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiViewProxy.m
@@ -1438,7 +1438,7 @@ LAYOUTFLAGS_SETTER(setHorizontalWrap, horizontalWrap, horizontalWrap, [self will
         // from the lang property conversion key
         id langKey = [properties objectForKey:key];
         if (langKey != nil) {
-          // eg. titleid -> title
+          // e.g. titleid -> title
           id convertKey = [table objectForKey:key];
           // check and make sure we don't already have that key
           // since you can't override it if already present

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/WebFont.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/WebFont.m
@@ -36,7 +36,7 @@
 
 - (UIFont *)font
 {
-  // TO DO: Refactor this function
+  // TODO: Refactor this function
   if (font == nil) {
     if (textStyle != nil && [textStyle isKindOfClass:[NSString class]] && family != nil) {
       UIFont *tempFont = [UIFont fontWithName:family size:self.size];

--- a/iphone/TitaniumKit/TitaniumKit/Sources/Kroll/KrollContext.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/Kroll/KrollContext.m
@@ -434,7 +434,7 @@ static JSValueRef StringFormatDecimalCallback(JSContextRef jsContext, JSObjectRe
     [formatter setLocale:locale];
     [formatter setNumberStyle:NSNumberFormatterDecimalStyle];
 
-    // Format handling to match the extremely vague android specs
+    // Format handling to match the extremely vague Android specs
     if (argCount == 3) {
       formatString = [KrollObject toID:ctx value:args[2]];
     }
@@ -618,7 +618,7 @@ static JSValueRef StringFormatDecimalCallback(JSContextRef jsContext, JSObjectRe
     stopped = YES;
     KrollContextCount++;
 
-    WARN_IF_BACKGROUND_THREAD_OBJ; // NSNotificationCenter is not threadsafe!
+    WARN_IF_BACKGROUND_THREAD_OBJ; // NSNotificationCenter is not thread-safe!
   }
   return self;
 }
@@ -647,7 +647,7 @@ static JSValueRef StringFormatDecimalCallback(JSContextRef jsContext, JSObjectRe
 
 - (void)unregisterForNotifications
 {
-  WARN_IF_BACKGROUND_THREAD_OBJ; // NSNotificationCenter is not threadsafe!
+  WARN_IF_BACKGROUND_THREAD_OBJ; // NSNotificationCenter is not thread-safe!
   [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 

--- a/iphone/TitaniumKit/TitaniumKit/Sources/Kroll/KrollObject.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/Kroll/KrollObject.m
@@ -22,7 +22,7 @@ JSClassRef JSObjectClassRef = NULL;
 
 /*
  *	Since JSStringRefs are not tied to any particular context, and are
- *	immutable, they are threadsafe and more importantly, ones that are in
+ *	immutable, they are thread-safe and more importantly, ones that are in
  *	constant use never need to garbage collected, but can be reused.
  */
 

--- a/iphone/TitaniumKit/TitaniumKit/Sources/Misc/TiSharedConfig.h
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/Misc/TiSharedConfig.h
@@ -96,7 +96,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Indicates whether or not the error screen should be shown if an
  error occurs. Defaults to `false` for `production` and `true` for `development` and `test`
- deploy types. Can be overriden by the `hide-error-controller`
+ deploy types. Can be overridden by the `hide-error-controller`
  CLI parameter.
  */
 @property (nonatomic, assign) BOOL showErrorController;

--- a/iphone/TitaniumKit/TitaniumKit/Sources/Modules/TiStreamProxy.h
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/Modules/TiStreamProxy.h
@@ -12,12 +12,12 @@
 #import <Foundation/Foundation.h>
 
 // This is meant to be a largely "virtual" class which defines the following behaviors:
-// 1. Interprets read()/write() calls to the appropriate interal function
+// 1. Interprets read()/write() calls to the appropriate internal function
 // 2. Provide protocol defining necessary internal functions; read/write, asynch read/write, readAll,
 @protocol TiStreamInternal <NSObject>
 @required
 // DEFINED BEHAVIOR: callback != nil indicates an asynch operation.  length==0 indicates to read all available data into
-// the buffer (and grow it if necessary).  These methods MAY be called by classes other than the TiStreamProxy ducktype (i.e. Ti.Stream module methods)
+// the buffer (and grow it if necessary).  These methods MAY be called by classes other than the TiStreamProxy ducktype (e.g. Ti.Stream module methods)
 - (NSInteger)readToBuffer:(TiBuffer *)buffer offset:(NSInteger)offset length:(NSInteger)length callback:(KrollCallback *)callback;
 - (NSInteger)writeFromBuffer:(TiBuffer *)buffer offset:(NSInteger)offset length:(NSInteger)length callback:(KrollCallback *)callback;
 

--- a/iphone/TitaniumKit/TitaniumKit/Sources/Modules/TiUIWindowProxy.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/Modules/TiUIWindowProxy.m
@@ -262,7 +262,7 @@
 
 - (void)viewWillAppear:(BOOL)animated; // Called when the view is about to made visible. Default does nothing
 {
-  // TO DO: Refactor navigation bar customisation iOS 13
+  // TODO: Refactor navigation bar customisation iOS 13
   if ([self shouldUseNavBarApperance]) {
     TiColor *newColor = [TiUtils colorValue:[self valueForKey:@"barColor"]];
     if (newColor == nil) {
@@ -1011,7 +1011,7 @@
     return;
   }
 
-  // Need to clear title for titleAttributes to apply correctly on iOS6.
+  // Need to clear title for titleAttributes to apply correctly on iOS 6.
   [[controller navigationItem] setTitle:nil];
   SETPROP(@"titleAttributes", setTitleAttributes);
   SETPROP(@"title", setTitle);

--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -161,15 +161,15 @@ class iOSBuilder extends Builder {
 		// when true, calls xcodebuild
 		this.forceRebuild = false;
 
-		// a list of relative paths to js files that need to be encrypted
+		// a list of relative paths to JS files that need to be encrypted
 		// note: the filename will have all periods replaced with underscores
 		// FIXME: Use a Map from original names -> encrypted names
 		this.jsFilesToEncrypt = [];
-		// a list of relative paths to js files that have been encrypted
+		// a list of relative paths to JS files that have been encrypted
 		// note: this is the original filename used by our require _index_.json and referenced within the app
 		this.jsFilesEncrypted = [];
 
-		// set to true if any js files changed so that we can trigger encryption to run
+		// set to true if any JS files changed so that we can trigger encryption to run
 		this.jsFilesChanged = false;
 
 		// an array of products (Xcode targets) being built
@@ -930,7 +930,7 @@ class iOSBuilder extends Builder {
 						process.exit(1);
 					}
 				} catch (e) {
-					// squelch and let the cli detect the bad version
+					// squelch and let the CLI detect the bad version
 				}
 			},
 			desc: 'iOS SDK version to build with',
@@ -1518,7 +1518,7 @@ class iOSBuilder extends Builder {
 			process.exit(1);
 		}
 
-		// process min ios version
+		// process min iOS version
 		this.minIosVersion = tiapp.ios['min-ios-ver'] && appc.version.gt(tiapp.ios['min-ios-ver'], this.packageJson.minIosVersion) ? tiapp.ios['min-ios-ver'] : this.packageJson.minIosVersion;
 
 		// process device family
@@ -1899,7 +1899,7 @@ class iOSBuilder extends Builder {
 				this.provisioningProfile = this.findProvisioningProfile(this.target, this.provisioningProfileUUID);
 			}
 
-			// add the ios specific default icon to the list of icons
+			// add the iOS specific default icon to the list of icons
 			this.defaultIcons.unshift(path.join(this.projectDir, 'DefaultIcon-ios.png'));
 
 			// manually inject the build profile settings
@@ -1950,7 +1950,7 @@ class iOSBuilder extends Builder {
 
 			// Transpilation details
 			this.transpile = cli.tiapp['transpile'] !== false; // Transpiling is an opt-out process now
-			// this.minSupportedIosSdk holds the target ios version to transpile down to
+			// this.minSupportedIosSdk holds the target iOS version to transpile down to
 			// If they're passing flag to do source-mapping, that overrides everything, so turn it on
 			if (cli.argv['source-maps']) {
 				this.sourceMaps = true;
@@ -2347,7 +2347,7 @@ class iOSBuilder extends Builder {
 									module.isFramework = false;
 
 									// For Obj-C static libraries, use the .a library or hashing
-									this.legacyModules.add(module.id); // Record that this won't support macos or arm64 sim!
+									this.legacyModules.add(module.id); // Record that this won't support macOS or arm64 sim!
 									nativeHashes.push(module.hash = this.hash(fs.readFileSync(module.libFile)));
 									// Try to load native module as framework (Swift)
 								} else if (fs.existsSync(path.join(module.modulePath, frameworkName))) {
@@ -2356,7 +2356,7 @@ class iOSBuilder extends Builder {
 									module.isFramework = true;
 
 									// For Swift frameworks, use the binary inside the .framework for hashing
-									this.legacyModules.add(module.id); // Record that this won't support macos or arm64 sim!
+									this.legacyModules.add(module.id); // Record that this won't support macOS or arm64 sim!
 									nativeHashes.push(module.hash = this.hash(fs.readFileSync(path.join(module.libFile, this.scrubbedModuleId(module.id)))));
 								} else if (fs.existsSync(path.join(module.modulePath, xcFrameworkOfLib))) {
 									module.libName = xcFrameworkOfLib;
@@ -2500,7 +2500,7 @@ class iOSBuilder extends Builder {
 				});
 			});
 
-			// titanium related tasks
+			// Titanium related tasks
 			this.writeDebugProfilePlists();
 			await this.copyResources();
 			await new Promise((resolve, reject) => {
@@ -2879,7 +2879,7 @@ class iOSBuilder extends Builder {
 				return true;
 			}
 
-			// check if the titanium sdk version changed
+			// check if the Titanium SDK version changed
 			if (fs.existsSync(this.xcodeProjectConfigFile)) {
 				// we have a previous build, see if the Titanium SDK changed
 				const conf = fs.readFileSync(this.xcodeProjectConfigFile).toString(),
@@ -2946,7 +2946,7 @@ class iOSBuilder extends Builder {
 				}
 			}
 
-			// check if the titanium sdk paths are different
+			// check if the Titanium SDK paths are different
 			if (manifest.iosSdkPath !== this.platformPath) {
 				this.logger.info('Forcing rebuild: Titanium SDK path changed since last build');
 				this.logger.info(`  Was: ${cyan(manifest.iosSdkPath)}`);
@@ -3417,7 +3417,7 @@ class iOSBuilder extends Builder {
 			});
 		}
 
-		// set the min ios version for the whole project
+		// set the min iOS version for the whole project
 		xobjs.XCConfigurationList[pbxProject.buildConfigurationList].buildConfigurations.forEach(function (buildConf) {
 			const buildSettings = xobjs.XCBuildConfiguration[buildConf.value].buildSettings;
 			buildSettings.IPHONEOS_DEPLOYMENT_TARGET = appc.version.format(this.minIosVer, 2);
@@ -3913,7 +3913,7 @@ class iOSBuilder extends Builder {
 					}
 
 					if (targetInfo.isExtension || targetInfo.isWatchAppV2orNewer || targetInfo.isAppClip) {
-						// add this target as a dependency of the titanium app's project
+						// add this target as a dependency of the Titanium app's project
 						const proxyUuid = this.generateXcodeUuid(xcodeProject);
 						xobjs.PBXContainerItemProxy || (xobjs.PBXContainerItemProxy = {});
 						xobjs.PBXContainerItemProxy[proxyUuid] = {
@@ -5358,7 +5358,7 @@ class iOSBuilder extends Builder {
 		});
 		await task.run();
 		if (this.useWebpack) {
-			// Merge Ti symbols from Webpack with the ones from legacy js processing
+			// Merge Ti symbols from Webpack with the ones from legacy JS processing
 			Object.keys(task.data.tiSymbols).forEach(file => {
 				const existingSymbols = this.tiSymbols[file] || [];
 				const additionalSymbols = task.data.tiSymbols[file];
@@ -5373,7 +5373,7 @@ class iOSBuilder extends Builder {
 	}
 
 	/**
-	 * @param {string[]} jsBootstrapFiles list of bootstrap js files to add to listing we generate
+	 * @param {string[]} jsBootstrapFiles list of bootstrap JS files to add to listing we generate
 	 * @returns {Promise<void>}
 	 */
 	async writeBootstrapJson(jsBootstrapFiles) {
@@ -5484,7 +5484,7 @@ class iOSBuilder extends Builder {
 
 	/**
 	 * @param {string} dest destination filepath
-	 * @param {object} json json to write to file
+	 * @param {object} json JSON to write to file
 	 */
 	async writeAssetContentsFile(dest, json) {
 		const contents = JSON.stringify(json, null, '  ');
@@ -6047,7 +6047,7 @@ class iOSBuilder extends Builder {
 			return;
 		}
 
-		// Turn callback api to promise...
+		// Turn callback API to promise...
 		const boundGenerateAppIcons = util.promisify(this.generateAppIcons).bind(this);
 		if (!defaultIcon) {
 			// we're going to fail, but we let generateAppIcons() do the dirty work
@@ -6737,7 +6737,7 @@ class iOSBuilder extends Builder {
 		if (Array.isArray(infoPlist.UIBackgroundModes) && infoPlist.UIBackgroundModes.indexOf('fetch') !== -1) {
 			hasFetch = true;
 		}
-		// if we're doing a simulator build or we're including all titanium modules, get it from source xcconfig file
+		// if we're doing a simulator build or we're including all Titanium modules, get it from source xcconfig file
 		if (this.target === 'simulator' || this.target === 'macos' || this.includeAllTiModules) {
 			const sourceConfigPath = path.join(this.platformPath, 'iphone', 'project.xcconfig');
 			const conf = fs.readFileSync(sourceConfigPath).toString();
@@ -7185,7 +7185,7 @@ async function processArchitecture() {
 	});
 }
 
-// create the builder instance and expose the public api
+// create the builder instance and expose the public API
 const builder = new iOSBuilder();
 export const config = builder.config.bind(builder);
 export const validate = builder.validate.bind(builder);

--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -483,7 +483,7 @@ class iOSBuilder extends Builder {
 							keychain:                   this.configOptionKeychain(),
 							'launch-bundle-id':           this.configOptionLaunchBundleId(),
 							'launch-url': {
-								// url for the application to launch in mobile Safari, as soon as the app boots up
+								// URL for the application to launch in mobile Safari, as soon as the app boots up
 								hidden: true
 							},
 							'output-dir':                 this.configOptionOutputDir(200),

--- a/iphone/cli/commands/_buildModule.js
+++ b/iphone/cli/commands/_buildModule.js
@@ -246,7 +246,7 @@ export class iOSModuleBuilder extends Builder {
 		const appName = this.moduleIdAsIdentifier;
 
 		if (this.isFramework && !contents.includes('TitaniumKit.xcframework')) {
-			this.logger.warn(`Module created with sdk < 9.2.0, need to add TitaniumKit.xcframework. The ${this.moduleName}.xcodeproj has been updated.`);
+			this.logger.warn(`Module created with SDK < 9.2.0, need to add TitaniumKit.xcframework. The ${this.moduleName}.xcodeproj has been updated.`);
 
 			xcodeProject.hash = xcodeParser.parse(contents);
 			const xobjs = xcodeProject.hash.project.objects,
@@ -429,7 +429,7 @@ FRAMEWORK_SEARCH_PATHS = $(inherited) "$(TITANIUM_SDK)/iphone/Frameworks/**"`);
 				);
 			},
 
-			// 2. compile all other js files in assets dir
+			// 2. compile all other JS files in assets dir
 			function (cb) {
 				try {
 					if (!fs.existsSync(this.assetsDir)) {
@@ -789,7 +789,7 @@ FRAMEWORK_SEARCH_PATHS = $(inherited) "$(TITANIUM_SDK)/iphone/Frameworks/**"`);
 		}
 		iosSim.SupportedArchitectures.forEach(arch => buildArchs.add(arch));
 
-		// MacOS Catalyst support is optional
+		// macOS Catalyst support is optional
 		const macos = xcFrameworkInfo.AvailableLibraries.find(l => l.SupportedPlatformVariant === 'maccatalyst');
 		if (!macos) {
 			this.logger.warn('The module is missing macOS support.');
@@ -931,7 +931,7 @@ FRAMEWORK_SEARCH_PATHS = $(inherited) "$(TITANIUM_SDK)/iphone/Frameworks/**"`);
 				}.bind(this));
 			}
 
-			// 6. assets folder, not including js files
+			// 6. assets folder, not including JS files
 			if (fs.existsSync(this.assetsDir)) {
 				this.dirWalker(this.assetsDir, function (file) {
 					if (path.extname(file) !== '.js') {

--- a/iphone/cli/hooks/frameworks.js
+++ b/iphone/cli/hooks/frameworks.js
@@ -794,7 +794,7 @@ class FrameworkInspector {
 				if (libInfo.SupportedPlatformVariant === MAC_CATALYST_PLATFORM_VARIANT) {
 					supportedPlatforms.add(MAC_CATALYST_PLATFORM_VARIANT);
 				} else {
-					// ios device and sim
+					// iOS device and sim
 					libInfo.SupportedArchitectures.forEach(a => archs.add(a));
 					supportedPlatforms.add(libInfo.SupportedPlatform); // should always be 'ios'
 				}
@@ -957,7 +957,7 @@ class FrameworkInfo {
 	 * Platform filter string used in xcode build file entries.
 	 *
 	 * Returns `ios` for frameworks that support iOS only, `maccatalyst` for
-	 * MacOS only frameworks, and `undefined` if both platforms are supported
+	 * macOS only frameworks, and `undefined` if both platforms are supported
 	 * or if there is no info about supported platforms.
 	 *
 	 * @return {string|undefined}

--- a/iphone/cli/hooks/run.js
+++ b/iphone/cli/hooks/run.js
@@ -71,7 +71,7 @@ export function init(logger, config, cli) {
 					line = m[4].trim();
 				}
 
-				// ignore logs from cli ignoreLog
+				// ignore logs from CLI ignoreLog
 				if (typeof ignoreLog === 'string') {
 					if (line.includes(ignoreLog)) {
 						return;

--- a/iphone/cli/hooks/storyboard.js
+++ b/iphone/cli/hooks/storyboard.js
@@ -3,7 +3,7 @@
  * and then configures them in the Xcode project
  */
 
-// TO DO: Can we merge storyboard.js and framework.js
+// TODO: Can we merge storyboard.js and framework.js
 
 import fs from 'fs-extra';
 import { IncrementalFileTask } from 'appc-tasks';

--- a/iphone/cli/lib/info.js
+++ b/iphone/cli/lib/info.js
@@ -147,14 +147,14 @@ export function render(logger, config, rpad, styleHeading, styleValue, styleBad)
 		logger.log('No Xcode installations found.'.grey + '\n');
 	}
 
-	// ios keychains
+	// iOS keychains
 	logger.log(
 		styleHeading('iOS Keychains') + '\n'
 		+ Object.keys(data.certs.keychains).sort().reverse().map(function (keychain) {
 			return '  ' + rpad(path.basename(keychain)) + ' = ' + styleValue(keychain);
 		}).join('\n') + '\n');
 
-	// ios certs
+	// iOS certs
 	logger.log(styleHeading('iOS Development Certificates'));
 	let counter = 0;
 	if (Object.keys(data.certs.keychains).length) {

--- a/iphone/iphone/README.md
+++ b/iphone/iphone/README.md
@@ -1,4 +1,4 @@
-# Building and Debugging the Tiatnium iOS Source
+# Building and Debugging the Titanium iOS Source
 > ###### Tested with Titanium SDK 6.x 
 
 ## Titanium Core
@@ -28,4 +28,4 @@ and click *+* to add the `FacebookIOS` target dependency. This will ensure that 
 Titanium source, the Facebook Module source is built as well.
 <img src="https://abload.de/img/bildschirmfoto2017-05q0kr7.png" height="400" />
 4. That's it! You can now set breakpoints in your native module, `require` the module in the `app.js`
-and change the module source without recompiling it everytime you change it.
+and change the module source without recompiling it every time you change it.

--- a/iphone/layout/layout/TiUtils.m
+++ b/iphone/layout/layout/TiUtils.m
@@ -149,14 +149,14 @@ static BOOL _isTesting = NO;
 
 + (BOOL)isRetinaDisplay
 {
-  // since we call this alot, cache it
+  // since we call this a lot, cache it
   static CGFloat scale = 0.0;
   if (scale == 0.0) {
     // NOTE: iPad in iPhone compatibility mode will return a scale factor of 2.0
     // when in 2x zoom, which leads to false positives and bugs. This tries to
     // future proof against possible different model names, but in the event of
     // an iPad with a retina display, this will need to be fixed.
-    // Credit to Brion on github for the origional fix.
+    // Credit to Brion on github for the original fix.
     if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone) {
       NSRange iPadStringPosition = [[[UIDevice currentDevice] model] rangeOfString:@"iPad"];
       if (iPadStringPosition.location != NSNotFound) {

--- a/iphone/layout/layoutTests/layoutTests.m
+++ b/iphone/layout/layoutTests/layoutTests.m
@@ -75,7 +75,7 @@ static TiView *createWindow(TiView *parent)
   WAIT_FOR(done)
 }
 
-- (void)test_AbsoluteLayout_LeftPropery
+- (void)test_AbsoluteLayout_LeftProperty
 {
   __block BOOL done = NO;
   TiView *view = [[TiView alloc] init];
@@ -96,7 +96,7 @@ static TiView *createWindow(TiView *parent)
   WAIT_FOR(done)
 }
 
-- (void)test_AbsoluteLayout_RightPropery
+- (void)test_AbsoluteLayout_RightProperty
 {
   __block BOOL done = NO;
   TiView *view = [[TiView alloc] init];
@@ -116,7 +116,7 @@ static TiView *createWindow(TiView *parent)
   WAIT_FOR(done)
 }
 
-- (void)test_AbsoluteLayout_TopPropery
+- (void)test_AbsoluteLayout_TopProperty
 {
   __block BOOL done = NO;
   TiView *view = [[TiView alloc] init];
@@ -135,7 +135,7 @@ static TiView *createWindow(TiView *parent)
   WAIT_FOR(done)
 }
 
-- (void)test_AbsoluteLayout_BottomPropery
+- (void)test_AbsoluteLayout_BottomProperty
 {
   __block BOOL done = NO;
   TiView *view = [[TiView alloc] init];

--- a/support/module/packaged/README.md
+++ b/support/module/packaged/README.md
@@ -2,7 +2,7 @@
 
 The modules listed inside `modules.json` will be bundled with the Titanium SDK.
 
-The easiest way to update this properly is to add/edit the url listing for a module and then run `node scons.js modules-integrity`.
+The easiest way to update this properly is to add/edit the URL listing for a module and then run `node scons.js modules-integrity`.
 That command will re-generate JSON content with the integrity hashes that is written to the modules.json file.
 
 We use integrity hashes now to verify that the remote file contents match our expectations as well as to make use of local cached copies of the modules

--- a/tests/Resources/bootstraps/simple.bootstrap.js
+++ b/tests/Resources/bootstraps/simple.bootstrap.js
@@ -8,7 +8,7 @@
 /* eslint no-unused-expressions: "off" */
 'use strict';
 
-// Note: This script's file name must end with "*.bootstrap.js" to be auto-loaded by Titainum.
+// Note: This script's file name must end with "*.bootstrap.js" to be auto-loaded by Titanium.
 
 // Log that this bootstrap was automatically loaded on startup.
 Ti.API.info('"simple.bootstrap.js" has been required-in.');

--- a/tests/Resources/bootstraps/ui.bootstrap.js
+++ b/tests/Resources/bootstraps/ui.bootstrap.js
@@ -8,7 +8,7 @@
 /* eslint no-unused-expressions: "off" */
 'use strict';
 
-// Note: This script's file name must end with "*.bootstrap.js" to be auto-loaded by Titainum.
+// Note: This script's file name must end with "*.bootstrap.js" to be auto-loaded by Titanium.
 
 // Log that this bootstrap was automatically loaded on startup.
 Ti.API.info('"ui.bootstrap.js" has been required-in.');

--- a/tests/Resources/console.test.js
+++ b/tests/Resources/console.test.js
@@ -161,7 +161,7 @@ describe('console', function () {
 		it('increases indent by 2 spaces', () => {
 			// FIXME: We can't just hijack console.log, because that's where we handle the indents!
 			// Maybe we need to add the constructor stuff so we can create a console hooked to our own "stream"?
-			// Note that we don't have a great mapping to stdout/stderr, because android has actual log priorities that map to the Ti.API/console methods
+			// Note that we don't have a great mapping to stdout/stderr, because Android has actual log priorities that map to the Ti.API/console methods
 			// Whereas Node assumes a "dumb" stdout without specific priorities
 			// instead it treats log/debug/info/dirxml as -> stdout, warn/error as -> stderr
 			const logs = [];
@@ -334,7 +334,7 @@ describe('console', function () {
 
 		// TODO: How do we test if a stream throws an async error?
 
-		it('doesnt handle sync errors on stdout write if ignoreErrors is false', () => {
+		it('doesn\'t handle sync errors on stdout write if ignoreErrors is false', () => {
 			const events = require('events');
 			const stdout = new events.EventEmitter();
 			stdout.write = function () {

--- a/tests/Resources/core.runtime.test.js
+++ b/tests/Resources/core.runtime.test.js
@@ -110,7 +110,7 @@ describe.windowsBroken('Core', () => {
 				should(createBuffer).be.a.Function();
 
 				// Attempt to call static method.
-				const result = createBuffer({}); // ios fails with: "self type check failed for Objective-C instance method"
+				const result = createBuffer({}); // iOS fails with: "self type check failed for Objective-C instance method"
 				should(result).be.a.Object();
 			});
 		});

--- a/tests/Resources/error.test.js
+++ b/tests/Resources/error.test.js
@@ -38,7 +38,7 @@ describe('Error', function () {
 			// FIXME We should attempt to format the iOS stack to look/feel similar to Android/Node if possible.
 
 			// iOS Has just the stacktrace without a preceding message/type. Also has 'column', 'line', 'sourceURL'
-			// does not have java stack trace
+			// does not have Java stack trace
 			should(ex).not.have.property('nativeStack');
 		}
 	});

--- a/tests/Resources/fs.test.js
+++ b/tests/Resources/fs.test.js
@@ -90,7 +90,7 @@ describe('fs', function () {
 		});
 
 		it('checks that this file is NOT writable properly', function (finished) {
-			// ios sim does report this as writable!
+			// iOS sim does report this as writable!
 			if (isIOSSim || isMacOS) {
 				// this.skip(); // FIXME: Call this.skip() once we upgrade to npm mocha
 				return finished();
@@ -322,7 +322,7 @@ describe('fs', function () {
 			fs.mkdir(subdirPath, err => {
 				try {
 					should.exist(err);
-					err.name.should.eql('Error'); // windows desktop fails here (because error is null)
+					err.name.should.eql('Error'); // Windows desktop fails here (because error is null)
 					err.message.should.eql(`ENOENT: no such file or directory, mkdir '${subdirPath}'`);
 					err.code.should.eql('ENOENT');
 					err.errno.should.eql(-2);
@@ -873,7 +873,7 @@ describe('fs', function () {
 			fs.rmdir(dirName, error => {
 				try {
 					should.exist(error);
-					error.name.should.eql('Error'); // windows desktop fails here
+					error.name.should.eql('Error'); // Windows desktop fails here
 					error.message.should.eql(`ENOTEMPTY: directory not empty, rmdir '${dirName}'`);
 					error.errno.should.eql(-66);
 					error.syscall.should.eql('rmdir');
@@ -1046,7 +1046,7 @@ describe('fs', function () {
 			fs.truncate(dest, err => {
 				try {
 					should.not.exist(err);
-					fs.readFileSync(dest, 'utf8').should.eql(''); // windows desktop fails here
+					fs.readFileSync(dest, 'utf8').should.eql(''); // Windows desktop fails here
 				} catch (e) {
 					return finished(e);
 				}
@@ -1061,7 +1061,7 @@ describe('fs', function () {
 				try {
 					should.not.exist(err);
 					const buffer = fs.readFileSync(dest);
-					buffer.length.should.eql(16384); // windows desktop gives 213231
+					buffer.length.should.eql(16384); // Windows desktop gives 213231
 					// TODO: Compare contents somehow?
 				} catch (e) {
 					return finished(e);
@@ -1080,7 +1080,7 @@ describe('fs', function () {
 			const dest = Ti.Filesystem.tempDirectory + `truncateSync_${Date.now()}.js`;
 			fs.copyFileSync(thisFilePath, dest);
 			fs.truncateSync(dest);
-			fs.readFileSync(dest, 'utf8').should.eql(''); // windows desktop fails here
+			fs.readFileSync(dest, 'utf8').should.eql(''); // Windows desktop fails here
 		});
 
 		it.windowsDesktopBroken('truncates to specified number of bytes', () => {
@@ -1088,7 +1088,7 @@ describe('fs', function () {
 			fs.copyFileSync(thisFilePath, dest);
 			fs.truncateSync(dest, 16384);
 			const buffer = fs.readFileSync(dest);
-			buffer.length.should.eql(16384); // windows desktop gives 213231
+			buffer.length.should.eql(16384); // Windows desktop gives 213231
 			// TODO: Compare contents somehow?
 		});
 	});
@@ -1124,7 +1124,7 @@ describe('fs', function () {
 			fs.unlink(dir, error => {
 				try {
 					should.exist(error);
-					error.name.should.eql('Error'); // windows fails here
+					error.name.should.eql('Error'); // Windows fails here
 					error.message.should.eql(`EISDIR: illegal operation on a directory, unlink '${dir}'`);
 					error.code.should.eql('EISDIR');
 					error.errno.should.eql(-21);
@@ -1170,7 +1170,7 @@ describe('fs', function () {
 
 		it.windowsDesktopBroken('deletes a file', () => {
 			const filename = path.join(Ti.Filesystem.tempDirectory, `unlinkSync${Date.now()}.txt`);
-			fs.writeFileSync(filename, 'Hello World!'); // windows desktop fails here
+			fs.writeFileSync(filename, 'Hello World!'); // Windows desktop fails here
 			// file should now exist
 			should(fs.existsSync(filename)).be.true();
 			// delete it
@@ -1182,7 +1182,7 @@ describe('fs', function () {
 		it.windowsDesktopBroken('throws trying to delete a directory', () => {
 			const dir = Ti.Filesystem.tempDirectory;
 			// dir should exist
-			should(fs.existsSync(dir)).be.true(); // windows desktop fails here
+			should(fs.existsSync(dir)).be.true(); // Windows desktop fails here
 			// try to delete it
 			try {
 				fs.unlinkSync(dir);
@@ -1230,7 +1230,7 @@ describe('fs', function () {
 		it.windowsDesktopBroken('writes a string to a file descriptor', finish => {
 			const filename = path.join(Ti.Filesystem.tempDirectory, `writeString${Date.now()}.txt`);
 			// ensure parent dir exists
-			should(fs.existsSync(Ti.Filesystem.tempDirectory)).be.true(); // windows desktop fails here
+			should(fs.existsSync(Ti.Filesystem.tempDirectory)).be.true(); // Windows desktop fails here
 			const fd = fs.openSync(filename, 'w');
 			const contents = 'Hello write with a string!';
 			fs.write(fd, contents, (err, bytes, string) => {
@@ -1253,7 +1253,7 @@ describe('fs', function () {
 		it.windowsDesktopBroken('writes a Buffer to a file descriptor', finish => {
 			const filename = path.join(Ti.Filesystem.tempDirectory, `writeBuffer${Date.now()}.txt`);
 			// ensure parent dir exists
-			should(fs.existsSync(Ti.Filesystem.tempDirectory)).be.true(); // windows desktop fails here
+			should(fs.existsSync(Ti.Filesystem.tempDirectory)).be.true(); // Windows desktop fails here
 			const fd = fs.openSync(filename, 'w');
 			const buffer = Buffer.from('Hello write with a Buffer!');
 			fs.write(fd, buffer, (err, bytes, bufferFromCallback) => {

--- a/tests/Resources/os.test.js
+++ b/tests/Resources/os.test.js
@@ -234,7 +234,7 @@ describe('os', function () {
 			userInfo.should.be.an.Object();
 			userInfo.should.have.a.property('uid').which.eql(-1);
 			userInfo.should.have.a.property('gid').which.eql(-1);
-			userInfo.should.have.a.property('username').which.is.a.String(); // "iPhone 7 Plus" on ios Simulator, "android-build" on android emulator
+			userInfo.should.have.a.property('username').which.is.a.String(); // "iPhone 7 Plus" on iOS Simulator, "android-build" on Android emulator
 			userInfo.should.have.a.property('homedir').which.eql(os.homedir());
 			userInfo.should.have.a.property('shell').which.eql(null);
 		});

--- a/tests/Resources/ti.app.ios.test.js
+++ b/tests/Resources/ti.app.ios.test.js
@@ -51,7 +51,7 @@ describe.ios('Titanium.App.iOS', function () {
 		should(searchableIndex).be.an.Object();
 		should(searchableIndex.apiName).eql('Ti.App.iOS.SearchableIndex');
 		should(searchableIndex.addToDefaultSearchableIndex).be.a.Function();
-		should(searchableIndex.deleteAllSearchableItemByDomainIdenifiers).be.a.Function();
+		should(searchableIndex.deleteAllSearchableItemByDomainIdentifiers).be.a.Function();
 		should(searchableIndex.deleteAllSearchableItems).be.a.Function();
 		should(searchableIndex.deleteAllSearchableItems).be.a.Function();
 		should(searchableIndex.deleteSearchableItemsByIdentifiers).be.a.Function();

--- a/tests/Resources/ti.app.properties.test.js
+++ b/tests/Resources/ti.app.properties.test.js
@@ -37,7 +37,7 @@ describe('Titanium.App.Properties', function () {
 		should(Ti.App.Properties.getBool('test_bool')).be.be.true();
 	});
 
-	it('setBool on property from tiapp doesnt change value', function () {
+	it('setBool on property from tiapp doesn\'t change value', function () {
 		should(Ti.App.Properties.getBool('presetBool')).be.be.true();
 		Ti.App.Properties.setBool('presetBool', false); // should log warning
 		should(Ti.App.Properties.getBool('presetBool')).be.be.true();
@@ -54,7 +54,7 @@ describe('Titanium.App.Properties', function () {
 		should(Ti.App.Properties.getDouble('test_double')).be.eql(1.321);
 	});
 
-	it('setDouble on property from tiapp doesnt change value', function () {
+	it('setDouble on property from tiapp doesn\'t change value', function () {
 		should(Ti.App.Properties.getDouble('presetDouble')).be.eql(1.23456);
 		Ti.App.Properties.setDouble('presetDouble', 6.54321); // should log warning
 		should(Ti.App.Properties.getDouble('presetDouble')).be.eql(1.23456);
@@ -71,7 +71,7 @@ describe('Titanium.App.Properties', function () {
 		should(Ti.App.Properties.getInt('test_int')).be.eql(1);
 	});
 
-	it('setInt on property from tiapp doesnt change value', function () {
+	it('setInt on property from tiapp doesn\'t change value', function () {
 		should(Ti.App.Properties.getInt('presetInt')).be.eql(1337);
 		Ti.App.Properties.setInt('presetInt', 666); // should log warning
 		should(Ti.App.Properties.getInt('presetInt')).be.eql(1337);
@@ -112,7 +112,7 @@ describe('Titanium.App.Properties', function () {
 		should(Ti.App.Properties.getString('test_string')).be.eql('some test string');
 	});
 
-	it('setString on property from tiapp doesnt change value', function () {
+	it('setString on property from tiapp doesn\'t change value', function () {
 		should(Ti.App.Properties.getString('presetString')).be.eql('Hello!');
 		Ti.App.Properties.setString('presetString', 'a new value'); // should log warning
 		should(Ti.App.Properties.getString('presetString')).be.eql('Hello!');
@@ -144,7 +144,7 @@ describe('Titanium.App.Properties', function () {
 		should(properties.contains('test_property')).be.be.false();
 	});
 
-	it('removeProperty doesnt remove properties from tiapp', function () {
+	it('removeProperty doesn\'t remove properties from tiapp', function () {
 		var properties = Ti.App.Properties.listProperties();
 		should(properties).be.a.Object();
 		should(properties.contains('presetString')).be.be.true();

--- a/tests/Resources/ti.blob.test.js
+++ b/tests/Resources/ti.blob.test.js
@@ -55,7 +55,7 @@ describe('Titanium.Blob', function () {
 				try {
 					should(blob).be.an.Object();
 					// should(blob).be.an.instanceof(Ti.Blob); // FIXME Crashes Windows, throws uncaught error on iOS & Android
-					// should(blob.getText()).equal(null); // FIXME 'blob.getText is not a function' on iOS
+					// should(blob.getText()).equal(null); // FIXME 'blob.getText is not a function on iOS
 					// should(blob.text).equal(null); // FIXME this is undefined on iOS, docs say it should be null
 					should.not.exist(blob.text);
 
@@ -549,7 +549,7 @@ describe('Titanium.Blob', function () {
 
 	// FIXME: This is breaking on Android emulator when setting the image view to the blob
 	// Canvas: trying to draw too large(211527936bytes) bitmap.
-	// it breaks on older android devices with an OutOfMemory Error on calling imageAsResized
+	// it breaks on older Android devices with an OutOfMemory Error on calling imageAsResized
 	it.androidBroken('resize very large image', function (finish) {
 		this.timeout(15000);
 		win = Ti.UI.createWindow({ backgroundColor: 'gray' });
@@ -583,10 +583,10 @@ describe('Titanium.Blob', function () {
 	});
 
 	// iOS had a bug where it reported Blob width/height as pts, but Android reported px
-	// And worse - numbers not divisble by the device scale (2, 3, etc) we could not reliably reproduce the *real* pixel size
-	// i.e. a 10 x 10 pixel image/view on a 3x device woudl report width/height of 3 and scale of 3, so just multiplying those we'd get 9
+	// And worse - numbers not divisible by the device scale (2, 3, etc) we could not reliably reproduce the *real* pixel size
+	// e.g. a 10 x 10 pixel image/view on a 3x device would report width/height of 3 and scale of 3, so just multiplying those we'd get 9
 	// when the real image was actually 10px.
-	// However, natively we *can* properly generate true pixel size because image would report scale like 3.33 that we coudl multiply by before returning
+	// However, natively we *can* properly generate true pixel size because image would report scale like 3.33 that we could multiply by before returning
 	it('image dimensions should be reported in pixels', finish => {
 		win = Ti.UI.createWindow();
 		const view = Ti.UI.createView({

--- a/tests/Resources/ti.blob.test.js
+++ b/tests/Resources/ti.blob.test.js
@@ -55,7 +55,7 @@ describe('Titanium.Blob', function () {
 				try {
 					should(blob).be.an.Object();
 					// should(blob).be.an.instanceof(Ti.Blob); // FIXME Crashes Windows, throws uncaught error on iOS & Android
-					// should(blob.getText()).equal(null); // FIXME 'blob.getText is not a function on iOS
+					// should(blob.getText()).equal(null); // FIXME 'blob.getText is not a function' on iOS
 					// should(blob.text).equal(null); // FIXME this is undefined on iOS, docs say it should be null
 					should.not.exist(blob.text);
 

--- a/tests/Resources/ti.buffer.test.js
+++ b/tests/Resources/ti.buffer.test.js
@@ -26,7 +26,7 @@ describe('Titanium.Buffer', function () {
 	});
 
 	// TODO Add tests for insert/append/fill/copy that use negative offsets/lengths
-	// TODO Add tests for methods/properties and pass in invalid types (i.e. pass in null/undefined/string for Number args)
+	// TODO Add tests for methods/properties and pass in invalid types (e.g. pass in null/undefined/string for Number args)
 
 	describe('.length', function () {
 		it('defaults to 0 when not specified', function () {

--- a/tests/Resources/ti.contacts.person.test.js
+++ b/tests/Resources/ti.contacts.person.test.js
@@ -259,7 +259,7 @@ describe.allBroken('Titanium.Contacts.Person', function () {
 		var person = Ti.Contacts.createPerson();
 		should(person.url).not.be.undefined();
 		should(person.url).be.an.Object();
-		// TODO Test modifying the url dictionary?
+		// TODO Test modifying the URL dictionary?
 		// TODO Try unknown keys (known are homepage, home, work, and/or other.)
 		// TODO Test non-string values in the array of values
 	});

--- a/tests/Resources/ti.filesystem.file.test.js
+++ b/tests/Resources/ti.filesystem.file.test.js
@@ -697,7 +697,7 @@ describe('Titanium.Filesystem.File', function () {
 			const result = nonExistentDir.getDirectoryListing();
 			should(nonExistentDir).be.ok();
 			should(nonExistentDir.exists()).be.false();
-			should.not.exist(result); // null or undefined // FIXME: ios returns undefined, test checked for exactly null before
+			should.not.exist(result); // null or undefined // FIXME: iOS returns undefined, test checked for exactly null before
 		});
 
 		it('returns null for file', function () {
@@ -706,7 +706,7 @@ describe('Titanium.Filesystem.File', function () {
 			should(file).be.ok();
 			should(file.exists()).be.true();
 			should(file.isFile()).be.true();
-			should.not.exist(result); // null or undefined // FIXME: ios returns undefined, test checked for exactly null before
+			should.not.exist(result); // null or undefined // FIXME: iOS returns undefined, test checked for exactly null before
 		});
 
 		it.windowsBroken('can access resource directory files', function () {
@@ -720,7 +720,7 @@ describe('Titanium.Filesystem.File', function () {
 			const rootPath = rootDir.nativePath;
 
 			const filesFound = {};
-			// FIXME: If this is ios and the JS files are encrypted, we cannot get the resource dir listing properly
+			// FIXME: If this is iOS and the JS files are encrypted, we cannot get the resource dir listing properly
 			// See TIMOB-27646 - encrypted JS files won't be in the listing
 			if (!isIOS || !Ti.App.Properties.getBool('js.encrypted', false)) {
 				filesFound[rootPath + 'app.js'] = false;
@@ -842,7 +842,7 @@ describe('Titanium.Filesystem.File', function () {
 
 			// Generate a file:// URI for the temp dir. Android reports one as-is, iOS reports an absolute filepath so we pre-pend file:// to it
 			// file:///data/user/0/com.appcelerator.testApp.testing/cache/_tmp on Android
-			// Note also, that IOS reports trailing slash, Android does not
+			// Note also, that iOS reports trailing slash, Android does not
 			const prefix = isIOS ? `file://${Ti.Filesystem.tempDirectory}` : `${Ti.Filesystem.tempDirectory}/`;
 			fileURI = `${prefix}app.js`;
 			console.log(`Copying app.js to ${fileURI}`);

--- a/tests/Resources/ti.geolocation.test.js
+++ b/tests/Resources/ti.geolocation.test.js
@@ -330,7 +330,7 @@ describe('Titanium.Geolocation', () => {
 
 				// can't get permissions on macOS or actual iOS devices, since it prompts
 				if ((isMacOS || isIOSDevice) && !Ti.Geolocation.hasLocationPermissions(permission)) {
-					return finish(); // FIXME: How can we limit to ios only, and skip on macos?
+					return finish(); // FIXME: How can we limit to iOS only, and skip on macOS?
 				}
 
 				Ti.Geolocation.requestLocationPermissions(permission, function (e) {
@@ -355,7 +355,7 @@ describe('Titanium.Geolocation', () => {
 
 				// can't get permissions on macOS or actual iOS devices, since it prompts
 				if ((isMacOS || isIOSDevice) && !Ti.Geolocation.hasLocationPermissions(permission)) {
-					return finish(); // FIXME: How can we limit to ios only, and skip on macos?
+					return finish(); // FIXME: How can we limit to iOS only, and skip on macOS?
 				}
 
 				const result = Ti.Geolocation.requestLocationPermissions(permission);
@@ -375,7 +375,7 @@ describe('Titanium.Geolocation', () => {
 
 				// can't get permissions on macOS or actual iOS devices, since it prompts
 				if ((isMacOS || isIOSDevice) && !Ti.Geolocation.hasLocationPermissions(permission)) {
-					return finish(); // FIXME: How can we limit to ios only, and skip on macos?
+					return finish(); // FIXME: How can we limit to iOS only, and skip on macOS?
 				}
 
 				function testCurrentHeading() {
@@ -417,7 +417,7 @@ describe('Titanium.Geolocation', () => {
 
 				// can't get permissions on macOS or actual iOS devices, since it prompts
 				if ((isMacOS || isIOSDevice) && !Ti.Geolocation.hasLocationPermissions(permission)) {
-					return finish(); // FIXME: How can we limit to ios only, and skip on macos?
+					return finish(); // FIXME: How can we limit to iOS only, and skip on macOS?
 				}
 
 				function testCurrentHeading() {
@@ -466,7 +466,7 @@ describe('Titanium.Geolocation', () => {
 
 				// can't get permissions on macOS or actual iOS devices, since it prompts
 				if ((isMacOS || isIOSDevice) && !Ti.Geolocation.hasLocationPermissions(permission)) {
-					return finish(); // FIXME: How can we limit to ios only, and skip on macos?
+					return finish(); // FIXME: How can we limit to iOS only, and skip on macOS?
 				}
 
 				Ti.Geolocation.accuracy = Ti.Geolocation.ACCURACY_HIGH;
@@ -514,7 +514,7 @@ describe('Titanium.Geolocation', () => {
 
 				// can't get permissions on macOS or actual iOS devices, since it prompts
 				if ((isMacOS || isIOSDevice) && !Ti.Geolocation.hasLocationPermissions(permission)) {
-					return finish(); // FIXME: How can we limit to ios only, and skip on macos?
+					return finish(); // FIXME: How can we limit to iOS only, and skip on macOS?
 				}
 
 				Ti.Geolocation.accuracy = Ti.Geolocation.ACCURACY_HIGH;

--- a/tests/Resources/ti.locale.test.js
+++ b/tests/Resources/ti.locale.test.js
@@ -136,14 +136,14 @@ describe('Titanium.Locale', () => {
 			});
 
 			// https://jira-archive.titaniumsdk.com/TIMOB-26651
-			it('handles locale/country specific languages (i.e. en-GB vs en-US)', () => {
+			it('handles locale/country specific languages (e.g. en-GB vs en-US)', () => {
 				Ti.Locale.language = 'en-GB';
 				should(Ti.Locale.getString('this_is_my_key')).eql('this is my en-GB value'); // This fails on Windows, gives 'this is my value'
 				should(L('this_is_my_key')).eql('this is my en-GB value'); // This fails on Windows, gives 'this is my value'
 			});
 
 			// and then this one fails because it's using en-GB strings after we tell it to be ja...
-			it('handles single segment language (i.e. ja)', () => {
+			it('handles single segment language (e.g. ja)', () => {
 				Ti.Locale.language = 'ja';
 				should(Ti.Locale.getString('this_is_my_key')).eql('これは私の値です');
 				should(L('this_is_my_key')).eql('これは私の値です');

--- a/tests/Resources/ti.media.audioplayer.test.js
+++ b/tests/Resources/ti.media.audioplayer.test.js
@@ -122,7 +122,7 @@ describe('Titanium.Media.AudioPlayer', () => {
 
 			// FIXME: This hangs on Android 5 and macOS! It's unclear why...
 			it.windowsMissing('gives around 45 seconds for test input', function (finish) {
-				// skip on older android since it intermittently hangs forever on android 5 emulator
+				// skip on older Android since it intermittently hangs forever on Android 5 emulator
 				if (OS_ANDROID && OS_VERSION_MAJOR < 6) {
 					return finish();
 				}
@@ -263,7 +263,7 @@ describe('Titanium.Media.AudioPlayer', () => {
 			});
 
 			it('called delayed after #start()', function (finish) {
-				// skip on older android since it intermittently hangs forever on android 5 emulator
+				// skip on older Android since it intermittently hangs forever on Android 5 emulator
 				if (OS_ANDROID && OS_VERSION_MAJOR < 6) {
 					return finish();
 				}

--- a/tests/Resources/ti.media.audioplayer.test.js
+++ b/tests/Resources/ti.media.audioplayer.test.js
@@ -452,7 +452,7 @@ describe('Titanium.Media.AudioPlayer', () => {
 	});
 
 	it.ios('TIMOB-26533', function (finish) {
-		//	Ti.Media.Audio player without url set is crashing while registering for event listener
+		//	Ti.Media.Audio player without URL set is crashing while registering for event listener
 		audioPlayer = null;
 		audioPlayer = Ti.Media.createAudioPlayer();
 

--- a/tests/Resources/ti.media.audiorecorder.test.js
+++ b/tests/Resources/ti.media.audiorecorder.test.js
@@ -155,7 +155,7 @@ describe('Titanium.Media.AudioRecorder', () => {
 	});
 
 	it('#start, #pause, #resume, #stop', function (finish) {
-		// skip on older android since it intermittently hangs forever on android 5 emulator
+		// skip on older Android since it intermittently hangs forever on Android 5 emulator
 		if (OS_ANDROID && OS_VERSION_MAJOR < 6) {
 			return finish();
 		}

--- a/tests/Resources/ti.media.sound.test.js
+++ b/tests/Resources/ti.media.sound.test.js
@@ -14,7 +14,7 @@ describe('Titanium.Media', () => {
 });
 
 describe('Titanium.Media.Sound', function () {
-	it.windowsPhoneBroken('apiName', function () { // this crashes windows phone
+	it.windowsPhoneBroken('apiName', function () { // this crashes Windows Phone
 		const sound = Ti.Media.createSound();
 		should(sound).have.a.readOnlyProperty('apiName').which.is.a.String();
 		should(sound.apiName).be.eql('Ti.Media.Sound');

--- a/tests/Resources/ti.media.test.js
+++ b/tests/Resources/ti.media.test.js
@@ -74,7 +74,7 @@ describe('Titanium.Media', () => {
 			it('is an Array', () => {
 				// TODO: Verify it's an array of numbers
 				should(Ti.Media).have.a.readOnlyProperty('availableCameras').which.is.an.Array();
-				should(Ti.Media.availableCameras).be.an.Array(); // necessary for ios devices due to way we sniff api usage to turn on/off defines
+				should(Ti.Media.availableCameras).be.an.Array(); // necessary for iOS devices due to way we sniff API usage to turn on/off defines
 			});
 
 			// TODO: Verify the members of the array are one of these constants!
@@ -88,7 +88,7 @@ describe('Titanium.Media', () => {
 
 		describe.ios('.availablePhotoGalleryMediaTypes', () => {
 			it('is am Array', () => {
-				// TODO: verify it's an array of Strings
+				// TODO: verify it's an array of strings
 				should(Ti.Media).have.a.property('availablePhotoGalleryMediaTypes').which.is.an.Array();
 			});
 
@@ -178,7 +178,7 @@ describe('Titanium.Media', () => {
 		describe('.isCameraSupported', () => {
 			it('is a Boolean', () => {
 				should(Ti.Media).have.a.readOnlyProperty('isCameraSupported').which.is.a.Boolean();
-				should(Ti.Media.isCameraSupported).be.a.Boolean(); // necessary for ios devices due to way we sniff api usage to turn on/off defines
+				should(Ti.Media.isCameraSupported).be.a.Boolean(); // necessary for iOS devices due to way we sniff API usage to turn on/off defines
 			});
 		});
 

--- a/tests/Resources/ti.media.videoplayer.test.js
+++ b/tests/Resources/ti.media.videoplayer.test.js
@@ -457,7 +457,7 @@ describe.androidARM64Broken('Titanium.Media.VideoPlayer', () => {
 		win.open();
 	});
 
-	it.ios('App should not crash when setting video player url to null (TIMOB-27799)', function (finish) {
+	it.ios('App should not crash when setting video player URL to null (TIMOB-27799)', function (finish) {
 		this.timeout(10000);
 
 		win = Ti.UI.createWindow();
@@ -479,7 +479,7 @@ describe.androidARM64Broken('Titanium.Media.VideoPlayer', () => {
 		win.open();
 	});
 
-	it.ios('App should not crash when setting url after video player creation (TIMOB-28217)', function (finish) {
+	it.ios('App should not crash when setting URL after video player creation (TIMOB-28217)', function (finish) {
 		this.timeout(10000);
 
 		win = Ti.UI.createWindow();

--- a/tests/Resources/ti.network.httpclient.test.js
+++ b/tests/Resources/ti.network.httpclient.test.js
@@ -675,7 +675,7 @@ describe('Titanium.Network.HTTPClient', function () {
 					}
 					return finish();
 				}
-				finish(new Error('invalid json response!\n\n' + JSON.stringify(response, null, 1)));
+				finish(new Error('invalid JSON response!\n\n' + JSON.stringify(response, null, 1)));
 			} catch (err) {
 				finish(err);
 			}

--- a/tests/Resources/ti.platform.displaycaps.test.js
+++ b/tests/Resources/ti.platform.displaycaps.test.js
@@ -29,8 +29,8 @@ describe('Titanium.Platform.DisplayCaps', () => {
 
 			it('is one of known values', () => {
 				should([
-					'xxxhigh', // Android 4x 560+ dpi (note that android's constant is for 640 == xxxhdpi)
-					'xxhigh', // Android 3x 400+ dpi (note that android's constant is for 480 == xxhdpi)
+					'xxxhigh', // Android 4x 560+ dpi (note that Android's constant is for 640 == xxxhdpi)
+					'xxhigh', // Android 3x 400+ dpi (note that Android's constant is for 480 == xxhdpi)
 					'xhigh', // iOS 3x, Android 280+ dpi (note their constant is for 320dpi == xhdpi!)
 					'high', // 2x on iOS, Android 240 dpi (hdpi)
 					'tvdpi', // Android 213 dpi (720p TV screen)

--- a/tests/Resources/ti.platform.test.js
+++ b/tests/Resources/ti.platform.test.js
@@ -460,7 +460,7 @@ describe('Titanium.Platform', () => {
 				}
 			});
 
-			// FIXME: macOS pops dialogs about no application set to open this url scheme
+			// FIXME: macOS pops dialogs about no application set to open this URL scheme
 			it.ios('(url, callback) with unhandled scheme passes Error to callback', finish => {
 				Ti.Platform.openURL('randomapp://', _e => finish());
 			});

--- a/tests/Resources/ti.platform.test.js
+++ b/tests/Resources/ti.platform.test.js
@@ -19,7 +19,7 @@ describe('Titanium.Platform', () => {
 
 	describe('properties', () => {
 		describe('.address', () => {
-			// may be undefined on ios sim!
+			// may be undefined on iOS sim!
 			before(function () {
 				if (IOS_SIM || OS_MACOS) {
 					this.skip();
@@ -32,7 +32,7 @@ describe('Titanium.Platform', () => {
 
 			it('matches IP address format if defined', () => {
 				should(Ti.Platform.address).match(/\d+\.\d+\.\d+\.\d+/);
-				// TODO Verify the format of the String. Should be an IP address, so like: /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/
+				// TODO Verify the format of the string. Should be an IP address, so like: /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/
 			});
 		});
 
@@ -172,7 +172,7 @@ describe('Titanium.Platform', () => {
 		});
 
 		describe('.netmask', () => {
-			// may be undefined on ios sim!
+			// may be undefined on iOS sim!
 			before(function () {
 				if (IOS_SIM || OS_MACOS) {
 					this.skip();

--- a/tests/Resources/ti.test.js
+++ b/tests/Resources/ti.test.js
@@ -33,7 +33,7 @@ describe('Titanium', () => {
 
 			it('matches expected format/value', () => {
 				should(Ti.version).not.eql('__VERSION__'); // This is the placeholder value used in iOS, let's ensure we replaced it!
-				should(Ti.version).match(/\d+\.\d+\.\d+/); // i.e. '9.0.0' (the short version string, no timestamp qualifier)
+				should(Ti.version).match(/\d+\.\d+\.\d+/); // e.g. '9.0.0' (the short version string, no timestamp qualifier)
 				// Build plugin "mocha.test.support" stores SDK version to app properties.
 				should(Ti.version).eql(Ti.App.Properties.getString('Ti.version'));
 			});
@@ -50,7 +50,7 @@ describe('Titanium', () => {
 
 			it('matches expected format/value', () => {
 				should(Ti.buildDate).not.eql('__TIMESTAMP__'); // This is the placeholder value used in iOS, let's ensure we replaced it!
-				should(Ti.buildDate).match(/[01]?\d\/[0123]?\d\/20\d{2} \d{2}:\d{2}/); // i.e. '4/14/2020 18:48'
+				should(Ti.buildDate).match(/[01]?\d\/[0123]?\d\/20\d{2} \d{2}:\d{2}/); // e.g. '4/14/2020 18:48'
 			});
 
 			it('has no getter', () => {

--- a/tests/Resources/ti.ui.button.test.js
+++ b/tests/Resources/ti.ui.button.test.js
@@ -108,7 +108,7 @@ describe('Titanium.UI.Button', function () {
 		win.addEventListener('focus', function () {
 			try {
 				view.image = Ti.Filesystem.getFile('Logo.png').read();
-				should(view.image).be.an.Object(); // ios gives null
+				should(view.image).be.an.Object(); // iOS gives null
 			} catch (err) {
 				return finish(err);
 			}

--- a/tests/Resources/ti.ui.clipboard.test.js
+++ b/tests/Resources/ti.ui.clipboard.test.js
@@ -30,7 +30,7 @@ describe('Titanium.UI.Clipboard', () => {
 	// we take in 'color' -> they report 'com.apple.uikit.color'
 	// we take in 'text/plain' -> they report 'public.plain-text'
 	// we take in 'url' -> they report 'public.url'
-	// setting an url can also give us 'public.utf8-plain-text'
+	// setting an URL can also give us 'public.utf8-plain-text'
 	// setting an image can give us multiple types: 'com.apple.uikit.image', 'public.png', 'public.jpeg'
 
 	describe('properties', () => {

--- a/tests/Resources/ti.ui.imageview.test.js
+++ b/tests/Resources/ti.ui.imageview.test.js
@@ -51,7 +51,7 @@ describe('Titanium.UI.ImageView', function () {
 			should(imageView.image).eql('path/to/logo.png');
 		});
 
-		// FIXME Android and iOS don't fire the 'load' event! Seems like android only fires load if image isn't in cache
+		// FIXME Android and iOS don't fire the 'load' event! Seems like Android only fires load if image isn't in cache
 		it.androidAndIosBroken('with a local file path', finish => {
 			const imageView = Ti.UI.createImageView();
 			imageView.addEventListener('load', function () {
@@ -66,7 +66,7 @@ describe('Titanium.UI.ImageView', function () {
 			imageView.image = Ti.Filesystem.resourcesDirectory + 'Logo.png';
 		});
 
-		// FIXME Android and iOS don't fire the 'load' event! Seems like android only fires load if image isn't in cache
+		// FIXME Android and iOS don't fire the 'load' event! Seems like Android only fires load if image isn't in cache
 		it.androidAndIosBroken('with a local path with separator', finish => {
 			const imageView = Ti.UI.createImageView();
 			imageView.addEventListener('load', function () {
@@ -83,7 +83,7 @@ describe('Titanium.UI.ImageView', function () {
 			imageView.image = Ti.Filesystem.resourcesDirectory + Ti.Filesystem.separator + 'Logo.png';
 		});
 
-		// FIXME Android and iOS don't fire the 'load' event! Seems like android only fires load if image isn't in cache
+		// FIXME Android and iOS don't fire the 'load' event! Seems like Android only fires load if image isn't in cache
 		it.androidAndIosBroken('with local path with /', finish => {
 			const imageView = Ti.UI.createImageView();
 			imageView.addEventListener('load', function () {
@@ -100,7 +100,7 @@ describe('Titanium.UI.ImageView', function () {
 			imageView.image = Ti.Filesystem.resourcesDirectory + '/Logo.png';
 		});
 
-		// FIXME Android and iOS don't fire the 'load' event! Seems like android only fires load if image isn't in cache
+		// FIXME Android and iOS don't fire the 'load' event! Seems like Android only fires load if image isn't in cache
 		it.androidAndIosBroken('with Ti.Filesystem.File.nativePath value', finish => {
 			const fromFile = Ti.Filesystem.getFile(Ti.Filesystem.resourcesDirectory, 'Logo.png');
 			const imageView = Ti.UI.createImageView();
@@ -152,7 +152,7 @@ describe('Titanium.UI.ImageView', function () {
 		});
 
 		// Windows: TIMOB-24985
-		// FIXME Android and iOS don't fire the 'load' event! Seems like android only fires load if image isn't in cache
+		// FIXME Android and iOS don't fire the 'load' event! Seems like Android only fires load if image isn't in cache
 		it.allBroken('with Ti.Fielsystem.File', finish => {
 			const fromFile = Ti.Filesystem.getFile(Ti.Filesystem.resourcesDirectory, 'Logo.png');
 

--- a/tests/Resources/ti.ui.ios.webviewconfiguration.test.js
+++ b/tests/Resources/ti.ui.ios.webviewconfiguration.test.js
@@ -129,4 +129,4 @@ describe.ios('Titanium.UI.iOS.WebViewConfiguration', function () {
 	});
 });
 
-// TO DO: Add more unit tests for WebViewConfiguration and WebViewDecisionHandlerProxy
+// TODO: Add more unit tests for WebViewConfiguration and WebViewDecisionHandlerProxy

--- a/tests/Resources/ti.ui.matrix2d.test.js
+++ b/tests/Resources/ti.ui.matrix2d.test.js
@@ -15,7 +15,7 @@ describe('Titanium.UI.Matrix2D', function () {
 	it.iosBroken('apiName', function () {
 		var matrix = Ti.UI.createMatrix2D();
 		should(matrix).have.readOnlyProperty('apiName').which.is.a.String();
-		should(matrix.apiName).be.eql('Ti.UI.Matrix2D'); // ios still reports Ti.UI.2DMatrix
+		should(matrix.apiName).be.eql('Ti.UI.Matrix2D'); // iOS still reports Ti.UI.2DMatrix
 	});
 
 	it('#invert()', function () {

--- a/tests/Resources/ti.ui.progressbar.test.js
+++ b/tests/Resources/ti.ui.progressbar.test.js
@@ -79,7 +79,7 @@ describe('Titanium.UI.ProgressBar', () => {
 			});
 		});
 
-		// FIXME: Add android support for the font property
+		// FIXME: Add Android support for the font property
 		describe.ios('.font', () => {
 			beforeEach(() => {
 				bar = Ti.UI.createProgressBar({

--- a/tests/Resources/ti.ui.test.js
+++ b/tests/Resources/ti.ui.test.js
@@ -419,7 +419,7 @@ describe('Titanium.UI', function () {
 			const suffix = OS_IOS ? `_${Ti.UI.semanticColorType}` : '';
 			const view = Ti.UI.createView({
 				backgroundColor,
-				// NOTE: use a number divisble by 1, 2, 3 or 4 because ios scale may be one of those numbers!
+				// NOTE: use a number divisible by 1, 2, 3 or 4 because iOS scale may be one of those numbers!
 				// And bug in TiBlob on iOS reports width/height in pts, not px
 				width: '12px',
 				height: '12px'

--- a/tests/Resources/ti.ui.view.test.js
+++ b/tests/Resources/ti.ui.view.test.js
@@ -352,7 +352,7 @@ describe('Titanium.UI.View', function () {
 
 	// FIXME: Windows 10 Store app fails for this...need to figure out why.
 	it.windowsBroken('animate (top)', function (finish) {
-		if (isCI && utilities.isMacOS()) { // for whatever reaosn this fails on ci nodes, but not locally. Maybe issue with headless mac?
+		if (isCI && utilities.isMacOS()) { // for whatever reaosn this fails on CI nodes, but not locally. Maybe issue with headless mac?
 			return finish(); // FIXME: skip when we move to official mocha package
 		}
 		win = Ti.UI.createWindow();
@@ -391,7 +391,7 @@ describe('Titanium.UI.View', function () {
 	});
 
 	it('animate (top) - autoreverse', function (finish) {
-		if (isCI && utilities.isMacOS()) { // for whatever reaosn this fails on ci nodes, but not locally. Maybe issue with headless mac?
+		if (isCI && utilities.isMacOS()) { // for whatever reason this fails on CI nodes, but not locally. Maybe issue with headless mac?
 			return finish(); // FIXME: skip when we move to official mocha package
 		}
 		win = Ti.UI.createWindow();
@@ -432,7 +432,7 @@ describe('Titanium.UI.View', function () {
 
 	// FIXME: Windows 10 Store app fails for this...need to figure out why.
 	it.windowsBroken('animate (left)', function (finish) {
-		if (isCI && utilities.isMacOS()) { // for whatever reaosn this fails on ci nodes, but not locally. Maybe issue with headless mac?
+		if (isCI && utilities.isMacOS()) { // for whatever reason this fails on CI nodes, but not locally. Maybe issue with headless mac?
 			return finish(); // FIXME: skip when we move to official mocha package
 		}
 		win = Ti.UI.createWindow();
@@ -522,7 +522,7 @@ describe('Titanium.UI.View', function () {
 
 	// FIXME: Windows 10 Store app fails for this...need to figure out why.
 	it.windowsBroken('animate (left %)', function (finish) {
-		if (isCI && utilities.isMacOS()) { // for whatever reaosn this fails on ci nodes, but not locally. Maybe issue with headless mac?
+		if (isCI && utilities.isMacOS()) { // for whatever reaosn this fails on CI nodes, but not locally. Maybe issue with headless mac?
 			return finish(); // FIXME: skip when we move to official mocha package
 		}
 		win = Ti.UI.createWindow();
@@ -559,7 +559,7 @@ describe('Titanium.UI.View', function () {
 
 	// FIXME: Windows 10 Store app fails for this...need to figure out why.
 	it.windowsBroken('animate (top %)', function (finish) {
-		if (isCI && utilities.isMacOS()) { // for whatever reaosn this fails on ci nodes, but not locally. Maybe issue with headless mac?
+		if (isCI && utilities.isMacOS()) { // for whatever reason this fails on CI nodes, but not locally. Maybe issue with headless mac?
 			return finish(); // FIXME: skip when we move to official mocha package
 		}
 		win = Ti.UI.createWindow();
@@ -595,7 +595,7 @@ describe('Titanium.UI.View', function () {
 
 	// FIXME: Windows 10 Store app fails for this...need to figure out why.
 	it.windowsBroken('animate (width %)', function (finish) {
-		if (isCI && utilities.isMacOS()) { // for whatever reaosn this fails on ci nodes, but not locally. Maybe issue with headless mac?
+		if (isCI && utilities.isMacOS()) { // for whatever reason this fails on CI nodes, but not locally. Maybe issue with headless mac?
 			return finish(); // FIXME: skip when we move to official mocha package
 		}
 		win = Ti.UI.createWindow();
@@ -632,7 +632,7 @@ describe('Titanium.UI.View', function () {
 
 	// FIXME: Windows 10 Store app fails for this...need to figure out why.
 	it.windowsBroken('animate (height %)', function (finish) {
-		if (isCI && utilities.isMacOS()) { // for whatever reaosn this fails on ci nodes, but not locally. Maybe issue with headless mac?
+		if (isCI && utilities.isMacOS()) { // for whatever reaosn this fails on CI nodes, but not locally. Maybe issue with headless mac?
 			return finish(); // FIXME: skip when we move to official mocha package
 		}
 		win = Ti.UI.createWindow();

--- a/tests/Resources/ti.ui.webview.test.js
+++ b/tests/Resources/ti.ui.webview.test.js
@@ -675,7 +675,7 @@ describe('Titanium.UI.WebView', function () {
 		win.open();
 	});
 
-	it('requestHeaders with redirecting url should work properly', function (finish) {
+	it('requestHeaders with redirecting URL should work properly', function (finish) {
 		win = Ti.UI.createWindow();
 		const webView = Ti.UI.createWebView({
 			url: 'https://mockbin.org/redirect/301?to=https%3A%2F%2Fgoogle.com',
@@ -752,7 +752,7 @@ describe('Titanium.UI.WebView', function () {
 
 				should(e).have.a.property('url').which.is.a.String();
 				should(e.url).startWith('https://www.google.com');
-				// Sometimes we get an url like: https://www.google.com/#spf=1588254369582
+				// Sometimes we get an URL like: https://www.google.com/#spf=1588254369582
 				// should(e.url).be.equalOneOf([ 'https://www.google.com/', 'https://www.google.com' ]);
 			} catch (err) {
 				return finish(err);

--- a/tests/Resources/ti.ui.window.test.js
+++ b/tests/Resources/ti.ui.window.test.js
@@ -246,8 +246,8 @@ describe('Titanium.UI.Window', function () {
 		});
 
 		it.ios('.leftNavButton with default color (no color value) and .rightNavButton with tintColor', finish => {
-			// TO DO: Snapshots for different iPads are different. Can not test with static image.
-			// Probably try with snapshot comparision (with and without color) at run time
+			// TODO: Snapshots for different iPads are different. Can not test with static image.
+			// Probably try with snapshot comparison (with and without color) at run time
 			if (utilities.isMacOS() || utilities.isIPad()) {
 				return finish(); // how to skip for iPad?
 			}
@@ -291,8 +291,8 @@ describe('Titanium.UI.Window', function () {
 		});
 
 		it.ios('.leftNavButton and .rightNavButton  with color and tintColor', finish => {
-			// TO DO: Snapshots for different iPads are different. Can not test with static image.
-			// Probably try with snapshot comparision (with and without color) at run time
+			// TODO: Snapshots for different iPads are different. Can not test with static image.
+			// Probably try with snapshot comparison (with and without color) at run time
 			if (utilities.isMacOS() || utilities.isIPad()) {
 				return finish(); // how to skip for iPad?
 			}
@@ -1004,7 +1004,7 @@ describe('Titanium.UI.Window', function () {
 		let thirdWindowOpen = 0;
 		let thirdWindowClose = 0;
 
-		// Create 3 windows in sucession, opening each, then once opened create.open next. Once last one is open,
+		// Create 3 windows in succession, opening each, then once opened create.open next. Once last one is open,
 		// schedule it to be closed, and as it gets closed schedule the one before it to close, etc.
 		// once last window is closed, verify the number of events we get fired on each window (close/open/focus/blur)
 
@@ -1057,7 +1057,7 @@ describe('Titanium.UI.Window', function () {
 			// now wrap up test!
 			try {
 				should(rootWindowFocus).be.eql(2);
-				should(rootWindowBlur).be.eql(2); // FIXME: ios gives us 1 here!
+				should(rootWindowBlur).be.eql(2); // FIXME: iOS gives us 1 here!
 				should(rootWindowOpen).be.eql(1);
 				should(rootWindowClose).be.eql(1);
 
@@ -1200,8 +1200,8 @@ describe('Titanium.UI.Window', function () {
 		win.close();
 		// wait until a window should have opened and fired the event...
 		setTimeout(() => finish(), 1000);
-		// locally android took 106,67,64ms
-		// ios took 1ms repeatedly
+		// locally Android took 106,67,64ms
+		// iOS took 1ms repeatedly
 		// so 1 second should be enough time.
 	});
 

--- a/tests/Resources/ti.xml.test.js
+++ b/tests/Resources/ti.xml.test.js
@@ -13,7 +13,7 @@ describe.windowsBroken('Titanium.XML', function () {
 	var testSource = {},
 		invalidSource = {};
 
-	// some common initialization specific to the xml suite
+	// some common initialization specific to the XML suite
 	function countNodes(node, type) {
 		var nodeCount = 0,
 			i,

--- a/tests/Resources/util.test.js
+++ b/tests/Resources/util.test.js
@@ -1176,11 +1176,11 @@ describe('util', () => {
 			function original(...args) {
 				return args;
 			}
-			const deprecated = util.deprecate(original, 'dont call me Al');
+			const deprecated = util.deprecate(original, 'don\'t call me Al');
 			// this should get called synchronously, so I don't think we need to do any setTimeout/async finished stuff
 			process.once('warning', warning => {
 				warning.name.should.eql('DeprecationWarning');
-				warning.message.should.eql('dont call me Al');
+				warning.message.should.eql('don\'t call me Al');
 			});
 			const result = deprecated(null, 123);
 			should(result).eql([ null, 123 ]);

--- a/tests/Resources/utilities/assertions.js
+++ b/tests/Resources/utilities/assertions.js
@@ -1,5 +1,5 @@
 'use strict';
-/* globals OS_ANDROID,OS_IOS */
+/* globals OS_ANDROID, OS_IOS */
 const should = require('should');
 const utilities = require('./utilities');
 const isIOSDevice = OS_IOS && !Ti.Platform.model.includes('(Simulator)');
@@ -322,7 +322,7 @@ should.Assertion.add('matchImage', function (image, options = { threshold: 0.1, 
 	}
 }, false);
 
-// TODO Add an assertion for "exclusive" group of constants: A set of constants whose values must be unique (basically an enum), i.e. Ti.UI.FILL vs SIZE vs UNKNOWN
+// TODO Add an assertion for "exclusive" group of constants: A set of constants whose values must be unique (basically an enum), e.g. Ti.UI.FILL vs SIZE vs UNKNOWN
 // TODO Use more custom assertions for things like color properties?
 module.exports = should;
 

--- a/tests/modules-source/ti.modulesdk920/android/.clang-format
+++ b/tests/modules-source/ti.modulesdk920/android/.clang-format
@@ -21,6 +21,6 @@ SpacesInParentheses: false
 TabWidth: 4
 UseTab: ForContinuationAndIndentation
 SpaceAfterCStyleCast: true
-# Spaces inside {} for array literals, i.e. "new Object[] { args }"
+# Spaces inside {} for array literals, e.g. "new Object[] { args }"
 Cpp11BracedListStyle: false
 ReflowComments: false


### PR DESCRIPTION
After https://github.com/tidev/titanium-sdk/pull/14340 here comes a larger PR.

**Description**

Fixes in logs and comments:
- fixed typos
- fixed wording: `ABI`, `Android`, `API`, `AVD`, `CI`, `CLI`, `CPU`, `e.g.`, `HTML`, `iOS`, `iPad`, `Java`, `JavaScript`, `JDK`, `JNI`, `JS`, `JSON`, `macOS`, `PDF`, `SDK`, `Titanium`, `TODO`, `URI`, `URL`, `Windows` (the OS), `XML`
- fixed `i.e.` &rarr;`e.g.` in sense of an example
- fixed apostrophe in contractions `don't`, `doesn't`, ...

 Fixes in code (not API-relevant):
- variable `overridenLayout` &rarr; `overriddenLayout`
- variable `resultElemet`&rarr; `resultElement`
- variable `tempLenght` &rarr; `tempLength`
- variable `unstrechedSize` &rarr; `unstretchedSize`
- variable `TiCanvasFillElipse` &rarr; `TiCanvasFillEllipse`
- variable `initBackGround` &rarr; `initBackground`
- function `initSearhController` &rarr; `initSearchController` in `TiUITableView`
- function `test_AbsoluteLayout_LeftPropery` &rarr; `test_AbsoluteLayout_LeftProperty`
- function `test_AbsoluteLayout_RightPropery` &rarr; `test_AbsoluteLayout_RightProperty`
- function `test_AbsoluteLayout_TopPropery` &rarr; `test_AbsoluteLayout_TopProperty`
- function `test_AbsoluteLayout_BottomPropery` &rarr; `test_AbsoluteLayout_BottomProperty`

Fixes in code (**API-relevant**):
-  function `deleteAllSearchableItemByDomainIdenifiers:` &rarr; `deleteAllSearchableItemByDomainIdentifiers:` in `TiAppiOSSearchableIndexProxy`
  - marked `deleteAllSearchableItemByDomainIdenifiers:` as _deprecated_
- function `isOrientationPortait` &rarr; `isOrientationPortrait` in `TiUtils`  
  - marked `isOrientationPortait` as _deprecated_

Fixes in code (potential bugs):
- call `ENSURE_IOS_API(@"10", @"Ti.App.iOS.SearchableItemAttributSet.postalCode")` &rarr; `ENSURE_IOS_API(@"10", @"Ti.App.iOS.SearchableItemAttributeSet.postalCode")`


