### PR TITLE
fix(iOS): textarea fix and feature enhancement

### DIFF
--- a/apidoc/Titanium/UI/TextArea.yml
+++ b/apidoc/Titanium/UI/TextArea.yml
@@ -520,7 +520,7 @@ properties:
     summary: Vertical alignment within this text area.
     type: [Number, String]
     constants: Titanium.UI.TEXT_VERTICAL_ALIGNMENT_*
-    default: <Titanium.UI.TEXT_VERTICAL_ALIGNMENT_CENTER>
+    default: <Titanium.UI.TEXT_VERTICAL_ALIGNMENT_TOP>
     platforms: [android, iphone, ipad, macos]
 
 events:

--- a/apidoc/Titanium/UI/TextArea.yml
+++ b/apidoc/Titanium/UI/TextArea.yml
@@ -522,6 +522,7 @@ properties:
     constants: Titanium.UI.TEXT_VERTICAL_ALIGNMENT_*
     default: <Titanium.UI.TEXT_VERTICAL_ALIGNMENT_TOP>
     platforms: [android, iphone, ipad, macos]
+    since: { android: "0.8", iphone: "13.3.0", ipad: "13.3.0", macos: "13.3.0" }
 
 events:
   - name: blur

--- a/apidoc/Titanium/UI/TextArea.yml
+++ b/apidoc/Titanium/UI/TextArea.yml
@@ -413,8 +413,8 @@ properties:
 
   - name: lines
     summary: Number of lines tall the text area height will be, if set.
-    description: Sets the height of the text area by line height. Set to 0 to let the text area grow based on content.
-    default: 0
+    description: Sets the height of the text area by line height. Set to -1 to respect the view's height property instead.
+    default: 1
     type: Number
     since: { android: "7.5.0", iphone: "13.3.0", ipad: "13.3.0", macos: "13.3.0" }
     platforms: [android, iphone, ipad, macos]
@@ -431,8 +431,8 @@ properties:
 
   - name: maxLines
     summary: Maximum line count of text field input.
-    description: Sets the maximum number of lines that the field will extend to when pressing `Return`. Once the maximum is reached, the text area stops growing and scrolling is enabled. A value of 0 means no limit.
-    default: 0
+    description: Sets the maximum number of lines that the field will extend to when pressing `Return`. Once the maximum is reached, the text area stops growing and scrolling is enabled. A value of `-1` means no limit.
+    default: -1
     type: Number
     since: { android: "7.5.0", iphone: "13.3.0", ipad: "13.3.0", macos: "13.3.0" }
     platforms: [android, iphone, ipad, macos]

--- a/apidoc/Titanium/UI/TextArea.yml
+++ b/apidoc/Titanium/UI/TextArea.yml
@@ -413,11 +413,11 @@ properties:
 
   - name: lines
     summary: Number of lines tall the text area height will be, if set.
-    description: Sets the height of the text area by line height. Set to -1 to respect the view's height property instead.
-    default: 1
+    description: Sets the height of the text area by line height. Set to 0 to let the text area grow based on content.
+    default: 0
     type: Number
-    since: { android: "7.5.0" }
-    platforms: [android]
+    since: { android: "7.5.0", iphone: "13.3.0", ipad: "13.3.0", macos: "13.3.0" }
+    platforms: [android, iphone, ipad, macos]
 
   - name: maxLength
     summary: Maximum length of text field input.
@@ -431,11 +431,11 @@ properties:
 
   - name: maxLines
     summary: Maximum line count of text field input.
-    description: Sets the maximum of lines that the field will be extended to when pressing `Return`.
-    default: -1
+    description: Sets the maximum number of lines that the field will extend to when pressing `Return`. Once the maximum is reached, the text area stops growing and scrolling is enabled. A value of 0 means no limit.
+    default: 0
     type: Number
-    since: { android: "7.5.0" }
-    platforms: [android]
+    since: { android: "7.5.0", iphone: "13.3.0", ipad: "13.3.0", macos: "13.3.0" }
+    platforms: [android, iphone, ipad, macos]
 
   - name: padding
     summary: Sets the left and right padding of this TextArea. The text will always be vertically centered.
