### PR TITLE
feat(ios): new iOS Ti.UI.Toolbar property: hideSharedBackground

### DIFF
--- a/apidoc/Titanium/UI/Toolbar.yml
+++ b/apidoc/Titanium/UI/Toolbar.yml
@@ -86,6 +86,23 @@ properties:
     default: true
     platforms: [iphone, ipad, macos]
 
+  - name: hideSharedBackground
+    summary: If `true`, each toolbar item is rendered in its own separate visual container.
+    description: |
+        On iOS 26 and later, UIToolbar uses the "Liquid Glass" design and automatically
+        groups adjacent items into shared glass backgrounds. Setting this property to `true`
+        prevents this grouping, giving each item its own separate glass container.
+
+        For finer control, individual toolbar items (buttons, labels, etc.) can set the
+        `hideSharedBackground` property to `true` to separate only those specific items, while
+        leaving others grouped.
+
+        This property has no effect on iOS versions prior to 26.0.
+    type: Boolean
+    default: false
+    platforms: [iphone, ipad]
+    since: "14.1.0"
+
   - name: contentInsetEndWithActions
     summary: Returns the margin after the toolbar's content when there are action buttons.
     type: Number

--- a/apidoc/Titanium/UI/Toolbar.yml
+++ b/apidoc/Titanium/UI/Toolbar.yml
@@ -101,7 +101,7 @@ properties:
     type: Boolean
     default: false
     platforms: [iphone, ipad]
-    since: "14.1.0"
+    since: "14.0.0"
 
   - name: contentInsetEndWithActions
     summary: Returns the margin after the toolbar's content when there are action buttons.

--- a/iphone/Classes/TiUIToolbar.m
+++ b/iphone/Classes/TiUIToolbar.m
@@ -109,6 +109,8 @@
       [result addObject:[thisProxy barButtonItem]];
       [thisProxy windowDidOpen];
     }
+
+#if IS_SDK_IOS_26
     BOOL toolbarSeparated = [TiUtils boolValue:[[self proxy] valueForUndefinedKey:@"hideSharedBackground"] def:NO];
     for (NSUInteger i = 0; i < result.count; i++) {
       UIBarButtonItem *item = result[i];
@@ -120,6 +122,7 @@
         }
       }
     }
+#endif
     [[self toolBar] setItems:result];
   } else {
     UIToolbar *toolbar = [self toolBar];

--- a/iphone/Classes/TiUIToolbar.m
+++ b/iphone/Classes/TiUIToolbar.m
@@ -109,6 +109,17 @@
       [result addObject:[thisProxy barButtonItem]];
       [thisProxy windowDidOpen];
     }
+    BOOL toolbarSeparated = [TiUtils boolValue:[[self proxy] valueForUndefinedKey:@"hideSharedBackground"] def:NO];
+    for (NSUInteger i = 0; i < result.count; i++) {
+      UIBarButtonItem *item = result[i];
+      TiViewProxy *proxy = value[i];
+      BOOL itemSeparated = [TiUtils boolValue:[proxy valueForUndefinedKey:@"hideSharedBackground"] def:NO];
+      if (toolbarSeparated || itemSeparated) {
+        if (@available(iOS 26.0, *)) {
+          item.hidesSharedBackground = YES;
+        }
+      }
+    }
     [[self toolBar] setItems:result];
   } else {
     UIToolbar *toolbar = [self toolBar];

--- a/tests/Resources/ti.ui.toolbar.test.js
+++ b/tests/Resources/ti.ui.toolbar.test.js
@@ -30,4 +30,26 @@ describe('Titanium.UI.Toolbar', function () {
 		should(toolbar.items).be.an.Array();
 		should(toolbar.items.length).eql(2);
 	});
+
+	it.androidMissing('hideSharedBackground', function () {
+		const toolbar = Ti.UI.createToolbar({
+			items: [ Ti.UI.createButton({ title: 'A' }), Ti.UI.createButton({ title: 'B' }) ],
+			hideSharedBackground: true
+		});
+
+		should(toolbar.hideSharedBackground).be.eql(true);
+	});
+
+	it.androidMissing('hideSharedBackground per item', function () {
+		const buttonA = Ti.UI.createButton({ title: 'A', hideSharedBackground: true });
+		const buttonB = Ti.UI.createButton({ title: 'B' });
+		const toolbar = Ti.UI.createToolbar({
+			items: [ buttonA, buttonB ],
+			bottom: 0
+		});
+
+		should(buttonA.hideSharedBackground).be.eql(true);
+		should(buttonB.hideSharedBackground).not.be.eql(true);
+		should(toolbar.items.length).eql(2);
+	});
 });


### PR DESCRIPTION
Add a new property `hideSharedBackground` to hide the Liquid Glass background around the toolbar items (for all or individual items):

<img width="640" height="492" alt="Simulator Screenshot - iPhone 17e - 2026-07-11 at 16 46 51" src="https://github.com/user-attachments/assets/80f55ba2-e99a-49e7-a768-bc37d031a07f" />


**Test**
```xml
<Alloy>
        <Window title="window" >
            <Toolbar id="toolbar" top="100">
                <Items>
                    <Button systemButton="Ti.UI.iOS.SystemButton.INFO_LIGHT" />
                    <FlexSpace/>
                    <Label id="title" text="title"/>
                    <FlexSpace/>
                    <Button systemButton="Ti.UI.iOS.SystemButton.ADD" />
                    <Button systemButton="Ti.UI.iOS.SystemButton.ADD" />
                </Items>
            </Toolbar>

            <Toolbar id="toolbar" top="200" hideSharedBackground="true">
                <Items>
                    <Button systemButton="Ti.UI.iOS.SystemButton.INFO_LIGHT" />
                    <FlexSpace/>
                    <Label id="title" text="title"/>
                    <FlexSpace/>
                    <Button systemButton="Ti.UI.iOS.SystemButton.ADD" />
                    <Button systemButton="Ti.UI.iOS.SystemButton.ADD" />
                </Items>
            </Toolbar>


            <Toolbar id="toolbar" top="300" hideSharedBackground="false">
                <Items>
                    <Button systemButton="Ti.UI.iOS.SystemButton.INFO_LIGHT" />
                    <FlexSpace/>
                    <Label id="title" text="title"/>
                    <FlexSpace/>
                    <Button systemButton="Ti.UI.iOS.SystemButton.ADD" hideSharedBackground="true"/>
                    <Button systemButton="Ti.UI.iOS.SystemButton.ADD" />
                </Items>
            </Toolbar>
        </Window>
</Alloy>
```