### PR TITLE
fix(ios): Ti.UI.Clipboard parity — text property, getText/setText, main-thread safety

### DIFF
--- a/iphone/Classes/TiUIClipboardProxy.h
+++ b/iphone/Classes/TiUIClipboardProxy.h
@@ -15,12 +15,21 @@ READONLY_PROPERTY(bool, allowCreation, AllowCreation);
 READONLY_PROPERTY(NSString *, name, Name);
 READONLY_PROPERTY(bool, unique, Unique);
 
+// "text" is exposed both as a JS property (clipboard.text / clipboard.text = x)
+// and as JS methods (clipboard.getText() / clipboard.setText(x)). JSExport only
+// routes JS property assignment through the native setter when the property is
+// declared via @property; without it, clipboard.text = x silently no-ops on
+// iOS 26. The GETTER/SETTER macros below expose the legacy getX/setX method
+// forms alongside the property.
+@property (nonatomic, copy) NSString *text;
+GETTER(NSString *, Text);
+SETTER(NSString *, Text);
+
 // Methods
 - (void)clearData:(NSString *)type;
 - (void)clearText;
 - (JSValue *)getData:(NSString *)type;
 - (NSArray<NSDictionary<NSString *, id> *> *)getItems;
-- (NSString *)getText;
 - (bool)hasData:(id)type;
 - (bool)hasText;
 - (bool)hasURLs;
@@ -30,7 +39,6 @@ JSExportAs(setData,
            -(void)setData
            : (NSString *)type withData
            : (JSValue *)data);
-- (void)setText:(NSString *)text;
 - (void)setItems:(NSDictionary<NSString *, id> *)items;
 - (void)remove;
 

--- a/iphone/Classes/TiUIClipboardProxy.m
+++ b/iphone/Classes/TiUIClipboardProxy.m
@@ -28,12 +28,25 @@ static ClipboardType mimeTypeToDataType(NSString *mimeType)
 
   // Types "URL" and "Text" are for IE compatibility. We want to have
   // a consistent interface with WebKit's HTML 5 DataTransfer.
