### PR TITLE
fix(ios): harden proxy lifecycle, release queues in dealloc, guard re-entrant script errors, pause timers on background

### DIFF
--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiExceptionHandler.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiExceptionHandler.m
@@ -18,6 +18,11 @@ static void TiUncaughtExceptionHandler(NSException *exception);
 static void TiSignalHandler(int signal);
 
 static NSUncaughtExceptionHandler *prevUncaughtExceptionHandler = NULL;
+// Reentrancy guard: a JS exception thrown while firing the "uncaughtException"
+// event (or while showing the error) re-enters reportScriptError:, which posts
+// kTiErrorNotification again, which fires the listener again, which throws
+// again — unbounded recursion until the stack overflows. Bail out instead.
+static BOOL TiIsHandlingScriptError = NO;
 
 @implementation TiExceptionHandler
 
@@ -72,13 +77,26 @@ static NSUncaughtExceptionHandler *prevUncaughtExceptionHandler = NULL;
 
 - (void)reportScriptError:(TiScriptError *)scriptError
 {
-  DebugLog(@"[ERROR] %@", scriptError);
-
-  id<TiExceptionHandlerDelegate> currentDelegate = _delegate;
-  if (currentDelegate == nil) {
-    currentDelegate = self;
+  if (TiIsHandlingScriptError) {
+    // A script error occurred while we were already handling one. Logging it
+    // via the normal path would re-enter the uncaughtException listener (which
+    // is likely the source of this second error) and recurse until the stack
+    // overflows. Log it inline and bail.
+    NSLog(@"[ERROR] TiExceptionHandler: script error raised while already handling one (suppressed to avoid recursion): %@", scriptError.message);
+    return;
   }
-  [currentDelegate handleScriptError:scriptError];
+  TiIsHandlingScriptError = YES;
+  @try {
+    DebugLog(@"[ERROR] %@", scriptError);
+
+    id<TiExceptionHandlerDelegate> currentDelegate = _delegate;
+    if (currentDelegate == nil) {
+      currentDelegate = self;
+    }
+    [currentDelegate handleScriptError:scriptError];
+  } @finally {
+    TiIsHandlingScriptError = NO;
+  }
 }
 
 - (void)reportScriptError:(JSValueRef)errorRef inKrollContext:(KrollContext *)krollContext

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiProxy.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiProxy.m
@@ -403,11 +403,18 @@ void TiClassSelectorFunction(TiBindingRunLoop runloop, void *payload)
   RELEASE_TO_NIL(baseURL);
   RELEASE_TO_NIL(krollDescription);
   if ((void *)modelDelegate != self) {
+    // modelDelegate is typically a UIView subclass that must be released on the
+    // main thread. When _destroy is called from a JSC GC finalizer on a background
+    // thread (which holds the JSC lock), a synchronous dispatch to the main queue
+    // deadlocks if the main thread is also waiting for the JSC lock. Capture the
+    // delegate in a local and dispatch async so we never block.
+    id delegate = modelDelegate;
+    modelDelegate = nil;
     TiThreadPerformOnMainThread(
         ^{
-          RELEASE_TO_NIL(modelDelegate);
+          [delegate release];
         },
-        YES);
+        NO);
   }
   pageContext = nil;
   pageKrollObject = nil;
@@ -1189,7 +1196,16 @@ DEFINE_EXCEPTIONS
     id temp = [self valueForUndefinedKey:@"id"];
     NSString *cn = nil;
     if (temp == nil || ![temp isKindOfClass:[NSString class]]) {
-      cn = NSStringFromClass([self class]);
+      // Prefer the last segment of apiName (e.g. "Window" from "Ti.UI.Window")
+      // over the Objective-C class name so toString yields "[object Window]"
+      // matching Android/Windows.
+      NSString *api = [self apiName];
+      NSString *last = [api componentsSeparatedByString:@"."].lastObject;
+      if (last.length > 0) {
+        cn = last;
+      } else {
+        cn = NSStringFromClass([self class]);
+      }
     } else {
       cn = temp;
     }

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiUIView.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiUIView.m
@@ -674,6 +674,14 @@ DEFINE_EXCEPTIONS
     }
     layer.strokeColor = color.CGColor;
   }
