### PR TITLE
feat: add font property to Ti.UI.ButtonBar

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/ButtonBarProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/ButtonBarProxy.java
@@ -15,6 +15,7 @@ import ti.modules.titanium.ui.widget.TiUIButtonBar;
 
 @Kroll.proxy(creatableInModule = UIModule.class, propertyAccessors = {
 	TiC.PROPERTY_LABELS,
+	TiC.PROPERTY_FONT,
 })
 public class ButtonBarProxy extends TiViewProxy
 {

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/OptionBarProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/OptionBarProxy.java
@@ -16,6 +16,7 @@ import ti.modules.titanium.ui.widget.TiUIOptionBar;
 @Kroll.proxy(creatableInModule = UIModule.class, propertyAccessors = {
 	TiC.PROPERTY_INDEX,
 	TiC.PROPERTY_LABELS,
+	TiC.PROPERTY_FONT,
 })
 public class OptionBarProxy extends TiViewProxy
 {

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIButtonBar.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIButtonBar.java
@@ -25,6 +25,7 @@ import org.appcelerator.titanium.view.TiUIView;
 public class TiUIButtonBar extends TiUIView
 {
 	private static final String TAG = "TiUIButtonBar";
+	private HashMap<String, Object> fontProperties;
 
 	public TiUIButtonBar(TiViewProxy proxy)
 	{
@@ -55,6 +56,9 @@ public class TiUIButtonBar extends TiUIView
 		}
 
 		// Apply given properties to view.
+		if (properties.containsKey(TiC.PROPERTY_FONT)) {
+			fontProperties = properties.getKrollDict(TiC.PROPERTY_FONT);
+		}
 		if (properties.containsKey(TiC.PROPERTY_LABELS)) {
 			processLabels(properties.get(TiC.PROPERTY_LABELS));
 		}
@@ -74,6 +78,9 @@ public class TiUIButtonBar extends TiUIView
 		// Handle property change.
 		if (key.equals(TiC.PROPERTY_LABELS)) {
 			processLabels(newValue);
+		} else if (key.equals(TiC.PROPERTY_FONT) && newValue instanceof HashMap) {
+			fontProperties = (HashMap<String, Object>) newValue;
+			applyFontToAllButtons();
 		} else {
 			super.propertyChanged(key, oldValue, newValue, proxy);
 		}
@@ -163,6 +170,9 @@ public class TiUIButtonBar extends TiUIView
 		}
 		MaterialButton button = new MaterialButton(context, null, attributeId);
 		button.setText(title);
+		if (fontProperties != null) {
+			TiUIHelper.styleText(button, fontProperties);
+		}
 		if ((accessibilityLabel != null) && !accessibilityLabel.isEmpty()) {
 			button.setContentDescription(accessibilityLabel);
 		}
@@ -186,6 +196,23 @@ public class TiUIButtonBar extends TiUIView
 				}
 			}
 		});
+	}
+
+	private void applyFontToAllButtons()
+	{
+		if (fontProperties == null) {
+			return;
+		}
+		MaterialButtonToggleGroup buttonGroup = getButtonGroup();
+		if (buttonGroup == null) {
+			return;
+		}
+		for (int i = 0; i < buttonGroup.getChildCount(); i++) {
+			View child = buttonGroup.getChildAt(i);
+			if (child instanceof MaterialButton) {
+				TiUIHelper.styleText((MaterialButton) child, fontProperties);
+			}
+		}
 	}
 
 	private MaterialButtonToggleGroup getButtonGroup()

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIOptionBar.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIOptionBar.java
@@ -31,6 +31,7 @@ public class TiUIOptionBar extends TiUIView
 
 	/** Set true to prevent "click" events from firing. Set false to allow these events. */
 	private boolean isIgnoringCheckEvent;
+	private HashMap<String, Object> fontProperties;
 
 	public TiUIOptionBar(TiViewProxy proxy)
 	{
@@ -74,6 +75,9 @@ public class TiUIOptionBar extends TiUIView
 		}
 
 		// Apply given properties to view.
+		if (properties.containsKey(TiC.PROPERTY_FONT)) {
+			fontProperties = properties.getKrollDict(TiC.PROPERTY_FONT);
+		}
 		if (properties.containsKey(TiC.PROPERTY_LABELS)) {
 			processLabels(properties.get(TiC.PROPERTY_LABELS));
 		}
