### PR TITLE
feat(android): cache ListView searchText

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/ListItemProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/ListItemProxy.java
@@ -831,6 +831,10 @@ public class ListItemProxy extends TiViewProxy
 			setProperty(TiC.PROPERTY_BACKGROUND_SELECTED_COLOR, selectionColor);
 		}
 
+		if (name.equals(TiC.PROPERTY_SEARCHABLE_TEXT) && value instanceof String) {
+			this.cachedSearchableTextLower = ((String) value).toLowerCase();
+		}
+
 		if (name.equals(TiC.PROPERTY_CAN_MOVE)) {
 			invalidate();
 		}
@@ -882,10 +886,6 @@ public class ListItemProxy extends TiViewProxy
 		super.setProperty(name, value);
 
 		processProperty(name, value);
-
-		if (TiC.PROPERTY_SEARCHABLE_TEXT.equals(name) && value instanceof String) {
-			this.cachedSearchableTextLower = ((String) value).toLowerCase();
-		}
 	}
 
 	/**

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/ListItemProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/ListItemProxy.java
@@ -58,6 +58,7 @@ public class ListItemProxy extends TiViewProxy
 	private boolean placeholder = false;
 	private boolean hasAddedItemEvents = false;
 	private boolean selected = false;
+	private String cachedSearchableTextLower = null;
 
 	public ListItemProxy()
 	{
@@ -881,6 +882,21 @@ public class ListItemProxy extends TiViewProxy
 		super.setProperty(name, value);
 
 		processProperty(name, value);
+
+		if (TiC.PROPERTY_SEARCHABLE_TEXT.equals(name) && value instanceof String) {
+			this.cachedSearchableTextLower = ((String) value).toLowerCase();
+		}
+	}
+
+	/**
+	 * Get cached lowercase searchable text for filtering.
+	 * Returns pre-computed lowercase version to avoid repeated toLowerCase() calls.
+	 *
+	 * @return Lowercase searchable text or null if not set.
+	 */
+	public String getSearchableTextLower()
+	{
+		return this.cachedSearchableTextLower;
 	}
 
 	/**

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/TiListView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/TiListView.java
@@ -711,11 +711,13 @@ public class TiListView extends TiSwipeRefreshLayout implements OnSearchChangeLi
 					.optBoolean(TiC.PROPERTY_FILTER_ALWAYS_INCLUDE, false);
 				// Handle search query.
 				if (query != null && !alwaysInclude) {
-					String searchableText = item.getProperties().optString(TiC.PROPERTY_SEARCHABLE_TEXT, null);
+					String searchableText;
+					if (caseInsensitive) {
+						searchableText = item.getSearchableTextLower();
+					} else {
+						searchableText = item.getProperties().optString(TiC.PROPERTY_SEARCHABLE_TEXT, null);
+					}
 					if (searchableText != null) {
-						if (caseInsensitive) {
-							searchableText = searchableText.toLowerCase();
-						}
 						if (!searchableText.contains(query)) {
 							continue;
 						}


### PR DESCRIPTION
Fixes one part of the #14407 issue:

```
3. Inefficient Search / Filter Implementation

Location: TiListView.java:681–719
Issue: toLowerCase() is called on every item's searchableText during filtering.
Impact: Repeated string allocations and increased CPU usage.
Recommendation: Cache the lowercase representation (lowercaseSearchableText) when the property is assigned.
```



**Example:**

```js
var win = Ti.UI.createWindow({});
var search = Titanium.UI.createSearchBar({
	showCancel: true,
	height: 43,
	top: 0,
});
search.addEventListener('cancel', function() {
	search.blur();
});
var listView = Ti.UI.createListView({
	searchView: search,
  // caseInsensitiveSearch: false // default is true
});
var listSection = Ti.UI.createListSection();
var fruits = ['Papaya', 'Peach', 'Pear', 'Persimmon', 'Pineapple', 'Pluot', 'Pomegranate'];
var data = [];
for (var i = 0; i < fruits.length; i++) {
	data.push({
		properties: {
			title: fruits[i],
			searchableText: fruits[i]
		}
	});
}
listSection.setItems(data);
listView.addEventListener('noresults', function(e) {
	alert("No results found!");
});
listView.sections = [listSection];
win.add(listView);
win.open();
```

This way it won't create a new lowercase string for each search update. 