### PR TITLE
feat(android): new Material3 stopIndicator property for Ti.UI.ProgressBar

### DIFF
--- a/android/modules/ui/src/java/ti/modules/titanium/ui/ProgressBarProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/ProgressBarProxy.java
@@ -25,6 +25,7 @@ import ti.modules.titanium.ui.widget.TiUIProgressBar;
 		TiC.PROPERTY_COLOR,
 		TiC.PROPERTY_TINT_COLOR,
 		TiC.PROPERTY_TRACK_TINT_COLOR,
+		TiC.PROPERTY_SHOW_STOP_INDICATOR,
 	})
 public class ProgressBarProxy extends TiViewProxy
 {
@@ -32,6 +33,7 @@ public class ProgressBarProxy extends TiViewProxy
 	{
 		super();
 		defaultValues.put(TiC.PROPERTY_ANIMATED, true);
+		defaultValues.put(TiC.PROPERTY_SHOW_STOP_INDICATOR, true);
 	}
 
 	@Override

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/ProgressBarProxy.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/ProgressBarProxy.java
@@ -25,7 +25,8 @@ import ti.modules.titanium.ui.widget.TiUIProgressBar;
 		TiC.PROPERTY_COLOR,
 		TiC.PROPERTY_TINT_COLOR,
 		TiC.PROPERTY_TRACK_TINT_COLOR,
-		TiC.PROPERTY_SHOW_STOP_INDICATOR,
+		TiC.PROPERTY_TRACK_THICKNESS,
+		TiC.PROPERTY_STOP_INDICATOR,
 	})
 public class ProgressBarProxy extends TiViewProxy
 {
@@ -33,7 +34,7 @@ public class ProgressBarProxy extends TiViewProxy
 	{
 		super();
 		defaultValues.put(TiC.PROPERTY_ANIMATED, true);
-		defaultValues.put(TiC.PROPERTY_SHOW_STOP_INDICATOR, true);
+		defaultValues.put(TiC.PROPERTY_STOP_INDICATOR, true);
 	}
 
 	@Override

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIProgressBar.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIProgressBar.java
@@ -24,6 +24,7 @@ public class TiUIProgressBar extends TiUIView
 	private MaterialTextView label;
 	private LinearProgressIndicator progress;
 	private LinearLayout view;
+	private int defaultStopIndicatorSize;
 
 	public TiUIProgressBar(final TiViewProxy proxy)
 	{
@@ -46,6 +47,7 @@ public class TiUIProgressBar extends TiUIView
 		progress = new LinearProgressIndicator(proxy.getActivity());
 		progress.setIndeterminate(false);
 		progress.setMax(1000);
+		defaultStopIndicatorSize = progress.getTrackStopIndicatorSize();
 
 		view.addView(label);
 		view.addView(progress);
@@ -71,6 +73,9 @@ public class TiUIProgressBar extends TiUIView
 		}
 		if (d.containsKey(TiC.PROPERTY_TRACK_TINT_COLOR)) {
 			this.progress.setTrackColor(TiConvert.toColor(d, TiC.PROPERTY_TRACK_TINT_COLOR, activity));
+		}
+		if (d.containsKey(TiC.PROPERTY_SHOW_STOP_INDICATOR)) {
+			handleSetShowStopIndicator(TiConvert.toBoolean(d, TiC.PROPERTY_SHOW_STOP_INDICATOR, true));
 		}
 		updateProgress();
 	}
@@ -98,6 +103,8 @@ public class TiUIProgressBar extends TiUIView
 		} else if (key.equals(TiC.PROPERTY_TRACK_TINT_COLOR)) {
 			// TODO: reset to default value when property is null
 			this.progress.setTrackColor(TiConvert.toColor(newValue, proxy.getActivity()));
+		} else if (key.equals(TiC.PROPERTY_SHOW_STOP_INDICATOR)) {
+			handleSetShowStopIndicator(TiConvert.toBoolean(newValue, true));
 		}
 	}
 