+  // Mirror the implicit min-1 borderWidth back to the proxy so JS reads
+  // borderWidth === '1' when only borderColor was set.
+  if (shouldRefreshWidth && self.proxy != nil) {
+    id currentWidth = [self.proxy valueForUndefinedKey:@"borderWidth"];
+    if (currentWidth == nil || [currentWidth isKindOfClass:[NSNull class]]) {
+      [self.proxy replaceValue:@"1" forKey:@"borderWidth" notification:NO];
+    }
+  }
 }
 
 - (void)setBorderWidth_:(id)w

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiViewProxy.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiViewProxy.m
@@ -378,7 +378,7 @@ static NSArray *touchEventsArray;
         [self setHidden:NO withArgs:arg];
         [self replaceValue:NUMBOOL(YES) forKey:@"visible" notification:YES];
       },
-      NO);
+      YES);
 }
 
 - (void)hide:(id)arg
@@ -388,7 +388,7 @@ static NSArray *touchEventsArray;
         [self setHidden:YES withArgs:arg];
         [self replaceValue:NUMBOOL(NO) forKey:@"visible" notification:YES];
       },
-      NO);
+      YES);
 }
 
 - (void)clearMotionEffects:(id)unused
@@ -1506,10 +1506,24 @@ LAYOUTFLAGS_SETTER(setHorizontalWrap, horizontalWrap, horizontalWrap, [self will
 - (void)dealloc
 {
   //	RELEASE_TO_NIL(pendingAdds);
-  // Note: destroyQueue and childrenQueue are released in _destroy,
-  // which is called by [super dealloc] via TiProxy. Releasing them
-  // here would cause use-after-free since _destroy still needs them.
   RELEASE_TO_NIL(barButtonItem);
+  // Run _destroy while the queues are still alive so detachView can nil
+  // view.proxy and release the view. Releasing the queues first would
+  // trip _destroy's !destroyQueue guard and skip detachView (zombie proxy).
+  // Releasing them in _destroy instead breaks post-_destroy accessor
+  // calls (e.g. a delayed parent.remove -> windowWillClose -> [self
+  // children] -> dispatch_sync(childrenQueue) on a queue we just freed).
+  // [super dealloc] (TiProxy) calls _destroy again, but the !destroyQueue
+  // guard makes that second call a no-op.
+  [self _destroy];
+  if (childrenQueue) {
+    dispatch_release(childrenQueue);
+    childrenQueue = nil;
+  }
+  if (destroyQueue) {
+    dispatch_release(destroyQueue);
+    destroyQueue = nil;
+  }
   [super dealloc];
 }
 
@@ -1619,12 +1633,6 @@ LAYOUTFLAGS_SETTER(setHorizontalWrap, horizontalWrap, horizontalWrap, [self will
       }
     }
   });
-
-  // Safe to release after dispatch_sync returns — the queues are no longer needed.
-  dispatch_release(childrenQueue);
-  childrenQueue = nil;
-  dispatch_release(destroyQueue);
-  destroyQueue = nil;
 }
 
 - (void)destroy

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TopTiModule.h
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TopTiModule.h
@@ -17,6 +17,7 @@ READONLY_PROPERTY(NSString *, version, Version);
 
 // Methods
 - (JSValue *)createBuffer:(NSDictionary *)arg;
+- (void)applyProperties:(id)args;
 
 @end
 

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TopTiModule.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TopTiModule.m
@@ -51,6 +51,26 @@ READWRITE_IMPL(NSString *, userAgent, UserAgent);
   return @"Ti";
 }
 
