### PR TITLE
chore(ios): removed iOS 8 & 9 guards and fallbacks

### DIFF
--- a/iphone/Classes/MediaModule.m
+++ b/iphone/Classes/MediaModule.m
@@ -985,7 +985,7 @@ MAKE_SYSTEM_PROP(VIDEO_REPEAT_MODE_ONE, VideoRepeatModeOne);
 #endif
 
 #if defined(USE_TI_MEDIAREQUESTCAMERAPERMISSIONS)
-// request camera access. for >= iOS 7
+// request camera access
 - (void)requestCameraPermissions:(id)arg
 {
   ENSURE_SINGLE_ARG(arg, KrollCallback);

--- a/iphone/Classes/MediaModule.m
+++ b/iphone/Classes/MediaModule.m
@@ -137,7 +137,7 @@ static NSDictionary *TI_filterableItemProperties;
                                                         MPMediaItemPropertyGenrePersistentID, @"genrePersistentID",
                                                         MPMediaItemPropertyComposerPersistentID, @"composerPersistentID",
                                                         MPMediaItemPropertyIsCloudItem, @"isCloudItem",
-                                                        [TiUtils isIOSVersionOrGreater:@"9.2"] ? MPMediaItemPropertyHasProtectedAsset : NO, @"hasProtectedAsset",
+                                                        MPMediaItemPropertyHasProtectedAsset, @"hasProtectedAsset",
                                                         MPMediaItemPropertyPodcastTitle, @"podcastTitle",
                                                         MPMediaItemPropertyPodcastPersistentID, @"podcastPersistentID",
                                                         nil];
@@ -985,7 +985,7 @@ MAKE_SYSTEM_PROP(VIDEO_REPEAT_MODE_ONE, VideoRepeatModeOne);
 #endif
 
 #if defined(USE_TI_MEDIAREQUESTCAMERAPERMISSIONS)
-// request camera access. for >= IOS7
+// request camera access. for >= iOS 7
 - (void)requestCameraPermissions:(id)arg
 {
   ENSURE_SINGLE_ARG(arg, KrollCallback);
@@ -1163,8 +1163,7 @@ MAKE_SYSTEM_PROP(VIDEO_REPEAT_MODE_ONE, VideoRepeatModeOne);
 #ifdef USE_TI_MEDIAHASMUSICLIBRARYPERMISSIONS
 - (NSNumber *)hasMusicLibraryPermissions:(id)unused
 {
-  // Will return true for iOS < 9.3, since authorization was introduced in iOS 9.3
-  return NUMBOOL(![TiUtils isIOSVersionOrGreater:@"9.3"] || [MPMediaLibrary authorizationStatus] == MPMediaLibraryAuthorizationStatusAuthorized);
+  return NUMBOOL([MPMediaLibrary authorizationStatus] == MPMediaLibraryAuthorizationStatusAuthorized);
 }
 #endif
 
@@ -1180,26 +1179,18 @@ MAKE_SYSTEM_PROP(VIDEO_REPEAT_MODE_ONE, VideoRepeatModeOne);
   ENSURE_SINGLE_ARG(args, KrollCallback);
   KrollCallback *callback = args;
 
-  if ([TiUtils isIOSVersionOrGreater:@"9.3"]) {
-    TiThreadPerformOnMainThread(
-        ^() {
-          [MPMediaLibrary requestAuthorization:^(MPMediaLibraryAuthorizationStatus status) {
-            BOOL granted = status == MPMediaLibraryAuthorizationStatusAuthorized;
-            KrollEvent *invocationEvent = [[KrollEvent alloc] initWithCallback:callback
-                                                                   eventObject:[TiUtils dictionaryWithCode:(granted ? 0 : 1) message:nil]
-                                                                    thisObject:self];
-            [[callback context] enqueue:invocationEvent];
-            RELEASE_TO_NIL(invocationEvent);
-          }];
-        },
-        NO);
-  } else {
-    NSDictionary *propertiesDict = [TiUtils dictionaryWithCode:0 message:nil];
-    NSArray *invocationArray = [[NSArray alloc] initWithObjects:&propertiesDict count:1];
-    [callback call:invocationArray thisObject:self];
-    [invocationArray release];
-    return;
-  }
+  TiThreadPerformOnMainThread(
+      ^() {
+        [MPMediaLibrary requestAuthorization:^(MPMediaLibraryAuthorizationStatus status) {
+          BOOL granted = status == MPMediaLibraryAuthorizationStatusAuthorized;
+          KrollEvent *invocationEvent = [[KrollEvent alloc] initWithCallback:callback
+                                                                 eventObject:[TiUtils dictionaryWithCode:(granted ? 0 : 1) message:nil]
+                                                                  thisObject:self];
+          [[callback context] enqueue:invocationEvent];
+          RELEASE_TO_NIL(invocationEvent);
+        }];
+      },
+      NO);
 }
 #endif
 
