### PR TITLE
feat(android): improve pinch&zoom in ImageView

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiImageView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiImageView.java
@@ -454,6 +454,9 @@ public class TiImageView extends ViewGroup
 		/** Last scale center point used during a pinch-zoom along the y-axis. */
 		private float lastFocusY;
 
+		/** Flag indicating whether a pinch-zoom gesture is in progress. */
+		private boolean isScaling = false;
+
 		public ZoomHandler(@NonNull TiImageView tiImageView)
 		{
 			this.tiImageView = tiImageView;
@@ -471,7 +474,11 @@ public class TiImageView extends ViewGroup
 
 		public boolean onTouchEvent(MotionEvent event)
 		{
-			return this.gestureDetector.onTouchEvent(event) || this.scaleGestureDetector.onTouchEvent(event);
+			this.scaleGestureDetector.onTouchEvent(event);
+			if (this.scaleGestureDetector.isInProgress() || this.isScaling) {
+				return true;
+			}
+			return this.gestureDetector.onTouchEvent(event);
 		}
 
 		@Override
@@ -534,8 +541,7 @@ public class TiImageView extends ViewGroup
 		@Override
 		public boolean onScroll(MotionEvent e1, MotionEvent e2, float dx, float dy)
 		{
-			// Only allow scrolls if image is zoomed and we're not in the middle of doing a pinch-zoom.
-			if (!this.scaleGestureDetector.isInProgress() && !this.matrix.isIdentity()) {
+			if (!this.isScaling && e2.getPointerCount() == 1 && !this.matrix.isIdentity()) {
 				this.matrix.postTranslate(-dx, -dy);
 				applyLimitsToMatrix();
 				this.tiImageView.requestLayout();
@@ -547,6 +553,7 @@ public class TiImageView extends ViewGroup
 		@Override
 		public boolean onScaleBegin(ScaleGestureDetector detector)
 		{
+			this.isScaling = true;
 			this.lastFocusX = detector.getFocusX();
 			this.lastFocusY = detector.getFocusY();
 			return true;
@@ -569,6 +576,7 @@ public class TiImageView extends ViewGroup
 		@Override
 		public void onScaleEnd(ScaleGestureDetector detector)
 		{
+			this.isScaling = false;
 			if (applyLimitsToMatrix()) {
 				this.tiImageView.requestLayout();
 			}


### PR DESCRIPTION
Will improve pinch & zoom (especially zoom out) in an Android ImageView

```js
var win = Ti.UI.createWindow();
var img = Ti.UI.createImageView({
	image:"https://picsum.photos/1000/2000",
	enableZoomControls:true,
	width: Ti.UI.FILL,
	height: Ti.UI.FILL,
})
win.add(img);
win.open();
```

**Test:**
* run the code above and zoom in & out
* Ti 13.1.1: you sometimes are stuck in "moving mode" when you try to zoom out
* This PR: should be able to zoom out 


**Note:**
* there is https://github.com/tidev/titanium-sdk/pull/14227 to improve the behavior in ScrollableViews
