### PR TITLE
feat(android): improve borderRadius, resorting and reflection code

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiUIHelper.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiUIHelper.java
@@ -57,8 +57,11 @@ import android.graphics.Canvas;
 import android.graphics.ColorFilter;
 import android.graphics.ColorMatrix;
 import android.graphics.ColorMatrixColorFilter;
+import android.graphics.Outline;
 import android.graphics.Paint;
+import android.graphics.Path;
 import android.graphics.Rect;
+import android.graphics.RectF;
 import android.graphics.Shader;
 import android.graphics.Typeface;
 import android.graphics.drawable.BitmapDrawable;
@@ -815,6 +818,14 @@ public class TiUIHelper
 		return null;
 	}
 
+	private static Path createRoundRectPath(Rect rect, float radius)
+	{
+		Path path = new Path();
+		RectF rectF = new RectF(rect);
+		path.addRoundRect(rectF, radius, radius, Path.Direction.CW);
+		return path;
+	}
+
 	public static KrollDict viewToImage(KrollDict proxyDict, View view)
 	{
 		KrollDict image = new KrollDict();
@@ -860,6 +871,26 @@ public class TiUIHelper
 
 			Bitmap bitmap = Bitmap.createBitmap(width, height, Config.ARGB_8888);
 			Canvas canvas = new Canvas(bitmap);
+
+			// Apply ViewOutlineProvider clipping to the software canvas.
+			// ViewOutlineProvider + setClipToOutline(true) only works in the
+			// hardware-accelerated pipeline; it is silently ignored when drawing
+			// to a software Canvas (see toImage() callers).
+			if (view.getClipToOutline() && view.getOutlineProvider() != null) {
+				Outline outline = new Outline();
+				view.getOutlineProvider().getOutline(view, outline);
+				if (!outline.isEmpty() && outline.canClip()) {
+					float radius = outline.getRadius();
+					Rect rect = new Rect();
+					outline.getRect(rect);
+					if (radius > 0) {
+						canvas.clipPath(createRoundRectPath(rect, radius));
+					} else {
+						canvas.clipRect(rect);
+					}
+				}
+			}
+
 			view.draw(canvas);
 
 			ByteArrayOutputStream bos = new ByteArrayOutputStream();

--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiBackgroundColorWrapper.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiBackgroundColorWrapper.java
@@ -7,8 +7,6 @@
 
 package org.appcelerator.titanium.view;
 
-import java.lang.reflect.Field;
-
 import org.appcelerator.kroll.common.Log;
 
 import android.graphics.Color;
@@ -30,15 +28,8 @@ public class TiBackgroundColorWrapper
 {
 	private static final String TAG = TiBackgroundColorWrapper.class.getSimpleName();
 
-	private static final String COLOR_DRAWABLE_STATE_VAR = "mState";
-	private static final String COLOR_DRAWABLE_USE_COLOR_VAR = "mUseColor";
 	private static final String ERR_BACKGROUND_COLOR = "Unable to determine the current background color."
 													   + " Transparent will be returned as the color value.";
-
-	// ColorDrawable reflection
-	private static Field cdBackgroundStateField = null;
-	private static Field cdBackgroundStateColorField = null;
-	private static boolean cdBackgroundReflectionReady = false;
 
 	private final View view;
 
@@ -137,31 +128,6 @@ public class TiBackgroundColorWrapper
 
 		Log.w(TAG, ERR_BACKGROUND_COLOR);
 		return Color.TRANSPARENT;
-	}
-
-	private void initColorDrawableReflection(ColorDrawable colorDrawable)
-	{
-		cdBackgroundReflectionReady = true;
-
-		Class<ColorDrawable> cdClass = ColorDrawable.class;
-
-		try {
-			cdBackgroundStateField = cdClass.getDeclaredField(COLOR_DRAWABLE_STATE_VAR);
-			cdBackgroundStateField.setAccessible(true);
-		} catch (Exception e) {
-			Log.e(TAG, "Reflection failed while trying to determine background color of view.", e);
-			cdBackgroundStateField = null;
-			return;
-		}
-
-		try {
-			cdBackgroundStateColorField =
-				cdBackgroundStateField.getType().getDeclaredField(COLOR_DRAWABLE_USE_COLOR_VAR);
-			cdBackgroundStateColorField.setAccessible(true);
-		} catch (Exception e) {
-			Log.e(TAG, "Reflection failed while trying to determine background color of view.", e);
-			cdBackgroundStateColorField = null;
-		}
 	}
 
 	public void setBackgroundColor(int value)

--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiBorderWrapperView.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiBorderWrapperView.java
@@ -41,6 +41,8 @@ public class TiBorderWrapperView extends FrameLayout
 	private int alpha = -1;
 	private Paint paint;
 	private Rect bounds;
+	private final Path outerPath = new Path();
+	private final Path innerPath = new Path();
 	private ViewOutlineProvider viewOutlineProvider;
 	public TiBorderWrapperView(Context context)
 	{
@@ -90,14 +92,15 @@ public class TiBorderWrapperView extends FrameLayout
 			paint.setAlpha(alpha);
 		}
 
-		Path outerPath = new Path();
+		outerPath.rewind();
+		innerPath.rewind();
 		if (hasRadius()) {
 			float[] innerRadius = new float[this.radius.length];
 			for (int i = 0; i < this.radius.length; i++) {
 				innerRadius[i] = this.radius[i] - padding;
 			}
 			outerPath.addRoundRect(innerRect, innerRadius, Direction.CCW);
-			Path innerPath = new Path(outerPath);
+			innerPath.set(outerPath);
 
 			// Draw border.
 			outerPath.addRoundRect(outerRect, this.radius, Direction.CW);

--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiCompositeLayout.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiCompositeLayout.java
@@ -367,9 +367,11 @@ public class TiCompositeLayout extends ViewGroup implements OnHierarchyChangeLis
 
 	public void resort()
 	{
+		if (needsSort) {
+			return;
+		}
 		setNeedsSort(true);
 		requestLayout();
-		invalidate();
 	}
 
 	public void onChildViewAdded(View parent, View child)

--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiUIView.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiUIView.java
@@ -36,6 +36,7 @@ import android.content.Context;
 import android.content.res.ColorStateList;
 import android.graphics.Color;
 import android.graphics.Matrix;
+import android.graphics.Outline;
 import android.graphics.Point;
 import android.graphics.Rect;
 import android.graphics.drawable.ColorDrawable;
@@ -61,6 +62,7 @@ import android.view.ScaleGestureDetector;
 import android.view.ScaleGestureDetector.SimpleOnScaleGestureListener;
 import android.view.View;
 import android.view.View.OnClickListener;
+import android.view.ViewOutlineProvider;
 import android.view.View.OnFocusChangeListener;
 import android.view.View.OnKeyListener;
 import android.view.View.OnTouchListener;
@@ -143,6 +145,7 @@ public abstract class TiUIView implements KrollProxyListener, OnFocusChangeListe
 
 	private boolean zIndexChanged = false;
 	protected TiBorderWrapperView borderView;
+	private boolean usingBorderOutline = false;
 	// For twofingertap detection
 	private boolean didScale = false;
 
@@ -451,6 +454,112 @@ public abstract class TiUIView implements KrollProxyListener, OnFocusChangeListe
 			|| d.containsKeyAndNotNull(TiC.PROPERTY_BACKGROUND_DISABLED_COLOR);
 	}
 
+	/**
+	 * Returns true if the borderRadius value is uniform across all corners.
+	 * Outline.setRoundRect() only supports a single radius, so non-uniform
+	 * arrays/strings must fall back to the TiBorderWrapperView path.
+	 */
+	private boolean isBorderRadiusUniform(Object radiusObj)
+	{
+		if (radiusObj instanceof Object[]) {
+			Object[] arr = (Object[]) radiusObj;
+			if (arr.length <= 1) {
+				return true;
+			}
+			String first = TiConvert.toString(arr[0]);
+			for (int i = 1; i < arr.length; i++) {
+				if (!first.equals(TiConvert.toString(arr[i]))) {
+					return false;
+				}
+			}
+			return true;
+		}
+		if (radiusObj instanceof String) {
+			String[] parts = ((String) radiusObj).split("\\s");
+			if (parts.length <= 1) {
+				return true;
+			}
+			String first = parts[0];
+			for (int i = 1; i < parts.length; i++) {
+				if (!first.equals(parts[i])) {
+					return false;
+				}
+			}
+			return true;
+		}
+		return true;
+	}
+
+	/**
+	 * Returns true if the view should use ViewOutlineProvider for borderRadius
+	 * instead of the TiBorderWrapperView: no border stroke and radius is uniform.
+	 */
+	private boolean canUseBorderOutline(KrollDict d)
+	{
+		return d.containsKeyAndNotNull(TiC.PROPERTY_BORDER_RADIUS)
+			&& !d.containsKeyAndNotNull(TiC.PROPERTY_BORDER_COLOR)
+			&& !(d.containsKeyAndNotNull(TiC.PROPERTY_BORDER_WIDTH)
+				&& TiConvert.toTiDimension(
+					TiConvert.toString(d.get(TiC.PROPERTY_BORDER_WIDTH)), TiDimension.TYPE_WIDTH).getValue() > 0f)
+			&& isBorderRadiusUniform(d.get(TiC.PROPERTY_BORDER_RADIUS));
+	}
+
+	/**
+	 * Attempts to apply a uniform borderRadius via ViewOutlineProvider.
+	 * Returns true if the outline was applied, false if it cannot be used
+	 * (caller should fall back to the wrapper).
+	 */
+	private boolean tryApplyBorderRadiusAsOutline(Object radiusObj)
+	{
+		if (nativeView == null) {
+			return false;
+		}
+
+		if (!isBorderRadiusUniform(radiusObj)) {
+			return false;
+		}
+
+		final float radiusPixels;
+		if (radiusObj instanceof Object[]) {
+			Object[] arr = (Object[]) radiusObj;
+			if (arr.length > 0) {
+				TiDimension dim = TiConvert.toTiDimension(arr[0], TiDimension.TYPE_WIDTH);
+				radiusPixels = dim != null ? (float) dim.getPixels(nativeView) : 0;
+			} else {
+				radiusPixels = 0;
+			}
+		} else if (radiusObj instanceof CharSequence) {
+			float parsedRadius = 0;
+			String text = radiusObj.toString();
+			String[] parts = text.split("\\s");
+			if (parts.length > 0 && parts[0].length() > 0) {
+				TiDimension dim = TiConvert.toTiDimension(parts[0], TiDimension.TYPE_WIDTH);
+				parsedRadius = dim != null ? (float) dim.getPixels(nativeView) : 0;
+			}
+			radiusPixels = parsedRadius;
+		} else {
+			TiDimension dim = TiConvert.toTiDimension(radiusObj, TiDimension.TYPE_WIDTH);
+			radiusPixels = dim != null ? (float) dim.getPixels(nativeView) : 0;
+		}
+
+		if (radiusPixels <= 0) {
+			nativeView.setOutlineProvider(null);
+			nativeView.setClipToOutline(false);
+			return true;
+		}
+
+		nativeView.setOutlineProvider(new ViewOutlineProvider() {
+			@Override
+			public void getOutline(View view, Outline outline)
+			{
+				outline.setRoundRect(0, 0, view.getWidth(), view.getHeight(), radiusPixels);
+			}
+		});
+		nativeView.setClipToOutline(true);
+		nativeView.invalidateOutline();
+		return true;
+	}
+
 	public float[] getPreTranslationValue(float[] points)
 	{
 		if (layoutParams.optionTransform != null) {
@@ -605,8 +714,7 @@ public abstract class TiUIView implements KrollProxyListener, OnFocusChangeListe
 				}
 			}
 			final View v = getOuterView();
-			if (v != null) {
-				bLayoutPending.set(true);
+			if (v != null && bLayoutPending.compareAndSet(false, true)) {
 				OnGlobalLayoutListener layoutListener = new OnGlobalLayoutListener() {
 					@Override
 					public void onGlobalLayout()
@@ -622,9 +730,8 @@ public abstract class TiUIView implements KrollProxyListener, OnFocusChangeListe
 					}
 				};
 				v.getViewTreeObserver().addOnGlobalLayoutListener(layoutListener);
+				nativeView.requestLayout();
 			}
-
-			nativeView.requestLayout();
 		}
 	}
 
