### PR TITLE
feat(ios): remove ImageView remote image fade-in animation

### DIFF
--- a/apidoc/Titanium/UI/ImageView.yml
+++ b/apidoc/Titanium/UI/ImageView.yml
@@ -192,15 +192,6 @@ properties:
     type: Number
     default: 200 ms in Release 2.1.1 and later. Platform-specific default in earlier releases.
 
-  - name: fadeInTime
-    summary: |
-        Duration in seconds for the fade-in transition when a remote image finishes loading.
-        Only applies when a `defaultImage` (or the built-in placeholder) is displayed while the remote image downloads.
-    type: Number
-    default: 0.5
-    platforms: [iphone, ipad, macos]
-    since: "13.3.0"
-
   - name: enableZoomControls
     summary: Show zoom controls when the user touches the image view.
     type: Boolean

--- a/apidoc/Titanium/UI/ImageView.yml
+++ b/apidoc/Titanium/UI/ImageView.yml
@@ -8,14 +8,14 @@ description: |
 
     Specifying either a `width` or `height` property for this view will scale its image(s) with
     the aspect ratio maintained, up to a maximum size that does not exceed its parent view.
-    
+
     #### Remote Images
-    
-    You can display both local and remote images in an ImageView. When loading remote images, you should 
-    set the defaultImage property to a local image, which will be displayed while the remote image is being 
+
+    You can display both local and remote images in an ImageView. When loading remote images, you should
+    set the defaultImage property to a local image, which will be displayed while the remote image is being
     downloaded. Remote images are cached automatically on the iOS-, Android- and Windows platform.
-    
-    Android Note: Android 6 and later uses runtime permissions to secure the user's privacy. 
+
+    Android Note: Android 6 and later uses runtime permissions to secure the user's privacy.
     Therefore, you should call <Titanium.Filesystem.requestStoragePermissions> before attempting to load remote images.
 
     Read more about remote images and general best practices in the [Image Best Practices Guide](https://titaniumsdk.com/guide/Titanium_SDK/Titanium_SDK_Guide/Best_Practices_and_Recommendations/Image_Best_Practices.html#caching-remote-images).
@@ -70,7 +70,7 @@ methods:
     platforms: [android, iphone, ipad, macos]
     returns:
         type: Titanium.Blob
-  
+
   - name: addSymbolEffect
     summary: Adds a symbol effect to the image view with specified options, animation, and callback.
     platforms: [iphone, ipad, macos]
@@ -191,6 +191,15 @@ properties:
         and [start](Titanium.UI.ImageView.start) need to be called for the new value to take effect.
     type: Number
     default: 200 ms in Release 2.1.1 and later. Platform-specific default in earlier releases.
+
+  - name: fadeInTime
+    summary: |
+        Duration in seconds for the fade-in transition when a remote image finishes loading.
+        Only applies when a `defaultImage` (or the built-in placeholder) is displayed while the remote image downloads.
+    type: Number
+    default: 0.5
+    platforms: [iphone, ipad, macos]
+    since: "13.2.0"
 
   - name: enableZoomControls
     summary: Show zoom controls when the user touches the image view.

--- a/apidoc/Titanium/UI/ImageView.yml
+++ b/apidoc/Titanium/UI/ImageView.yml
@@ -199,7 +199,7 @@ properties:
     type: Number
     default: 0.5
     platforms: [iphone, ipad, macos]
-    since: "13.2.0"
+    since: "13.3.0"
 
   - name: enableZoomControls
     summary: Show zoom controls when the user touches the image view.

--- a/iphone/Classes/TiUIImageView.h
+++ b/iphone/Classes/TiUIImageView.h
@@ -33,6 +33,8 @@
   TiDimension height;
   CGFloat autoHeight;
   CGFloat autoWidth;
+  CGFloat fadeInTime;
+  BOOL fadeInTimeSet;
   NSInteger loadCount;
   NSInteger readyCount;
   NSInteger loadTotal;

--- a/iphone/Classes/TiUIImageView.h
+++ b/iphone/Classes/TiUIImageView.h
@@ -33,8 +33,6 @@
   TiDimension height;
   CGFloat autoHeight;
   CGFloat autoWidth;
-  CGFloat fadeInTime;
-  BOOL fadeInTimeSet;
   NSInteger loadCount;
   NSInteger readyCount;
   NSInteger loadTotal;

--- a/iphone/Classes/TiUIImageView.m
+++ b/iphone/Classes/TiUIImageView.m
@@ -326,8 +326,9 @@ DEFINE_EXCEPTIONS
 
     // do a nice fade in animation to replace the new incoming image
     // with our placeholder
+    CGFloat duration = fadeInTimeSet ? fadeInTime : 0.5;
     [UIView beginAnimations:nil context:nil];
-    [UIView setAnimationDuration:0.5];
+    [UIView setAnimationDuration:duration];
     [UIView setAnimationDelegate:self];
     [UIView setAnimationDidStopSelector:@selector(animationCompleted:finished:context:)];
 
@@ -788,6 +789,12 @@ DEFINE_EXCEPTIONS
   [self.proxy replaceValue:NUMINT(dur) forKey:@"duration" notification:NO];
 
   [self updateTimer];
+}
+
+- (void)setFadeInTime_:(id)value
+{
+  fadeInTime = [TiUtils floatValue:value def:0.5];
+  fadeInTimeSet = YES;
 }
 
 - (void)setRepeatCount_:(id)count

