### PR TITLE
fix(android): use i18n app name in AndroidManifest

### DIFF
--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -73,6 +73,7 @@ class AndroidBuilder extends Builder {
 		};
 
 		this.targets = [ 'emulator', 'device', 'dist-playstore' ];
+		this.appName = null;
 	}
 
 	config(logger, config, cli) {
@@ -1666,6 +1667,7 @@ class AndroidBuilder extends Builder {
 
 		this.appid = this.tiapp.id;
 		this.appid.indexOf('.') === -1 && (this.appid = 'com.' + this.appid);
+		this.appName = this.tiapp.name;
 
 		this.classname = this.tiapp.name.split(/[^A-Za-z0-9_]/).map(function (word) {
 			return appc.string.capitalize(word.toLowerCase());
@@ -3230,6 +3232,7 @@ class AndroidBuilder extends Builder {
 				}
 				localeData.strings.app_name = appName;
 			}
+			this.appName = appName;
 
 			// Create the XML content for all localized strings.
 			const dom = new DOMParser().parseFromString('<resources/>', 'text/xml');
@@ -3693,7 +3696,7 @@ class AndroidBuilder extends Builder {
 		mainManifestContent = ejs.render(mainManifestContent.toString(), {
 			appChildXmlLines: appChildXmlLines,
 			appIcon: this.appIconManifestValue,
-			appLabel: this.tiapp.name,
+			appLabel: this.appName,
 			classname: this.classname,
 			storagePermissionMaxSdkVersion: neededManifestSettings.storagePermissionMaxSdkVersion,
 			packageName: this.appid,


### PR DESCRIPTION
Fixes i18n app name in Androids AndroidManfiest.xml `android:label` field.

**Current issues:**

If you use [i18n app names](https://titaniumsdk.com/guide/Titanium_SDK/Titanium_SDK_How-tos/Cross-Platform_Mobile_Development_In_Titanium/Internationalization.html#app-name-localization) it will not use that value for the AndroidManifest file.

**Testing:**
* set `<name>muenzen</name>` (instead of Münzen) in tiapp.xml
* create the en/app.xml  file and add `<string name="appname">Münzen</string>` (see [i18n app names](https://titaniumsdk.com/guide/Titanium_SDK/Titanium_SDK_How-tos/Cross-Platform_Mobile_Development_In_Titanium/Internationalization.html#app-name-localization) )
* the app on you home screen is called `Münzen` but in your app infos (click and hold - infos) it will show `muenzen` and when you receive a push it will show `muenzen`
* check `build/android/app/build/intermediates/merged_manifests/debug/processDebugManifest/AndroidManifest.xml` and search for the `android:label` field. It is set to `muenzen`.

After this PR the `android:label` field is set to `Münzen`, the app info shows `Münzen` and a push notification will show `Münzen` as the app name in the top left corner