### PR TITLE
fix(android): opening M3 theme could load wrong theme

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/TabGroupProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/TabGroupProxy.java
@@ -431,8 +431,8 @@ public class TabGroupProxy extends TiWindowProxy implements TiActivityWindow
 				int theme = TiRHelper.getResource("style."
 					+ themeName.replaceAll("[^A-Za-z0-9_]", "_"));
 				topActivity.setTheme(theme);
-				topActivity.getApplicationContext().setTheme(theme);
 			} catch (Exception e) {
+				Log.w(TAG, "Could not apply theme: " + e.getMessage());
 			}
 		}
 

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIBottomNavigation.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIBottomNavigation.java
@@ -33,7 +33,6 @@ import com.google.android.material.shape.CornerFamily;
 import com.google.android.material.shape.MaterialShapeDrawable;
 import com.google.android.material.shape.ShapeAppearanceModel;
 
-import org.appcelerator.titanium.TiApplication;
 import org.appcelerator.titanium.TiBaseActivity;
 import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.TiDimension;
@@ -176,7 +175,7 @@ public class TiUIBottomNavigation extends TiUIAbstractTabGroup implements Bottom
 			int id_content = TiRHelper.getResource("id.bottomNavBar_content");
 			int id_bottomNavigation = TiRHelper.getResource("id.bottomNavBar");
 
-			LayoutInflater inflater = LayoutInflater.from(TiApplication.getAppRootOrCurrentActivity());
+			LayoutInflater inflater = LayoutInflater.from(activity);
 			layout = (RelativeLayout) inflater.inflate(id_layout, null, false);
 			bottomNavigation = layout.findViewById(id_bottomNavigation);
 			centerView = layout.findViewById(id_content);
@@ -393,7 +392,7 @@ public class TiUIBottomNavigation extends TiUIAbstractTabGroup implements Bottom
 				BottomNavigationMenuView bottomMenuView =
 					((BottomNavigationMenuView) this.bottomNavigation.getChildAt(0));
 				bottomMenuView.getChildAt(index).setBackgroundColor(TiConvert.toColor(
-					tabProxy.getProperty(TiC.PROPERTY_BACKGROUND_COLOR), TiApplication.getAppRootOrCurrentActivity()
+					tabProxy.getProperty(TiC.PROPERTY_BACKGROUND_COLOR), tabProxy.getActivity()
 				));
 			}
 		} catch (Exception e) {


### PR DESCRIPTION
when you open a BottomNavigation window with a M3 theme it was not using the correct theme for that window


```js
const win = Ti.UI.createWindow();
win.addEventListener("click", function() {
	let tab1 = Ti.UI.createTab({
		window: Ti.UI.createWindow({
			backgroundColor: "backgroundColor",
			theme: "Theme.Titanium.Material3.DayNight.NoTitleBar"
		}),
    icon:"/images/appicon.png",
		title: 'tab1'
	});
	let tab2 = Ti.UI.createTab({
		window: Ti.UI.createWindow({
			backgroundColor: "backgroundColor",
			theme: "Theme.Titanium.Material3.DayNight.NoTitleBar"
		}),
    icon:"/images/appicon.png",
		title: 'tab2'
	});

	let bottomNav = Ti.UI.createTabGroup({
		tabs: [tab1, tab2],
		theme: "Theme.Titanium.Material3.DayNight.NoTitleBar",
		experimental: true,
		style: Ti.UI.Android.TABS_STYLE_BOTTOM_NAVIGATION,
	});

	bottomNav.open();
})

win.open();
```


**13.2.0:**
will open a M2 theme when you click on the window:

[Bildschirmaufnahme_20260513_161643.webm](https://github.com/user-attachments/assets/8046c1a9-16f1-4a81-a77e-af7f31612329)


**with this fix:**
will open the correct M3 theme when you click on the window:

[Bildschirmaufnahme_20260513_161716.webm](https://github.com/user-attachments/assets/660c299b-9d3d-48e7-a614-f8ab11cd3c13)



