### PR TITLE
chore: hyperloop 8.0.1 (#14485)

### DIFF
--- a/support/module/packaged/modules.json
+++ b/support/module/packaged/modules.json
@@ -54,8 +54,8 @@
 	"commonjs": {},
 	"hyperloop": {
 		"hyperloop": {
-			"url": "https://github.com/tidev/hyperloop.next/releases/download/v8.0.0/hyperloop-8.0.0.zip",
-			"integrity": "sha512-g/aOHIgGxhCp93vk6vwO8dICEZBxw5DBGg4ChWU4kg30Ac39xl8JLgInCKQCO5uzc3L0vlLTxi65o3yVNCy84A=="
+			"url": "https://github.com/tidev/hyperloop.next/releases/download/v8.0.1/hyperloop-8.0.1.zip",
+			"integrity": "sha512-iBkiXejrVYDYXl9MB2eziSTl5fZzjiZXsCKt5lxvGmtO9R1Iaxwvlu5v/Nhmy0GMaf+bra5JhChRAaD1O4lRtg=="
 		}
 	}
 }


### PR DESCRIPTION
13_3_X backport of https://github.com/tidev/titanium-sdk/pull/14485