### PR TITLE
fix(ios): window safe-area / home-indicator insets and auto-size layout constraints

### DIFF
--- a/iphone/Classes/Layout/TiLayoutView.m
+++ b/iphone/Classes/Layout/TiLayoutView.m
@@ -793,11 +793,9 @@ DEFINE_EXCEPTIONS
     }
 
     if (IS_AUTOSIZE(width) || (IS_UNDEFINED(width) && IS_AUTOSIZE(_defaultWidth))) {
-      [self addConstraints:TI_CONSTR(TI_STRING(@"H:[self(0@20)]"), viewsDict)]; // should try to be 0 width with a very low priority
       [superview addConstraints:TI_CONSTR(TI_STRING(@"H:[self(<=superview)]"), viewsDict)];
     }
     if (IS_AUTOSIZE(height) || (IS_UNDEFINED(height) && IS_AUTOSIZE(_defaultHeight))) {
-      [self addConstraints:TI_CONSTR(TI_STRING(@"V:[self(0@20)]"), viewsDict)]; // should try to be 0 height with a very low priority
       [superview addConstraints:TI_CONSTR(TI_STRING(@"V:[self(<=superview)]"), viewsDict)];
     }
   }

--- a/iphone/TitaniumKit/TitaniumKit/Sources/Modules/TiUIWindowProxy.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/Modules/TiUIWindowProxy.m
@@ -1118,16 +1118,19 @@
     edgeInsets = [self defaultEdgeInsetsForSafeAreaInset:safeAreaInset];
   }
 
-  [self setValue:@{ @"top" : NUMFLOAT(edgeInsets.top),
-    @"left" : NUMFLOAT(edgeInsets.left),
-    @"bottom" : NUMFLOAT(edgeInsets.bottom),
-    @"right" : NUMFLOAT(edgeInsets.right) }
-          forKey:@"safeAreaPadding"];
-
   BOOL safeAreaInsetsChanged = !UIEdgeInsetsEqualToEdgeInsets(edgeInsets, oldSafeAreaInsets);
   oldSafeAreaInsets = edgeInsets;
 
   if (self.shouldExtendSafeArea) {
+    // Only report the safe-area insets as padding when the window extends
+    // under the safe area. When extendSafeArea is false the content is laid
+    // out within the safe area already, so no additional padding is needed
+    // and safeAreaPadding must stay zero.
+    [self setValue:@{ @"top" : NUMFLOAT(edgeInsets.top),
+      @"left" : NUMFLOAT(edgeInsets.left),
+      @"bottom" : NUMFLOAT(edgeInsets.bottom),
+      @"right" : NUMFLOAT(edgeInsets.right) }
+            forKey:@"safeAreaPadding"];
     return safeAreaInsetsChanged;
   }
 
@@ -1198,6 +1201,18 @@
   }
   edgeInsets.top = safeAreaInset.top;
   edgeInsets.bottom = safeAreaInset.bottom;
+  // The child controller's view safeAreaInsets report a zero bottom inset when
+  // edgesForExtendedLayout excludes the bottom edge (the Titanium default when
+  // "extendEdges" is unset). The home-indicator area is still part of the
+  // screen's safe area, so fall back to the enclosing UINavigationController's
+  // view safeAreaInsets, which extends under the home indicator by default.
+  UINavigationController *navController = [self.tab controller];
+  if (navController != nil && navController.view != nil) {
+    CGFloat navBottom = navController.view.safeAreaInsets.bottom;
+    if (navBottom > edgeInsets.bottom) {
+      edgeInsets.bottom = navBottom;
+    }
+  }
   return edgeInsets;
 }
 


### PR DESCRIPTION
**Window and layout fixes:**

- Report the home-indicator bottom inset for windows inside a NavigationWindow.
- Only set safeAreaPadding when extendSafeArea is true (fixes incorrect insets on windows that do not extend under bars).
- Remove conflicting auto-size height/width constraints in TiLayoutView that produced ambiguous layout.
