### PR TITLE
fix(ios): fix containment issues once and for all

### DIFF
--- a/iphone/Classes/TiUINavigationWindowProxy.m
+++ b/iphone/Classes/TiUINavigationWindowProxy.m
@@ -397,33 +397,12 @@
 {
   if (navController && [self viewAttached]) {
     UIViewController *parentController = [self windowHoldingController];
-    [parentController addChildViewController:navController];
-    [navController didMoveToParentViewController:parentController];
-    [navController viewWillAppear:animated];
+    if (navController.parentViewController != parentController) {
+      [parentController addChildViewController:navController];
+      [navController didMoveToParentViewController:parentController];
+    }
   }
   [super viewWillAppear:animated];
-}
-- (void)viewWillDisappear:(BOOL)animated
-{
-  if ([self viewAttached]) {
-    [navController viewWillDisappear:animated];
-  }
-  [super viewWillDisappear:animated];
-}
-
-- (void)viewDidAppear:(BOOL)animated
-{
-  if ([self viewAttached]) {
-    [navController viewDidAppear:animated];
-  }
-  [super viewDidAppear:animated];
-}
-- (void)viewDidDisappear:(BOOL)animated
-{
-  if ([self viewAttached]) {
-    [navController viewDidDisappear:animated];
-  }
-  [super viewDidDisappear:animated];
 }
 
 - (BOOL)homeIndicatorAutoHide

--- a/iphone/Classes/TiUITabGroup.m
+++ b/iphone/Classes/TiUITabGroup.m
@@ -701,10 +701,12 @@ DEFINE_EXCEPTIONS
       ^{
         isTabBarHidden = NO;
         UIViewController *parentController = TiApp.controller.topPresentedController;
-        [parentController addChildViewController:self.tabController];
+        if (self.tabController.parentViewController != parentController) {
+          [parentController addChildViewController:self.tabController];
+          [self.tabController didMoveToParentViewController:parentController];
+        }
         [self addSubview:self.tabController.view];
         self.tabController.view.frame = self.bounds;
-        [self.tabController didMoveToParentViewController:parentController];
       },
       NO);
 }

--- a/iphone/Classes/TiUITabGroupProxy.m
+++ b/iphone/Classes/TiUITabGroupProxy.m
@@ -228,38 +228,12 @@ static NSArray *tabGroupKeySequence;
   if ([self viewAttached]) {
     UITabBarController *tabController = [(TiUITabGroup *)[self view] tabController];
     UIViewController *parentController = [self windowHoldingController];
-    [parentController addChildViewController:tabController];
-    [tabController didMoveToParentViewController:parentController];
-    [tabController viewWillAppear:animated];
+    if (tabController.parentViewController != parentController) {
+      [parentController addChildViewController:tabController];
+      [tabController didMoveToParentViewController:parentController];
+    }
   }
   [super viewWillAppear:animated];
-}
-
-- (void)viewDidAppear:(BOOL)animated;
-{
-  if ([self viewAttached]) {
-    UITabBarController *tabController = [(TiUITabGroup *)[self view] tabController];
-    [tabController viewDidAppear:animated];
-  }
-  [super viewDidAppear:animated];
-}
-
-- (void)viewWillDisappear:(BOOL)animated;
-{
-  if ([self viewAttached]) {
-    UITabBarController *tabController = [(TiUITabGroup *)[self view] tabController];
-    [tabController viewWillDisappear:animated];
-  }
-  [super viewWillDisappear:animated];
-}
-
-- (void)viewDidDisappear:(BOOL)animated;
-{
-  if ([self viewAttached]) {
-    UITabBarController *tabController = [(TiUITabGroup *)[self view] tabController];
-    [tabController viewDidDisappear:animated];
-  }
-  [super viewDidDisappear:animated];
 }
 
 - (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator


### PR DESCRIPTION
A follow-up of https://github.com/tidev/titanium-sdk/pull/14261 with a more focussed approach of recognizing different containment references and comparing them. Also fixing this (related) issue:

```
  Calling -viewDidAppear: directly on a view controller is not supported, and may result in out-of-order callbacks and other inconsistent behavior. Use the -beginAppearanceTransition:animated: and -endAppearanceTransition APIs on          
  UIViewController to manually drive appearance callbacks instead. Make a symbolic breakpoint at UIViewControllerAlertForAppearanceCallbackMisuse to catch this in the debugger. View controller: <UINavigationController: 0x105833000> 
```