-  // support text, text.plain, public.text, public.plain-text, public.utf8-plain-text
-  if ([mimeType isEqualToString:@"text"] || [mimeType hasPrefix:@"text/plain"] || UTTypeConformsTo((CFStringRef)mimeType, kUTTypeText)) {
+  // Support both MIME types and UTI strings: text, text/plain, text.plain,
+  // public.text, public.plain-text, public.utf8-plain-text. We check the
+  // known UTI strings explicitly because UTTypeConformsTo (deprecated
+  // MobileCoreServices C API) is unreliable on newer iOS versions and was
+  // causing public.plain-text to fall through to CLIPBOARD_UNKNOWN.
+  if ([mimeType isEqualToString:@"text"]
+      || [mimeType hasPrefix:@"text/plain"]
+      || [mimeType isEqualToString:@"text.plain"]
+      || [mimeType isEqualToString:@"public.text"]
+      || [mimeType isEqualToString:@"public.plain-text"]
+      || [mimeType isEqualToString:@"public.utf8-plain-text"]
+      || UTTypeConformsTo((CFStringRef)mimeType, kUTTypeText)) {
     return CLIPBOARD_TEXT;
   }
 
-  if ([mimeType isEqualToString:@"url"] || [mimeType hasPrefix:@"text/uri-list"] || UTTypeConformsTo((CFStringRef)mimeType, kUTTypeURL)) {
+  if ([mimeType isEqualToString:@"url"]
+      || [mimeType hasPrefix:@"text/uri-list"]
+      || [mimeType isEqualToString:@"public.url"]
+      || UTTypeConformsTo((CFStringRef)mimeType, kUTTypeURL)) {
     return CLIPBOARD_URI_LIST;
   }
 
@@ -96,12 +109,20 @@ static NSString *mimeTypeToUTType(NSString *mimeType)
   if (self = [super init]) {
     isUnique = [TiUtils boolValue:dict[@"unique"] def:false];
     shouldCreatePasteboard = [TiUtils boolValue:dict[@"allowCreation"] def:true];
-    if (isUnique) {
-      _pasteboard = [[UIPasteboard pasteboardWithUniqueName] retain];
-    } else {
-      NSString *pasteboardName = dict[@"name"];
-      _pasteboard = [[UIPasteboard pasteboardWithName:pasteboardName create:shouldCreatePasteboard] retain];
-    }
+    NSString *pasteboardName = dict[@"name"];
+    // UIPasteboard must be created on the main thread; on iOS 26 a named
+    // pasteboard created from a background thread reports its name correctly
+    // but silently drops writes, so clipboard.text reads back nil after a
+    // setText.
+    TiThreadPerformOnMainThread(
+        ^{
+          if (isUnique) {
+            _pasteboard = [[UIPasteboard pasteboardWithUniqueName] retain];
+          } else {
+            _pasteboard = [[UIPasteboard pasteboardWithName:pasteboardName create:shouldCreatePasteboard] retain];
+          }
+        },
+        YES);
   }
   return self;
 }
@@ -150,37 +171,48 @@ GETTER_IMPL(bool, allowCreation, AllowCreation);
   if (mimeType == nil) {
     mimeType = @"application/octet-stream";
   }
-  UIPasteboard *board = [self pasteboard];
-
-  ClipboardType dataType = mimeTypeToDataType(mimeType);
-  switch (dataType) {
-  case CLIPBOARD_TEXT: {
-    board.strings = nil;
-    break;
-  }
-  case CLIPBOARD_URI_LIST: {
-    board.URLs = nil;
-    break;
-  }
-  case CLIPBOARD_IMAGE: {
-    board.images = nil;
-    break;
-  }
-  case CLIPBOARD_COLOR: {
-    board.colors = nil;
-    break;
-  }
-  case CLIPBOARD_UNKNOWN:
-  default: {
-    [[self pasteboard] setItems:@[]];
-  }
-  }
+  NSString *finalMimeType = mimeType;
+  // UIPasteboard mutators must run on the main thread; off-main-thread writes
+  // are silently dropped or delayed on iOS 26, so subsequent main-thread reads
+  // see stale state.
+  TiThreadPerformOnMainThread(
+      ^{
+        UIPasteboard *board = [self pasteboard];
+        ClipboardType dataType = mimeTypeToDataType(finalMimeType);
+        switch (dataType) {
+        case CLIPBOARD_TEXT: {
+          board.strings = nil;
+          break;
+        }
+        case CLIPBOARD_URI_LIST: {
+          board.URLs = nil;
+          break;
+        }
+        case CLIPBOARD_IMAGE: {
+          board.images = nil;
+          break;
+        }
+        case CLIPBOARD_COLOR: {
+          board.colors = nil;
+          break;
+        }
+        case CLIPBOARD_UNKNOWN:
+        default: {
+          [board setItems:@[]];
+        }
+        }
+      },
+      YES);
 }
 
 - (void)clearText
 {
-  UIPasteboard *board = [self pasteboard];
-  board.strings = nil;
+  TiThreadPerformOnMainThread(
+      ^{
+        UIPasteboard *board = [self pasteboard];
+        board.strings = nil;
+      },
+      YES);
 }
 
 - (id)getData:(NSString *)mimeType
@@ -231,10 +263,13 @@ GETTER_IMPL(bool, allowCreation, AllowCreation);
   }
 }
 
-- (NSString *)getText
+- (NSString *)text
 {
   return [self getData:@"text/plain"];
 }