--- a/iphone/Classes/TiUIImageView.m
+++ b/iphone/Classes/TiUIImageView.m
@@ -319,28 +319,13 @@ DEFINE_EXCEPTIONS
   [self setTintedImage:image];
 
   if (placeholderLoading) {
-    UIImageView *iv = [self imageView];
-    iv.alpha = 0;
-
     [(TiViewProxy *)[self proxy] contentsWillChange];
 
-    // do a nice fade in animation to replace the new incoming image
-    // with our placeholder
-    CGFloat duration = fadeInTimeSet ? fadeInTime : 0.5;
-    [UIView beginAnimations:nil context:nil];
-    [UIView setAnimationDuration:duration];
-    [UIView setAnimationDelegate:self];
-    [UIView setAnimationDidStopSelector:@selector(animationCompleted:finished:context:)];
-
     for (UIView *view in [self subviews]) {
-      if (view != iv) {
+      if (view != [self imageView]) {
         [view setAlpha:0];
       }
     }
-
-    iv.alpha = 1;
-
-    [UIView commitAnimations];
 
     placeholderLoading = NO;
     [self fireLoadEventWithState:@"image"];
@@ -789,12 +774,6 @@ DEFINE_EXCEPTIONS
   [self.proxy replaceValue:NUMINT(dur) forKey:@"duration" notification:NO];
 
   [self updateTimer];
-}
-
-- (void)setFadeInTime_:(id)value
-{
-  fadeInTime = [TiUtils floatValue:value def:0.5];
-  fadeInTimeSet = YES;
 }
 
 - (void)setRepeatCount_:(id)count


### PR DESCRIPTION
Currently the iOS imageView will fade in a remote image with `defaultImage` for 0.5 seconds but removes the default image right away so it will have a blank screen in-between. This PR will remove that animation and just show the image.

**Test**

```js
const win = Ti.UI.createWindow();
const img = Ti.UI.createImageView({
	width: 200,
	height: 200,
	image: "/images/DefaultIcon.png",
	defaultImage: "/images/DefaultIcon.png",
	borderWidth: 1,
	borderColor: "red",
})
win.add(img);
setTimeout(function() {
	img.image = "https://picsum.photos/seed/"+Math.floor(Math.random()*1000)+"/2000"
}, 2000);
win.open();
```
