### PR TITLE
feat(android): add deprecation note for old events in ScrollableView

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/ScrollableViewProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/ScrollableViewProxy.java
@@ -9,6 +9,7 @@ package ti.modules.titanium.ui;
 import android.app.Activity;
 import android.os.Message;
 
+import org.appcelerator.kroll.common.Log;
 import org.appcelerator.kroll.KrollDict;
 import org.appcelerator.kroll.annotations.Kroll;
 import org.appcelerator.titanium.TiC;
@@ -311,6 +312,7 @@ public class ScrollableViewProxy extends TiViewProxy
 		}
 		// TODO: Deprecate old event
 		if (hasListeners("dragEnd")) {
+			Log.w(TAG, "dragEnd is deprecated.  Use " + TiC.EVENT_DRAGEND + " instead.");
 			KrollDict options = new KrollDict();
 			options.put("view", currentView);
 			options.put("currentPage", currentPage);
@@ -328,6 +330,7 @@ public class ScrollableViewProxy extends TiViewProxy
 		}
 		// TODO: Deprecate old event
 		if (hasListeners("scrollEnd")) {
+			Log.w(TAG, "scrollEnd is deprecated.  Use " + TiC.EVENT_SCROLLEND + " instead.");
 			KrollDict options = new KrollDict();
 			options.put("view", currentView);
 			options.put("currentPage", currentPage);

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/ScrollableViewProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/ScrollableViewProxy.java
@@ -310,7 +310,7 @@ public class ScrollableViewProxy extends TiViewProxy
 			options.put("currentPage", currentPage);
 			fireEvent(TiC.EVENT_DRAGEND, options);
 		}
-		// TODO: Deprecate old event
+
 		if (hasListeners("dragEnd")) {
 			Log.w(TAG, "dragEnd is deprecated.  Use " + TiC.EVENT_DRAGEND + " instead.");
 			KrollDict options = new KrollDict();
@@ -328,7 +328,7 @@ public class ScrollableViewProxy extends TiViewProxy
 			options.put("currentPage", currentPage);
 			fireEvent(TiC.EVENT_SCROLLEND, options);
 		}
-		// TODO: Deprecate old event
+
 		if (hasListeners("scrollEnd")) {
 			Log.w(TAG, "scrollEnd is deprecated.  Use " + TiC.EVENT_SCROLLEND + " instead.");
 			KrollDict options = new KrollDict();


### PR DESCRIPTION
the `TODO` was added 14 years ago :smile: but there was no warning. 

There are a few of these warnings (search for ` is deprecated. Use`). I think in the next bigger SDK update we should search for these and remove them.