### PR TITLE
feat(android): update cpp files for unpachted v8 versions

### DIFF
--- a/android/runtime/v8/src/native/V8Runtime.cpp
+++ b/android/runtime/v8/src/native/V8Runtime.cpp
@@ -6,6 +6,7 @@
  */
 #include <stdio.h>
 #include <cstring>
+#include <string>
 
 #include <v8-platform.h>
 #include <libplatform/libplatform.h>
@@ -90,14 +91,24 @@ static void krollLog(const FunctionCallbackInfo<Value>& args)
 
 	Local<String> tag = args[0].As<String>();
 	Local<String> message = args[1].As<String>();
-	Local<String> space = STRING_NEW(isolate, " ");
-	for (uint32_t i = 2; i < len; ++i) {
-		message = String::Concat(isolate, String::Concat(isolate, message, space), args[i].As<String>());
-	}
 
-	String::Utf8Value tagValue(isolate, tag);
-	String::Utf8Value messageValue(isolate, message);
-	__android_log_print(ANDROID_LOG_DEBUG, *tagValue, *messageValue);
+	if (len > 2) {
+		String::Utf8Value firstMessage(isolate, message);
+		std::string combined(*firstMessage, firstMessage.length());
+
+		for (uint32_t i = 2; i < len; ++i) {
+			String::Utf8Value argValue(isolate, args[i].As<String>());
+			combined += ' ';
+			combined.append(*argValue, argValue.length());
+		}
+
+		String::Utf8Value tagValue(isolate, tag);
+		__android_log_print(ANDROID_LOG_DEBUG, *tagValue, "%s", combined.c_str());
+	} else {
+		String::Utf8Value tagValue(isolate, tag);
+		String::Utf8Value messageValue(isolate, message);
+		__android_log_print(ANDROID_LOG_DEBUG, *tagValue, *messageValue);
+	}
 }
 
 /* static */

--- a/android/runtime/v8/src/native/V8Util.cpp
+++ b/android/runtime/v8/src/native/V8Util.cpp
@@ -220,6 +220,7 @@ void V8Util::openJSErrorDialog(Isolate* isolate, TryCatch &tryCatch)
 }
 
 static int uncaughtExceptionCounter = 0;
