### PR TITLE
fix(android): fix padding unit in ScrollableView

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIScrollableView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIScrollableView.java
@@ -17,6 +17,7 @@ import org.appcelerator.titanium.proxy.TiViewProxy;
 import org.appcelerator.titanium.util.TiConvert;
 import org.appcelerator.titanium.view.TiCompositeLayout;
 import org.appcelerator.titanium.view.TiUIView;
+import org.appcelerator.titanium.TiDimension;
 
 import ti.modules.titanium.ui.ScrollableViewProxy;
 import ti.modules.titanium.ui.widget.listview.ListItemProxy;
@@ -513,24 +514,24 @@ public class TiUIScrollableView extends TiUIView
 		int paddingTop = mPager.getPaddingTop();
 		int paddingBottom = mPager.getPaddingBottom();
 
-		if (d.containsKey(TiC.PROPERTY_LEFT)) {
-			paddingLeft = TiConvert.toInt(d.get(TiC.PROPERTY_LEFT), 0);
-		}
-
-		if (d.containsKey(TiC.PROPERTY_RIGHT)) {
-			paddingRight = TiConvert.toInt(d.get(TiC.PROPERTY_RIGHT), 0);
-		}
-
-		if (d.containsKey(TiC.PROPERTY_TOP)) {
-			paddingTop = TiConvert.toInt(d.get(TiC.PROPERTY_TOP), 0);
-		}
-
-		if (d.containsKey(TiC.PROPERTY_BOTTOM)) {
-			paddingBottom = TiConvert.toInt(d.get(TiC.PROPERTY_BOTTOM), 0);
-		}
-
 		RecyclerView recyclerView = (RecyclerView) mPager.getChildAt(0);
 		if (recyclerView != null) {
+			if (d.containsKey(TiC.PROPERTY_LEFT)) {
+				paddingLeft = TiConvert.toTiDimension(d.get(TiC.PROPERTY_LEFT), TiDimension.TYPE_LEFT)
+					.getAsPixels(recyclerView);
+			}
+			if (d.containsKey(TiC.PROPERTY_RIGHT)) {
+				paddingRight = TiConvert.toTiDimension(d.get(TiC.PROPERTY_RIGHT), TiDimension.TYPE_RIGHT)
+					.getAsPixels(recyclerView);
+			}
+			if (d.containsKey(TiC.PROPERTY_TOP)) {
+				paddingTop = TiConvert.toTiDimension(d.get(TiC.PROPERTY_TOP), TiDimension.TYPE_TOP)
+					.getAsPixels(recyclerView);
+			}
+			if (d.containsKey(TiC.PROPERTY_BOTTOM)) {
+				paddingBottom = TiConvert.toTiDimension(d.get(TiC.PROPERTY_BOTTOM), TiDimension.TYPE_BOTTOM)
+					.getAsPixels(recyclerView);
+			}
 			recyclerView.setPadding(paddingLeft, paddingTop, paddingRight, paddingBottom);
 		}
 	}


### PR DESCRIPTION
This one is in the SDK for too long :-)
The left/right padding of a ScrollableView is applied not in the correct unit:

13.2.0:
<img width="800" height="216" alt="Screenshot_20260628-215249" src="https://github.com/user-attachments/assets/a42adb01-3061-4797-946a-4dc5e4b411ea" />
red box and padding should be `40`

This PR will apply the normal TiDimension conversion:
<img width="800" height="216" alt="Screenshot_20260628-215221" src="https://github.com/user-attachments/assets/95311ca3-4b27-4ac5-9567-2e05b621e893" />
red box and padding are `40`


**Example:**
```js
var win = Ti.UI.createWindow();

var view1 = Ti.UI.createView({ backgroundColor:'#123' });
var view2 = Ti.UI.createView({ backgroundColor:'#246' });
var view3 = Ti.UI.createView({ backgroundColor:'#48b' });
var view4 = Ti.UI.createView({ backgroundColor:'red', width: 40,height: 40 });
view1.add(view4);

// Common params
var params = {
  views:[view1,view2,view3],
  clipViews:false,
  showPagingControl:false,
	top: 0,
	padding: {
		left:40,
		right:40,
  }
};

var scrollableView = Ti.UI.createScrollableView(params);
win.add(scrollableView);
win.open();
```

**Note:**
* iOS uses `width`, so it just affects Android ([apidocs](https://titaniumsdk.com/api/titanium/ui/scrollableview.html#scrollable-view-with-multiple-visible-views))
* will be a breaking change as you have to remove your own dpi calculation if you use that