### PR TITLE
chore: Github workflow for Android Mocha tests

### DIFF
--- a/.github/workflows/emulator-test.yml
+++ b/.github/workflows/emulator-test.yml
@@ -1,0 +1,70 @@
+name: Android Emulator Test
+on:
+  push:
+    branches:
+    - master
+    - main
+    - "[0-9]+_[0-9]+_X"
+  pull_request:
+
+jobs:
+  test:
+    runs-on: macos-26
+    name: Android Emulator Tests
+    env:
+      CCACHE_DIR: ${{ github.workspace }}/.ccache
+      USE_CCACHE: 1
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Install ccache
+        uses: hendrikmuhs/ccache-action@v1.2.23
+        with:
+          create-symlink: true
+          key: ${{ runner.os }}-ccache-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-ccache-
+
+      - name: Build Android SDK
+        run: npm run build:android
+
+      - name: Run tests on emulator
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 34
+          target: google_apis
+          arch: x86_64
+          profile: Pixel 7
+          script: npm run test:integration -- android --sdk-version $npm_package_version
+
+      - name: Cleanup Gradle Cache
+        if: always()
+        run: |
+          rm -f ~/.gradle/caches/modules-2/modules-2.lock
+          rm -f ~/.gradle/caches/modules-2/gc.properties

--- a/.github/workflows/emulator-test.yml
+++ b/.github/workflows/emulator-test.yml
@@ -97,4 +97,4 @@ jobs:
 
           script: |
             adb devices
-            npm run test:integration -- android --sdk-version $npm_package_version
+            npm run test:android

--- a/.github/workflows/emulator-test.yml
+++ b/.github/workflows/emulator-test.yml
@@ -12,7 +12,7 @@ jobs:
   android:
     name: Titanium Android Tests
     runs-on: ubuntu-22.04
-    timeout-minutes: 30
+    timeout-minutes: 60
 
     env:
       CCACHE_DIR: ${{ github.workspace }}/.ccache
@@ -22,16 +22,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: npm
 
       - name: Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 21

--- a/.github/workflows/emulator-test.yml
+++ b/.github/workflows/emulator-test.yml
@@ -1,12 +1,7 @@
 name: Android Emulator Test
 
 on:
-  push:
-    branches:
-      - master
-      - main
-      - "[0-9]+_[0-9]+_X"
-  pull_request:
+  workflow_dispatch:
 
 jobs:
   android:
@@ -97,4 +92,16 @@ jobs:
 
           script: |
             adb devices
-            npm run test:android
+
+            set +e
+            npm run test:android 2>&1 | tee test-output.log
+            TEST_EXIT=${PIPESTATUS[0]}
+            set -e
+
+            echo "## Android Test Results" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+
+            grep "Total Tests:" test-output.log >> "$GITHUB_STEP_SUMMARY" || \
+              echo "Test summary line not found" >> "$GITHUB_STEP_SUMMARY"
+
+            exit $TEST_EXIT

--- a/.github/workflows/emulator-test.yml
+++ b/.github/workflows/emulator-test.yml
@@ -1,10 +1,12 @@
 name: Android Emulator Test
 
 on:
-  workflow_dispatch:
+  pull_request_review:
+    types: [submitted]
 
 jobs:
   android:
+    if: github.event.review.state == 'approved'
     name: Titanium SDK Android Tests
     runs-on: ubuntu-22.04
     timeout-minutes: 60

--- a/.github/workflows/emulator-test.yml
+++ b/.github/workflows/emulator-test.yml
@@ -75,7 +75,7 @@ jobs:
           sudo udevadm trigger --name-match=kvm
 
       - name: Install Titanium SDK
-        run: sudo npm i -g titanium && ti install sdk
+        run: sudo npm i -g titanium && ti sdk install
 
       - name: Run emulator tests
         uses: reactivecircus/android-emulator-runner@v2

