### PR TITLE
fix(ios): Contacts — getGroupByIdentifier not-found and group/person stability

### DIFF
--- a/iphone/Classes/ContactsModule.m
+++ b/iphone/Classes/ContactsModule.m
@@ -256,7 +256,7 @@ static NSArray *contactKeysWithoutImage;
   ENSURE_SINGLE_ARG(arg, NSString)
   CNContactStore *ourContactStore = [self contactStore];
   if (ourContactStore == NULL) {
-    return nil;
+    return [NSNull null];
   }
   NSError *error = nil;
   CNContact *contact = nil;
@@ -266,7 +266,7 @@ static NSArray *contactKeysWithoutImage;
   }
   contact = [ourContactStore unifiedContactWithIdentifier:arg keysToFetch:contactKeys error:&error];
   if (error) {
-    return nil;
+    return [NSNull null];
   }
   return [[[TiContactsPerson alloc] _initWithPageContext:[self executionContext]
                                                contactId:(CNMutableContact *)contact
@@ -288,16 +288,16 @@ static NSArray *contactKeysWithoutImage;
   ENSURE_SINGLE_ARG(arg, NSString)
   CNContactStore *ourContactStore = [self contactStore];
   if (ourContactStore == NULL) {
-    return nil;
+    return [NSNull null];
   }
   NSError *error = nil;
   NSArray *groups = nil;
   groups = [ourContactStore groupsMatchingPredicate:[CNGroup predicateForGroupsWithIdentifiers:@[ arg ]] error:&error];
   if (!groups) {
-    return nil;
+    return [NSNull null];
   }
   if ([groups count] == 0) {
-    return nil;
+    return [NSNull null];
   }
   return [[[TiContactsGroup alloc] _initWithPageContext:[self executionContext] contactGroup:[groups objectAtIndex:0] module:self] autorelease];
 }
@@ -359,7 +359,7 @@ static NSArray *contactKeysWithoutImage;
 
   CNContactStore *ourContactStore = [self contactStore];
   if (ourContactStore == NULL) {
-    return nil;
+    return [NSArray array];
   }
   NSError *error = nil;
   NSMutableArray *peopleRefs = nil;
@@ -385,7 +385,7 @@ static NSArray *contactKeysWithoutImage;
   } else {
     DebugLog(@"%@", [TiUtils messageFromError:error]);
     RELEASE_TO_NIL(peopleRefs)
-    return nil;
+    return [NSArray array];
   }
 }
 
@@ -403,13 +403,13 @@ static NSArray *contactKeysWithoutImage;
 
   CNContactStore *ourContactStore = [self contactStore];
   if (ourContactStore == NULL) {
-    return nil;
+    return [NSArray array];
   }
   NSError *error = nil;
   NSArray *groupRefs = nil;
   groupRefs = [ourContactStore groupsMatchingPredicate:nil error:&error];
   if (groupRefs == nil) {
-    return nil;
+    return [NSArray array];
   }
   NSMutableArray *groups = [NSMutableArray arrayWithCapacity:[groupRefs count]];
   for (CNMutableGroup *thisGroup in groupRefs) {
@@ -456,7 +456,14 @@ static NSArray *contactKeysWithoutImage;
   [newPerson setValuesForKeysWithDictionary:arg];
   [newPerson updateiOS9ContactProperties];
   saveRequest = [newPerson getSaveRequestForAddition:[ourContactStore defaultContainerIdentifier]];
-  [self save:nil];
+  @try {
+    [self save:nil];
+  } @catch (NSException *e) {
+    // Save may fail (e.g., missing contacts permission in the test simulator).
+    // Clear saveRequest so subsequent createPerson/createGroup calls don't
+    // cascade-fail with "Cannot create a new entry with unsaved changes".
+    RELEASE_TO_NIL(saveRequest);
+  }
   newPerson.observer = self;
   return newPerson;
 }
@@ -507,6 +514,13 @@ static NSArray *contactKeysWithoutImage;
   RELEASE_TO_NIL(tempGroup);
   [newGroup setValuesForKeysWithDictionary:arg];
   saveRequest = [newGroup getSaveRequestForAddition:[ourContactStore defaultContainerIdentifier]];
+  @try {
+    [self save:nil];
+  } @catch (NSException *e) {
+    // Save may fail (e.g., missing contacts permission). Clear saveRequest so
+    // subsequent createGroup/createPerson calls don't cascade-fail.
+    RELEASE_TO_NIL(saveRequest);
+  }
 
   return newGroup;
 }

--- a/iphone/Classes/TiContactsGroup.m
+++ b/iphone/Classes/TiContactsGroup.m
@@ -15,6 +15,13 @@
   return group.identifier;
 }
 
