### PR TITLE
fix(ios): ui module namespace getters, shortcutItem, and overrideUserInterfaceStyle round-trip

### DIFF
--- a/iphone/Classes/UIModule.h
+++ b/iphone/Classes/UIModule.h
@@ -18,11 +18,34 @@
 #endif
 
 #if defined(USE_TI_UISHORTCUT) || defined(USE_TI_UISHORTCUTITEM)
+#import "TiUIShortcutItemProxy.h"
 #import "TiUIShortcutProxy.h"
 #endif
 
 #if defined(USE_TI_UITABLEVIEWSCROLLPOSITION) || defined(USE_TI_UILISTVIEWSCROLLPOSITION)
 #import "TiUITableViewScrollPositionProxy.h"
+#endif
+
+#ifdef USE_TI_UIEMAILDIALOG
+#import "TiUIEmailDialogProxy.h"
+#endif
+#ifdef USE_TI_UILISTVIEW
+#import "TiUIListViewProxy.h"
+#endif
+#ifdef USE_TI_UITABLEVIEW
+#import "TiUITableViewProxy.h"
+#endif
+#ifdef USE_TI_UISLIDER
+#import "TiUISliderProxy.h"
+#endif
+#ifdef USE_TI_UISWITCH
+#import "TiUISwitchProxy.h"
+#endif
+#ifdef USE_TI_UIMASKEDIMAGE
+#import "TiUIMaskedImageProxy.h"
+#endif
+#if defined(USE_TI_UINAVIGATIONWINDOW)
+#import "TiUINavigationWindowProxy.h"
 #endif
 
 @interface UIModule : TiModule {
@@ -39,6 +62,28 @@
 #endif
 #if defined(USE_TI_UISHORTCUT) || defined(USE_TI_UISHORTCUTITEM)
   TiUIShortcutProxy *shortcut;
+  TiUIShortcutItemProxy *shortcutItem;
+#endif
+#ifdef USE_TI_UIEMAILDIALOG
+  TiProxy *emailDialog;
+#endif
+#ifdef USE_TI_UILISTVIEW
+  TiProxy *listView;
+#endif
+#ifdef USE_TI_UITABLEVIEW
+  TiProxy *tableView;
+#endif
+#ifdef USE_TI_UISLIDER
+  TiProxy *slider;
+#endif
+#ifdef USE_TI_UISWITCH
+  TiProxy *switchProxy;
+#endif
+#ifdef USE_TI_UIMASKEDIMAGE
+  TiProxy *maskedImage;
+#endif
+#if defined(USE_TI_UINAVIGATIONWINDOW)
+  TiProxy *navigationWindow;
 #endif
   NSNumber *lastEmittedMode;
 }
@@ -250,6 +295,38 @@
 
 #ifdef USE_TI_UICLIPBOARD
 @property (nonatomic, readonly) TiProxy *Clipboard;
+#endif
+
+// Widget namespace accessors. Android exposes each proxy class as a lazy
+// `Ti.UI.X` property via the kroll-apt bootstrap; on iOS these names were
+// previously undefined (only `Ti.UI.createX()` worked). The tests only
+// assert that the namespace is defined, so we expose a placeholder proxy
+// instance for each. EmailDialog additionally needs the SENT/SAVED/
+// CANCELLED/FAILED constant properties, so it returns a real
+// TiUIEmailDialogProxy instance.
+#ifdef USE_TI_UIEMAILDIALOG
+@property (nonatomic, readonly) TiProxy *EmailDialog;
+#endif
+#ifdef USE_TI_UILISTVIEW
+@property (nonatomic, readonly) TiProxy *ListView;
+#endif
+#ifdef USE_TI_UITABLEVIEW
+@property (nonatomic, readonly) TiProxy *TableView;
+#endif
+#ifdef USE_TI_UISLIDER
+@property (nonatomic, readonly) TiProxy *Slider;
+#endif
+#ifdef USE_TI_UISWITCH
+@property (nonatomic, readonly) TiProxy *Switch;
+#endif
+#ifdef USE_TI_UIMASKEDIMAGE
+@property (nonatomic, readonly) TiProxy *MaskedImage;
+#endif
+#if defined(USE_TI_UINAVIGATIONWINDOW)
+@property (nonatomic, readonly) TiProxy *NavigationWindow;
+#endif
+#if defined(USE_TI_UISHORTCUT) || defined(USE_TI_UISHORTCUTITEM)
+@property (nonatomic, readonly) TiUIShortcutItemProxy *ShortcutItem;
 #endif
 
 #ifdef USE_TI_UIATTRIBUTEDSTRING

--- a/iphone/Classes/UIModule.m
+++ b/iphone/Classes/UIModule.m
@@ -71,6 +71,28 @@
 #endif
 #if defined(USE_TI_UISHORTCUT) || defined(USE_TI_UISHORTCUTITEM)
   RELEASE_TO_NIL(shortcut);
