### PR TITLE
fix(ios): include LaunchLogos again

### DIFF
--- a/cli/lib/gather.js
+++ b/cli/lib/gather.js
@@ -297,8 +297,8 @@ export class Categorizer {
 					// in the LaunchScreen.storyboard
 					const m = relPath.match(LAUNCH_LOGO_REGEXP);
 					if (m) {
-						info.scale = m[1];
-						info.device = m[2];
+						info.scale = m[1]?.replace('@', '');
+						info.device = m[2]?.replace('~', '');
 						results.launchLogos.set(relPath, info);
 						return;
 					}

--- a/cli/lib/gather.js
+++ b/cli/lib/gather.js
@@ -297,7 +297,7 @@ export class Categorizer {
 					// in the LaunchScreen.storyboard
 					const m = relPath.match(LAUNCH_LOGO_REGEXP);
 					if (m) {
-						info.scale = m[1]?.replace('@', '');
+						info.scale = m[1]?.replace(/@|x/g, '');
 						info.device = m[2]?.replace('~', '');
 						results.launchLogos.set(relPath, info);
 						return;

--- a/cli/lib/gather.js
+++ b/cli/lib/gather.js
@@ -295,7 +295,7 @@ export class Categorizer {
 				} else if (this.platform === 'ios') {
 					// if the image is the LaunchLogo.png, then let that pass so we can use it
 					// in the LaunchScreen.storyboard
-					const m = info.name.match(LAUNCH_LOGO_REGEXP);
+					const m = relPath.match(LAUNCH_LOGO_REGEXP);
 					if (m) {
 						info.scale = m[1];
 						info.device = m[2];

--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -6177,7 +6177,7 @@ class iOSBuilder extends Builder {
 					// size?
 					idiom: img.device || 'universal',
 					filename: img.name + '.' + img.ext,
-					scale: (img.scale || 1) + 'x'
+					scale: img.scale || '1x'
 				});
 
 				const dest = path.join(assetCatalogDir, img.name + '.' + img.ext);

--- a/iphone/cli/commands/_build.js
+++ b/iphone/cli/commands/_build.js
@@ -6177,7 +6177,7 @@ class iOSBuilder extends Builder {
 					// size?
 					idiom: img.device || 'universal',
 					filename: img.name + '.' + img.ext,
-					scale: img.scale || '1x'
+					scale: (img.scale || 1) + 'x'
 				});
 
 				const dest = path.join(assetCatalogDir, img.name + '.' + img.ext);


### PR DESCRIPTION
fixes #14354 

`info.name` only includes the file name without the ending. `relPath` has the full filename including ending which is required by the regex.

**Test:**

* create a blank app
* put the following LaunchLogos into Resources/iphone/
[LaunchLogo.zip](https://github.com/user-attachments/files/23939424/LaunchLogo.zip) 
* build the app and check for the orange launch logo instead of the default Ti logo
* if it is too fast: remove the tabgroup.open() from the test app