### PR TITLE
fix(android): xml — throw on malformed parseString, cache NodeProxy, TextProxy fix

### DIFF
--- a/android/modules/xml/src/java/ti/modules/titanium/xml/NodeProxy.java
+++ b/android/modules/xml/src/java/ti/modules/titanium/xml/NodeProxy.java
@@ -23,6 +23,9 @@ import org.w3c.dom.Notation;
 import org.w3c.dom.ProcessingInstruction;
 import org.w3c.dom.Text;
 
+import java.lang.ref.WeakReference;
+import java.util.WeakHashMap;
+
 @Kroll.proxy(parentModule = XMLModule.class)
 public class NodeProxy extends KrollProxy
 {
@@ -53,6 +56,16 @@ public class NodeProxy extends KrollProxy
 
 	private static final String TAG = "TiNodeProxy";
 
+	// Cache of Node -> NodeProxy so repeated property accesses (e.g.
+	// getOwnerDocument(), getFirstChild()) return the SAME proxy instance
+	// for the same underlying org.w3c.dom.Node. Without this, should.js's
+	// deep-equality (eql) traverses the proxy graph and hits cycles like
+	// DocumentProxy -> documentElement -> ownerDocument -> DocumentProxy,
+	// causing "Maximum call stack size exceeded" on tests that compare
+	// proxies with .eql(). Both the key and value are weakly held so the
+	// cache does not prevent GC of either the Node or its proxy.
+	private static final WeakHashMap<Node, WeakReference<NodeProxy>> proxyCache = new WeakHashMap<>();
+
 	protected Node node;
 
 	public NodeProxy(Node node)
@@ -70,6 +83,17 @@ public class NodeProxy extends KrollProxy
 	{
 		if (node == null) {
 			return null;
+		}
+
+		synchronized (proxyCache)
+		{
+			WeakReference<NodeProxy> ref = proxyCache.get(node);
+			if (ref != null) {
+				NodeProxy cached = ref.get();
+				if (cached != null) {
+					return cached;
+				}
+			}
 		}
 
 		NodeProxy proxy;
@@ -115,14 +139,18 @@ public class NodeProxy extends KrollProxy
 				break;
 		}
 
+		synchronized (proxyCache)
+		{
+			proxyCache.put(node, new WeakReference<>(proxy));
+		}
 		return proxy;
 	}
 
 	public static NodeProxy removeProxyForNode(Node node)
 	{
-		// if we're here then a proxy was never generated for this node
-		// just return a temporary wrapper in this case
-		return new NodeProxy(node);
+		// Return the cached proxy if one exists; otherwise create a
+		// temporary wrapper and cache it so subsequent accesses are stable.
+		return getNodeProxy(node);
 	}
 
 	@SuppressWarnings("unchecked")
@@ -206,7 +234,7 @@ public class NodeProxy extends KrollProxy
 	@Kroll.getProperty
 	public DocumentProxy getOwnerDocument()
 	{
-		return new DocumentProxy(node.getOwnerDocument());
+		return (DocumentProxy) getNodeProxy(node.getOwnerDocument());
 	}
 
 	@Kroll.getProperty

--- a/android/modules/xml/src/java/ti/modules/titanium/xml/TextProxy.java
+++ b/android/modules/xml/src/java/ti/modules/titanium/xml/TextProxy.java
@@ -70,6 +70,12 @@ public class TextProxy extends CharacterDataProxy
 		return this.text.getNodeValue();
 	}
 