@@ -855,18 +962,25 @@ public abstract class TiUIView implements KrollProxyListener, OnFocusChangeListe
 
 				if (hasBorder) {
 					if (borderView == null && parent != null) {
-						// Since we have to create a new border wrapper view, we need to remove this view, and re-add
-						// it.
-						// This will ensure the border wrapper view is added correctly.
-						TiUIView parentView = parent.getOrCreateView();
-						if (parentView != null) {
-							int removedChildIndex = parentView.findChildIndex(this);
-							parentView.remove(this);
-							initializeBorder(d, bgColor);
-							if (removedChildIndex == -1) {
-								parentView.add(this);
-							} else {
-								parentView.add(this, removedChildIndex);
+						// Use outline for uniform borderRadius-only (no border stroke).
+						// Falls through to TiBorderWrapperView for non-uniform radii.
+						if (key.startsWith(TiC.PROPERTY_BORDER_PREFIX) && canUseBorderOutline(d)) {
+							usingBorderOutline = true;
+							handleBorderProperty(key, newValue);
+						} else {
+							// Since we have to create a new border wrapper view, we need to remove this view, and re-add
+							// it.
+							// This will ensure the border wrapper view is added correctly.
+							TiUIView parentView = parent.getOrCreateView();
+							if (parentView != null) {
+								int removedChildIndex = parentView.findChildIndex(this);
+								parentView.remove(this);
+								initializeBorder(d, bgColor);
+								if (removedChildIndex == -1) {
+									parentView.add(this);
+								} else {
+									parentView.add(this, removedChildIndex);
+								}
 							}
 						}
 					} else if (key.startsWith(TiC.PROPERTY_BORDER_PREFIX)) {
@@ -1499,6 +1613,20 @@ public abstract class TiUIView implements KrollProxyListener, OnFocusChangeListe
 	{
 		if (hasBorder(d)) {
 
+			// Use ViewOutlineProvider for borderRadius-only with uniform radius.
+			// Falls through to TiBorderWrapperView for non-uniform radii.
+			if (canUseBorderOutline(d)) {
+				usingBorderOutline = true;
+				if (tryApplyBorderRadiusAsOutline(d.get(TiC.PROPERTY_BORDER_RADIUS))) {
+					if (bgColor != null) {
+						nativeView.setBackgroundColor(bgColor);
+					}
+					nativeView.postInvalidate();
+					return;
+				}
+			}
+			usingBorderOutline = false;
+
 			if (nativeView != null) {
 
 				if (borderView == null) {
@@ -1571,6 +1699,12 @@ public abstract class TiUIView implements KrollProxyListener, OnFocusChangeListe
 
 	private void handleBorderProperty(String property, Object value)
 	{
+		if (usingBorderOutline && borderView == null) {
+			if (TiC.PROPERTY_BORDER_RADIUS.equals(property)) {
+				tryApplyBorderRadiusAsOutline(value);
+			}
+			return;
+		}
 		if (TiC.PROPERTY_BORDER_COLOR.equals(property)) {
 			int color = value != null ? TiConvert.toColor(value.toString(), proxy.getActivity()) : Color.TRANSPARENT;
 			borderView.setColor(color);


### PR DESCRIPTION
## Changes

**1. Reuse Path objects in TiBorderWrapperView (TiBorderWrapperView.java:44-45, 95-96)**
- Pre-allocated outerPath and innerPath as instance fields
- In onDraw(), calls path.rewind() instead of new Path() each frame
- Eliminates per-frame GC churn from path allocation

**2. Border without wrapper via ViewOutlineProvider (TiUIView.java:37,65,476-520,913-917,1565-1574,1639-1645)**
- When only borderRadius is set (no border color/width), uses ViewOutlineProvider + setClipToOutline(true) on the native view directly
- Avoids the costly hierarchy mutation (remove from parent, wrap, re-add) that TiBorderWrapperView required
- Falls back to the wrapper when border stroke properties are present
- Only applies on API 21+ (all modern Android)

**3. Only re-sort on zIndex change (TiCompositeLayout.java:369-375)**
- resort() now returns early if needsSort is already true, preventing redundant requestLayout() calls
- Removed invalidate() from resort() since requestLayout() already schedules a draw pass
- Works with existing onChildViewAdded/onChildViewRemoved listeners that also set needsSort

**4. Eliminate reflection in TiBackgroundColorWrapper (TiBackgroundColorWrapper.java - entire file)**
- Removed all unused reflection code: cdBackgroundStateField, cdBackgroundStateColorField, cdBackgroundReflectionReady, initColorDrawableReflection(), Field import
- ColorDrawable.getColor() has been available since API 11 and already handled correctly in getBackgroundColor() — the reflection code was dead code

**5. Batch invalidate-only properties (TiUIView.java:665)**
- layoutNativeView() now uses bLayoutPending.compareAndSet(false, true) to skip redundant setup when a layout pass is already pending
- Prevents setting up duplicate OnGlobalLayoutListener instances and redundant requestLayout() calls when multiple layout properties change in sequence (e.g., setting left, top, width, height at once via applyProperties())

## Test code

<details>
<summary>Test borderRadius and toImage()</summary>

```js
const win = Ti.UI.createWindow({ backgroundColor:"#ddd" });
const view = Ti.UI.createView({width: 50, height: 50, borderRadius: 25, left: 10, backgroundColor:"red"});
const img = Ti.UI.createImageView({ image:"/image.jpg", backgroundColor:"#999", borderRadius: 25, height: 50, width: 50, right: 10});
const img_check1 = Ti.UI.createImageView({ width: 50, height: 50, bottom: 10, left: 10})
const img_check2 = Ti.UI.createImageView({ width: 50, height: 50, bottom: 10, right: 10})

win.add([img,view, img_check1, img_check2]);

win.addEventListener("open", function() {
	setTimeout(function() {
		img_check1.image = view.toImage();
		img_check2.image = img.toImage();
	}, 1000)
})

win.open();
```
</details>

<details>
<summary>Performance benchmark</summary>

```js
function formatNum(n)
{
	return String(Math.round(n)).replace(/\B(?=(\d{3})+(?!\d))/g, ',');
}

function benchBorders(win, finish)
{
	var results = [];
  var ITERATIONS = 1000;

	var outlineView = Ti.UI.createView({
		width: 50, height: 50, top: 10, left: 10,
		backgroundColor: 'red',
		borderRadius: 10
	});
	win.add(outlineView);

	var borderView = Ti.UI.createView({
		width: 50, height: 50, top: 10, left: 70,
		backgroundColor: 'blue',
		borderColor: 'black', borderWidth: 3, borderRadius: 10
	});
	win.add(borderView);

	var plainView = Ti.UI.createView({
		width: 50, height: 50, top: 10, left: 130,
		backgroundColor: 'green'
	});
	win.add(plainView);

	// Wait for layout.
	setTimeout(function () {
		var start, elapsed, i;

		// --- borderView backgroundColor (triggers redraw with path reuse) ---
		start = Date.now();
		for (i = 0; i < ITERATIONS; i++) {
			borderView.backgroundColor = (i % 2 === 0) ? 'blue' : 'lightblue';
		}
		elapsed = Date.now() - start;
		var borderColorMs = elapsed;
		results.push('borderColorChange(' + ITERATIONS + 'x): ' + elapsed + 'ms');

		// --- outlineView borderRadius (uses ViewOutlineProvider) ---
		start = Date.now();
		for (i = 0; i < ITERATIONS; i++) {
			outlineView.borderRadius = (i % 20) + 5;
		}
		elapsed = Date.now() - start;
		var outlineRadiusMs = elapsed;
		results.push('outlineRadiusChange(' + ITERATIONS + 'x): ' + elapsed + 'ms');

		// --- plainView backgroundColor (baseline) ---
		start = Date.now();
		for (i = 0; i < ITERATIONS; i++) {
			plainView.backgroundColor = (i % 2 === 0) ? 'green' : 'lightgreen';
		}
		elapsed = Date.now() - start;
		var plainColorMs = elapsed;
		results.push('plainColorChange(' + ITERATIONS + 'x): ' + elapsed + 'ms');

		results.forEach(function (r) { Ti.API.info(r); });
		finish(null, 'Border', [
			{ label: 'borderColorChange', ms: borderColorMs },
			{ label: 'outlineRadiusChange', ms: outlineRadiusMs },
			{ label: 'plainColorChange (baseline)', ms: plainColorMs }
		]);
	}, 300);
}

function benchZIndex(win, finish)
{
	var COUNT = 20;
  var ITERATIONS = 100;
	var views = [];
	var colors = [
		'red', 'blue', 'green', 'orange', 'purple', 'cyan',
		'magenta', 'yellow', 'brown', 'pink'
	];

	// Lay out in a diagonal stack.
	for (var i = 0; i < COUNT; i++) {
		var v = Ti.UI.createView({
			width: 80, height: 80,
			left: i * 8 + 10,
			top: i * 8 + 60,
			backgroundColor: colors[i % colors.length],
			opacity: 0.85,
			zIndex: i
		});
		win.add(v);
		views.push(v);
	}

	setTimeout(function () {
		var start = Date.now();
		for (var j = 0; j < ITERATIONS; j++) {
			for (var k = 0; k < COUNT; k++) {
				views[k].zIndex = (k + j) % COUNT;
			}
		}
		var elapsed = Date.now() - start;
		Ti.API.info('zIndexResort(' + (ITERATIONS * COUNT) + ' changes): ' + elapsed + 'ms');
		finish(null, 'Z-Index', [
			{ label: 'zIndexChanges(' + (ITERATIONS * COUNT) + ')', ms: elapsed }
		]);
	}, 300);
}

function benchBatchLayout(win, finish)
{
  var ITERATIONS = 100;

	var v = Ti.UI.createView({
		width: 80, height: 80, top: 60, left: 10,
		backgroundColor: 'purple'
	});
	win.add(v);

	setTimeout(function () {
		// Individual setters.
		var start = Date.now();
		for (var i = 0; i < ITERATIONS; i++) {
			v.left = 10 + i;
			v.top = 60 + i;
			v.width = 80 + (i % 20);
			v.height = 80 + (i % 20);
		}
		var individualMs = Date.now() - start;

		// Batched via applyProperties.
		start = Date.now();
		for (i = 0; i < ITERATIONS; i++) {
			v.applyProperties({
				left: 10 + i,
				top: 60 + i,
				width: 80 + (i % 20),
				height: 80 + (i % 20)
			});
		}
		var batchedMs = Date.now() - start;

		Ti.API.info('individualSetters(' + ITERATIONS + 'x4): ' + individualMs + 'ms');
		Ti.API.info('applyProperties(' + ITERATIONS + 'x4): ' + batchedMs + 'ms');
		Ti.API.info('ratio: ' + (individualMs / Math.max(batchedMs, 1)).toFixed(2) + 'x');

		finish(null, 'Batch Layout', [
			{ label: 'individualSetters(' + ITERATIONS + 'x4)', ms: individualMs },
			{ label: 'applyProperties(' + ITERATIONS + 'x4)', ms: batchedMs },
			{ label: 'ratio (individual / batched)', ms: null, ratio: (individualMs / Math.max(batchedMs, 1)).toFixed(2) }
		]);
	}, 300);
}


function benchViewCreation(win, finish)
{
	// Create many views with borderRadius only (no border stroke).
	// After optimization: uses ViewOutlineProvider, no wrapper/hierarchy mutation.
  var COUNT = 400;

	setTimeout(function () {
		var start = Date.now();
		for (var i = 0; i < COUNT; i++) {
			var v = Ti.UI.createView({
				width: 28, height: 28,
				left: (i % 20) * 32 + 10,
				top: Math.floor(i / 20) * 32 + 60,
				backgroundColor: 'orange',
				borderRadius: 14
			});
			win.add(v);
		}
		var elapsed = Date.now() - start;
		Ti.API.info('createViewsWithBorderRadius(' + COUNT + 'x): ' + elapsed + 'ms');
		finish(null, 'View Creation', [
			{ label: 'createViewsWithBorderRadius(' + COUNT + 'x)', ms: elapsed }
		]);
	}, 300);
}


(function () {

	// ── App state ────────────────────────────────────────────
	var results = [];          // { suite, metrics: [{label, ms, ratio?}] }
	var pending = 0;
	var benchWindow;

	// ── Helpers ──────────────────────────────────────────────
	function benchComplete(err, suiteName, metrics)
	{
		pending--;
		if (err) {
			Ti.API.error(suiteName + ' failed: ' + err);
		} else {
			results.push({ suite: suiteName, metrics: metrics });
		}
		if (pending === 0) {
			renderResults();
		}
	}

	// ── Results scroll view ──────────────────────────────────
	function renderResults()
	{
		var scroll = Ti.UI.createScrollView({
			top: 0, left: 0, right: 0, bottom: 0,
			backgroundColor: '#1a1a2e',
			contentHeight: Ti.UI.SIZE
		});

		var y = 10;

		// Title
		scroll.add(Ti.UI.createLabel({
			top: y, left: 16, right: 16,
			text: 'Render Engine Benchmarks',
			color: '#e94560',
			font: { fontSize: 20, fontWeight: 'bold' },
			textAlign: Ti.UI.TEXT_ALIGNMENT_CENTER,
			height: Ti.UI.SIZE
		}));
		y += 40;

		// Results per suite.
		for (var s = 0; s < results.length; s++) {
			var suite = results[s];

			scroll.add(Ti.UI.createLabel({
				top: y, left: 16, right: 16,
				text: suite.suite,
				color: '#0f3460',
				backgroundColor: '#e94560',
				font: { fontSize: 15, fontWeight: 'bold' },
				padding: { left: 8, top: 4, bottom: 4 },
				height: Ti.UI.SIZE
			}));
			y += 28;

			for (var m = 0; m < suite.metrics.length; m++) {
				var met = suite.metrics[m];
				var line = '  ' + met.label + ': ';
				if (met.ms !== null) {
					line += formatNum(met.ms) + ' ms';
				}
				if (met.ratio) {
					line += '  (' + met.ratio + 'x)';
				}

				scroll.add(Ti.UI.createLabel({
					top: y, left: 16, right: 16,
					text: line,
					color: '#eee',
					font: { fontSize: 13, fontFamily: 'monospace' },
					height: Ti.UI.SIZE
				}));
				y += 22;
			}

			y += 8;
		}

		// Note
		scroll.add(Ti.UI.createLabel({
			top: y, left: 16, right: 16, bottom: 20,
			text: 'Lower is better. Results logged via Ti.API.info.',
			color: '#888',
			font: { fontSize: 11 },
			textAlign: Ti.UI.TEXT_ALIGNMENT_CENTER,
			height: Ti.UI.SIZE
		}));

		benchWindow.removeAllChildren();
		benchWindow.add(scroll);
	}

	// ── Launch ───────────────────────────────────────────────
	benchWindow = Ti.UI.createWindow({
		backgroundColor: '#1a1a2e',
		orientationModes: [ Ti.UI.PORTRAIT ]
	});

	var statusLabel = Ti.UI.createLabel({
		top: 100, left: 20, right: 20,
		text: 'Running benchmarks...',
		color: '#eee',
		font: { fontSize: 16 },
		textAlign: Ti.UI.TEXT_ALIGNMENT_CENTER,
		height: Ti.UI.SIZE
	});
	benchWindow.add(statusLabel);

	benchWindow.open();

	// Run all 4 benchmarks, each in an isolated child view.
	pending = 4;

	var runBench = function (benchFn, name) {
		var container = Ti.UI.createView({
			top: -2000, left: -2000,  // offscreen to not flicker
			width: 10, height: 10,
			backgroundColor: 'transparent'
		});
		benchWindow.add(container);

		benchFn(container, function (err, suiteName, metrics) {
			benchWindow.remove(container);
			benchComplete(err, suiteName, metrics);
		});
	};

	runBench(benchBorders);
	runBench(benchZIndex);
	runBench(benchBatchLayout);
	runBench(benchViewCreation);
})();
```
</details>

## Results

13.2.0:
<img width="480" height="445" alt="Screenshot_20260523-200732" src="https://github.com/user-attachments/assets/12d46e5c-96bc-4c87-ab83-4c34076edefa" />

13.3.0:
<img width="480" height="445" alt="Screenshot_20260523-200815" src="https://github.com/user-attachments/assets/18949860-7fc2-4b9b-83a2-d7a001e24b98" />
(border parts are a little slower but produce less UI so the it should benefit scrolling)

TiBorderWrapper is gone now and a border on a image will just generate:
<img width="533" height="235" alt="Bildschirmfoto_20260523_201641" src="https://github.com/user-attachments/assets/43aaeeaa-bad2-4d05-921a-4c717143e214" />


Sorry had to blur usernames but in a listview it currently looks like this (13.2.0):
<img width="888" height="354" alt="Bildschirmfoto_20260523_211409" src="https://github.com/user-attachments/assets/d9d1e903-cab0-4585-bcea-78dfc59059c9" />
each round image is producing a borderWrapperView + an imageview

with 13.3.0 it will just be a single image, no nested element for each of the rows:
<img width="906" height="426" alt="Bildschirmfoto_20260523_211259" src="https://github.com/user-attachments/assets/001988d1-9275-4cd8-a0ef-fe93c1bd883b" />

Custom borderRadius with an array still works fine too:
<img width="240" height="108" alt="Screenshot_20260523-213133" src="https://github.com/user-attachments/assets/e124223a-424d-4fa3-9d32-eb92bb4b992f" />

Fixes https://github.com/tidev/titanium-sdk/issues/13464