### PR TITLE
feat: add web view API to hide input accessory views

### DIFF
--- a/apidoc/Titanium/UI/WebView.yml
+++ b/apidoc/Titanium/UI/WebView.yml
@@ -921,6 +921,22 @@ properties:
     platforms: [iphone, ipad, macos]
     since: {iphone: "13.2.0", ipad: "13.2.0", macos: "13.2.0"}
 
+  - name: autoAdjustScrollViewInsets
+    summary: |
+        Specifies whether or not the web view should automatically adjust its scroll view insets.
+    description: |
+        When the value is `true`, it allows the web view to adjust its scroll view insets in response
+        to the screen areas consumed by the status bar, navigation bar, toolbar and tab bar (safe areas).
+
+        This is useful when displaying a web view that extends under navigation bars or into
+        safe area regions, ensuring content is not obscured.
+
+        The default behavior assumes that this is `false`.
+    type: Boolean
+    default: false
+    platforms: [iphone, ipad, macos]
+    since: {iphone: "13.2.0", ipad: "13.2.0", macos: "13.2.0"}
+
   - name: ignoreSslError
     summary: Controls whether to ignore invalid SSL certificates or not.
     description: |

--- a/apidoc/Titanium/UI/WebView.yml
+++ b/apidoc/Titanium/UI/WebView.yml
@@ -907,6 +907,20 @@ properties:
     platforms: [iphone, ipad, macos]
     since: {iphone: "6.1.0", ipad: "6.1.0", macos: "9.2.0"}
 
+  - name: hideKeyboardAccessoryView
+    summary: A Boolean value indicating whether to hide the keyboard accessory bar.
+    description: |
+        When this property is set to `true`, the keyboard accessory bar (the bar with "Previous",
+        "Next" and "Done" buttons that appears above the keyboard when focusing input fields in
+        web content) is hidden. This can be useful when you want to provide your own custom
+        input accessory or simply want a cleaner keyboard appearance.
+
+        Set to `false` (the default) to show the standard keyboard accessory bar.
+    type: Boolean
+    default: false
+    platforms: [iphone, ipad, macos]
+    since: {iphone: "13.2.0", ipad: "13.2.0", macos: "13.2.0"}
+
   - name: ignoreSslError
     summary: Controls whether to ignore invalid SSL certificates or not.
     description: |

--- a/iphone/Classes/TiUIWebView.m
+++ b/iphone/Classes/TiUIWebView.m
@@ -398,6 +398,19 @@ static NSString *const baseInjectScript = @"Ti._hexish=function(a){var r='';var 
   [[self webView] setHideInputAccessoryView:[TiUtils boolValue:value def:NO]];
 }
 
+- (void)setAutoAdjustScrollViewInsets_:(id)value
+{
+  ENSURE_TYPE(value, NSNumber);
+
+  [[self proxy] replaceValue:value forKey:@"autoAdjustScrollViewInsets" notification:NO];
+
+  if ([TiUtils boolValue:value def:NO]) {
+    [[[self webView] scrollView] setContentInsetAdjustmentBehavior:UIScrollViewContentInsetAdjustmentAlways];
+  } else {
+    [[[self webView] scrollView] setContentInsetAdjustmentBehavior:UIScrollViewContentInsetAdjustmentNever];
+  }
+}
+
 - (void)reload
 {
   if (_webView == nil) {

--- a/iphone/Classes/TiUIWebView.m
+++ b/iphone/Classes/TiUIWebView.m
@@ -10,6 +10,7 @@
 #import "TiUIWebViewProxy.h"
 #import "TiUIiOSWebViewConfigurationProxy.h"
 #import "TiUIiOSWebViewDecisionHandlerProxy.h"
+#import "TiWebView.h"
 
 #import <TitaniumKit/Mimetypes.h>
 #import <TitaniumKit/SBJSON.h>
@@ -82,7 +83,7 @@ static NSString *const baseInjectScript = @"Ti._hexish=function(a){var r='';var 
 
     _willHandleTouches = [TiUtils boolValue:[[self proxy] valueForKey:@"willHandleTouches"] def:YES];
 
-    _webView = [[WKWebView alloc] initWithFrame:[self bounds] configuration:config];
+    _webView = [[TiWebView alloc] initWithFrame:[self bounds] configuration:config];
 #if TARGET_OS_SIMULATOR && __IPHONE_OS_VERSION_MAX_ALLOWED >= 160400
     if (@available(iOS 16.4, *)) {
       _webView.inspectable = YES;
@@ -387,6 +388,14 @@ static NSString *const baseInjectScript = @"Ti._hexish=function(a){var r='';var 
 {
   [self _setKeyboardDisplayRequiresUserAction:[TiUtils boolValue:value]];
   [[self proxy] replaceValue:value forKey:@"keyboardDisplayRequiresUserAction" notification:NO];
+}
+
+- (void)setHideKeyboardAccessoryView_:(id)value
+{
+  ENSURE_TYPE(value, NSNumber);
+
+  [[self proxy] replaceValue:value forKey:@"hideKeyboardAccessoryView" notification:NO];
+  [[self webView] setHideInputAccessoryView:[TiUtils boolValue:value def:NO]];
 }
 
 - (void)reload

--- a/iphone/Classes/TiWebView.h
+++ b/iphone/Classes/TiWebView.h
@@ -1,0 +1,18 @@
+//
+//  TiWebView.h
+//  Titanium
+//
+//  Created by Hans Knöchel on 02.02.26.
+//
+
+#import <WebKit/WebKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface TiWebView : WKWebView
+
+@property (nonatomic, assign) BOOL hideInputAccessoryView;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/iphone/Classes/TiWebView.m
+++ b/iphone/Classes/TiWebView.m
@@ -1,0 +1,20 @@
+//
+//  TiWebView.m
+//  Titanium
+//
+//  Created by Hans Knöchel on 02.02.26.
+//
+
+#import "TiWebView.h"
+
+@implementation TiWebView
+
+- (__kindof UIView *)inputAccessoryView
+{
+  if (self.hideInputAccessoryView) {
+    return nil;
+  }
+  return [super inputAccessoryView];
+}
+
+@end

--- a/iphone/iphone/Titanium.xcodeproj/project.pbxproj
+++ b/iphone/iphone/Titanium.xcodeproj/project.pbxproj
@@ -159,6 +159,7 @@
 		3A0E54371BE811CD003EE654 /* TiUIiOSMenuPopupProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A0E54361BE811CD003EE654 /* TiUIiOSMenuPopupProxy.m */; };
 		3A1E40511BEAC73D00943233 /* TiUIiOSMenuPopup.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A1E40501BEAC73D00943233 /* TiUIiOSMenuPopup.m */; };
 		3A275F3E1BA881B300EC4912 /* TiUIActivityIndicatorStyleProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A275F3D1BA881B300EC4912 /* TiUIActivityIndicatorStyleProxy.m */; };