@@ -1210,7 +1201,7 @@ MAKE_SYSTEM_PROP(VIDEO_REPEAT_MODE_ONE, VideoRepeatModeOne);
 
   NSString *musicPermission = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSAppleMusicUsageDescription"];
 
-  if ([TiUtils isIOSVersionOrGreater:@"9.3"] && [MPMediaLibrary authorizationStatus] != MPMediaLibraryAuthorizationStatusAuthorized) {
+  if ([MPMediaLibrary authorizationStatus] != MPMediaLibraryAuthorizationStatusAuthorized) {
     NSLog(@"[ERROR] It looks like you are accessing the music-library without sufficient permissions. Please use the Ti.Media.hasMusicLibraryPermissions() method to validate the permissions and only call this method if permissions are granted.");
   }
 
@@ -2000,7 +1991,7 @@ MAKE_SYSTEM_PROP(VIDEO_REPEAT_MODE_ONE, VideoRepeatModeOne);
   }
 
   BOOL isVideo = [mediaType isEqualToString:(NSString *)kUTTypeMovie];
-  BOOL isLivePhoto = ([TiUtils isIOSVersionOrGreater:@"9.1"] && [mediaType isEqualToString:(NSString *)kUTTypeLivePhoto]);
+  BOOL isLivePhoto = [mediaType isEqualToString:(NSString *)kUTTypeLivePhoto];
 
   NSURL *mediaURL = [editingInfo objectForKey:UIImagePickerControllerMediaURL];
 