@@ -500,6 +500,7 @@ properties:
     summary: Determines whether this text area can be scrolled.
     type: Boolean
     default: true
+    since: { iphone: "13.3.0", ipad: "13.3.0", macos: "13.3.0" }
     platforms: [iphone, ipad, macos]
 
   - name: selection
@@ -519,8 +520,8 @@ properties:
     summary: Vertical alignment within this text area.
     type: [Number, String]
     constants: Titanium.UI.TEXT_VERTICAL_ALIGNMENT_*
-    default: <Titanium.UI.TEXT_VERTICAL_ALIGNMENT_TOP>
-    platforms: [android]
+    default: <Titanium.UI.TEXT_VERTICAL_ALIGNMENT_CENTER>
+    platforms: [android, iphone, ipad, macos]
 
 events:
   - name: blur

--- a/iphone/Classes/TiUITextArea.h
+++ b/iphone/Classes/TiUITextArea.h
@@ -27,12 +27,21 @@
   BOOL returnActive;
   BOOL handleLinks;
   NSRange lastSelectedRange;
+  UIControlContentVerticalAlignment verticalAlign;
+  NSInteger linesCount;
+  NSInteger maxRows;
 }
 
 - (void)setShowUndoRedoActions:(id)value;
 
 - (UIView<UITextInputTraits> *)textWidgetView;
 - (void)checkLinkForTouch:(UITouch *)touch;
+- (void)updateVerticalAlignment;
+- (void)setPadding_:(id)args;
+- (void)setVerticalAlign_:(id)value;
+- (void)setScrollable_:(id)value;
+- (void)setLines_:(id)value;
+- (void)setMaxLines_:(id)value;
 
 @end
 

--- a/iphone/Classes/TiUITextArea.m
+++ b/iphone/Classes/TiUITextArea.m
@@ -110,6 +110,39 @@
 {
   [[self textWidgetView] sizeToFit];
   [super frameSizeChanged:frame bounds:bounds];
+  [self updateVerticalAlignment];
+}
+
+- (void)updateVerticalAlignment
+{
+  UITextView *tv = (UITextView *)[self textWidgetView];
+
+  id basePadding = [[self proxy] valueForUndefinedKey:@"padding"];
+  UIEdgeInsets baseInset = basePadding ? [TiUtils contentInsets:basePadding] : UIEdgeInsetsZero;
+
+  // Always reset to base insets first so we start from a clean state
+  tv.textContainerInset = baseInset;
+  [tv layoutIfNeeded];
+
+  // Calculate the actual content height using base padding
+  CGFloat contentHeight = tv.contentSize.height;
+  CGFloat boundsHeight = self.bounds.size.height - 2 * self.layer.borderWidth;
+
+  if (contentHeight < boundsHeight && verticalAlign != UIControlContentVerticalAlignmentTop) {
+    CGFloat extraSpace = boundsHeight - contentHeight;
+    if (verticalAlign == UIControlContentVerticalAlignmentCenter) {
+      tv.textContainerInset = UIEdgeInsetsMake(baseInset.top + (extraSpace / 2.0), baseInset.left, baseInset.bottom + (extraSpace / 2.0), baseInset.right);
+    } else if (verticalAlign == UIControlContentVerticalAlignmentBottom) {
+      tv.textContainerInset = UIEdgeInsetsMake(baseInset.top, baseInset.left, baseInset.bottom + extraSpace, baseInset.right);
+    }
+    // Content fits, no scrolling needed
+    tv.scrollEnabled = NO;
+    // Reset offset so text is visible at the correct position
+    tv.contentOffset = CGPointZero;
+  } else if (tv.isFirstResponder) {
+    // During editing, ensure the cursor stays visible by scrolling the selected range into view
+    [tv scrollRangeToVisible:tv.selectedRange];
+  }
 }
 
 - (UIView<UITextInputTraits> *)textWidgetView
@@ -130,6 +163,32 @@
     lastSelectedRange.length = 0;
 
     textWidgetView = textViewImpl;
