### PR TITLE
feat(android): set gradle/java idle timeouts

### DIFF
--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -2230,6 +2230,7 @@ class AndroidBuilder extends Builder {
 		gradleProperties.push({ key: 'org.gradle.configuration-cache', value: 'true' });
 		gradleProperties.push({ key: 'android.builtInKotlin', value: 'false' });
 		gradleProperties.push({ key: 'android.newDsl', value: 'false' });
+		gradleProperties.push({ key: 'org.gradle.daemon.idletimeout', value: '600000' });
 		await gradlew.writeGradlePropertiesFile(gradleProperties);
 
 		// Copy optional "gradle.properties" file contents from Titanium project to the above generated file.

--- a/android/cli/commands/_build.js
+++ b/android/cli/commands/_build.js
@@ -2230,7 +2230,7 @@ class AndroidBuilder extends Builder {
 		gradleProperties.push({ key: 'org.gradle.configuration-cache', value: 'true' });
 		gradleProperties.push({ key: 'android.builtInKotlin', value: 'false' });
 		gradleProperties.push({ key: 'android.newDsl', value: 'false' });
-		gradleProperties.push({ key: 'org.gradle.daemon.idletimeout', value: '600000' });
+		gradleProperties.push({ key: 'org.gradle.daemon.idletimeout', value: '1800000' });
 		await gradlew.writeGradlePropertiesFile(gradleProperties);
 
 		// Copy optional "gradle.properties" file contents from Titanium project to the above generated file.

--- a/android/cli/commands/_buildModule.js
+++ b/android/cli/commands/_buildModule.js
@@ -525,7 +525,7 @@ export class AndroidModuleBuilder extends Builder {
 		gradleProperties.push({ key: 'android.nonTransitiveRClass', value: 'false' });
 		gradleProperties.push({ key: 'android.builtInKotlin', value: 'false' });
 		gradleProperties.push({ key: 'android.newDsl', value: 'false' });
-		gradleProperties.push({ key: 'org.gradle.daemon.idletimeout', value: '300000' });
+		gradleProperties.push({ key: 'org.gradle.daemon.idletimeout', value: '600000' });
 		gradleProperties.push({
 			key: 'org.gradle.jvmargs',
 			value: `-Xmx${this.javacMaxMemory} -Dkotlin.daemon.jvm.options="-Xmx${this.javacMaxMemory}"`

--- a/android/cli/commands/_buildModule.js
+++ b/android/cli/commands/_buildModule.js
@@ -525,6 +525,7 @@ export class AndroidModuleBuilder extends Builder {
 		gradleProperties.push({ key: 'android.nonTransitiveRClass', value: 'false' });
 		gradleProperties.push({ key: 'android.builtInKotlin', value: 'false' });
 		gradleProperties.push({ key: 'android.newDsl', value: 'false' });
+		gradleProperties.push({ key: 'org.gradle.daemon.idletimeout', value: '300000' });
 		gradleProperties.push({
 			key: 'org.gradle.jvmargs',
 			value: `-Xmx${this.javacMaxMemory} -Dkotlin.daemon.jvm.options="-Xmx${this.javacMaxMemory}"`

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -11,8 +11,8 @@ org.gradle.jvmargs=-Xmx2g
 # Enable parallel build execution
 org.gradle.parallel=true
 
-# Kill idle Gradle daemon after 5 minutes of inactivity
-org.gradle.daemon.idletimeout=300000
+# Kill idle Gradle daemon after 10 minutes of inactivity
+org.gradle.daemon.idletimeout=600000
 
 # Enable usage of Google's AndroidX libraries.
 # Note: Jetifier is not needed for test app since it doesn't use Google's deprecated support libraries.

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -11,6 +11,9 @@ org.gradle.jvmargs=-Xmx2g
 # Enable parallel build execution
 org.gradle.parallel=true
 
+# Kill idle Gradle daemon after 5 minutes of inactivity
+org.gradle.daemon.idletimeout=300000
+
 # Enable usage of Google's AndroidX libraries.
 # Note: Jetifier is not needed for test app since it doesn't use Google's deprecated support libraries.
 android.useAndroidX=true


### PR DESCRIPTION
So that's why I always have  multiple Java processes running the whole time :rofl: 

The default is `Default is 10800000 (3 hours).` ([source](https://docs.gradle.org/current/userguide/build_environment.html) search for `idletimeout`) if not set!

Here I'm adding a timeout for building the SDK, modules and apps. Since you don't build apps or modules regularly I've set those to 5mins and the app part to 10min. It's only idle time, so if you don't build an app for 10mins again it will stop the gradle daemon process.

| File | Build Type | Timeout |
|---|---|---|
| `android/gradle.properties:15` | SDK build | 10 min |
| `android/cli/commands/_build.js:2231` | App build | 30 min |
| `android/cli/commands/_buildModule.js:528` | Module build | 10 min |

**How to test**
* look at the process list and kill all java processes and gradle 
* build an app. You should see something like this:
```
[INFO]  [GRADLE] Starting a Gradle Daemon, 1 stopped Daemon could not be reused, use --status for details
[INFO]  [GRADLE] Reusing configuration cache.
```
* build app again: it will reuse the gradle daemon
* watch the process list again and you can see `java` in there
* wait for 10mins and `java` will be gone :+1: 
* build app again: it will start a new gradle (takes only a few seconds longer, so not a big time loss)

**Question**
Are the times fine like this? I think 3 hours is a bit long 