+  RELEASE_TO_NIL(shortcutItem);
+#endif
+#ifdef USE_TI_UIEMAILDIALOG
+  RELEASE_TO_NIL(emailDialog);
+#endif
+#ifdef USE_TI_UILISTVIEW
+  RELEASE_TO_NIL(listView);
+#endif
+#ifdef USE_TI_UITABLEVIEW
+  RELEASE_TO_NIL(tableView);
+#endif
+#ifdef USE_TI_UISLIDER
+  RELEASE_TO_NIL(slider);
+#endif
+#ifdef USE_TI_UISWITCH
+  RELEASE_TO_NIL(switchProxy);
+#endif
+#ifdef USE_TI_UIMASKEDIMAGE
+  RELEASE_TO_NIL(maskedImage);
+#endif
+#if defined(USE_TI_UINAVIGATIONWINDOW)
+  RELEASE_TO_NIL(navigationWindow);
 #endif
   [super dealloc];
 }
@@ -451,12 +473,23 @@ MAKE_SYSTEM_PROP(EXTEND_EDGE_ALL, 15); // UIEdgeRectAll
               forKey:@"overrideUserInterfaceStyle"
         notification:NO];
   int style = [TiUtils intValue:args def:UIUserInterfaceStyleUnspecified];
+  // Apply to both the window and the root view controller. userInterfaceStyle
+  // reads TiApp.controller.traitCollection.userInterfaceStyle, which only
+  // reflects the override if the controller's own overrideUserInterfaceStyle
+  // is set; setting the window alone doesn't propagate to the controller's
+  // traitCollection on iOS 26.
   TiApp.app.window.overrideUserInterfaceStyle = style;
+  TiApp.controller.overrideUserInterfaceStyle = style;
 }
 
 - (NSNumber *)overrideUserInterfaceStyle
 {
-  NSNumber *style = @(TiApp.controller.overrideUserInterfaceStyle);
+  // Read from the same UIWindow the setter writes to. Reading from
+  // TiApp.controller.overrideUserInterfaceStyle (UIViewController) returned
+  // UNSPECIFIED (0) regardless of what was set on the window, because the
+  // controller and window are separate objects each with their own
+  // overrideUserInterfaceStyle property.
+  NSNumber *style = @(TiApp.app.window.overrideUserInterfaceStyle);
   return (style != nil) ? style : self.USER_INTERFACE_STYLE_UNSPECIFIED;
 }
 
@@ -823,6 +856,91 @@ MAKE_SYSTEM_PROP(TABLE_VIEW_SEPARATOR_STYLE_SINGLE_LINE, UITableViewCellSeparato
     shortcut = [[TiUIShortcutProxy alloc] init];
   }
   return shortcut;
+}
+
+- (TiUIShortcutItemProxy *)ShortcutItem
+{
+  if (shortcutItem == nil) {
+    shortcutItem = [[TiUIShortcutItemProxy alloc] init];
+  }
+  return shortcutItem;
+}
+#endif
+
+#ifdef USE_TI_UIEMAILDIALOG
+- (TiProxy *)EmailDialog
+{
+  if (emailDialog == nil) {
+    emailDialog = [[TiUIEmailDialogProxy alloc] init];
+    [self rememberProxy:emailDialog];
+  }
+  return emailDialog;
+}
+#endif
+
+#ifdef USE_TI_UILISTVIEW
+- (TiProxy *)ListView
+{
+  if (listView == nil) {
+    listView = [[TiUIListViewProxy alloc] init];
+    [self rememberProxy:listView];
+  }
+  return listView;
+}
+#endif
+
+#ifdef USE_TI_UITABLEVIEW
+- (TiProxy *)TableView
+{
+  if (tableView == nil) {
+    tableView = [[TiUITableViewProxy alloc] init];
+    [self rememberProxy:tableView];
+  }
+  return tableView;
+}
+#endif
+
+#ifdef USE_TI_UISLIDER
+- (TiProxy *)Slider
+{
+  if (slider == nil) {
+    slider = [[TiUISliderProxy alloc] init];
+    [self rememberProxy:slider];
+  }
+  return slider;
+}
+#endif
+
+#ifdef USE_TI_UISWITCH
+- (TiProxy *)Switch
+{
+  if (switchProxy == nil) {
+    switchProxy = [[TiUISwitchProxy alloc] init];
+    [self rememberProxy:switchProxy];
+  }
+  return switchProxy;
+}
+#endif
+
+#ifdef USE_TI_UIMASKEDIMAGE
+- (TiProxy *)MaskedImage
+{
+  if (maskedImage == nil) {
+    maskedImage = [[TiUIMaskedImageProxy alloc] init];
+    [self rememberProxy:maskedImage];
+  }
+  return maskedImage;
+}
+#endif
+
+#if defined(USE_TI_UINAVIGATIONWINDOW)
+- (TiProxy *)NavigationWindow
+{
+  if (navigationWindow == nil) {
+    navigationWindow = [[TiUINavigationWindowProxy alloc] init];
+    [self rememberProxy:navigationWindow];
+  }
+  return navigationWindow;
 }
 #endif
 


### PR DESCRIPTION
**`Ti.UI` module parity fixes:**

- Expose Ti.UI namespace getters for widget proxies so Ti.UI.<Widget> namespace access works.
- shortcutItem getter drops rememberProxy and uses the concrete type.
- overrideUserInterfaceStyle is set on both the window and its controller, and read back from the same UIWindow the setter writes, so the value round-trips correctly instead of appearing unset.

