### PR TITLE
fix(android): fixed Android environment detection in CLI info

### DIFF
--- a/android/cli/lib/info.js
+++ b/android/cli/lib/info.js
@@ -18,7 +18,7 @@ export function detect(types, config, next) {
 		return dir !== '/' && scan(dir);
 	}(__dirname)));
 
-	import('./detect.js').then(({ default: mod }) => {
+	import('./detect.js').then((mod) => {
 		// detect Android environment
 		mod.detect(config, null, function (result) {
 			// detect devices


### PR DESCRIPTION
Fixes #14374.

**Description:**

- ChatGPT says: `android/cli/lib/detect.js` has no `default export`, so `mod` is undefined in:
https://github.com/tidev/titanium-sdk/blob/53dcb9b7de731a8b44b31b21494682fdbd9a0a00/android/cli/lib/info.js#L21
- changed the import from `{ default: mod }` to `mod`
- `ti info -t android` works fine again