### PR TITLE
fix(ios): borderWidth renders at double thickness when borderRadius is an array (iOS) #14442

### DIFF
--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiUIView.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiUIView.m
@@ -640,6 +640,8 @@ DEFINE_EXCEPTIONS
     _borderLayer.fillColor = UIColor.clearColor.CGColor;
     _borderLayer.strokeColor = self.layer.borderColor;
     _borderLayer.lineWidth = self.layer.borderWidth * 2;
+    self.layer.borderColor = nil;
+    self.layer.borderWidth = 0;
     [self.layer addSublayer:_borderLayer];
   }
   return _borderLayer;


### PR DESCRIPTION
Fix for issue #14442