@@ -98,6 +102,9 @@ public class TiUIOptionBar extends TiUIView
 			checkOption(TiConvert.toInt(newValue));
 		} else if (key.equals(TiC.PROPERTY_LABELS)) {
 			processLabels(newValue);
+		} else if (key.equals(TiC.PROPERTY_FONT) && newValue instanceof HashMap) {
+			fontProperties = (HashMap<String, Object>) newValue;
+			applyFontToAllButtons();
 		} else {
 			super.propertyChanged(key, oldValue, newValue, proxy);
 		}
@@ -207,6 +214,9 @@ public class TiUIOptionBar extends TiUIView
 		MaterialButton button = new MaterialButton(context, null, attributeId);
 		button.setEnabled(isEnabled);
 		button.setText(title);
+		if (fontProperties != null) {
+			TiUIHelper.styleText(button, fontProperties);
+		}
 		if (proxy.hasPropertyAndNotNull(TiC.PROPERTY_SELECTED_BACKGROUND_COLOR)) {
 			ColorStateList oldColors = button.getBackgroundTintList();
 			int col = TiConvert.toColor((String) proxy.getProperty(TiC.PROPERTY_SELECTED_BACKGROUND_COLOR), context);
@@ -294,6 +304,23 @@ public class TiUIOptionBar extends TiUIView
 					}
 					return;
 				}
+			}
+		}
+	}
+
+	private void applyFontToAllButtons()
+	{
+		if (fontProperties == null) {
+			return;
+		}
+		MaterialButtonToggleGroup buttonGroup = getButtonGroup();
+		if (buttonGroup == null) {
+			return;
+		}
+		for (int i = 0; i < buttonGroup.getChildCount(); i++) {
+			View child = buttonGroup.getChildAt(i);
+			if (child instanceof MaterialButton) {
+				TiUIHelper.styleText((MaterialButton) child, fontProperties);
 			}
 		}
 	}

--- a/apidoc/Titanium/UI/ButtonBar.yml
+++ b/apidoc/Titanium/UI/ButtonBar.yml
@@ -94,6 +94,13 @@ properties:
     since: "9.0.0"
     osver: {ios: {min: "13.0"}}
 
+  - name: font
+    summary: Font to use for the button labels.
+    description: |
+        For information about font values, see the "Fonts" section of <Titanium.UI>.
+    type: Font
+    platforms: [iphone, ipad, android, macos]
+
 examples:
   - title: Simple 3 button button bar
     example: |

--- a/apidoc/Titanium/UI/ButtonBar.yml
+++ b/apidoc/Titanium/UI/ButtonBar.yml
@@ -100,6 +100,7 @@ properties:
         For information about font values, see the "Fonts" section of <Titanium.UI>.
     type: Font
     platforms: [iphone, ipad, android, macos]
+    since: 14.0.0
 
 examples:
   - title: Simple 3 button button bar

--- a/apidoc/Titanium/UI/OptionBar.yml
+++ b/apidoc/Titanium/UI/OptionBar.yml
@@ -57,6 +57,7 @@ properties:
         For information about font values, see the "Fonts" section of <Titanium.UI>.
     type: Font
     platforms: [iphone, ipad, android, macos]
+    since: 14.0.0
 
   - name: layout
     summary: Specifies the layout direction such as 'horizontal' or 'vertical'.

--- a/apidoc/Titanium/UI/OptionBar.yml
+++ b/apidoc/Titanium/UI/OptionBar.yml
@@ -51,6 +51,13 @@ properties:
     type: [Array<String>, Array<BarItemType>]
     availability: creation
 
+  - name: font
+    summary: Font to use for the option labels.
+    description: |
+        For information about font values, see the "Fonts" section of <Titanium.UI>.
+    type: Font
+    platforms: [iphone, ipad, android, macos]
+
   - name: layout
     summary: Specifies the layout direction such as 'horizontal' or 'vertical'.
     description: |

--- a/iphone/Classes/TiUIButtonBar.m
+++ b/iphone/Classes/TiUIButtonBar.m
@@ -7,6 +7,7 @@
 #import "TiUIButtonBar.h"
 #import <TitaniumKit/TiUtils.h>
 #import <TitaniumKit/TiViewProxy.h>
+#import <TitaniumKit/WebFont.h>
 #import <TitaniumKit/Webcolor.h>
 
 @implementation TiUIButtonBar