+static Persistent<Function> jsonStringifyFunction;
 
 void V8Util::fatalException(Isolate* isolate, TryCatch &tryCatch)
 {
@@ -240,22 +241,29 @@ Local<String> V8Util::jsonStringify(Isolate* isolate, Local<Value> value)
 
 	TryCatch tryCatch(isolate);
 
-	MaybeLocal<Value> jsonGlobal = context->Global()->Get(context, STRING_NEW(isolate, "JSON"));
-	if (jsonGlobal.IsEmpty()) {
-		LOGE(TAG, "!!!! JSON global not found/accessible !!!");
-		return scope.Escape(STRING_NEW(isolate, "ERROR"));
+	Local<Function> stringify;
+	if (jsonStringifyFunction.IsEmpty()) {
+		MaybeLocal<Value> jsonGlobal = context->Global()->Get(context, STRING_NEW(isolate, "JSON"));
+		if (jsonGlobal.IsEmpty()) {
+			LOGE(TAG, "!!!! JSON global not found/accessible !!!");
+			return scope.Escape(STRING_NEW(isolate, "ERROR"));
+		}
+
+		Local<Object> jsonObject = jsonGlobal.ToLocalChecked().As<Object>();
+		MaybeLocal<Value> stringifyValue = jsonObject->Get(context, STRING_NEW(isolate, "stringify"));
+		if (stringifyValue.IsEmpty()) {
+			LOGE(TAG, "!!!! JSON.stringifyValue not found/accessible !!!");
+			return scope.Escape(STRING_NEW(isolate, "ERROR"));
+		}
+
+		stringify = stringifyValue.ToLocalChecked().As<Function>();
+		jsonStringifyFunction.Reset(isolate, stringify);
+	} else {
+		stringify = jsonStringifyFunction.Get(isolate);
 	}
 
-	Local<Object> jsonObject = jsonGlobal.ToLocalChecked().As<Object>();
-	MaybeLocal<Value> stringifyValue = jsonObject->Get(context, STRING_NEW(isolate, "stringify"));
-	if (stringifyValue.IsEmpty()) {
-		LOGE(TAG, "!!!! JSON.stringifyValue not found/accessible !!!");
-		return scope.Escape(STRING_NEW(isolate, "ERROR"));
-	}
-
-	Local<Function> stringify = stringifyValue.ToLocalChecked().As<Function>();
 	Local<Value> args[] = { value };
-	MaybeLocal<Value> result = stringify->Call(context, jsonObject, 1, args);
+	MaybeLocal<Value> result = stringify->Call(context, stringify, 1, args);
 	if (result.IsEmpty()) {
 		LOGE(TAG, "!!!! JSON.stringify() result is null/undefined.!!!");
 		return scope.Escape(STRING_NEW(isolate, "ERROR"));
@@ -296,6 +304,7 @@ bool V8Util::isNaN(Isolate* isolate, Local<Value> value)
 void V8Util::dispose()
 {
 	isNaNFunction.Reset();
+	jsonStringifyFunction.Reset();
 }
 
 std::string V8Util::stackTraceString(Isolate* isolate, Local<StackTrace> frames, int maxCount) {

--- a/android/runtime/v8/src/native/V8Util.h
+++ b/android/runtime/v8/src/native/V8Util.h
@@ -22,9 +22,25 @@
 #define STRING_NEW(isolate, string_literal) \
 	v8::String::NewFromUtf8(isolate, string_literal "", v8::NewStringType::kNormal).ToLocalChecked()
 
+namespace titanium {
+	// Helper for DEFINE_CONSTANT to work with both Object and Template
+	template <typename T>
+	inline void SetConstant(v8::Isolate* isolate, T target, v8::Local<v8::String> name, v8::Local<v8::Value> value) {
+		target->Set(isolate->GetCurrentContext(), name, value,
+			static_cast<v8::PropertyAttribute>(v8::ReadOnly | v8::DontDelete)).FromJust();
+	}
+	template <>
+	inline void SetConstant<v8::Local<v8::ObjectTemplate>>(v8::Isolate* isolate, v8::Local<v8::ObjectTemplate> target, v8::Local<v8::String> name, v8::Local<v8::Value> value) {
+		target->Set(name, value, static_cast<v8::PropertyAttribute>(v8::ReadOnly | v8::DontDelete));
+	}
+	template <>
+	inline void SetConstant<v8::Local<v8::FunctionTemplate>>(v8::Isolate* isolate, v8::Local<v8::FunctionTemplate> target, v8::Local<v8::String> name, v8::Local<v8::Value> value) {
+		target->PrototypeTemplate()->Set(name, value, static_cast<v8::PropertyAttribute>(v8::ReadOnly | v8::DontDelete));
+	}
+}
+
 #define DEFINE_CONSTANT(isolate, target, name, value) \
-	(target)->Set(NEW_SYMBOL(isolate, name),          \
-		value, static_cast<v8::PropertyAttribute>(v8::ReadOnly | v8::DontDelete))
+	titanium::SetConstant(isolate, target, NEW_SYMBOL(isolate, name), value)
 
 #define DEFINE_INT_CONSTANT(isolate, target, name, value) \
 	DEFINE_CONSTANT(isolate, target, name, v8::Integer::New(isolate, value))
@@ -72,8 +88,8 @@
 	LOGV(TAG, __VA_ARGS__); \
 	for (uint32_t i = 0; i < frameCount; i++) { \
 		v8::Local<v8::StackFrame> frame = stackTrace->GetFrame(i); \
-		v8::String::Utf8Value fnName(frame->GetFunctionName()); \
-		v8::String::Utf8Value scriptUrl(frame->GetScriptName()); \
+		v8::String::Utf8Value fnName(isolate, frame->GetFunctionName()); \
+		v8::String::Utf8Value scriptUrl(isolate, frame->GetScriptName()); \
 		LOGV(TAG, "    at %s [%s:%d:%d]", *fnName, *scriptUrl, frame->GetLineNumber(), frame->GetColumn()); \
 	} \
 }

--- a/android/runtime/v8/src/native/V8Util.h
+++ b/android/runtime/v8/src/native/V8Util.h
@@ -22,25 +22,9 @@
 #define STRING_NEW(isolate, string_literal) \
 	v8::String::NewFromUtf8(isolate, string_literal "", v8::NewStringType::kNormal).ToLocalChecked()
 
-namespace titanium {
-	// Helper for DEFINE_CONSTANT to work with both Object and Template
-	template <typename T>
-	inline void SetConstant(v8::Isolate* isolate, T target, v8::Local<v8::String> name, v8::Local<v8::Value> value) {
-		target->Set(isolate->GetCurrentContext(), name, value,
-			static_cast<v8::PropertyAttribute>(v8::ReadOnly | v8::DontDelete)).FromJust();
-	}
-	template <>
-	inline void SetConstant<v8::Local<v8::ObjectTemplate>>(v8::Isolate* isolate, v8::Local<v8::ObjectTemplate> target, v8::Local<v8::String> name, v8::Local<v8::Value> value) {
-		target->Set(name, value, static_cast<v8::PropertyAttribute>(v8::ReadOnly | v8::DontDelete));
-	}
-	template <>
-	inline void SetConstant<v8::Local<v8::FunctionTemplate>>(v8::Isolate* isolate, v8::Local<v8::FunctionTemplate> target, v8::Local<v8::String> name, v8::Local<v8::Value> value) {
-		target->PrototypeTemplate()->Set(name, value, static_cast<v8::PropertyAttribute>(v8::ReadOnly | v8::DontDelete));
-	}
-}
-
 #define DEFINE_CONSTANT(isolate, target, name, value) \
-	titanium::SetConstant(isolate, target, NEW_SYMBOL(isolate, name), value)
+	(target)->Set(NEW_SYMBOL(isolate, name),          \
+		value, static_cast<v8::PropertyAttribute>(v8::ReadOnly | v8::DontDelete))
 
 #define DEFINE_INT_CONSTANT(isolate, target, name, value) \
 	DEFINE_CONSTANT(isolate, target, name, v8::Integer::New(isolate, value))
@@ -87,7 +71,7 @@ namespace titanium {
 	uint32_t frameCount = stackTrace->GetFrameCount(); \
 	LOGV(TAG, __VA_ARGS__); \
 	for (uint32_t i = 0; i < frameCount; i++) { \
-		v8::Local<v8::StackFrame> frame = stackTrace->GetFrame(i); \
+		v8::Local<v8::StackFrame> frame = stackTrace->GetFrame(isolate, i); \
 		v8::String::Utf8Value fnName(isolate, frame->GetFunctionName()); \
 		v8::String::Utf8Value scriptUrl(isolate, frame->GetScriptName()); \
 		LOGV(TAG, "    at %s [%s:%d:%d]", *fnName, *scriptUrl, frame->GetLineNumber(), frame->GetColumn()); \


### PR DESCRIPTION
just a draft PR for an unpatched v8 version: https://github.com/tidev/v8_titanium/pull/57

Changes also include:

1. V8Runtime.cpp:80-110 - Fixed O(n²) string concatenation in krollLog:
- Uses std::string for accumulation (O(n))
- Only converts to V8 strings at the end for logging

2. V8Util.cpp - Added JSON.stringify caching:
- Added static jsonStringifyFunction Persistent to cache the function
- First call looks up JSON.stringify and caches it
- Subsequent calls use the cached function directly
- Updated dispose() to clean up the cached function