### PR TITLE
chore: allowed multiple arguments for further scons commands

### DIFF
--- a/build/scons-clean.js
+++ b/build/scons-clean.js
@@ -9,7 +9,9 @@ import { fileURLToPath } from 'node:url';
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 const { version } = fs.readJsonSync(path.join(__dirname, '../package.json'));
 
-program.option('-v, --sdk-version [version]', 'Override the SDK version we report', process.env.PRODUCT_VERSION || version)
+program
+	.allowExcessArguments()
+	.option('-v, --sdk-version [version]', 'Override the SDK version we report', process.env.PRODUCT_VERSION || version)
 	.option('-t, --version-tag [tag]', 'Override the SDK version tag we report')
 	.option('-s, --android-sdk [path]', 'Explicitly set the path to the Android SDK used for building')
 	.option('-a, --all', 'Clean every OS/platform')

--- a/build/scons-install.js
+++ b/build/scons-install.js
@@ -10,6 +10,7 @@ const __dirname = fileURLToPath(new URL('.', import.meta.url));
 const { version } = fs.readJsonSync(path.join(__dirname, '../package.json'));
 
 program
+	.allowExcessArguments()
 	.option('-v, --sdk-version [version]', 'Override the SDK version we report', process.env.PRODUCT_VERSION || version)
 	.option('-t, --version-tag [tag]', 'Override the SDK version tag we report')
 	.option('-s, --symlink', 'If possible, symlink the SDK folder to destination rather than copying')

--- a/build/scons-package.js
+++ b/build/scons-package.js
@@ -10,6 +10,7 @@ const __dirname = fileURLToPath(new URL('.', import.meta.url));
 const { version } = fs.readJsonSync(path.join(__dirname, '../package.json'));
 
 program
+	.allowExcessArguments()
 	.option('-a, --all', 'Build a zipfile for every OS')
 	.option('-v, --sdk-version [version]', 'Override the SDK version we report', process.env.PRODUCT_VERSION || version)
 	.option('-t, --version-tag [tag]', 'Override the SDK version tag we report')


### PR DESCRIPTION
**Introduction:**

https://github.com/tidev/titanium-sdk/pull/14312 allowed multiple arguments for the scons command `build`, `cleanbuild` and `test`.
Running e.g. `npm run clean:ios` or directly `node ./build/scons clean ios` still produces:

`error: too many arguments. Expected 0 arguments but got 1.`

**Description:**
- allowed multiple arguments also for`clean`, `install` and `package` command