### PR TITLE
fix(android): null pointer check in cpp files

### DIFF
--- a/android/runtime/v8/src/native/Proxy.cpp
+++ b/android/runtime/v8/src/native/Proxy.cpp
@@ -309,6 +309,10 @@ void Proxy::hasListenersForEventType(const v8::FunctionCallbackInfo<v8::Value>& 
 	}
 	Proxy* proxy = NativeObject::Unwrap<Proxy>(holder);
 
+	if (proxy == nullptr) {
+		return;
+	}
+
 	// TODO Support Symbols for event types?
 	Local<String> eventType = args[0].As<String>();
 	Local<Boolean> hasListeners = args[1]->ToBoolean(isolate);
@@ -349,6 +353,10 @@ void Proxy::onEventFired(const v8::FunctionCallbackInfo<v8::Value>& args)
 		holder = holder->FindInstanceInPrototypeChain(baseProxyTemplate.Get(isolate));
 	}
 	Proxy* proxy = NativeObject::Unwrap<Proxy>(holder);
+
+	if (proxy == nullptr) {
+		return;
+	}
 
 	// TODO Support Symbols for event types?
 	Local<String> eventType = args[0].As<String>();

--- a/android/runtime/v8/src/native/Proxy.cpp
+++ b/android/runtime/v8/src/native/Proxy.cpp
@@ -310,6 +310,7 @@ void Proxy::hasListenersForEventType(const v8::FunctionCallbackInfo<v8::Value>& 
 	Proxy* proxy = NativeObject::Unwrap<Proxy>(holder);
 
 	if (proxy == nullptr) {
+		JSException::Error(isolate, "Failed to unwrap Proxy instance.");
 		return;
 	}
 
@@ -355,6 +356,7 @@ void Proxy::onEventFired(const v8::FunctionCallbackInfo<v8::Value>& args)
 	Proxy* proxy = NativeObject::Unwrap<Proxy>(holder);
 
 	if (proxy == nullptr) {
+		JSException::Error(isolate, "Failed to unwrap Proxy instance.");
 		return;
 	}
 


### PR DESCRIPTION
Was investigating some crashlogs and saw this one:
```
#06  pc 0x000000000080ca0c  /data/app/split_config.arm64_v8a.apk!libkroll-v8.so (titanium::Proxy::hasListenersForEventType(v8::FunctionCallbackInfo<v8::Value> const&)+348) (BuildId: id)
#07  pc 0x00000000009fa9ac  /data/app/split_config.arm64_v8a.apk!libkroll-v8.so (v8::internal::FunctionCallbackArguments::Call(v8::internal::CallHandlerInfo)+540) (BuildId: id)
#08  pc 0x00000000009fa08c  /data/app/split_config.arm64_v8a.apk!libkroll-v8.so (BuildId: id)
#09  pc 0x00000000009f9874  /data/app/split_config.arm64_v8a.apk!libkroll-v8.so (BuildId: id)
#10  pc 0x00000000012d1a48  /data/app/split_config.arm64_v8a.apk!libkroll-v8.so (BuildId: id)
```

running it thorugh AI with the SDK folder it said:

> Root cause: The code doesn't check if proxy is null after unwrapping. If holder isn't a valid proxy wrapper or the unwrapping fails, proxy becomes null, and calling proxy->getJavaObject() crashes.
> This typically happens when:
> 1. A JavaScript proxy object gets garbage collected or invalidated
> 2. An event is fired on an object that no longer has a valid native wrapper
> Fix approach: Add a null check for proxy before accessing its methods, returning early if null. Similar null-check patterns exist elsewhere in this file.

which sounds like a good idea. I guess inside the app there is a event that is trying to fire but the window is closed already.

Fix is:

> Summary of changes made to android/runtime/v8/src/native/Proxy.cpp:
> 1. Line 312-314: Added null check in hasListenersForEventType() - returns early if proxy is null
> 2. Line 357-359: Added null check in onEventFired() - returns early if proxy is null
> These null checks prevent the crash when a JavaScript proxy object gets garbage collected or invalidated, and an event is fired on an object that no longer has a valid native wrapper.
> 

So if the proxy is null somehow it will just return and not continue. I can't reproduce it locally as it was just a crash in the Google Play Store. But it makes sense and hopefully it will get rid of these crashes