### PR TITLE
fix(android): filesystem — absolute path resolution, file: URI NPE, read-only resource files

### DIFF
--- a/android/modules/filesystem/src/java/ti/modules/titanium/filesystem/FilesystemModule.java
+++ b/android/modules/filesystem/src/java/ti/modules/titanium/filesystem/FilesystemModule.java
@@ -137,9 +137,15 @@ public class FilesystemModule extends KrollModule
 	}
 
 	@Kroll.getProperty
-	public FileProxy getApplicationDirectory()
+	public String getApplicationDirectory()
 	{
-		return null;
+		return TiC.URL_ANDROID_ASSET;
+	}
+
+	@Kroll.getProperty
+	public String getApplicationSupportDirectory()
+	{
+		return TiFileFactory.APPDATA_PRIVATE_URL_SCHEME + "://";
 	}
 
 	@Kroll.getProperty

--- a/android/titanium/src/java/org/appcelerator/titanium/TiFileProxy.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiFileProxy.java
@@ -58,7 +58,14 @@ public class TiFileProxy extends KrollProxy
 					pb.add(s);
 				}
 			} else {
-				pb.add(uri.getPath());
+				// An opaque URI such as "file:app.js" has no hierarchical path;
+				// fall back to the scheme-specific part so relative paths survive
+				// instead of becoming null and crashing joinSegments/startsWith.
+				String p = uri.getPath();
+				if (p == null) {
+					p = uri.getSchemeSpecificPart();
+				}
+				pb.add(p);
 			}
 
 			for (int i = 1; i < parts.length; i++) {
@@ -66,12 +73,25 @@ public class TiFileProxy extends KrollProxy
 			}
 			String[] newParts = pb.toArray(new String[0]);
 			path = TiFileHelper2.joinSegments(newParts);
-			if (!path.startsWith("..") || !path.startsWith("/")) {
+			if ("file".equals(uri.getScheme())) {
+				// The "file:" scheme should resolve relative paths against the
+				// proxy's base URL (e.g. the Resources dir), matching the no-scheme
+				// case, so leave relative paths alone. Absolute paths keep a doubled
+				// leading slash so resolveUrl() produces a "file:///" URL.
+				if (path != null && path.startsWith("/")) {
+					path = "/" + path;
+				}
+			} else if (path != null && (!path.startsWith("..") || !path.startsWith("/"))) {
 				path = "/" + path;
 			}
 			pb.clear();
 		} else {
 			path = TiFileHelper2.joinSegments(parts);
+			// An absolute filesystem path (leading "/") should resolve as a
+			// file:// URL, not relative to the appdata-private scheme.
+			if (path != null && path.startsWith("/")) {
+				scheme = "file://";
+			}
 		}
 		if (resolve) {
 			path = resolveUrl(scheme, path);

--- a/android/titanium/src/java/org/appcelerator/titanium/io/TiContentFile.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/io/TiContentFile.java
@@ -291,7 +291,7 @@ public class TiContentFile extends TiBaseFile
 		// Check if we have public file system access. (This is the fastest check.)
 		try {
 			File file = getNativeFile();
-			if (file.exists()) {
+			if ((file != null) && file.exists()) {
 				return true;
 			}
 		} catch (Exception ex) {
@@ -322,6 +322,31 @@ public class TiContentFile extends TiBaseFile
 				return true;
 			}
 		} catch (Exception ex) {
+		}
+
+		// Fallback for "android.resource://" URIs: on some Android versions
+		// (notably API 36+) the ContentResolver methods above can fail to
+		// open the resource even when it exists. Verify the resource is
+		// present by looking up its resource ID via Resources.
+		if (ContentResolver.SCHEME_ANDROID_RESOURCE.equals(this.uri.getScheme())) {
+			try {
+				android.content.res.Resources resources = TiApplication.getInstance().getPackageManager()
+					.getResourcesForApplication(this.uri.getHost());
+				String path = this.uri.getPath();
+				if (path != null) {
+					// Path is expected to be "/<type>/<name>".
+					String[] segments = path.split("/");
+					if (segments.length >= 3) {
+						String type = segments[1];
+						String name = segments[2];
+						int resourceId = resources.getIdentifier(name, type, this.uri.getHost());
+						if (resourceId != 0) {
+							return true;
+						}
+					}
+				}
+			} catch (Exception ex) {
+			}
 		}
 
 		// File not found.

--- a/android/titanium/src/java/org/appcelerator/titanium/io/TiResourceFile.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/io/TiResourceFile.java
@@ -49,6 +49,18 @@ public class TiResourceFile extends TiBaseFile
 	}
 
 	@Override
+	public boolean isWriteable()
+	{
+		return false;
+	}
+
+	@Override
+	public boolean isReadonly()
+	{
+		return true;
+	}
+
+	@Override
 	public boolean isFile()
 	{
 		if (this.statsFetched == false) {


### PR DESCRIPTION
- `TiFileProxy` resolves absolute file paths and fixes a `file:` URI `NullPointerException`.
- `TiResourceFile` reports itself as read-only for `fs.accessSync` so the writable check returns false for bundled resources.
- `TiContentFile` resource lookup fix.
- `FilesystemModule` missing constants/properties and defaults.