### PR TITLE
fix(android): improve Window focus/blur events

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiBaseActivity.java
@@ -1456,6 +1456,9 @@ public abstract class TiBaseActivity extends AppCompatActivity implements TiActi
 				}
 			}
 		}
+		if (this.window != null) {
+			this.window.onWindowFocusChange(hasFocus);
+		}
 		super.onWindowFocusChanged(hasFocus);
 	}
 

--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/TiWindowProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/TiWindowProxy.java
@@ -294,6 +294,9 @@ public abstract class TiWindowProxy extends TiViewProxy
 	 */
 	public void onWindowFocusChange(boolean focused)
 	{
+		if (this.isFocused == focused) {
+			return;
+		}
 		this.isFocused = focused;
 		fireEvent((focused) ? TiC.EVENT_FOCUS : TiC.EVENT_BLUR, null, false);
 	}


### PR DESCRIPTION
Will fire blur/focus event when you drag down the statusbar on your phone.

**Note:** This will also fire when an alert is shown! That is currently not the case. So I'm not sure if we should use a different event for this as it may cause problems in existing apps.

```js
var win = Ti.UI.createWindow({});
var btn = Ti.UI.createButton({
	title: "alert",
})

win.add(btn);
win.open();

win.addEventListener("focus", function(){
	console.log("win focus")
})
win.addEventListener("blur", function(){
	console.log("win blur")
})

btn.addEventListener("click", function(e) {
	alert(1);
})
```

I could change it to `windowblur` and `windowfocus` so you have a different event for these new blur/focus and it won't break any exisint `blur`/`focus` usage on a window
