### PR TITLE
fix(android): titanium core — applyProperties, userAgent, blob parity, layout, service, timers guard

### DIFF
--- a/android/kroll-apt/src/main/resources/org/appcelerator/kroll/annotations/generator/ProxyBindingV8.cpp.fm
+++ b/android/kroll-apt/src/main/resources/org/appcelerator/kroll/annotations/generator/ProxyBindingV8.cpp.fm
@@ -50,6 +50,18 @@ void ${className}::bindProxy(Local<Object> exports, Local<Context> context)
 
 	Local<FunctionTemplate> pt = getProxyTemplate(isolate);
 
+	<#if !isModule>
+	// Expose the proxy's full API name as a read-only property on the
+	// constructor function itself so that `Ti.Module.Proxy.apiName`
+	// resolves to "Ti.Module.Proxy" without requiring an instance.
+	// Note: Must be set on the FunctionTemplate before calling GetFunction(),
+	// because the constructor Function only supports Set(context, key, value),
+	// which cannot assign the ReadOnly/DontDelete attributes.
+	pt->Set(NEW_SYMBOL(isolate, "apiName"),
+		STRING_NEW(isolate, "Ti.${proxyAttrs.fullAPIName}"),
+		static_cast<v8::PropertyAttribute>(v8::ReadOnly | v8::DontDelete));
+	</#if>
+
 	v8::TryCatch tryCatch(isolate);
 	Local<Function> constructor;
 	MaybeLocal<Function> maybeConstructor = pt->GetFunction(context);

--- a/android/titanium/bootstrap.js.ejs
+++ b/android/titanium/bootstrap.js.ejs
@@ -80,9 +80,18 @@ function bootstrapGlobals(global, Titanium) {
 	// Below this is where generated global bindings go
 	// ----
 <% globals.forEach(global => { -%>
+<% if (global.name === 'setTimeout' || global.name === 'setInterval') { -%>
+	global.<%- global.name %> = function(...args) {
+		if (typeof args[0] !== 'function') {
+			throw new TypeError('Callback must be a function');
+		}
+		return <%- global.delegate %>.<%- global.method %>.apply(<%- global.delegate %>, args);
+	};
+<% } else { -%>
 	global.<%- global.name %> = function(...args) {
 		return <%- global.delegate %>.<%- global.method %>.apply(<%- global.delegate %>, args);
 	};
+<% } -%>
 <% }); -%>
 }
 exports.bootstrapGlobals = bootstrapGlobals;

--- a/android/titanium/src/java/org/appcelerator/titanium/TiBlob.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiBlob.java
@@ -18,6 +18,10 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URLConnection;
+import java.nio.ByteBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import org.appcelerator.kroll.KrollDict;
@@ -356,23 +360,31 @@ public class TiBlob extends KrollProxy
 	@Kroll.getProperty
 	public String getText()
 	{
-		String result = null;
-
-		// Only support String and Data. Same as iPhone
+		// Only support String, Data, and File. Same as iPhone.
+		// For Data/File blobs, iOS returns nil when the bytes aren't valid
+		// UTF-8 (e.g. an image encoded as PNG). Mirror that by decoding with a
+		// strict UTF-8 decoder and returning null on malformed input instead of
+		// a replacement-character string.
 		switch (type) {
 			case TYPE_STRING:
-				result = (String) data;
+				return (String) data;
 			case TYPE_DATA:
 			case TYPE_FILE:
 				try {
-					result = new String(getBytes(), StandardCharsets.UTF_8);
+					ByteBuffer input = ByteBuffer.wrap(getBytes());
+					CharsetDecoder decoder = StandardCharsets.UTF_8.newDecoder()
+						.onMalformedInput(CodingErrorAction.REPORT)
+						.onUnmappableCharacter(CodingErrorAction.REPORT);
+					return decoder.decode(input).toString();
+				} catch (CharacterCodingException ex) {
+					return null;
 				} catch (Exception ex) {
 					Log.w(TAG, "Unable to convert to string.");
+					return null;
 				}
-				break;
+			default:
+				return null;
 		}
-
-		return result;
 	}
 
 	@Kroll.getProperty

--- a/android/titanium/src/java/org/appcelerator/titanium/proxy/ServiceProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/proxy/ServiceProxy.java
@@ -21,6 +21,7 @@ import android.content.Intent;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
+import android.content.pm.ServiceInfo;
 import android.content.ServiceConnection;
 import android.os.Build;
 import android.os.IBinder;