@@ -133,7 +140,11 @@ public class TiUIProgressBar extends TiUIView
 
 	private int convertRange(double min, double max, double value, int base)
 	{
-		return (int) Math.floor((value / (max - min)) * base);
+		if (max <= min) {
+			return 0;
+		}
+		double fraction = (value - min) / (max - min);
+		return (int) Math.floor(Math.max(0.0, Math.min(1.0, fraction)) * base);
 	}
 
 	public void updateProgress()
@@ -151,5 +162,10 @@ public class TiUIProgressBar extends TiUIView
 	protected void handleSetMessageColor(int color)
 	{
 		label.setTextColor(color);
+	}
+
+	private void handleSetShowStopIndicator(boolean show)
+	{
+		progress.setTrackStopIndicatorSize(show ? defaultStopIndicatorSize : 0);
 	}
 }

--- a/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIProgressBar.java
+++ b/android/modules/ui/src/java/ti/modules/titanium/ui/widget/TiUIProgressBar.java
@@ -11,9 +11,11 @@ import android.view.Gravity;
 import android.widget.LinearLayout;
 import com.google.android.material.progressindicator.LinearProgressIndicator;
 import com.google.android.material.textview.MaterialTextView;
+import java.util.HashMap;
 import org.appcelerator.kroll.KrollDict;
 import org.appcelerator.kroll.KrollProxy;
 import org.appcelerator.titanium.TiC;
+import org.appcelerator.titanium.TiDimension;
 import org.appcelerator.titanium.proxy.TiViewProxy;
 import org.appcelerator.titanium.util.TiConvert;
 import org.appcelerator.titanium.util.TiUIHelper;
@@ -74,8 +76,13 @@ public class TiUIProgressBar extends TiUIView
 		if (d.containsKey(TiC.PROPERTY_TRACK_TINT_COLOR)) {
 			this.progress.setTrackColor(TiConvert.toColor(d, TiC.PROPERTY_TRACK_TINT_COLOR, activity));
 		}
-		if (d.containsKey(TiC.PROPERTY_SHOW_STOP_INDICATOR)) {
-			handleSetShowStopIndicator(TiConvert.toBoolean(d, TiC.PROPERTY_SHOW_STOP_INDICATOR, true));
+		// Apply the track thickness before the stop indicator since Material clamps
+		// the stop indicator size to the track thickness when it is set.
+		if (d.containsKey(TiC.PROPERTY_TRACK_THICKNESS)) {
+			handleSetTrackThickness(d.get(TiC.PROPERTY_TRACK_THICKNESS));
+		}
+		if (d.containsKey(TiC.PROPERTY_STOP_INDICATOR)) {
+			handleSetStopIndicator(d.get(TiC.PROPERTY_STOP_INDICATOR));
 		}
 		updateProgress();
 	}
@@ -103,8 +110,12 @@ public class TiUIProgressBar extends TiUIView
 		} else if (key.equals(TiC.PROPERTY_TRACK_TINT_COLOR)) {
 			// TODO: reset to default value when property is null
 			this.progress.setTrackColor(TiConvert.toColor(newValue, proxy.getActivity()));
-		} else if (key.equals(TiC.PROPERTY_SHOW_STOP_INDICATOR)) {
-			handleSetShowStopIndicator(TiConvert.toBoolean(newValue, true));
+		} else if (key.equals(TiC.PROPERTY_TRACK_THICKNESS)) {
+			handleSetTrackThickness(newValue);
+			// Re-apply the stop indicator so its size is re-clamped to the new thickness.
+			handleSetStopIndicator(proxy.getProperty(TiC.PROPERTY_STOP_INDICATOR));
+		} else if (key.equals(TiC.PROPERTY_STOP_INDICATOR)) {
+			handleSetStopIndicator(newValue);
 		}
 	}
 
@@ -164,8 +175,31 @@ public class TiUIProgressBar extends TiUIView
 		label.setTextColor(color);
 	}
 
