### PR TITLE
chore(docs): fixing documentation

### DIFF
--- a/apidoc/Titanium/Stream/Stream.yml
+++ b/apidoc/Titanium/Stream/Stream.yml
@@ -173,7 +173,6 @@ methods:
         optional: true
     returns:
       - type: Titanium.Buffer
-      - type: void
 
   - name: write
     summary: Asynchronously writes data from a buffer to an [IOStream](Titanium.IOStream).

--- a/apidoc/Titanium/UI/Android/CollapseToolbar.yml
+++ b/apidoc/Titanium/UI/Android/CollapseToolbar.yml
@@ -13,9 +13,9 @@ since: "12.1.0"
 platforms: [android]
 excludes:
     events: [click, dblclick, doubletap, focus, keypressed, longclick, longpress, pinch, postlayout,
-             singletap, swipe, touchcancel, touchend, touchmove, touchstart, twofingertap]
-    methods: [add, animate, convertPointToView, remove, removeAllChildren, toImage, addEventListener, applyProperties,
-              fireEvent, getViewById, hide, insertAt, removeEventListener, replaceAt, show]
+             singletap, swipe, touchcancel, touchend, touchmove, touchstart, twofingertap, rotate]
+    methods: [add, animate, convertPointToView, remove, removeAllChildren, toImage, applyProperties,
+              getViewById, hide, insertAt, replaceAt, show]
     properties: [accessibilityHidden, accessibilityHint, accessibilityLabel, accessibilityValue,
                  anchorPoint, animatedCenter, backgroundColor, backgroundDisabledColor,
                  backgroundDisabledImage, backgroundFocusedColor, backgroundFocusedImage, backgroundGradient,


### PR DESCRIPTION
While creating a new update for [DefinetlyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/75166) I found some issues:

1. Fixing the generator: https://github.com/tidev/docs-devkit/pull/262
2. Fixing two places in the docs (this PR)

It looks like the generator has special cases for the three events ('addEventListener', 'removeEventListener', 'fireEvent') and outputs them twice when you put them in the exclude part.

This PR will add remove them from the exclude part (not 100% correct but the tests will pass, have to adjust that in the future).


Errors from the DefinetlyTyped test tool that are fix with this PR:
```
17851:5    error  TypeScript@5.6, 5.7, 5.8, 5.9, 6.0 compile error: 
Duplicate identifier 'addEventListener'                                                                                                                                                                                                                                          @definitelytyped/expect

  17851:5    error  TypeScript@5.6, 5.7, 5.8, 5.9, 6.0 compile error: 
Subsequent property declarations must have the same type.  Property 'addEventListener' must be of type '<K extends keyof CollapseToolbarEventMap>(name: K, callback: (this: CollapseToolbar, event: CollapseToolbarEventMap[K]) => void) => void', but here has type 'never'     @definitelytyped/expect

  17876:5    error  TypeScript@5.6, 5.7, 5.8, 5.9, 6.0 compile error: 
Duplicate identifier 'fireEvent'                                                                                                                                                                                                                                                 @definitelytyped/expect

  17876:5    error  TypeScript@5.6, 5.7, 5.8, 5.9, 6.0 compile error: 
Subsequent property declarations must have the same type.  Property 'fireEvent' must be of type '<K extends keyof CollapseToolbarEventMap>(name: K, event?: CollapseToolbarEventMap[K]) => void', but here has type 'never'                                                      @definitelytyped/expect

  17911:5    error  TypeScript@5.6, 5.7, 5.8, 5.9, 6.0 compile error: 
Duplicate identifier 'removeEventListener'                                                                                                                                                                                                                                       @definitelytyped/expect

  17911:5    error  TypeScript@5.6, 5.7, 5.8, 5.9, 6.0 compile error: 
Subsequent property declarations must have the same type.  Property 'removeEventListener' must be of type '<K extends keyof CollapseToolbarEventMap>(name: K, callback: (this: CollapseToolbar, event: CollapseToolbarEventMap[K]) => void) => void', but here has type 'never'  @definitelytyped/expect

  64823:150  error  void is only valid as a return type or generic type argument or the type of a `this` parameter                                                                                                                                                                                                                                      @typescript-eslint/no-invalid-void-type
```