### PR TITLE
fix(android): fix layout regression introduced in #14476

### DIFF
--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiCompositeLayout.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiCompositeLayout.java
@@ -886,9 +886,13 @@ public class TiCompositeLayout extends ViewGroup implements OnHierarchyChangeLis
 						horizontalLayoutTopBuffer = 0;
 						horizontalLayoutLastIndexBeforeWrap = 0;
 						horizontalLayoutPreviousRight = 0;
-						if (count > 1) {
-							updateRowForHorizontalWrap(right, i);
-						}
+						// Always compute the row height, even with a single
+						// child. Without this, a one-child horizontal layout
+						// leaves horizontalLayoutLineHeight at 0, causing
+						// computePosition() to center the child in a zero-height
+						// area and produce a negative y (e.g. -measuredHeight/2).
+						// This is the root cause of TIMOB-23372 #4/#5.
+						updateRowForHorizontalWrap(right, i);
 					}
 					computeHorizontalLayoutPosition(params, childMeasuredWidth, childMeasuredHeight, right, top, bottom,
 													horizontal, vertical, i);
@@ -1084,16 +1088,21 @@ public class TiCompositeLayout extends ViewGroup implements OnHierarchyChangeLis
 			rowWidth += child.getMeasuredWidth() + getViewWidthPadding(child, getWidth());
 			rowHeight = child.getMeasuredHeight() + getViewHeightPadding(child, parentHeight);
 
+			// Always track the tallest child seen so far, even when the row
+			// overflows maxRight. Without this, a child whose width exceeds
+			// the available space leaves horizontalLayoutLineHeight at 0,
+			// causing computePosition() to center the child in a zero-height
+			// area and produce a negative y (e.g. -measuredHeight/2).
+			if (horizontalLayoutLineHeight < rowHeight) {
+				horizontalLayoutLineHeight = rowHeight;
+			}
+
 			if (rowWidth > maxRight) {
 				horizontalLayoutLastIndexBeforeWrap = i - 1;
 				return;
 
 			} else if (rowWidth == maxRight) {
 				break;
-			}
-
-			if (horizontalLayoutLineHeight < rowHeight) {
-				horizontalLayoutLineHeight = rowHeight;
 			}
 		}
 


### PR DESCRIPTION
This only affects the current main branch:

In https://github.com/tidev/titanium-sdk/pull/14476 - Change 4 - the `count > 1` was added to "skips pre-scan entirely for single-child horizontal layouts". Turns out that there was an old JIRA ticket that this causes issues: https://jira-archive.titaniumsdk.com/TIMOB-23372 

<img width="480" height="90" alt="617411216-43927c24-4443-4d1c-a675-1c0df0babcf5" src="https://github.com/user-attachments/assets/3e042a6b-ebe1-4ef6-bad8-949b9a2812fc" />

And @mbender74 found this in his test-suite PR https://github.com/tidev/titanium-sdk/pull/14487


---
  ### `TiCompositeLayout` — TIMOB-23372  (`label.rect.y = -10`)
  - **Root cause:** For single-child horizontal layouts, `updateRowForHorizontalWrap()` was never called because of an `if (count > 1)` guard.
  `horizontalLayoutLineHeight` stayed at `0`, so `computePosition()` centered the child in a zero-height area and produced `label.rect.y = -measuredHeight/2` (e.g.
  `-10`).
  - **Fix:** Always call `updateRowForHorizontalWrap()` for the first child, even when there is only one child. Also moved the `horizontalLayoutLineHeight` tracking
   **before** the `rowWidth > maxRight` early return, so a child wider than the available space still contributes its height to the row.
---

I've made this into a separate PR so we have a clean main branch again that doesn't have this layout issue anymore