### PR TITLE
fix(android): move MimeTypeHelper log from error to debug

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiMimeTypeHelper.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiMimeTypeHelper.java
@@ -224,12 +224,12 @@ public class TiMimeTypeHelper
 					}
 				}
 			} catch (Exception ex) {
-				Log.e(TAG, ex.getMessage());
+				Log.d(TAG, uri.getPath() + ": " + ex.getMessage(), Log.DEBUG_MODE);
 			} finally {
 				try {
 					mediaRetriever.release();
 				} catch (IOException ex) {
-					Log.e(TAG, ex.getMessage());
+					Log.d(TAG, uri.getPath() + ": " + ex.getMessage(), Log.DEBUG_MODE);
 				}
 			}
 		}


### PR DESCRIPTION
This code path gets hit frequently — for example when TiUIWebView (line 556) or TiResponseCache (line 419) calls getMimeType() on a URL whose path has no file extension. For every non-media file that reaches this code path (.js, .html, .png, images, etc.), setDataSource fails with 0x80000000 (MEDIA_ERROR_UNKNOWN) and the exception is logged at ERROR level.

That's why I'm moving it from ERROR to DEBUG so it won't show:
```
[ERROR] TiMimeTypeHelper: (main) [8,21907] setDataSource failed: status = 0x80000000
[ERROR] TiMimeTypeHelper: (main) [910,22817] setDataSource failed: status = 0x80000000
[ERROR] TiMimeTypeHelper: (main) [4,22821] setDataSource failed: status = 0x80000000
[ERROR] TiMimeTypeHelper: (main) [929,23750] setDataSource failed: status = 0x80000000
[ERROR] TiMimeTypeHelper: (main) [6,23756] setDataSource failed: status = 0x80000000 
```
if you download or create files with no ending as it still works.

Also adding the filename in the DEBUG log output so it's more useful.