### PR TITLE
fix(android): webview URL with large GET data

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
@@ -44,6 +44,7 @@ import org.appcelerator.titanium.proxy.TiViewProxy;
 import org.appcelerator.titanium.util.TiConvert;
 import org.appcelerator.titanium.util.TiMimeTypeHelper;
 import org.appcelerator.titanium.util.TiUIHelper;
+import org.appcelerator.titanium.util.TiUrl;
 import org.appcelerator.titanium.view.TiBackgroundDrawable;
 import org.appcelerator.titanium.view.TiCompositeLayout;
 import org.appcelerator.titanium.view.TiUIView;
@@ -584,7 +585,7 @@ public class TiUIWebView extends TiUIView
 		final Uri finalUri = Uri.parse(getProxy().resolveUrl(null, url));
 
 		// Reconstruct URL, omitting any query parameters.
-		final String finalUrl = finalUri.toString().replace(query, "");
+		final String finalUrl = finalUri.getScheme() + TiUrl.SCHEME_SUFFIX + finalUri.getPath();
 
 		if (TiFileFactory.isLocalScheme(finalUrl) && mightBeHtml(finalUrl)) {
 			TiBaseFile tiFile = TiFileFactory.createTitaniumFile(finalUrl, false);
@@ -593,6 +594,9 @@ public class TiUIWebView extends TiUIView
 				InputStream fis = null;
 				try {
 					fis = tiFile.getInputStream();
+					if (fis == null) {
+						throw new IOException("Unable to open input stream for \"" + finalUrl + "\"");
+					}
 					InputStreamReader reader = new InputStreamReader(fis, StandardCharsets.UTF_8);
 					BufferedReader breader = new BufferedReader(reader);
 					String line = breader.readLine();

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
@@ -44,7 +44,6 @@ import org.appcelerator.titanium.proxy.TiViewProxy;
 import org.appcelerator.titanium.util.TiConvert;
 import org.appcelerator.titanium.util.TiMimeTypeHelper;
 import org.appcelerator.titanium.util.TiUIHelper;
-import org.appcelerator.titanium.util.TiUrl;
 import org.appcelerator.titanium.view.TiBackgroundDrawable;
 import org.appcelerator.titanium.view.TiCompositeLayout;
 import org.appcelerator.titanium.view.TiUIView;
@@ -585,7 +584,7 @@ public class TiUIWebView extends TiUIView
 		final Uri finalUri = Uri.parse(getProxy().resolveUrl(null, url));
 
 		// Reconstruct URL, omitting any query parameters.
-		final String finalUrl = finalUri.getScheme() + TiUrl.SCHEME_SUFFIX + finalUri.getPath();
+		final String finalUrl = finalUri.buildUpon().clearQuery().build().toString();
 
 		if (TiFileFactory.isLocalScheme(finalUrl) && mightBeHtml(finalUrl)) {
 			TiBaseFile tiFile = TiFileFactory.createTitaniumFile(finalUrl, false);


### PR DESCRIPTION
In one of my apps I'm using a webview to display two graphs. I wanted to prefill it with data when the page is set and tried to attach all of the data using `$.www_chart.url = 'www/chart.html?data=' + encodeURIComponent(JSON.stringify(graphValues))` and my app was crashing:
```
[ERROR] TiAssetHelper: Error while opening asset "Resources/www/chart.html?data=[90.3,90.3,90.3,9....
[ERROR] TiAssetHelper:  at android.content.res.AssetManager.nativeOpenAsset(Native Method)
[ERROR] TiAssetHelper:  at android.content.res.AssetManager.open(AssetManager.java:1012)
[ERROR] TiAssetHelper:  at android.content.res.AssetManager.open(AssetManager.java:989)
[ERROR] TiAssetHelper:  at org.appcelerator.kroll.util.KrollAssetHelper.openAsset(KrollAssetHelper.java:136)
[ERROR] TiAssetHelper:  at org.appcelerator.titanium.io.TiResourceFile.getInputStream(TiResourceFile.java:70)
[ERROR] TiAssetHelper:  at ti.modules.titanium.ui.widget.webview.TiUIWebView.setUrl(TiUIWebView.java:595)
[ERROR] TiAssetHelper:  at ti.modules.titanium.ui.widget.webview.TiUIWebView.processProperties(TiUIWebView.java:413)
```

The issue is:
> With large/encoded data (base64 +, /, =, URL-encoded chars), the extracted query string doesn't exactly match how it appears in finalUri.toString() after passing through the resolveUrl() pipeline. The replace silently fails, and the query leaks into the path passed to AssetManager.open("Resources/page.html?data=<HUGE_DATA>"). That file doesn't exist → "TiAssetHelper: Error while opening asset" → Null InputStream → uncaught NullPointerException crash.


**Test (from an old ticket https://github.com/tidev/titanium-sdk/pull/11564 about URL query parameters):**

index.html
```html
<!DOCTYPE html>
<html>
    <body>
        <script>
            alert('query: ' + window.location.search);
        </script>
    </body>
</html>
```

```js
const win = Ti.UI.createWindow();
const webView = Ti.UI.createWebView({
	url: 'app://index.html?data=1234'
        // url: '/index.html?data=1234'
        // url: 'file:///android_asset/Resources/index.html?data=1234'
});

win.add(webView);
win.open();
```

The fix works with 640 array points attached in the URL.

**The Fix:**
**Fix 1 — Line 587**: Replaced fragile finalUri.toString().replace(query, "") with finalUri.buildUpon().clearQuery().build().toString(). This uses Uri.Builder.clearQuery() to strip the query string properly, regardless of encoding or data size. Works for both local (file:///android_asset/...) and remote (https://...) URLs.

**Fix 2 — Lines 596-598**: Added null-check on the InputStream after tiFile.getInputStream(). If the asset can't be opened, it throws IOException instead of an uncaught NullPointerException, so the error is handled gracefully by the existing catch block and falls through to the direct WebView load path.