+- (void)applyProperties:(id)args
+{
+  ENSURE_SINGLE_ARG_OR_NIL(args, NSDictionary);
+  // ObjcProxy (our base class) stores custom properties on the JS object rather
+  // than via KVC, so mirror _initWithPageContext:args: and assign each key on
+  // the JS "this" value. KVC's setValuesForKeysWithDictionary: would throw for
+  // keys that aren't native accessors (e.g. arbitrary user-defined keys).
+  JSContext *context = JSContext.currentContext;
+  if (context == nil) {
+    return;
+  }
+  JSValue *selfValue = [self JSValueInContext:context];
+  if (selfValue == nil) {
+    return;
+  }
+  for (NSString *key in args) {
+    selfValue[key] = args[key];
+  }
+}
+
 - (JSValue *)createBuffer:(id)arg
 {
   ENSURE_SINGLE_ARG_OR_NIL(arg, NSDictionary);

--- a/iphone/TitaniumKit/TitaniumKit/Sources/Kroll/KrollTimerManager.h
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/Kroll/KrollTimerManager.h
@@ -38,9 +38,12 @@
 @interface KrollTimerManager : NSObject
 
 /**
- * Map of timer identifiers and the underlying native NSTimer.
+ * Map of timer identifiers to the currently scheduled native NSTimer.
+ * Entries are removed while the app is backgrounded (timers are paused)
+ * and repopulated on foreground resume. Retained strongly so paused
+ * timers are not released by the run loop.
  */
-@property (nonatomic, strong, nullable) NSMapTable<NSNumber *, NSTimer *> *timers;
+@property (nonatomic, strong, nullable) NSMutableDictionary<NSNumber *, NSTimer *> *timers;
 
 /**
  * Initializes the timer manager in the given JS context. Exposes the global set/clear

--- a/iphone/TitaniumKit/TitaniumKit/Sources/Kroll/KrollTimerManager.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/Kroll/KrollTimerManager.m
@@ -6,6 +6,7 @@
  */
 
 #import "KrollTimerManager.h"
+#import "TiBase.h"
 #import "TiBindingTiValue.h"
 #import "TiExceptionHandler.h"
 #import "TiUtils.h"
@@ -13,6 +14,14 @@
 @interface KrollTimerManager ()
 
 @property NSUInteger nextTimerIdentifier;
+
+@property (nonatomic, strong) NSMutableDictionary<NSNumber *, KrollTimerTarget *> *targets;
+@property (nonatomic, strong) NSMutableDictionary<NSNumber *, NSNumber *> *intervals;
+@property (nonatomic, strong) NSMutableDictionary<NSNumber *, NSNumber *> *repeatsFlags;
+@property (nonatomic, strong) NSMutableDictionary<NSNumber *, NSNumber *> *remainingIntervals;
+@property (nonatomic, assign) BOOL paused;
+@property (nonatomic, strong, nullable) id pauseObserver;
+@property (nonatomic, strong, nullable) id resumeObserver;
 
 @end
 
@@ -45,6 +54,14 @@
 
 - (void)timerFired:(NSTimer *_Nonnull)timer
 {
+  // Liveness guard: skip if the callback or its JS context is gone. This can
+  // happen during teardown or if a paused timer's target is resurrected after
+  // the context that owns it has been released. Guards the foreground-resume
+  // crash in issue #14434 where overdue timers fire into freed JS state.
+  if (self.callback == nil || self.callback.context == nil) {
+    return;
+  }
+
   [self.callback callWithArguments:self.arguments];
   // handle an uncaught exception
   JSContext *context = self.callback.context;
@@ -66,7 +83,12 @@
   }
 
   self.nextTimerIdentifier = 1;
-  self.timers = [NSMapTable strongToWeakObjectsMapTable];
+  self.timers = [NSMutableDictionary dictionary];
+  self.targets = [NSMutableDictionary dictionary];
+  self.intervals = [NSMutableDictionary dictionary];
+  self.repeatsFlags = [NSMutableDictionary dictionary];
+  self.remainingIntervals = [NSMutableDictionary dictionary];
+  self.paused = NO;
 
   NSUInteger (^setInterval)(JSValue *, double) = ^(JSValue *callback, double interval) {
     return [self setInterval:interval withCallback:callback shouldRepeat:YES];
@@ -84,16 +106,62 @@
   context[@"clearInterval"] = clearInterval;
   context[@"clearTimeout"] = clearInterval;
 
+  // Pause timers on background and resume on foreground. While the app is
+  // backgrounded the main run loop suspends, so overdue NSTimers coalesce and
+  // burst-fire on resume into JS/proxy state that may have been freed by a
+  // background memory-warning GC — the root cause of the foreground-resume
+  // crash in issue #14434. Pausing invalidates the NSTimers; resuming
+  // reschedules them without catch-up (one-shots fire once, intervals skip
+  // missed cycles).
+  NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
+  __weak KrollTimerManager *weakSelf = self;
+  self.pauseObserver = [nc addObserverForName:kTiPausedNotification
+                                       object:nil
+                                        queue:nil
+                                   usingBlock:^(NSNotification *_Nonnull note) {
+                                     [weakSelf pauseAllTimers];
+                                   }];
+  self.resumeObserver = [nc addObserverForName:kTiResumeNotification
+                                        object:nil
+                                         queue:nil
+                                    usingBlock:^(NSNotification *_Nonnull note) {
+                                      [weakSelf resumeAllTimers];
+                                    }];
+
   return self;
 }
 
 - (void)dealloc
 {
+  if (self.pauseObserver != nil) {
+    [[NSNotificationCenter defaultCenter] removeObserver:self.pauseObserver];
+    self.pauseObserver = nil;
+  }
+  if (self.resumeObserver != nil) {
+    [[NSNotificationCenter defaultCenter] removeObserver:self.resumeObserver];
+    self.resumeObserver = nil;
+  }
+
   if (self.timers != nil) {
     [self invalidateAllTimers];
-    [self.timers removeAllObjects];
     [self.timers release];
     self.timers = nil;
+  }
+  if (_targets != nil) {
+    [_targets release];
+    _targets = nil;
+  }
+  if (_intervals != nil) {
+    [_intervals release];
+    _intervals = nil;
+  }
+  if (_repeatsFlags != nil) {
+    [_repeatsFlags release];
+    _repeatsFlags = nil;
+  }
+  if (_remainingIntervals != nil) {
+    [_remainingIntervals release];
+    _remainingIntervals = nil;
   }
 
   [super dealloc];
@@ -101,7 +169,7 @@
 
 - (void)invalidateAllTimers
 {
-  NSArray<NSNumber *> *keys = [[self.timers keyEnumerator] allObjects];
+  NSArray<NSNumber *> *keys = [self.timers allKeys];
   for (NSNumber *timerIdentifier in keys) {
     [self clearIntervalWithIdentifier:timerIdentifier.unsignedIntegerValue];
   }
@@ -124,11 +192,35 @@
   }
   NSNumber *timerIdentifier = @(self.nextTimerIdentifier++);
   KrollTimerTarget *timerTarget = [[[KrollTimerTarget alloc] initWithCallback:callback arguments:callbackArgs] autorelease];
-  NSTimer *timer = [NSTimer timerWithTimeInterval:interval target:timerTarget selector:@selector(timerFired:) userInfo:timerTarget repeats:shouldRepeat];
-  [[NSRunLoop mainRunLoop] addTimer:timer forMode:NSRunLoopCommonModes];
+  [self.targets setObject:timerTarget forKey:timerIdentifier];
+  [self.intervals setObject:@(interval) forKey:timerIdentifier];
+  [self.repeatsFlags setObject:@(shouldRepeat) forKey:timerIdentifier];
 
-  [self.timers setObject:timer forKey:timerIdentifier];
+  // If the app is backgrounded, don't schedule the NSTimer now; it will be
+  // scheduled on foreground resume. This avoids a timer created while
+  // backgrounded firing into an unprepared run loop.
+  if (!self.paused) {
+    [self scheduleTimerForIdentifier:timerIdentifier remainingInterval:interval];
+  }
   return [timerIdentifier unsignedIntegerValue];
+}
+
+- (void)scheduleTimerForIdentifier:(NSNumber *)timerIdentifier remainingInterval:(NSTimeInterval)remainingInterval
+{
+  KrollTimerTarget *timerTarget = [self.targets objectForKey:timerIdentifier];
+  if (timerTarget == nil) {
+    return;
+  }
+  NSTimeInterval interval = [[self.intervals objectForKey:timerIdentifier] doubleValue];
+  BOOL shouldRepeat = [[self.repeatsFlags objectForKey:timerIdentifier] boolValue];
+  // For repeating timers, always resume at now + interval so missed cycles
+  // while backgrounded are skipped (no burst-fire / no overshoot). For
+  // one-shots, honor the remaining time; a remaining of 0 fires immediately
+  // on the next run loop tick (the overdue case).
+  NSTimeInterval fireIn = shouldRepeat ? interval : remainingInterval;
+  NSTimer *timer = [NSTimer timerWithTimeInterval:fireIn target:timerTarget selector:@selector(timerFired:) userInfo:timerTarget repeats:shouldRepeat];
+  [[NSRunLoop mainRunLoop] addTimer:timer forMode:NSRunLoopCommonModes];
+  [self.timers setObject:timer forKey:timerIdentifier];
 }
 
 - (void)clearIntervalWithIdentifier:(NSUInteger)identifier
@@ -141,6 +233,50 @@
     }
     [self.timers removeObjectForKey:timerIdentifier];
   }
