### PR TITLE
fix(android): fix endless loop in setLanguage pre API 33

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiLocaleManager.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiLocaleManager.java
@@ -95,6 +95,11 @@ public class TiLocaleManager
 
 	private static void setLocaleForPreApi33(Locale locale, boolean shouldRestartApp)
 	{
+		// Skip if the requested language is already set.
+		Locale previouseLocale = Locale.getDefault();
+		if (previouseLocale.equals(locale)) {
+			return;
+		}
 		Locale.setDefault(locale);
 
 		Resources resources = TiApplication.getInstance().getBaseContext().getResources();


### PR DESCRIPTION
the API 33+ route has a check for setting the same language again:
https://github.com/tidev/titanium-sdk/blob/main/android/titanium/src/java/org/appcelerator/titanium/util/TiLocaleManager.java#L85-L88

pre API 33 doesn't have this and running:
```js
Ti.Locale.setLanguage('en');
```
on an Android 12 phone will end up in an endless restart loop.
With this PR it will max restart once if the locale is different