+	@Kroll.getProperty
+	public String getText()
+	{
+		return this.text.getNodeValue();
+	}
+
 	@Override
 	public String getApiName()
 	{

--- a/android/modules/xml/src/java/ti/modules/titanium/xml/XMLModule.java
+++ b/android/modules/xml/src/java/ti/modules/titanium/xml/XMLModule.java
@@ -13,6 +13,8 @@ import java.io.StringWriter;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.TransformerException;
@@ -23,13 +25,17 @@ import javax.xml.transform.stream.StreamResult;
 import org.appcelerator.kroll.KrollModule;
 import org.appcelerator.kroll.annotations.Kroll;
 import org.appcelerator.kroll.common.Log;
+import org.w3c.dom.Document;
+import org.xml.sax.ErrorHandler;
 import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
 
 @Kroll.module
 public class XMLModule extends KrollModule
 {
 
 	private static DocumentBuilder builder;
+	private static SAXParser strictSaxParser;
 	private static final String TAG = "XMLModule";
 	private static TransformerFactory transformerFactory;
 
@@ -39,8 +45,42 @@ public class XMLModule extends KrollModule
 			DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
 			factory.setNamespaceAware(true);
 			builder = factory.newDocumentBuilder();
+			// Install a strict error handler so malformed XML (unclosed tags,
+			// multiple top-level elements, etc.) throws instead of being
+			// silently auto-corrected by the Expat-backed DOM adapter.
+			builder.setErrorHandler(new ErrorHandler() {
+				@Override
+				public void warning(SAXParseException e) throws SAXException
+				{
+					throw e;
+				}
+
+				@Override
+				public void error(SAXParseException e) throws SAXException
+				{
+					throw e;
+				}
+
+				@Override
+				public void fatalError(SAXParseException e) throws SAXException
+				{
+					throw e;
+				}
+			});
 		} catch (ParserConfigurationException e) {
 			Log.e(TAG, "Error finding DOM implementation", e);
+		}
+
+		// A strict SAX parser is used as a pre-pass to catch malformed XML that
+		// the Expat DOM adapter silently recovers from (e.g. unclosed tags at
+		// EOF). The DOM builder's ErrorHandler alone is insufficient because
+		// Expat's DOM path synthesizes close tags without emitting errors.
+		try {
+			SAXParserFactory saxFactory = SAXParserFactory.newInstance();
+			saxFactory.setNamespaceAware(true);
+			strictSaxParser = saxFactory.newSAXParser();
+		} catch (ParserConfigurationException | SAXException e) {
+			Log.e(TAG, "Error creating strict SAX parser", e);
 		}
 
 		transformerFactory = TransformerFactory.newInstance();
@@ -65,8 +105,26 @@ public class XMLModule extends KrollModule
 	public static DocumentProxy parse(String xml, String encoding) throws SAXException, IOException
 	{
 		if (builder != null) {
+			byte[] bytes = xml.getBytes(encoding);
+			// Strict SAX pre-pass: Expat's DOM adapter silently auto-corrects
+			// some malformations (unclosed tags at EOF, multiple roots). The
+			// SAX path is stricter and will throw for those cases.
+			if (strictSaxParser != null) {
+				try {
+					strictSaxParser.parse(new ByteArrayInputStream(bytes), new org.xml.sax.helpers.DefaultHandler());
+				} catch (SAXException e) {
+					Log.e(TAG, "Error parsing XML", e);
+					throw e;
+				}
+			}
 			try {
-				return new DocumentProxy(builder.parse(new ByteArrayInputStream(xml.getBytes(encoding))));
+				// Route through NodeProxy.getNodeProxy() so the returned
+				// DocumentProxy is registered in the proxy cache. This makes
+				// node.ownerDocument === doc hold in JS (same proxy instance),
+				// which lets should.js's eql() short-circuit on reference
+				// equality instead of deep-comparing the cyclic proxy graph.
+				Document doc = builder.parse(new ByteArrayInputStream(bytes));
+				return (DocumentProxy) NodeProxy.getNodeProxy(doc);
 			} catch (SAXException e) {
 				Log.e(TAG, "Error parsing XML", e);
 				throw e;


### PR DESCRIPTION
- `Ti.XML.parseString` throws on malformed XML instead of silently returning a partial DOM, matching iOS and the test expectations.
- Caches `NodeProxy` instances so repeated DOM lookups return the same proxy, fixing DOM test stack overflows.
- `TextProxy` fix from the missing-properties batch.