### PR TITLE
fix(android): avoid WindowLeaked error when closing VideoPlayer windows

### DIFF
--- a/android/modules/media/src/java/android/widget/TiVideoView8.java
+++ b/android/modules/media/src/java/android/widget/TiVideoView8.java
@@ -34,6 +34,7 @@ import org.appcelerator.titanium.TiApplication;
 
 import ti.modules.titanium.media.MediaModule;
 import ti.modules.titanium.media.TiPlaybackListener;
+import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.res.AssetFileDescriptor;
@@ -498,13 +499,21 @@ public class TiVideoView8 extends SurfaceView implements MediaPlayerControl
 						}
 						start();
 						if (mMediaController != null) {
-							mMediaController.show();
+							// Check if the activity is finishing to avoid WindowLeaked error
+							Context context = getContext();
+							if (!(context instanceof Activity) || !((Activity) context).isFinishing()) {
+								mMediaController.show();
+							}
 						}
 					} else if (!isPlaying() && (seekToPosition != 0 || getCurrentPosition() > 0)) {
 						if (mMediaController != null) {
-							// Show the media controls when we're paused into a
-							// video and make 'em stick.
-							mMediaController.show(0);
+							// Check if the activity is finishing to avoid WindowLeaked error
+							Context context = getContext();
+							if (!(context instanceof Activity) || !((Activity) context).isFinishing()) {
+								// Show the media controls when we're paused into a
+								// video and make 'em stick.
+								mMediaController.show(0);
+							}
 						}
 					}
 				}
@@ -610,6 +619,11 @@ public class TiVideoView8 extends SurfaceView implements MediaPlayerControl
 				}
 				start();
 				if (mMediaController != null) {
+					// Check if the activity is finishing to avoid WindowLeaked error
+					Context context = getContext();
+					if (context instanceof Activity && ((Activity) context).isFinishing()) {
+						return;
+					}
 					mMediaController.show();
 				}
 			}


### PR DESCRIPTION
**Test code**
Note: add a video.mp4 into /app/assets/

```js
let win = Ti.UI.createWindow()
let btn = Ti.UI.createButton({
	title: "open"
})
btn.addEventListener("click", function() {
	let childWin = Ti.UI.createWindow()
	var videoPlayer = Titanium.Media.createVideoPlayer({
		top: 2,
		autoplay: true,
		backgroundColor: 'blue',
		height: 300,
		width: 300,
		mediaControlStyle: Titanium.Media.VIDEO_CONTROL_DEFAULT,
		scalingMode: Titanium.Media.VIDEO_SCALING_RESIZE_ASPECT
	});
	let btnClose = Ti.UI.createButton({
		title: "close",
		bottom: 20
	})
	btnClose.addEventListener("click", function(){
		tab.popToRootWindow();
	})
	videoPlayer.url = './video.mp4';
	childWin.add([videoPlayer,btnClose]);
	tab.open(childWin)
})
win.add(btn);
var tab = Ti.UI.createTab({
	window: win
})
var tabgroup = Ti.UI.createTabGroup({
	tabs: [tab]
});
tabgroup.open();
```

