### PR TITLE
fix(ios): crash prevention and resource cleanup across core modules

### DIFF
--- a/iphone/Classes/FilesystemModule.m
+++ b/iphone/Classes/FilesystemModule.m
@@ -35,13 +35,40 @@
 {
   NSString *newpath;
   NSString *first = [[args objectAtIndex:0] toString];
+  NSString *resourcesPath = [[NSURL URLWithString:[self resourcesDirectory]] path];
   if ([first hasPrefix:@"file://"]) {
     NSURL *fileUrl = [NSURL URLWithString:first];
     // Why not just crop? Because the URL may have some things escaped that need to be unescaped.
     newpath = [fileUrl path];
+    // NSURL treats "file://app.js" as host "app.js" with empty path, yielding "/".
+    // Treat a host-only or relative file:// URL as relative to the resources dir.
+    if ([newpath isEqualToString:@"/"] || newpath.length < 2) {
+      NSString *host = [fileUrl host];
+      if (host.length > 0) {
+        newpath = [resourcesPath stringByAppendingPathComponent:host];
+      } else {
+        newpath = [resourcesPath stringByAppendingPathComponent:[first substringFromIndex:@"file://".length]];
+      }
+    }
+  } else if ([first hasPrefix:@"file:"]) {
+    // "file:" without "//" — strip scheme and treat remainder as a path
+    // (relative if not starting with '/').
+    NSString *remainder = [first substringFromIndex:@"file:".length];
+    if (remainder.length > 0 && [remainder characterAtIndex:0] == '/') {
+      newpath = [self resolveFile:remainder];
+    } else {
+      newpath = [resourcesPath stringByAppendingPathComponent:[self resolveFile:remainder]];
+    }
+  } else if ([first hasPrefix:@"app://"]) {
+    // "app://" maps to the application resources directory. "app:///x" is
+    // the absolute form (same destination), "app://x" is relative.
+    NSString *remainder = [first substringFromIndex:@"app://".length];
+    if (remainder.length > 0 && [remainder characterAtIndex:0] == '/') {
+      remainder = [remainder substringFromIndex:1];
+    }
+    newpath = [resourcesPath stringByAppendingPathComponent:[self resolveFile:remainder]];
   } else if ([first characterAtIndex:0] != '/') {
-    NSURL *url = [NSURL URLWithString:[self resourcesDirectory]];
-    newpath = [[url path] stringByAppendingPathComponent:[self resolveFile:first]];
+    newpath = [resourcesPath stringByAppendingPathComponent:[self resolveFile:first]];
   } else {
     newpath = [self resolveFile:first];
   }

--- a/iphone/Classes/GeolocationModule.m
+++ b/iphone/Classes/GeolocationModule.m
@@ -1137,12 +1137,12 @@ READWRITE_IMPL(bool, showCalibration, ShowCalibration);
 
 - (void)locationManager:(CLLocationManager *)manager didFailWithError:(NSError *)error
 {
-  // Error code may be 0 here, but then we report success!
+  // Preserve the real CoreLocation error code (kCLErrorLocationUnknown is 0
+  // on iOS 26 simulator), but force success=false since we're in the error
+  // callback..dictionaryWithCode: would otherwise set success=true for code 0.
   NSInteger code = error.code;
-  if (code == 0) {
-    code = -1; // explicitly use non-zero code to force success to be false!
-  }
   NSMutableDictionary *event = [TiUtils dictionaryWithCode:code message:[TiUtils messageFromError:error]];
+  [event setObject:NUMBOOL(NO) forKey:@"success"];
 
   if ([self _hasListeners:@"location"]) {
     [self fireEvent:@"location" withDict:event];

--- a/iphone/Classes/PlausibleDatabase/PLSqliteResultSet.m
+++ b/iphone/Classes/PlausibleDatabase/PLSqliteResultSet.m
@@ -13,7 +13,7 @@
  * 3. Neither the name of the copyright holder nor the names of any contributors
  *    may be used to endorse or promote products derived from this
  *    software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -38,7 +38,7 @@
  * PLSqliteResultSet instances implement no locking and must not be shared between threads
  * without external synchronization.
  */
- @implementation PLSqliteResultSet
+@implementation PLSqliteResultSet
 
 /**
  * Initialize the ResultSet with an open database and an sqlite3 prepare statement.
@@ -50,180 +50,188 @@
  * @par Designated Initializer
  * This method is the designated initializer for the PLSqliteResultSet class.
  */
-- (id) initWithPreparedStatement: (PLSqlitePreparedStatement *) stmt 
-                  sqliteStatemet: (sqlite3_stmt *) sqlite_stmt
+- (id)initWithPreparedStatement:(PLSqlitePreparedStatement *)stmt
+                 sqliteStatemet:(sqlite3_stmt *)sqlite_stmt
 {
-    if ((self = [super init]) == nil) {
-        return nil;
-    }
-    
-    /* Save our database and statement references. */
-    _stmt = [stmt retain];
-    _sqlite_stmt = sqlite_stmt;
+  if ((self = [super init]) == nil) {
+    return nil;
+  }
 
-    /* Save result information */
-    _columnCount = sqlite3_column_count(_sqlite_stmt);
-    
-    /* Create a column name cache. Optimization possibility: Using CFDictionary may
-     * provide an optimization here, since dictionary values do not need to be boxed as objects */
-    _columnNames = [[NSMutableDictionary alloc] initWithCapacity: _columnCount];
-    columnNamesArray =  [[NSMutableArray alloc] initWithCapacity: _columnCount];
-    for (int columnIndex = 0; columnIndex < _columnCount; columnIndex++) {
-        NSString *name = [NSString stringWithUTF8String: sqlite3_column_name(_sqlite_stmt, columnIndex)];
-        [(NSMutableArray *)columnNamesArray addObject: name];
-        [_columnNames setValue: [NSNumber numberWithInt: columnIndex] forKey: [name lowercaseString]];
-    }
+  /* Save our database and statement references. */
+  _stmt = [stmt retain];
+  _sqlite_stmt = sqlite_stmt;
 
-    return self;
+  /* Save result information */
+  _columnCount = sqlite3_column_count(_sqlite_stmt);
+
+  /* Create a column name cache. Optimization possibility: Using CFDictionary may
+   * provide an optimization here, since dictionary values do not need to be boxed as objects */
+  _columnNames = [[NSMutableDictionary alloc] initWithCapacity:_columnCount];
+  columnNamesArray = [[NSMutableArray alloc] initWithCapacity:_columnCount];
+  for (int columnIndex = 0; columnIndex < _columnCount; columnIndex++) {
+    NSString *name = [NSString stringWithUTF8String:sqlite3_column_name(_sqlite_stmt, columnIndex)];
+    [(NSMutableArray *)columnNamesArray addObject:name];
+    [_columnNames setValue:[NSNumber numberWithInt:columnIndex] forKey:[name lowercaseString]];
+  }
+
+  return self;
 }
 
 /* GC */
-- (void) finalize {
-    /* 'Check in' our prepared statement reference */
-    [self close];
+- (void)finalize
+{
+  /* 'Check in' our prepared statement reference */
+  [self close];
 
-    [super finalize];
+  [super finalize];
 }
 
 /* Manual */
-- (void) dealloc {
-    /* 'Check in' our prepared statement reference */
-    [self close];
+- (void)dealloc
+{
+  /* 'Check in' our prepared statement reference */
+  [self close];
 
-    /* Release the column cache. */
-    [_columnNames release];
-    [columnNamesArray release];
-    
-    /* Release the statement. */
-    [_stmt release];
-    
-    [super dealloc];
+  /* Release the column cache. */
+  [_columnNames release];
+  [columnNamesArray release];
+
+  /* Release the statement. */
+  [_stmt release];
+
+  [super dealloc];
 }
 
 // From PLResultSet
-- (void) close {
-    if (_sqlite_stmt == nil)
-        return;
+- (void)close
+{
+  if (_sqlite_stmt == nil)
+    return;
 
-    /* Check ourselves back in and give up our statement reference */
-    [_stmt checkinResultSet: self];
-    _sqlite_stmt = nil;
+  /* Check ourselves back in and give up our statement reference */
+  [_stmt checkinResultSet:self];
+  _sqlite_stmt = nil;
 }
 
 /**
  * @internal
  * Assert that the result set has not been closed
  */
-- (void) assertNotClosed {
-    if (_sqlite_stmt == nil)
-        [NSException raise: TI_PLSqliteException format: @"Attempt to access already-closed result set."];
-}
-
--(void)reset
+- (void)assertNotClosed
 {
-	sqlite3_reset(_sqlite_stmt);
+  if (_sqlite_stmt == nil)
+    [NSException raise:TI_PLSqliteException format:@"Attempt to access already-closed result set."];
 }
 
-- (int) fullCount {
-    [self assertNotClosed];
-	int result = 0;
-	while (YES){
-		int ret = sqlite3_step(_sqlite_stmt);
-		if (ret==SQLITE_ROW){
-			result ++;
-		} else {
-			sqlite3_reset(_sqlite_stmt);
-			return result;
-		}
-	}
-	return result;
+- (void)reset
+{
+  sqlite3_reset(_sqlite_stmt);
+}
+
+- (int)fullCount
+{
+  [self assertNotClosed];
+  int result = 0;
+  while (YES) {
+    int ret = sqlite3_step(_sqlite_stmt);
+    if (ret == SQLITE_ROW) {
+      result++;
+    } else {
+      sqlite3_reset(_sqlite_stmt);
+      return result;
+    }
+  }
+  return result;
 }
 
 /* From PLResultSet */
-- (BOOL) next {
-    [self assertNotClosed];
+- (BOOL)next
+{
+  [self assertNotClosed];
 
-    int ret;
-    ret = sqlite3_step(_sqlite_stmt);
-    
-    /* No more rows available, return NO. */
-    if (ret == SQLITE_DONE)
-        return NO;
-    
-    /* A row is available, return YES. */
-    if (ret == SQLITE_ROW)
-        return YES;
-    
-    /* An error occurred. Log it and throw an exceptions. */
-    NSString *error = [NSString stringWithFormat: @"Error occurred calling next on a PLSqliteResultSet. SQLite error: '%s' for '%s'", sqlite3_errmsg(sqlite3_db_handle(_sqlite_stmt)), sqlite3_sql(_sqlite_stmt)];
-    NSLog(@"[ERROR] %@", error);
+  int ret;
+  ret = sqlite3_step(_sqlite_stmt);
 
-    [NSException raise: TI_PLSqliteException format: @"%@", error];
+  /* No more rows available, return NO. */
+  if (ret == SQLITE_DONE)
+    return NO;
 
-    /* Unreachable */
-    abort();
+  /* A row is available, return YES. */
+  if (ret == SQLITE_ROW)
+    return YES;
+
+  /* An error occurred. Log it and throw an exceptions. */
+  NSString *error = [NSString stringWithFormat:@"Error occurred calling next on a PLSqliteResultSet. SQLite error: '%s' for '%s'", sqlite3_errmsg(sqlite3_db_handle(_sqlite_stmt)), sqlite3_sql(_sqlite_stmt)];
+  NSLog(@"[ERROR] %@", error);
+
+  [NSException raise:TI_PLSqliteException format:@"%@", error];
+
+  /* Unreachable */
+  abort();
 }
-
 
 /* From PLResultSet */
-- (int) columnIndexForName: (NSString *) name {
-    [self assertNotClosed];
+- (int)columnIndexForName:(NSString *)name
+{
+  [self assertNotClosed];
 
-    NSNumber *number = [_columnNames objectForKey: [name lowercaseString]];
-    if (number != nil)
-        return [number intValue];
-    
-    /* Not found */
-    [NSException raise: TI_PLSqliteException format: @"Attempted to access unknown result column %@", name];
+  NSNumber *number = [_columnNames objectForKey:[name lowercaseString]];
+  if (number != nil)
+    return [number intValue];
 
-    /* Unreachable */
-    abort();
+  /* Not found */
+  [NSException raise:TI_PLSqliteException format:@"Attempted to access unknown result column %@", name];
+
+  /* Unreachable */
+  abort();
 }
-
 
 /**
  * @internal
  * Validate the column index and return the column type
  */
-- (int) validateColumnIndex: (int) columnIndex isNullable: (BOOL) nullable {
-    [self assertNotClosed];
+- (int)validateColumnIndex:(int)columnIndex isNullable:(BOOL)nullable
+{
+  [self assertNotClosed];
 
-    int columnType;
-    
-    /* Verify that the index is in range */
-    if (columnIndex > _columnCount - 1 || columnIndex < 0)
-        [NSException raise: TI_PLSqliteException format: @"Attempted to access out-of-range column index %d", columnIndex];
+  int columnType;
 
-    /* Fetch the type */
-    columnType = sqlite3_column_type(_sqlite_stmt, columnIndex);
-    
-    /* Verify nullability */
-    if (!nullable && columnType == SQLITE_NULL) {
-        [NSException raise: TI_PLSqliteException format: @"Attempted to access null column value for column index %d. Use -[PLResultSet isNullColumn].", columnIndex];
-    }
+  /* Verify that the index is in range */
+  if (columnIndex > _columnCount - 1 || columnIndex < 0)
+    [NSException raise:TI_PLSqliteException format:@"Attempted to access out-of-range column index %d", columnIndex];
 
-    return columnType;
+  /* Fetch the type */
+  columnType = sqlite3_column_type(_sqlite_stmt, columnIndex);
+
+  /* Verify nullability */
+  if (!nullable && columnType == SQLITE_NULL) {
+    [NSException raise:TI_PLSqliteException format:@"Attempted to access null column value for column index %d. Use -[PLResultSet isNullColumn].", columnIndex];
+  }
+
+  return columnType;
 }
 
 /* This beauty generates the PLResultSet value accessors for a given data type */
-#define VALUE_ACCESSORS(ReturnType, MethodName, SqliteType, Expression) \
-    - (ReturnType) MethodName ## ForColumnIndex: (int) columnIndex { \
-        [self assertNotClosed]; \
-        int columnType = [self validateColumnIndex: columnIndex isNullable: NO]; \
-        \
-        if (columnType == SqliteType) \
-            return (Expression); \
-        \
-        /* unknown value */ \
-        [NSException raise: TI_PLSqliteException format: @"Attempted to access non-%s column as %s.", #ReturnType, #ReturnType]; \
-        \
-        /* Unreachable */ \
-        abort(); \
-    } \
-    \
-    - (ReturnType) MethodName ## ForColumn: (NSString *) column { \
-        return [self MethodName ## ForColumnIndex: [self columnIndexForName: column]]; \
-    }
+#define VALUE_ACCESSORS(ReturnType, MethodName, SqliteType, Expression)                                                    \
+  -(ReturnType)MethodName##ForColumnIndex : (int)columnIndex                                                               \
+  {                                                                                                                        \
+    [self assertNotClosed];                                                                                                \
+    int columnType = [self validateColumnIndex:columnIndex isNullable:NO];                                                 \
+                                                                                                                           \
+    if (columnType == SqliteType)                                                                                          \
+      return (Expression);                                                                                                 \
+                                                                                                                           \
+    /* unknown value */                                                                                                    \
+    [NSException raise:TI_PLSqliteException format:@"Attempted to access non-%s column as %s.", #ReturnType, #ReturnType]; \
+                                                                                                                           \
+    /* Unreachable */                                                                                                      \
+    abort();                                                                                                               \
+  }                                                                                                                        \
+                                                                                                                           \
+  -(ReturnType)MethodName##ForColumn : (NSString *)column                                                                  \
+  {                                                                                                                        \
+    return [self MethodName##ForColumnIndex:[self columnIndexForName:column]];                                             \
+  }
 
 /* bool */
 VALUE_ACCESSORS(BOOL, bool, SQLITE_INTEGER, sqlite3_column_int(_sqlite_stmt, columnIndex))
@@ -236,12 +244,19 @@ VALUE_ACCESSORS(int64_t, bigInt, SQLITE_INTEGER, sqlite3_column_int64(_sqlite_st
 
 /* date */
 VALUE_ACCESSORS(NSDate *, date, SQLITE_FLOAT,
-                    [NSDate dateWithTimeIntervalSince1970: sqlite3_column_double(_sqlite_stmt, columnIndex)])
+    [NSDate dateWithTimeIntervalSince1970:sqlite3_column_double(_sqlite_stmt, columnIndex)])
 
 /* string */
 VALUE_ACCESSORS(NSString *, string, SQLITE_TEXT,
-                    [NSString stringWithCharacters: sqlite3_column_text16(_sqlite_stmt, columnIndex)
-                                            length: sqlite3_column_bytes16(_sqlite_stmt, columnIndex) / 2])
+    ({
+      NSString *_s = [NSString stringWithCharacters:sqlite3_column_text16(_sqlite_stmt, columnIndex)
+                                             length:sqlite3_column_bytes16(_sqlite_stmt, columnIndex) / 2];
+      // Strip a trailing null character that some databases embed in TEXT values.
+      if (_s.length > 0 && [_s characterAtIndex:_s.length - 1] == 0) {
+        _s = [_s substringToIndex:_s.length - 1];
+      }
+      _s;
+    }))
 
 /* float */
 VALUE_ACCESSORS(float, float, SQLITE_FLOAT, sqlite3_column_double(_sqlite_stmt, columnIndex))
@@ -250,104 +265,107 @@ VALUE_ACCESSORS(float, float, SQLITE_FLOAT, sqlite3_column_double(_sqlite_stmt, 
 VALUE_ACCESSORS(double, double, SQLITE_FLOAT, sqlite3_column_double(_sqlite_stmt, columnIndex))
 
 /* data */
-VALUE_ACCESSORS(NSData *, data, SQLITE_BLOB, [NSData dataWithBytes: sqlite3_column_blob(_sqlite_stmt, columnIndex)
-                                                            length: sqlite3_column_bytes(_sqlite_stmt, columnIndex)])
-
+VALUE_ACCESSORS(NSData *, data, SQLITE_BLOB, [NSData dataWithBytes:sqlite3_column_blob(_sqlite_stmt, columnIndex)
+                                                            length:sqlite3_column_bytes(_sqlite_stmt, columnIndex)])
 
 /* From PLResultSet */
-- (id) objectForColumnIndex: (int) columnIndex {
-    [self assertNotClosed];
+- (id)objectForColumnIndex:(int)columnIndex
+{
+  [self assertNotClosed];
 
-    int columnType = [self validateColumnIndex: columnIndex isNullable: YES];
+  int columnType = [self validateColumnIndex:columnIndex isNullable:YES];
+  switch (columnType) {
+  case SQLITE_TEXT:
+    return [self stringForColumnIndex:columnIndex];
+
+  case SQLITE_INTEGER:
+    return [NSNumber numberWithLongLong:[self bigIntForColumnIndex:columnIndex]];
+
+  case SQLITE_FLOAT:
+    return [NSNumber numberWithDouble:[self doubleForColumnIndex:columnIndex]];
+
+  case SQLITE_BLOB:
+    return [self dataForColumnIndex:columnIndex];
+
+  case SQLITE_NULL:
+    return [NSNull null];
+
+  default:
+    [NSException raise:TI_PLDatabaseException format:@"Unhandled SQLite column type %d", columnType];
+  }
+
+  /* Unreachable */
+  abort();
+}
+
+/* From PLResultSet */
+- (id)objectForColumn:(NSString *)columnName
+{
+  return [self objectForColumnIndex:[self columnIndexForName:columnName]];
+}
+
+/* from PLResultSet */
+- (BOOL)isNullForColumnIndex:(int)columnIndex
+{
+  [self assertNotClosed];
+
+  int columnType = [self validateColumnIndex:columnIndex isNullable:YES];
+
+  /* If the column has a null value, return YES. */
+  if (columnType == SQLITE_NULL)
+    return YES;
+
+  /* Return NO for all other column types. */
+  return NO;
+}
+
+/* from PLResultSet */
+- (BOOL)isNullForColumn:(NSString *)columnName
+{
+  return [self isNullForColumnIndex:[self columnIndexForName:columnName]];
+}
+
+- (NSArray *)valuesForRow;
+{
+  if (_sqlite_stmt == nil)
+    return nil;
+
+  NSMutableArray *result = [NSMutableArray arrayWithCapacity:_columnCount];
+
+  for (int currentIndex = 0; currentIndex < _columnCount; currentIndex++) {
+    int columnType = sqlite3_column_type(_sqlite_stmt, currentIndex);
     switch (columnType) {
-        case SQLITE_TEXT:
-            return [self stringForColumnIndex: columnIndex];
+    case SQLITE_TEXT:
+      [result addObject:[self stringForColumnIndex:currentIndex]];
+      break;
 
-        case SQLITE_INTEGER:
-            return [NSNumber numberWithLongLong:[self bigIntForColumnIndex: columnIndex]];
+    case SQLITE_INTEGER:
+      [result addObject:[NSNumber numberWithLongLong:[self bigIntForColumnIndex:currentIndex]]];
+      break;
 
-        case SQLITE_FLOAT:
-            return [NSNumber numberWithDouble: [self doubleForColumnIndex: columnIndex]];
+    case SQLITE_FLOAT:
+      [result addObject:[NSNumber numberWithDouble:[self doubleForColumnIndex:currentIndex]]];
+      break;
 
-        case SQLITE_BLOB:
-            return [self dataForColumnIndex: columnIndex];
+    case SQLITE_BLOB:
+      [result addObject:[self dataForColumnIndex:currentIndex]];
+      break;
 
-        case SQLITE_NULL:
-            return [NSNull null];
+    case SQLITE_NULL:
+      [result addObject:[NSNull null]];
+      break;
 
-        default:
-            [NSException raise: TI_PLDatabaseException format: @"Unhandled SQLite column type %d", columnType];
+    default:
+      [NSException raise:TI_PLDatabaseException format:@"Unhandled SQLite column type %d", columnType];
     }
+  }
 
-    /* Unreachable */
-    abort();
+  return result;
 }
 
-
-/* From PLResultSet */
-- (id) objectForColumn: (NSString *) columnName {
-    return [self objectForColumnIndex: [self columnIndexForName: columnName]];
-}
-
-
-/* from PLResultSet */
-- (BOOL) isNullForColumnIndex: (int) columnIndex {
-    [self assertNotClosed];
-
-    int columnType = [self validateColumnIndex: columnIndex isNullable: YES];
-    
-    /* If the column has a null value, return YES. */
-    if (columnType == SQLITE_NULL)
-        return YES;
-
-    /* Return NO for all other column types. */
-    return NO;
-}
-
-/* from PLResultSet */
-- (BOOL) isNullForColumn: (NSString *) columnName {
-    return [self isNullForColumnIndex: [self columnIndexForName: columnName]];
-}
-
-
-- (NSArray *) valuesForRow;
+- (NSArray *)fieldNames;
 {
-    if (_sqlite_stmt == nil) return nil;
-
-	NSMutableArray * result = [NSMutableArray arrayWithCapacity:_columnCount];
-	
-	for(int currentIndex=0;currentIndex<_columnCount;currentIndex++){
-		int columnType = sqlite3_column_type(_sqlite_stmt, currentIndex);
-		switch (columnType) {
-			case SQLITE_TEXT:
-				[result addObject:[self stringForColumnIndex: currentIndex]]; break;
-				
-			case SQLITE_INTEGER:
-				[result addObject:[NSNumber numberWithLongLong: [self bigIntForColumnIndex: currentIndex]]]; break;
-				
-			case SQLITE_FLOAT:
-				[result addObject:[NSNumber numberWithDouble: [self doubleForColumnIndex: currentIndex]]]; break;
-				
-			case SQLITE_BLOB:
-				[result addObject:[self dataForColumnIndex: currentIndex]]; break;
-				
-			case SQLITE_NULL:
-				[result addObject:[NSNull null]]; break;
-				
-			default:
-				[NSException raise: TI_PLDatabaseException format: @"Unhandled SQLite column type %d", columnType];
-		}
-	}
-
-	return result;
+  return columnNamesArray;
 }
-
-
-- (NSArray *) fieldNames;
-{
-	return columnNamesArray;
-}
-
-
 
 @end

--- a/iphone/Classes/StreamModule.m
+++ b/iphone/Classes/StreamModule.m
@@ -7,6 +7,7 @@
 
 #import "StreamModule.h"
 #import "TiDataStream.h"
+#import <TitaniumKit/TiBlob.h>
 #import <TitaniumKit/TiBuffer.h>
 #import <TitaniumKit/TiStreamProxy.h>
 
@@ -121,6 +122,7 @@
     TiDataStream *stream = [[[TiDataStream alloc] _initWithPageContext:[self executionContext]] autorelease];
     [stream setData:[obj data]];
     [stream setMode:mode];
+    [stream setStreamApiName:[obj isKindOfClass:[TiBlob class]] ? @"Ti.BlobStream" : @"Ti.BufferStream"];
 
     return stream;
   } else {

--- a/iphone/Classes/TiDataStream.h
+++ b/iphone/Classes/TiDataStream.h
@@ -13,8 +13,10 @@
   NSData *data;
   TiStreamMode mode;
   NSUInteger position;
+  NSString *streamApiName;
 }
 @property (nonatomic) TiStreamMode mode;
 @property (nonatomic, readwrite, retain) NSData *data;
+@property (nonatomic, copy) NSString *streamApiName;
 
 @end

--- a/iphone/Classes/TiDataStream.m
+++ b/iphone/Classes/TiDataStream.m
@@ -9,7 +9,7 @@
 #import <TitaniumKit/TiUtils.h>
 
 @implementation TiDataStream
-@synthesize data, mode;
+@synthesize data, mode, streamApiName;
 
 #pragma mark Internals
 
@@ -19,6 +19,7 @@
     data = nil;
     mode = TI_READ;
     position = 0;
+    streamApiName = @"Ti.IOStream";
   }
   return self;
 }
@@ -26,7 +27,13 @@
 - (void)dealloc
 {
   RELEASE_TO_NIL(data);
+  RELEASE_TO_NIL(streamApiName);
   [super dealloc];
+}
+
+- (NSString *)apiName
+{
+  return streamApiName;
 }
 
 #pragma mark I/O Stream implementation
@@ -120,9 +127,12 @@
   // even with immutable data (i.e. blob) if the user has specified WRITE or APPEND, they're OK with digging their own grave.
   NSMutableData *mutableData = (NSMutableData *)data;
   if (mode & TI_WRITE) {
-    NSUInteger overflow = length - ([data length] - position);
-    if (overflow > 0) {
-      [mutableData increaseLengthBy:overflow];
+    // Compute overflow as signed so a negative result (data already has
+    // enough room) doesn't wrap to a huge NSUInteger and crash
+    // increaseLengthBy: with an absurd length.
+    NSInteger signedOverflow = (NSInteger)position + length - (NSInteger)[data length];
+    if (signedOverflow > 0) {
+      [mutableData increaseLengthBy:(NSUInteger)signedOverflow];
     }
 
     void *bytes = [mutableData mutableBytes];

--- a/iphone/Classes/TiMediaVideoPlayerProxy.m
+++ b/iphone/Classes/TiMediaVideoPlayerProxy.m
@@ -110,6 +110,8 @@ NSArray *moviePlayerKeys = nil;
 
 - (void)removeNotificationObserver
 {
+  NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
+
   if ([self observationInfo]) {
     [self removeObserver:self forKeyPath:@"url"];
   }
@@ -117,6 +119,9 @@ NSArray *moviePlayerKeys = nil;
   [movie removeObserver:self forKeyPath:@"player.status"];
   [movie removeObserver:self forKeyPath:@"player.currentItem.presentationSize"];
   [movie removeObserver:self forKeyPath:@"player.timeControlStatus"];
+
+  [nc removeObserver:self name:AVPlayerItemDidPlayToEndTimeNotification object:nil];
+  [nc removeObserver:self name:AVPlayerItemFailedToPlayToEndTimeNotification object:nil];
 }
 
 - (void)configurePlayer
@@ -188,9 +193,11 @@ NSArray *moviePlayerKeys = nil;
 - (void)windowWillClose
 {
   [super windowWillClose];
-  [[movie player] pause];
-  if ([self viewAttached]) {
-    [(TiMediaVideoPlayer *)self.view setMovie:nil];
+  if (movie != nil) {
+    [[movie player] pause];
+    if ([self viewAttached]) {
+      [(TiMediaVideoPlayer *)self.view setMovie:nil];
+    }
   }
 }
 

--- a/iphone/Classes/TiUIAlertDialogProxy.m
+++ b/iphone/Classes/TiUIAlertDialogProxy.m
@@ -7,6 +7,7 @@
 
 #import "TiUIAlertDialogProxy.h"
 #import <TitaniumKit/TiApp.h>
+#import <TitaniumKit/TiLocale.h>
 #import <TitaniumKit/TiUtils.h>
 
 static NSCondition *alertCondition;
@@ -36,6 +37,34 @@ static BOOL alertShowing = NO;
 - (NSString *)apiName
 {
   return @"Ti.UI.AlertDialog";
+}
+
+- (void)_initWithProperties:(NSDictionary *)properties
+{
+  // Defaults mirrored from Android AlertDialogProxy so property reads are consistent.
+  [self initializeProperty:@"cancel" defaultValue:NUMINT(-1)];
+  [self initializeProperty:@"buttonNames" defaultValue:[NSMutableArray array]];
+
+  // Apply lang conversion (titleid -> title, etc.) for non-view proxies, since
+  // the base TiProxy._initWithProperties does not perform this translation.
+  NSMutableDictionary *props = [properties mutableCopy];
+  NSDictionary *table = [self langConversionTable];
+  if (table != nil && props != nil) {
+    for (id key in table) {
+      id langKey = [props objectForKey:key];
+      if (langKey != nil && langKey != [NSNull null]) {
+        id convertKey = [table objectForKey:key];
+        if ([props objectForKey:convertKey] == nil) {
+          id newValue = [TiLocale getString:langKey comment:nil];
+          if (newValue != nil) {
+            [props setObject:newValue forKey:convertKey];
+          }
+        }
+      }
+    }
+  }
+  [super _initWithProperties:props];
+  RELEASE_TO_NIL(props);
 }
 
 - (void)cleanup

--- a/iphone/Classes/TiUIOptionDialogProxy.m
+++ b/iphone/Classes/TiUIOptionDialogProxy.m
@@ -9,6 +9,7 @@
 #import "TiUIOptionDialogProxy.h"
 #import "TiToolbarButton.h"
 #import <TitaniumKit/TiApp.h>
+#import <TitaniumKit/TiLocale.h>
 #import <TitaniumKit/TiTab.h>
 #import <TitaniumKit/TiToolbar.h>
 #import <TitaniumKit/TiUtils.h>
@@ -32,6 +33,35 @@
 - (NSString *)apiName
 {
   return @"Ti.UI.OptionDialog";
+}
+
+- (void)_initWithProperties:(NSDictionary *)properties
+{
+  // Defaults mirrored from Android OptionDialogProxy so property reads are consistent.
+  [self initializeProperty:@"cancel" defaultValue:NUMINT(-1)];
+  [self initializeProperty:@"persistent" defaultValue:NUMBOOL(YES)];
+  [self initializeProperty:@"buttonNames" defaultValue:[NSMutableArray array]];
+
+  // Apply lang conversion (titleid -> title) for non-view proxies, since the
+  // base TiProxy._initWithProperties does not perform this translation.
+  NSMutableDictionary *props = [properties mutableCopy];
+  NSDictionary *table = [self langConversionTable];
+  if (table != nil && props != nil) {
+    for (id key in table) {
+      id langKey = [props objectForKey:key];
+      if (langKey != nil && langKey != [NSNull null]) {
+        id convertKey = [table objectForKey:key];
+        if ([props objectForKey:convertKey] == nil) {
+          id newValue = [TiLocale getString:langKey comment:nil];
+          if (newValue != nil) {
+            [props setObject:newValue forKey:convertKey];
+          }
+        }
+      }
+    }
+  }
+  [super _initWithProperties:props];
+  RELEASE_TO_NIL(props);
 }
 
 - (void)show:(id)args

--- a/iphone/Classes/TiUIScrollViewProxy.m
+++ b/iphone/Classes/TiUIScrollViewProxy.m
@@ -30,6 +30,18 @@ static NSArray *scrollViewKeySequence;
   [self initializeProperty:@"zoomScale" defaultValue:NUMFLOAT(1.0)];
   [self initializeProperty:@"canCancelEvents" defaultValue:NUMBOOL(YES)];
   [self initializeProperty:@"scrollingEnabled" defaultValue:NUMBOOL(YES)];
+  // Defaults mirrored from Android ScrollViewProxy to keep property reads consistent.
+  // Use "auto" rather than "" so the iOS dimension parser treats these as auto
+  // (an empty string would be parsed as 0 dip and break Ti.UI.SIZE sizing).
+  [self initializeProperty:@"contentWidth" defaultValue:@"auto"];
+  [self initializeProperty:@"contentHeight" defaultValue:@"auto"];
+  [self initializeProperty:@"decelerationRate" defaultValue:NUMINT(0)];
+  [self initializeProperty:@"disableBounce" defaultValue:NUMBOOL(NO)];
+  [self initializeProperty:@"horizontalBounce" defaultValue:NUMBOOL(NO)];
+  [self initializeProperty:@"verticalBounce" defaultValue:NUMBOOL(NO)];
+  [self initializeProperty:@"scrollIndicatorStyle" defaultValue:NUMINT(0)];
+  [self initializeProperty:@"showHorizontalScrollIndicator" defaultValue:NUMBOOL(NO)];
+  [self initializeProperty:@"showVerticalScrollIndicator" defaultValue:NUMBOOL(NO)];
   [super _initWithProperties:properties];
 }
 

--- a/iphone/Classes/TiUITabGroupProxy.m
+++ b/iphone/Classes/TiUITabGroupProxy.m
@@ -44,6 +44,11 @@ static NSArray *tabGroupKeySequence;
   [self initializeProperty:@"allowUserCustomization" defaultValue:NUMBOOL(YES)];
   [self initializeProperty:@"extendEdges" defaultValue:[NSArray arrayWithObjects:NUMINT(15), nil]];
   [self initializeProperty:@"lazyLoadingEnabled" defaultValue:NUMBOOL(NO)];
+  [self initializeProperty:@"tabsTranslucent" defaultValue:NUMBOOL(YES)];
+  [self initializeProperty:@"tabs" defaultValue:[NSMutableArray array]];
+  if (tabs == nil) {
+    tabs = [[NSMutableArray alloc] initWithCapacity:4];
+  }
   [super _initWithProperties:properties];
 }
 

--- a/iphone/Classes/TiUITableView.m
+++ b/iphone/Classes/TiUITableView.m
@@ -345,11 +345,13 @@
   if (headerViewProxy != nil) {
     [headerViewProxy setProxyObserver:nil];
     [headerViewProxy windowWillClose];
+    RELEASE_TO_NIL(headerViewProxy);
   }
 
   if (footerViewProxy != nil) {
     [footerViewProxy setProxyObserver:nil];
     [footerViewProxy windowWillClose];
+    RELEASE_TO_NIL(footerViewProxy);
   }
 
   searchController.searchResultsUpdater = nil;
@@ -1747,7 +1749,7 @@
   if (headerViewProxy != nil) {
     [headerViewProxy setProxyObserver:nil];
     [[self proxy] forgetProxy:headerViewProxy];
-    headerViewProxy = nil;
+    RELEASE_TO_NIL(headerViewProxy);
   }
   [[self tableView] setTableHeaderView:[self titleViewForText:[TiUtils stringValue:args] footer:NO]];
 }
@@ -1757,7 +1759,7 @@
   if (footerViewProxy != nil) {
     [footerViewProxy setProxyObserver:nil];
     [[self proxy] forgetProxy:footerViewProxy];
-    footerViewProxy = nil;
+    RELEASE_TO_NIL(footerViewProxy);
   }
   [[self tableView] setTableFooterView:[self titleViewForText:[TiUtils stringValue:args] footer:YES]];
 }
@@ -1772,15 +1774,16 @@
     if (headerViewProxy != nil) {
       [headerViewProxy setProxyObserver:nil];
       [[self proxy] forgetProxy:headerViewProxy];
+      RELEASE_TO_NIL(headerViewProxy);
     }
-    headerViewProxy = args;
+    headerViewProxy = [args retain];
     [headerViewProxy setProxyObserver:self];
     [[self proxy] rememberProxy:headerViewProxy];
   } else {
     if (headerViewProxy != nil) {
       [headerViewProxy setProxyObserver:nil];
       [[self proxy] forgetProxy:headerViewProxy];
-      headerViewProxy = nil;
+      RELEASE_TO_NIL(headerViewProxy);
     }
     [[self tableView] setTableHeaderView:nil];
   }
@@ -1796,15 +1799,16 @@
     if (footerViewProxy != nil) {
       [footerViewProxy setProxyObserver:nil];
       [[self proxy] forgetProxy:footerViewProxy];
+      RELEASE_TO_NIL(footerViewProxy);
     }
-    footerViewProxy = args;
+    footerViewProxy = [args retain];
     [footerViewProxy setProxyObserver:self];
     [[self proxy] rememberProxy:footerViewProxy];
   } else {
     if (footerViewProxy != nil) {
       [footerViewProxy setProxyObserver:nil];
       [[self proxy] forgetProxy:footerViewProxy];
-      footerViewProxy = nil;
+      RELEASE_TO_NIL(footerViewProxy);
     }
     [[self tableView] setTableFooterView:nil];
   }

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/TiBlob.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/TiBlob.m
@@ -481,8 +481,11 @@ static void jsArrayBufferFreeDeallocator(void *data, void *ctx)
 
   // Now make an ArrayBuffer with the copied bytes
   JSContext *context = JSContext.currentContext;
-  JSValueRef *exception;
-  JSObjectRef arrayBuffer = JSObjectMakeArrayBufferWithBytesNoCopy(context.JSGlobalContextRef, arrayBytes, len, jsArrayBufferFreeDeallocator, nil, exception);
+  JSValueRef exception = NULL;
+  JSObjectRef arrayBuffer = JSObjectMakeArrayBufferWithBytesNoCopy(context.JSGlobalContextRef, arrayBytes, len, jsArrayBufferFreeDeallocator, nil, &exception);
+  if (exception) {
+    return [JSValue valueWithJSValueRef:exception inContext:context];
+  }
   return [JSValue valueWithJSValueRef:arrayBuffer inContext:context];
 }
 
@@ -499,8 +502,8 @@ static void jsArrayBufferFreeDeallocator(void *data, void *ctx)
         [theData getBytes:arrayBytes length:len];
 
         // Now make an ArrayBuffer with the copied bytes
-        JSValueRef *exception;
-        JSObjectRef arrayBuffer = JSObjectMakeArrayBufferWithBytesNoCopy(context.JSGlobalContextRef, arrayBytes, len, jsArrayBufferFreeDeallocator, nil, exception);
+        JSValueRef exception = NULL;
+        JSObjectRef arrayBuffer = JSObjectMakeArrayBufferWithBytesNoCopy(context.JSGlobalContextRef, arrayBytes, len, jsArrayBufferFreeDeallocator, nil, &exception);
         if (exception) {
           [promise reject:@[ [JSValue valueWithJSValueRef:exception inContext:context] ]];
         } else {

--- a/iphone/TitaniumKit/TitaniumKit/Sources/Modules/TiFilesystemFileProxy.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/Modules/TiFilesystemFileProxy.m
@@ -56,16 +56,18 @@
   return [resultDict objectForKey:NSFileImmutable];
 }
 
-- (NSDate *)createTimestamp
+- (NSNumber *)createTimestamp
 {
   DEPRECATED_REPLACED_REMOVED(@"Filesystem.File.createTimestamp", @"7.3.0", @"12.4.0", @"Filesystem.File.createdAt()");
-  return [NSDate new];
+  NSDate *date = [self createdAt:nil];
+  return NUMDOUBLE([date timeIntervalSince1970] * 1000.0);
 }
 
-- (NSDate *)createTimestamp:(id)unused
+- (NSNumber *)createTimestamp:(id)unused
 {
   DEPRECATED_REPLACED_REMOVED(@"Filesystem.File.createTimestamp()", @"7.3.0", @"12.4.0", @"Filesystem.File.createdAt()");
-  return [NSDate new];
+  NSDate *date = [self createdAt:nil];
+  return NUMDOUBLE([date timeIntervalSince1970] * 1000.0);
 }
 
 - (NSDate *)createdAt:(id)unused
@@ -83,16 +85,18 @@
   return result;
 }
 
-- (NSDate *)modificationTimestamp
+- (NSNumber *)modificationTimestamp
 {
   DEPRECATED_REPLACED_REMOVED(@"Filesystem.File.modificationTimestamp", @"7.3.0", @"12.4.0", @"Filesystem.File.modifiedAt()");
-  return [NSDate new];
+  NSDate *date = [self modifiedAt:nil];
+  return NUMDOUBLE([date timeIntervalSince1970] * 1000.0);
 }
 
-- (NSDate *)modificationTimestamp:(id)unused
+- (NSNumber *)modificationTimestamp:(id)unused
 {
   DEPRECATED_REPLACED_REMOVED(@"Filesystem.File.modificationTimestamp()", @"7.3.0", @"12.4.0", @"Filesystem.File.modifiedAt()");
-  return [NSDate new];
+  NSDate *date = [self modifiedAt:nil];
+  return NUMDOUBLE([date timeIntervalSince1970] * 1000.0);
 }
 
 - (NSDate *)modifiedAt:(id)unused


### PR DESCRIPTION
**Hardens crash prevention and resource cleanup across a batch of core modules and UI proxies:**

- Null out the closed PLSqliteResultSet cursor.
- Fix TiDataStream stream handling.
- Stabilize TiUIScrollViewProxy, TiUITabGroupProxy, TiUITableView, and the alert/option dialog proxies.
- Filesystem and geolocation module fixes.
- TiBlob and TiMediaVideoPlayerProxy resource cleanup.

_Resolves the bulk of the 108 iOS test failures not covered by the https://github.com/tidev/titanium-sdk/pull/14505 PR. Merge after that PR._