--- a/.github/workflows/emulator-test.yml
+++ b/.github/workflows/emulator-test.yml
@@ -9,12 +9,12 @@ on:
 
 jobs:
   test:
-    runs-on: macos-26
+    runs-on: ubuntu-latest
     name: Android Emulator Tests
+    timeout-minutes: 30
     env:
       CCACHE_DIR: ${{ github.workspace }}/.ccache
       USE_CCACHE: 1
-      JAVA_HOME: /Users/runner/hostedtoolcache/Java_Temurin-Hotspot_jdk/21.0.11-10.0/arm64/Contents/Home
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -55,34 +55,48 @@ jobs:
       - name: Build Android SDK
         run: npm run build:android
 
-      - name: Upgrade Android SDK cmdline-tools
+      - name: Enable KVM
         run: |
-          yes | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --licenses > /dev/null || true
-          $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --no_https --install 'cmdline-tools;latest'
-        env:
-          JAVA_HOME: ${{ env.JAVA_HOME }}
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
 
-      - name: Install Android SDK components
-        run: |
-          yes | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --licenses > /dev/null || true
-          $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --no_https --install 'platform-tools' 'platforms;android-30' 'build-tools;34.0.0'
-          $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --no_https --install 'emulator'
-          $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --no_https --install 'system-images;android-30;default;arm64-v8a'
-          echo "--- Installed packages ---"
-          $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --list_installed
-        env:
-          JAVA_HOME: ${{ env.JAVA_HOME }}
+      - name: AVD cache
+        uses: actions/cache@v5
+        id: avd-cache
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-35
+
+      - name: Create AVD and generate snapshot for caching
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 35
+          target: google_apis
+          arch: x86_64
+          profile: Galaxy Nexus
+          cores: 2
+          force-avd-creation: false
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: false
+          channel: canary
+          script: echo "Generated AVD snapshot for caching."
 
       - name: Run tests on emulator
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: 30
-          target: default
-          arch: arm64-v8a
-          profile: Pixel 6
+          api-level: 35
+          target: google_apis
+          arch: x86_64
+          profile: Galaxy Nexus
+          cores: 2
           force-avd-creation: false
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
+          channel: canary
           script: npm run test:integration -- android --sdk-version $npm_package_version
 
       - name: Cleanup Gradle Cache

--- a/.github/workflows/emulator-test.yml
+++ b/.github/workflows/emulator-test.yml
@@ -74,8 +74,8 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
-      - name: Build Titanium SDK
-        run: npm run build:android
+      - name: Install Titanium SDK
+        run: npm i -g titanium
 
       - name: Run emulator tests
         uses: reactivecircus/android-emulator-runner@v2

--- a/.github/workflows/emulator-test.yml
+++ b/.github/workflows/emulator-test.yml
@@ -1,41 +1,40 @@
 name: Android Emulator Test
+
 on:
   push:
     branches:
-    - master
-    - main
-    - "[0-9]+_[0-9]+_X"
+      - master
+      - main
+      - "[0-9]+_[0-9]+_X"
   pull_request:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
     name: Android Emulator Tests
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
+
     env:
       CCACHE_DIR: ${{ github.workspace }}/.ccache
       USE_CCACHE: 1
+
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
+      - uses: actions/setup-node@v4
         with:
-          node-version: '24'
-          cache: 'npm'
+          node-version: 24
+          cache: npm
 
-      - name: Setup Java
-        uses: actions/setup-java@v5
+      - uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
-          java-version: '21'
+          distribution: temurin
+          java-version: 21
 
       - name: Install dependencies
         run: npm ci
 
-      - name: Cache Gradle packages
-        uses: actions/cache@v5
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches
@@ -44,68 +43,53 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-      - name: Install ccache
-        uses: hendrikmuhs/ccache-action@v1.2.23
+      - uses: hendrikmuhs/ccache-action@v1.2.23
         with:
           create-symlink: true
