### PR TITLE
chore: github workflows

### DIFF
--- a/.github/actions/build-android/action.yml
+++ b/.github/actions/build-android/action.yml
@@ -84,7 +84,7 @@ runs:
         dist/tmp/common
       shell: bash
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: android-build
         retention-days: 1

--- a/.github/actions/build-ios/action.yml
+++ b/.github/actions/build-ios/action.yml
@@ -38,7 +38,7 @@ runs:
         iphone/TitaniumKit/build/TitaniumKit.xcframework
       shell: bash
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: ios-build
         retention-days: 1

--- a/.github/actions/package/action.yml
+++ b/.github/actions/package/action.yml
@@ -70,21 +70,21 @@ runs:
       shell: bash
 
     - name: Archive OSX artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: mobilesdk-${{ inputs.vtag }}-osx
         path: |
           dist/mobilesdk-*-osx.zip
 
     - name: Archive win32 artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: mobilesdk-${{ inputs.vtag }}-win32
         path: |
           dist/mobilesdk-*-win32.zip
 
     - name: Archive Linux artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: mobilesdk-${{ inputs.vtag }}-linux
         path: |

--- a/.github/actions/package/action.yml
+++ b/.github/actions/package/action.yml
@@ -41,7 +41,7 @@ runs:
         restore-keys: |
           ${{ runner.os }}-gradle-
 
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v8
       with:
         name: android-build
 
@@ -49,7 +49,7 @@ runs:
       run: tar -xzvf android-build.tar.gz
       shell: bash
 
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v8
       with:
         name: ios-build
 
@@ -98,7 +98,7 @@ runs:
         rm -f ~/.gradle/caches/modules-2/gc.properties
       shell: bash
 
-    - uses: geekyeggo/delete-artifact@v5
+    - uses: geekyeggo/delete-artifact@v6
       with:
         name: |
           android-build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,15 +135,15 @@ jobs:
         ref: ${{ github.event.inputs.branch }}
     - run: echo ${{ env.vtag }}
     - name: Download Linux artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: mobilesdk-${{ env.vtag }}-linux
     - name: Download macOS artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: mobilesdk-${{ env.vtag }}-osx
     - name: Download Windows artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: mobilesdk-${{ env.vtag }}-win32
     - name: Create and push tag


### PR DESCRIPTION
Fixing:
> node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/upload-artifact@v4. Actions will be forced to run with Node.js 24 by default starting June 16th, 2026.

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/download-artifact@v4, actions/upload-artifact@v4, geekyeggo/delete-artifact@v5.