### PR TITLE
fix(android): fix BottomNavigation selection when using activeTab

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIBottomNavigation.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIBottomNavigation.java
@@ -531,7 +531,9 @@ public class TiUIBottomNavigation extends TiUIAbstractTabGroup implements Bottom
 		currentlySelectedIndex = tabIndex;
 
 		if (bottomNavigation != null && bottomNavigation.getMenu() != null) {
-			bottomNavigation.getMenu().getItem(tabIndex).setChecked(true);
+			if (tabIndex < bottomNavigation.getMenu().size()) {
+				bottomNavigation.getMenu().getItem(tabIndex).setChecked(true);
+			}
 		}
 
 		TabProxy tp = ((TabProxy) tabsArray.get(tabIndex));

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIBottomNavigation.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIBottomNavigation.java
@@ -530,7 +530,9 @@ public class TiUIBottomNavigation extends TiUIAbstractTabGroup implements Bottom
 		}
 		currentlySelectedIndex = tabIndex;
 
-		bottomNavigation.getMenu().getItem(tabIndex).setChecked(true);
+		if (bottomNavigation != null && bottomNavigation.getMenu() != null) {
+			bottomNavigation.getMenu().getItem(tabIndex).setChecked(true);
+		}
 
 		TabProxy tp = ((TabProxy) tabsArray.get(tabIndex));
 		if (tp != null) {

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIBottomNavigation.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIBottomNavigation.java
@@ -49,7 +49,7 @@ import ti.modules.titanium.ui.TabGroupProxy;
 import ti.modules.titanium.ui.TabProxy;
 
 /**
- * TabGroup implementation using BottomNavigationView as a controller.
+ * TabGroup implementation using BottomNavigationView XML as a controller.
  */
 public class TiUIBottomNavigation extends TiUIAbstractTabGroup implements BottomNavigationView.OnItemSelectedListener
 {
@@ -529,6 +529,8 @@ public class TiUIBottomNavigation extends TiUIAbstractTabGroup implements Bottom
 			}
 		}
 		currentlySelectedIndex = tabIndex;
+
+		bottomNavigation.getMenu().getItem(tabIndex).setChecked(true);
 
 		TabProxy tp = ((TabProxy) tabsArray.get(tabIndex));
 		if (tp != null) {


### PR DESCRIPTION
Currently when using the `experimental` Android BottomNavigation the selection won't change when you use `activeTab` to select the tab using code. The content is changing but the old button is still highlighted.

https://github.com/user-attachments/assets/fb2cad7b-429a-42b2-956c-565bfa26dbc1


**Test:**
```js
let win1 = Ti.UI.createWindow({backgroundColor:"red"});
let win2 = Ti.UI.createWindow({backgroundColor:"green"});
let tab1 = Ti.UI.createTab({ window: win1, title: 'tab1', tintColor:"red", activeTintColor:"green", icon: '/images/appicon.png'});
let tab2 = Ti.UI.createTab({window: win2, title: 'tab2', tintColor:"red",  activeTintColor:"green", icon: '/images/appicon.png'});

let bottomNav = Ti.UI.createTabGroup({
	tabs: [tab1, tab2],
	theme: "Theme.Titanium.Material3.DayNight",
  experimental: true,
  style: Ti.UI.Android.TABS_STYLE_BOTTOM_NAVIGATION,
  activeTab: 1
});

bottomNav.open();

setTimeout(function(){
	bottomNav.activeTab = 0
}, 2000)
```

* run the app
* wait 2 seconds
* current issue (13.0.1): tab is changing but selection is still on the first menu item
* with this fix: tab is changing and selection is changing

[fixed](https://github.com/user-attachments/assets/50e7616e-d2ae-426b-b92e-698c680df26a)

