### PR TITLE
fix(android): cameraX rotation fix for orientation-lock enabled

### DIFF
--- a/android/modules/media/src/java/ti/modules/titanium/media/TiCameraXActivity.java
+++ b/android/modules/media/src/java/ti/modules/titanium/media/TiCameraXActivity.java
@@ -427,7 +427,20 @@ public class TiCameraXActivity extends TiBaseActivity implements CameraXConfig.P
 				if (orientationEventListener == null || orientation == ORIENTATION_UNKNOWN) {
 					return;
 				}
-				int rotation = getWindowManager().getDefaultDisplay().getRotation();
+				// Convert physical device orientation (degrees) to a Surface rotation constant.
+				// This avoids relying on display rotation which is wrong when orientation-lock is on.
+				// OrientationEventListener 90 = tilted CCW (top-left) = display ROTATION_270.
+				// OrientationEventListener 270 = tilted CW (top-right) = display ROTATION_90.
+				int rotation;
+				if (orientation >= 315 || orientation < 45) {
+					rotation = Surface.ROTATION_0;
+				} else if (orientation >= 45 && orientation < 135) {
+					rotation = Surface.ROTATION_270;
+				} else if (orientation >= 135 && orientation < 225) {
+					rotation = Surface.ROTATION_180;
+				} else {
+					rotation = Surface.ROTATION_90;
+				}
 				if (lastDisplayOrientation != rotation) {
 					imageCapture.setTargetRotation(rotation);
 					lastDisplayOrientation = rotation;


### PR DESCRIPTION
```js
var win = Ti.UI.createWindow();
var img = Ti.UI.createImageView();
win.addEventListener("click", function() {
	Ti.Media.requestCameraPermissions(function(e) {
		if (e.success) {
			var overlay = Ti.UI.createView();
			var btn = Ti.UI.createButton({
				bottom: 0,
				title: "take"
			})
			overlay.add(btn);
			Ti.Media.showCamera({
				overlay: overlay,
				useCameraX: true,
				success: function(e) {
					img.image = e.media;

					console.log(e.media.uprightWidth, "x", e.media.uprightHeight)
				}
			});

			btn.addEventListener("click", function() {
				Ti.Media.takePicture();
			})
		}
	});
})
win.add(img);
win.open();
```

Set your phone to "orientation lock" and turn the camera sideways when you take a picture. Currently it is taking the "locked" orientation and the image is rotated. This PR will use the real rotation and the image is correct when you look at it again holding the phone upwards.