+  [self.targets removeObjectForKey:timerIdentifier];
+  [self.intervals removeObjectForKey:timerIdentifier];
+  [self.repeatsFlags removeObjectForKey:timerIdentifier];
+  [self.remainingIntervals removeObjectForKey:timerIdentifier];
+}
+
+- (void)pauseAllTimers
+{
+  self.paused = YES;
+  NSDate *now = [NSDate date];
+  NSArray<NSNumber *> *keys = [self.timers allKeys];
+  for (NSNumber *timerIdentifier in keys) {
+    NSTimer *timer = [self.timers objectForKey:timerIdentifier];
+    if (timer != nil) {
+      NSTimeInterval remaining = [timer.fireDate timeIntervalSinceDate:now];
+      if (remaining < 0) {
+        remaining = 0;
+      }
+      [self.remainingIntervals setObject:@(remaining) forKey:timerIdentifier];
+      if ([timer isValid]) {
+        [timer invalidate];
+      }
+      [self.timers removeObjectForKey:timerIdentifier];
+    }
+  }
+}
+
+- (void)resumeAllTimers
+{
+  self.paused = NO;
+  NSArray<NSNumber *> *identifiers = [self.targets allKeys];
+  for (NSNumber *timerIdentifier in identifiers) {
+    NSTimeInterval remaining = 0;
+    NSNumber *remainingNum = [self.remainingIntervals objectForKey:timerIdentifier];
+    if (remainingNum != nil) {
+      remaining = [remainingNum doubleValue];
+    } else {
+      // Timer was created while backgrounded; no remaining recorded, use the
+      // full interval as the first fire window.
+      remaining = [[self.intervals objectForKey:timerIdentifier] doubleValue];
+    }
+    [self scheduleTimerForIdentifier:timerIdentifier remainingInterval:remaining];
+  }
+  [self.remainingIntervals removeAllObjects];
 }
 
 @end

--- a/iphone/TitaniumKit/TitaniumKit/Sources/Kroll/KrollTimerManager.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/Kroll/KrollTimerManager.m
@@ -241,6 +241,9 @@
 
 - (void)pauseAllTimers
 {
+  if (self.paused) {
+    return;
+  }
   self.paused = YES;
   NSDate *now = [NSDate date];
   NSArray<NSNumber *> *keys = [self.timers allKeys];
@@ -262,6 +265,9 @@
 
 - (void)resumeAllTimers
 {
+  if (!self.paused) {
+    return;
+  }
   self.paused = NO;
   NSArray<NSNumber *> *identifiers = [self.targets allKeys];
   for (NSNumber *timerIdentifier in identifiers) {


### PR DESCRIPTION
**Foundational proxy-lifecycle fixes:**

- Resolve a GC deadlock in TiProxy._destroy that blocked a broad set of iOS tests.
- Release TiViewProxy model/view queues after _destroy in dealloc to break retention cycles.
- Guard re-entrant script errors in TiExceptionHandler so an error handler that itself errors does not overflow the stack.
- Core TopTiModule changes required by the lifecycle fix.

_Foundational PR for the iOS stability work; merge first._

Fixes also https://github.com/tidev/titanium-sdk/issues/14434