+		3A2BC6332F30D81400D4CBD4 /* TiWebView.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A2BC6322F30D81400D4CBD4 /* TiWebView.m */; };
 		3A320F992B6EDC7600009E90 /* TiSymbolEffectManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A320F982B6EDC7600009E90 /* TiSymbolEffectManager.m */; };
 		3A38F30424D6EBBD00CC6EFB /* TiUtils+Addons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A38F30324D6EBBD00CC6EFB /* TiUtils+Addons.swift */; };
 		3A3BBAF51D3E2F0F008450DF /* TiAppiOSUserNotificationCenterProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A3BBAF41D3E2F0F008450DF /* TiAppiOSUserNotificationCenterProxy.m */; };
@@ -606,6 +607,8 @@
 		3A1E40501BEAC73D00943233 /* TiUIiOSMenuPopup.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TiUIiOSMenuPopup.m; sourceTree = "<group>"; };
 		3A275F3C1BA881B300EC4912 /* TiUIActivityIndicatorStyleProxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TiUIActivityIndicatorStyleProxy.h; sourceTree = "<group>"; };
 		3A275F3D1BA881B300EC4912 /* TiUIActivityIndicatorStyleProxy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TiUIActivityIndicatorStyleProxy.m; sourceTree = "<group>"; };
+		3A2BC6312F30D81400D4CBD4 /* TiWebView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TiWebView.h; sourceTree = "<group>"; };
+		3A2BC6322F30D81400D4CBD4 /* TiWebView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TiWebView.m; sourceTree = "<group>"; };
 		3A320F972B6EDC7600009E90 /* TiSymbolEffectManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TiSymbolEffectManager.h; sourceTree = "<group>"; };
 		3A320F982B6EDC7600009E90 /* TiSymbolEffectManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TiSymbolEffectManager.m; sourceTree = "<group>"; };
 		3A38F30324D6EBBD00CC6EFB /* TiUtils+Addons.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TiUtils+Addons.swift"; sourceTree = "<group>"; };
@@ -1321,6 +1324,8 @@
 				24EB02BF111BF827001DC2D1 /* TiUIWebView.h */,
 				24EB02C0111BF827001DC2D1 /* TiUIWebView.m */,
 				24EB06EC111D03F9001DC2D1 /* bridge.txt */,
+				3A2BC6312F30D81400D4CBD4 /* TiWebView.h */,
+				3A2BC6322F30D81400D4CBD4 /* TiWebView.m */,
 			);
 			name = Webview;
 			sourceTree = "<group>";
@@ -2163,6 +2168,7 @@
 				1923696620E48D4300567508 /* TiUIiOSWebViewProcessPoolProxy.m in Sources */,
 				DBF4B13B200FD93400777136 /* TiUIApplicationShortcutsProxy.m in Sources */,
 				24CA8B85111161FE0084E2DE /* TiUITabGroupProxy.m in Sources */,
+				3A2BC6332F30D81400D4CBD4 /* TiWebView.m in Sources */,
 				24CA8B8C111161FE0084E2DE /* TiUISwitchProxy.m in Sources */,
 				24CA8B8D111161FE0084E2DE /* TiUISwitch.m in Sources */,
 				24CA8B8F111161FE0084E2DE /* TiUISliderProxy.m in Sources */,


### PR DESCRIPTION
These new APIs allow it to disable the web kit accessory view for input fields inside web views, making it possible to provide a real native experience for input interactions within web view containers. In addition, they allow to handle the safe area padding as part of the scroll insets.

| `hideKeyboardAccessoryView: false` (default) | `hideKeyboardAccessoryView: true` |
|--------|--------|
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-02-03 at 09 33 40" src="https://github.com/user-attachments/assets/a883f687-c507-46a9-94c5-63233de71b79" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-02-03 at 09 33 57" src="https://github.com/user-attachments/assets/162df8e1-d1d6-48e6-aa46-2396f1e7847f" /> | 