### PR TITLE
fix(ios): fix liveview restart

### DIFF
--- a/iphone/Classes/AppModule.m
+++ b/iphone/Classes/AppModule.m
@@ -74,8 +74,10 @@ extern NSString *const TI_APPLICATION_GUID;
   NSNotification *notification = [NSNotification notificationWithName:kTiContextShutdownNotification object:[appDelegate krollBridge]];
   [nc postNotification:notification];
 
+  /* Reboot via scene-aware method (creates new window, controller, and bridge) */
+  [appDelegate rebootApp];
+
   /* Begin foregrounding simulation */
-  [appDelegate application:app didFinishLaunchingWithOptions:[appDelegate launchOptions]];
   [appDelegate applicationWillEnterForeground:app];
   [appDelegate applicationDidBecomeActive:app];
   /* End foregrounding simulation */

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiApp.h
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiApp.h
@@ -294,4 +294,13 @@
 - (void)performCompletionHandlerForBackgroundTransferWithKey:(NSString *)key;
 - (void)watchKitExtensionRequestHandler:(id)key withUserInfo:(NSDictionary *)userInfo;
 
+/**
+ Re-initializes the UI and JS runtime against the existing UIWindowScene.
+
+ Used by LiveView (<Ti.App._restart>) to perform a hot restart of the application
+ without leaving the scene session. Tears down the old window, controller, and
+ KrollBridge, then creates fresh ones against the first connected UIWindowScene.
+ */
+- (void)rebootApp;
+
 @end

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiApp.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiApp.m
@@ -1252,6 +1252,35 @@ extern void UIColorFlushCache(void);
   return kjsBridge;
 }
 
+- (void)rebootApp
+{
+  UIWindowScene *windowScene = nil;
+  for (UIScene *scene in [UIApplication sharedApplication].connectedScenes) {
+    if ([scene isKindOfClass:[UIWindowScene class]]) {
+      windowScene = (UIWindowScene *)scene;
+      break;
+    }
+  }
+
+  if (windowScene == nil) {
+    NSLog(@"[ERROR] LiveView restart failed: no UIWindowScene found");
+    return;
+  }
+
+  // Release old window and create a new one with the existing scene
+  RELEASE_TO_NIL(window);
+  window = [[UIWindow alloc] initWithWindowScene:windowScene];
+
+  // Release old bridge so boot creates a fresh one
+  RELEASE_TO_NIL(kjsBridge);
+
+  // Initialize controller with the new window
+  [self initController];
+
+  // Boot the fresh JS runtime
+  [self boot];
+}
+
 #pragma mark UIWindowSceneDelegate
 
 - (UISceneConfiguration *)application:(UIApplication *)application configurationForConnectingSceneSession:(UISceneSession *)connectingSceneSession options:(UISceneConnectionOptions *)options


### PR DESCRIPTION
fixes https://github.com/tidev/titanium-sdk/issues/14480


## AI analysis

### Problem Analysis

The LiveView restart flow is broken because _resumeRestart: in AppModule.m calls:

[appDelegate application:app didFinishLaunchingWithOptions:[appDelegate launchOptions]];

Prior to the multi-scene support, didFinishLaunchingWithOptions: was responsible for:

1. Creating the UIWindow
2. Calling initController (creates TiRootViewController, sets root VC)
3. Calling boot (creates fresh KrollBridge, loads JS)

With the scene delegate architecture added, those three responsibilities were moved to scene:willConnectToSession:. Now didFinishLaunchingWithOptions: at TiApp.m:450-452 explicitly says:
```
// Do not boot here. With the scene lifecycle, booting happens in
// scene:willConnectToSession: — which is forwarded to this same (app-delegate)
// instance — so the window can be created against the connecting UIWindowScene.
```
So after _resumeRestart: tears down the UI and bridge, calling didFinishLaunchingWithOptions: does nothing to rebuild them — the app ends up with no window, no controller, and no JS bridge.

**Note:**
only tested it with 
```js
var win = Titanium.UI.createWindow();

var view = Ti.UI.createView({
	width: 200,
	height: 60,
	backgroundColor: "white",
	borderColor: "red",
	borderWidth: 10,
	borderRadius: 20,
	top: 100
});
win.add(view);
win.open();
```
and liveview and it's fully AI generated, so I don't know if it is correct :smile: But liveview restart is working again. That's why it's draft only in case there is a better way to do it.