### PR TITLE
fix(ios): fixed broken TabBar layout for iOS 26

### DIFF
--- a/iphone/Classes/TiUITabProxy.m
+++ b/iphone/Classes/TiUITabProxy.m
@@ -59,13 +59,17 @@
   // since we're special proxy type instead of normal, we force in values
   [self replaceValue:nil forKey:@"title" notification:NO];
   [self replaceValue:nil forKey:@"icon" notification:NO];
-  [self replaceValue:nil forKey:@"badge" notification:NO];
+  [self replaceValue:nil forKey:@"iconInsets" notification:NO];
+  [self replaceValue:nil forKey:@"activeIcon" notification:NO];
   [self replaceValue:NUMBOOL(YES) forKey:@"iconIsMask" notification:NO];
   [self replaceValue:NUMBOOL(YES) forKey:@"activeIconIsMask" notification:NO];
   [self replaceValue:nil forKey:@"titleColor" notification:NO];
   [self replaceValue:nil forKey:@"activeTitleColor" notification:NO];
   [self replaceValue:nil forKey:@"tintColor" notification:NO];
   [self replaceValue:nil forKey:@"activeTintColor" notification:NO];
+  [self replaceValue:nil forKey:@"badge" notification:NO];
+  [self replaceValue:nil forKey:@"badgeColor" notification:NO];
+
   [[NSNotificationCenter defaultCenter] addObserver:self
                                            selector:@selector(didChangeTraitCollection:)
                                                name:kTiTraitCollectionChanged
@@ -646,19 +650,9 @@
     }
   }
 
-  UITabBarItem *tabBarItem = [controller tabBarItem];
-  if (tabBarItem == nil || systemTab == YES) {
-    // init tab bar item
-    UITabBarItem *newItem = [[[UITabBarItem alloc] initWithTitle:title image:image selectedImage:activeImage] autorelease];
-    [controller setTabBarItem:newItem];
-
-    tabBarItem = [controller tabBarItem];
-  } else {
-    // reuse tab bar item
-    [tabBarItem setTitle:title];
-    [tabBarItem setImage:image];
-    [tabBarItem setSelectedImage:activeImage];
-  }
+  // (re-)init tab bar item
+  UITabBarItem *tabBarItem = [[[UITabBarItem alloc] initWithTitle:title image:image selectedImage:activeImage] autorelease];
+  [controller setTabBarItem:tabBarItem];
 
   // title appearance
   TiColor *titleColor = [TiUtils colorValue:[self valueForKey:@"titleColor"]];


### PR DESCRIPTION
Fixes #14145 for further cases.

**Introduction:**

- https://github.com/tidev/titanium-sdk/pull/14324 has fixed #14145 for most cases, but unfortunately it fails under **iOS 26** when icon and/or title for TabBarItem are set at the `open` event resp. in certain cases with Alloy
- the TabBar layout at iPhone (not iPad) is then broken: misaligned and truncated TabBarItem titles
- Ti SDK 13.1.0.GA is affected
<img width="370" height="75" alt="" src="https://github.com/user-attachments/assets/d1d1c2f5-9ab9-4abe-915e-3bc1a7431d23" />

**Reproducible sample:**

```
const numberOfTabs = 4;
let buttons = [],
	labels = [],
	tabs = [],
	windows = [];

for (let i = 0; i < numberOfTabs; i++) {
	windows[i] = Ti.UI.createWindow({ layout: 'vertical' });
	labels[i] = Ti.UI.createLabel({ text: `Window${i+1}` });
	buttons[i] = Ti.UI.createButton({ title: `Tab${i+1}++` });
	buttons[i].addEventListener('click', function () {
		tabs[i].badge = tabs[i].badge + 1; // update badge value
	});

	windows[i].add(labels[i]);
	windows[0].add(buttons[i]);
	tabs[i] = Ti.UI.createTab({ window: windows[i] });
}

const tabGroup = Ti.UI.createTabGroup({
    tabs: tabs
});

// before open event
for (let i = 0; i < numberOfTabs; i++) {
	tabs[i].title = `Tab${i+1}`;
	//tabs[i].icon = `/assets/images/tab${i+1}.png`;
}

tabGroup.addEventListener('open', function() {
	// at open event
	for (let i = 0; i < numberOfTabs; i++) {
		//tabs[i].title = `Tab${i+1}`;
		tabs[i].icon = `/assets/images/tab${i+1}.png`;
	}
});

tabGroup.open();

setTimeout(function(){
	// after open event
	for (let i = 0; i < numberOfTabs; i++) {
		//tabs[i].title = `Tab${i+1}`;
		//tabs[i].icon = `/assets/images/tab${i+1}.png`;
	}
}, 1000);
```

**Description:**

- reverted the reuse of a TabBarItem
  - a performance optimization must be done later in another way
- BTW added missing initial values in `(void)_configure` for consistency reasons
  - since this is a special proxy type instead of normal, values are forced into