### PR TITLE
feat(android): wavy style for Android ProgressBar

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/ProgressBarProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/ProgressBarProxy.java
@@ -25,6 +25,7 @@ import ti.modules.titanium.ui.widget.TiUIProgressBar;
 		TiC.PROPERTY_COLOR,
 		TiC.PROPERTY_TINT_COLOR,
 		TiC.PROPERTY_TRACK_TINT_COLOR,
+		TiC.PROPERTY_STYLE,
 	})
 public class ProgressBarProxy extends TiViewProxy
 {

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/android/ProgressBarStyleModule.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/android/ProgressBarStyleModule.java
@@ -1,0 +1,30 @@
+/**
+ * Titanium SDK
+ * Copyright TiDev, Inc. 04/07/2022-Present. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+package ti.modules.titanium.ui.android;
+
+import org.appcelerator.kroll.KrollModule;
+import org.appcelerator.kroll.annotations.Kroll;
+
+@Kroll.module(parentModule = AndroidModule.class)
+public class ProgressBarStyleModule extends KrollModule
+{
+	@Kroll.constant
+	public static final int DEFAULT = 0;
+	@Kroll.constant
+	public static final int WAVY = 1;
+
+	public ProgressBarStyleModule()
+	{
+		super();
+	}
+
+	@Override
+	public String getApiName()
+	{
+		return "Ti.UI.Android.ProgressBarStyle";
+	}
+}

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiImageView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiImageView.java
@@ -38,7 +38,6 @@ import org.appcelerator.titanium.util.TiExifOrientation;
 import org.appcelerator.titanium.util.TiUIHelper;
 import org.appcelerator.titanium.util.TiColorHelper;
 import ti.modules.titanium.media.MediaModule;
-import com.google.android.material.R;
 
 public class TiImageView extends ViewGroup
 {
@@ -66,7 +65,8 @@ public class TiImageView extends ViewGroup
 	{
 		super(context);
 
-		this.defaultRippleColor = MaterialColors.getColor(context, R.attr.colorControlHighlight, Color.DKGRAY);
+		this.defaultRippleColor = MaterialColors.getColor(
+			context, androidx.appcompat.R.attr.colorControlHighlight, Color.DKGRAY);
 		this.imageRippleColor = this.defaultRippleColor;
 
 		this.imageView = new ImageView(context);

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIButton.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIButton.java
@@ -60,19 +60,19 @@ public class TiUIButton extends TiUIView
 		styleId = TiConvert.toInt(proxy.getProperty(TiC.PROPERTY_STYLE), styleId);
 		switch (styleId) {
 			case UIModule.BUTTON_STYLE_OPTION_POSITIVE:
-				styleId = R.attr.buttonBarPositiveButtonStyle;
+				styleId = androidx.appcompat.R.attr.buttonBarPositiveButtonStyle;
 				break;
 			case UIModule.BUTTON_STYLE_OPTION_NEGATIVE:
-				styleId = R.attr.buttonBarNegativeButtonStyle;
+				styleId = androidx.appcompat.R.attr.buttonBarNegativeButtonStyle;
 				break;
 			case UIModule.BUTTON_STYLE_OPTION_NEUTRAL:
-				styleId = R.attr.buttonBarNeutralButtonStyle;
+				styleId = androidx.appcompat.R.attr.buttonBarNeutralButtonStyle;
 				break;
 			case UIModule.BUTTON_STYLE_OUTLINED:
 				styleId = R.attr.materialButtonOutlinedStyle;
 				break;
 			case UIModule.BUTTON_STYLE_TEXT:
-				styleId = R.attr.borderlessButtonStyle;
+				styleId = androidx.appcompat.R.attr.borderlessButtonStyle;
 				break;
 			case UIModule.BUTTON_STYLE_FILLED:
 			default:

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIProgressBar.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIProgressBar.java
@@ -7,6 +7,7 @@
 package ti.modules.titanium.ui.widget;
 
 import android.app.Activity;
+import android.util.DisplayMetrics;
 import android.view.Gravity;
 import android.widget.LinearLayout;
 import com.google.android.material.progressindicator.LinearProgressIndicator;
@@ -18,6 +19,8 @@ import org.appcelerator.titanium.proxy.TiViewProxy;
 import org.appcelerator.titanium.util.TiConvert;
 import org.appcelerator.titanium.util.TiUIHelper;
 import org.appcelerator.titanium.view.TiUIView;
+
+import ti.modules.titanium.ui.android.ProgressBarStyleModule;
 
 public class TiUIProgressBar extends TiUIView
 {
@@ -72,6 +75,9 @@ public class TiUIProgressBar extends TiUIView
 		if (d.containsKey(TiC.PROPERTY_TRACK_TINT_COLOR)) {
 			this.progress.setTrackColor(TiConvert.toColor(d, TiC.PROPERTY_TRACK_TINT_COLOR, activity));
 		}
+		if (d.containsKey(TiC.PROPERTY_STYLE)) {
+			handleSetStyle(TiConvert.toInt(d, TiC.PROPERTY_STYLE));
+		}
 		updateProgress();
 	}
 
@@ -98,6 +104,10 @@ public class TiUIProgressBar extends TiUIView
 		} else if (key.equals(TiC.PROPERTY_TRACK_TINT_COLOR)) {
 			// TODO: reset to default value when property is null
 			this.progress.setTrackColor(TiConvert.toColor(newValue, proxy.getActivity()));
+		} else if (key.equals(TiC.PROPERTY_STYLE)) {
+			handleSetStyle(TiConvert.toInt(newValue));
+		} else if (key.equals(TiC.PROPERTY_ANIMATED)) {
+			handleSetStyle(TiConvert.toInt(proxy.getProperty(TiC.PROPERTY_STYLE)));
 		}
 	}
 
@@ -151,5 +161,24 @@ public class TiUIProgressBar extends TiUIView
 	protected void handleSetMessageColor(int color)
 	{
 		label.setTextColor(color);
+	}
+
+	private void handleSetStyle(int style)
+	{
+		boolean isAnimated = TiConvert.toBoolean(proxy.getProperty(TiC.PROPERTY_ANIMATED), true);
+
+		if (style == ProgressBarStyleModule.WAVY) {
+			DisplayMetrics dm = proxy.getActivity().getResources().getDisplayMetrics();
+			int amplitudeDp = 3;
+			int wavelengthDp = 16;
+			int speedDp = isAnimated ? 1 : 0;
+			progress.setWaveAmplitude((int) (amplitudeDp * dm.density + 0.5f));
+			progress.setWavelength((int) (wavelengthDp * dm.density + 0.5f));
+			progress.setWaveSpeed((int) (speedDp * dm.density + 0.5f));
+		} else {
+			progress.setWaveAmplitude(0);
+			progress.setWavelength(0);
+			progress.setWaveSpeed(0);
+		}
 	}
 }

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUITabbedBar.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUITabbedBar.java
@@ -451,6 +451,6 @@ public class TiUITabbedBar extends TiUIView implements MenuItem.OnMenuItemClickL
 	@ColorInt
 	private static int getTabRippleColorFrom(Context context)
 	{
-		return MaterialColors.getColor(context, com.google.android.material.R.attr.colorPrimary, Color.DKGRAY);
+		return MaterialColors.getColor(context, androidx.appcompat.R.attr.colorPrimary, Color.DKGRAY);
 	}
 }

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/TiRecyclerViewHolder.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/listview/TiRecyclerViewHolder.java
@@ -64,9 +64,9 @@ public abstract class TiRecyclerViewHolder<V extends TiViewProxy> extends Recycl
 	{
 		super(viewGroup);
 
-		COLOR_NORMAL = MaterialColors.getColor(context, com.google.android.material
+		COLOR_NORMAL = MaterialColors.getColor(context, androidx.appcompat
 			.R.attr.colorButtonNormal, Color.DKGRAY);
-		COLOR_PRIMARY = MaterialColors.getColor(context, com.google.android.material.R.attr.colorPrimary, Color.DKGRAY);
+		COLOR_PRIMARY = MaterialColors.getColor(context, androidx.appcompat.R.attr.colorPrimary, Color.DKGRAY);
 		COLOR_SELECTED = ColorUtils.setAlphaComponent(COLOR_PRIMARY, 20);
 
 		if (resources == null) {

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/searchbar/TiUISearchBar.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/searchbar/TiUISearchBar.java
@@ -26,7 +26,7 @@ import org.appcelerator.titanium.util.TiConvert;
 import org.appcelerator.titanium.util.TiUIHelper;
 import org.appcelerator.titanium.view.TiUIView;
 import ti.modules.titanium.ui.UIModule;
-import com.google.android.material.R;
+import androidx.appcompat.R;
 
 public class TiUISearchBar extends TiUIView
 {

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIAbstractTabGroup.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIAbstractTabGroup.java
@@ -216,7 +216,7 @@ public abstract class TiUIAbstractTabGroup extends TiUIView
 		try {
 			final int[] idArray = new int[] {
 				android.R.attr.colorBackground,
-				R.attr.colorPrimary,
+				androidx.appcompat.R.attr.colorPrimary,
 				R.attr.colorSurface,
 				R.attr.colorOnSurface
 			};

--- a/android/templates/build/ti.constants.gradle
+++ b/android/templates/build/ti.constants.gradle
@@ -10,7 +10,7 @@ project.ext {
 	tiAndroidXAppCompatLibVersion = '1.7.0'
 	tiAndroidXCoreLibVersion = '1.13.1'
 	tiAndroidXFragmentLibVersion = '1.8.6'
-	tiMaterialLibVersion = '1.12.0'
+	tiMaterialLibVersion = '1.13.0'
 	tiPlayServicesBaseLibVersion = '18.3.0'
 	tiManifestPlaceholders = [
 		tiActivityConfigChanges: 'density|fontScale|keyboard|keyboardHidden|layoutDirection|locale|mcc|mnc|navigation|orientation|screenLayout|screenSize|smallestScreenSize|touchscreen|uiMode'

--- a/apidoc/Titanium/UI/Android/ProgressBarStyle.yml
+++ b/apidoc/Titanium/UI/Android/ProgressBarStyle.yml
@@ -1,0 +1,18 @@
+---
+name: Titanium.UI.Android.ProgressBarStyle
+summary: |
+    A set of constants for the styles used on the `style` property of <Titanium.UI.ProgressBar>.
+extends: Titanium.Proxy
+platforms: [android]
+since: "14.0.0"
+createable: false
+properties:
+  - name: DEFAULT
+    summary: The standard linear progress indicator style. This is the default.
+    type: Number
+    permission: read-only
+
+  - name: WAVY
+    summary: A wavy Material 3 linear progress indicator style.
+    type: Number
+    permission: read-only

--- a/apidoc/Titanium/UI/ProgressBar.yml
+++ b/apidoc/Titanium/UI/ProgressBar.yml
@@ -75,9 +75,13 @@ properties:
 
   - name: style
     summary: Style of the progress bar.
-    description: For iOS, progress bar styles are constants defined in [ProgressBarStyle](Titanium.UI.iOS.ProgressBarStyle).
+    description: |
+        On iOS, progress bar styles are constants defined in [ProgressBarStyle](Titanium.UI.iOS.ProgressBarStyle).
+
+        On Android, progress bar styles are constants defined in [ProgressBarStyle](Titanium.UI.Android.ProgressBarStyle).
     type: Number
-    platforms: [iphone,ipad, macos]
+    platforms: [iphone, ipad, macos, android]
+    since: {android: "14.0.0"}
 
   - name: value
     summary: Current value of the progress bar.


### PR DESCRIPTION
Adding the `style` property to Ti.UI.ProgressBar for Android with ` Ti.UI.Android.ProgressBarStyle.WAVY`

<img width="400" height="136" alt="Screenshot_20260711-151101" src="https://github.com/user-attachments/assets/a9a32395-a97d-4f1f-839f-53c8a13118da" />

**Test:**
```js
const win = Ti.UI.createWindow();
const pb1 = Ti.UI.createProgressBar({
	top: 80,
	min: 0,
	max: 100,
	width: 200,
	animated: true,
	value: 50
});
const pb2 = Ti.UI.createProgressBar({
	top: 120,
	min: 0,
	max: 100,
	animated: true,
	width: 200,
	value: 50,
	style: Ti.UI.Android.ProgressBarStyle.WAVY
});

setInterval(function(){
	pb1.value += 10;
	pb2.value += 10;

	if (pb1.value==100) pb1.value = 0;
	if (pb2.value==100) pb2.value = 0;

}, 1000)

win.add([pb1, pb2]);
win.open();
```

**Note:**
* Amplitude and Wavelength are currently fixed.
* I had to upgrade the Material libary to 1.13.0. Because of that change some `R.` constants moved:
`com.google.android.material.R.attr.colorButtonNormal` -> `androidx.appcompat.R.attr.colorButtonNormal`