### PR TITLE
fix: fix module packaging process

### DIFF
--- a/build/lib/packager.js
+++ b/build/lib/packager.js
@@ -263,8 +263,11 @@ export class Packager {
 			subDirs[iosIndex] = 'iphone';
 		}
 		await Promise.all(subDirs.map(d => fs.emptyDir(path.join(modulesDir, d))));
-		// Now download/extract/copy the modules
-		await Promise.all(modules.map(m => this.handleModule(m)));
+		// Copying multiple module trees into the same destination in parallel races on shared parent
+		// directories and can leave the package in a partially copied state.
+		for (const module of modules) {
+			await this.handleModule(module);
+		}
 
 		// Need to wipe directories of multi-platform modules for platforms we don't need!
 		// i.e. modules/iphone on win32 builds (there because of hyperloop)

--- a/build/lib/utils.js
+++ b/build/lib/utils.js
@@ -12,7 +12,6 @@ import { fileURLToPath } from 'node:url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const titanium = path.resolve(__dirname, '..', '..', 'node_modules', 'titanium', 'bin', 'ti.js');
 const exec = util.promisify(childProcess.exec);
-const execFile = util.promisify(childProcess.execFile);
 
 const tempDir = os.tmpdir();
 
@@ -298,22 +297,12 @@ export async function cacheExtract(inFile, integrity, outDir, extractFunc) {
 */
 export function unzip(zipfile, dest) {
 	return fs.ensureDir(dest).then(async () => {
-		if (os.platform() === 'win32') {
-			await execFile('powershell.exe', [
-				'-NoProfile',
-				'-NonInteractive',
-				'-Command',
-				'Expand-Archive',
-				'-LiteralPath',
-				zipfile,
-				'-DestinationPath',
-				dest,
-				'-Force'
-			]);
+		if (os.platform() !== 'win32') {
+			await exec('unzip -q -o "' + zipfile + '" -d "' + dest + '"');
 			return;
 		}
 
-		await execFile('unzip', [ '-q', '-o', zipfile, '-d', dest ]);
+		await util.promisify(appc.zip.unzip)(zipfile, dest, null);
 	});
 }
 

--- a/build/lib/utils.js
+++ b/build/lib/utils.js
@@ -12,6 +12,7 @@ import { fileURLToPath } from 'node:url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const titanium = path.resolve(__dirname, '..', '..', 'node_modules', 'titanium', 'bin', 'ti.js');
 const exec = util.promisify(childProcess.exec);
+const execFile = util.promisify(childProcess.execFile);
 
 const tempDir = os.tmpdir();
 
@@ -296,7 +297,24 @@ export async function cacheExtract(inFile, integrity, outDir, extractFunc) {
 * @returns {Promise<void>}
 */
 export function unzip(zipfile, dest) {
-	return util.promisify(appc.zip.unzip)(zipfile, dest, null);
+	return fs.ensureDir(dest).then(async () => {
+		if (os.platform() === 'win32') {
+			await execFile('powershell.exe', [
+				'-NoProfile',
+				'-NonInteractive',
+				'-Command',
+				'Expand-Archive',
+				'-LiteralPath',
+				zipfile,
+				'-DestinationPath',
+				dest,
+				'-Force'
+			]);
+			return;
+		}
+
+		await execFile('unzip', [ '-q', '-o', zipfile, '-d', dest ]);
+	});
 }
 
 /**


### PR DESCRIPTION
After facing this build error randomly on my machine, I have had Codex to find the root cause and its fix.

**Problem:** SDK build process exits randomly at "package modules step" without any clear error. e.g.

```
....
Writing manifest.json
Including pre-packaged native modules...
Copying /var/folders/4x/p2x6d02x32v06h28tzl__6th0000gn/T/timob-build/ti.applesignin-iphone-3.1.2 to /Users/p.saini/Projects/titanium-sdk/dist/mobilesdk-13.3.0-osx
```

Sometimes here
```
Copying /var/folders/4x/p2x6d02x32v06h28tzl__6th0000gn/T/timob-build/com.appcelerator.urlSession-iphone-4.0.1 to /Users/p.saini/Projects/titanium-sdk/dist/mobilesdk-13.3.0-osx
```

**Codex's RCA:**
```
The break was in the packaging phase, not Xcode.

`npm run ios` was exiting during packaged module extraction inside `build/lib/utils.js (line 297)`. 

I reproduced it directly: the build stopped in `cacheUnzip()` while re-extracting cached module ZIPs such as `com.appcelerator.urlSession-iphone-4.0.1.zip`. 

The current node-appc unzip path never returned for those module ZIPs, so Node exited with a half-built dist/mobilesdk-13.3.0-osx tree and never reached zipPlatforms(), zip(), or install().
```
