### PR TITLE
feat(android): use ConcurrentHashMap in TiRhelper and TiUIHelper

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiRHelper.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiRHelper.java
@@ -6,9 +6,8 @@
  */
 package org.appcelerator.titanium.util;
 
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.appcelerator.kroll.common.Log;
 import org.appcelerator.titanium.TiApplication;
@@ -22,8 +21,8 @@ public class TiRHelper
 {
 	private static final String TAG = "TiRHelper";
 
-	private static final Map<String, Class<?>> clsCache = Collections.synchronizedMap(new HashMap<>());
-	private static final Map<String, Integer> valCache = Collections.synchronizedMap(new HashMap<>());
+	private static final Map<String, Class<?>> clsCache = new ConcurrentHashMap<>();
+	private static final Map<String, Integer> valCache = new ConcurrentHashMap<>();
 
 	private static final String clsPrefixAndroid = "android.R$";
 	private static String clsPrefixApplication = null;

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiUIHelper.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiUIHelper.java
@@ -14,9 +14,9 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -99,8 +99,8 @@ public class TiUIHelper
 	public static final String MIME_TYPE_PNG = "image/png";
 
 	private static Method overridePendingTransition;
-	private static final Map<String, String> resourceImageKeys = Collections.synchronizedMap(new HashMap<>());
-	private static final Map<String, Typeface> mCustomTypeFaces = Collections.synchronizedMap(new HashMap<>());
+	private static final Map<String, String> resourceImageKeys = new ConcurrentHashMap<>();
+	private static final Map<String, Typeface> mCustomTypeFaces = new ConcurrentHashMap<>();
 
 	public static OnClickListener createDoNothingListener()
 	{

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiUIHelper.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiUIHelper.java
@@ -425,11 +425,12 @@ public class TiUIHelper
 
 	private static Typeface loadTypeface(Context context, String fontFamily)
 	{
-		if (context == null) {
+		if (context == null || fontFamily == null) {
 			return null;
 		}
-		if (mCustomTypeFaces.containsKey(fontFamily)) {
-			return mCustomTypeFaces.get(fontFamily);
+		Typeface cached = mCustomTypeFaces.get(fontFamily);
+		if (cached != null || mCustomTypeFaces.containsKey(fontFamily)) {
+			return cached;
 		}
 		AssetManager mgr = context.getAssets();
 		try {
@@ -438,10 +439,7 @@ public class TiUIHelper
 				if (f.equalsIgnoreCase(fontFamily)
 					|| f.toLowerCase().startsWith(fontFamily.toLowerCase() + ".")) {
 					Typeface tf = Typeface.createFromAsset(mgr, customFontPath + "/" + f);
-					synchronized (mCustomTypeFaces)
-					{
-						mCustomTypeFaces.put(fontFamily, tf);
-					}
+					mCustomTypeFaces.put(fontFamily, tf);
 					return tf;
 				}
 			}
@@ -449,7 +447,6 @@ public class TiUIHelper
 			Log.e(TAG, "Unable to load 'fonts' assets. Perhaps doesn't exist? " + e.getMessage());
 		}
 
-		mCustomTypeFaces.put(fontFamily, null);
 		return null;
 	}
 


### PR DESCRIPTION
Some AI recommendations:

**High Priority**: Replace Collections.synchronizedMap() in TiRHelper.java - this is called frequently during resource lookups
**Medium Priority**: Replace Collections.synchronizedMap() in TiUIHelper.java - used for font and image caching

These changes improve concurrent read/write performance by using ConcurrentHashMap which provides:
- Non-blocking reads
- Fine-grained locking (lock striping) instead of global synchronization
- Better scalability under contention


There was one issue with fonts caching that is fixed with:

 ConcurrentHashMap doesn't allow null values, but the original code cached negative lookups with null. Changes made:
1. Added null check for fontFamily 
2. Removed the synchronized block (ConcurrentHashMap handles concurrency)
3. Removed caching of negative lookups (the put(null) at line 452)

Tested two apps, kitchensink and hyperloop examples. All worked fine, they are pretty fast so I didn't see any big improvement :-) 