### PR TITLE
feat(android): pre-compile regex patterns

### DIFF
--- a/android/modules/network/src/java/ti/modules/titanium/network/TiHTTPClient.java
+++ b/android/modules/network/src/java/ti/modules/titanium/network/TiHTTPClient.java
@@ -98,6 +98,8 @@ public class TiHTTPClient
 	// Regular expressions for detecting charset information in response documents (ex: html, xml).
 	private static final String HTML_META_TAG_REGEX = "charset=([^\"\']*)";
 	private static final String XML_DECLARATION_TAG_REGEX = "encoding=[\"\']([^\"\']*)[\"\']";
+	private static final Pattern HTML_META_TAG_PATTERN = Pattern.compile(HTML_META_TAG_REGEX);
+	private static final Pattern XML_DECLARATION_TAG_PATTERN = Pattern.compile(XML_DECLARATION_TAG_REGEX);
 
 	private static AtomicInteger httpClientThreadCounter;
 	private HttpURLConnection client;
@@ -540,16 +542,16 @@ public class TiHTTPClient
 	 */
 	private String detectResponseDataEncoding()
 	{
-		String regex;
+		Pattern pattern;
 		if (contentType == null) {
 			Log.w(TAG, "Could not detect charset, no content type specified.", Log.DEBUG_MODE);
 			return null;
 
 		} else if (contentType.contains("xml")) {
-			regex = XML_DECLARATION_TAG_REGEX;
+			pattern = XML_DECLARATION_TAG_PATTERN;
 
 		} else if (contentType.contains("html")) {
-			regex = HTML_META_TAG_REGEX;
+			pattern = HTML_META_TAG_PATTERN;
 
 		} else {
 			Log.w(TAG, "Cannot detect charset, unknown content type: " + contentType, Log.DEBUG_MODE);
@@ -563,7 +565,6 @@ public class TiHTTPClient
 			responseSequence = responseOut.toString();
 		}
 		if (responseSequence != null) {
-			Pattern pattern = Pattern.compile(regex);
 			Matcher matcher = pattern.matcher(responseSequence);
 			if (matcher.find()) {
 				return matcher.group(1);

--- a/android/titanium/src/java/org/appcelerator/titanium/TiApplication.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiApplication.java
@@ -74,6 +74,8 @@ public abstract class TiApplication extends Application implements KrollApplicat
 
 	protected static TiApplication tiApp = null;
 
+	private static final Pattern UNIT_PATTERN = Pattern.compile("system|px|dp|dip|mm|cm|in");
+
 	public static final String DEPLOY_TYPE_DEVELOPMENT = "development";
 	public static final String DEPLOY_TYPE_TEST = "test";
 	public static final String DEPLOY_TYPE_PRODUCTION = "production";
@@ -814,9 +816,7 @@ public abstract class TiApplication extends Application implements KrollApplicat
 	{
 		if (defaultUnit == null) {
 			defaultUnit = getAppProperties().getString(PROPERTY_DEFAULT_UNIT, SYSTEM_UNIT);
-			// Check to make sure default unit is valid, otherwise use system
-			Pattern unitPattern = Pattern.compile("system|px|dp|dip|mm|cm|in");
-			Matcher m = unitPattern.matcher(defaultUnit);
+			Matcher m = UNIT_PATTERN.matcher(defaultUnit);
 			if (!m.matches()) {
 				defaultUnit = SYSTEM_UNIT;
 			}


### PR DESCRIPTION
another AI recommendation:

These changes avoid regex compilation overhead on each method call, improving performance for:
- Default unit validation (called frequently during dimension parsing)
- HTTP response charset detection (called for each HTTP request)

**TiApplication.java** (titanium/src/java/org/appcelerator/titanium/TiApplication.java):
- Added private static final Pattern UNIT_PATTERN as pre-compiled static field
- Updated getDefaultUnit() to use the pre-compiled pattern

**TiHTTPClient.java** (modules/network/src/java/ti/modules/titanium/network/TiHTTPClient.java):
- Added HTML_META_TAG_PATTERN and XML_DECLARATION_TAG_PATTERN as pre-compiled static fields
- Updated detectResponseDataEncoding() to use pre-compiled patterns instead of calling Pattern.compile() on each request
