### PR TITLE
feat(android): keepHardwareMode property in Ti.UI.View

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiUIView.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiUIView.java
@@ -2210,7 +2210,9 @@ public abstract class TiUIView implements KrollProxyListener, OnFocusChangeListe
 
 	protected void disableHWAcceleration()
 	{
-		if (this.borderView != null) {
+		if (this.borderView != null && !(proxy.hasProperty("keepHardwareMode")
+			&& TiConvert.toBoolean(proxy.getProperty("keepHardwareMode"), false))
+		) {
 			this.borderView.setLayerType(View.LAYER_TYPE_SOFTWARE, null);
 		}
 	}

--- a/apidoc/Titanium/UI/View.yml
+++ b/apidoc/Titanium/UI/View.yml
@@ -1555,6 +1555,15 @@ properties:
         Defaults to `undefined`.
     type: [Number,String]
 
+  - name: keepHardwareMode
+    summary: A value indicating the render mode of the View
+    description: |
+        Set to true to keep hardware mode when using a border and transparent backgrounds.
+    type: Boolean
+    default: false
+    platforms: [android]
+    since: {android: "13.1.0"}
+
   - name: layout
     type: String
     summary: |

--- a/apidoc/Titanium/UI/View.yml
+++ b/apidoc/Titanium/UI/View.yml
@@ -1562,7 +1562,7 @@ properties:
     type: Boolean
     default: false
     platforms: [android]
-    since: {android: "13.1.0"}
+    since: {android: "13.2.0"}
 
   - name: layout
     type: String


### PR DESCRIPTION
fixes https://github.com/tidev/titanium-sdk/issues/14365

This goes back to a really old Jira ticket: https://jira-archive.titaniumsdk.com/TIMOB-24898

As soon as a view has a border and transparent backgroundColor it will switch back to layerType SOFTWARE:

https://github.com/tidev/titanium-sdk/blob/main/android/titanium/src/java/org/appcelerator/titanium/view/TiUIView.java#L2203-L2208

In this example code
```js
const win = Ti.UI.createWindow({
	backgroundColor: 'red',
	layout: 'vertical'
});

const scrollView = Ti.UI.createScrollView({
	layout: 'vertical',
	width: Ti.UI.FILL,
	height: Ti.UI.FILL,
	scrollType: 'vertical',
	showVerticalScrollIndicator: true
});

const longText = ("Lorem ipsum dolor sit amet, \n").repeat(50);

const txt = Ti.UI.createLabel({
	text: longText,
	width: Ti.UI.FILL,
	height: Ti.UI.SIZE,
	borderColor: 'black',
	borderWidth: 2,
	wordWrap: true,
	color: 'black',
//	keepHardwareMode: true,            // <-------------------- new property
	backgroundColor: '#44ffffff',
	textAlign: Ti.UI.TEXT_ALIGNMENT_CENTER,
	verticalAlign: Ti.UI.TEXT_VERTICAL_ALIGNMENT_CENTER,
	shadowColor: '#888',
	shadowOffset: {
		x: 15,
		y: 15
	},
	shadowRadius: 3,
	borderRadius: '2mm',
	bottom: '1.5mm',
	top: 0,
	left: 0,
	right: 0,
	font: {
		fontSize: '4mm'
	}
});

scrollView.add(txt);
win.add(scrollView);
win.open();
```

it won't show the label and displays:

```
View: TiBorderWrapperView not displayed because it is too large to fit into a software layer (or drawing cache), needs 23828480 bytes, only 14622720 available
```

If you use the new property `keepHardwareMode: true` in the example it won't switch to software mode and displays the label without any warning.

**Note:** I don't want to remove the whole software layer part even though it might just be an issue on older hardware (jira ticket is from 2017) but it would be nice to have the option NOT to do it if you experience issues like the user in the ticket.