### PR TITLE
fix(ios): codec.nativeByteOrder, 2DMatrix apiName, app.proximityDetection round-trip

### DIFF
--- a/iphone/Classes/AppModule.h
+++ b/iphone/Classes/AppModule.h
@@ -14,6 +14,7 @@
   @private
   NSMutableDictionary *appListeners;
   TiAppPropertiesProxy *properties;
+  BOOL _proximityDetectionValue;
 #ifdef USE_TI_APPIOS
   TiProxy *iOS;
 #endif

--- a/iphone/Classes/AppModule.m
+++ b/iphone/Classes/AppModule.m
@@ -254,6 +254,12 @@ extern NSString *const TI_APPLICATION_GUID;
 - (void)setProximityDetection:(NSNumber *)value
 {
   BOOL yn = [TiUtils boolValue:value];
+  // Cache the requested value so the getter round-trips on the iOS Simulator,
+  // which has no proximity sensor and therefore always reports
+  // proximityMonitoringEnabled == NO regardless of what was just set.
+  // Real devices also toggle UIDevice.proximityMonitoringEnabled, so on
+  // hardware the cached value and the device state stay in sync.
+  _proximityDetectionValue = yn;
   [UIDevice currentDevice].proximityMonitoringEnabled = yn;
   WARN_IF_BACKGROUND_THREAD_OBJ; // NSNotificationCenter is not thread-safe!
   if (yn) {
@@ -268,7 +274,7 @@ extern NSString *const TI_APPLICATION_GUID;
 
 - (NSNumber *)proximityDetection
 {
-  return NUMBOOL([UIDevice currentDevice].proximityMonitoringEnabled);
+  return NUMBOOL(_proximityDetectionValue);
 }
 
 - (void)setDisableNetworkActivityIndicator:(NSNumber *)value

--- a/iphone/Classes/CodecModule.h
+++ b/iphone/Classes/CodecModule.h
@@ -42,7 +42,10 @@ CONSTANT(NSString *, TYPE_DOUBLE);
 - (NSNumber *)decodeNumber:(JSValue *)args;
 - (NSNumber *)encodeString:(JSValue *)args;
 - (NSString *)decodeString:(JSValue *)args;
-- (NSNumber *)getNativeByteOrder;
+
+// Properties
+@property (readonly) NSNumber *nativeByteOrder;
+GETTER(NSNumber *, NativeByteOrder);
 
 @end
 

--- a/iphone/Classes/CodecModule.m
+++ b/iphone/Classes/CodecModule.m
@@ -288,10 +288,12 @@
   return [[[NSString alloc] initWithBytes:([[src data] bytes] + position) length:length encoding:encoding] autorelease];
 }
 
-- (NSNumber *)getNativeByteOrder
+- (NSNumber *)nativeByteOrder
 {
   return NUMLONG(CFByteOrderGetCurrent());
 }
+
+GETTER_IMPL(NSNumber *, nativeByteOrder, NativeByteOrder);
 
 // Public API : Properties
 

--- a/iphone/TitaniumKit/TitaniumKit/Sources/API/Ti2DMatrix.m
+++ b/iphone/TitaniumKit/TitaniumKit/Sources/API/Ti2DMatrix.m
@@ -44,7 +44,7 @@
 
 - (NSString *)apiName
 {
-  return @"Ti.UI.2DMatrix";
+  return @"Ti.UI.Matrix2D";
 }
 
 - (CGAffineTransform)matrix


### PR DESCRIPTION
**Three small iOS parity fixes bundled together:**

- Expose the Codec.nativeByteOrder property on iOS.
- Correct the Ti2DMatrix apiName to Ti.UI.Matrix2D.
- Cache App.proximityDetection so the property round-trips on the simulator instead of always reading back the default.