* start the app
* click on "open" to open a child window
* video starts playing
* press the "close" button so it will call `tab.popToRootWindow();`
* 13.2.0 will show:
```
[ERROR] WindowManager: android.view.WindowLeaked: Activity org.appcelerator.titanium.TiActivity has leaked window com.android.internal.policy.DecorView{55d44a5 V.ED..... R.....ID 0,0-900,264 aid=1073741836}[] that was originally added here
[ERROR] WindowManager:  at android.view.ViewRootImpl.<init>(ViewRootImpl.java:1380)
[ERROR] WindowManager:  at android.view.ViewRootImpl.<init>(ViewRootImpl.java:1367)
[ERROR] WindowManager:  at android.view.WindowManagerGlobal.addView(WindowManagerGlobal.java:493)
[ERROR] WindowManager:  at android.view.WindowManagerImpl.addView(WindowManagerImpl.java:180)
[ERROR] WindowManager:  at android.widget.MediaController.show(MediaController.java:406)
[ERROR] WindowManager:  at android.widget.MediaController.show(MediaController.java:356)
[ERROR] WindowManager:  at android.widget.TiVideoView8$6.surfaceChanged(TiVideoView8.java:613)
[ERROR] WindowManager:  at android.view.SurfaceView.updateSurface(SurfaceView.java:1513)
[ERROR] WindowManager:  at android.view.SurfaceView.setFrame(SurfaceView.java:720)
[ERROR] WindowManager:  at android.view.View.layout(View.java:25902)
[ERROR] WindowManager:  at org.appcelerator.titanium.view.TiCompositeLayout.onLayout(TiCompositeLayout.java:939)
[ERROR] WindowManager:  at android.view.View.layout(View.java:25908)
[ERROR] WindowManager:  at android.view.ViewGroup.layout(ViewGroup.java:6468)
[ERROR] WindowManager:  at org.appcelerator.titanium.view.TiCompositeLayout.onLayout(TiCompositeLayout.java:939)
[ERROR] WindowManager:  at android.view.View.layout(View.java:25908)
[ERROR] WindowManager:  at android.view.ViewGroup.layout(ViewGroup.java:6468)
[ERROR] WindowManager:  at org.appcelerator.titanium.view.TiCompositeLayout.onLayout(TiCompositeLayout.java:939)
[ERROR] WindowManager:  at android.view.View.layout(View.java:25908)
[ERROR] WindowManager:  at android.view.ViewGroup.layout(ViewGroup.java:6468)
[ERROR] WindowManager:  at android.widget.FrameLayout.layoutChildren(FrameLayout.java:332)
[ERROR] WindowManager:  at android.widget.FrameLayout.onLayout(FrameLayout.java:270)
[ERROR] WindowManager:  at android.view.View.layout(View.java:25908)
[ERROR] WindowManager:  at android.view.ViewGroup.layout(ViewGroup.java:6468)
[ERROR] WindowManager:  at androidx.appcompat.widget.ActionBarOverlayLayout.onLayout(ActionBarOverlayLayout.java:553)
[ERROR] WindowManager:  at android.view.View.layout(View.java:25908)
[ERROR] WindowManager:  at android.view.ViewGroup.layout(ViewGroup.java:6468)
[ERROR] WindowManager:  at android.widget.FrameLayout.layoutChildren(FrameLayout.java:332)
[ERROR] WindowManager:  at android.widget.FrameLayout.onLayout(FrameLayout.java:270)
[ERROR] WindowManager:  at android.view.View.layout(View.java:25908)
[ERROR] WindowManager:  at android.view.ViewGroup.layout(ViewGroup.java:6468)
[ERROR] WindowManager:  at android.widget.LinearLayout.setChildFrame(LinearLayout.java:1891)
[ERROR] WindowManager:  at android.widget.LinearLayout.layoutVertical(LinearLayout.java:1729)
[ERROR] WindowManager:  at android.widget.LinearLayout.onLayout(LinearLayout.java:1638)
[ERROR] WindowManager:  at android.view.View.layout(View.java:25908)
[ERROR] WindowManager:  at android.view.ViewGroup.layout(ViewGroup.java:6468)
[ERROR] WindowManager:  at android.widget.FrameLayout.layoutChildren(FrameLayout.java:332)
[ERROR] WindowManager:  at android.widget.FrameLayout.onLayout(FrameLayout.java:270)
[ERROR] WindowManager:  at com.android.internal.policy.DecorView.onLayout(DecorView.java:797)
[ERROR] WindowManager:  at android.view.View.layout(View.java:25908)
[ERROR] WindowManager:  at android.view.ViewGroup.layout(ViewGroup.java:6468)
[ERROR] WindowManager:  at android.view.ViewRootImpl.performLayout(ViewRootImpl.java:5340)
[ERROR] WindowManager:  at android.view.ViewRootImpl.performTraversals(ViewRootImpl.java:4449)
[ERROR] WindowManager:  at android.view.ViewRootImpl.doTraversal(ViewRootImpl.java:3293)
[ERROR] WindowManager:  at android.view.ViewRootImpl$TraversalRunnable.run(ViewRootImpl.java:11143)
[ERROR] WindowManager:  at android.view.Choreographer$CallbackRecord.run(Choreographer.java:1647)
[ERROR] WindowManager:  at android.view.Choreographer$CallbackRecord.run(Choreographer.java:1656)
[ERROR] WindowManager:  at android.view.Choreographer.doCallbacks(Choreographer.java:1252)
[ERROR] WindowManager:  at android.view.Choreographer.doFrame(Choreographer.java:1181)
[ERROR] WindowManager:  at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:1630)
[ERROR] WindowManager:  at android.os.Handler.handleCallback(Handler.java:1095)
[ERROR] WindowManager:  at android.os.Handler.dispatchMessageImpl(Handler.java:135)
[ERROR] WindowManager:  at android.os.Handler.dispatchMessage(Handler.java:125)
[ERROR] WindowManager:  at android.os.Looper.loopOnce(Looper.java:269)
[ERROR] WindowManager:  at android.os.Looper.loop(Looper.java:367)
[ERROR] WindowManager:  at android.app.ActivityThread.main(ActivityThread.java:9333)
[ERROR] WindowManager:  at java.lang.reflect.Method.invoke(Native Method)
[ERROR] WindowManager:  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:566)
[ERROR] WindowManager:  at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:929)
```

with this PR the window will close with an error