### PR TITLE
chore: github actions

### DIFF
--- a/.github/actions/build-android/action.yml
+++ b/.github/actions/build-android/action.yml
@@ -20,13 +20,13 @@ runs:
       shell: bash
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ inputs.node-version }}
         cache: 'npm'
 
     - name: Setup Java
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         distribution: 'adopt'
         java-version: ${{ inputs.java-version }}
@@ -36,7 +36,7 @@ runs:
       shell: bash
 
     - name: Cache Gradle packages
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ~/.gradle/caches
@@ -58,7 +58,7 @@ runs:
           ${{ runner.os }}-ccache-
 
     - name: Cache V8
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: dist/android/libv8
         key: libv8-${{ hashFiles('dist/android/libv8/**') }}

--- a/.github/actions/build-ios/action.yml
+++ b/.github/actions/build-ios/action.yml
@@ -10,7 +10,7 @@ runs:
   using: composite
   steps:
     - name: Use Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ inputs.node-version }}
         cache: 'npm'

--- a/.github/actions/package/action.yml
+++ b/.github/actions/package/action.yml
@@ -16,13 +16,13 @@ runs:
   using: composite
   steps:
     - name: Use Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ inputs.node-version }}
         cache: 'npm'
 
     - name: Use JDK
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         distribution: 'adopt'
         java-version: ${{ inputs.java-version }}
@@ -32,7 +32,7 @@ runs:
       shell: bash
 
     - name: Cache Gradle packages
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ~/.gradle/caches
@@ -58,7 +58,7 @@ runs:
       shell: bash
 
     - name: Cache Native Modules
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ${{ env.SDK_BUILD_CACHE_DIR }}
         key: native-modules-${{ github.sha }}


### PR DESCRIPTION
Upgrade github actions because of the Node 20 deprecation