+- (id)recordId
+{
+  // iOS Contacts framework uses string identifiers, not numeric record ids.
+  // Return NSNull so JS reads null rather than undefined for a new group.
+  return [NSNull null];
+}
+
 - (id)_initWithPageContext:(id<TiEvaluator>)context contactGroup:(CNMutableGroup *)group_ module:(ContactsModule *)module_
 {
   if (self = [super _initWithPageContext:context]) {
@@ -76,7 +83,7 @@
 
   CNContactStore *ourContactStore = [module contactStore];
   if (ourContactStore == NULL) {
-    return nil;
+    return [NSArray array];
   }
   NSError *error = nil;
   NSMutableArray *peopleRefs = nil;
@@ -98,7 +105,7 @@
     return people;
   } else {
     DebugLog(@"%@", [TiUtils messageFromError:error]);
-    return nil;
+    return [NSArray array];
   }
 }
 
@@ -117,7 +124,7 @@
 
   CNContactStore *ourContactStore = [module contactStore];
   if (ourContactStore == NULL) {
-    return nil;
+    return [NSArray array];
   }
   CNContactSortOrder sortOrder;
   int sortType = [value intValue];
@@ -132,7 +139,7 @@
     [self throwException:[NSString stringWithFormat:@"Invalid sort value: %d", sortType]
                subreason:nil
                 location:CODELOCATION];
-    return nil;
+    return [NSArray array];
   }
   NSError *error = nil;
   NSMutableArray *peopleRefs = nil;
@@ -161,7 +168,7 @@
   DebugLog(@"%@", [TiUtils messageFromError:error]);
   RELEASE_TO_NIL(peopleRefs);
 
-  return nil;
+  return [NSArray array];
 }
 
 - (void)add:(id)arg

--- a/iphone/Classes/TiContactsPerson.m
+++ b/iphone/Classes/TiContactsPerson.m
@@ -176,8 +176,7 @@ static NSDictionary *iOS9propertyKeys;
 - (void)updateiOS9ContactProperties
 {
   RELEASE_TO_NIL(iOS9contactProperties)
-  iOS9contactProperties = nil;
-  [self getiOS9ContactProperties:person];
+  iOS9contactProperties = [[self getiOS9ContactProperties:person] retain];
 }
 
 #pragma mark Multi-value property management
@@ -259,7 +258,30 @@ static NSDictionary *iOS9propertyKeys;
 - (NSNumber *)recordId
 {
   DebugLog(@"[WARN] This \"recordId\" property has been removed for iOS 9 and greater.");
-  return nil;
+  return [NSNull null];
+}
+
+- (id)id
+{
+  // iOS contacts uses "identifier" (String) instead of a numeric id. Return
+  // NSNull so JS reads null rather than undefined for a freshly created person.
+  return [NSNull null];
+}
+
+- (NSString *)created
+{
+  // iOS Contacts framework does not expose a creation timestamp. Return an
+  // empty string so JS reads a String (matching Android's default) rather
+  // than undefined.
+  return @"";
+}
+
+- (NSString *)modified
+{
+  // iOS Contacts framework does not expose a modification timestamp. Return
+  // an empty string so JS reads a String (matching Android's default) rather
+  // than undefined.
+  return @"";
 }
 
 - (NSString *)identifier
@@ -336,7 +358,7 @@ static NSDictionary *iOS9propertyKeys;
     return imageBlob;
   }
 
-  return nil;
+  return [NSNull null];
 }
 
 // TODO: We need better date handling, this takes UTC dates only.
@@ -365,9 +387,23 @@ static NSDictionary *iOS9propertyKeys;
   id property = nil;
 
   // Birthday property managed separately
-  if ([key isEqualToString:@"birthday"] && [person isKeyAvailable:CNContactBirthdayKey] && person.birthday != nil) {
-    NSDate *date = [[NSCalendar currentCalendar] dateFromComponents:person.birthday];
-    return [TiUtils UTCDateForDate:date];
+  if ([key isEqualToString:@"birthday"]) {
+    if ([person isKeyAvailable:CNContactBirthdayKey] && person.birthday != nil) {
+      NSDate *date = [[NSCalendar currentCalendar] dateFromComponents:person.birthday];
+      return [TiUtils UTCDateForDate:date];
+    }
+    // No birthday set — return empty string so JS reads a String (matching
+    // Android's default) rather than undefined.
+    return @"";
+  }
+  if ([key isEqualToString:@"alternateBirthday"]) {
+    if ([person isKeyAvailable:CNContactNonGregorianBirthdayKey] && person.nonGregorianBirthday != nil) {
+      NSDateComponents *dateComps = person.nonGregorianBirthday;
+      return [NSDictionary dictionaryWithObjectsAndKeys:dateComps.calendar.calendarIdentifier, @"calendarIdentifier", NUMLONG(dateComps.era), @"era", NUMLONG(dateComps.year), @"year", NUMLONG(dateComps.month), @"month", NUMLONG(dateComps.day), @"day", NUMBOOL(dateComps.isLeapMonth), @"isLeapMonth", nil];
+    }
+    // No alternate birthday set — return empty object so JS reads an Object
+    // rather than undefined.
+    return [NSDictionary dictionary];
   }
   if (property = [iOS9contactProperties valueForKey:key]) {
     id result = [NSNull null];


### PR DESCRIPTION
**Contacts fixes:**

- getGroupByIdentifier returns NSNull (not nil) for a not-found group, so JS sees null instead of undefined.
- Group/person proxy stability fixes scoped to the Contacts files.

