### PR TITLE
fix(android): validate sessionid in Chrome debug session

### DIFF
--- a/android/modules/android/src/java/ti/modules/titanium/android/AndroidModule.java
+++ b/android/modules/android/src/java/ti/modules/titanium/android/AndroidModule.java
@@ -712,7 +712,6 @@ public class AndroidModule extends KrollModule
 				currentActivity.requestPermissions(filteredPermissions.toArray(new String[0]), REQUEST_CODE);
 				return;
 			}
-			// Min supported SDK is 24, so runtime permission APIs are always available.
 			KrollDict response = new KrollDict();
 			response.putCodeAndMessage(0, null);
 			if (permissionCallback != null) {

--- a/android/modules/android/src/java/ti/modules/titanium/android/AndroidModule.java
+++ b/android/modules/android/src/java/ti/modules/titanium/android/AndroidModule.java
@@ -712,7 +712,7 @@ public class AndroidModule extends KrollModule
 				currentActivity.requestPermissions(filteredPermissions.toArray(new String[0]), REQUEST_CODE);
 				return;
 			}
-			// FIXME: If we're not on API level 23+, shouldn't we reject/error?
+			// Min supported SDK is 24, so runtime permission APIs are always available.
 			KrollDict response = new KrollDict();
 			response.putCodeAndMessage(0, null);
 			if (permissionCallback != null) {

--- a/android/runtime/v8/src/java/org/appcelerator/kroll/runtime/v8/JSDebugger.java
+++ b/android/runtime/v8/src/java/org/appcelerator/kroll/runtime/v8/JSDebugger.java
@@ -35,6 +35,9 @@ public final class JSDebugger
 	// Are we ready to continue? Has the debugger been connected and we've processed the first set of messages?
 	private final AtomicBoolean ready = new AtomicBoolean(false);
 
+	// The session UUID generated for this debugger instance, validated when a client connects
+	private String sessionId;
+
 	// Holding place for messages received from V8 intended for debugger
 	private final LinkedBlockingQueue<String> v8Messages = new LinkedBlockingQueue<>();
 
@@ -120,9 +123,8 @@ public final class JSDebugger
 		synchronized (this.waitLock)
 		{
 			try {
-				// FIXME Use this UUID to store sessions and enforce it's used when a client is connecting
-				String id = UUID.randomUUID().toString();
-				String url = "127.0.0.1:" + this.port + "/" + id;
+				this.sessionId = UUID.randomUUID().toString();
+				String url = "127.0.0.1:" + this.port + "/" + this.sessionId;
 				Log.w(TAG, "Debugger listening on ws://" + url);
 				Log.w(
 					TAG,
@@ -163,6 +165,12 @@ public final class JSDebugger
 		@Override
 		public void onOpen(WebSocket conn, ClientHandshake handshake)
 		{
+			String resourceDescriptor = conn.getResourceDescriptor();
+			if (resourceDescriptor == null || !resourceDescriptor.endsWith("/" + sessionId)) {
+				Log.w(TAG, "Debugger client rejected: invalid session UUID");
+				conn.close();
+				return;
+			}
 			// Start up V8MessageHandler to process responses we get
 			try {
 				Log.w(TAG, "Debugger client connected");


### PR DESCRIPTION
Fixing two FIXME parts in the code

* FIXME Use this UUID to store sessions and enforce it's used when a client is connecting
* FIXME: If we're not on API level 23+, shouldn't we reject/error?

The second one is just removed as we are minSDK 24 now!


**Testing:**
* build an app with `ti build -p android  -T device --debug-host localhost:8989`
* use the chrome link and change the ID value at the end