### PR TITLE
fix(ios): propery handle incremental builds in Xcode

### DIFF
--- a/build/scons-xcode-project-build.js
+++ b/build/scons-xcode-project-build.js
@@ -63,7 +63,11 @@ async function generateBundle(outputDir) {
 
 async function main(tmpBundleDir) {
 	await fs.emptyDir(tmpBundleDir);
-	await generateBundle(appDir); // run rollup/babel to generate single bundled ti.main.js in app
+	// Build bundles outside the .app to avoid wiping the executable via fs.emptyDir.
+	await generateBundle(tmpBundleDir); // run rollup/babel to generate bundled ti.main.js/ti.kernel.js
+	await fs.copy(path.join(tmpBundleDir, 'ti.main.js'), path.join(appDir, 'ti.main.js'));
+	await fs.copy(path.join(tmpBundleDir, 'ti.kernel.js'), path.join(appDir, 'ti.kernel.js'));
+
 	console.log(`Removing temp dir used for bundling: ${tmpBundleDir}`);
 	await fs.remove(tmpBundleDir); // remove tmp location
 	console.log(`Copying xcode resources: ${xcodeProjectResources} -> ${appDir}`);


### PR DESCRIPTION
This PR fixes the "Executable Path is a Directory" error alerts after every second build, caused by a logic error in the transpilation process inside the scons-process.

To verify, simply run an app in the Xcode project twice and notice that the incremental build now succeeds as well.