@@ -130,8 +131,15 @@
   }
 
   UIColor *newColor = [self reverseColorOf:color];
-  [[self segmentedControl] setTitleTextAttributes:@{ NSForegroundColorAttributeName : color } forState:UIControlStateNormal];
-  [[self segmentedControl] setTitleTextAttributes:@{ NSForegroundColorAttributeName : newColor } forState:UIControlStateSelected];
+  UISegmentedControl *control = [self segmentedControl];
+
+  NSMutableDictionary *normalAttrs = [NSMutableDictionary dictionaryWithDictionary:[control titleTextAttributesForState:UIControlStateNormal]];
+  normalAttrs[NSForegroundColorAttributeName] = color;
+  [control setTitleTextAttributes:normalAttrs forState:UIControlStateNormal];
+
+  NSMutableDictionary *selectedAttrs = [NSMutableDictionary dictionaryWithDictionary:[control titleTextAttributesForState:UIControlStateSelected]];
+  selectedAttrs[NSForegroundColorAttributeName] = newColor;
+  [control setTitleTextAttributes:selectedAttrs forState:UIControlStateSelected];
 
   [[self segmentedControl] setSelectedSegmentTintColor:color];
 }
@@ -145,21 +153,44 @@
 - (void)setTextColor_:(id)value
 {
   UIColor *color = [[TiUtils colorValue:value] color];
+  UISegmentedControl *control = [self segmentedControl];
 
-  [[self segmentedControl] setTitleTextAttributes:@{ NSForegroundColorAttributeName : color } forState:UIControlStateNormal];
+  NSMutableDictionary *attrs = [NSMutableDictionary dictionaryWithDictionary:[control titleTextAttributesForState:UIControlStateNormal]];
+  attrs[NSForegroundColorAttributeName] = color;
+  [control setTitleTextAttributes:attrs forState:UIControlStateNormal];
 }
 
 - (void)setSelectedTextColor_:(id)value
 {
   UIColor *color = [[TiUtils colorValue:value] color];
+  UISegmentedControl *control = [self segmentedControl];
 
-  [[self segmentedControl] setTitleTextAttributes:@{ NSForegroundColorAttributeName : color } forState:UIControlStateSelected];
+  NSMutableDictionary *attrs = [NSMutableDictionary dictionaryWithDictionary:[control titleTextAttributesForState:UIControlStateSelected]];
+  attrs[NSForegroundColorAttributeName] = color;
+  [control setTitleTextAttributes:attrs forState:UIControlStateSelected];
 }
 
 - (void)setSelectedButtonColor_:(id)value
 {
   UIColor *color = [[TiUtils colorValue:value] color];
   [[self segmentedControl] setSelectedSegmentTintColor:color];
+}
+
+- (void)setFont_:(id)font
+{
+  if (font != nil) {
+    WebFont *f = [TiUtils fontValue:font def:nil];
+    UIFont *newFont = [f font];
+    UISegmentedControl *control = [self segmentedControl];
+
+    NSMutableDictionary *normalAttrs = [NSMutableDictionary dictionaryWithDictionary:[control titleTextAttributesForState:UIControlStateNormal]];
+    normalAttrs[NSFontAttributeName] = newFont;
+    [control setTitleTextAttributes:normalAttrs forState:UIControlStateNormal];
+
+    NSMutableDictionary *selectedAttrs = [NSMutableDictionary dictionaryWithDictionary:[control titleTextAttributesForState:UIControlStateSelected]];
+    selectedAttrs[NSFontAttributeName] = newFont;
+    [control setTitleTextAttributes:selectedAttrs forState:UIControlStateSelected];
+  }
 }
 
 - (void)setIndex_:(id)value


### PR DESCRIPTION
Add the `font` property to  Ti.UI.ButtonBar
```js
const win = Ti.UI.createWindow();
var bar = Ti.UI.createButtonBar({
  labels: ['One', 'Two', 'Three'],
	font: { fontSize: 20, fontWeight: "bold" },
});

win.add(bar);
win.open();
```

<img width="480" height="202" alt="Simulator Screenshot - iPhone 17e - 2026-07-07 at 18 30 37" src="https://github.com/user-attachments/assets/e203a3d5-eb0c-4b8a-aa8c-5414c6f13f8f" />
<img width="480" height="159" alt="Screenshot_20260707-183036" src="https://github.com/user-attachments/assets/fbcbb908-3f59-4553-bee9-9e5214325350" />