+
+GETTER_IMPL(NSString *, text, Text);
+SETTER_IMPL(NSString *, Text);
 
 - (bool)hasData:(id)type
 {
@@ -280,22 +315,52 @@ GETTER_IMPL(bool, allowCreation, AllowCreation);
 
 - (bool)hasText
 {
-  return [[self pasteboard] hasStrings];
+  __block BOOL result = NO;
+  // UIPasteboard reads must run on the main thread; off-main-thread reads on
+  // iOS 26 return a stale snapshot that poisons subsequent main-thread reads.
+  // Use board.string (not hasStrings): on iOS 26 hasStrings is not kept in
+  // sync with a freshly written string, so it returns NO right after a
+  // board.string = assignment.
+  TiThreadPerformOnMainThread(
+      ^{
+        NSString *str = [[self pasteboard] string];
+        result = str != nil && [str length] > 0;
+      },
+      YES);
+  return result;
 }
 
 - (bool)hasColors
 {
-  return [[self pasteboard] hasColors];
+  __block BOOL result = NO;
+  TiThreadPerformOnMainThread(
+      ^{
+        result = [[self pasteboard] hasColors];
+      },
+      YES);
+  return result;
 }
 
 - (bool)hasImages
 {
-  return [[self pasteboard] hasImages];
+  __block BOOL result = NO;
+  TiThreadPerformOnMainThread(
+      ^{
+        result = [[self pasteboard] hasImages];
+      },
+      YES);
+  return result;
 }
 
 - (bool)hasURLs
 {
-  return [[self pasteboard] hasURLs];
+  __block BOOL result = NO;
+  TiThreadPerformOnMainThread(
+      ^{
+        result = [[self pasteboard] hasURLs];
+      },
+      YES);
+  return result;
 }
 
 - (void)setItems:(NSDictionary<NSString *, id> *)args
@@ -371,50 +436,64 @@ GETTER_IMPL(bool, allowCreation, AllowCreation);
   data = [self JSValueToNative:data];
   // TODO: If value is NSNull or undefined, should we throw or just clear the data for the given mime type?
 
-  UIPasteboard *board = [self pasteboard];
-  ClipboardType dataType = mimeTypeToDataType(mimeType);
-  switch (dataType) {
-  case CLIPBOARD_TEXT: {
-    board.string = [TiUtils stringValue:data];
-    break;
-  }
-  case CLIPBOARD_URI_LIST: {
-    board.URL = [NSURL URLWithString:[TiUtils stringValue:data]];
-    break;
-  }
-  case CLIPBOARD_IMAGE: {
-    UIImage *image = [TiUtils toImage:data proxy:self];
-    if (image) {
-      board.image = image;
-    } else {
-      board.image = nil;
-    }
-    break;
-  }
-  case CLIPBOARD_COLOR: {
-    board.color = [[TiUtils colorValue:data] color];
-    break;
-  }
-  case CLIPBOARD_UNKNOWN:
-  default: {
-    NSData *raw;
-    if ([data isKindOfClass:[TiBlob class]]) {
-      raw = [(TiBlob *)data data];
-    } else if ([data isKindOfClass:[TiFile class]]) {
-      raw = [[(TiFile *)data blob] data];
-    } else {
-      raw = [[TiUtils stringValue:data] dataUsingEncoding:NSUTF8StringEncoding];
-    }
+  JSValue *finalData = data;
+  NSString *finalMimeType = mimeType;
+  // UIPasteboard mutators must run on the main thread; off-main-thread writes
+  // are silently dropped or delayed on iOS 26, so subsequent main-thread reads
+  // see stale state.
+  TiThreadPerformOnMainThread(
+      ^{
+        UIPasteboard *board = [self pasteboard];
+        ClipboardType dataType = mimeTypeToDataType(finalMimeType);
+        switch (dataType) {
+        case CLIPBOARD_TEXT: {
+          board.string = [TiUtils stringValue:finalData];
+          break;
+        }
+        case CLIPBOARD_URI_LIST: {
+          board.URL = [NSURL URLWithString:[TiUtils stringValue:finalData]];
+          break;
+        }
+        case CLIPBOARD_IMAGE: {
+          UIImage *image = [TiUtils toImage:finalData proxy:self];
+          if (image) {
+            board.image = image;
+          } else {
+            board.image = nil;
+          }
+          break;
+        }
+        case CLIPBOARD_COLOR: {
+          board.color = [[TiUtils colorValue:finalData] color];
+          break;
+        }
+        case CLIPBOARD_UNKNOWN:
+        default: {
+          NSData *raw;
+          if ([finalData isKindOfClass:[TiBlob class]]) {
+            raw = [(TiBlob *)finalData data];
+          } else if ([finalData isKindOfClass:[TiFile class]]) {
+            raw = [[(TiFile *)finalData blob] data];
+          } else {
+            raw = [[TiUtils stringValue:finalData] dataUsingEncoding:NSUTF8StringEncoding];
+          }
 
-    [board setData:raw forPasteboardType:mimeTypeToUTType(mimeType)];
-  }
-  }
+          [board setData:raw forPasteboardType:mimeTypeToUTType(finalMimeType)];
+        }
+        }
+      },
+      YES);
 }
 
 - (void)setText:(NSString *)text
 {
-  UIPasteboard *board = [self pasteboard];
-  board.string = text;
+  NSString *finalText = text;
+  TiThreadPerformOnMainThread(
+      ^{
+        UIPasteboard *board = [self pasteboard];
+        board.string = finalText;
+      },
+      YES);
 }
 
 @end


### PR DESCRIPTION
**Brings `Ti.UI.Clipboard` on iOS to parity with the cross-platform API and the Android implementation:**

- Expose text both as a property and via getText()/setText() methods.
- hasText() reads board.string so it reflects what was actually written.
- Dispatch all mutators and has* probes to the main thread (UIPasteboard is main-thread-only); create named/unique pasteboards on the main thread.
- Handle plain-text UTIs explicitly in mimeTypeToDataType so non-UTI strings resolve to the correct data type.

Resolves several iosBroken Clipboard tests.