-	private void handleSetShowStopIndicator(boolean show)
+	private void handleSetStopIndicator(Object value)
 	{
-		progress.setTrackStopIndicatorSize(show ? defaultStopIndicatorSize : 0);
+		boolean enabled;
+		int size = defaultStopIndicatorSize;
+		if (value instanceof HashMap) {
+			KrollDict options = new KrollDict((HashMap<String, Object>) value);
+			enabled = TiConvert.toBoolean(options, TiC.PROPERTY_ENABLED, true);
+			if (options.containsKeyAndNotNull(TiC.PROPERTY_SIZE)) {
+				TiDimension dimension =
+					TiConvert.toTiDimension(options.get(TiC.PROPERTY_SIZE), TiDimension.TYPE_WIDTH);
+				if (dimension != null) {
+					size = dimension.getAsPixels(progress);
+				}
+			}
+		} else {
+			enabled = TiConvert.toBoolean(value, true);
+		}
+		progress.setTrackStopIndicatorSize(enabled ? size : 0);
+	}
+
+	private void handleSetTrackThickness(Object value)
+	{
+		TiDimension dimension = TiConvert.toTiDimension(value, TiDimension.TYPE_HEIGHT);
+		if (dimension != null) {
+			progress.setTrackThickness(dimension.getAsPixels(progress));
+		}
 	}
 }

--- a/android/titanium/src/java/org/appcelerator/titanium/TiC.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiC.java
@@ -739,6 +739,7 @@ public class TiC
 	public static final String PROPERTY_SHOW_PAGING_CONTROL = "showPagingControl";
 	public static final String PROPERTY_SHOW_PROGRESS = "showProgress";
 	public static final String PROPERTY_SHOW_SELECTION_CHECK = "showSelectionCheck";
+	public static final String PROPERTY_SHOW_STOP_INDICATOR = "showStopIndicator";
 	public static final String PROPERTY_SISTER = "sister";
 	public static final String PROPERTY_SIZE = "size";
 	public static final String PROPERTY_SNAPPING = "snapping";

--- a/android/titanium/src/java/org/appcelerator/titanium/TiC.java
+++ b/android/titanium/src/java/org/appcelerator/titanium/TiC.java
@@ -739,7 +739,6 @@ public class TiC
 	public static final String PROPERTY_SHOW_PAGING_CONTROL = "showPagingControl";
 	public static final String PROPERTY_SHOW_PROGRESS = "showProgress";
 	public static final String PROPERTY_SHOW_SELECTION_CHECK = "showSelectionCheck";
-	public static final String PROPERTY_SHOW_STOP_INDICATOR = "showStopIndicator";
 	public static final String PROPERTY_SISTER = "sister";
 	public static final String PROPERTY_SIZE = "size";
 	public static final String PROPERTY_SNAPPING = "snapping";
@@ -758,6 +757,7 @@ public class TiC
 	public static final String PROPERTY_STATE = "state";
 	public static final String PROPERTY_STATUS = "status";
 	public static final String PROPERTY_STOP = "stop";
+	public static final String PROPERTY_STOP_INDICATOR = "stopIndicator";
 	public static final String PROPERTY_STREET = "street";
 	public static final String PROPERTY_STREET1 = "street1";
 	public static final String PROPERTY_STYLE = "style";
@@ -808,6 +808,7 @@ public class TiC
 	public static final String PROPERTY_TOOLBAR = "toolbar";
 	public static final String PROPERTY_TOOLBAR_ENABLED = "toolbarEnabled";
 	public static final String PROPERTY_SOUND_EFFECTS_ENABLED = "soundEffectsEnabled";
+	public static final String PROPERTY_TRACK_THICKNESS = "trackThickness";
 	public static final String PROPERTY_TRACK_TINT_COLOR = "trackTintColor";
 	public static final String PROPERTY_TRANSFORM = "transform";
 	public static final String PROPERTY_TRANSLATION_X = "translationX";

--- a/apidoc/Titanium/UI/ProgressBar.yml
+++ b/apidoc/Titanium/UI/ProgressBar.yml
@@ -73,6 +73,16 @@ properties:
     summary: Minimum value of the progress bar.
     type: Number
 