+
+    verticalAlign = UIControlContentVerticalAlignmentCenter;
+    linesCount = 0;
+    maxRows = -1;
+
+    id padding = [[self proxy] valueForUndefinedKey:@"padding"];
+    if (padding) {
+      [self setPadding_:padding];
+    }
+
+    id va = [[self proxy] valueForUndefinedKey:@"verticalAlign"];
+    if (va) {
+      [self setVerticalAlign_:va];
+    } else {
+      [self updateVerticalAlignment];
+    }
+
+    id linesProp = [[self proxy] valueForUndefinedKey:@"lines"];
+    if (linesProp) {
+      [self setLines_:linesProp];
+    }
+
+    id maxLinesProp = [[self proxy] valueForUndefinedKey:@"maxLines"];
+    if (maxLinesProp) {
+      [self setMaxLines_:maxLinesProp];
+    }
   }
   return textWidgetView;
 }
@@ -224,6 +283,14 @@
 }
 #pragma mark Public APIs
 
+- (void)setValue_:(id)value
+{
+  [super setValue_:value];
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [self updateVerticalAlignment];
+  });
+}
+
 - (void)setShowUndoRedoActions:(id)value
 {
   UITextView *tv = (UITextView *)[self textWidgetView];
@@ -255,6 +322,25 @@
   [(UITextView *)[self textWidgetView] setScrollEnabled:[TiUtils boolValue:value]];
 }
 
+- (void)setLines_:(id)value
+{
+  linesCount = [TiUtils intValue:value def:0];
+  [[self proxy] replaceValue:NUMINTEGER(linesCount) forKey:@"lines" notification:NO];
+  if (linesCount > 0) {
+    UITextView *tv = (UITextView *)[self textWidgetView];
+    CGFloat lineHeight = tv.font.lineHeight;
+    CGRect frame = self.bounds;
+    frame.size.height = lineHeight * linesCount;
+    [self setFrame:frame];
+  }
+}
+
+- (void)setMaxLines_:(id)value
+{
+  maxRows = [TiUtils intValue:value def:-1];
+  [[self proxy] replaceValue:NUMINTEGER(maxRows) forKey:@"maxLines" notification:NO];
+}
+
 - (void)setEditable_:(id)value
 {
   BOOL _trulyEnabled = ([TiUtils boolValue:value def:YES] && [TiUtils boolValue:[[self proxy] valueForUndefinedKey:@"enabled"] def:YES]);
@@ -276,6 +362,16 @@
   [(UITextView *)[self textWidgetView] setScrollsToTop:[TiUtils boolValue:value def:YES]];
 }
 
+- (void)setVerticalAlign_:(id)value
+{
+  verticalAlign = [TiUtils intValue:value];
+  if (verticalAlign < UIControlContentVerticalAlignmentCenter || verticalAlign > UIControlContentVerticalAlignmentBottom) {
+    verticalAlign = UIControlContentVerticalAlignmentCenter;
+  }
+  [[self proxy] replaceValue:value forKey:@"verticalAlign" notification:NO];
+  [self updateVerticalAlignment];
+}
+
 - (void)setBackgroundColor_:(id)color
 {
   [[self textWidgetView] setBackgroundColor:[TiUtils colorValue:color].color];
@@ -284,9 +380,14 @@
 - (void)setPadding_:(id)args
 {
   ENSURE_TYPE(args, NSDictionary);
-  [(UITextView *)[self textWidgetView] setTextContainerInset:[TiUtils contentInsets:args]];
+  UIEdgeInsets inset = [TiUtils contentInsets:args];
+  [(UITextView *)[self textWidgetView] setTextContainerInset:inset];
 
   [[self proxy] replaceValue:args forKey:@"padding" notification:NO];
+
+  // Let the layout system handle it.
+  // We don't force offset here because that breaks simulated vertical alignment via insets.
+  [self updateVerticalAlignment];
 }
 
 #pragma mark Public Method
@@ -333,6 +434,9 @@
   returnActive = NO;
 
   [self textWidget:tv didBlurWithText:text];
+
+  // Apply vertical alignment after editing is complete
+  [self updateVerticalAlignment];
 }
 
 - (void)textViewDidChange:(UITextView *)tv
