### PR TITLE
fix(android): apply null checks on `localOverlayProxy`

### DIFF
--- a/android/modules/media/src/java/ti/modules/titanium/media/TiCameraActivity.java
+++ b/android/modules/media/src/java/ti/modules/titanium/media/TiCameraActivity.java
@@ -291,16 +291,27 @@ public class TiCameraActivity extends TiBaseActivity implements SurfaceHolder.Ca
 	{
 		super.onPause();
 
-		// Stop video capture if recording.
-		stopVideoCapture();
-
-		// Stop the camera preview so that other apps can use the camera.
-		stopPreview();
-		previewLayout.removeView(preview);
-		cameraLayout.removeView(localOverlayProxy.getOrCreateView().getNativeView());
 		try {
-			camera.release();
-			camera = null;
+			// Stop video capture if recording.
+			stopVideoCapture();
+
+			// Stop the camera preview so that other apps can use the camera.
+			stopPreview();
+			previewLayout.removeView(preview);
+
+			if (localOverlayProxy != null) {
+				TiUIView overlayView = localOverlayProxy.peekView();
+				if (overlayView != null) {
+					View overlayNativeView = overlayView.getNativeView();
+					if (overlayNativeView != null) {
+						cameraLayout.removeView(overlayNativeView);
+					}
+				}
+			}
+			if (camera != null) {
+				camera.release();
+				camera = null;
+			}
 		} catch (Throwable t) {
 			Log.d(TAG, "Camera is not open, unable to release", Log.DEBUG_MODE);
 		}


### PR DESCRIPTION
Based on some internal crash reports, the `localOverlayProxy` is null and prevents the activity to be paused properly.

- Also moved the surrounding code into try-catch to cover any hidden issues.

> Fatal Exception: java.lang.RuntimeException: Unable to pause activity {ti.modules.titanium.media.TiCameraActivity}: java.lang.NullPointerException: Attempt to invoke virtual method 'org.appcelerator.titanium.view.TiUIView org.appcelerator.titanium.proxy.TiViewProxy.getOrCreateView()' on a null object reference
       at android.app.ActivityThread.performPauseActivityIfNeeded(ActivityThread.java:4755)
       at android.app.ActivityThread.performPauseActivity(ActivityThread.java:4706)
       at android.app.ActivityThread.handlePauseActivity(ActivityThread.java:4657)