### PR TITLE
fix(android): fix blob LruCache crash on recycled bitmaps

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiBlobLruCache.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiBlobLruCache.java
@@ -9,6 +9,8 @@ package org.appcelerator.titanium.util;
 import android.graphics.Bitmap;
 import androidx.collection.LruCache;
 
+import java.util.concurrent.ConcurrentHashMap;
+
 public class TiBlobLruCache extends LruCache<String, Bitmap>
 {
 	// Get max available VM memory, exceeding this amount will throw an
@@ -18,6 +20,14 @@ public class TiBlobLruCache extends LruCache<String, Bitmap>
 
 	// Use 1/8th of the available memory for this memory cache.
 	private static final int cacheSize = maxMemory / 8;
+
+	// Track original bitmap sizes so sizeOf() returns consistent values
+	// even after a bitmap has been recycled externally. LruCache requires
+	// sizeOf() to be consistent for the lifetime of an entry; returning 0
+	// for recycled bitmaps causes the internal size accounting to break,
+	// leading to "sizeOf() is reporting inconsistent results!" crashes
+	// when evictAll() or trimToSize() is called under memory pressure.
+	private final ConcurrentHashMap<String, Integer> sizeMap = new ConcurrentHashMap<>();
 
 	private static class InstanceHolder
 	{
@@ -37,8 +47,33 @@ public class TiBlobLruCache extends LruCache<String, Bitmap>
 	@Override
 	protected int sizeOf(String key, Bitmap bitmap)
 	{
-		int byteCount = bitmap.getRowBytes() * bitmap.getHeight();
-		return byteCount / 1024;
+		// Return the cached size if available. This ensures consistency
+		// even if the bitmap has been recycled since it was added.
+		Integer cachedSize = sizeMap.get(key);
+		if (cachedSize != null) {
+			return cachedSize;
+		}
+
+		// Bitmap is recycled and was never tracked (shouldn't happen in
+		// normal use, but guard against it defensively).
+		if (bitmap.isRecycled()) {
+			return 0;
+		}
+
+		int byteCount = (bitmap.getRowBytes() * bitmap.getHeight()) / 1024;
+		sizeMap.put(key, byteCount);
+		return byteCount;
+	}
+
+	@Override
+	protected void entryRemoved(boolean evicted, String key, Bitmap oldValue, Bitmap newValue)
+	{
+		// Clean up tracked size when an entry is fully removed.
+		// When newValue is non-null this is a replacement and the new
+		// entry's size will be tracked by the next sizeOf() call.
+		if (newValue == null) {
+			sizeMap.remove(key);
+		}
 	}
 
 	public void addBitmapToMemoryCache(String key, Bitmap bitmap)


### PR DESCRIPTION
## Summary

- Fixes Android crash: `TiBlobLruCache.sizeOf() is reporting inconsistent results!` when repeatedly resizing images via `imageAsResized()` under memory pressure
- Tracks original bitmap sizes in a `ConcurrentHashMap` so `sizeOf()` returns consistent values even after a bitmap is recycled externally, satisfying the `LruCache` contract
- Overrides `entryRemoved()` to clean up tracked sizes when entries are evicted

## Root Cause

PR #14156 made `sizeOf()` return `0` for recycled bitmaps to suppress warnings. This broke `LruCache` internal accounting — when `evictAll()` (called from `onTrimMemory`) subtracted `0` instead of the original size, the cache ended up with an empty map but non-zero size counter, triggering an `IllegalStateException` crash.

## Test plan

- [ ] Run the reproduction case from #14232: open photo gallery, select and resize 4+ different images in sequence on a Pixel device
- [ ] Verify no crash and `imageAsResized()` returns valid blobs each time
- [ ] Verify no "Called getRowBytes() on a recycle()'d bitmap!" warnings in logcat
- [ ] Test `onTrimMemory` / `onLowMemory` paths by simulating memory pressure while images are cached

Fixes #14232