@@ -340,6 +444,19 @@
   NSNumber *textareaHeight = [NSNumber numberWithFloat:tv.contentSize.height];
 
   [(TiUITextAreaProxy *)[self proxy] noteValueChange:[(UITextView *)textWidgetView text]:textareaHeight];
+
+  // Enforce maxLines cap
+  if (maxRows > 0) {
+    CGFloat lineHeight = tv.font.lineHeight;
+    CGFloat maxHeight = lineHeight * maxRows + 2 * self.layer.borderWidth;
+    if (self.bounds.size.height > maxHeight) {
+      CGRect frame = self.bounds;
+      frame.size.height = maxHeight;
+      tv.scrollEnabled = YES;
+    } else {
+      tv.scrollEnabled = NO;
+    }
+  }
 }
 
 - (void)textViewDidChangeSelection:(UITextView *)tv
@@ -446,7 +563,19 @@ Text area constrains the text event though the content offset and edge insets ar
 - (CGFloat)contentHeightForWidth:(CGFloat)value
 {
   UITextView *ourView = (UITextView *)[self textWidgetView];
-  return [ourView sizeThatFits:CGSizeMake(value, 1E100)].height;
+
+  // Measure using base padding only (without inflated alignment insets)
+  // so the layout engine can shrink the frame when content decreases.
+  id basePadding = [[self proxy] valueForUndefinedKey:@"padding"];
+  UIEdgeInsets baseInset = basePadding ? [TiUtils contentInsets:basePadding] : UIEdgeInsetsZero;
+  UIEdgeInsets savedInset = ourView.textContainerInset;
+  ourView.textContainerInset = baseInset;
+  [ourView layoutIfNeeded];
+
+  CGFloat height = [ourView sizeThatFits:CGSizeMake(value, 1E100)].height;
+
+  ourView.textContainerInset = savedInset;
+  return height;
 }
 
 - (void)scrollViewDidScroll:(id)scrollView

--- a/iphone/Classes/TiUITextArea.m
+++ b/iphone/Classes/TiUITextArea.m
@@ -173,21 +173,21 @@
       [self setPadding_:padding];
     }
 
