### PR TITLE
fix(android): disable ripple in M3 BottomNavigation

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIBottomNavigation.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIBottomNavigation.java
@@ -9,7 +9,6 @@ package ti.modules.titanium.ui.widget.tabgroup;
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.res.ColorStateList;
-import android.graphics.Color;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.RippleDrawable;
 import android.os.Build;
@@ -61,7 +60,7 @@ public class TiUIBottomNavigation extends TiUIAbstractTabGroup implements Bottom
 	private int currentlySelectedIndex = -1;
 	private int lastNightMode = -1;
 	private ArrayList<MenuItem> mMenuItemsArray;
-	private RelativeLayout layout = null;
+	private RelativeLayout layout;
 	private FrameLayout centerView;
 	private BottomNavigationView bottomNavigation;
 	private ArrayList<Object> tabsArray = new ArrayList<Object>();
@@ -371,7 +370,8 @@ public class TiUIBottomNavigation extends TiUIAbstractTabGroup implements Bottom
 			TiViewProxy tabProxy = ((TabProxy) tabsArray.get(index));
 			boolean hasTouchFeedback = TiConvert.toBoolean(tabProxy.getProperty(TiC.PROPERTY_TOUCH_FEEDBACK), true);
 			boolean hasTouchFeedbackColor = tabProxy.hasPropertyAndNotNull(TiC.PROPERTY_TOUCH_FEEDBACK_COLOR);
-			if (hasCustomBackground(tabProxy) || hasCustomIconTint(tabProxy) || hasTouchFeedbackColor) {
+			if (hasTouchFeedback && (hasCustomBackground(tabProxy) || hasCustomIconTint(tabProxy)
+				|| hasTouchFeedbackColor)) {
 				BottomNavigationMenuView bottomMenuView =
 					((BottomNavigationMenuView) this.bottomNavigation.getChildAt(0));
 				Drawable drawable = createBackgroundDrawableForState(tabProxy, android.R.attr.state_checked);
@@ -385,8 +385,9 @@ public class TiUIBottomNavigation extends TiUIAbstractTabGroup implements Bottom
 			}
 
 			if (!hasTouchFeedback) {
-				Drawable drawable = new RippleDrawable(ColorStateList.valueOf(Color.TRANSPARENT), null, null);
-				this.bottomNavigation.getChildAt(0).setBackground(drawable);
+				BottomNavigationMenuView bottomMenuView =
+					((BottomNavigationMenuView) this.bottomNavigation.getChildAt(0));
+				bottomMenuView.getChildAt(index).setBackground(null);
 			}
 
 			if (tabProxy.hasPropertyAndNotNull(TiC.PROPERTY_BACKGROUND_COLOR)) {

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIBottomNavigation.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIBottomNavigation.java
@@ -385,9 +385,14 @@ public class TiUIBottomNavigation extends TiUIAbstractTabGroup implements Bottom
 			}
 
 			if (!hasTouchFeedback) {
-				BottomNavigationMenuView bottomMenuView =
-					((BottomNavigationMenuView) this.bottomNavigation.getChildAt(0));
-				bottomMenuView.getChildAt(index).setBackground(null);
+				// Don't clear background - only remove the ripple wrapping.
+				// Apply state drawable background if custom tab colors are defined.
+				if (hasCustomBackground(tabProxy)) {
+					BottomNavigationMenuView bottomMenuView =
+						((BottomNavigationMenuView) this.bottomNavigation.getChildAt(0));
+					Drawable drawable = createBackgroundDrawableForState(tabProxy, android.R.attr.state_checked);
+					bottomMenuView.getChildAt(index).setBackground(drawable);
+				}
 			}
 
 			if (tabProxy.hasPropertyAndNotNull(TiC.PROPERTY_BACKGROUND_COLOR)) {


### PR DESCRIPTION
Currently `touchFeedback: false` has no effect in an experimental BottomNavigation with M3 theme:

[Bildschirmaufnahme_20260514_112044.webm](https://github.com/user-attachments/assets/32b10d12-9ceb-4f88-b240-e49fb478b282)

This PR will respect the touchFeedback: false setting:


[Bildschirmaufnahme_20260514_111903.webm](https://github.com/user-attachments/assets/47e75591-d5e0-4d6c-8c23-a8c0a870021c)

**Test**
```js
let tab1 = Ti.UI.createTab({
	window: Ti.UI.createWindow(),
	touchFeedback: false,
	title: '1',
	activeTintColor: "green",
	icon: '/images/appicon.png'
});
let tab2 = Ti.UI.createTab({
	window: Ti.UI.createWindow(),
	title: '2',
	tintColor: "red",
	icon: '/images/appicon.png'
});
let tab3 = Ti.UI.createTab({
	window: Ti.UI.createWindow(),
	backgroundFocusedColor: 'green',
	// touchFeedback: false,  // ------------ uncomment to test `backgroundFocusedColor`
	title: '2',
	tintColor: "red",
	icon: '/images/appicon.png'
});


let bottomNav = Ti.UI.createTabGroup({
	tabs: [tab1, tab2, tab3],
	indicatorColor: "red",
	// tabsBackgroundSelectedColor: "blue", // ------------ uncomment to test `tabsBackgroundSelectedColor`
	theme: "Theme.Titanium.Material3.DayNight",
	experimental: true,
	style: Ti.UI.Android.TABS_STYLE_BOTTOM_NAVIGATION
});

bottomNav.open();
```

* tab1 has no ripple, tab2 still has ripple
* enable `tabsBackgroundSelectedColor` to see the backgroundColor