### PR TITLE
fix(android): code clean up and null checkes

### DIFF
--- a/android/modules/media/src/java/ti/modules/titanium/media/TiCameraActivity.java
+++ b/android/modules/media/src/java/ti/modules/titanium/media/TiCameraActivity.java
@@ -325,6 +325,19 @@ public class TiCameraActivity extends TiBaseActivity implements SurfaceHolder.Ca
 			cameraActivity = null;
 		}
 
+		// Clear all static references to prevent memory leaks
+		mediaContext = null;
+		callbackContext = null;
+		successCallback = null;
+		errorCallback = null;
+		cancelCallback = null;
+		androidbackCallback = null;
+		overlayProxy = null;
+		camera = null;
+		recorder = null;
+		videoContentUri = null;
+		videoParcelFileDescriptor = null;
+
 		// Destroy this activity.
 		super.onDestroy();
 	}

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiWebViewBinding.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiWebViewBinding.java
@@ -114,6 +114,17 @@ public class TiWebViewBinding
 
 	public void destroy()
 	{
+		// Remove JavaScript interfaces to prevent memory leaks
+		// This must be done before setting webView to null
+		if (webView != null) {
+			if (interfacesAdded) {
+				webView.removeJavascriptInterface("TiApp");
+				webView.removeJavascriptInterface("TiAPI");
+				webView.removeJavascriptInterface("_TiReturn");
+				interfacesAdded = false;
+			}
+		}
+
 		// remove any event listener that have already been added to the Ti.APP through
 		// this web view instance
 		appBinding.clearEventListeners();

--- a/android/titanium/src/java/org/appcelerator/titanium/TiExceptionHandler.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiExceptionHandler.java
@@ -253,6 +253,11 @@ public class TiExceptionHandler implements Handler.Callback, KrollExceptionHandl
 												.setCancelable(false);
 
 		final AlertDialog dialog = builder.create();
+
+		// Check if the activity is finishing to avoid WindowLeaked error
+		if (activity == null || activity.isFinishing() || activity.isDestroyed()) {
+			return;
+		}
 		dialog.show();
 
 		final Window window = activity.getWindow();
@@ -263,6 +268,11 @@ public class TiExceptionHandler implements Handler.Callback, KrollExceptionHandl
 
 	private static void showMaterialThemeErrorDialog(@NonNull Activity activity)
 	{
+		// Check if the activity is finishing to avoid WindowLeaked error
+		if (activity == null || activity.isFinishing() || activity.isDestroyed()) {
+			return;
+		}
+
 		AlertDialog.Builder builder = new AlertDialog.Builder(activity, R.style.Theme_Titanium_Dialog_Error);
 		builder.setTitle("Developer Error");
 		builder.setMessage(

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiUIHelper.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiUIHelper.java
@@ -142,14 +142,19 @@ public class TiUIHelper
 			negativeListener = createKillListener();
 		}
 
-		new MaterialAlertDialogBuilder(context)
+		AlertDialog dialog = new MaterialAlertDialogBuilder(context)
 			.setTitle(title)
 			.setMessage(message)
 			.setPositiveButton("Continue", positiveListener)
 			.setNegativeButton("Kill", negativeListener)
 			.setCancelable(false)
-			.create()
-			.show();
+			.create();
+
+		// Check if the context is an Activity and if it's finishing to avoid WindowLeaked error
+		if (context instanceof Activity && ((Activity) context).isFinishing()) {
+			return;
+		}
+		dialog.show();
 	}
 
 	public static void linkifyIfEnabled(TextView tv, Object autoLink)

--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiUIView.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiUIView.java
@@ -1379,6 +1379,13 @@ public abstract class TiUIView implements KrollProxyListener, OnFocusChangeListe
 			children.clear();
 			children = null;
 		}
+		// Clear detector to prevent memory leak
+		detector = null;
+		// Clear touchView WeakReference to prevent memory leak
+		if (touchView != null) {
+			touchView.clear();
+			touchView = null;
+		}
 		proxy = null;
 		layoutParams = null;
 	}


### PR DESCRIPTION
Some places found with AI checks that might cause memory leaks:

* TiWebViewBinding.java - Remove JavaScript interfaces before destroying
* TiCameraActivity.java - Nullify all static fields in onDestroy()
* TiUIView.java - Clear detector and touchView in release()
* prevent WindowLeaked errors (see https://github.com/tidev/titanium-sdk/pull/14435 for the error message)