### PR TITLE
chore(ios): removed unused imports and const in install hook

### DIFF
--- a/iphone/cli/hooks/install.js
+++ b/iphone/cli/hooks/install.js
@@ -7,11 +7,7 @@
 
 import appc from 'node-appc';
 import async from 'async';
-import fs from 'node:fs';
 import ioslib from 'ioslib';
-import path from 'node:path';
-
-const { run } = appc.subprocess;
 
 export const cliVersion = '>=3.2';
 


### PR DESCRIPTION
**Description:**

I've overseen the 3 GitHub CI warnings in [iphone/cli/hooks/install.js](https://github.com/tidev/titanium-sdk/pull/14331/files#diff-8d3765ae1580530f1b71165fd8e589835550849746562c3cd98747c17ed6e306) when [dropping iTunes Sync](https://github.com/tidev/titanium-sdk/pull/14331).
- 2 imports and 1 const were no longer used, so removed it now
