### PR TITLE
fix(ios): fix Ti.UI.Button styling and events on Mac Catalyst

### DIFF
--- a/iphone/Classes/TiUIButton.m
+++ b/iphone/Classes/TiUIButton.m
@@ -171,7 +171,14 @@
 - (UIButton *)button
 {
   if (button == nil) {
+#if TARGET_OS_MACCATALYST
+    // On Mac Catalyst, UIButtonTypeRoundedRect (system button) ignores programmatic styling
+    // (title color, font, size) and doesn't deliver touch events via UIControlEventAllTouchEvents.
+    // Force UIButtonTypeCustom so styling and events work correctly.
+    UIButtonType defaultType = UIButtonTypeCustom;
+#else
     UIButtonType defaultType = [self hasImageProperties] ? UIButtonTypeCustom : UIButtonTypeRoundedRect;
+#endif
     style = [TiUtils intValue:[self.proxy valueForKey:@"style"] def:defaultType];
     UIView *btn = [TiButtonUtil buttonWithType:style];
     button = (UIButton *)[btn retain];


### PR DESCRIPTION
## Summary

`Ti.UI.Button` is completely unusable on Mac Catalyst when using the default `UIButtonTypeRoundedRect` (system button) style. Two problems:

1. **Styling is ignored**: programmatic properties like title color, font family, font size, and font weight are all overridden by the native macOS system button rendering. Only backgroundColor applies.
2. **Events don't fire**: `click` and `singletap` events never fire because Mac Catalyst translates system buttons into native macOS controls, redirecting events away from `UIControlEventAllTouchEvents`.

The root cause for both issues is the same: Mac Catalyst translates `UIButtonTypeRoundedRect`/`UIButtonTypeSystem` into native macOS controls that manage their own appearance and event handling, bypassing what Titanium sets programmatically. `UIButtonTypeCustom` buttons are not affected because they skip this translation layer.

The fix forces `UIButtonTypeCustom` as the default button type on Mac Catalyst via `#if TARGET_OS_MACCATALYST`. This is the same behavior that was triggered by setting `backgroundSelectedColor` to any value, which was the only workaround before this fix.

No changes to button appearance or behavior on iOS.

## Test plan

- [ ] `Ti.UI.Button` with `onClick` handler fires on Mac
- [ ] `Ti.UI.Button` with `onSingletap` handler fires on Mac
- [ ] Button styling (color, font, fontSize, fontWeight) applies correctly on Mac
- [ ] Unstyled button shows visible text on Mac (white highlighted, default normal)
- [ ] Styled buttons (backgroundColor, color, etc.) work correctly on Mac
- [ ] No regression on iOS simulator/device