### PR TITLE
fix(ios): added dSYM for TitaniumKit.framework

### DIFF
--- a/build/lib/ios.js
+++ b/build/lib/ios.js
@@ -61,7 +61,7 @@ export class IOS {
 
 		return new Promise((resolve, reject) => {
 			const buildScript = path.join(ROOT_DIR, 'support/iphone/build_titaniumkit.sh');
-			const child = spawn(buildScript, [ '-v', this.sdkVersion, '-t', this.timestamp, '-h', this.gitHash ], { stdio: 'inherit' });
+			const child = spawn(buildScript, [ '-v', this.sdkVersion, '-t', this.timestamp, '-h', this.gitHash, '-d' ], { stdio: 'inherit' });
 			child.on('error', reject);
 			child.on('close', code => {
 				if (code) {

--- a/support/iphone/build_titaniumkit.sh
+++ b/support/iphone/build_titaniumkit.sh
@@ -11,14 +11,19 @@ cd ../../iphone/TitaniumKit
 SDK_VERSION=""
 TIMESTAMP=""
 GIT_HASH=""
+ADD_DEBUG_SYMBOLS=false
+SIMULATOR_DEBUG_SYMBOLS=""
+DEVICE_DEBUG_SYMBOLS=""
+MAC_DEBUG_SYMBOLS=""
 
-while getopts v:t:h: option
+while getopts v:t:h:d option
 do
 case "${option}"
 in
 v) SDK_VERSION=${OPTARG};;
 t) TIMESTAMP=${OPTARG};;
-h) GIT_HASH=$OPTARG;;
+h) GIT_HASH=${OPTARG};;
+d) ADD_DEBUG_SYMBOLS=true;;
 esac
 done
 
@@ -55,14 +60,22 @@ MAC_ARCHIVE_PATH="$(pwd)/build/macCatalyst.xcarchive"
 DEVICE_ARCHIVE_PATH="$(pwd)/build/iosdevice.xcarchive"
 SIMULATOR_ARCHIVE_PATH="$(pwd)/build/simulator.xcarchive"
 
+# Debug symbols for symbolicated crash reports
+if [ "$ADD_DEBUG_SYMBOLS" = true ]
+then
+      SIMULATOR_DEBUG_SYMBOLS="-debug-symbols $SIMULATOR_ARCHIVE_PATH/dSYMs/$FRAMEWORK_NAME.framework.dSYM"
+      DEVICE_DEBUG_SYMBOLS="-debug-symbols $DEVICE_ARCHIVE_PATH/dSYMs/$FRAMEWORK_NAME.framework.dSYM"
+      MAC_DEBUG_SYMBOLS="-debug-symbols $MAC_ARCHIVE_PATH/dSYMs/$FRAMEWORK_NAME.framework.dSYM"
+fi
+
 UNIVERSAL_LIBRARY_DIR="$(pwd)/build"
 
-FRAMEWORK="${UNIVERSAL_LIBRARY_DIR}/${FRAMEWORK_NAME}.xcframework"
+FRAMEWORK_PATH="${UNIVERSAL_LIBRARY_DIR}/${FRAMEWORK_NAME}.xcframework"
 
 mkdir -p "${UNIVERSAL_LIBRARY_DIR}"
 
 # Clean previous archives/output if they exist
-rm -rf "$MAC_ARCHIVE_PATH" "$DEVICE_ARCHIVE_PATH" "$SIMULATOR_ARCHIVE_PATH" "$FRAMEWORK"
+rm -rf "$MAC_ARCHIVE_PATH" "$DEVICE_ARCHIVE_PATH" "$SIMULATOR_ARCHIVE_PATH" "$FRAMEWORK_PATH"
 
 #----- Make macCatalyst archive
 xcodebuild archive \
@@ -94,15 +107,15 @@ SKIP_INSTALL=NO \
 BUILD_LIBRARIES_FOR_DISTRIBUTION=YES \
 SUPPORTS_MACCATALYST=NO
 
-# restore TopTiModule.m
+# Restore TopTiModule.m
 rm TitaniumKit/Sources/API/TopTiModule.m
 mv TitaniumKit/Sources/API/TopTiModule.bak TitaniumKit/Sources/API/TopTiModule.m
 
 #----- Make XCFramework
 # Ensure we remove any pre-existing output to avoid duplicate variant errors
-rm -rf "$FRAMEWORK"
+rm -rf "$FRAMEWORK_PATH"
 xcodebuild -create-xcframework \
--framework $SIMULATOR_ARCHIVE_PATH/Products/Library/Frameworks/$FRAMEWORK_NAME.framework \
--framework $DEVICE_ARCHIVE_PATH/Products/Library/Frameworks/$FRAMEWORK_NAME.framework \
--framework $MAC_ARCHIVE_PATH/Products/Library/Frameworks/$FRAMEWORK_NAME.framework \
--output $FRAMEWORK
+-framework $SIMULATOR_ARCHIVE_PATH/Products/Library/Frameworks/$FRAMEWORK_NAME.framework $SIMULATOR_DEBUG_SYMBOLS \
+-framework $DEVICE_ARCHIVE_PATH/Products/Library/Frameworks/$FRAMEWORK_NAME.framework $DEVICE_DEBUG_SYMBOLS \
+-framework $MAC_ARCHIVE_PATH/Products/Library/Frameworks/$FRAMEWORK_NAME.framework $MAC_DEBUG_SYMBOLS \
+-output $FRAMEWORK_PATH


### PR DESCRIPTION
Fixes #14157.

**Introduction:**

- dSYM debug symbols are currently generated for the 3 xcarchives (simulator, device, mac), but not for the xcframework.
- If you select *"Upload your app's symbols to receive symbolicated reports from Apple"* during distribution process in Xcode Organizer you get a warning `The archive did not include a dSYM for the TitaniumKit.framework` and therefore unsymbolicated crash reports.
- You can test it with *Validate App* in Xcode Organizer.

**Description:**

- added option `-d` (without argument) for script `build_titaniumkit.sh` to enable debug symbols in the xcframework
  - `build/lib/ios.js` set this option by default, but in this way you have the opportunity to disabled it
- added dSYM debug symbols via `-debug-symbols` in the command `xcodebuild -create-xcframework`
- BTW renamed variable `FRAMEWORK` to `FRAMEWORK_PATH` in the script to avoid confusion with `FRAMEWORK_NAME`