### PR TITLE
fix(ios): tabgroup navigationwindow fix

### DIFF
--- a/iphone/Classes/TiUITabGroup.m
+++ b/iphone/Classes/TiUITabGroup.m
@@ -704,7 +704,7 @@ DEFINE_EXCEPTIONS
   TiThreadPerformOnMainThread(
       ^{
         isTabBarHidden = NO;
-        UIViewController *parentController = TiApp.controller.topPresentedController;
+        UIViewController *parentController = [self.proxy windowHoldingController];
         [parentController addChildViewController:self.tabController];
         [self addSubview:self.tabController.view];
         self.tabController.view.frame = self.bounds;

--- a/iphone/Classes/TiUITabGroupProxy.m
+++ b/iphone/Classes/TiUITabGroupProxy.m
@@ -227,9 +227,11 @@ static NSArray *tabGroupKeySequence;
 {
   if ([self viewAttached]) {
     UITabBarController *tabController = [(TiUITabGroup *)[self view] tabController];
-    UIViewController *parentController = [self windowHoldingController];
-    [parentController addChildViewController:tabController];
-    [tabController didMoveToParentViewController:parentController];
+    if (tabController.parentViewController == nil) {
+      UIViewController *parentController = [self windowHoldingController];
+      [parentController addChildViewController:tabController];
+      [tabController didMoveToParentViewController:parentController];
+    }
     [tabController viewWillAppear:animated];
   }
   [super viewWillAppear:animated];


### PR DESCRIPTION
Fix for https://github.com/tidev/titanium-sdk/issues/14021

## Summary

  Fixes `UIViewControllerHierarchyInconsistency` crash when a `Ti.UI.TabGroup` is wrapped in a `Ti.UI.NavigationWindow`.

  ### Before
  When a TabGroup is used inside a NavigationWindow, the app terminates immediately with:
  child view controller: should have parent view controller:
  but actual parent is:

  ### Root Cause
  `TiUITabGroup.open:` was using `TiApp.controller.topPresentedController` to find the parent view controller for `addChildViewController:`. This always returns `TiRootViewController`, which is correct for
  standalone TabGroups but wrong when the TabGroup is nested inside a NavigationWindow.

  The fix uses `[self.proxy windowHoldingController]` which correctly returns the `TiViewController` that wraps the TabGroup's window, regardless of whether it's standalone or nested.

  ### Changes

  - **`TiUITabGroup.open:`** — Use `windowHoldingController` instead of `topPresentedController` to get the correct parent `TiViewController`
  - **`TiUITabGroupProxy.viewWillAppear:`** — Add `parentViewController == nil` guard to prevent double `addChildViewController:` when the tabController was already added in `open:`

  ### Files Changed

  - `iphone/Classes/TiUITabGroup.m` — Fix parent controller selection in `open:`
  - `iphone/Classes/TiUITabGroupProxy.m` — Add parent guard in `viewWillAppear:`