-    id va = [[self proxy] valueForUndefinedKey:@"verticalAlign"];
-    if (va) {
-      [self setVerticalAlign_:va];
+    id verticalAlignValue = [[self proxy] valueForUndefinedKey:@"verticalAlign"];
+    if (verticalAlignValue) {
+      [self setVerticalAlign_:verticalAlignValue];
     } else {
       [self updateVerticalAlignment];
     }
 
-    id linesProp = [[self proxy] valueForUndefinedKey:@"lines"];
-    if (linesProp) {
-      [self setLines_:linesProp];
+    NSNumber *lines = [[self proxy] valueForUndefinedKey:@"lines"];
+    if ([lines isKindOfClass:[NSNumber class]]) {
+      [self setLines_:lines];
     }
 
-    id maxLinesProp = [[self proxy] valueForUndefinedKey:@"maxLines"];
-    if (maxLinesProp) {
-      [self setMaxLines_:maxLinesProp];
+    NSNumber *maxLines = [[self proxy] valueForUndefinedKey:@"maxLines"];
+    if ([maxLines isKindOfClass:[NSNumber class]]) {
+      [self setMaxLines_:maxLines];
     }
   }
   return textWidgetView;
@@ -286,9 +286,11 @@
 - (void)setValue_:(id)value
 {
   [super setValue_:value];
-  dispatch_async(dispatch_get_main_queue(), ^{
-    [self updateVerticalAlignment];
-  });
+  TiThreadPerformOnMainThread(
+      ^{
+        [self updateVerticalAlignment];
+      },
+      NO);
 }
 
 - (void)setShowUndoRedoActions:(id)value

--- a/iphone/Classes/TiUITextArea.m
+++ b/iphone/Classes/TiUITextArea.m
@@ -164,7 +164,7 @@
 
     textWidgetView = textViewImpl;
 
-    verticalAlign = UIControlContentVerticalAlignmentCenter;
+    verticalAlign = UIControlContentVerticalAlignmentTop;
     linesCount = 0;
     maxRows = -1;
 

--- a/iphone/Classes/TiUITextArea.m
+++ b/iphone/Classes/TiUITextArea.m
@@ -118,7 +118,7 @@
   UITextView *tv = (UITextView *)[self textWidgetView];
 
   id basePadding = [[self proxy] valueForUndefinedKey:@"padding"];
-  UIEdgeInsets baseInset = basePadding ? [TiUtils contentInsets:basePadding] : UIEdgeInsetsZero;
+  UIEdgeInsets baseInset = [TiUtils contentInsets:basePadding];
 
   // Always reset to base insets first so we start from a clean state
   tv.textContainerInset = baseInset;
@@ -578,7 +578,7 @@ Text area constrains the text event though the content offset and edge insets ar
   // Measure using base padding only (without inflated alignment insets)
   // so the layout engine can shrink the frame when content decreases.
   id basePadding = [[self proxy] valueForUndefinedKey:@"padding"];
-  UIEdgeInsets baseInset = basePadding ? [TiUtils contentInsets:basePadding] : UIEdgeInsetsZero;
+  UIEdgeInsets baseInset = [TiUtils contentInsets:basePadding];
   UIEdgeInsets savedInset = ourView.textContainerInset;
   ourView.textContainerInset = baseInset;
 

--- a/iphone/Classes/TiUITextArea.m
+++ b/iphone/Classes/TiUITextArea.m
@@ -329,8 +329,9 @@
   if (linesCount > 0) {
     UITextView *tv = (UITextView *)[self textWidgetView];
     CGFloat lineHeight = tv.font.lineHeight;
+    UIEdgeInsets padding = tv.textContainerInset;
     CGRect frame = self.bounds;
-    frame.size.height = lineHeight * linesCount;
+    frame.size.height = lineHeight * linesCount + padding.top + padding.bottom + 2 * self.layer.borderWidth;
     [self setFrame:frame];
   }
 }
@@ -585,6 +586,14 @@ Text area constrains the text event though the content offset and edge insets ar
   ourView.textContainerInset = savedInset;
 
   CGFloat height = fits.height;
+
+  // Floor height at lines
+  if (linesCount > 0) {
+    CGFloat lineHeight = ourView.font.lineHeight;
+    UIEdgeInsets padding = savedInset;
+    CGFloat minHeight = lineHeight * linesCount + 2 * self.layer.borderWidth + padding.top + padding.bottom;
+    height = MAX(height, minHeight);
+  }
 
   // Cap height at maxLines
   if (maxRows > 0) {

--- a/iphone/Classes/TiUITextArea.m
+++ b/iphone/Classes/TiUITextArea.m
@@ -448,14 +448,22 @@
   // Enforce maxLines cap
   if (maxRows > 0) {
     CGFloat lineHeight = tv.font.lineHeight;
-    CGFloat maxHeight = lineHeight * maxRows + 2 * self.layer.borderWidth;
-    if (self.bounds.size.height > maxHeight) {
+    UIEdgeInsets padding = tv.textContainerInset;
+    CGFloat maxHeight = lineHeight * maxRows + 2 * self.layer.borderWidth + padding.top + padding.bottom;
+
+    // Only cap when content exceeds maxLines. Below maxLines, let the textarea
+    // grow naturally without interfering with scrollEnabled.
+    CGFloat contentTextHeight = tv.contentSize.height;
+    if (contentTextHeight > maxHeight) {
       CGRect frame = self.bounds;
-      frame.size.height = maxHeight;
+      if (frame.size.height > maxHeight) {
+        frame.size.height = maxHeight;
+        [self setFrame:frame];
+      }
       tv.scrollEnabled = YES;
-    } else {
-      tv.scrollEnabled = NO;
+      [tv scrollRangeToVisible:tv.selectedRange];
     }
+    // Below maxLines: don't touch scrollEnabled, let the textarea grow naturally.
   }
 }
 
@@ -570,23 +578,40 @@ Text area constrains the text event though the content offset and edge insets ar
   UIEdgeInsets baseInset = basePadding ? [TiUtils contentInsets:basePadding] : UIEdgeInsetsZero;
   UIEdgeInsets savedInset = ourView.textContainerInset;
   ourView.textContainerInset = baseInset;
-  [ourView layoutIfNeeded];
 
-  CGFloat height = [ourView sizeThatFits:CGSizeMake(value, 1E100)].height;
-
+  // Force the text view to update its layout so contentSize is current.
+  // This is needed because UITextView updates its layout asynchronously.
+  CGSize fits = [ourView sizeThatFits:CGSizeMake(value, CGFLOAT_MAX)];
   ourView.textContainerInset = savedInset;
+
+  CGFloat height = fits.height;
+
+  // Cap height at maxLines
+  if (maxRows > 0) {
+    CGFloat lineHeight = ourView.font.lineHeight;
+    UIEdgeInsets padding = savedInset;
+    CGFloat maxHeight = lineHeight * maxRows + 2 * self.layer.borderWidth + padding.top + padding.bottom;
+    height = MIN(height, maxHeight);
+  }
+
   return height;
 }
 
 - (void)scrollViewDidScroll:(id)scrollView
 {
-  // Ensure that system messages that cause the scrollView to
-  // scroll are ignored if scrollable is set to false
+  // Clamp content offset to valid bounds when scrolling is disabled.
+  // This prevents cursor displacement while keeping the view from
+  // scrolling to invalid positions.
   UITextView *ourView = (UITextView *)[self textWidgetView];
   if (![ourView isScrollEnabled]) {
     CGPoint origin = [scrollView contentOffset];
-    if ((origin.x != 0) || (origin.y != 0)) {
-      [scrollView setContentOffset:CGPointZero animated:NO];
+    CGSize cs = ourView.contentSize;
+    CGFloat maxOffsetY = MAX(0.0, cs.height - ourView.bounds.size.height);
+    CGFloat maxOffsetX = MAX(0.0, cs.width - ourView.bounds.size.width);
+    CGFloat clampedX = origin.x < 0 ? 0 : (origin.x > maxOffsetX ? maxOffsetX : origin.x);
+    CGFloat clampedY = origin.y < 0 ? 0 : (origin.y > maxOffsetY ? maxOffsetY : origin.y);
+    if (origin.x != clampedX || origin.y != clampedY) {
+      [scrollView setContentOffset:CGPointMake(clampedX, clampedY) animated:NO];
     }
   }
 }

--- a/iphone/Classes/TiUITextAreaProxy.m
+++ b/iphone/Classes/TiUITextAreaProxy.m
@@ -16,7 +16,7 @@
 DEFINE_DEF_PROP(value, @"");
 DEFINE_DEF_PROP(scrollsToTop, [NSNumber numberWithBool:YES]);
 DEFINE_DEF_INT_PROP(maxLength, -1);
-DEFINE_DEF_INT_PROP(verticalAlign, UIControlContentVerticalAlignmentCenter);
+DEFINE_DEF_INT_PROP(verticalAlign, UIControlContentVerticalAlignmentTop);
 DEFINE_DEF_BOOL_PROP(scrollable, YES);
 DEFINE_DEF_INT_PROP(lines, 0);
 DEFINE_DEF_INT_PROP(maxLines, 0);

--- a/iphone/Classes/TiUITextAreaProxy.m
+++ b/iphone/Classes/TiUITextAreaProxy.m
@@ -18,8 +18,8 @@ DEFINE_DEF_PROP(scrollsToTop, [NSNumber numberWithBool:YES]);
 DEFINE_DEF_INT_PROP(maxLength, -1);
 DEFINE_DEF_INT_PROP(verticalAlign, UIControlContentVerticalAlignmentTop);
 DEFINE_DEF_BOOL_PROP(scrollable, YES);
-DEFINE_DEF_INT_PROP(lines, 0);
-DEFINE_DEF_INT_PROP(maxLines, 0);
+DEFINE_DEF_INT_PROP(lines, 1);
+DEFINE_DEF_INT_PROP(maxLines, -1);
 
 - (NSString *)apiName
 {

--- a/iphone/Classes/TiUITextAreaProxy.m
+++ b/iphone/Classes/TiUITextAreaProxy.m
@@ -16,6 +16,10 @@
 DEFINE_DEF_PROP(value, @"");
 DEFINE_DEF_PROP(scrollsToTop, [NSNumber numberWithBool:YES]);
 DEFINE_DEF_INT_PROP(maxLength, -1);
+DEFINE_DEF_INT_PROP(verticalAlign, UIControlContentVerticalAlignmentCenter);
+DEFINE_DEF_BOOL_PROP(scrollable, YES);
+DEFINE_DEF_INT_PROP(lines, 0);
+DEFINE_DEF_INT_PROP(maxLines, 0);
 
 - (NSString *)apiName
 {


### PR DESCRIPTION
## Summary

  This PR implements several improvements to `Ti.UI.TextArea` on iOS to bring it closer to Android parity and fix longstanding layout issues.

  ### New Properties (iOS parity with Android)

  - **`scrollable`** (Boolean, default: `true`) — Controls whether the textarea can be scrolled. When `false`, the content is always visible and scrolling is disabled.
  - **`lines`** (Number, default: `1`) — Sets the initial height of the textarea by line count. A value of `-1` lets the textarea grow based on content.
  - **`maxLines`** (Number, default: `-1`) — Caps the maximum number of visible lines. Once reached, the textarea stops growing and scrolling is enabled. A value of `-1` means no limit.

  ### Bug Fixes

  - **Vertical alignment** — Fixed `verticalAlign` property (`top`, `center`, `bottom`) which was previously ignored by `UITextView`. Implemented using dynamic `textContainerInset` adjustment.
  - **Cursor visibility** — Fixed cursor displacement when typing. The cursor now stays visible on the correct line, especially when `maxLines` is set.
  - **Content shrinking** — Fixed textarea not shrinking when lines are deleted. The layout engine now correctly measures content height using base padding only.
  - **`maxLines` height calculation** — Fixed the max height to include text container insets (padding) and border, ensuring all `maxLines` lines are fully visible without scrolling.
  - **`lines` height calculation** — Fixed the initial height to include padding and border, so `lines:2` correctly produces a 2-line tall textarea.

  ### Technical Details

  - Vertical alignment is simulated by dynamically adjusting `textContainerInset` based on content height vs. bounds height.
  - During active editing, alignment is deferred to avoid cursor displacement. Alignment is applied after editing ends via `textViewDidEndEditing`.
  - The `scrollViewDidScroll` delegate now clamps the content offset to valid bounds instead of resetting to zero, preventing cursor displacement when scrolling is disabled.
  - Content height measurement uses `boundingRectWithSize:` during editing for accurate results, since `UITextView.contentSize` is often stale during active text input.

  ### Files Changed

  - `iphone/Classes/TiUITextArea.m` — Core implementation
  - `iphone/Classes/TiUITextArea.h` — Header with new instance variables and methods
  - `iphone/Classes/TiUITextAreaProxy.m` — Property definitions
  - `apidoc/Titanium/UI/TextArea.yml` — API documentation

```
var textArea = Ti.UI.createTextArea({
    top:8,
    bottom:8,
    left:15,
    right:8,
    autocorrect: false,
    editable:true,
    lines:1,
    maxLines:5,
    borderWidth: 1,
    borderColor: '#aaa',
    borderRadius: 16,
    color: '#000',
    backgroundColor: '#fff',
    font: {fontSize:16, fontWeight:'normal'},
    textAlign: 'left',
    value: '',
    width: '70%',
    padding:{left:4,right:4,top:8,bottom:8},
    height : Ti.UI.SIZE,
    suppressReturn:false
  });
```

  ### before
<img width="400" alt="before" src="https://github.com/user-attachments/assets/aa6ec207-ac93-4f79-aa98-557a77632c32" />

### after
<img width="400" alt="after" src="https://github.com/user-attachments/assets/5da8c2e9-1492-49cd-8a77-a72cd6df3a2d" />