+  - name: showStopIndicator
+    summary: Determines whether the Material 3 stop indicator dot is shown at the end of the track.
+    description: |
+        Material 3 themes render a small dot (the "stop indicator") at the trailing end of the
+        progress bar track. Set this to `false` to hide it.
+    type: Boolean
+    default: true
+    platforms: [android]
+    since: "14.0.0"
+
   - name: style
     summary: Style of the progress bar.
     description: For iOS, progress bar styles are constants defined in [ProgressBarStyle](Titanium.UI.iOS.ProgressBarStyle).

--- a/apidoc/Titanium/UI/ProgressBar.yml
+++ b/apidoc/Titanium/UI/ProgressBar.yml
@@ -63,6 +63,18 @@ properties:
     platforms: [iphone, ipad, android, macos]
     since: {iphone: "3.1.3", ipad: "3.1.3", android: "8.0.0"}
 
+  - name: trackThickness
+    summary: Thickness of the progress bar track.
+    description: |
+        Can be either a number (interpreted in the app's default unit) or a string with a
+        unit suffix, for example `"8dp"`. The Material 3 theme default is `4dp`.
+
+        This also defines the maximum size of the stop indicator dot
+        (see <Titanium.UI.ProgressBar.stopIndicator>), which cannot be larger than the track.
+    type: [Number, String]
+    platforms: [android]
+    since: "14.0.0"
+
   - name: trackTintColor
     summary: The color shown for the portion of the progress bar that is not filled.
     type: [String, Titanium.UI.Color]
@@ -73,12 +85,21 @@ properties:
     summary: Minimum value of the progress bar.
     type: Number
 
-  - name: showStopIndicator
-    summary: Determines whether the Material 3 stop indicator dot is shown at the end of the track.
+  - name: stopIndicator
+    summary: Shows, hides or configures the Material 3 stop indicator dot at the end of the track.
     description: |
         Material 3 themes render a small dot (the "stop indicator") at the trailing end of the
-        progress bar track. Set this to `false` to hide it.
-    type: Boolean
+        progress bar track. Set this to `false` to hide it or `true` to show it with its default
+        size. Alternatively, pass a <StopIndicatorOptions> dictionary to also set a custom size:
+
+        ``` js
+        progressBar.stopIndicator = { enabled: true, size: 12 };
+        ```
+
+        Note that the stop indicator cannot be larger than the track: Material clamps its size
+        to the track thickness (`4dp` by default). To show a larger stop indicator, increase
+        <Titanium.UI.ProgressBar.trackThickness> as well.
+    type: [Boolean, StopIndicatorOptions]
     default: true
     platforms: [android]
     since: "14.0.0"
@@ -159,3 +180,23 @@ examples:
             style: Titanium.UI.iOS.ProgressBarStyle.PLAIN
         }
         ```
+---
+name: StopIndicatorOptions
+summary: Dictionary of options for the <Titanium.UI.ProgressBar.stopIndicator> property.
+platforms: [android]
+since: "14.0.0"
+properties:
+  - name: enabled
+    summary: Determines whether the stop indicator is shown.
+    type: Boolean
+    default: true
+
+  - name: size
+    summary: Custom size of the stop indicator. If not set, the default size is used.
+    description: |
+        Can be either a number (interpreted in the app's default unit) or a string with a
+        unit suffix, for example `"4dp"`.
+
+        The size is clamped to the track thickness, so values larger than
+        <Titanium.UI.ProgressBar.trackThickness> (`4dp` by default) have no visible effect.
+    type: [Number, String]

--- a/tests/Resources/ti.ui.progressbar.test.js
+++ b/tests/Resources/ti.ui.progressbar.test.js
@@ -14,8 +14,20 @@ const should = require('./utilities/assertions');
 
 describe('Titanium.UI.ProgressBar', () => {
 	let bar;
-	afterEach(() => {
+	let win;
+	afterEach(done => { // fires after every test in sub-suites too...
 		bar = null;
+		if (win && !win.closed) {
+			win.addEventListener('close', function listener () {
+				win.removeEventListener('close', listener);
+				win = null;
+				done();
+			});
+			win.close();
+		} else {
+			win = null;
+			done();
+		}
 	});
 
 	describe('properties', () => {
@@ -174,6 +186,34 @@ describe('Titanium.UI.ProgressBar', () => {
 			});
 		});
 
+		describe.android('.showStopIndicator', () => {
+			it('is a Boolean', () => {
+				bar = Ti.UI.createProgressBar();
+				should(bar).have.property('showStopIndicator').which.is.a.Boolean();
+			});
+
+			it('defaults to true', () => {
+				bar = Ti.UI.createProgressBar();
+				should(bar.showStopIndicator).be.true();
+			});
+
+			it('can be initialized false', () => {
+				bar = Ti.UI.createProgressBar({ showStopIndicator: false });
+				should(bar.showStopIndicator).be.false();
+			});
+
+			it('can be set false', () => {
+				bar = Ti.UI.createProgressBar();
+				bar.showStopIndicator = false;
+				should(bar.showStopIndicator).be.false();
+			});
+
+			it('has no accessors', () => {
+				bar = Ti.UI.createProgressBar();
+				should(bar).not.have.accessors('showStopIndicator');
+			});
+		});
+
 		describe.ios('.style', () => {
 			beforeEach(() => {
 				bar = Ti.UI.createProgressBar({ style: Ti.UI.iOS.ProgressBarStyle.BAR });
@@ -264,6 +304,40 @@ describe('Titanium.UI.ProgressBar', () => {
 			it('has no accessors', () => {
 				should(bar).not.have.accessors('value');
 			});
+		});
+	});
+
+	describe('rendering', () => {
+		it('renders with a non-zero min range', finish => {
+			win = Ti.UI.createWindow();
+			bar = Ti.UI.createProgressBar({ min: 50, max: 100, value: 75 });
+			win.add(bar);
+			win.addEventListener('open', function openListener () {
+				win.removeEventListener('open', openListener);
+				try {
+					bar.value = 100;
+				} catch (err) {
+					return finish(err);
+				}
+				finish();
+			});
+			win.open();
+		});
+
+		it('renders with an empty min/max range', finish => {
+			win = Ti.UI.createWindow();
+			bar = Ti.UI.createProgressBar({ min: 0, max: 0, value: 0 });
+			win.add(bar);
+			win.addEventListener('open', function openListener () {
+				win.removeEventListener('open', openListener);
+				try {
+					bar.value = 1;
+				} catch (err) {
+					return finish(err);
+				}
+				finish();
+			});
+			win.open();
 		});
 	});
 });

--- a/tests/Resources/ti.ui.progressbar.test.js
+++ b/tests/Resources/ti.ui.progressbar.test.js
@@ -186,31 +186,63 @@ describe('Titanium.UI.ProgressBar', () => {
 			});
 		});
 
-		describe.android('.showStopIndicator', () => {
-			it('is a Boolean', () => {
-				bar = Ti.UI.createProgressBar();
-				should(bar).have.property('showStopIndicator').which.is.a.Boolean();
-			});
-
+		describe.android('.stopIndicator', () => {
 			it('defaults to true', () => {
 				bar = Ti.UI.createProgressBar();
-				should(bar.showStopIndicator).be.true();
+				should(bar.stopIndicator).be.true();
 			});
 
 			it('can be initialized false', () => {
-				bar = Ti.UI.createProgressBar({ showStopIndicator: false });
-				should(bar.showStopIndicator).be.false();
+				bar = Ti.UI.createProgressBar({ stopIndicator: false });
+				should(bar.stopIndicator).be.false();
 			});
 
 			it('can be set false', () => {
 				bar = Ti.UI.createProgressBar();
-				bar.showStopIndicator = false;
-				should(bar.showStopIndicator).be.false();
+				bar.stopIndicator = false;
+				should(bar.stopIndicator).be.false();
+			});
+
+			it('can be initialized with an object', () => {
+				bar = Ti.UI.createProgressBar({ stopIndicator: { enabled: true, size: 12 } });
+				should(bar.stopIndicator).be.an.Object();
+				should(bar.stopIndicator.enabled).be.true();
+				should(bar.stopIndicator.size).eql(12);
+			});
+
+			it('can be set to an object', () => {
+				bar = Ti.UI.createProgressBar();
+				bar.stopIndicator = { enabled: false };
+				should(bar.stopIndicator).be.an.Object();
+				should(bar.stopIndicator.enabled).be.false();
 			});
 
 			it('has no accessors', () => {
 				bar = Ti.UI.createProgressBar();
-				should(bar).not.have.accessors('showStopIndicator');
+				should(bar).not.have.accessors('stopIndicator');
+			});
+		});
+
+		describe.android('.trackThickness', () => {
+			it('can be initialized', () => {
+				bar = Ti.UI.createProgressBar({ trackThickness: 10 });
+				should(bar.trackThickness).eql(10);
+			});
+
+			it('can be set', () => {
+				bar = Ti.UI.createProgressBar();
+				bar.trackThickness = 10;
+				should(bar.trackThickness).eql(10);
+			});
+
+			it('accepts a String with unit suffix', () => {
+				bar = Ti.UI.createProgressBar({ trackThickness: '8dp' });
+				should(bar.trackThickness).eql('8dp');
+			});
+
+			it('has no accessors', () => {
+				bar = Ti.UI.createProgressBar();
+				should(bar).not.have.accessors('trackThickness');
 			});
 		});
 


### PR DESCRIPTION
**stopIndicator**
If you use a Material3 Theme and a ProgressBar it looks like this by default:
<img width="538" height="69" alt="Screenshot_20260727-205415" src="https://github.com/user-attachments/assets/64c36d5a-ca85-4c48-9f3e-37d000f8ec1e" />
Notice the little "stop indicator" dot at the end. Currently there is no way to remove that so I've added a new property `stopIndicator` to fix that.

<img width="400" height="297" alt="Screenshot_20260731-120824" src="https://github.com/user-attachments/assets/a223c792-32f1-4fb5-ade3-4ec89d725d3f" />


**Bug fix:**
There is also a bug in the value calculation when you don't use min:0. The example code in 13.3.1 will show a full bar when you use min:50, max:100, value: 75 but it should be at 50%.

1. convertRange at TiUIProgressBar.java:134 ignores min in the numerator: (value / (max - min)) should be ((value - min) / (max - min)). With min: 50, max: 100, value: 75 the bar shows 150% (clamped to full) instead of 50%. It only works correctly when min is 0.
2. If min == max (both default to 0 when unset), the division yields NaN/Infinity — no crash, but the bar silently shows a nonsense value rather than guarding the degenerate range.

This is fixed in this PR too.


**Test code:**
```js
var win = Ti.UI.createWindow({
	theme: "Theme.Titanium.Material3.DayNight",
	layout:"vertical"
});
win.add(Ti.UI.createProgressBar({
	top: 10, width: 250, min: 0, max: 100, value: 10,
}));
win.add(Ti.UI.createProgressBar({
	top: 10, width: 250, min: 0, max: 100, value: 30,
	stopIndicator: false
}));
win.add(Ti.UI.createProgressBar({
	top: 10, width: 250, min: 0, max: 100, value: 50,
	trackThickness: 10,
	stopIndicator: { enabled: true, size: 10}
}));
win.add(Ti.UI.createProgressBar({
	top: 10, width: 250, min: 0, max: 100, value: 50,
	trackThickness: 10,
	stopIndicator: { enabled: true, size: 5}
}));
win.add(Ti.UI.createProgressBar({
	top: 10, width: 250, min: 50, max: 100, value: 75,
	trackThickness: 20,
	stopIndicator: { size: 20}
}));
win.add(Ti.UI.createProgressBar({
	top: 10, width: 250, min: 50, max: 100, value: 95,
	stopIndicator: { enabled: false }
}));
win.open();
```

If you run this code without the M3 theme is will just show the progressbar as usual, `stopIndicator` is ignored