### PR TITLE
fix(ios): emit tab focus separately from selected

### DIFF
--- a/iphone/Classes/TiUITabGroup.m
+++ b/iphone/Classes/TiUITabGroup.m
@@ -103,7 +103,7 @@ DEFINE_EXCEPTIONS
   }
 }
 
-- (void)handleDidShowTab:(TiUITabProxy *)newFocus
+- (void)handleDidShowTab:(TiUITabProxy *)newFocus selected:(BOOL)selected
 {
   // Do nothing if no tabs are being focused or blurred (or the window is opening)
   if (focusedTabProxy == nil && newFocus == nil) {
@@ -165,6 +165,10 @@ DEFINE_EXCEPTIONS
   // TIMOB-15187. Don't fire focus of tabs if proxy does not have focus
   if ([(TiUITabGroupProxy *)[self proxy] canFocusTabs]) {
     [focusedTabProxy handleDidFocus:event];
+  }
+
+  if (selected) {
+    [focusedTabProxy handleDidSelect:event];
   }
 }
 
@@ -272,7 +276,7 @@ DEFINE_EXCEPTIONS
   NSUInteger stackHeight = [moreViewControllerStack count];
   if (stackHeight < 2) { // No more faux roots.
     if (focusedTabProxy != nil) {
-      [self handleDidShowTab:nil];
+      [self handleDidShowTab:nil selected:NO];
     }
     // Ensure that the moreController has only top edge extended
     [TiUtils configureController:viewController withObject:[NSDictionary dictionaryWithObject:NUMINT(1) forKey:@"extendEdges"]];
@@ -296,7 +300,7 @@ DEFINE_EXCEPTIONS
 
   if (stackHeight == 2) { // One for the picker, one for the faux root.
     if (tabProxy != focusedTabProxy) {
-      [self handleDidShowTab:tabProxy];
+      [self handleDidShowTab:tabProxy selected:YES];
     }
   }
 
@@ -352,7 +356,7 @@ DEFINE_EXCEPTIONS
     }
   }
 
-  [self handleDidShowTab:shouldPassVC ? (TiUITabProxy *)[(UINavigationController *)viewController delegate] : nil];
+  [self handleDidShowTab:shouldPassVC ? (TiUITabProxy *)[(UINavigationController *)viewController delegate] : nil selected:YES];
 }
 
 - (void)tabBarController:(UITabBarController *)tabBarController didEndCustomizingViewControllers:(NSArray *)viewControllers changed:(BOOL)changed

--- a/iphone/Classes/TiUITabGroupProxy.m
+++ b/iphone/Classes/TiUITabGroupProxy.m
@@ -199,7 +199,7 @@ static NSArray *tabGroupKeySequence;
     UITabBarController *tabController = [(TiUITabGroup *)[self view] tabController];
     NSUInteger blessedController = [tabController selectedIndex];
     if (blessedController != NSNotFound) {
-      [[tabs objectAtIndex:blessedController] handleDidFocus:nil];
+      [[tabs objectAtIndex:blessedController] handleDidFocus:[((TiUITabGroup *)self.view) focusEvent]];
     }
   }
   [super gainFocus];

--- a/iphone/Classes/TiUITabProxy.h
+++ b/iphone/Classes/TiUITabProxy.h
@@ -51,6 +51,7 @@
 - (void)handleDidBlur:(NSDictionary *)event;
 - (void)handleWillFocus;
 - (void)handleDidFocus:(NSDictionary *)event;
+- (void)handleDidSelect:(NSDictionary *)event;
 - (void)handleWillShowViewController:(UIViewController *)viewController animated:(BOOL)animated;
 - (void)handleDidShowViewController:(UIViewController *)viewController animated:(BOOL)animated;
 - (void)updateTabBarItem;

--- a/iphone/Classes/TiUITabProxy.m
+++ b/iphone/Classes/TiUITabProxy.m
@@ -528,6 +528,13 @@
     }
   }
 
+  if ([self _hasListeners:@"focus"]) {
+    [self fireEvent:@"focus" withObject:event withSource:self propagate:NO reportSuccess:NO errorCode:0 message:nil];
+  }
+}
+
+- (void)handleDidSelect:(NSDictionary *)event
+{
   if ([self _hasListeners:@"selected"]) {
     [self fireEvent:@"selected" withObject:event withSource:self propagate:NO reportSuccess:NO errorCode:0 message:nil];
   }


### PR DESCRIPTION
## Summary
- Fix iOS tab focus restoration so it emits `focus` instead of `selected`.
- Keep `selected` scoped to actual tab selection changes.
- Preserve the active tab event payload when a TabGroup regains focus.

## Changes
- Update Tab proxy focus handling to emit `focus` and move `selected` to an explicit selection handler.
- Update TabGroup selection paths to mark real selections separately from focus restoration.
- Pass the TabGroup focus payload to the active tab when focus returns.

## Test Plan
- `npm run lint:objc -- iphone/Classes/TiUITabGroup.m iphone/Classes/TiUITabGroupProxy.m iphone/Classes/TiUITabProxy.m iphone/Classes/TiUITabProxy.h`
- `git diff --check`
- `npm run ios-sanity-check`
- `npm run build:ios`

Closes #14438