### PR TITLE
chore(android): fix gradle warning in SDK build

### DIFF
--- a/android/titanium/build.gradle
+++ b/android/titanium/build.gradle
@@ -46,7 +46,7 @@ android {
 	ndkVersion = project.ext.tiNdkVersion
 	namespace = 'org.appcelerator.titanium'
 	defaultConfig {
-		compileSdk 35
+		compileSdkVersion 35
 		minSdkVersion 24
 		targetSdkVersion 35
 		versionName tiBuildVersionString


### PR DESCRIPTION
Missed that gradle warning. When you build the SDK it will show you:

```
Build file '/home/miga/tools/titanium-sdk/android/titanium/build.gradle': line 49
Properties should be assigned using the 'propName = value' syntax. Setting a property via the Gradle-generated 'propName value' or 'propName(value)' syntax in Groovy DSL has been deprecated. This is scheduled to be removed in Gradle 10.0. Use assignment ('compileSdk = <value>') instead. Consult the upgrading guide for further information: https://docs.gradle.org/8.14.3/userguide/upgrading_version_8.html#groovy_space_assignment_syntax
```
as it should be `compileSdkVersion` instead of `compileSdk`. 