### PR TITLE
fix(ios): avoid reusing background completion handlers

### DIFF
--- a/iphone/Classes/TiAppiOSProxy.m
+++ b/iphone/Classes/TiAppiOSProxy.m
@@ -977,7 +977,7 @@
   if ([handlerIdentifier rangeOfString:@"Session"].location != NSNotFound) {
     [[TiApp app] performCompletionHandlerForBackgroundTransferWithKey:handlerIdentifier];
   } else {
-    [[TiApp app] performCompletionHandlerWithKey:handlerIdentifier andResult:UIBackgroundFetchResultNoData removeAfterExecution:NO];
+    [[TiApp app] performCompletionHandlerWithKey:handlerIdentifier andResult:UIBackgroundFetchResultNoData];
   }
 }
 

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiApp.h
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiApp.h
@@ -297,7 +297,7 @@ TI_INLINE void waitForMemoryPanicCleared() // WARNING: This must never be run on
 - (void)registerBackgroundService:(TiProxy *)proxy;
 - (void)unregisterBackgroundService:(TiProxy *)proxy;
 - (void)stopBackgroundService:(TiProxy *)proxy;
-- (void)performCompletionHandlerWithKey:(NSString *)key andResult:(UIBackgroundFetchResult)result removeAfterExecution:(BOOL)removeAfterExecution;
+- (void)performCompletionHandlerWithKey:(NSString *)key andResult:(UIBackgroundFetchResult)result;
 - (void)performCompletionHandlerForBackgroundTransferWithKey:(NSString *)key;
 - (void)watchKitExtensionRequestHandler:(id)key withUserInfo:(NSDictionary *)userInfo;
 

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiApp.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiApp.m
@@ -759,8 +759,7 @@ TI_INLINE void waitForMemoryPanicCleared(void); // WARNING: This must never be r
 {
   if (pendingCompletionHandlers != nil) {
     for (NSString *key in [pendingCompletionHandlers allKeys]) {
-      // Do not remove from the pending handlers for now, as it's removed after the enumeration finished
-      [self performCompletionHandlerWithKey:key andResult:UIBackgroundFetchResultFailed removeAfterExecution:NO];
+      [self performCompletionHandlerWithKey:key andResult:UIBackgroundFetchResultFailed];
     }
   }
   RELEASE_TO_NIL(pendingCompletionHandlers);
@@ -772,19 +771,17 @@ TI_INLINE void waitForMemoryPanicCleared(void); // WARNING: This must never be r
   NSString *key = (NSString *)timer.userInfo;
   if ([pendingCompletionHandlers objectForKey:key]) {
     // Send an event notifying the developer that the background-fetch failed
-    [self performCompletionHandlerWithKey:key andResult:UIBackgroundFetchResultFailed removeAfterExecution:YES];
+    [self performCompletionHandlerWithKey:key andResult:UIBackgroundFetchResultFailed];
   }
 }
 
 // Gets called when user ends finishes with backgrounding stuff. By default this would always be called with UIBackgroundFetchResultNoData.
-- (void)performCompletionHandlerWithKey:(NSString *)key andResult:(UIBackgroundFetchResult)result removeAfterExecution:(BOOL)removeAfterExecution
+- (void)performCompletionHandlerWithKey:(NSString *)key andResult:(UIBackgroundFetchResult)result
 {
-  if ([pendingCompletionHandlers objectForKey:key]) {
-    void (^completionHandler)(UIBackgroundFetchResult) = [pendingCompletionHandlers objectForKey:key];
+  void (^completionHandler)(UIBackgroundFetchResult) = [pendingCompletionHandlers objectForKey:key];
+  if (completionHandler != nil) {
+    [pendingCompletionHandlers removeObjectForKey:key];
     completionHandler(result);
-    if (removeAfterExecution) {
-      [pendingCompletionHandlers removeObjectForKey:key];
-    }
   } else {
     DebugLog(@"[ERROR] The specified completion handler with ID = %@ has already expired or been removed from the system", key);
   }


### PR DESCRIPTION
## Summary
- remove the internal state that allowed a background/silent-push completion handler to be invoked without being removed
- make `performCompletionHandlerWithKey:` one-shot again so a handled silent push cannot be flushed a second time on foreground
- keep the fix scoped to the existing iOS completion-handler lifecycle instead of the newer GCD/scene changes

## Issue
- fixes #14418