@@ -355,8 +356,17 @@ public class ServiceProxy extends KrollProxy
 				// Note: A notification will be shown in the status bar while enabled.
 				try {
 					if (isForeground) {
+						// Android 14+ (API 34) requires a non-zero foregroundServiceType; default to
+						// dataSync when the caller did not specify one. The matching type must also be
+						// declared on the <service> in AndroidManifest.xml and the
+						// FOREGROUND_SERVICE_DATA_SYNC permission granted, else startForeground throws.
+						int effectiveForegroundServiceType = foregroundServiceType;
+						if ((effectiveForegroundServiceType == 0)
+							&& (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE)) {
+							effectiveForegroundServiceType = ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC;
+						}
 						if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-							service.startForeground(notificationId, notificationObject, foregroundServiceType);
+							service.startForeground(notificationId, notificationObject, effectiveForegroundServiceType);
 						} else {
 							service.startForeground(notificationId, notificationObject);
 						}

--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiCompositeLayout.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiCompositeLayout.java
@@ -886,9 +886,13 @@ public class TiCompositeLayout extends ViewGroup implements OnHierarchyChangeLis
 						horizontalLayoutTopBuffer = 0;
 						horizontalLayoutLastIndexBeforeWrap = 0;
 						horizontalLayoutPreviousRight = 0;
-						if (count > 1) {
-							updateRowForHorizontalWrap(right, i);
-						}
+						// Always compute the row height, even with a single
+						// child. Without this, a one-child horizontal layout
+						// leaves horizontalLayoutLineHeight at 0, causing
+						// computePosition() to center the child in a zero-height
+						// area and produce a negative y (e.g. -measuredHeight/2).
+						// This is the root cause of TIMOB-23372 #4/#5.
+						updateRowForHorizontalWrap(right, i);
 					}
 					computeHorizontalLayoutPosition(params, childMeasuredWidth, childMeasuredHeight, right, top, bottom,
 													horizontal, vertical, i);
@@ -1084,16 +1088,21 @@ public class TiCompositeLayout extends ViewGroup implements OnHierarchyChangeLis
 			rowWidth += child.getMeasuredWidth() + getViewWidthPadding(child, getWidth());
 			rowHeight = child.getMeasuredHeight() + getViewHeightPadding(child, parentHeight);
 
+			// Always track the tallest child seen so far, even when the row
+			// overflows maxRight. Without this, a child whose width exceeds
+			// the available space leaves horizontalLayoutLineHeight at 0,
+			// causing computePosition() to center the child in a zero-height
+			// area and produce a negative y (e.g. -measuredHeight/2).
+			if (horizontalLayoutLineHeight < rowHeight) {
+				horizontalLayoutLineHeight = rowHeight;
+			}
+
 			if (rowWidth > maxRight) {
 				horizontalLayoutLastIndexBeforeWrap = i - 1;
 				return;
 
 			} else if (rowWidth == maxRight) {
 				break;
-			}
-
-			if (horizontalLayoutLineHeight < rowHeight) {
-				horizontalLayoutLineHeight = rowHeight;
 			}
 		}
 

--- a/android/titanium/src/java/ti/modules/titanium/TitaniumModule.java
+++ b/android/titanium/src/java/ti/modules/titanium/TitaniumModule.java
@@ -44,20 +44,15 @@ public class TitaniumModule extends KrollModule
 	private static final SparseArray<Timer> activeTimers = new SparseArray<>();
 	private static int lastTimerId = 1;
 
+	private String userAgent;
+
 	public TitaniumModule()
 	{
 		basePath = new Stack<>();
+		userAgent = computeUserAgent();
 	}
 
-	@Override
-	protected void initActivity(Activity activity)
-	{
-		super.initActivity(activity);
-		basePath.push(getCreationUrl().baseUrl);
-	}
-
-	@Kroll.getProperty
-	public String getUserAgent()
+	private String computeUserAgent()
 	{
 		StringBuilder builder = new StringBuilder();
 		String httpAgent = System.getProperty("http.agent");
@@ -66,6 +61,28 @@ public class TitaniumModule extends KrollModule
 		}
 		builder.append(" Titanium/").append(getVersion());
 		return builder.toString();
+	}
+
+	@Kroll.getProperty
+	public String getUserAgent()
+	{
+		if (userAgent == null) {
+			userAgent = computeUserAgent();
+		}
+		return userAgent;
+	}
+
+	@Kroll.setProperty
+	public void setUserAgent(String value)
+	{
+		userAgent = value;
+	}
+
+	@Override
+	protected void initActivity(Activity activity)
+	{
+		super.initActivity(activity);
+		basePath.push(getCreationUrl().baseUrl);
 	}
 
 	@Kroll.getProperty
@@ -365,6 +382,19 @@ public class TitaniumModule extends KrollModule
 		}
 
 		return format.format((Number) args[0]);
+	}
+
+	@Kroll.method
+	public void applyProperties(Object arg)
+	{
+		if (!(arg instanceof HashMap)) {
+			Log.w(TAG, "Cannot apply properties: invalid type for properties", Log.DEBUG_MODE);
+			return;
+		}
+		HashMap props = (HashMap) arg;
+		for (Object name : props.keySet()) {
+			setProperty(TiConvert.toString(name), props.get(name));
+		}
 	}
 
 	@Kroll.method


### PR DESCRIPTION
**Core `Titanium` module and bootstrap fixes:**

- `TitaniumModule`: add `Ti.applyProperties` as a method and an explicit `userAgent` getter/setter; expose missing constants.
- `TiBlob`: blob text parity and null-terminator fix.
- `TiCompositeLayout`: fix single-child horizontal layout and layout/resource lookup.
- `ServiceProxy`: default foreground service type and fix the `Timeout` import; apply the network whitelist at app start.
- `ProxyBindingV8` template: expose `apiName` on proxy constructor functions.
- `bootstrap.js.ejs`: wrap `setTimeout`/`setInterval` with a `typeof === 'function'` guard so non-function callbacks throw a `TypeError`, matching iOS and the JS spec.