--- a/iphone/Classes/TiApp+Addons.m
+++ b/iphone/Classes/TiApp+Addons.m
@@ -100,7 +100,7 @@
 {
   NSMutableDictionary *dict = [NSMutableDictionary dictionaryWithDictionary:@{ @"activityType" : [userActivity activityType] }];
 
-  if ([TiUtils isIOSVersionOrGreater:@"9.0"] && [[userActivity activityType] isEqualToString:CSSearchableItemActionType]) {
+  if ([[userActivity activityType] isEqualToString:CSSearchableItemActionType]) {
     if ([userActivity userInfo] != nil) {
       [dict setObject:[[userActivity userInfo] objectForKey:CSSearchableItemActivityIdentifier] forKey:@"searchableItemActivityIdentifier"];
     }

--- a/iphone/Classes/TiUIAttributedStringProxy.m
+++ b/iphone/Classes/TiUIAttributedStringProxy.m
@@ -107,7 +107,7 @@
         paragraphStyle.lineHeightMultiple = [TiUtils floatValue:objectValue];
       } else if ([key isEqualToString:@"hyphenationFactor"]) {
         paragraphStyle.hyphenationFactor = (float)[TiUtils floatValue:objectValue];
-      } else if ([TiUtils isIOSVersionOrGreater:@"9.0"] && [key isEqualToString:@"allowsDefaultTighteningForTruncation"]) {
+      } else if ([key isEqualToString:@"allowsDefaultTighteningForTruncation"]) {
         paragraphStyle.allowsDefaultTighteningForTruncation = [TiUtils boolValue:objectValue];
       } else {
         DebugLog(@"[WARN] Ti.UI.ATTRIBUTE_PARAGRAPH_STYLE - Unsupported property %@", key);

--- a/iphone/Classes/TiUILabel.m
+++ b/iphone/Classes/TiUILabel.m
@@ -97,7 +97,7 @@
   CGSize actualLabelSize = [[self label] sizeThatFits:CGSizeMake(initialLabelFrame.size.width, 0)];
   UIControlContentVerticalAlignment alignment = verticalAlign;
   if (alignment == UIControlContentVerticalAlignmentFill) {
-    // IOS7 layout issue fix with attributed string.
+    // iOS 7 layout issue fix with attributed string.
     if (actualLabelSize.height < initialLabelFrame.size.height) {
       alignment = UIControlContentVerticalAlignmentCenter;
     } else {

--- a/iphone/Classes/TiUISlider.m
+++ b/iphone/Classes/TiUISlider.m
@@ -263,7 +263,7 @@
 {
   CGFloat result = [[self sliderView] sizeThatFits:CGSizeZero].height;
 
-  // IOS7 DP3 sizeThatFits always returns zero for regular slider
+  // iOS 7 DP3 sizeThatFits always returns zero for regular slider
   if (result == 0) {
     result = 30.0;
   }

--- a/iphone/Classes/TiUIiOSProxy.m
+++ b/iphone/Classes/TiUIiOSProxy.m
@@ -600,29 +600,18 @@ MAKE_SYSTEM_PROP(KEYBOARD_DISMISS_MODE_INTERACTIVE, UIScrollViewKeyboardDismissM
 
 - (NSNumber *)LIVEPHOTO_PLAYBACK_STYLE_FULL
 {
-  if ([TiUtils isIOSVersionOrGreater:@"9.1"]) {
-    return NUMINTEGER(PHLivePhotoViewPlaybackStyleFull);
-  }
-  return nil;
+  return NUMINTEGER(PHLivePhotoViewPlaybackStyleFull);
 }
 
 - (NSNumber *)LIVEPHOTO_PLAYBACK_STYLE_HINT
 {
-  if ([TiUtils isIOSVersionOrGreater:@"9.1"]) {
-    return NUMINTEGER(PHLivePhotoViewPlaybackStyleHint);
-  }
-
-  return nil;
+  return NUMINTEGER(PHLivePhotoViewPlaybackStyleHint);
 }
 #endif
 
 #ifdef USE_TI_UIIOSLIVEPHOTOBADGE
 - (TiBlob *)createLivePhotoBadge:(id)value
 {
-  if (![TiUtils isIOSVersionOrGreater:@"9.1"]) {
-    return nil;
-  }
-
   ENSURE_ARG_COUNT(value, 1);
   ENSURE_ARRAY(value);
   id option = [value objectAtIndex:0];
@@ -643,20 +632,14 @@ MAKE_SYSTEM_PROP(KEYBOARD_DISMISS_MODE_INTERACTIVE, UIScrollViewKeyboardDismissM
 #ifdef USE_TI_UIIOSLIVEPHOTO_BADGE_OPTIONS_OVER_CONTENT
 - (NSNumber *)LIVEPHOTO_BADGE_OPTIONS_OVER_CONTENT
 {
-  if ([TiUtils isIOSVersionOrGreater:@"9.1"]) {
-    return NUMINTEGER(PHLivePhotoBadgeOptionsOverContent);
-  }
-  return NUMINT(0);
+  return NUMINTEGER(PHLivePhotoBadgeOptionsOverContent);
 }
 #endif
 
 #ifdef USE_TI_UIIOSLIVEPHOTO_BADGE_OPTIONS_LIVE_OFF
 - (NSNumber *)LIVEPHOTO_BADGE_OPTIONS_LIVE_OFF
 {
-  if ([TiUtils isIOSVersionOrGreater:@"9.1"]) {
-    return NUMINTEGER(PHLivePhotoBadgeOptionsLiveOff);
-  }
-  return NUMINT(0);
+  return NUMINTEGER(PHLivePhotoBadgeOptionsLiveOff);
 }
 #endif
 

--- a/iphone/Classes/WatchSessionModule.m
+++ b/iphone/Classes/WatchSessionModule.m
@@ -130,7 +130,7 @@
 
 - (NSNumber *)isActivated
 {
-  if ([TiUtils isIOSVersionOrGreater:@"9.3"] && [WCSession isSupported]) {
+  if ([WCSession isSupported]) {
     return NUMBOOL([[self watchSession] activationState] == WCSessionActivationStateActivated);
   }
   return NUMBOOL(NO);
@@ -156,7 +156,7 @@
 
 - (NSNumber *)activationState
 {
-  if ([TiUtils isIOSVersionOrGreater:@"9.3"] && [WCSession isSupported]) {
+  if ([WCSession isSupported]) {
     return [NSNumber numberWithInteger:[[self watchSession] activationState]];
   }
 
@@ -448,25 +448,16 @@
 
 - (NSNumber *)ACTIVATION_STATE_NOT_ACTIVATED
 {
-  if (![TiUtils isIOSVersionOrGreater:@"9.3"]) {
-    return nil;
-  }
   return NUMINTEGER(WCSessionActivationStateNotActivated);
 }
 
 - (NSNumber *)ACTIVATION_STATE_INACTIVE
 {
-  if (![TiUtils isIOSVersionOrGreater:@"9.3"]) {
-    return nil;
-  }
   return NUMINTEGER(WCSessionActivationStateInactive);
 }
 
 - (NSNumber *)ACTIVATION_STATE_ACTIVATED
 {
-  if (![TiUtils isIOSVersionOrGreater:@"9.3"]) {
-    return nil;
-  }
   return NUMINTEGER(WCSessionActivationStateActivated);
 }
 
@@ -481,10 +472,8 @@
     @"isComplicationEnabled" : [self isComplicationEnabled]
   }];
 
-  if ([TiUtils isIOSVersionOrGreater:@"9.3"]) {
-    [dict setObject:[self isActivated] forKey:@"isActivated"];
-    [dict setObject:[self activationState] forKey:@"activationState"];
-  }
+  [dict setObject:[self isActivated] forKey:@"isActivated"];
+  [dict setObject:[self activationState] forKey:@"activationState"];
 
   [dict setObject:[self hasContentPending] forKey:@"hasContentPending"];
   [dict setObject:[self remainingComplicationUserInfoTransfers] forKey:@"remainingComplicationUserInfoTransfers"];

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiApp.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiApp.m
@@ -359,7 +359,7 @@ TI_INLINE void waitForMemoryPanicCleared(void); // WARNING: This must never be r
   if (userActivity != nil && [userActivity isKindOfClass:[NSUserActivity class]]) {
     NSMutableDictionary *dict = [NSMutableDictionary dictionaryWithDictionary:@{ @"activityType" : [userActivity activityType] }];
 
-    if ([TiUtils isIOSVersionOrGreater:@"9.0"] && [[userActivity activityType] isEqualToString:CSSearchableItemActionType]) {
+    if ([[userActivity activityType] isEqualToString:CSSearchableItemActionType]) {
       if ([userActivity userInfo] != nil) {
         [dict setObject:[[userActivity userInfo] objectForKey:CSSearchableItemActivityIdentifier] forKey:@"searchableItemActivityIdentifier"];
       }
@@ -392,12 +392,6 @@ TI_INLINE void waitForMemoryPanicCleared(void); // WARNING: This must never be r
   if (_localNotification != nil) {
     localNotification = [[[self class] dictionaryWithLocalNotification:_localNotification] retain];
     [launchOptions removeObjectForKey:UIApplicationLaunchOptionsLocalNotificationKey];
-
-    // Queue the "localnotificationaction" event for iOS 9 and lower.
-    // For iOS 10+, the "userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler" delegate handles it
-    if ([TiUtils isIOSVersionLower:@"9.0"]) {
-      [self tryToPostNotification:localNotification withNotificationName:kTiLocalNotificationAction completionHandler:nil];
-    }
   }
 
   // Map launched URL

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiRootViewController.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiRootViewController.m
@@ -1066,7 +1066,6 @@
   [self adjustFrameForUpSideDownOrientation:nil];
 }
 
-// iOS 5 support. Begin Section. Drop in 3.2
 - (BOOL)automaticallyForwardAppearanceAndRotationMethodsToChildViewControllers
 {
   return YES;
@@ -1076,9 +1075,6 @@
 {
   return [self shouldRotateToInterfaceOrientation:toInterfaceOrientation checkModal:YES];
 }
-// iOS 5 support. End Section
-
-// iOS 6 new stuff.
 
 - (BOOL)shouldAutomaticallyForwardRotationMethods
 {
@@ -1135,11 +1131,11 @@
 
 - (UIInterfaceOrientationMask)supportedInterfaceOrientations
 {
-  // iOS 6. If forcing status bar orientation, this must return 0.
+  // If forcing status bar orientation, this must return 0.
   if (forcingStatusBarOrientation) {
     return 0;
   }
-  // iOS 6. If we are presenting a modal view controller, get the supported
+  // If we are presenting a modal view controller, get the supported
   // orientations from the modal view controller
   UIViewController *topmostController = [self topPresentedControllerCheckingPopover:YES];
   if (topmostController != self) {

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiRootViewController.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiRootViewController.m
@@ -1066,7 +1066,7 @@
   [self adjustFrameForUpSideDownOrientation:nil];
 }
 
-// IOS5 support. Begin Section. Drop in 3.2
+// iOS 5 support. Begin Section. Drop in 3.2
 - (BOOL)automaticallyForwardAppearanceAndRotationMethodsToChildViewControllers
 {
   return YES;
@@ -1076,9 +1076,9 @@
 {
   return [self shouldRotateToInterfaceOrientation:toInterfaceOrientation checkModal:YES];
 }
-// IOS5 support. End Section
+// iOS 5 support. End Section
 
-// IOS6 new stuff.
+// iOS 6 new stuff.
 
 - (BOOL)shouldAutomaticallyForwardRotationMethods
 {
@@ -1135,11 +1135,11 @@
 
 - (UIInterfaceOrientationMask)supportedInterfaceOrientations
 {
-  // IOS6. If forcing status bar orientation, this must return 0.
+  // iOS 6. If forcing status bar orientation, this must return 0.
   if (forcingStatusBarOrientation) {
     return 0;
   }
-  // IOS6. If we are presenting a modal view controller, get the supported
+  // iOS 6. If we are presenting a modal view controller, get the supported
   // orientations from the modal view controller
   UIViewController *topmostController = [self topPresentedControllerCheckingPopover:YES];
   if (topmostController != self) {

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiUtils.h
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiUtils.h
@@ -618,55 +618,55 @@ typedef enum {
 
  @return _YES_ if the current OS version is equal to or greater than 7.0, _NO_ otherwise.
  */
-+ (BOOL)isIOS7OrGreater __deprecated_msg("Use isIOSVersionOrGreater insted");
++ (BOOL)isIOS7OrGreater __deprecated_msg("Use isIOSVersionOrGreater instead");
 
 /**
  Whether or not the current OS version is equal to or greater than 8.0.
 
  @return _YES_ if the current OS version is equal to or greater than 8.0, _NO_ otherwise.
  */
-+ (BOOL)isIOS8OrGreater __deprecated_msg("Use isIOSVersionOrGreater insted");
++ (BOOL)isIOS8OrGreater __deprecated_msg("Use isIOSVersionOrGreater instead");
 
 /**
  Whether or not the current OS version is equal to or greater than 8.2.
 
- @return _YES_ if the current OS version is equal to or greater thann 8.2, _NO_ otherwise.
+ @return _YES_ if the current OS version is equal to or greater than 8.2, _NO_ otherwise.
  */
-+ (BOOL)isIOS82rGreater __deprecated_msg("Use isIOSVersionOrGreater insted");
++ (BOOL)isIOS82rGreater __deprecated_msg("Use isIOSVersionOrGreater instead");
 
 /**
  Whether or not the current OS version is equal to or greater than 9.0.
  @return _YES_ if the current OS version is equal to or greater than 9.0, _NO_ otherwise.
  */
-+ (BOOL)isIOS9OrGreater __deprecated_msg("Use isIOSVersionOrGreater insted");
++ (BOOL)isIOS9OrGreater __deprecated_msg("Use isIOSVersionOrGreater instead");
 
 /**
  Whether or not the current OS version is equal to or greater than 9.1.
 
  @return _YES_ if the current OS version is equal to or greater than 9.1, _NO_ otherwise.
  */
-+ (BOOL)isIOS9_1OrGreater __deprecated_msg("Use isIOSVersionOrGreater insted");
++ (BOOL)isIOS9_1OrGreater __deprecated_msg("Use isIOSVersionOrGreater instead");
 
 /**
  Whether or not the current OS version is equal to or greater than 9.3.
 
  @return _YES_ if the current OS version is equal to or greater than 9.3, _NO_ otherwise.
  */
-+ (BOOL)isIOS9_3OrGreater __deprecated_msg("Use isIOSVersionOrGreater insted");
++ (BOOL)isIOS9_3OrGreater __deprecated_msg("Use isIOSVersionOrGreater instead");
 
 /**
  Whether or not the current OS version is equal to or greater than 10.0.
 
  @return _YES_ if the current OS version is equal to or greater than 10.0, _NO_ otherwise.
  */
-+ (BOOL)isIOS10OrGreater __deprecated_msg("Use isIOSVersionOrGreater insted");
++ (BOOL)isIOS10OrGreater __deprecated_msg("Use isIOSVersionOrGreater instead");
 
 /**
  Whether or not the current OS version is equal to or greater than 11.0.
 
  @return _YES_ if the current OS version is equal to or greater than 11.0, _NO_ otherwise.
  */
-+ (BOOL)isIOS11OrGreater __deprecated_msg("Use isIOSVersionOrGreater insted");
++ (BOOL)isIOS11OrGreater __deprecated_msg("Use isIOSVersionOrGreater instead");
 
 /**
  Whether or not the current OS version is equal to or greater than the specified version.

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiUtils.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiUtils.m
@@ -1251,14 +1251,11 @@ If the new path starts with / and the base URL is app://..., we have to massage 
     NSMutableDictionary *dict = [NSMutableDictionary dictionaryWithObjectsAndKeys:
                                                          [NSNumber numberWithFloat:point.x], @"x",
                                                      [NSNumber numberWithFloat:point.y], @"y",
+                                                     [NSNumber numberWithFloat:touch.altitudeAngle], @"altitudeAngle",
                                                      [NSNumber numberWithFloat:touch.force], @"force",
                                                      [NSNumber numberWithFloat:touch.maximumPossibleForce], @"maximumPossibleForce",
                                                      [NSNumber numberWithDouble:touch.timestamp], @"timestamp",
                                                      nil];
-
-    if ([self isIOSVersionOrGreater:@"9.1"]) {
-      [dict setValue:[NSNumber numberWithFloat:touch.altitudeAngle] forKey:@"altitudeAngle"];
-    }
 
     if ([self validatePencilWithTouch:touch]) {
       [dict setValue:[NSNumber numberWithFloat:[touch azimuthUnitVectorInView:view].dx] forKey:@"azimuthUnitVectorInViewX"];
@@ -2182,7 +2179,7 @@ If the new path starts with / and the base URL is app://..., we have to massage 
 
 + (BOOL)livePhotoSupported
 {
-  return [self isIOSVersionOrGreater:@"9.1"];
+  return YES;
 }
 
 + (NSString *)currentArchitecture
@@ -2204,11 +2201,7 @@ If the new path starts with / and the base URL is app://..., we have to massage 
 
 + (BOOL)validatePencilWithTouch:(UITouch *)touch
 {
-  if ([self isIOSVersionOrGreater:@"9.1"]) {
-    return [touch type] == UITouchTypeStylus;
-  } else {
-    return NO;
-  }
+  return [touch type] == UITouchTypeStylus;
 }
 
 // Credits: http://stackoverflow.com/a/14525049/5537752

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiViewController.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiViewController.m
@@ -70,7 +70,6 @@
   [super viewDidLayoutSubviews];
 }
 
-// iOS 5 support. Begin Section. Drop in 3.2
 - (BOOL)automaticallyForwardAppearanceAndRotationMethodsToChildViewControllers
 {
   return YES;
@@ -80,9 +79,7 @@
 {
   return TI_ORIENTATION_ALLOWED(_supportedOrientations, toInterfaceOrientation) ? YES : NO;
 }
-// iOS 5 support. End Section
 
-// iOS 6 new stuff.
 - (BOOL)shouldAutomaticallyForwardRotationMethods
 {
   return YES;

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiViewController.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiViewController.m
@@ -70,7 +70,7 @@
   [super viewDidLayoutSubviews];
 }
 
-// IOS5 support. Begin Section. Drop in 3.2
+// iOS 5 support. Begin Section. Drop in 3.2
 - (BOOL)automaticallyForwardAppearanceAndRotationMethodsToChildViewControllers
 {
   return YES;
@@ -80,9 +80,9 @@
 {
   return TI_ORIENTATION_ALLOWED(_supportedOrientations, toInterfaceOrientation) ? YES : NO;
 }
-// IOS5 support. End Section
+// iOS 5 support. End Section
 
-// IOS6 new stuff.
+// iOS 6 new stuff.
 - (BOOL)shouldAutomaticallyForwardRotationMethods
 {
   return YES;

--- a/iphone/layout/layout/TiUtils.h
+++ b/iphone/layout/layout/TiUtils.h
@@ -70,7 +70,10 @@ typedef enum {
 + (BOOL)isIPad;
 + (BOOL)isRetinaDisplay;
 + (BOOL)isRetinaHDDisplay;
-+ (BOOL)isIOS8OrGreater;
+/**
+ * @deprecated
+ */
++ (BOOL)isIOS8OrGreater __attribute__((deprecated));
 + (CGFloat)floatValue:(id)value;
 + (CGFloat)floatValue:(id)value def:(CGFloat)def;
 + (void)setView:(UIView *)view positionRect:(CGRect)frameRect;

--- a/iphone/layout/layout/TiUtils.h
+++ b/iphone/layout/layout/TiUtils.h
@@ -70,9 +70,6 @@ typedef enum {
 + (BOOL)isIPad;
 + (BOOL)isRetinaDisplay;
 + (BOOL)isRetinaHDDisplay;
-/**
- * @deprecated
- */
 + (BOOL)isIOS8OrGreater __attribute__((deprecated));
 + (CGFloat)floatValue:(id)value;
 + (CGFloat)floatValue:(id)value def:(CGFloat)def;

--- a/iphone/layout/layout/TiUtils.m
+++ b/iphone/layout/layout/TiUtils.m
@@ -171,10 +171,7 @@ static BOOL _isTesting = NO;
 
 + (BOOL)isRetinaHDDisplay
 {
-  if ([TiUtils isIOS8OrGreater]) {
-    return ([UIScreen mainScreen].scale == 3.0);
-  }
-  return NO;
+  return ([UIScreen mainScreen].scale == 3.0);
 }
 
 + (BOOL)isIOS8OrGreater


### PR DESCRIPTION
**Introduction:**
- `minIosVersion` is meanwhile at `15.0`

**Description:**

- removed guards regarding to iOS 8.0 and iOS 9.x and fallbacks for < iOS 8.0 resp. < iOS 9.x
- marked `isIOS8OrGreater` in `iphone/layout/layout/TiUtils.h` as _deprecated_
  - the one in TitaniumKit has been there for a while
- BTW fixed some typos and wording (`iOS `)