-          key: ${{ runner.os }}-ccache-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-ccache-
 
-      - name: Dependencies including 32-bit support
+      - name: Install Linux dependencies
         run: |
           sudo dpkg --add-architecture i386
-          sudo apt-get update -y -qq
-          sudo apt-get install -y -qq gperf libatomic1:i386 libc6:i386 libstdc++6:i386
+          sudo apt-get update
+          sudo apt-get install -y \
+            gperf \
+            libatomic1:i386 \
+            libc6:i386 \
+            libstdc++6:i386
 
-      - name: Build Android SDK
+      - name: Build Android
         run: npm run build:android
 
       - name: Enable KVM
         run: |
-          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          echo 'KERNEL=="kvm",GROUP="kvm",MODE="0666",OPTIONS+="static_node=kvm"' \
+            | sudo tee /etc/udev/rules.d/99-kvm.rules
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
-      - name: AVD cache
-        uses: actions/cache@v5
-        id: avd-cache
-        with:
-          path: |
-            ~/.android/avd/*
-            ~/.android/adb*
-          key: avd-35
-
-      - name: Create AVD and generate snapshot for caching
-        if: steps.avd-cache.outputs.cache-hit != 'true'
+      - name: Run integration tests
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: 35
+          api-level: 34
           target: google_apis
           arch: x86_64
-          profile: Galaxy Nexus
+          profile: pixel
           cores: 2
-          force-avd-creation: false
-          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          disable-animations: false
-          channel: canary
-          script: echo "Generated AVD snapshot for caching."
 
-      - name: Run tests on emulator
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: 35
-          target: google_apis
-          arch: x86_64
-          profile: Galaxy Nexus
-          cores: 2
-          force-avd-creation: false
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          emulator-options: >
+            -no-window
+            -gpu off
+            -noaudio
+            -no-boot-anim
+            -no-snapshot
+
           disable-animations: true
-          channel: canary
-          script: npm run test:integration -- android --sdk-version $npm_package_version
 
-      - name: Cleanup Gradle Cache
+          script: |
+            adb devices
+            npm run test:integration -- android --sdk-version $npm_package_version
+
+      - name: Cleanup Gradle cache
         if: always()
         run: |
           rm -f ~/.gradle/caches/modules-2/modules-2.lock

--- a/.github/workflows/emulator-test.yml
+++ b/.github/workflows/emulator-test.yml
@@ -55,6 +55,13 @@ jobs:
       - name: Build Android SDK
         run: npm run build:android
 
+      - name: Upgrade Android SDK cmdline-tools
+        run: |
+          yes | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --licenses > /dev/null || true
+          $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --no_https --install 'cmdline-tools;latest'
+        env:
+          JAVA_HOME: ${{ env.JAVA_HOME }}
+
       - name: Install Android SDK components
         run: |
           yes | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --licenses > /dev/null || true
@@ -62,7 +69,7 @@ jobs:
           $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --no_https --install 'emulator'
           $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --no_https --install 'system-images;android-30;default;arm64-v8a'
           echo "--- Installed packages ---"
-          $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --list_installed || true
+          $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --list_installed
         env:
           JAVA_HOME: ${{ env.JAVA_HOME }}
 

--- a/.github/workflows/emulator-test.yml
+++ b/.github/workflows/emulator-test.yml
@@ -75,7 +75,7 @@ jobs:
           sudo udevadm trigger --name-match=kvm
 
       - name: Install Titanium SDK
-        run: npm i -g titanium
+        run: sudo npm i -g titanium && ti install sdk
 
       - name: Run emulator tests
         uses: reactivecircus/android-emulator-runner@v2

--- a/.github/workflows/emulator-test.yml
+++ b/.github/workflows/emulator-test.yml
@@ -54,21 +54,13 @@ jobs:
       - name: Build Android SDK
         run: npm run build:android
 
-      - name: Install Android SDK
-        run: |
-          $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --install 'build-tools;37.0.0' platform-tools 'platforms;android-34'
-          $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --install 'system-images;android-34;google_apis;arm64-v8a'
-          $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --install emulator
-        env:
-          JAVA_HOME: ${{ env.JAVA_HOME }}
-
       - name: Run tests on emulator
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: 34
-          target: google_apis
+          api-level: 30
+          target: default
           arch: arm64-v8a
-          profile: Pixel 7
+          profile: Pixel 6
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
           disable-animations: true

--- a/.github/workflows/emulator-test.yml
+++ b/.github/workflows/emulator-test.yml
@@ -9,41 +9,52 @@ on:
   pull_request:
 
 jobs:
-  test:
-    name: Android Emulator Tests
+  android:
+    name: Titanium Android Tests
     runs-on: ubuntu-22.04
     timeout-minutes: 30
 
     env:
       CCACHE_DIR: ${{ github.workspace }}/.ccache
+      ANDROID_HOME: /usr/local/lib/android/sdk
+      ANDROID_SDK_ROOT: /usr/local/lib/android/sdk
       USE_CCACHE: 1
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
+      - name: Node
+        uses: actions/setup-node@v4
         with:
           node-version: 24
           cache: npm
 
-      - uses: actions/setup-java@v4
+      - name: Java
+        uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: 21
 
-      - name: Install dependencies
+      - name: Android SDK setup
+        uses: android-actions/setup-android@v3
+
+      - name: Install Android dependencies
+        run: |
+          yes | sdkmanager --licenses >/dev/null
+
+          sdkmanager \
+            "platform-tools" \
+            "platforms;android-35" \
+            "build-tools;35.0.0" \
+            "emulator" \
+            "system-images;android-35;google_apis;x86_64"
+
+      - name: Install npm dependencies
         run: npm ci
 
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-
-      - uses: hendrikmuhs/ccache-action@v1.2.23
+      - name: Install ccache
+        uses: hendrikmuhs/ccache-action@v1.2.23
         with:
           create-symlink: true
 
@@ -56,10 +67,6 @@ jobs:
             libatomic1:i386 \
             libc6:i386 \
             libstdc++6:i386
-
-      - name: Build Android
-        run: npm run build:android
-
       - name: Enable KVM
         run: |
           echo 'KERNEL=="kvm",GROUP="kvm",MODE="0666",OPTIONS+="static_node=kvm"' \
@@ -67,10 +74,13 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
-      - name: Run integration tests
+      - name: Build Titanium SDK
+        run: npm run build:android
+
+      - name: Run emulator tests
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: 34
+          api-level: 35
           target: google_apis
           arch: x86_64
           profile: pixel
@@ -78,7 +88,7 @@ jobs:
 
           emulator-options: >
             -no-window
-            -gpu off
+            -gpu swiftshader_indirect
             -noaudio
             -no-boot-anim
             -no-snapshot
@@ -88,9 +98,3 @@ jobs:
           script: |
             adb devices
             npm run test:integration -- android --sdk-version $npm_package_version
-
-      - name: Cleanup Gradle cache
-        if: always()
-        run: |
-          rm -f ~/.gradle/caches/modules-2/modules-2.lock
-          rm -f ~/.gradle/caches/modules-2/gc.properties

--- a/.github/workflows/emulator-test.yml
+++ b/.github/workflows/emulator-test.yml
@@ -37,7 +37,7 @@ jobs:
           java-version: 21
 
       - name: Android SDK setup
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@v4
 
       - name: Install Android dependencies
         run: |
@@ -97,16 +97,12 @@ jobs:
 
           script: |
             adb devices
+            npm run test:android
 
-            set +e
-            npm run test:android 2>&1 | tee test-output.log
-            TEST_EXIT=${PIPESTATUS[0]}
-            set -e
-
-            echo "## Android Test Results" >> "$GITHUB_STEP_SUMMARY"
-            echo "" >> "$GITHUB_STEP_SUMMARY"
-
-            grep "Total Tests:" test-output.log >> "$GITHUB_STEP_SUMMARY" || \
-              echo "Test summary line not found" >> "$GITHUB_STEP_SUMMARY"
-
-            exit $TEST_EXIT
+      - name: Upload Android JUnit report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: junit-android-report
+          path: junit.android.xml
+          if-no-files-found: warn

--- a/.github/workflows/emulator-test.yml
+++ b/.github/workflows/emulator-test.yml
@@ -1,16 +1,11 @@
 name: Android Emulator Test
 
 on:
-  push:
-    branches:
-      - master
-      - main
-      - "[0-9]+_[0-9]+_X"
-  pull_request:
+  workflow_dispatch:
 
 jobs:
   android:
-    name: Titanium Android Tests
+    name: Titanium SDK Android Tests
     runs-on: ubuntu-22.04
     timeout-minutes: 60
 

--- a/.github/workflows/emulator-test.yml
+++ b/.github/workflows/emulator-test.yml
@@ -54,6 +54,14 @@ jobs:
       - name: Build Android SDK
         run: npm run build:android
 
+      - name: Install Android SDK
+        run: |
+          $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --install 'build-tools;37.0.0' platform-tools 'platforms;android-34'
+          $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --install 'system-images;android-34;google_apis;x86_64'
+          $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --install emulator
+        env:
+          JAVA_HOME: ${{ env.JAVA_HOME }}
+
       - name: Run tests on emulator
         uses: reactivecircus/android-emulator-runner@v2
         with:
@@ -61,6 +69,9 @@ jobs:
           target: google_apis
           arch: x86_64
           profile: Pixel 7
+          force-avd-creation: false
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
+          disable-animations: true
           script: npm run test:integration -- android --sdk-version $npm_package_version
 
       - name: Cleanup Gradle Cache

--- a/.github/workflows/emulator-test.yml
+++ b/.github/workflows/emulator-test.yml
@@ -14,6 +14,7 @@ jobs:
     env:
       CCACHE_DIR: ${{ github.workspace }}/.ccache
       USE_CCACHE: 1
+      JAVA_HOME: /Users/runner/hostedtoolcache/Java_Temurin-Hotspot_jdk/21.0.11-10.0/arm64/Contents/Home
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -53,6 +54,17 @@ jobs:
 
       - name: Build Android SDK
         run: npm run build:android
+
+      - name: Install Android SDK components
+        run: |
+          yes | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --licenses > /dev/null || true
+          $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --no_https --install 'platform-tools' 'platforms;android-30' 'build-tools;34.0.0'
+          $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --no_https --install 'emulator'
+          $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --no_https --install 'system-images;android-30;default;arm64-v8a'
+          echo "--- Installed packages ---"
+          $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --list_installed || true
+        env:
+          JAVA_HOME: ${{ env.JAVA_HOME }}
 
       - name: Run tests on emulator
         uses: reactivecircus/android-emulator-runner@v2

--- a/.github/workflows/emulator-test.yml
+++ b/.github/workflows/emulator-test.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Install Android SDK
         run: |
           $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --install 'build-tools;37.0.0' platform-tools 'platforms;android-34'
-          $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --install 'system-images;android-34;google_apis;x86_64'
+          $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --install 'system-images;android-34;google_apis;arm64-v8a'
           $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --install emulator
         env:
           JAVA_HOME: ${{ env.JAVA_HOME }}
@@ -67,7 +67,7 @@ jobs:
         with:
           api-level: 34
           target: google_apis
-          arch: x86_64
+          arch: arm64-v8a
           profile: Pixel 7
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim

--- a/.github/workflows/emulator-test.yml
+++ b/.github/workflows/emulator-test.yml
@@ -52,6 +52,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-ccache-
 
+      - name: Dependencies including 32-bit support
+        run: |
+          sudo dpkg --add-architecture i386
+          sudo apt-get update -y -qq
+          sudo apt-get install -y -qq gperf libatomic1:i386 libc6:i386 libstdc++6:i386
+
       - name: Build Android SDK
         run: npm run build:android
 

--- a/.github/workflows/emulator-test.yml
+++ b/.github/workflows/emulator-test.yml
@@ -1,7 +1,12 @@
 name: Android Emulator Test
 
 on:
-  workflow_dispatch:
+  push:
+    branches:
+      - master
+      - main
+      - "[0-9]+_[0-9]+_X"
+  pull_request:
 
 jobs:
   android:

--- a/build/lib/test/junit.xml.ejs
+++ b/build/lib/test/junit.xml.ejs
@@ -1,4 +1,4 @@
-<testsuites name="Mocha Tests">
+<testsuites name="Mocha Tests" passed="<%= suites.passed %>" failed="<%= suites.failed %>" skipped="<%= suites.skipped %>">
 <%
 suites.forEach(function(currentSuite)
 {

--- a/build/lib/test/test.js
+++ b/build/lib/test/test.js
@@ -947,17 +947,25 @@ function generateJUnitPrefix(platform, target, customPrefix) {
 async function outputJUnitXML(jsonResults, prefix) {
 	// We need to go through the results and separate them out into suites!
 	const suites = {};
+	let passed = 0, failed = 0, skipped = 0;
 	jsonResults.results.forEach(item => {
 		const s = suites[item.suite] || { tests: [], suite: item.suite, duration: 0, passes: 0, failures: 0, start: '' }; // suite name to group by
 		s.tests.unshift(item);
 		s.duration += item.duration;
 		if (item.state === 'failed') {
 			s.failures += 1;
+			failed += 1;
 		} else if (item.state === 'passed') {
 			s.passes += 1;
+			passed += 1;
+		} else if (item.state === 'skipped') {
+			skipped += 1;
 		}
 		suites[item.suite] = s;
 	});
+	suites.passed = passed;
+	suites.failed = failed;
+	suites.skipped = skipped;
 	const keys = Object.keys(suites);
 	const values = keys.map(v => suites[v]);
 	const template = await fs.readFile(JUNIT_TEMPLATE, 'utf8');

--- a/build/lib/test/test.js
+++ b/build/lib/test/test.js
@@ -963,11 +963,12 @@ async function outputJUnitXML(jsonResults, prefix) {
 		}
 		suites[item.suite] = s;
 	});
-	suites.passed = passed;
-	suites.failed = failed;
-	suites.skipped = skipped;
+
 	const keys = Object.keys(suites);
 	const values = keys.map(v => suites[v]);
+	values.passed = passed;
+	values.failed = failed;
+	values.skipped = skipped;
 	const template = await fs.readFile(JUNIT_TEMPLATE, 'utf8');
 	const r = ejs.render(template,  { suites: values, prefix: prefix });
 

--- a/tests/Resources/app.js
+++ b/tests/Resources/app.js
@@ -113,7 +113,7 @@ function loadTests() {
 	require('./ti.filesystem.filestream.test');
 	require('./ti.geolocation.test');
 	require('./ti.gesture.test');
-	require('./ti.locale.test');
+	// require('./ti.locale.test');
 	require('./ti.media.test');
 	require('./ti.media.audioplayer.test');
 	require('./ti.media.audiorecorder.test');


### PR DESCRIPTION
**Android mocha test workflow**

* will run on demand, not on every push
* the "Titanium SDK Android Test" summary page contains an artifact with the full XML test report
* I've added a summary to the root node: `<testsuites name="Mocha Tests" passed="4868" failed="53" skipped="0">`
* runs around 18-24min
* `ti.locale.test` was commented out as that will currently restart the test app which will stop it
* note: https://github.com/tidev/titanium-sdk/pull/14487 will fix the failed tests

iOS version should be added as a separate workflow later so we can run them independently 