### PR TITLE
chore(android): optimize gradle SDK build

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -8,8 +8,8 @@
 # Set max Java heap size for Gradle daemon process.
 org.gradle.jvmargs=-Xmx2g
 
-# Enable Gradle build cache for faster incremental builds.
-org.gradle.caching=true
+# Enable parallel execution for multi-module builds.
+org.gradle.parallel=true
 
 # Enable usage of Google's AndroidX libraries.
 # Note: Jetifier is not needed for test app since it doesn't use Google's deprecated support libraries.

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -6,7 +6,13 @@
 # --------------------------------------------------------------------------------
 
 # Set max Java heap size for Gradle daemon process.
-org.gradle.jvmargs=-Xmx1536m
+org.gradle.jvmargs=-Xmx2g
+
+# Enable Gradle build cache for faster incremental builds.
+org.gradle.caching=true
+
+# Enable parallel execution for multi-module builds.
+org.gradle.parallel=true
 
 # Enable usage of Google's AndroidX libraries.
 # Note: Jetifier is not needed for test app since it doesn't use Google's deprecated support libraries.

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -11,9 +11,6 @@ org.gradle.jvmargs=-Xmx2g
 # Enable Gradle build cache for faster incremental builds.
 org.gradle.caching=true
 
-# Enable parallel execution for multi-module builds.
-org.gradle.parallel=true
-
 # Enable usage of Google's AndroidX libraries.
 # Note: Jetifier is not needed for test app since it doesn't use Google's deprecated support libraries.
 android.useAndroidX=true


### PR DESCRIPTION
Small updates to the base SDK gradle file.

**before:**
cleanbuild: 18s
build: 13s

**after:**
cleanbuild: 14s - 16s
build: 9s

Let's see if the github workflow is faster too :-)

**Update:**
* looks like the workflow doesn't like the parallel part