### PR TITLE
chore(android): update kotlin to 2.3.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,7 +6,7 @@
  */
 
 buildscript {
-	ext.kotlin_version = '1.9.23'
+	ext.kotlin_version = '2.0.0'
 
 	repositories {
 		google()

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,7 +6,7 @@
  */
 
 buildscript {
-	ext.kotlin_version = '2.0.0'
+	ext.kotlin_version = '2.3.0'
 
 	repositories {
 		google()

--- a/android/templates/build/root.build.gradle
+++ b/android/templates/build/root.build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-	ext.kotlin_version = '1.9.23'
+	ext.kotlin_version = '2.0.0'
 
 	repositories {
 		google()

--- a/android/templates/build/root.build.gradle
+++ b/android/templates/build/root.build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-	ext.kotlin_version = '2.0.0'
+	ext.kotlin_version = '2.3.0'
 
 	repositories {
 		google()


### PR DESCRIPTION
Update Ti Kotlin version to 2.3.0

Tested with my MLKit module (kotlin based) and it will fix a titanium-stripe (https://github.com/hansemannn/titanium-stripe) build error with the latest version. That is using a higher kotlin version in their strip-android version ("The actual metadata version is 2.1.0, but the compiler version 1.9.0 can read versions up to 2.0.0.").