### PR TITLE
feat(ios): parity for Toolbar height property

### DIFF
--- a/iphone/Classes/TiUIToolbar.m
+++ b/iphone/Classes/TiUIToolbar.m
@@ -36,7 +36,7 @@
 {
   if (toolBar == nil) {
     toolBar = [[UIToolbar alloc] initWithFrame:[self bounds]];
-    [toolBar setAutoresizingMask:UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleBottomMargin];
+    [toolBar setAutoresizingMask:UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin];
     [self addSubview:toolBar];
     id extendVal = [[self proxy] valueForUndefinedKey:@"extendBackground"];
     extendsBackground = [TiUtils boolValue:extendVal def:NO];
@@ -84,7 +84,17 @@
   CGRect toolBounds;
   toolBounds.size = [[self toolBar] sizeThatFits:ourBounds.size];
   toolBounds.origin.x = 0.0;
-  toolBounds.origin.y = hideTopBorder ? -1.0 : 0.0;
+
+  TiDimension heightDim = ((TiViewProxy *)[self proxy]).layoutProperties->height;
+  if (!TiDimensionIsUndefined(heightDim) && !TiDimensionIsAuto(heightDim) && !TiDimensionIsAutoFill(heightDim) && !TiDimensionIsAutoSize(heightDim)) {
+    toolBounds.origin.y = (ourBounds.size.height - toolBounds.size.height) / 2.0;
+    if (hideTopBorder) {
+      toolBounds.origin.y -= 1.0;
+    }
+  } else {
+    toolBounds.origin.y = hideTopBorder ? -1.0 : 0.0;
+  }
+
   [toolBar setFrame:toolBounds];
 }
 #endif
@@ -168,6 +178,11 @@
 
 - (CGFloat)verifyHeight:(CGFloat)suggestedHeight
 {
+  TiDimension heightDim = ((TiViewProxy *)[self proxy]).layoutProperties->height;
+  if (!TiDimensionIsUndefined(heightDim) && !TiDimensionIsAuto(heightDim) && !TiDimensionIsAutoFill(heightDim) && !TiDimensionIsAutoSize(heightDim)) {
+    return suggestedHeight;
+  }
+
   CGFloat result = [[self toolBar] sizeThatFits:CGSizeZero].height;
   if (hideTopBorder) {
     result -= 1.0;


### PR DESCRIPTION
Currently the iOS Toolbar will use an automatically generated height while Android allows the user to specify a custom height already. For Liquid Glass it doesn't have any padding around the buttons as they are bigger.

This PR will allow `height` to be set on iOS and still keeps the buttons centered. If on height is set it will use the current way.

13.3.0:

<img width="400" height="186" alt="Simulator Screenshot - iPhone 17e - 2026-07-07 at 17 07 24" src="https://github.com/user-attachments/assets/a9f6122d-a9c1-41aa-bbd4-a0f6f947e591" />

with this PR and height="60":

<img width="400" height="247" alt="Simulator Screenshot - iPhone 17e - 2026-07-07 at 17 15 39" src="https://github.com/user-attachments/assets/a96e36ec-0144-4b1b-a29b-4c33025aebbf" />


**Test**

use the kitchensink app: https://github.com/tidev/kitchensink-v2 and add `height="60" backgroundColor="red"` to https://github.com/tidev/kitchensink-v2/blob/master/app/views/controls/toolbar.xml#L3

**Note**

Android has this option already and `height` is mentioned in the Toolbar docs too but it was not working on iOS