### PR TITLE
fix(ios): added dSYM for Swift framework-based modules

### DIFF
--- a/iphone/cli/commands/_buildModule.js
+++ b/iphone/cli/commands/_buildModule.js
@@ -757,16 +757,16 @@ FRAMEWORK_SEARCH_PATHS = $(inherited) "$(TITANIUM_SDK)/iphone/Frameworks/**"`);
 
 		const moduleId = this.isFramework ? this.moduleIdAsIdentifier : this.moduleId;
 		const findLib = function (dest) {
-			let libPath = this.isFramework ? '.xcarchive/Products/Library/Frameworks/' + moduleId + '.framework' : '.xcarchive/Products/usr/local/lib/lib' + this.moduleId + '.a';
+			let libPath = this.isFramework ? `.xcarchive/Products/Library/Frameworks/${moduleId}.framework` : `.xcarchive/Products/usr/local/lib/lib${moduleId}.a`;
 			const lib = path.join(this.projectDir, 'build', dest + libPath);
 			this.logger.info(`Looking for ${lib}`);
 
 			if (!fs.existsSync(lib)) {
 				// unfortunately the initial module project template incorrectly
 				// used the camel-cased module id
-				libPath = '.xcarchive/Products/usr/local/lib/lib' + this.moduleIdAsIdentifier + '.a';
+				libPath = `.xcarchive/Products/usr/local/lib/lib${this.moduleIdAsIdentifier}.a`;
 				const newLib = path.join(this.projectDir, 'build', dest + libPath);
-				this.logger.debug('Searching library: ' + newLib);
+				this.logger.debug(`Searching library: ${newLib}`);
 				if (!fs.existsSync(newLib)) {
 					return new Error(`Unable to find the built Release-${dest} library`);
 				} else {
@@ -803,11 +803,9 @@ FRAMEWORK_SEARCH_PATHS = $(inherited) "$(TITANIUM_SDK)/iphone/Frameworks/**"`);
 			return next(lib);
 		}
 		args.push('-create-xcframework');
-		args.push(buildType);
-		args.push(lib);
+		args.push(buildType, lib);
 		if (!this.isFramework) {
-			args.push('-headers');
-			args.push(headerPath);
+			args.push('-headers', headerPath);
 		} else {
 			// Include dSYM files in xcframework for symbolicated crash reports
 			const dSym = findDSYM('iphoneos');
@@ -818,11 +816,9 @@ FRAMEWORK_SEARCH_PATHS = $(inherited) "$(TITANIUM_SDK)/iphone/Frameworks/**"`);
 		if (lib instanceof Error) {
 			return next(lib);
 		}
-		args.push(buildType);
-		args.push(lib);
+		args.push(buildType, lib);
 		if (!this.isFramework) {
-			args.push('-headers');
-			args.push(headerPath);
+			args.push('-headers', headerPath);
 		} else {
 			// Include dSYM files in xcframework for symbolicated crash reports
 			const dSym = findDSYM('iphonesimulator');
@@ -834,11 +830,9 @@ FRAMEWORK_SEARCH_PATHS = $(inherited) "$(TITANIUM_SDK)/iphone/Frameworks/**"`);
 			if (lib instanceof Error) {
 				this.logger.warn('The module is missing macOS support. Ignoring mac target for this module...');
 			} else {
-				args.push(buildType);
-				args.push(lib);
+				args.push(buildType, lib);
 				if (!this.isFramework) {
-					args.push('-headers');
-					args.push(headerPath);
+					args.push('-headers', headerPath);
 				} else {
 					// Include dSYM files in xcframework for symbolicated crash reports
 					const dSym = findDSYM('macosx');

--- a/iphone/cli/commands/_buildModule.js
+++ b/iphone/cli/commands/_buildModule.js
@@ -776,15 +776,15 @@ FRAMEWORK_SEARCH_PATHS = $(inherited) "$(TITANIUM_SDK)/iphone/Frameworks/**"`);
 			}
 			return lib;
 		}.bind(this);
-		const findDSym = function (dest) {
-			// find dSYM for framework
-			const dSymPath = '.xcarchive/dSYMs/' + moduleId + '.framework.dSYM';
+		// Find the debug symbols (dSYM) for the generated framework
+		const findDSYM = function (dest) {
+			const dSymPath = `.xcarchive/dSYMs/${moduleId}.framework.dSYM`;
 			const dSym = path.join(this.projectDir, 'build', dest + dSymPath);
-			this.logger.info(`Looking for dSYM ${dSym}`);
+			this.logger.debug(`Looking for dSYM ${dSym}`);
 
 			if (!fs.existsSync(dSym)) {
-				this.logger.warn(`Unable to find the Release-${dest} dSYM. Crash reports regarding ${moduleId}.framework may be unsymbolicated.`);
-				return false;
+				this.logger.warn(`Unable to find the Release-${dest} dSYM. Crash reports for ${moduleId} may be unsymbolicated.`);
+				return null;
 			}
 			return dSym;
 		}.bind(this);
@@ -809,12 +809,9 @@ FRAMEWORK_SEARCH_PATHS = $(inherited) "$(TITANIUM_SDK)/iphone/Frameworks/**"`);
 			args.push('-headers');
 			args.push(headerPath);
 		} else {
-			const dSym = findDSym('iphoneos');
-			if (dSym !== false) {
-				// include dSYM files in xcframework for symbolicated crash reports
-				args.push('-debug-symbols');
-				args.push(dSym);
-			}
+			// Include dSYM files in xcframework for symbolicated crash reports
+			const dSym = findDSYM('iphoneos');
+			dSym && args.push('-debug-symbols', dSym);
 		}
 
 		lib = findLib('iphonesimulator');
