### PR TITLE
fix(android): fix remote URL handling in video player

### DIFF
--- a/android/modules/media/src/java/android/widget/TiVideoView8.java
+++ b/android/modules/media/src/java/android/widget/TiVideoView8.java
@@ -346,7 +346,15 @@ public class TiVideoView8 extends SurfaceView implements MediaPlayerControl
 			Map<String, String> headers = new HashMap<>();
 			headers.put("Cache-Control", "no-cache");
 
-			mMediaPlayer.setDataSource(TiApplication.getAppRootOrCurrentActivity(), mUri, headers);
+			// MediaPlayer.setDataSource(Context, Uri, headers) may route through ContentResolver and fail for http(s) URLs.
+			// Use the string overload for http(s) so we can play remote videos reliably.
+			String scheme = (mUri != null) ? mUri.getScheme() : null;
+
+			if ((scheme != null) && scheme.startsWith("http")) {
+				mMediaPlayer.setDataSource(mUri.toString());
+			} else {
+				mMediaPlayer.setDataSource(TiApplication.getAppRootOrCurrentActivity(), mUri, headers);
+			}
 		} catch (Exception e) {
 			Log.e(TAG, "Error setting video data source: " + e.getMessage(), e);
 		}

--- a/android/modules/media/src/java/android/widget/TiVideoView8.java
+++ b/android/modules/media/src/java/android/widget/TiVideoView8.java
@@ -348,9 +348,9 @@ public class TiVideoView8 extends SurfaceView implements MediaPlayerControl
 
 			// MediaPlayer.setDataSource(Context, Uri, headers) may route through ContentResolver and fail for http(s) URLs.
 			// Use the string overload for http(s) so we can play remote videos reliably.
-			String scheme = (mUri != null) ? mUri.getScheme() : null;
+			String scheme = mUri != null ? mUri.getScheme() : null;
 
-			if ((scheme != null) && scheme.startsWith("http")) {
+			if (scheme != null && scheme.startsWith("http")) {
 				mMediaPlayer.setDataSource(mUri.toString());
 			} else {
 				mMediaPlayer.setDataSource(TiApplication.getAppRootOrCurrentActivity(), mUri, headers);


### PR DESCRIPTION
When opening a remote URL in Android VideoPlayer, the app sometimes freeze with ANR, and sometimes the video is played with unusually long time. But every time the app logs the below exception. This PR opens the remote URLs via the correct method so the Android does not behave differently.

```
MediaPlayer Error setting data source via ContentResolver
            java.io.FileNotFoundException: No content provider: https://some-app/video.mp4
            	at android.content.ContentResolver.openTypedAssetFileDescriptor(ContentResolver.java:2031)
            	at android.content.ContentResolver.openAssetFileDescriptor(ContentResolver.java:1860)
            	at android.content.ContentResolver.openAssetFileDescriptor(ContentResolver.java:1775)
            	at android.media.MediaPlayer.attemptDataSource(MediaPlayer.java:1180)
            	at android.media.MediaPlayer.setDataSource(MediaPlayer.java:1146)
            	at android.media.MediaPlayer.setDataSource(MediaPlayer.java:1170)
            	at android.widget.TiVideoView8.setDataSource(TiVideoView8.java:349)
            	at android.widget.TiVideoView8.openVideo(TiVideoView8.java:395)
            	at android.widget.TiVideoView8.-$$Nest$mopenVideo(Unknown Source:0)
            	at android.widget.TiVideoView8$6.surfaceCreated(TiVideoView8.java:643)
            	at android.view.SurfaceView.updateSurface(SurfaceView.java:1369)
            	at android.view.SurfaceView.lambda$new$0(SurfaceView.java:238)
            	at android.view.SurfaceView.$r8$lambda$NfZyM_TG8F8lqzaOVZ7noREFjzU(Unknown Source:0)
            	at android.view.SurfaceView$$ExternalSyntheticLambda1.onPreDraw(D8$$SyntheticClass:0)
            	at android.view.ViewTreeObserver.dispatchOnPreDraw(ViewTreeObserver.java:1179)
            	at android.view.ViewRootImpl.performTraversals(ViewRootImpl.java:4786)
            	at android.view.ViewRootImpl.doTraversal(ViewRootImpl.java:3371)
            	at android.view.ViewRootImpl$TraversalRunnable.run(ViewRootImpl.java:11301)
            	at android.view.Choreographer$CallbackRecord.run(Choreographer.java:1679)
            	at android.view.Choreographer$CallbackRecord.run(Choreographer.java:1688)
            	at android.view.Choreographer.doCallbacks(Choreographer.java:1272)
            	at android.view.Choreographer.doFrame(Choreographer.java:1169)
            	at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:1662)
            	at android.os.Handler.handleCallback(Handler.java:1037)
            	at android.os.Handler.dispatchMessage(Handler.java:108)
            	at android.os.Looper.loopOnce(Looper.java:304)
            	at android.os.Looper.loop(Looper.java:430)
            	at android.app.ActivityThread.main(ActivityThread.java:9345)
            	at java.lang.reflect.Method.invoke(Native Method)
            	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:593)
            	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:953)
```