### PR TITLE
feat(android): async backgroundImage, WebView.setUrl and TiSound

### DIFF
--- a/android/modules/media/src/java/ti/modules/titanium/media/TiSound.java
+++ b/android/modules/media/src/java/ti/modules/titanium/media/TiSound.java
@@ -174,19 +174,11 @@ public class TiSound implements MediaPlayer.OnCompletionListener, MediaPlayer.On
 			mp.setOnInfoListener(this);
 			mp.setOnBufferingUpdateListener(this);
 
-			if (remote) { // try async
-				mp.setOnPreparedListener(this);
-				mp.prepareAsync();
-				playPending = true;
-			} else {
-				mp.prepare();
-				setState(STATE_INITIALIZED);
-				setVolume(volume);
-				if (proxy.hasProperty(TiC.PROPERTY_TIME)) {
-					setTime(TiConvert.toInt(proxy.getProperty(TiC.PROPERTY_TIME)));
-				}
-				startPlaying();
-			}
+			// Prepare asynchronously for both local and remote sources so that
+			// buffering/decoding never blocks the calling (main) thread.
+			mp.setOnPreparedListener(this);
+			mp.prepareAsync();
+			playPending = true;
 
 		} catch (Throwable t) {
 			Log.w(TAG, "Issue while initializing : ", t);
@@ -254,29 +246,25 @@ public class TiSound implements MediaPlayer.OnCompletionListener, MediaPlayer.On
 
 	private void prepareAndPlay() throws IllegalStateException, IOException
 	{
+		// Prepare asynchronously for both local and remote sources so that
+		// buffering/decoding never blocks the calling (main) thread.
 		prepareRequired = false;
-		if (remote) {
-			playPending = true;
-			mp.setOnPreparedListener(new MediaPlayer.OnPreparedListener() {
-				@Override
-				public void onPrepared(MediaPlayer mp)
-				{
-					mp.setOnPreparedListener(null);
-					mp.seekTo(0);
-					playPending = false;
-					if (!stopPending && !pausePending) {
-						startPlaying();
-					}
-					pausePending = false;
-					stopPending = false;
+		playPending = true;
+		mp.setOnPreparedListener(new MediaPlayer.OnPreparedListener() {
+			@Override
+			public void onPrepared(MediaPlayer mp)
+			{
+				mp.setOnPreparedListener(null);
+				mp.seekTo(0);
+				playPending = false;
+				if (!stopPending && !pausePending) {
+					startPlaying();
 				}
-			});
-			mp.prepareAsync();
-		} else {
-			mp.prepare();
-			mp.seekTo(0);
-			startPlaying();
-		}
+				pausePending = false;
+				stopPending = false;
+			}
+		});
+		mp.prepareAsync();
 	}
 
 	public void reset()

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/UIModule.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/UIModule.java
@@ -21,6 +21,7 @@ import org.appcelerator.titanium.proxy.ColorProxy;
 import org.appcelerator.titanium.util.TiAnimationCurve;
 import org.appcelerator.titanium.util.TiColorHelper;
 import org.appcelerator.titanium.util.TiDeviceOrientation;
+import org.appcelerator.titanium.util.TiLoadImageManager;
 import org.appcelerator.titanium.util.TiUIHelper;
 
 import android.app.Activity;
@@ -55,6 +56,7 @@ public class UIModule extends KrollModule implements TiApplication.Configuration
 {
 	private static final String TAG = "TiUIModule";
 	private int lastEmittedStyle;
+	private int backgroundImageLoadToken;
 
 	@Kroll.constant
 	public static final int RETURN_KEY_TYPE_ACTION = 0;
@@ -568,9 +570,11 @@ public class UIModule extends KrollModule implements TiApplication.Configuration
 	{
 		TiRootActivity root = TiApplication.getInstance().getRootActivity();
 		if (root != null) {
-			Drawable imageDrawable = null;
+			// Invalidates any still-loading result from a previous call.
+			final int token = ++this.backgroundImageLoadToken;
 
 			if (image instanceof Number) {
+				Drawable imageDrawable = null;
 				try {
 					imageDrawable = TiUIHelper.getResourceDrawable((Integer) image);
 				} catch (Resources.NotFoundException e) {
@@ -579,11 +583,23 @@ public class UIModule extends KrollModule implements TiApplication.Configuration
 						+ "An integer id was provided but no such drawable resource exists.";
 					Log.w(TAG, warningMessage);
 				}
-			} else {
-				imageDrawable = TiUIHelper.getResourceDrawable(image);
+				root.setBackgroundImage(imageDrawable);
+				return;
 			}
 
-			root.setBackgroundImage(imageDrawable);
+			// Load the image off the main thread since it may involve file I/O and bitmap decoding.
+			TiLoadImageManager.getInstance().load(
+				() -> TiUIHelper.getResourceDrawable(image),
+				(Drawable imageDrawable) -> {
+					// Drop the result if the property changed again while loading.
+					if (token != this.backgroundImageLoadToken) {
+						return;
+					}
+					TiRootActivity rootActivity = TiApplication.getInstance().getRootActivity();
+					if (rootActivity != null) {
+						rootActivity.setBackgroundImage(imageDrawable);
+					}
+				});
 		}
 	}
 

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/android/CollapseToolbarProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/android/CollapseToolbarProxy.java
@@ -37,7 +37,7 @@ public class CollapseToolbarProxy extends TiViewProxy
 	@Kroll.setProperty
 	public void setImage(Object obj)
 	{
-		collapseToolbar.setImage(TiDrawableReference.fromObject(this, obj).getBitmap(false));
+		collapseToolbar.setImageSource(TiDrawableReference.fromObject(this, obj));
 	}
 
 	@Kroll.setProperty

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiToolbar.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiToolbar.java
@@ -16,8 +16,10 @@ import org.appcelerator.titanium.TiBaseActivity;
 import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.TiDimension;
 import org.appcelerator.titanium.proxy.TiViewProxy;
+import android.graphics.drawable.Drawable;
 import org.appcelerator.titanium.util.TiColorHelper;
 import org.appcelerator.titanium.util.TiConvert;
+import org.appcelerator.titanium.util.TiLoadImageManager;
 import org.appcelerator.titanium.view.TiCompositeLayout;
 import org.appcelerator.titanium.view.TiDrawableReference;
 import org.appcelerator.titanium.view.TiToolbarStyleHandler;
@@ -238,8 +240,20 @@ public class TiToolbar extends TiUIView
 	public void setLogo(Object object)
 	{
 		logo = object;
-		TiDrawableReference tiDrawableReference = TiDrawableReference.fromObject(proxy, object);
-		((MaterialToolbar) getNativeView()).setLogo(tiDrawableReference.getDrawable());
+		if (object == null) {
+			((MaterialToolbar) getNativeView()).setLogo(null);
+			return;
+		}
+		// Load the image off the main thread since it may involve file I/O and bitmap decoding.
+		TiLoadImageManager.getInstance().load(
+			() -> TiDrawableReference.fromObject(proxy, object).getDrawable(),
+			(Drawable drawable) -> {
+				// Drop the result if the "logo" property changed again while loading.
+				MaterialToolbar toolbarView = (MaterialToolbar) getNativeView();
+				if ((toolbarView != null) && (this.logo == object)) {
+					toolbarView.setLogo(drawable);
+				}
+			});
 	}
 
 	/**
@@ -261,8 +275,15 @@ public class TiToolbar extends TiUIView
 		if (object instanceof Number) {
 			this.toolbar.setNavigationIcon(TiConvert.toInt(object));
 		} else if (object != null) {
-			TiDrawableReference tiDrawableReference = TiDrawableReference.fromObject(proxy, object);
-			this.toolbar.setNavigationIcon(tiDrawableReference.getDrawable());
+			// Load the image off the main thread since it may involve file I/O and bitmap decoding.
+			TiLoadImageManager.getInstance().load(
+				() -> TiDrawableReference.fromObject(proxy, object).getDrawable(),
+				(Drawable drawable) -> {
+					// Drop the result if the "navigationIcon" property changed again while loading.
+					if (this.navigationIcon == object) {
+						this.toolbar.setNavigationIcon(drawable);
+					}
+				});
 		} else {
 			this.toolbar.setNavigationIcon(null);
 		}
@@ -285,8 +306,15 @@ public class TiToolbar extends TiUIView
 	{
 		this.overflowMenuIcon = object;
 		if (object != null) {
-			TiDrawableReference tiDrawableReference = TiDrawableReference.fromObject(proxy, object);
-			this.toolbar.setOverflowIcon(tiDrawableReference.getDrawable());
+			// Load the image off the main thread since it may involve file I/O and bitmap decoding.
+			TiLoadImageManager.getInstance().load(
+				() -> TiDrawableReference.fromObject(proxy, object).getDrawable(),
+				(Drawable drawable) -> {
+					// Drop the result if the "overflowIcon" property changed again while loading.
+					if (this.overflowMenuIcon == object) {
+						this.toolbar.setOverflowIcon(drawable);
+					}
+				});
 		} else {
 			this.toolbar.setOverflowIcon(null);
 		}

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIButton.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIButton.java
@@ -29,6 +29,7 @@ import org.appcelerator.titanium.TiApplication;
 import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.proxy.TiViewProxy;
 import org.appcelerator.titanium.util.TiConvert;
+import org.appcelerator.titanium.util.TiLoadImageManager;
 import org.appcelerator.titanium.util.TiUIHelper;
 import org.appcelerator.titanium.view.TiUIView;
 
@@ -43,6 +44,7 @@ public class TiUIButton extends TiUIView
 	private static final float DEFAULT_SHADOW_RADIUS = 1f;
 
 	private int defaultColor;
+	private int imageLoadToken;
 	private ColorStateList defaultRippleColor;
 	private float shadowRadius = DEFAULT_SHADOW_RADIUS;
 	private float shadowX = 0f;
@@ -320,11 +322,28 @@ public class TiUIButton extends TiUIView
 			return;
 		}
 
-		// Fetch the image.
-		Drawable drawable = null;
-		Object imageObject = this.proxy.getProperty(TiC.PROPERTY_IMAGE);
-		if (imageObject != null) {
-			drawable = TiUIHelper.getResourceDrawable(imageObject);
+		// Fetch the image off the main thread since it may involve file I/O and bitmap decoding.
+		final int token = ++this.imageLoadToken;
+		final Object imageObject = this.proxy.getProperty(TiC.PROPERTY_IMAGE);
+		if (imageObject == null) {
+			applyButtonImage(null);
+			return;
+		}
+		TiLoadImageManager.getInstance().load(
+			() -> TiUIHelper.getResourceDrawable(imageObject),
+			(Drawable drawable) -> {
+				// Drop the result if the "image" property changed or proxy was released while loading.
+				if ((token == this.imageLoadToken) && (this.proxy != null)) {
+					applyButtonImage(drawable);
+				}
+			});
+	}
+
+	private void applyButtonImage(Drawable drawable)
+	{
+		AppCompatButton button = (AppCompatButton) getNativeView();
+		if (button == null) {
+			return;
 		}
 
 		// Update button's image/icon.

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUICollapseToolbar.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUICollapseToolbar.java
@@ -29,6 +29,7 @@ import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.TiDimension;
 import org.appcelerator.titanium.proxy.TiViewProxy;
 import org.appcelerator.titanium.util.TiConvert;
+import org.appcelerator.titanium.util.TiLoadImageManager;
 import org.appcelerator.titanium.util.TiRHelper;
 import org.appcelerator.titanium.view.TiCompositeLayout;
 import org.appcelerator.titanium.view.TiDrawableReference;
@@ -51,6 +52,7 @@ public class TiUICollapseToolbar extends TiUIView
 	KrollFunction homeIconFunction = null;
 	boolean homeAsUp = false;
 	TiViewProxy localContentView = null;
+	private int imageLoadToken;
 
 	public TiUICollapseToolbar(TiViewProxy proxy)
 	{
@@ -180,6 +182,26 @@ public class TiUICollapseToolbar extends TiUIView
 		homeAsUp = value;
 	}
 
+	/**
+	 * Decodes the given image reference off the main thread and shows it when ready.
+	 */
+	public void setImageSource(TiDrawableReference source)
+	{
+		final int token = ++this.imageLoadToken;
+		if (source == null) {
+			setImage(null);
+			return;
+		}
+		TiLoadImageManager.getInstance().load(
+			() -> source.getBitmap(false),
+			(Bitmap bitmap) -> {
+				// Drop the result if the "image" property changed again while decoding.
+				if (token == this.imageLoadToken) {
+					setImage(bitmap);
+				}
+			});
+	}
+
 	public void setImage(Bitmap bitmap)
 	{
 		if (bitmap == null) {
@@ -231,9 +253,7 @@ public class TiUICollapseToolbar extends TiUIView
 			setBarColor(TiConvert.toColor(d.getString(TiC.PROPERTY_BAR_COLOR), activity));
 		}
 		if (d.containsKey(TiC.PROPERTY_IMAGE)) {
-			Bitmap bmp = TiDrawableReference.fromObject(activity,
-				d.get(TiC.PROPERTY_IMAGE)).getBitmap(false);
-			setImage(bmp);
+			setImageSource(TiDrawableReference.fromObject(activity, d.get(TiC.PROPERTY_IMAGE)));
 		}
 		if (d.containsKey(TiC.PROPERTY_TITLE)) {
 			setTitle(d.getString(TiC.PROPERTY_TITLE));

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIFloatingActionButton.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIFloatingActionButton.java
@@ -17,13 +17,16 @@ import org.appcelerator.titanium.TiApplication;
 import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.TiDimension;
 import org.appcelerator.titanium.proxy.TiViewProxy;
+import android.graphics.drawable.Drawable;
 import org.appcelerator.titanium.util.TiConvert;
+import org.appcelerator.titanium.util.TiLoadImageManager;
 import org.appcelerator.titanium.view.TiDrawableReference;
 import org.appcelerator.titanium.view.TiUIView;
 
 public class TiUIFloatingActionButton extends TiUIView
 {
 	private static final String TAG = "TiUIFloatingActionButton";
+	private Object imageObject;
 	FloatingActionButton fab;
 
 	public TiUIFloatingActionButton(TiViewProxy proxy)
@@ -87,11 +90,19 @@ public class TiUIFloatingActionButton extends TiUIView
 
 	private void setImage(Object obj)
 	{
+		this.imageObject = obj;
 		if (obj == null) {
 			fab.setImageDrawable(null);
 		} else {
-			TiDrawableReference source = TiDrawableReference.fromObject(getProxy(), obj);
-			fab.setImageDrawable(source.getDrawable());
+			// Load the image off the main thread since it may involve file I/O and bitmap decoding.
+			TiLoadImageManager.getInstance().load(
+				() -> TiDrawableReference.fromObject(getProxy(), obj).getDrawable(),
+				(Drawable drawable) -> {
+					// Drop the result if the "image" property changed again while loading.
+					if (this.imageObject == obj) {
+						fab.setImageDrawable(drawable);
+					}
+				});
 		}
 	}
 

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIImageView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIImageView.java
@@ -646,6 +646,21 @@ public class TiUIImageView extends TiUIView implements OnLifecycleEvent, Handler
 
 	private void setImageInternal()
 	{
+		// If the target image is already cached, show it right away and skip the default image.
+		if (imageSources != null && imageSources.size() == 1 && imageSources.get(0) != null
+			&& !imageSources.get(0).isTypeNull()) {
+			var key = imageSources.get(0).getKey();
+			Bitmap bitmap = TiImageCache.getBitmap(key);
+			if (bitmap != null) {
+				setImage(bitmap, isAutoRotateEnabled() ? TiImageCache.getOrientation(key) : null);
+				if (!firedLoad) {
+					fireLoad(TiC.PROPERTY_IMAGE);
+					firedLoad = true;
+				}
+				return;
+			}
+		}
+
 		// Set default image or clear previous image first.
 		if (defaultImageSource != null) {
 			setDefaultImage();
@@ -659,20 +674,7 @@ public class TiUIImageView extends TiUIView implements OnLifecycleEvent, Handler
 		}
 
 		if (imageSources.size() == 1) {
-			TiDrawableReference imageref = imageSources.get(0);
-
-			// Check if the image is cached in memory
-			var key = imageref.getKey();
-			Bitmap bitmap = TiImageCache.getBitmap(key);
-			if (bitmap != null) {
-				setImage(bitmap, isAutoRotateEnabled() ? TiImageCache.getOrientation(key) : null);
-				if (!firedLoad) {
-					fireLoad(TiC.PROPERTY_IMAGE);
-					firedLoad = true;
-				}
-			} else {
-				TiLoadImageManager.getInstance().load(imageref, loadImageListener);
-			}
+			TiLoadImageManager.getInstance().load(imageSources.get(0), loadImageListener);
 		} else {
 			setImages();
 		}
@@ -680,14 +682,33 @@ public class TiUIImageView extends TiUIView implements OnLifecycleEvent, Handler
 
 	private void setDefaultImage()
 	{
-		if (defaultImageSource == null) {
+		final TiDrawableReference source = this.defaultImageSource;
+		if (source == null) {
 			setImage(null, null);
 			return;
 		}
-		// Have to set default image in the UI thread to make sure it shows before the image
-		// is ready. Don't need to retry decode because we don't want to block UI.
-		TiExifOrientation orientation = isAutoRotateEnabled() ? defaultImageSource.getExifOrientation() : null;
-		setImage(defaultImageSource.getBitmap(false), orientation);
+
+		// Clear the previous image while the default image decodes in the background.
+		setImage(null, null);
+
+		// Decode the default image off the main thread to avoid blocking the UI.
+		TiLoadImageManager.getInstance().load(
+			() -> {
+				TiExifOrientation orientation = isAutoRotateEnabled() ? source.getExifOrientation() : null;
+				Bitmap bitmap = source.getBitmap(false);
+				return (bitmap != null) ? new TiImageInfo(source.getKey(), bitmap, orientation) : null;
+			},
+			(TiImageInfo imageInfo) -> {
+				// Only show the default image if nothing else was applied while it was decoding
+				// and the "defaultImage" property has not changed. The actual image may have
+				// already finished loading, in which case the default image must not replace it.
+				TiImageView view = getView();
+				if ((imageInfo == null) || (view == null) || (view.getImageBitmap() != null)
+					|| (this.defaultImageSource != source)) {
+					return;
+				}
+				setImage(imageInfo.getBitmap(), imageInfo.getOrientation());
+			});
 	}
 
 	@Override

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIMaskedImage.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIMaskedImage.java
@@ -36,6 +36,7 @@ import org.appcelerator.titanium.TiApplication;
 import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.proxy.TiViewProxy;
 import org.appcelerator.titanium.util.TiConvert;
+import org.appcelerator.titanium.util.TiLoadImageManager;
 import org.appcelerator.titanium.view.TiCompositeLayout;
 import org.appcelerator.titanium.view.TiDrawableReference;
 import org.appcelerator.titanium.view.TiUIView;
@@ -52,6 +53,8 @@ public class TiUIMaskedImage extends TiUIView
 	 * Set to null when view's release() method has been called.
 	 */
 	private TiUIMaskedImage.MaskedDrawable maskedDrawable;
+	private int imageLoadToken;
+	private int maskLoadToken;
 
 	public TiUIMaskedImage(final TiViewProxy proxy)
 	{
@@ -223,14 +226,24 @@ public class TiUIMaskedImage extends TiUIView
 	private void updateImageDrawableWith(Object value)
 	{
 		if (this.maskedDrawable != null) {
-			Drawable drawable = null;
-			if (value != null) {
-				drawable = loadDrawableFrom(value);
-				if (drawable == null) {
-					Log.w(TAG, "Failed to load image.");
-				}
+			if (value == null) {
+				this.maskedDrawable.setImageDrawable(null);
+				return;
 			}
-			this.maskedDrawable.setImageDrawable(drawable);
+			// Load the image off the main thread since it may involve file I/O and bitmap decoding.
+			final int token = ++this.imageLoadToken;
+			TiLoadImageManager.getInstance().load(
+				() -> loadDrawableFrom(value),
+				(Drawable drawable) -> {
+					// Drop the result if the "image" property changed again while loading.
+					if ((token != this.imageLoadToken) || (this.maskedDrawable == null)) {
+						return;
+					}
+					if (drawable == null) {
+						Log.w(TAG, "Failed to load image.");
+					}
+					this.maskedDrawable.setImageDrawable(drawable);
+				});
 		}
 	}
 
@@ -241,14 +254,24 @@ public class TiUIMaskedImage extends TiUIView
 	private void updateMaskDrawableWith(Object value)
 	{
 		if (this.maskedDrawable != null) {
-			Drawable drawable = null;
-			if (value != null) {
-				drawable = loadDrawableFrom(value);
-				if (drawable == null) {
-					Log.w(TAG, "Failed to load mask.");
-				}
+			if (value == null) {
+				this.maskedDrawable.setMaskDrawable(null);
+				return;
 			}
-			this.maskedDrawable.setMaskDrawable(drawable);
+			// Load the mask off the main thread since it may involve file I/O and bitmap decoding.
+			final int token = ++this.maskLoadToken;
+			TiLoadImageManager.getInstance().load(
+				() -> loadDrawableFrom(value),
+				(Drawable drawable) -> {
+					// Drop the result if the "mask" property changed again while loading.
+					if ((token != this.maskLoadToken) || (this.maskedDrawable == null)) {
+						return;
+					}
+					if (drawable == null) {
+						Log.w(TAG, "Failed to load mask.");
+					}
+					this.maskedDrawable.setMaskDrawable(drawable);
+				});
 		}
 	}
 

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIOptionBar.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIOptionBar.java
@@ -22,6 +22,7 @@ import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.proxy.TiViewProxy;
 import org.appcelerator.titanium.R;
 import org.appcelerator.titanium.util.TiConvert;
+import org.appcelerator.titanium.util.TiLoadImageManager;
 import org.appcelerator.titanium.util.TiUIHelper;
 import org.appcelerator.titanium.view.TiUIView;
 
@@ -168,23 +169,19 @@ public class TiUIOptionBar extends TiUIView
 				// Fetch the optional "accessibilityLabel" property.
 				String accessibilityLabel = TiConvert.toString(hashMap.get(TiC.PROPERTY_ACCESSIBILITY_LABEL), null);
 
-				// Fetch the optional "image" property and load it as a drawable.
-				Drawable imageDrawable = null;
+				// Fetch the optional "image" property. It is loaded asynchronously by addButton().
 				Object imageObject = hashMap.get(TiC.PROPERTY_IMAGE);
-				if (imageObject != null) {
-					imageDrawable = TiUIHelper.getResourceDrawable(imageObject);
-				}
 
 				// Fetch the optional "enabled" flag.
 				boolean isEnabled = TiConvert.toBoolean(hashMap.get(TiC.PROPERTY_ENABLED), true);
 
 				// Add the button.
-				addButton(title, accessibilityLabel, imageDrawable, isEnabled);
+				addButton(title, accessibilityLabel, imageObject, isEnabled);
 			}
 		}
 	}
 
-	private void addButton(String title, String accessibilityLabel, Drawable imageDrawable, boolean isEnabled)
+	private void addButton(String title, String accessibilityLabel, Object imageObject, boolean isEnabled)
 	{
 		// Fetch the button group view.
 		MaterialButtonToggleGroup buttonGroup = getButtonGroup();
@@ -200,7 +197,7 @@ public class TiUIOptionBar extends TiUIView
 		// Create a button with given settings and add it to view group.
 		Context context = buttonGroup.getContext();
 		int attributeId = com.google.android.material.R.attr.materialButtonOutlinedStyle;
-		if (title.isEmpty() && (imageDrawable != null)) {
+		if (title.isEmpty() && (imageObject != null)) {
 			context = new ContextThemeWrapper(context, R.style.Widget_Titanium_OutlinedButton_IconOnly);
 			attributeId = com.google.android.material.R.attr.materialButtonToggleGroupStyle;
 		}
@@ -262,8 +259,15 @@ public class TiUIOptionBar extends TiUIView
 		if ((accessibilityLabel != null) && !accessibilityLabel.isEmpty()) {
 			button.setContentDescription(accessibilityLabel);
 		}
-		if (imageDrawable != null) {
-			button.setIcon(imageDrawable);
+		if (imageObject != null) {
+			// Load the image off the main thread since it may involve file I/O and bitmap decoding.
+			TiLoadImageManager.getInstance().load(
+				() -> TiUIHelper.getResourceDrawable(imageObject),
+				(Drawable imageDrawable) -> {
+					if (imageDrawable != null) {
+						button.setIcon(imageDrawable);
+					}
+				});
 		}
 		if (buttonGroup.getOrientation() != MaterialButtonToggleGroup.HORIZONTAL) {
 			button.setInsetTop(0);

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUITabbedBar.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUITabbedBar.java
@@ -29,6 +29,7 @@ import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.proxy.TiViewProxy;
 import org.appcelerator.titanium.util.TiColorHelper;
 import org.appcelerator.titanium.util.TiConvert;
+import org.appcelerator.titanium.util.TiLoadImageManager;
 import org.appcelerator.titanium.util.TiUIHelper;
 import org.appcelerator.titanium.view.TiDrawableReference;
 import org.appcelerator.titanium.view.TiUIView;
@@ -46,6 +47,7 @@ public class TiUITabbedBar extends TiUIView implements MenuItem.OnMenuItemClickL
 	private ArrayList<MenuItem> bottomNavigationMenuItems = new ArrayList<>();
 	private int bottomNavigationIndex = -1;
 	private boolean skipClickEvent = false;
+	private int dataSetToken;
 
 	/**
 	 * Constructs a TiUIView object with the associated proxy.
@@ -206,6 +208,9 @@ public class TiUITabbedBar extends TiUIView implements MenuItem.OnMenuItemClickL
 
 	private void parseDataSet()
 	{
+		// Invalidates any still-loading icon results from a previous data set.
+		++this.dataSetToken;
+
 		Object[] labels = ((Object[]) getProxy().getProperty(TiC.PROPERTY_LABELS));
 		if (labels == null || labels.length == 0) {
 			return;
@@ -232,26 +237,50 @@ public class TiUITabbedBar extends TiUIView implements MenuItem.OnMenuItemClickL
 			HashMap item = ((HashMap) labels[i]);
 			// The proxy has an "image" property
 			if (item.containsKey(TiC.PROPERTY_IMAGE)) {
-				// Try to load a drawable from the property
-				Drawable drawable =
-					TiDrawableReference.fromObject(getProxy(), item.get(TiC.PROPERTY_IMAGE)).getDrawable();
-				// If a drawable is successfully loaded add it as an icon and proceed to the next item.
-				if (drawable != null) {
-					addItem(drawable);
-					continue;
-				}
-				// If drawable was not loaded successfully try to fallback to a title.
-				// If we have a title - use it.
-				if (item.containsKey(TiC.PROPERTY_TITLE)) {
-					addItem(item.get(TiC.PROPERTY_TITLE));
-					continue;
-				}
-				// Otherwise add an empty button (parity with iOS)
-				addItem(null);
+				// Add the item now to preserve item order, showing the title (if any) until the
+				// icon is loaded off the main thread. If loading fails the title remains,
+				// or an empty button when there is no title (parity with iOS).
+				addItem(item.get(TiC.PROPERTY_TITLE));
+				final Object imageObject = item.get(TiC.PROPERTY_IMAGE);
+				final int index = i;
+				final int token = this.dataSetToken;
+				TiLoadImageManager.getInstance().load(
+					() -> TiDrawableReference.fromObject(getProxy(), imageObject).getDrawable(),
+					(Drawable drawable) -> {
+						// Drop the result if loading failed or the data set was rebuilt.
+						if ((drawable != null) && (token == this.dataSetToken)) {
+							setItemIcon(index, drawable);
+						}
+					});
+				continue;
 			}
 			if (item.containsKey(TiC.PROPERTY_TITLE)) {
 				addItem(item.get(TiC.PROPERTY_TITLE));
 			}
+		}
+	}
+
+	private void setItemIcon(int index, Drawable drawable)
+	{
+		switch (this.style) {
+			case AndroidModule.TABS_STYLE_DEFAULT:
+				TabLayout.Tab tab = (this.tabLayout != null) ? this.tabLayout.getTabAt(index) : null;
+				if (tab != null) {
+					tab.setText(null);
+					tab.setIcon(drawable);
+					TiUITabLayoutTabGroup.scaleIconToFit(tab);
+					if (proxy.hasPropertyAndNotNull(TiC.PROPERTY_TINT_COLOR)) {
+						setTintColor(tab, TiC.PROPERTY_TINT_COLOR);
+					}
+				}
+				break;
+			case AndroidModule.TABS_STYLE_BOTTOM_NAVIGATION:
+				if (index < this.bottomNavigationMenuItems.size()) {
+					MenuItem menuItem = this.bottomNavigationMenuItems.get(index);
+					menuItem.setTitle(null);
+					menuItem.setIcon(drawable);
+				}
+				break;
 		}
 	}
 

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIBottomNavigation.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIBottomNavigation.java
@@ -40,6 +40,7 @@ import org.appcelerator.titanium.proxy.TiViewProxy;
 import org.appcelerator.titanium.proxy.TiWindowProxy;
 import org.appcelerator.titanium.util.TiConvert;
 import org.appcelerator.titanium.util.TiIconDrawable;
+import org.appcelerator.titanium.util.TiLoadImageManager;
 import org.appcelerator.titanium.util.TiRHelper;
 import org.appcelerator.titanium.util.TiUIHelper;
 import org.appcelerator.titanium.view.TiUIView;
@@ -539,10 +540,21 @@ public class TiUIBottomNavigation extends TiUIAbstractTabGroup implements Bottom
 		}
 
 		if (tabProxy.hasPropertyAndNotNull(TiC.PROPERTY_ICON)) {
-			this.bottomNavigation.getMenu().getItem(index).setIcon(setIcon(
-				tabProxy.getProperty(TiC.PROPERTY_ICON),
-				tabProxy.getProperty("iconFamily")
-			));
+			// Load the icon off the main thread since it may involve file I/O and bitmap decoding.
+			final Object iconProperty = tabProxy.getProperty(TiC.PROPERTY_ICON);
+			final Object iconFamilyProperty = tabProxy.getProperty("iconFamily");
+			TiLoadImageManager.getInstance().load(
+				() -> setIcon(iconProperty, iconFamilyProperty),
+				(Drawable drawable) -> {
+					// Drop the result if the tab was removed/changed while loading.
+					if ((index >= this.tabs.size()) || (tabsArray == null) || (index >= tabsArray.size())
+						|| (tabsArray.get(index) != tabProxy)) {
+						return;
+					}
+					this.bottomNavigation.getMenu().getItem(index).setIcon(drawable);
+					updateIconTint();
+				});
+			return;
 		}
 		updateIconTint();
 	}

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIBottomNavigationTabGroup.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUIBottomNavigationTabGroup.java
@@ -35,6 +35,7 @@ import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.TiDimension;
 import org.appcelerator.titanium.proxy.TiViewProxy;
 import org.appcelerator.titanium.util.TiConvert;
+import org.appcelerator.titanium.util.TiLoadImageManager;
 import org.appcelerator.titanium.util.TiUIHelper;
 import org.appcelerator.titanium.view.TiCompositeLayout;
 
@@ -486,9 +487,18 @@ public class TiUIBottomNavigationTabGroup extends TiUIAbstractTabGroup implement
 			return;
 		}
 
-		final Drawable drawable = TiUIHelper.getResourceDrawable(tabProxy.getProperty(TiC.PROPERTY_ICON));
-		this.mBottomNavigationView.getMenu().getItem(index).setIcon(drawable);
-		updateIconTint();
+		// Load the icon off the main thread since it may involve file I/O and bitmap decoding.
+		final Object iconProperty = tabProxy.getProperty(TiC.PROPERTY_ICON);
+		TiLoadImageManager.getInstance().load(
+			() -> TiUIHelper.getResourceDrawable(iconProperty),
+			(Drawable drawable) -> {
+				// Drop the result if the tab was removed/changed while loading.
+				if ((index >= this.tabs.size()) || (this.tabs.get(index).getProxy() != tabProxy)) {
+					return;
+				}
+				this.mBottomNavigationView.getMenu().getItem(index).setIcon(drawable);
+				updateIconTint();
+			});
 	}
 
 	@Override

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUITabLayoutTabGroup.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tabgroup/TiUITabLayoutTabGroup.java
@@ -13,6 +13,7 @@ import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.TiDimension;
 import org.appcelerator.titanium.proxy.TiViewProxy;
 import org.appcelerator.titanium.util.TiConvert;
+import org.appcelerator.titanium.util.TiLoadImageManager;
 import org.appcelerator.titanium.util.TiUIHelper;
 import org.appcelerator.titanium.view.TiCompositeLayout;
 
@@ -378,10 +379,23 @@ public class TiUITabLayoutTabGroup extends TiUIAbstractTabGroup implements TabLa
 			return;
 		}
 
-		TabLayout.Tab tab = this.mTabLayout.getTabAt(index);
-		tab.setIcon(TiUIHelper.getResourceDrawable(tabProxy.getProperty(TiC.PROPERTY_ICON)));
-		scaleIconToFit(tab);
-		updateIconTint();
+		// Load the icon off the main thread since it may involve file I/O and bitmap decoding.
+		final Object iconProperty = tabProxy.getProperty(TiC.PROPERTY_ICON);
+		TiLoadImageManager.getInstance().load(
+			() -> TiUIHelper.getResourceDrawable(iconProperty),
+			(Drawable drawable) -> {
+				// Drop the result if the tab was removed/changed while loading.
+				if ((index >= this.tabs.size()) || (this.tabs.get(index).getProxy() != tabProxy)) {
+					return;
+				}
+				TabLayout.Tab tab = this.mTabLayout.getTabAt(index);
+				if (tab == null) {
+					return;
+				}
+				tab.setIcon(drawable);
+				scaleIconToFit(tab);
+				updateIconTint();
+			});
 	}
 
 	@Override

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TableViewHolder.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/tableview/TableViewHolder.java
@@ -12,6 +12,7 @@ import org.appcelerator.titanium.TiC;
 import org.appcelerator.titanium.TiDimension;
 import org.appcelerator.titanium.proxy.TiViewProxy;
 import org.appcelerator.titanium.util.TiConvert;
+import org.appcelerator.titanium.util.TiLoadImageManager;
 import org.appcelerator.titanium.util.TiRHelper;
 import org.appcelerator.titanium.util.TiUIHelper;
 import org.appcelerator.titanium.view.TiBackgroundDrawable;
@@ -232,22 +233,31 @@ public class TableViewHolder extends TiRecyclerViewHolder<TableViewRowProxy>
 				this.title.setTextColor(this.defaultTextColors);
 			}
 
-			// Handle row left and right images.
-			if (properties.containsKeyAndNotNull(TiC.PROPERTY_LEFT_IMAGE)) {
-				final String url = properties.getString(TiC.PROPERTY_LEFT_IMAGE);
-				final Drawable drawable = TiUIHelper.getResourceDrawable((Object) url);
-				if (drawable != null) {
-					this.leftImage.setImageDrawable(drawable);
-					this.leftImage.setVisibility(View.VISIBLE);
-				}
-			}
-
-			// Handle selection, override row left image.
-			if (tableViewProperties.optBoolean(TiC.PROPERTY_SHOW_SELECTION_CHECK, false)
+			// Determine if the selection check drawable takes priority over the row's left image.
+			final boolean selectionOverridesLeftImage =
+				tableViewProperties.optBoolean(TiC.PROPERTY_SHOW_SELECTION_CHECK, false)
 				&& tableViewProperties.optBoolean(TiC.PROPERTY_EDITING, false)
 				&& tableViewProperties.optBoolean(TiC.PROPERTY_ALLOWS_SELECTION_DURING_EDITING, false)
 				&& tableViewProperties.optBoolean(TiC.PROPERTY_ALLOWS_MULTIPLE_SELECTION_DURING_EDITING, false)
-				&& !proxy.isPlaceholder()) {
+				&& !proxy.isPlaceholder();
+
+			// Handle row left and right images.
+			// Load them off the main thread to avoid file I/O and bitmap decoding while scrolling.
+			if (!selectionOverridesLeftImage && properties.containsKeyAndNotNull(TiC.PROPERTY_LEFT_IMAGE)) {
+				final String url = properties.getString(TiC.PROPERTY_LEFT_IMAGE);
+				TiLoadImageManager.getInstance().load(
+					() -> TiUIHelper.getResourceDrawable((Object) url),
+					(Drawable drawable) -> {
+						// Drop the result if this holder was recycled for another row while loading.
+						if ((drawable != null) && (this.proxy != null) && (this.proxy.get() == proxy)) {
+							this.leftImage.setImageDrawable(drawable);
+							this.leftImage.setVisibility(View.VISIBLE);
+						}
+					});
+			}
+
+			// Handle selection, override row left image.
+			if (selectionOverridesLeftImage) {
 
 				if (selected) {
 					this.leftImage.setImageDrawable(checkcircleDrawable);
@@ -259,11 +269,15 @@ public class TableViewHolder extends TiRecyclerViewHolder<TableViewRowProxy>
 
 			if (properties.containsKeyAndNotNull(TiC.PROPERTY_RIGHT_IMAGE)) {
 				final String url = properties.getString(TiC.PROPERTY_RIGHT_IMAGE);
-				final Drawable drawable = TiUIHelper.getResourceDrawable((Object) url);
-				if (drawable != null) {
-					this.rightImage.setImageDrawable(drawable);
-					this.rightImage.setVisibility(View.VISIBLE);
-				}
+				TiLoadImageManager.getInstance().load(
+					() -> TiUIHelper.getResourceDrawable((Object) url),
+					(Drawable drawable) -> {
+						// Drop the result if this holder was recycled for another row while loading.
+						if ((drawable != null) && (this.proxy != null) && (this.proxy.get() == proxy)) {
+							this.rightImage.setImageDrawable(drawable);
+							this.rightImage.setVisibility(View.VISIBLE);
+						}
+					});
 			} else {
 				final boolean hasCheck = properties.optBoolean(TiC.PROPERTY_HAS_CHECK, false);
 				final boolean hasChild = properties.optBoolean(TiC.PROPERTY_HAS_CHILD, false);

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/webview/TiUIWebView.java
@@ -41,6 +41,7 @@ import org.appcelerator.titanium.io.TiBaseFile;
 import org.appcelerator.titanium.io.TiFileFactory;
 import org.appcelerator.titanium.proxy.TiViewProxy;
 import org.appcelerator.titanium.util.TiConvert;
+import org.appcelerator.titanium.util.TiLoadImageManager;
 import org.appcelerator.titanium.util.TiMimeTypeHelper;
 import org.appcelerator.titanium.util.TiUIHelper;
 import org.appcelerator.titanium.view.TiBackgroundDrawable;
@@ -56,6 +57,7 @@ public class TiUIWebView extends TiUIView
 	private TiWebViewClient client;
 	private TiWebChromeClient chromeClient;
 	private boolean bindingCodeInjected = false;
+	private int urlLoadToken;
 	private boolean isLocalHTML = false;
 	private boolean disableContextMenu = false;
 	private final HashMap<String, String> extraHeaders = new HashMap<>();
@@ -585,61 +587,59 @@ public class TiUIWebView extends TiUIView
 		final String finalUrl = finalUri.buildUpon().clearQuery().build().toString();
 
 		if (TiFileFactory.isLocalScheme(finalUrl) && mightBeHtml(finalUrl)) {
-			TiBaseFile tiFile = TiFileFactory.createTitaniumFile(finalUrl, false);
+			final TiBaseFile tiFile = TiFileFactory.createTitaniumFile(finalUrl, false);
 			if (tiFile != null) {
-				StringBuilder out = new StringBuilder();
-				InputStream fis = null;
-				try {
-					fis = tiFile.getInputStream();
-					if (fis == null) {
-						throw new IOException("Unable to open input stream for \"" + finalUrl + "\"");
-					}
-					InputStreamReader reader = new InputStreamReader(fis, StandardCharsets.UTF_8);
-					BufferedReader breader = new BufferedReader(reader);
-					String line = breader.readLine();
-					while (line != null) {
-						if (!bindingCodeInjected) {
-							int pos = line.indexOf("<html");
-							if (pos >= 0) {
-								int posEnd = line.indexOf(">", pos);
-								if (posEnd > pos) {
-									out.append(line.substring(pos, posEnd + 1));
-									out.append(TiWebViewBinding.SCRIPT_TAG_INJECTION_CODE);
-									if ((posEnd + 1) < line.length()) {
-										out.append(line.substring(posEnd + 1));
-									}
-									out.append("\n");
-									bindingCodeInjected = true;
-									line = breader.readLine();
-									continue;
-								}
+				// Read the file off the main thread to avoid blocking the UI.
+				// Binding code injection is handled by setHtmlInternal() on the main thread.
+				final int token = ++this.urlLoadToken;
+				TiLoadImageManager.getInstance().load(
+					() -> readTextFrom(tiFile, finalUrl),
+					(String html) -> {
+						// Drop the result if another URL was set while reading.
+						if (token != this.urlLoadToken) {
+							return;
+						}
+						if (html != null) {
+							String baseUrl = tiFile.nativePath();
+							if (baseUrl == null) {
+								baseUrl = finalUrl;
 							}
+							setHtmlInternal(html, baseUrl + query, "text/html");
+						} else {
+							Log.e(TAG, "Problem reading from " + url + ". Will let WebView try loading it directly.");
+							loadUrlDirectly(finalUrl + query);
 						}
-						out.append(line);
-						out.append("\n");
-						line = breader.readLine();
-					}
-					String baseUrl = tiFile.nativePath();
-					if (baseUrl == null) {
-						baseUrl = finalUrl;
-					}
-					setHtmlInternal(out.toString(), baseUrl + query, "text/html");
-					return;
-				} catch (IOException ioe) {
-					Log.e(TAG,
-						  "Problem reading from " + url + ": " + ioe.getMessage()
-							  + ". Will let WebView try loading it directly.",
-						  ioe);
-				} finally {
-					if (fis != null) {
-						try {
-							fis.close();
-						} catch (IOException e) {
-							Log.w(TAG, "Problem closing stream: " + e.getMessage(), e);
-						}
-					}
-				}
+					});
+				return;
 			}
+		}
+
+		loadUrlDirectly(finalUrl + query);
+	}
+
+	private String readTextFrom(TiBaseFile tiFile, String finalUrl) throws IOException
+	{
+		try (InputStream fis = tiFile.getInputStream()) {
+			if (fis == null) {
+				throw new IOException("Unable to open input stream for \"" + finalUrl + "\"");
+			}
+			StringBuilder out = new StringBuilder();
+			BufferedReader breader = new BufferedReader(new InputStreamReader(fis, StandardCharsets.UTF_8));
+			String line = breader.readLine();
+			while (line != null) {
+				out.append(line);
+				out.append("\n");
+				line = breader.readLine();
+			}
+			return out.toString();
+		}
+	}
+
+	private void loadUrlDirectly(String url)
+	{
+		WebView webView = getWebView();
+		if (webView == null) {
+			return;
 		}
 
 		Log.d(TAG, "WebView will load " + url + " directly without code injection.", Log.DEBUG_MODE);
@@ -651,9 +651,9 @@ public class TiUIWebView extends TiUIView
 		}
 		isLocalHTML = false;
 		if (extraHeaders.size() > 0) {
-			webView.loadUrl(finalUrl + query, extraHeaders);
+			webView.loadUrl(url, extraHeaders);
 		} else {
-			webView.loadUrl(finalUrl + query);
+			webView.loadUrl(url);
 		}
 	}
 

--- a/android/titanium/src/java/org/appcelerator/titanium/util/TiLoadImageManager.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/util/TiLoadImageManager.java
@@ -6,6 +6,7 @@
  */
 package org.appcelerator.titanium.util;
 
+import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.appcelerator.kroll.common.Log;
@@ -14,6 +15,7 @@ import android.graphics.Bitmap;
 import android.os.Handler;
 import android.os.Looper;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 /**
  * Manages the asynchronous opening of InputStreams from URIs so that
@@ -24,6 +26,10 @@ public class TiLoadImageManager
 	public interface Listener {
 		void onLoadImageFinished(@NonNull TiDrawableReference drawableRef, @NonNull TiImageInfo imageInfo);
 		void onLoadImageFailed(@NonNull TiDrawableReference drawableRef);
+	}
+
+	public interface AsyncListener<T> {
+		void onResult(@Nullable T result);
 	}
 
 	private static final String TAG = "TiLoadImageManager";
@@ -45,6 +51,24 @@ public class TiLoadImageManager
 	{
 		handler = new Handler(Looper.getMainLooper());
 		threadPool = Executors.newFixedThreadPool(Math.max(Runtime.getRuntime().availableProcessors(), 2));
+	}
+
+	/**
+	 * Runs the given task on this manager's background thread pool and delivers its
+	 * result to the given listener on the main UI thread. Delivers null if the task throws.
+	 */
+	public <T> void load(@NonNull Callable<T> task, @NonNull AsyncListener<T> listener)
+	{
+		this.threadPool.execute(() -> {
+			T result = null;
+			try {
+				result = task.call();
+			} catch (Exception ex) {
+				Log.e(TAG, "Exception loading resource: " + ex.getLocalizedMessage());
+			}
+			final T finalResult = result;
+			handler.post(() -> listener.onResult(finalResult));
+		});
 	}
 
 	public void load(TiDrawableReference drawableRef, TiLoadImageManager.Listener listener)

--- a/android/titanium/src/java/org/appcelerator/titanium/view/TiUIView.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/view/TiUIView.java
@@ -27,6 +27,7 @@ import org.appcelerator.titanium.proxy.TiViewProxy;
 import org.appcelerator.titanium.util.TiAnimationBuilder;
 import org.appcelerator.titanium.util.TiAnimationBuilder.TiMatrixAnimation;
 import org.appcelerator.titanium.util.TiConvert;
+import org.appcelerator.titanium.util.TiLoadImageManager;
 import org.appcelerator.titanium.util.TiUIHelper;
 import org.appcelerator.titanium.view.TiCompositeLayout.LayoutParams;
 
@@ -112,6 +113,7 @@ public abstract class TiUIView implements KrollProxyListener, OnFocusChangeListe
 	protected LayoutParams layoutParams;
 	protected TiAnimationBuilder animBuilder;
 	protected TiBackgroundDrawable background;
+	private int backgroundImageLoadToken;
 
 	public TiBackgroundDrawable getBackground()
 	{
@@ -1485,12 +1487,45 @@ public abstract class TiUIView implements KrollProxyListener, OnFocusChangeListe
 				applyCustomBackground(false);
 			}
 			if (background != null) {
-				Drawable bgDrawable = TiUIHelper.buildBackgroundDrawable(
-					bg, TiConvert.toBoolean(d, TiC.PROPERTY_BACKGROUND_REPEAT, false), bgColor, bgSelected,
-					bgSelectedColor, bgDisabled, bgDisabledColor, bgFocused, bgFocusedColor, gradientDrawable,
-					proxy.getActivity());
-
-				background.setBackgroundDrawable(bgDrawable);
+				final boolean tileImage = TiConvert.toBoolean(d, TiC.PROPERTY_BACKGROUND_REPEAT, false);
+				final Activity activity = proxy.getActivity();
+				final boolean hasImageFile
+					= (bg != null) || (bgSelected != null) || (bgFocused != null) || (bgDisabled != null);
+				if (!hasImageFile) {
+					// Colors and gradients involve no file I/O. Apply them immediately to avoid flicker.
+					background.setBackgroundDrawable(TiUIHelper.buildBackgroundDrawable(
+						bg, tileImage, bgColor, bgSelected, bgSelectedColor, bgDisabled, bgDisabledColor,
+						bgFocused, bgFocusedColor, gradientDrawable, activity));
+				} else {
+					// Image files must be read and decoded. Do it off the main thread to avoid blocking the UI.
+					final String fBg = bg;
+					final String fBgColor = bgColor;
+					final String fBgSelected = bgSelected;
+					final String fBgSelectedColor = bgSelectedColor;
+					final String fBgDisabled = bgDisabled;
+					final String fBgDisabledColor = bgDisabledColor;
+					final String fBgFocused = bgFocused;
+					final String fBgFocusedColor = bgFocusedColor;
+					final Drawable fGradientDrawable = gradientDrawable;
+					final TiBackgroundDrawable targetBackground = background;
+					final int token = ++this.backgroundImageLoadToken;
+					TiLoadImageManager.getInstance().load(
+						() -> TiUIHelper.buildBackgroundDrawable(
+							fBg, tileImage, fBgColor, fBgSelected, fBgSelectedColor, fBgDisabled,
+							fBgDisabledColor, fBgFocused, fBgFocusedColor, fGradientDrawable, activity),
+						(Drawable bgDrawable) -> {
+							// Drop the result if the background was changed/removed while loading.
+							if ((bgDrawable == null) || (token != this.backgroundImageLoadToken)
+								|| (this.background != targetBackground)) {
+								return;
+							}
+							targetBackground.setBackgroundDrawable(bgDrawable);
+							View outerView = getOuterView();
+							if (outerView != null) {
+								outerView.postInvalidate();
+							}
+						});
+				}
 			}
 		}
 	}


### PR DESCRIPTION
_Putting it as a draft, just to have it here._


Fix 1 — background images (TiUIView.handleBackgroundImage)

When any backgroundImage/backgroundSelectedImage/etc. is set, the file read + bitmap decode (and, for remote URLs, the previously blocking network download) now happens on the background pool; only background.setBackgroundDrawable(...) + invalidate runs on main. Color/gradient-only backgrounds still apply synchronously so they don't flicker. A token plus an identity check on the TiBackgroundDrawable drops stale results if the property changes again or the background is removed mid-load.

Fix 2 — getResourceDrawable call sites

- TableViewHolder — row leftImage/rightImage decode no longer happens during scroll binding; results are dropped if the holder was recycled for another row, and the left image respects the selection-check override that previously relied on execution order.
- TiUIButton, TiUIOptionBar, UIModule.setBackgroundImage (app root background), and all three tab-group icon updaters (TiUIBottomNavigationTabGroup, TiUITabLayoutTabGroup, TiUIBottomNavigation) now load icons asynchronously with stale-result guards (property/tab unchanged when the result arrives).

Fix 3 — remaining widget decodes

- TiUIImageView: if the target image is already in TiImageCache it's shown immediately and the defaultImage decode is skipped entirely (a small perf win over the old code). Otherwise the default image decodes in the background and is only applied if the view is still empty — so it can never overwrite the real image that finished loading first.
- TiUICollapseToolbar (+ its proxy), TiToolbar (logo, navigation icon, overflow icon), TiUIFloatingActionButton, and TiUIMaskedImage (both image and mask) all decode off-thread with the same guard pattern. The masked-image compositing still happens at draw time on main — that part is inherent to drawing.
- TiUITabbedBar: items are added immediately (title as placeholder) to preserve order, and the icon swaps in when decoded; failed loads keep the title fallback, matching the old fallback semantics.

Fix 4 — TiSound

Local files/assets now use prepareAsync() exactly like remote URLs already did (both in initializeAndPlay and prepareAndPlay), reusing the existing onPrepared/playPending/pausePending machinery — so MediaPlayer.prepare() no longer stalls the main thread on first play.

Fix 5 — TiUIWebView.setUrl

The local HTML file is now read on the background pool; setHtmlInternal() (which already handles binding-script injection on its own) runs on main once the content is ready. A token drops the result if another URL is set meanwhile, and read failures fall back to letting the WebView load the URL directly, as before.

Test code: [app.js](https://github.com/user-attachments/files/30297991/app.js)

13.3.1:

[ui_13_3_1.webm](https://github.com/user-attachments/assets/bf5ce1b9-dd30-401b-8d4e-10b9593b2e02)

This PR:

[ui_14_0_0.webm](https://github.com/user-attachments/assets/0525dd04-6381-4165-9051-ac33418ce6e2)
