### PR TITLE
fix(android): v8 memory cleanup

### DIFF
--- a/android/runtime/v8/src/native/TypeConverter.cpp
+++ b/android/runtime/v8/src/native/TypeConverter.cpp
@@ -468,6 +468,7 @@ Local<Array> TypeConverter::javaArrayToJsArray(Isolate* isolate, JNIEnv *env, jb
 	for (int i = 0; i < arrayLength; i++) {
 		jsArray->Set(context, (uint32_t) i, Boolean::New(isolate, arrayElements[i]));
 	}
+	env->ReleaseBooleanArrayElements(javaBooleanArray, arrayElements, JNI_ABORT);
 
 	return jsArray;
 }
@@ -508,6 +509,7 @@ jshortArray TypeConverter::jsArrayToJavaShortArray(Isolate* isolate, JNIEnv *env
 		}
 	}
 	env->SetShortArrayRegion(javaShortArray, 0, arrayLength, shortBuffer);
+	delete[] shortBuffer;
 
 	return javaShortArray;
 }
@@ -558,6 +560,7 @@ jintArray TypeConverter::jsArrayToJavaIntArray(Isolate* isolate, JNIEnv *env, Lo
 		}
 	}
 	env->SetIntArrayRegion(javaIntArray, 0, arrayLength, intBuffer);
+	delete[] intBuffer;
 
 	return javaIntArray;
 }
@@ -581,6 +584,7 @@ Local<Array> TypeConverter::javaArrayToJsArray(Isolate* isolate, JNIEnv *env, ji
 	for (int i = 0; i < arrayLength; i++) {
 		jsArray->Set(context, (uint32_t) i, Integer::New(isolate, arrayElements[i]));
 	}
+	env->ReleaseIntArrayElements(javaIntArray, arrayElements, JNI_ABORT);
 
 	return jsArray;
 }
@@ -643,6 +647,7 @@ jlongArray TypeConverter::jsArrayToJavaLongArray(Isolate* isolate, JNIEnv *env, 
 		}
 	}
 	env->SetLongArrayRegion(javaLongArray, 0, arrayLength, longBuffer);
+	delete[] longBuffer;
 
 	return javaLongArray;
 }
@@ -683,6 +688,7 @@ jfloatArray TypeConverter::jsArrayToJavaFloatArray(Isolate* isolate, JNIEnv *env
 		}
 	}
 	env->SetFloatArrayRegion(javaFloatArray, 0, arrayLength, floatBuffer);
+	delete[] floatBuffer;
 
 	return javaFloatArray;
 }
@@ -743,6 +749,7 @@ jdoubleArray TypeConverter::jsArrayToJavaDoubleArray(Isolate* isolate, JNIEnv *e
 		}
 	}
 	env->SetDoubleArrayRegion(javaDoubleArray, 0, arrayLength, doubleBuffer);
+	delete[] doubleBuffer;
 
 	return javaDoubleArray;
 }
@@ -1218,6 +1225,7 @@ Local<Array> TypeConverter::javaLongArrayToJsNumberArray(Isolate* isolate, JNIEn
 	for (int i = 0; i < arrayLength; i++) {
 		jsArray->Set(context, (uint32_t) i, Number::New(isolate, arrayElements[i]));
 	}
+	env->ReleaseLongArrayElements(javaLongArray, arrayElements, JNI_ABORT);
 	return jsArray;
 }
 

--- a/android/runtime/v8/src/native/V8Util.cpp
+++ b/android/runtime/v8/src/native/V8Util.cpp
@@ -66,7 +66,9 @@ Local<Value> V8Util::newInstanceFromConstructorTemplate(Persistent<FunctionTempl
 	EscapableHandleScope scope(isolate);
 
 	const int argc = args.Length();
-	Local<Value>* argv = new Local<Value>[argc];
+	const int stackLimit = 8;
+	Local<Value> stackBuf[stackLimit];
+	Local<Value>* argv = (argc <= stackLimit) ? stackBuf : new Local<Value>[argc];
 	for (int i = 0; i < argc; ++i) {
 		argv[i] = args[i];
 	}
@@ -79,12 +81,13 @@ Local<Value> V8Util::newInstanceFromConstructorTemplate(Persistent<FunctionTempl
 	Local<Function> function;
 	MaybeLocal<Function> maybeFunction = t.Get(isolate)->GetFunction(context);
 	if (!maybeFunction.ToLocal(&function)) {
+		if (argv != stackBuf) delete[] argv;
 		V8Util::fatalException(isolate, tryCatch);
 		return scope.Escape(Undefined(isolate));
 	}
 
 	MaybeLocal<Object> maybeInstance = function->NewInstance(context, argc, argv);
-	delete[] argv;
+	if (argv != stackBuf) delete[] argv;
 	if (!maybeInstance.ToLocal(&instance)) {
 		V8Util::fatalException(isolate, tryCatch);
 		return scope.Escape(Undefined(isolate));


### PR DESCRIPTION
Fixes several memory leaks in the Android V8 bridge and reduces unnecessary heap allocations.

### Changes

**`TypeConverter.cpp` — JNI array memory leaks:**
- Added `Release*ArrayElements(..., JNI_ABORT)` after `javaArrayToJsArray` conversions (boolean, int, long) to release pinned JNI array memory.
- Added `delete[]` for temporary C++ buffers (`shortBuffer`, `intBuffer`, `longBuffer`, `floatBuffer`, `doubleBuffer`) in `jsArrayToJava*Array` methods that were heap-allocated but never freed.

**`V8Util.cpp` — Heap allocation reduction:**
- `newInstanceFromConstructorTemplate` now uses a stack-allocated buffer for ≤8 args (the common case), falling back to `new` only for larger argument counts. Reduces per-call heap churn for constructor invocations.

### Impact

These leaks accumulate over time during heavy V8↔JNI interop (e.g., large array passes, frequent object construction). The JNI release calls prevent pinned memory from growing unbounded, and the buffer deletes prevent leaked native allocations.

### Results

I was running some apps creating massiv arrays in a loop, listviews and views. Dumping meminfo and comparing it. I didn't see that much of a improvement but most of the time something like this:

> Native Heap: The delete[] buffer fixes saved 1.2 MB of native memory that was previously leaked. This scales linearly with array conversions — in a long-running app doing repeated jsArrayToJava*Array calls, this will improve the memory. The JNI_ABORT releases and stack argv are too small to measure individually but are correct and cost nothing. These are safe, worthwhile fixes for long-running apps.

