### PR TITLE
fix(ios): fix TableView search field position

### DIFF
--- a/iphone/Classes/TiUIListView.m
+++ b/iphone/Classes/TiUIListView.m
@@ -2356,12 +2356,16 @@ static TiViewProxy *FindViewProxyWithBindIdContainingPoint(UIView *view, CGPoint
 
 - (void)keyboardDidShowAtHeight:(CGFloat)keyboardTop
 {
+  if ([searchController isActive])
+    return;
   CGRect minimumContentRect = [_tableView bounds];
   InsetScrollViewForKeyboard(_tableView, keyboardTop, minimumContentRect.size.height + minimumContentRect.origin.y);
 }
 
 - (void)scrollToShowView:(TiUIView *)firstResponderView withKeyboardHeight:(CGFloat)keyboardTop
 {
+  if ([searchController isActive])
+    return;
   if ([_tableView isScrollEnabled]) {
     CGRect minimumContentRect = [_tableView bounds];
 
@@ -2629,10 +2633,8 @@ static TiViewProxy *FindViewProxyWithBindIdContainingPoint(UIView *view, CGPoint
 {
   NSDictionary *userInfo = [notification userInfo];
   CGRect keyboardEndFrame = [[userInfo objectForKey:UIKeyboardFrameEndUserInfoKey] CGRectValue];
-  CGPoint convertedOrigin = [self.superview convertPoint:self.frame.origin toView:searchControllerPresenter.view];
-
-  CGRect mainScreenBounds = [[UIScreen mainScreen] bounds];
-  CGFloat height = keyboardEndFrame.origin.y - mainScreenBounds.size.height < 0 ? keyboardEndFrame.origin.y - convertedOrigin.y : keyboardEndFrame.origin.y;
+  CGRect convertedFrame = [[[TiApp app] topMostView] convertRect:keyboardEndFrame fromView:nil];
+  CGFloat height = convertedFrame.origin.y;
 
   [self keyboardDidShowAtHeight:height];
 }
@@ -2641,10 +2643,8 @@ static TiViewProxy *FindViewProxyWithBindIdContainingPoint(UIView *view, CGPoint
 {
   NSDictionary *userInfo = [notification userInfo];
   CGRect keyboardEndFrame = [[userInfo objectForKey:UIKeyboardFrameEndUserInfoKey] CGRectValue];
-  CGPoint convertedOrigin = [self.superview convertPoint:self.frame.origin toView:searchControllerPresenter.view];
-
-  CGRect mainScreenBounds = [[UIScreen mainScreen] bounds];
-  CGFloat height = keyboardEndFrame.origin.y - mainScreenBounds.size.height < 0 ? keyboardEndFrame.origin.y - convertedOrigin.y : keyboardEndFrame.origin.y;
+  CGRect convertedFrame = [[[TiApp app] topMostView] convertRect:keyboardEndFrame fromView:nil];
+  CGFloat height = convertedFrame.origin.y;
 
   [self keyboardDidShowAtHeight:height];
 }

--- a/iphone/Classes/TiUIListView.m
+++ b/iphone/Classes/TiUIListView.m
@@ -2356,16 +2356,18 @@ static TiViewProxy *FindViewProxyWithBindIdContainingPoint(UIView *view, CGPoint
 
 - (void)keyboardDidShowAtHeight:(CGFloat)keyboardTop
 {
-  if ([searchController isActive])
+  if ([searchController isActive]) {
     return;
+  }
   CGRect minimumContentRect = [_tableView bounds];
   InsetScrollViewForKeyboard(_tableView, keyboardTop, minimumContentRect.size.height + minimumContentRect.origin.y);
 }
 
 - (void)scrollToShowView:(TiUIView *)firstResponderView withKeyboardHeight:(CGFloat)keyboardTop
 {
-  if ([searchController isActive])
+  if ([searchController isActive]) {
     return;
+  }
   if ([_tableView isScrollEnabled]) {
     CGRect minimumContentRect = [_tableView bounds];
 

--- a/iphone/Classes/TiUITableView.m
+++ b/iphone/Classes/TiUITableView.m
@@ -2799,16 +2799,18 @@
 
 - (void)keyboardDidShowAtHeight:(CGFloat)keyboardTop
 {
-  if ([searchController isActive])
+  if ([searchController isActive]) {
     return;
+  }
   CGRect minimumContentRect = [tableview bounds];
   InsetScrollViewForKeyboard(tableview, keyboardTop, minimumContentRect.size.height + minimumContentRect.origin.y);
 }
 
 - (void)scrollToShowView:(TiUIView *)firstResponderView withKeyboardHeight:(CGFloat)keyboardTop
 {
-  if ([searchController isActive])
+  if ([searchController isActive]) {
     return;
+  }
   if ([tableview isScrollEnabled]) {
     CGRect minimumContentRect = [tableview bounds];
 

--- a/iphone/Classes/TiUITableView.m
+++ b/iphone/Classes/TiUITableView.m
@@ -2541,10 +2541,8 @@
 {
   NSDictionary *userInfo = [notification userInfo];
   CGRect keyboardEndFrame = [[userInfo objectForKey:UIKeyboardFrameEndUserInfoKey] CGRectValue];
-  CGPoint convertedOrigin = [self.superview convertPoint:self.frame.origin toView:searchControllerPresenter.view];
-
-  CGRect mainScreenBounds = [[UIScreen mainScreen] bounds];
-  CGFloat height = keyboardEndFrame.origin.y - mainScreenBounds.size.height < 0 ? keyboardEndFrame.origin.y - convertedOrigin.y : keyboardEndFrame.origin.y;
+  CGRect convertedFrame = [[[TiApp app] topMostView] convertRect:keyboardEndFrame fromView:nil];
+  CGFloat height = convertedFrame.origin.y;
 
   [self keyboardDidShowAtHeight:height];
 }
@@ -2553,10 +2551,8 @@
 {
   NSDictionary *userInfo = [notification userInfo];
   CGRect keyboardEndFrame = [[userInfo objectForKey:UIKeyboardFrameEndUserInfoKey] CGRectValue];
-  CGPoint convertedOrigin = [self.superview convertPoint:self.frame.origin toView:searchControllerPresenter.view];
-
-  CGRect mainScreenBounds = [[UIScreen mainScreen] bounds];
-  CGFloat height = keyboardEndFrame.origin.y - mainScreenBounds.size.height < 0 ? keyboardEndFrame.origin.y - convertedOrigin.y : keyboardEndFrame.origin.y;
+  CGRect convertedFrame = [[[TiApp app] topMostView] convertRect:keyboardEndFrame fromView:nil];
+  CGFloat height = convertedFrame.origin.y;
 
   [self keyboardDidShowAtHeight:height];
 }
@@ -2803,12 +2799,16 @@
 
 - (void)keyboardDidShowAtHeight:(CGFloat)keyboardTop
 {
+  if ([searchController isActive])
+    return;
   CGRect minimumContentRect = [tableview bounds];
   InsetScrollViewForKeyboard(tableview, keyboardTop, minimumContentRect.size.height + minimumContentRect.origin.y);
 }
 
 - (void)scrollToShowView:(TiUIView *)firstResponderView withKeyboardHeight:(CGFloat)keyboardTop
 {
+  if ([searchController isActive])
+    return;
   if ([tableview isScrollEnabled]) {
     CGRect minimumContentRect = [tableview bounds];
 

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiUIView.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiUIView.m
@@ -33,7 +33,8 @@ void InsetScrollViewForKeyboard(UIScrollView *scrollView, CGFloat keyboardTop, C
   // As such, obscuredHeight is now how much actually matters of scrollVisibleRect.
 
   CGFloat bottomInset = MAX(0, obscuredHeight - unimportantArea);
-  [scrollView setContentInset:UIEdgeInsetsMake(0, 0, bottomInset, 0)];
+  UIEdgeInsets existingInsets = [scrollView contentInset];
+  [scrollView setContentInset:UIEdgeInsetsMake(existingInsets.top, existingInsets.left, bottomInset, existingInsets.right)];
 
   CGPoint offset = [scrollView contentOffset];
 


### PR DESCRIPTION
Fixes https://github.com/tidev/titanium-sdk/issues/14289 (some videos in the issue)

Search view in the following example is moving up under the notch:

<img width="300" height="135" alt="Simulator Screenshot - iPhone Air - 2026-05-31 at 18 36 00" src="https://github.com/user-attachments/assets/56243614-1c35-4ef9-aad7-39aca88cd38c" />


```js
const win = Ti.UI.createWindow({
  title: 'Window',
  autoAdjustScrollViewInsets:true
});
var newData = Ti.UI.createTableViewRow({
  title: 'element 1'
})
var newData2 = Ti.UI.createTableViewRow({
  title: 'row 2'
})
var newData3 = Ti.UI.createTableViewRow({
  title: 'item 3'
})
const table = Ti.UI.createTableView({
  search: Ti.UI.createSearchBar(),
  data: [newData, newData2, newData3]
});
win.add(table);
win.open();
```

This PR will fix that. 

<img width="300" height="135" alt="Simulator Screenshot - iPhone Air - 2026-05-31 at 18 34 51" src="https://github.com/user-attachments/assets/61c737ff-0251-49d1-b0e6-f01d08d4f2db" />


**Note:** It's AI generated. I only did visual tests of the test code above and check that KitchenSink and my own apps still look/behave the same. 