@@ -827,12 +824,9 @@ FRAMEWORK_SEARCH_PATHS = $(inherited) "$(TITANIUM_SDK)/iphone/Frameworks/**"`);
 			args.push('-headers');
 			args.push(headerPath);
 		} else {
-			const dSym = findDSym('iphonesimulator');
-			if (dSym !== false) {
-				// include dSYM files in xcframework for symbolicated crash reports
-				args.push('-debug-symbols');
-				args.push(dSym);
-			}
+			// Include dSYM files in xcframework for symbolicated crash reports
+			const dSym = findDSYM('iphonesimulator');
+			dSym && args.push('-debug-symbols', dSym);
 		}
 
 		if (this.isMacOSEnabled) {
@@ -846,12 +840,9 @@ FRAMEWORK_SEARCH_PATHS = $(inherited) "$(TITANIUM_SDK)/iphone/Frameworks/**"`);
 					args.push('-headers');
 					args.push(headerPath);
 				} else {
-					const dSym = findDSym('macosx');
-					if (dSym !== false) {
-						// include dSYM files in xcframework for symbolicated crash reports
-						args.push('-debug-symbols');
-						args.push(dSym);
-					}
+					// Include dSYM files in xcframework for symbolicated crash reports
+					const dSym = findDSYM('macosx');
+					dSym && args.push('-debug-symbols', dSym);
 				}
 			}
 		}


### PR DESCRIPTION
Fixes https://github.com/hansemannn/titanium-review-dialog/issues/17.

**Introduction:**

- If you select _"Upload your app's symbols to receive symbolicated reports from Apple"_ during distribution process in Xcode Organizer you currently get a warning `The archive did not include a dSYM for the ******.framework` and therefore unsymbolicated crash reports, if you use a Titanium module which is based on a Swift xcframework.
  - e.g. https://github.com/hansemannn/titanium-review-dialog since iOS-v4
- You can test it with _Validate App_ in Xcode Organizer.

**Description:**

- added dSYM debug symbols via `-debug-symbols` in the command `xcodebuild -create-xcframework`
  - added helper function `findDSym()` for this purpose
- BTW improved some logs regarding creating the xcframework