### PR TITLE
chore: github workflow

### DIFF
--- a/.github/actions/build-android/action.yml
+++ b/.github/actions/build-android/action.yml
@@ -28,7 +28,7 @@ runs:
     - name: Setup Java
       uses: actions/setup-java@v5
       with:
-        distribution: 'adopt'
+        distribution: 'temurin'
         java-version: ${{ inputs.java-version }}
 
     - name: Install dependencies
@@ -50,7 +50,7 @@ runs:
       shell: bash
 
     - name: Install ccache
-      uses: hendrikmuhs/ccache-action@v1.2
+      uses: hendrikmuhs/ccache-action@v1.2.23
       with:
         create-symlink: true
         key: ${{ runner.os }}-ccache-${{ github.sha }}

--- a/.github/actions/package/action.yml
+++ b/.github/actions/package/action.yml
@@ -24,7 +24,7 @@ runs:
     - name: Use JDK
       uses: actions/setup-java@v5
       with:
-        distribution: 'adopt'
+        distribution: 'temurin'
         java-version: ${{ inputs.java-version }}
 
     - name: Install dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
           java-version: '21'
 
   ios:
-    runs-on: macos-15
+    runs-on: macos-26
     name: iOS
     env:
       CCACHE_DIR: ${{ github.workspace }}/.ccache
@@ -57,7 +57,7 @@ jobs:
       run: npm run lint:js
 
   package:
-    runs-on: macos-15
+    runs-on: macos-26
     name: Package
     env:
       SDK_BUILD_CACHE_DIR: ${{ github.workspace }}/.native-modules

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
         uses: ./.github/actions/build-android
         with:
           node-version: '24'
-          java-version: '17'
+          java-version: '21'
 
   ios:
     runs-on: macos-15
@@ -76,5 +76,5 @@ jobs:
       uses: ./.github/actions/package
       with:
         node-version: '24'
-        java-version: '17'
+        java-version: '21'
         vtag: ${{ env.vtag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,7 +81,7 @@ jobs:
           java-version: '21'
 
   ios:
-    runs-on: macos-15
+    runs-on: macos-26
     name: iOS
     needs: [validate]
     env:
@@ -100,7 +100,7 @@ jobs:
           node-version: '24'
 
   package:
-    runs-on: macos-15
+    runs-on: macos-26
     name: Package
     env:
       SDK_BUILD_CACHE_DIR: ${{ github.workspace }}/.native-modules

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
         uses: ./.github/actions/build-android
         with:
           node-version: '24'
-          java-version: '17'
+          java-version: '21'
 
   ios:
     runs-on: macos-15
@@ -117,7 +117,7 @@ jobs:
       uses: ./.github/actions/package
       with:
         node-version: '24'
-        java-version: '17'
+        java-version: '21'
         vtag: ${{ env.vtag }}
 
   release:


### PR DESCRIPTION
Fix for other workflow warnings:
```
AdoptOpenJDK has moved to Eclipse Temurin

Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: hendrikmuhs/ccache-action@v1.2
```

and upgrading to java 21 + macos-25